### PR TITLE
[9.x] Adds support for "chainable" taps

### DIFF
--- a/src/Illuminate/Support/HigherOrderTapProxy.php
+++ b/src/Illuminate/Support/HigherOrderTapProxy.php
@@ -12,14 +12,23 @@ class HigherOrderTapProxy
     public $target;
 
     /**
+     * If the tap proxy is chainable.
+     *
+     * @var bool
+     */
+    public $chainable;
+
+    /**
      * Create a new tap proxy instance.
      *
      * @param  mixed  $target
+     * @param  bool  $chainable
      * @return void
      */
-    public function __construct($target)
+    public function __construct($target, $chainable = false)
     {
         $this->target = $target;
+        $this->chainable = $chainable;
     }
 
     /**
@@ -33,6 +42,26 @@ class HigherOrderTapProxy
     {
         $this->target->{$method}(...$parameters);
 
+        return $this->chainable ? $this : $this->target;
+    }
+
+    /**
+     * Create a new chainable tap proxy.
+     *
+     * @return static
+     */
+    public function chain()
+    {
+        return new static($this->target, true);
+    }
+
+    /**
+     * Return the target being tapped.
+     *
+     * @return mixed
+     */
+    public function then()
+    {
         return $this->target;
     }
 }

--- a/src/Illuminate/Support/HigherOrderTapProxy.php
+++ b/src/Illuminate/Support/HigherOrderTapProxy.php
@@ -56,12 +56,17 @@ class HigherOrderTapProxy
     }
 
     /**
-     * Return the target being tapped.
+     * Call the given Closure with the given value then return the value.
      *
+     * @param  callable|null  $callback
      * @return mixed
      */
-    public function then()
+    public function then($callback = null)
     {
-        return $this->target;
+        if (is_null($callback)) {
+            return $this->target;
+        }
+
+        return with($this->target, $callback);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -391,7 +391,7 @@ class SupportHelpersTest extends TestCase
         $mock = m::mock();
         $mock->shouldReceive('foo')->times(5)->andReturn('foo');
         $this->assertEquals('foo2', tap($mock)->chain()->foo()->foo()->foo()->foo()->then(
-            fn ($target) => $object->slug = $target->foo() . $object->id,
+            fn ($target) => $object->slug = $target->foo().$object->id,
         ));
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -386,8 +386,13 @@ class SupportHelpersTest extends TestCase
 
         $mock = m::mock();
         $mock->shouldReceive('foo')->times(5)->andReturn('foo');
-
         $this->assertEquals('foo', tap($mock)->chain()->foo()->foo()->foo()->foo()->then()->foo());
+
+        $mock = m::mock();
+        $mock->shouldReceive('foo')->times(5)->andReturn('foo');
+        $this->assertEquals('foo2', tap($mock)->chain()->foo()->foo()->foo()->foo()->then(
+            fn ($target) => $object->slug = $target->foo() . $object->id,
+        ));
     }
 
     public function testThrow()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -381,8 +381,13 @@ class SupportHelpersTest extends TestCase
         })->id);
 
         $mock = m::mock();
-        $mock->shouldReceive('foo')->once()->andReturn('bar');
+        $mock->shouldReceive('foo')->once()->andReturn('foo');
         $this->assertEquals($mock, tap($mock)->foo());
+
+        $mock = m::mock();
+        $mock->shouldReceive('foo')->times(5)->andReturn('foo');
+
+        $this->assertEquals('foo', tap($mock)->chain()->foo()->foo()->foo()->foo()->then()->foo());
     }
 
     public function testThrow()


### PR DESCRIPTION
Originally posted https://github.com/laravel/framework/pull/40505, this pull request is an alternative implementation making the `HigherOrderTapProxy` immutable, and contains slightly different method / property names.

```php
$slug = tap($user)
    ->chain()
    ->save()
    ->withoutBroadcasting(fn () => /** ... */ })
    ->then(fn ($user) => $user->slug); // breaks the chain, and returns the callback result

$slug = tap($user)
    ->chain()
    ->save()
    ->withoutBroadcasting(fn () => /** ... */ })
    ->then() // breaks the chain, uses the $user object now...
    ->slug;
```