### PR TITLE
[8.x] Make AliasLoader class extendable by packages

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -5,6 +5,13 @@ namespace Illuminate\Foundation;
 class AliasLoader
 {
     /**
+     * The array of alias loader objects.
+     *
+     * @var array
+     */
+    protected $loaders = [];
+
+    /**
      * The array of class aliases.
      *
      * @var array
@@ -63,6 +70,17 @@ class AliasLoader
     }
 
     /**
+     * Appends an alias loader to the loaders property.
+     *
+     * @param  object  $loader
+     * @return void
+     */
+    public function addLoader($loader)
+    {
+        $this->loaders[] = $loader;
+    }
+
+    /**
      * Load a class alias if it is registered.
      *
      * @param  string  $alias
@@ -70,6 +88,12 @@ class AliasLoader
      */
     public function load($alias)
     {
+        foreach ($this->loaders as $loader) {
+            if ($loader->canLoad($alias)) {
+                return $loader->load($alias);
+            }
+        }
+
         if (static::$facadeNamespace && strpos($alias, static::$facadeNamespace) === 0) {
             $this->loadFacade($alias);
 


### PR DESCRIPTION
### Problem:
In my recent PR I changed AliasLoader class in a way that it was able to create real-time facades with useful docblocks, but rejected.
Ok, but there is no way of easily overriding the current real-time implementation of real-time facades.

### Benefit:
I think if laravel allows package developers to introduce custom loaders, there would be a lot of opportunities for code generators. Developers can use non-existent classes in their code and refresh the browser. Then the packages can create a new class and fill it with an appropriate boilerplate.

For example, a package may allow me to mention a listener class in EventServiceProvider and refresh the browser, so that the package can intercept and create an empty listener in the right directory based on the fact that the class name ends with Listener and its namespace.

Also, the current implementation of real-time facades can be extracted into a collective package and be removed in future versions of laravel.

### Break Possibility:
It only boils down to cases in which AliasLoader is extended and there is an `addLoader` method in the subclass with a different signature which is extremely unlikely. (Since we have introduced a new method)

### Note: 
You may also want to create an interface with two methods `canLoad` and `load` for loaders to implement.
