### PR TITLE
[8.x] Added getOrPut on Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -430,16 +430,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * or add to collection if not exists.
      *
      * @param  mixed  $key
-     * @param  callable  $callback
+     * @param  mixed  $value
      * @return mixed
      */
-    public function getOrPut($key, callable $callback)
+    public function getOrPut($key, mixed $value)
     {
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];
         }
 
-        $this->offsetSet($key, $value = $callback());
+        $this->offsetSet($key, $value = value($value));
 
         return $value;
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -433,7 +433,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  mixed  $value
      * @return mixed
      */
-    public function getOrPut($key, mixed $value)
+    public function getOrPut($key, $value)
     {
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -426,6 +426,25 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get an item from the collection by key
+     * or add to collection if not exists
+     *
+     * @param  mixed     $key
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function getOrPut($key, callable $callback)
+    {
+        if (array_key_exists($key, $this->items)) {
+            return $this->items[$key];
+        }
+
+        $this->offsetSet($key, $value = $callback());
+
+        return $value;
+    }
+
+    /**
      * Group an associative array by a field or using a callback.
      *
      * @param  array|callable|string  $groupBy

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -427,9 +427,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Get an item from the collection by key
-     * or add to collection if not exists
+     * or add to collection if not exists.
      *
-     * @param  mixed     $key
+     * @param  mixed  $key
      * @param  callable  $callback
      * @return mixed
      */

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -426,8 +426,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Get an item from the collection by key
-     * or add to collection if not exists.
+     * Get an item from the collection by key or add it to collection if it does not exist.
      *
      * @param  mixed  $key
      * @param  mixed  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2148,6 +2148,15 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
+    public function testGetOrPut()
+    {
+        $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
+
+        $this->assertEquals('taylor', $data->getOrPut('name', fn () => null));
+        $this->assertEquals('foo', $data->getOrPut('email', fn () => null));
+        $this->assertEquals('male', $data->getOrPut('gender', fn () => 'male'));
+    }
+
     public function testPut()
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2152,6 +2152,16 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
 
+        $this->assertEquals('taylor', $data->getOrPut('name', null));
+        $this->assertEquals('foo', $data->getOrPut('email', null));
+        $this->assertEquals('male', $data->getOrPut('gender', 'male'));
+
+        $this->assertEquals('taylor', $data->get('name'));
+        $this->assertEquals('foo', $data->get('email'));
+        $this->assertEquals('male', $data->get('gender'));
+
+        $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
+
         $this->assertEquals('taylor', $data->getOrPut('name', function () {
             return null;
         }));
@@ -2163,6 +2173,10 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('male', $data->getOrPut('gender', function () {
             return 'male';
         }));
+
+        $this->assertEquals('taylor', $data->get('name'));
+        $this->assertEquals('foo', $data->get('email'));
+        $this->assertEquals('male', $data->get('gender'));
     }
 
     public function testPut()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2152,9 +2152,17 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
 
-        $this->assertEquals('taylor', $data->getOrPut('name', fn () => null));
-        $this->assertEquals('foo', $data->getOrPut('email', fn () => null));
-        $this->assertEquals('male', $data->getOrPut('gender', fn () => 'male'));
+        $this->assertEquals('taylor', $data->getOrPut('name', function () {
+            return null;
+        }));
+
+        $this->assertEquals('foo', $data->getOrPut('email', function () {
+            return null;
+        }));
+
+        $this->assertEquals('male', $data->getOrPut('gender', function () {
+            return 'male';
+        }));
     }
 
     public function testPut()


### PR DESCRIPTION
On often changing collections we need to check every time if a key value exists or add if not:

```php
/**
 * @param string $key
 * @param array $data
 *
 * @return mixed
 */
protected function getValueFromCollection(string $key, array $data): mixed
{
    if ($this->collection->has($key) === false) {
        $this->collection->put($key, $this->create($data));
    }

    return $this->collection->get($key);
}
```

We want to avoid this common check adding a `getOrPut` method on collections and allow to simplify as:

```php
/**
 * @param string $key
 * @param array $data
 *
 * @return mixed
 */
protected function getValueFromCollection(string $key, array $data): mixed
{
    return $this->collection->getOrPut($key, fn () => $this->create($data));
}
```

Also fixed values are valid:

```php
/**
 * @param string $key
 * @param mixed $value
 *
 * @return mixed
 */
protected function getValueFromCollection(string $key, mixed $value): mixed
{
    return $this->collection->getOrPut($key, $value);
}
```

On batch processes with collections caching models creation, this change help us a lot with code simplification.

What do you think?