### PR TITLE
[10.x] Return a `Stringable` from the Translator instead of a regular string

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -823,7 +823,7 @@ if (! function_exists('trans')) {
      *
      * @param  string|null  $key
      * @param  array  $replace
-     * @param  string|null  $locale
+     * @param  Stringable|null  $locale
      * @return \Illuminate\Contracts\Translation\Translator|string|array|null
      */
     function trans($key = null, $replace = [], $locale = null)
@@ -858,7 +858,7 @@ if (! function_exists('__')) {
      *
      * @param  string|null  $key
      * @param  array  $replace
-     * @param  string|null  $locale
+     * @param  Stringable|null  $locale
      * @return string|array|null
      */
     function __($key = null, $replace = [], $locale = null)

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -213,6 +213,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         if (is_string($line)) {
             $line = $this->makeReplacements($line, $replace);
+
             return $this->castLine($line);
         } elseif (is_array($line) && count($line) > 0) {
             foreach ($line as $key => $value) {

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -67,7 +67,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
     /**
      * Cast the line to the correct type.
-     * @param  string|array $line
+     *
+     * @param  string|array  $line
      * @return Stringable|array
      */
     protected function castLine($line)

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Translation;
 
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\Translation\Translator;

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Translation;
 
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\Translation\Translator;
 use Mockery as m;
@@ -51,8 +53,8 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
         $this->assertEquals(['tree bar', 'breeze bar'], $t->get('foo::bar.qux', ['foo' => 'bar'], 'en'));
-        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
+        $this->assertSame('breeze bar', (string) $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', (string) $t->get('foo::bar.foo'));
     }
 
     public function testGetMethodForNonExistingReturnsSameKey()
@@ -61,9 +63,9 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'unknown', 'foo')->andReturn([]);
-        $this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+        $this->assertSame('foo::unknown', (string) $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo::bar.unknown', (string) $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo::unknown.bar', (string) $t->get('foo::unknown.bar'));
     }
 
     public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
@@ -71,7 +73,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze <p>test</p>']);
-        $this->assertSame('breeze <p>test</p>', $t->get('foo.bar', [], 'en'));
+        $this->assertSame('breeze <p>test</p>', (string) $t->get('foo.bar', [], 'en'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
@@ -79,8 +81,8 @@ class TranslationTranslatorTest extends TestCase
         $t = $this->getMockBuilder(Translator::class)->onlyMethods([])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :0 :Foo :BAR']);
-        $this->assertSame('breeze john Bar FOO', $t->get('foo::bar.baz', ['john', 'foo' => 'bar', 'bar' => 'foo'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
+        $this->assertSame('breeze john Bar FOO', (string) $t->get('foo::bar.baz', ['john', 'foo' => 'bar', 'bar' => 'foo'], 'en'));
+        $this->assertSame('foo', (string) $t->get('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
@@ -88,9 +90,9 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo :foobar']);
-        $this->assertSame('breeze bar taylor', $t->get('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
-        $this->assertSame('breeze foo bar baz taylor', $t->get('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
+        $this->assertSame('breeze bar taylor', (string) $t->get('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
+        $this->assertSame('breeze foo bar baz taylor', (string) $t->get('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
+        $this->assertSame('foo', (string) $t->get('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
@@ -100,8 +102,8 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('lv', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
-        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-        $this->assertSame('foo', $t->get('foo::bar.foo'));
+        $this->assertSame('breeze bar', (string) $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', (string) $t->get('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
@@ -109,7 +111,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
-        $this->assertSame('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
+        $this->assertSame('breeze bar', (string) $t->get('foo.bar', ['foo' => 'bar']));
     }
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()
@@ -140,35 +142,35 @@ class TranslationTranslatorTest extends TestCase
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
-        $this->assertSame('one', $t->get('foo'));
+        $this->assertSame('one', (string) $t->get('foo'));
     }
 
     public function testGetJsonReplaces()
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
-        $this->assertSame('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
+        $this->assertSame('bar onetwo three', (string) $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
     }
 
     public function testGetJsonHasAtomicReplacements()
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['Hello :foo!' => 'Hello :foo!']);
-        $this->assertSame('Hello baz:bar!', $t->get('Hello :foo!', ['foo' => 'baz:bar', 'bar' => 'abcdef']));
+        $this->assertSame('Hello baz:bar!', (string) $t->get('Hello :foo!', ['foo' => 'baz:bar', 'bar' => 'abcdef']));
     }
 
     public function testGetJsonReplacesForAssociativeInput()
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
-        $this->assertSame('bar eye see', $t->get('foo :i :c', ['i' => 'eye', 'c' => 'see']));
+        $this->assertSame('bar eye see', (string) $t->get('foo :i :c', ['i' => 'eye', 'c' => 'see']));
     }
 
     public function testGetJsonPreservesOrder()
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['to :name I give :greeting' => ':greeting :name']);
-        $this->assertSame('Greetings David', $t->get('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
+        $this->assertSame('Greetings David', (string) $t->get('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
     }
 
     public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
@@ -176,7 +178,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
-        $this->assertSame('one', $t->get('foo.bar'));
+        $this->assertSame('one', (string) $t->get('foo.bar'));
     }
 
     public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
@@ -184,7 +186,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one :message']);
-        $this->assertSame('one two', $t->get('foo.bar', ['message' => 'two']));
+        $this->assertSame('one two', (string) $t->get('foo.bar', ['message' => 'two']));
     }
 
     public function testGetJsonForNonExistingReturnsSameKey()
@@ -192,7 +194,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
-        $this->assertSame('Foo that bar', $t->get('Foo that bar'));
+        $this->assertSame('Foo that bar', (string) $t->get('Foo that bar'));
     }
 
     public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
@@ -200,7 +202,17 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
-        $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
+        $this->assertSame('foo baz', (string) $t->get('foo :message', ['message' => 'baz']));
+    }
+
+    public function testGetStringReturnsStringable()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
+        $this->assertIsArray($t->get('foo::bar.qux', ['foo' => 'bar'], 'en'));
+        $this->assertInstanceOf(Stringable::class, $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertInstanceOf(Stringable::class, $t->get('foo::bar.foo'));
     }
 
     protected function getLoader()


### PR DESCRIPTION
This pull request adds the ability to return a `Stringable` from the Translator instead of normal strings. This allows the developer to easily manipulate strings before being displayed, for example to change their case or to concatenate translations.

## Example

Consider the following translation file:

```php
return [
    'file' => 'File',
    
    'phrases' => [
        'select' => 'Select',
        'search' => 'Search',
    ]
];
```

Now, the developer wants to display the text 'Select file'. In the old situation, the developer would have to do something like this:

```blade
{{ Str::of(__('phrases.select'))->append(' ')->append(__('file'))->lower()->ucfirst() }}

// or

{{ Str::ucfirst(__('phrases.select')) }} {{ Str::lower(__('file')) }}
```

When returning a `Stringable`, the developer will now be able to do something like this:

```blade
{{ __('phrases.select')->append(' ')->append(__('file'))->lower()->ucfirst() }}
```

Another example:
```blade
{{ Str::upper(__('phrases.search')) }}

// becomes

{{ __('phrases.search')->upper() }}
```

The beauty is that PHP will always coerce a `Stringable` to a string when needed, so it will not be a big backwards incompatible change, whilst still providing developers with a lot of fluent methods on a translation. 

*I noticed that there are several validation errors failing in the testsuite. I suspect that is because of it trying to do an operation on a `Stringable` that is only allowed on a string. I've really looked into this, but I can't find the place where the problem is. I would be grateful if someone with more experience can explain where the problem lies, so that I can fix it, or if that person would be willing to fix it himself. Most likely it's only a small change somewhere in the Validator or MessageBag. Thanks!*