### PR TITLE
[8.x] Improve PhpRedis flushing

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -12,6 +12,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     public function flushdb()
     {
         $arguments = func_get_args();
+
         $async = strtoupper((string) $arguments[0] ?? null) === 'ASYNC';
 
         foreach ($this->client->_masters() as $master) {

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -7,12 +7,17 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     /**
      * Flush the selected Redis database.
      *
+     * @param  string|null  $modifier
      * @return mixed
      */
-    public function flushdb()
+    public function flushdb($modifier = null)
     {
+        $async = strtoupper($modifier) === 'ASYNC';
+
         foreach ($this->client->_masters() as $master) {
-            $this->client->flushdb($master);
+            $async
+                ? $this->command('rawCommand', [$master, 'flushdb', 'async'])
+                : $this->command('flushdb', [$master]);
         }
     }
 }

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -4,5 +4,15 @@ namespace Illuminate\Redis\Connections;
 
 class PhpRedisClusterConnection extends PhpRedisConnection
 {
-    //
+    /**
+     * Flush the selected Redis database.
+     *
+     * @return void
+     */
+    public function flushdb()
+    {
+        foreach ($this->client->_masters() as $master) {
+            $this->client->flushdb($master);
+        }
+    }
 }

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -7,7 +7,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     /**
      * Flush the selected Redis database.
      *
-     * @return void
+     * @return mixed
      */
     public function flushdb()
     {

--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -5,14 +5,14 @@ namespace Illuminate\Redis\Connections;
 class PhpRedisClusterConnection extends PhpRedisConnection
 {
     /**
-     * Flush the selected Redis database.
+     * Flush the selected Redis database on all master nodes.
      *
-     * @param  string|null  $modifier
      * @return mixed
      */
-    public function flushdb($modifier = null)
+    public function flushdb()
     {
-        $async = strtoupper($modifier) === 'ASYNC';
+        $arguments = func_get_args();
+        $async = strtoupper((string) $arguments[0] ?? null) === 'ASYNC';
 
         foreach ($this->client->_masters() as $master) {
             $async

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -494,10 +494,15 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Flush the selected Redis database.
      *
+     * @param  string  $modifier
      * @return void
      */
-    public function flushdb()
+    public function flushdb($modifier = null)
     {
+        if (strtoupper($modifier) === 'ASYNC') {
+            return $this->command('flushdb', [true]);
+        }
+
         return $this->command('flushdb');
     }
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -494,8 +494,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Flush the selected Redis database.
      *
-     * @param  string  $modifier
-     * @return void
+     * @param  string|null  $modifier
+     * @return mixed
      */
     public function flushdb($modifier = null)
     {

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Redis;
-use RedisCluster;
 use RedisException;
 
 /**
@@ -499,13 +498,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function flushdb()
     {
-        if (! $this->client instanceof RedisCluster) {
-            return $this->command('flushdb');
-        }
-
-        foreach ($this->client->_masters() as $master) {
-            $this->client->flushDb($master);
-        }
+        return $this->command('flushdb');
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -494,12 +494,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Flush the selected Redis database.
      *
-     * @param  string|null  $modifier
      * @return mixed
      */
-    public function flushdb($modifier = null)
+    public function flushdb()
     {
-        if (strtoupper($modifier) === 'ASYNC') {
+        $arguments = func_get_args();
+
+        if (strtoupper((string) $arguments[0] ?? null) === 'ASYNC') {
             return $this->command('flushdb', [true]);
         }
 


### PR DESCRIPTION
Followup to #40446 to make PhpRedis connections behave like Predis as usual.

- Move cluster flush logic into `PhpRedisClusterConnection`
- Added support for `ASYNC` modifier to both PhpRedis `flushdb()` methods
- `PhpRedisClusterConnection::flushdb()` will now fire `CommandExecuted` events as well
