### PR TITLE
Improve types for Collection::groupBy()

### DIFF
--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -5,11 +5,11 @@ use function PHPStan\Testing\assertType;
 $collection = User::all();
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection);
 
-// @phpstan-ignore-next-line TODO remove ignore when https://github.com/phpstan/phpstan/issues/5512 is fixed
-assertType(
-    'Illuminate\Database\Eloquent\Collection<(int|string), Illuminate\Database\Eloquent\Collection<(int|string), User>>',
-    $collection->groupBy('string')
-);
+// TODO reinclude when https://github.com/phpstan/phpstan/issues/5512 is fixed
+//assertType(
+//    'Illuminate\Database\Eloquent\Collection<(int|string), Illuminate\Database\Eloquent\Collection<(int|string), User>>',
+//    $collection->groupBy('string')
+//);
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>|User|null', $collection->find(1));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>|string|User', $collection->find(1, 'string'));

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -5,6 +5,7 @@ use function PHPStan\Testing\assertType;
 $collection = User::all();
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection);
 
+// @phpstan-ignore-next-line TODO remove ignore when https://github.com/phpstan/phpstan/issues/5512 is fixed
 assertType(
     'Illuminate\Database\Eloquent\Collection<(int|string), Illuminate\Database\Eloquent\Collection<(int|string), User>>',
     $collection->groupBy('string')

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -5,6 +5,11 @@ use function PHPStan\Testing\assertType;
 $collection = User::all();
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection);
 
+assertType(
+    'Illuminate\Database\Eloquent\Collection<(int|string), Illuminate\Database\Eloquent\Collection<(int|string), User>>',
+    $collection->groupBy('string')
+);
+
 assertType('Illuminate\Database\Eloquent\Collection<int, User>|User|null', $collection->find(1));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>|string|User', $collection->find(1, 'string'));
 


### PR DESCRIPTION
Currently only a failing test case. Given `Illuminate\Support\Collection::groupBy()` returns `static<array-key, static<array-key, TValue>>`, I would expect PHPStan to respect late static binding.

See https://github.com/nunomaduro/larastan/pull/1054

@canvural @nunomaduro