### PR TITLE
[8.x] Pruning Models: Get the default path for the models from a method instead

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -96,7 +96,7 @@ class PruneCommand extends Command
             throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }
 
-        return collect((new Finder)->in(app_path('Models'))->files()->name('*.php'))
+        return collect((new Finder)->in($this->getDefaultPath())->files()->name('*.php'))
             ->map(function ($model) {
                 $namespace = $this->laravel->getNamespace();
 
@@ -112,6 +112,16 @@ class PruneCommand extends Command
             })->filter(function ($model) {
                 return $this->isPrunable($model);
             })->values();
+    }
+
+    /**
+     * Get the default path for the models.
+     *
+     * @return string
+     */
+    protected function getDefaultPath()
+    {
+        return app_path('Models');
     }
 
     /**

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -115,7 +115,7 @@ class PruneCommand extends Command
     }
 
     /**
-     * Get the default path for the models.
+     * Get the default path where models are located.
      *
      * @return string
      */


### PR DESCRIPTION
Hi there,

We want to use the "Pruning Models" feature but use a custom model namespace. The Artisan make command allow for overriding the used namespace by creating your own `getDefaultNamespace` method.

This PR adds the same functionality to the `PruneCommand`.