### PR TITLE
[9.x] Ensure `str()` can always be cast to string

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -273,6 +273,11 @@ if (! function_exists('str')) {
                 {
                     return Str::$method(...$parameters);
                 }
+
+                public function __toString()
+                {
+                    return '';
+                }
             };
         }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -379,6 +379,10 @@ class SupportHelpersTest extends TestCase
         $strAccessor = str();
         $this->assertTrue((new \ReflectionClass($strAccessor))->isAnonymous());
         $this->assertSame($strAccessor->limit('string-value', 3), 'str...');
+
+        $strAccessor = str();
+        $this->assertTrue((new \ReflectionClass($strAccessor))->isAnonymous());
+        $this->assertSame((string) $strAccessor, '');
     }
 
     public function testTap()


### PR DESCRIPTION
```php
$str = str();

if (false) {
   $str->limit('string-value', 3);
}

echo $str;
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>
