### PR TITLE
[8.x] Add only and except features to MorphTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -424,10 +424,11 @@ class MorphTo extends BelongsTo
     /**
      * Check if morphable type is excluded from dictionary.
      *
-     * @param  string $type
+     * @param  string  $type
      * @return bool
      */
-    protected function isMorphTypeExcluded($type) {
+    protected function isMorphTypeExcluded($type)
+    {
         $morphTypeKey = $this->getDictionaryKey($type);
 
         return array_key_exists($morphTypeKey, $this->exclusionDictionary);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -401,7 +401,7 @@ class MorphTo extends BelongsTo
             // Prevent relation initialization for excluded morph types.
 
             $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});
-            $relationNotExcluded = !array_key_exists($morphTypeKey, $this->exclusionDictionary);
+            $relationNotExcluded = ! array_key_exists($morphTypeKey, $this->exclusionDictionary);
 
             if ($relationNotExcluded) {
                 $model->setRelation($relation, $this->getDefaultFor($model));

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -398,12 +398,7 @@ class MorphTo extends BelongsTo
     public function initRelation(array $models, $relation)
     {
         foreach ($models as $model) {
-            // Prevent relation initialization for excluded morph types.
-
-            $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});
-            $isRelationExcluded = array_key_exists($morphTypeKey, $this->exclusionDictionary);
-
-            if (! $isRelationExcluded) {
+            if (! $this->isMorphTypeExcluded($model->{$this->morphType})) {
                 $model->setRelation($relation, $this->getDefaultFor($model));
             }
         }
@@ -424,6 +419,18 @@ class MorphTo extends BelongsTo
         );
 
         return $this;
