### PR TITLE
[9.x] Introduce annotated builder contracts

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Builder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+use Illuminate\Contracts\Database\Query\Builder as BaseContract;
+
+/**
+ * This interface is intentionally empty and exists mostly to improve IDE support
+ * and provide a simple type-hinting option for those who prefer it.
+ *
+ * @mixin \Illuminate\Database\Eloquent\Builder
+ */
+interface Builder extends BaseContract
+{
+
+}

--- a/src/Illuminate/Contracts/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Builder.php
@@ -12,5 +12,4 @@ use Illuminate\Contracts\Database\Query\Builder as BaseContract;
  */
 interface Builder extends BaseContract
 {
-
 }

--- a/src/Illuminate/Contracts/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Builder.php
@@ -5,8 +5,7 @@ namespace Illuminate\Contracts\Database\Eloquent;
 use Illuminate\Contracts\Database\Query\Builder as BaseContract;
 
 /**
- * This interface is intentionally empty and exists mostly to improve IDE support
- * and provide a simple type-hinting option for those who prefer it.
+ * This interface is intentionally empty and exists to improve IDE support.
  *
  * @mixin \Illuminate\Database\Eloquent\Builder
  */

--- a/src/Illuminate/Contracts/Database/Query/Builder.php
+++ b/src/Illuminate/Contracts/Database/Query/Builder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Query;
+
+/**
+ * This interface is intentionally empty and exists mostly to improve IDE support
+ * and provide a simple type-hinting option for those who prefer it.
+ *
+ * @mixin \Illuminate\Database\Query\Builder
+ */
+interface Builder
+{
+
+}

--- a/src/Illuminate/Contracts/Database/Query/Builder.php
+++ b/src/Illuminate/Contracts/Database/Query/Builder.php
@@ -3,8 +3,7 @@
 namespace Illuminate\Contracts\Database\Query;
 
 /**
- * This interface is intentionally empty and exists mostly to improve IDE support
- * and provide a simple type-hinting option for those who prefer it.
+ * This interface is intentionally empty and exists to improve IDE support.
  *
  * @mixin \Illuminate\Database\Query\Builder
  */

--- a/src/Illuminate/Contracts/Database/Query/Builder.php
+++ b/src/Illuminate/Contracts/Database/Query/Builder.php
@@ -10,5 +10,4 @@ namespace Illuminate\Contracts\Database\Query;
  */
 interface Builder
 {
-
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent;
 use BadMethodCallException;
 use Closure;
 use Exception;
+use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Concerns\QueriesRelationships;
@@ -24,7 +25,7 @@ use ReflectionMethod;
  *
  * @mixin \Illuminate\Database\Query\Builder
  */
-class Builder
+class Builder implements BuilderContract
 {
     use BuildsQueries, ForwardsCalls, QueriesRelationships {
         BuildsQueries::sole as baseSole;

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Closure;
+use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -13,7 +14,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 
-abstract class Relation
+abstract class Relation implements BuilderContract
 {
     use ForwardsCalls, Macroable {
         Macroable::__call as macroCall;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use Carbon\CarbonPeriod;
 use Closure;
 use DateTimeInterface;
+use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
@@ -25,7 +26,7 @@ use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 
-class Builder
+class Builder implements BuilderContract
 {
     use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;


### PR DESCRIPTION
This is a revised version of #37956 that also brings in the new tests from #40402. Instead of adding any methods to the interface, I've added `@mixin` annotations. I've also added two contracts to address the differences between Eloquent queries and base queries.

As a result, you can do the following:

```php
use Illuminate\Contracts\Database\Query\Builder;

return Model::query()
  ->whereNotExists(function(Builder $query) {
    // no need to know that $query is a Query\Builder
  })
  ->whereHas('relation', function(Builder $query) {
    // no need to know that $query is an Eloquent\Builder
  })
  ->with('relation', function(Builder $query) {
    // no need to know that $query is an Eloquent\Relation
  });
```

If you need to use **Eloquent**-specific features, then you need to type-hint the Eloquent builder:

```php
use Illuminate\Contracts\Database\Eloquent\Builder as Eloquent;
use Illuminate\Contracts\Database\Query\Builder;

return Model::query()
  ->whereNotExists(function(Builder $query) {
    // only do base builder operations here
  })
  ->whereHas('relation', function(Eloquent $query) {
    // maybe I need another whereHas() here
  });
```

The `@mixin` annotations provide good IDE support without needing to change the existing Builders at all:

![image](https://user-images.githubusercontent.com/21592/150603009-b850fe50-3d9b-4761-b642-dd1e3a5c8bc3.png)

I hope this works out as a good compromise for the `9.x` release!