### PR TITLE
[9.x] Adds `package` argument to `vendor:publish` command

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -28,7 +28,7 @@ class VendorPublishCommand extends Command
         'docker' => 'docker files',
         'public' => 'assets',
         'resources/views' => 'views',
-        'resources/lang' => 'resources',
+        'resources/lang' => 'translations',
         'sail' => 'binary',
     ];
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -168,7 +168,7 @@ class VendorPublishCommand extends Command
         $providerPackage = null;
 
         while (true) {
-            if ($currentPackageFolder == dirname(base_path())) {
+            if ($currentPackageFolder == '/' || $currentPackageFolder == dirname(base_path())) {
                 return;
             }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -26,6 +26,7 @@ class VendorPublishCommand extends Command
         'database/migrations' => 'migrations',
         'database' => 'database files',
         'docker' => 'docker files',
+        'lang' => 'translations',
         'public' => 'assets',
         'resources/views' => 'views',
         'resources/lang' => 'translations',

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -131,9 +131,10 @@ class VendorPublishCommand extends Command
         if ($package = $this->argument('package')) {
             $this->discoverFromPackage($package);
 
-            $this->promptForPackageAndTag();
-        }
-        if (! $this->providers && ! $this->tags) {
+            if ($this->providers) {
+                $this->promptForPackageAndTag();
+            }
+        } else if (! $this->providers && ! $this->tags) {
             $this->promptForPackageAndTag();
         }
     }

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -203,7 +203,7 @@ class VendorPublishCommand extends Command
 
             if (! $this->option('all') && count($tagChoices = $this->tagChoices()) > 1) {
                 $tagChoice = $this->choice(
-                    'Would you like to publish any tag in particular?',
+                    'Would you like to publish a specific tag?',
                     collect(['all' => 'Publish all files'] + $tagChoices)->sortKeys()->toArray(),
                     'all',
                 );

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -203,7 +203,7 @@ class VendorPublishCommand extends Command
             if (! $this->option('all') && count($tagChoices = $this->tagChoices()) > 1) {
                 $tagChoice = $this->choice(
                     'Would you like to publish any tag in particular?',
-                    collect(['all' => 'everything'] + $tagChoices)->sortKeys()->toArray(),
+                    collect(['all' => 'Publish all files'] + $tagChoices)->sortKeys()->toArray(),
                     'all',
                 );
             }

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -175,7 +175,7 @@ class VendorPublishCommand extends Command
             $composerFileName = "$currentPackageFolder/composer.json";
 
             if (File::exists($composerFileName)) {
-                return json_decode(File::get($composerFileName), true)['name'];
+                return json_decode(File::get($composerFileName), true)['name'] ?? null;
             }
 
             $currentPackageFolder = dirname($currentPackageFolder);
@@ -288,9 +288,11 @@ class VendorPublishCommand extends Command
      */
     protected function publishableProviders()
     {
-        return collect(ServiceProvider::publishableProviders())->groupBy(function ($provider) {
-            return $this->packageFromProvider($provider);
-        })->map->toArray()->toArray();
+        return collect(ServiceProvider::publishableProviders())->groupBy(
+            fn ($provider) => $this->packageFromProvider($provider)
+        )->filter(
+            fn ($description, $package) => ! empty($package)
+        )->map->toArray()->toArray();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -134,7 +134,7 @@ class VendorPublishCommand extends Command
             if ($this->providers) {
                 $this->promptForPackageAndTag();
             }
-        } else if (! $this->providers && ! $this->tags) {
+        } elseif (! $this->providers && ! $this->tags) {
             $this->promptForPackageAndTag();
         }
     }


### PR DESCRIPTION
This pull request introduces a few changes to the `vendor:publish` command.

<img width="100%" alt="Screenshot 2022-01-25 at 14 52 34" src="https://user-images.githubusercontent.com/5457236/150999970-2cc2d1d3-6468-4c98-ba8a-27de878851d0.png">

---

So, if this pull request gets merged, to get started, when users type `php artisan vendor:publish`, they will be asked to select a package, instead of selecting a provider class:
<p align="center">
<img width="70%" alt="1" src="https://user-images.githubusercontent.com/5457236/150991543-cc408e24-bbb3-4c2d-850e-0e3fb625327e.png">
</p>
As you can see, I've added a small description next to the package name, and the description contains details of the files that will be published. In addition, the user can enjoy nice autocompletion while selecting the package:
<p align="center">
<img width="70%" alt="2" src="https://user-images.githubusercontent.com/5457236/150991852-d4433d87-aef3-49db-9d69-0d28f303e367.png">
</p>

Next, once the user selects the package, he will be able to select which files (tags) he wish to publish:
<p align="center">
<img width="70%" alt="3" src="https://user-images.githubusercontent.com/5457236/150992211-f0e7be1d-2098-4395-9f16-91c38533c91e.png">
</p>

But of course, if there is 1 or 0 tags, we will publish everything of that package.
<p align="center">
<img width="70%" alt="4" src="https://user-images.githubusercontent.com/5457236/150992753-ff5a4700-7b0a-4d2a-8cf7-917cab93225c.png">
</p>

Now, this pull request also adds the new argument `package` that users may use to specify the package directly. Yet, we will question the user about the tags, if the user don't specify it via the `--tag` option:
<p align="center">
<img width="70%" alt="5" src="https://user-images.githubusercontent.com/5457236/150992806-e3874d93-92ae-436b-85ff-9b74d2753c08.png">
</p>

Next, the user may combine the argument `package` with the `--all` option, to publish everything related to the given package:
<p align="center">
<img width="70%" alt="6" src="https://user-images.githubusercontent.com/5457236/150993168-684da4da-0260-47d5-b992-e7cc4fc95a93.png">
</p>

Finally, it's important to keep in mind that there is no breaking changes - and previous options work on the same way:

<p align="center">
<img width="70%" alt="7" src="https://user-images.githubusercontent.com/5457236/150993448-da7f8118-8861-4179-8f16-00eddcf0dc15.png">
</p>
