### PR TITLE
[9.x] Fix event:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -55,9 +55,7 @@ class EventListCommand extends Command
      */
     protected function getEvents()
     {
-        $events = [];
-
-        $events = $this->addListenersOnDispatcher($events);
+        $events = $this->getListenersOnDispatcher();
 
         if ($this->filteringByEvent()) {
             $events = $this->filterEvents($events);
@@ -69,19 +67,24 @@ class EventListCommand extends Command
     }
 
     /**
-     * Adds the event / listeners on the dispatcher object to the given list.
+     * Get the event / listeners from the dispatcher object.
      *
-     * @param  array  $events
      * @return array
      */
-    protected function addListenersOnDispatcher(array $events)
+    protected function getListenersOnDispatcher()
     {
+        $events = [];
         foreach ($this->getRawListeners() as $event => $rawListeners) {
             foreach ($rawListeners as $rawListener) {
                 if (is_string($rawListener)) {
                     $events[$event][] = $rawListener;
                 } elseif ($rawListener instanceof Closure) {
                     $events[$event][] = $this->stringifyClosure($rawListener);
+                } elseif (is_array($rawListener) && count($rawListener) === 2) {
+                    if (is_object($rawListener[0])) {
+                        $rawListener[0] = get_class($rawListener[0]);
+                    }
+                    $events[$event][] = implode('@', $rawListener);
                 }
             }
         }


### PR DESCRIPTION
According to the issue reported as a comment on the pull request: https://github.com/laravel/framework/pull/35037#issuecomment-1017555186

The `event:list` command can not list listeners which are in the form of arrays. `[object, 'method']` or `["class", "method"]`

Currently, on a fresh laravel 9 installation the `event:list` can only print 4, with this change it will discover 8

- Note: There is a little bit of refactoring going on in this PR, let me say that the `getListenersOnDispatcher` is not present on laravel 8, and the changes to it will not affect previous versions. see https://github.com/laravel/framework/pull/35221

### Before
![image](https://user-images.githubusercontent.com/6961695/150442016-2fb2f48d-cfd3-4380-a0e0-ebe79854a6f6.png)

### After
![image](https://user-images.githubusercontent.com/6961695/150442072-e29de16c-4a2e-4f43-be72-3bd5d9e9ce44.png)

