### PR TITLE
[9.x] Remove useless `reduceWithKeys` method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -803,21 +803,6 @@ trait EnumeratesValues
     }
 
     /**
-     * Reduce an associative collection to a single value.
-     *
-     * @template TReduceWithKeysInitial
-     * @template TReduceWithKeysReturnType
-     *
-     * @param  callable(TReduceWithKeysInitial|TReduceWithKeysReturnType, TValue): TReduceWithKeysReturnType  $callback
-     * @param  TReduceWithKeysInitial  $initial
-     * @return TReduceWithKeysReturnType
-     */
-    public function reduceWithKeys(callable $callback, $initial = null)
-    {
-        return $this->reduce($callback, $initial);
-    }
-
-    /**
      * Create a collection of all elements that do not pass a given truth test.
      *
      * @param  (callable(TValue): bool)|bool  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3966,20 +3966,6 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testReduceWithKeys($collection)
-    {
-        $data = new $collection([
-            'foo' => 'bar',
-            'baz' => 'qux',
-        ]);
-        $this->assertSame('foobarbazqux', $data->reduceWithKeys(function ($carry, $element, $key) {
-            return $carry .= $key.$element;
-        }));
-    }
-
-    /**
-     * @dataProvider collectionClassProvider
-     */
     public function testReduceSpread($collection)
     {
         $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -547,21 +547,6 @@ assertType('int', $collection
         return 1;
     }, 0));
 
-assertType('int', $collection
-    ->reduceWithKeys(function ($null, $user) {
-        assertType('User', $user);
-        assertType('int|null', $null);
-
-        return 1;
-    }));
-assertType('int', $collection
-    ->reduceWithKeys(function ($int, $user) {
-        assertType('User', $user);
-        assertType('int', $int);
-
-        return 1;
-    }, 0));
-
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->replace([1]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->replace([new User]));
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -546,21 +546,6 @@ assertType('int', $collection
         return 1;
     }, 0));
 
-assertType('int', $collection
-    ->reduceWithKeys(function ($null, $user) {
-        assertType('User', $user);
-        assertType('int|null', $null);
-
-        return 1;
-    }));
-assertType('int', $collection
-    ->reduceWithKeys(function ($int, $user) {
-        assertType('User', $user);
-        assertType('int', $int);
-
-        return 1;
-    }, 0));
-
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection::make([1])->replace([1]));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->replace([new User]));
 


### PR DESCRIPTION
The original introduction of `reduceWithKeys` was kind of not ideal [for two reasons](https://github.com/laravel/framework/pull/35839#issuecomment-759551607): the name is inconsistent with the other `*WithKeys` method, and it really should've never been a separate method - `reduce` itself could handle keys too.

...and [that's what we ultimately did](https://github.com/laravel/framework/pull/35878): we added `$key` support to the regular `reduce` method.

[We decided](https://github.com/laravel/framework/pull/35878#discussion_r557434475) to keep `reduceWithKeys` in 8.x, and then remove it completely in 9.x. I think #35901 was trying to do that, but evidently it's still around. So this PR removes it.

