### PR TITLE
[8.x] Add Request::values method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -330,6 +330,17 @@ trait InteractsWithInput
     }
 
     /**
+     * Get a subset of request values by the provided key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function values($key)
+    {
+        return Arr::get($this->only($key), $key);
+    }
+
+    /**
      * Get a subset containing the provided keys with values from the input data.
      *
      * @param  array|mixed  $keys

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -675,7 +675,7 @@ class HttpRequestTest extends TestCase
                 ['reviews' => [['id' => 1], ['id' => 2]]],
                 ['reviews' => [['id' => 3], ['foo' => 'bar']]],
                 ['reviews' => [['id' => 4], ['id' => 5], ['id' => 6]]],
-            ]
+            ],
         ]);
         $this->assertEquals([1, 2, 3, null, 4, 5, 6], $request->values('products.*.reviews.*.id'));
         $this->assertSame($reviews, $request->values('products.*'));

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -649,6 +649,39 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['name', 'foo'], $request->keys());
     }
 
+    public function testValuesMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
+        $this->assertEquals('Taylor', $request->values('name'));
+        $this->assertNull($request->values('missing'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar', 'baz']]);
+        $this->assertEquals(['bar', 'baz'], $request->values('foo'));
+
+        $request = Request::create('/', 'GET', [
+            'products' => $products = [
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+                ['foo' => 'bar'],
+            ]
+        ]);
+        $this->assertEquals([1,2,3,null], $request->values('products.*.id'));
+        $this->assertEquals([null,null,null,'bar'], $request->values('products.*.foo'));
+        $this->assertSame($products, $request->values('products.*'));
+
+        $request = Request::create('/', 'GET', [
+            'products' => $reviews = [
+                ['reviews' => [['id' => 1], ['id' => 2]]],
+                ['reviews' => [['id' => 3], ['foo' => 'bar']]],
+                ['reviews' => [['id' => 4], ['id' => 5], ['id' => 6]]],
+            ]
+        ]);
+        $this->assertEquals([1,2,3,null,4,5,6], $request->values('products.*.reviews.*.id'));
+        $this->assertSame($reviews, $request->values('products.*'));
+        $this->assertSame($reviews, $request->values('products'));
+    }
+
     public function testOnlyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -664,10 +664,10 @@ class HttpRequestTest extends TestCase
                 ['id' => 2],
                 ['id' => 3],
                 ['foo' => 'bar'],
-            ]
+            ],
         ]);
-        $this->assertEquals([1,2,3,null], $request->values('products.*.id'));
-        $this->assertEquals([null,null,null,'bar'], $request->values('products.*.foo'));
+        $this->assertEquals([1, 2, 3, null], $request->values('products.*.id'));
+        $this->assertEquals([null, null, null, 'bar'], $request->values('products.*.foo'));
         $this->assertSame($products, $request->values('products.*'));
 
         $request = Request::create('/', 'GET', [
@@ -677,7 +677,7 @@ class HttpRequestTest extends TestCase
                 ['reviews' => [['id' => 4], ['id' => 5], ['id' => 6]]],
             ]
         ]);
-        $this->assertEquals([1,2,3,null,4,5,6], $request->values('products.*.reviews.*.id'));
+        $this->assertEquals([1, 2, 3, null, 4, 5, 6], $request->values('products.*.reviews.*.id'));
         $this->assertSame($reviews, $request->values('products.*'));
         $this->assertSame($reviews, $request->values('products'));
     }


### PR DESCRIPTION
## Description

This PR introduces the `Request::values()` method, making it super easy to retrieve a subset of nested array values using dot and asterisk syntax. If the request key is not an array, the request value retrieved is simply returned.

## Example

```php
$data = [
    'name' => 'Steve',
    'companies' => [
        ['id' => 1],
        ['id' => 2],
        ['id' => 3],
    ],
];

// Request submitted...

// With "only":
// ['companies' => ['*' => ['id' => [1,2,3]]]]
$ids = $request->only('companies.*.id');

// With "values":
// [1,2,3]
$ids = $request->values('companies.*.id');

// Steve
$name = $request->values('name');

// null
$request->values('missing');
```

## Note

Not sure if you'd like this named plural or singular. Since it's pointless to use this method to retrieve single request values, I named it plural to signify it's likely usage.

---

Thanks for your time! No hard feelings on closure ❤️ 