### PR TITLE
[9.x] Extend str() helper to provide access to the Str class

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -261,11 +261,21 @@ if (! function_exists('str')) {
     /**
      * Get a new stringable object from the given string.
      *
-     * @param  string  $string
-     * @return \Illuminate\Support\Stringable
+     * @param  string|null  $string
+     * @return \Illuminate\Support\Stringable|mixed
      */
-    function str($string)
+    function str($string = null)
     {
+        if (! isset($string)) {
+            return new class
+            {
+                public function __call($method, $parameters)
+                {
+                    return Str::$method(...$parameters);
+                }
+            };
+        }
+
         return Str::of($string);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -266,7 +266,7 @@ if (! function_exists('str')) {
      */
     function str($string = null)
     {
-        if (! isset($string)) {
+        if (func_num_args() === 0) {
             return new class
             {
                 public function __call($method, $parameters)

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -372,6 +372,10 @@ class SupportHelpersTest extends TestCase
         $this->assertInstanceOf(Stringable::class, $stringable);
         $this->assertSame('string-value', (string) $stringable);
 
+        $stringable = str($name = null);
+        $this->assertInstanceOf(Stringable::class, $stringable);
+        $this->assertTrue($stringable->isEmpty());
+
         $strAccessor = str();
         $this->assertTrue((new \ReflectionClass($strAccessor))->isAnonymous());
         $this->assertSame($strAccessor->limit('string-value', 3), 'str...');

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -371,6 +371,10 @@ class SupportHelpersTest extends TestCase
 
         $this->assertInstanceOf(Stringable::class, $stringable);
         $this->assertSame('string-value', (string) $stringable);
+
+        $strAccessor = str();
+        $this->assertTrue((new \ReflectionClass($strAccessor))->isAnonymous());
+        $this->assertSame($strAccessor->limit('string-value', 3), 'str...');
     }
 
     public function testTap()


### PR DESCRIPTION
### What?

Recently @nunomaduro added a `str()`-helper in https://github.com/laravel/framework/pull/40520. On of the reasons for a `str()`-helper in the original PR (https://github.com/laravel/framework/pull/31707) was that this helper would reduce the imports of the `Illuminate\Support\Str` class.

This PR extends the recently added string helper to provide access to all other methods of the Str class.
```php
str('some-string'); // \Illuminate\Support\Stringable as per the referenced PR
str()->random(16); // QDae31W1nFshBV97
str()->uuid(); // 85d57da7-12d0-4594-ad00-ff1eb1bcfff9
```

### Why?
With the current state of this helper you will still need to use `Illuminate\Support\Str` in your file when you use a function different from `Str::of`. With this PR there is no need to use the Str class whenever you want to generate a random string or use other functions of the Str class.

### Return type
I added `mixed` as a return type because the string helper can now return an anonymous class. I know that strictly speaking mixed includes Stringable, but without explicitly having Stringable in the doc, IDE autocomplete wouldn't work
