### PR TITLE
[8.x] Match Redirect Facade DocBlock to actual class

### DIFF
--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -3,17 +3,17 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Http\RedirectResponse action(string $action, array $parameters = [], int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse action(string $action, mixed $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse away(string $path, int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse back(int $status = 302, array $headers = [], $fallback = false)
  * @method static \Illuminate\Http\RedirectResponse guest(string $path, int $status = 302, array $headers = [], bool $secure = null)
  * @method static \Illuminate\Http\RedirectResponse home(int $status = 302)
  * @method static \Illuminate\Http\RedirectResponse intended(string $default = '/', int $status = 302, array $headers = [], bool $secure = null)
  * @method static \Illuminate\Http\RedirectResponse refresh(int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\RedirectResponse route(string $route, array $parameters = [], int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse route(string $route, mixed $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse secure(string $path, int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\RedirectResponse signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\RedirectResponse temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [], int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse signedRoute(string $name, mixed $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, mixed $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse to(string $path, int $status = 302, array $headers = [], bool $secure = null)
  * @method static \Illuminate\Routing\UrlGenerator getUrlGenerator()
  * @method static void setSession(\Illuminate\Session\Store $session)


### PR DESCRIPTION
The current Redirect Facade DocBlocks show `$parameters` as an array when in fact `mixed` is accepted (according to Redirector.php), causing an IDE warning (at least in PHPStorm).

Before:

```php
$postId = 3;

Redirect::route('posts.show', $postId); // IDE warning, but works perfectly
```

After:

```php
$postId = 3;

Redirect::route('posts.show', $postId); // No IDE warning
```