### PR TITLE
[8.x] Fixed the appends property to work with the new Accessor method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -613,7 +613,7 @@ trait HasAttributes
     {
         try {
             return $this->{'get'.Str::studly($key).'Attribute'}($value);
-        } catch (\BadMethodCallException $exception) {
+        } catch (BadMethodCallException $exception) {
             if (method_exists($this, Str::studly($key)) && $this->{Str::studly($key)}($value) instanceof Attribute) {
                 return $this->{Str::studly($key)};
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -25,7 +25,6 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
-use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionNamedType;
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use BadMethodCallException;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use DateTimeInterface;
@@ -24,6 +25,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
+use ReflectionFunction;
 use ReflectionMethod;
 use ReflectionNamedType;
 
@@ -609,7 +611,15 @@ trait HasAttributes
      */
     protected function mutateAttribute($key, $value)
     {
-        return $this->{'get'.Str::studly($key).'Attribute'}($value);
+        try {
+            return $this->{'get'.Str::studly($key).'Attribute'}($value);
+        } catch (\BadMethodCallException $exception) {
+            if (method_exists($this, Str::studly($key)) && $this->{Str::studly($key)}($value) instanceof Attribute) {
+                return $this->{Str::studly($key)};
+            }
+
+            throw $exception;
+        }
     }
 
     /**


### PR DESCRIPTION
When using the new attribute casting method from PR #40022 you are currently unable to include the method in the 'appends' property as you would when using the older method.

Currently:
```
$appends = ['title'];

public function title(): Attribute
{
    return ucfirst($this->name);
}

$model->toArray(); // throws a BadMethodCallException
```

This PR allows methods that return the Attribute object to be included in the 'appends' property