### PR TITLE
[9.x] Remove deprecated `reduceMany` method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -766,22 +766,6 @@ trait EnumeratesValues
      * @param  mixed  ...$initial
      * @return array
      *
-     * @deprecated Use "reduceSpread" instead
-     *
-     * @throws \UnexpectedValueException
-     */
-    public function reduceMany(callable $callback, ...$initial)
-    {
-        return $this->reduceSpread($callback, ...$initial);
-    }
-
-    /**
-     * Reduce the collection to multiple aggregate values.
-     *
-     * @param  callable  $callback
-     * @param  mixed  ...$initial
-     * @return array
-     *
      * @throws \UnexpectedValueException
      */
     public function reduceSpread(callable $callback, ...$initial)


### PR DESCRIPTION
It was deprecated right after it was released in 8.x, because it was renamed to `reduceSpread` to match the existing `eachSpread` and `mapSpread` methods.