+    }
+
+    /**
+     * Check if morphable type is excluded from dictionary.
+     *
+     * @param  string $type
+     * @return bool
+     */
+    protected function isMorphTypeExcluded($type) {
+        $morphTypeKey = $this->getDictionaryKey($type);
+
+        return array_key_exists($morphTypeKey, $this->exclusionDictionary);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -371,15 +371,15 @@ class MorphTo extends BelongsTo
      * @param  array  $types
      * @return $this
      */
-    public function morphWithout(array $types)
+    public function morphExcept(array $types)
     {
-        $withoutMorphTypeKeys = array_map(function ($key) {
+        $exceptMorphTypeKeys = array_map(function ($key) {
             return $this->getDictionaryKey($key);
         }, $types);
 
         // We prevent unwanted eager loading by moving excluded morph types on exclusion dictionary.
         foreach ($this->dictionary as $morphTypeKey => $foreignKeyKeys) {
-            if (in_array($morphTypeKey, $withoutMorphTypeKeys, true)) {
+            if (in_array($morphTypeKey, $exceptMorphTypeKeys, true)) {
                 $this->exclusionDictionary[$morphTypeKey] = $foreignKeyKeys;
                 unset($this->dictionary[$morphTypeKey]);
             }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -36,7 +36,7 @@ class MorphTo extends BelongsTo
     /**
      * All of the dictionary items that must be excluded from eager loading.
      *
-     * @var bool
+     * @var array
      */
     protected $exclusionDictionary = [];
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -401,9 +401,9 @@ class MorphTo extends BelongsTo
             // Prevent relation initialization for excluded morph types.
 
             $morphTypeKey = $this->getDictionaryKey($model->{$this->morphType});
-            $relationNotExcluded = ! array_key_exists($morphTypeKey, $this->exclusionDictionary);
+            $isRelationExcluded = array_key_exists($morphTypeKey, $this->exclusionDictionary);
 
-            if ($relationNotExcluded) {
+            if (! $isRelationExcluded) {
                 $model->setRelation($relation, $this->getDefaultFor($model));
             }
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -410,9 +410,7 @@ class MorphTo extends BelongsTo
      */
     protected function isMorphTypeAllowed($type)
     {
-        $morphTypeKey = $this->getDictionaryKey($type);
-
-        return array_key_exists($morphTypeKey, $this->dictionary);
+        return array_key_exists($this->getDictionaryKey($type), $this->dictionary);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -422,7 +422,7 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Check if morphable type is excluded from dictionary.
+     * Check if morph type is excluded from dictionary.
      *
      * @param  string  $type
      * @return bool

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -76,10 +76,10 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
         $this->assertFalse($comments[1]->relationLoaded('commentable'));
     }
 
-    public function testWithoutMorphLoading()
+    public function testExceptMorphLoading()
     {
         $comments = Comment::with(['commentable' => function (MorphTo $morphTo) {
-            $morphTo->morphWithout([Post::class]);
+            $morphTo->morphExcept([Post::class]);
         }])->get();
 
         $this->assertFalse($comments[0]->relationLoaded('commentable'));

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -65,6 +65,29 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
         $this->assertTrue($comments[0]->commentable->relationLoaded('user'));
     }
+
+    public function testOnlyMorphLoading()
+    {
+        $comments = Comment::with(['commentable' => function (MorphTo $morphTo) {
+            $morphTo->morphOnly([Post::class]);
+        }])
+            ->get();
+
+        $this->assertTrue($comments[0]->relationLoaded('commentable'));
+        $this->assertFalse($comments[1]->relationLoaded('commentable'));
+    }
+
+    public function testWithoutMorphLoading()
+    {
+        $comments = Comment::with(['commentable' => function (MorphTo $morphTo) {
+            $morphTo->morphWithout([Post::class]);
+        }])
+            ->get();
+
+        $this->assertFalse($comments[0]->relationLoaded('commentable'));
+        $this->assertTrue($comments[1]->relationLoaded('commentable'));
+        $this->assertInstanceOf(Video::class, $comments[1]->getRelation('commentable'));
+    }
 }
 
 class Comment extends Model

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -70,8 +70,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     {
         $comments = Comment::with(['commentable' => function (MorphTo $morphTo) {
             $morphTo->morphOnly([Post::class]);
-        }])
-            ->get();
+        }])->get();
 
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
         $this->assertFalse($comments[1]->relationLoaded('commentable'));
@@ -81,8 +80,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     {
         $comments = Comment::with(['commentable' => function (MorphTo $morphTo) {
             $morphTo->morphWithout([Post::class]);
-        }])
-            ->get();
+        }])->get();
 
         $this->assertFalse($comments[0]->relationLoaded('commentable'));
         $this->assertTrue($comments[1]->relationLoaded('commentable'));

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -69,7 +69,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     public function testOnlyMorphLoading()
     {
         $comments = Comment::with(['commentable' => function (MorphTo $morphTo) {
-            $morphTo->morphOnly([Post::class]);
+            $morphTo->only([Post::class]);
         }])->get();
 
         $this->assertTrue($comments[0]->relationLoaded('commentable'));
@@ -79,7 +79,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     public function testExceptMorphLoading()
     {
         $comments = Comment::with(['commentable' => function (MorphTo $morphTo) {
-            $morphTo->morphExcept([Post::class]);
+            $morphTo->except([Post::class]);
         }])->get();
 
         $this->assertFalse($comments[0]->relationLoaded('commentable'));


### PR DESCRIPTION
### Why

We have a use case that cannot be solved actually.
We have a lot of `Comment` and we want to eager load only specific morphable types. Actually, all types are eager loaded.

#### Example:

The `Comment` model can morph to `Post` or `Video`.
We want to fetch all `Comment` with `commentable` only if the `commentable_type` is type of `Post::class`.
We don't want to eager load `Video::class` firstly because the relation is not used and secondly to save memory and database queries.

### Proposal

Adding 2 features to `MorphTo`:

- `only(array $types)`
  - Eager load only given morph types
- `except(array $types)`
  - Prevent eager load of given morph types

To make this behavior easily understandable by developers, it seems that the best place to call these functions is in the `with()` callback:

```php
$comments = Comment::with(['commentable' => function (MorphTo $morphTo) {
                $morphTo->only([Post::class]);
                // $morphTo->except([Video::class]);
            }])
            ->get();
```

The main challenge here is that the dictionary containing relations to eager load is built before we can interact with it. In other words, the dictionary is already built in the `with` callback.

Then the `getResultsByType()` function will eager load all morph types present in the dictionary. And this is exactly what we want to avoid here. To prevent undesirable eager loads by the `getResultsByType()` function, morph types that must not be eager loaded are removed from `$dictionary`.

But due to the `eagerLoadRelation()` behavior in the `Builder` class, the relation even if it should not be loaded, is initialized with `null` value. It's a bad thing because the relation is now considered as loaded by the `relationLoaded()` function. And therefore can't be lazy-loaded. To keep a valid behavior of the eager load mechanism we need to prevent relation initialization by checking `$dictionary`.

# Update
- I have found a better way to prevent relation initialization directly in `initRelation()` function.
- Method renamed to `only` and `except`

----

- This can solve some heavy performances issues on morphable eager loads
- I have added tests that cover this behavior
- Functions can be renamed if they seem ambiguous to you
- I did my best to add these features by limiting changes as much as possible.