### PR TITLE
[8.x] Add missing mailer always-functions to facade docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Testing\Fakes\MailFake;
 
 /**
  * @method static \Illuminate\Mail\Mailer mailer(string|null $name = null)
+ * @method static void alwaysFrom(string $address, string|null $name = null)
+ * @method static void alwaysReplyTo(string $address, string|null $name = null)
+ * @method static void alwaysReturnPath(string $address)
+ * @method static void alwaysTo(string $address, string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail bcc($users)
  * @method static \Illuminate\Mail\PendingMail to($users)
  * @method static \Illuminate\Support\Collection queued(string $mailable, \Closure|string $callback = null)


### PR DESCRIPTION
I was just made aware of the "always" functions of the mailer by a tweet from @fideloper. But I realized that IDE autocomplete for those functions doesn't work with the mail facade. This PR adds the functions to the class docblock for better autocomplete.