### PR TITLE
[8.x] Add better bitwise operators support

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -204,6 +204,15 @@ class Builder
     ];
 
     /**
+     * All of the available binary operators.
+     *
+     * @var string[]
+     */
+    public $binaryOperators = [
+        '&', '|', '^', '<<', '>>', '&~',
+    ];
+
+    /**
      * Whether to use write pdo for the select.
      *
      * @var bool
@@ -754,6 +763,10 @@ class Builder
             }
         }
 
+        if ($this->isBinaryOperator($operator)) {
+            $type = 'Binary';
+        }
+
         // Now that we are working with just a simple query we can put the elements
         // in our array and add the query binding to our array of bindings that
         // will be bound to each SQL statements when it is finally executed.
@@ -835,6 +848,12 @@ class Builder
     {
         return ! in_array(strtolower($operator), $this->operators, true) &&
                ! in_array(strtolower($operator), $this->grammar->getOperators(), true);
+    }
+
+    protected function isBinaryOperator($operator)
+    {
+        return in_array(strtolower($operator), $this->binaryOperators, true) ||
+               in_array(strtolower($operator), $this->grammar->getBinaryOperators(), true);
     }
 
     /**
@@ -1913,6 +1932,10 @@ class Builder
         // we will set the operators to '=' and set the values appropriately.
         if ($this->invalidOperator($operator)) {
             [$value, $operator] = [$operator, '='];
+        }
+
+        if ($this->isBinaryOperator($operator)) {
+            $type = 'binary';
         }
 
         $this->havings[] = compact('type', 'column', 'operator', 'value', 'boolean');

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -22,6 +22,15 @@ class PostgresGrammar extends Grammar
     ];
 
     /**
+     * The grammar specific binary operators.
+     *
+     * @var array
+     */
+    protected $binaryOperators = [
+        '~', '&', '|', '#', '<<', '>>', '<<=', '>>=',
+    ];
+
+    /**
      * {@inheritdoc}
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2153,6 +2153,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($connection = m::mock(Connection::class));
         $connection->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
+        $grammar->shouldReceive('getBinaryOperators')->andReturn([]);
         $connection->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
@@ -2440,6 +2441,7 @@ class EloquentModelSaveStub extends Model
     {
         $mock = m::mock(Connection::class);
         $mock->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
+        $grammar->shouldReceive('getBinaryOperators')->andReturn([]);
         $mock->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
         $mock->shouldReceive('getName')->andReturn('name');
         $mock->shouldReceive('query')->andReturnUsing(function () use ($mock, $grammar, $processor) {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3209,6 +3209,25 @@ SQL;
         $this->assertEquals(['John Doe'], $builder->getBindings());
     }
 
+    public function testBinaryOperators()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('bar', '&', 1);
+        $this->assertSame('select * from "users" where ("bar" & ?) != 0', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('bar', '#', 1);
+        $this->assertSame('select * from "users" where ("bar" # ?) != 0', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->having('bar', '&', 1);
+        $this->assertSame('select * from "users" having ("bar" & ?) != 0', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->having('bar', '#', 1);
+        $this->assertSame('select * from "users" having ("bar" # ?) != 0', $builder->toSql());
+    }
+
     public function testMergeWheresCanMergeWheresAndBindings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
### Impetus

This addresses the problem mentioned in issue #40484

### Changes

Since the bitwise operators are fundamentally different from other, in the sense that they do not produce boolean expression but integer based expressions, I elected to treat them differently from others.

Currently, both MySQL and SQLite support "implicit casting" of integer to boolean, but SQL Server and PostgreSQL do not.
The idea is to have a uniform behavior across all supported databases.

Previously this would yield a PDOException on PostgreSQL for instance :
~~~php
$builder->select('*')->from('foo')->where('bar', '&', 1)->get(); // MySQL is cool with that, PostgreSQL looks upon you and declares that argument of WHERE must be type boolean, not type integer
~~~

The proposed implementation is database agnostic (as far as I'm aware at least). This is done by forcing a comparison, thus transforming the expression into a boolean one.

### What next

This could open the door to support for basic arithmetic operators (e.g. `+`, `-`, etc...), although I would argue those appear even more elusively in WHERE clauses.