### PR TITLE
[8.x] Add phpredis serialization and compression support to the cache component

### DIFF
--- a/src/Illuminate/Cache/LuaScripts.php
+++ b/src/Illuminate/Cache/LuaScripts.php
@@ -22,4 +22,20 @@ else
 end
 LUA;
     }
+
+    /**
+     * Get the Lua script that sets a key only when it does not yet exist.
+     *
+     * KEYS[1] - The name of the key
+     * ARGV[1] - Value of the key
+     * ARGV[2] - Time in seconds how long to keep the key
+     *
+     * @return string
+     */
+    public static function add()
+    {
+        return <<<'LUA'
+return redis.call('exists',KEYS[1])<1 and redis.call('setex',KEYS[1],ARGV[2],ARGV[1])
+LUA;
+    }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -2,15 +2,18 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Exception;
 use Illuminate\Foundation\Application;
 use Illuminate\Redis\RedisManager;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
+use Redis;
+use Throwable;
+use UnexpectedValueException;
 
 trait InteractsWithRedis
 {
     /**
-     * Indicate connection failed if redis is not available.
+     * Indicates connection failed if redis is not available.
      *
      * @var bool
      */
@@ -21,53 +24,7 @@ trait InteractsWithRedis
      *
      * @var \Illuminate\Redis\RedisManager[]
      */
-    private $redis;
-
-    /**
-     * Setup redis connection.
-     *
-     * @return void
-     */
-    public function setUpRedis()
-    {
-        if (! extension_loaded('redis')) {
-            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
-        }
-
-        if (static::$connectionFailedOnceWithDefaultsSkip) {
-            $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
-        }
-
-        $app = $this->app ?? new Application;
-        $host = Env::get('REDIS_HOST', '127.0.0.1');
-        $port = Env::get('REDIS_PORT', 6379);
-
-        foreach ($this->redisDriverProvider() as $driver) {
-            $this->redis[$driver[0]] = new RedisManager($app, $driver[0], [
-                'cluster' => false,
-                'options' => [
-                    'prefix' => 'test_',
-                ],
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 5,
-                    'timeout' => 0.5,
-                    'name' => 'default',
-                ],
-            ]);
-        }
-
-        try {
-            $this->redis['phpredis']->connection()->flushdb();
-        } catch (Exception $e) {
-            if ($host === '127.0.0.1' && $port === 6379 && Env::get('REDIS_HOST') === null) {
-                static::$connectionFailedOnceWithDefaultsSkip = true;
-
-                $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
-            }
-        }
-    }
+    private $redisManagers = [];
 
     /**
      * Teardown redis connection.
@@ -76,38 +33,333 @@ trait InteractsWithRedis
      */
     public function tearDownRedis()
     {
-        $this->redis['phpredis']->connection()->flushdb();
-
-        foreach ($this->redisDriverProvider() as $driver) {
-            $this->redis[$driver[0]]->connection()->disconnect();
+        /** @var \Illuminate\Redis\RedisManager $redisManager */
+        foreach ($this->redisManagers as $label => $redisManager) {
+            $redisManager->connection()->flushdb();
+            $redisManager->connection()->disconnect();
         }
     }
 
     /**
-     * Get redis driver provider.
+     * Builds a redis manager from a predefined list of available connection
+     * configurations.
+     *
+     * If a driver and a config are given, they are used to create a new redis
+     * connection instead of the defaulting to a predefined list of connections.
+     * This way you can also create for example cluster or a very customized
+     * redis connection.
+     *
+     * @param  string  $connection  Connection label.
+     * @param  string  $driver  Optional driver to use together with a config.
+     * @param  array  $config  Optional config to use for the connection.
+     * @return \Illuminate\Redis\RedisManager
+     */
+    public function getRedisManager($connection, $driver = 'phpredis', $config = [])
+    {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped(
+                'The redis extension is not installed. Please install the extension to enable '.__CLASS__
+            );
+        }
+
+        if (static::$connectionFailedOnceWithDefaultsSkip) {
+            $this->markTestSkipped(
+                'Trying default host/port failed, please set environment variable '.
+                'REDIS_HOST & REDIS_PORT to enable '.__CLASS__
+            );
+        }
+
+        if (! empty($config)) {
+            return $this->redisManagers[$connection] = $this->initializeRedisManager($driver, $config);
+        }
+
+        if (array_key_exists($connection, $this->redisManagers)) {
+            return $this->redisManagers[$connection];
+        }
+
+        $config = [
+            'cluster' => false,
+            'default' => [
+                'host' => env('REDIS_HOST', '127.0.0.1'),
+                'port' => (int) env('REDIS_PORT', 6379),
+                'timeout' => 0.5,
+                'database' => 5,
+                'options' => [
+                    'name' => 'base',
+                ],
+            ],
+        ];
+
+        switch ($connection) {
+            case 'predis':
+                $driver = 'predis';
+                $config['default']['options']['name'] = 'predis';
+                break;
+            case 'phpredis':
+                $config['default']['options']['name'] = 'phpredis';
+                break;
+            case 'phpredis_url':
+                $config['default']['options']['name'] = 'phpredis_url';
+                $config['default']['url'] = "redis://user@{$config['default']['host']}:{$config['default']['port']}";
+                $config['default']['host'] = 'overwrittenByUrl';
+                $config['default']['port'] = 'overwrittenByUrl';
+                break;
+            case 'phpredis_prefix':
+                $config['default']['options']['name'] = 'phpredis_prefix';
+                $config['default']['options']['prefix'] = 'laravel:';
+                break;
+            case 'phpredis_persistent':
+                $config['default']['options']['name'] = 'phpredis_persistent';
+                $config['default']['persistent'] = true;
+                $config['default']['persistent_id'] = 'laravel';
+                break;
+            case 'phpredis_scan_noretry':
+                $config['default']['options']['name'] = 'phpredis_scan_noretry';
+                $config['default']['options']['scan'] = Redis::SCAN_NORETRY;
+                break;
+            case 'phpredis_scan_retry':
+                $config['default']['options']['name'] = 'phpredis_scan_retry';
+                $config['default']['options']['scan'] = Redis::SCAN_RETRY;
+                break;
+            case 'phpredis_scan_prefix':
+                $config['default']['options']['name'] = 'phpredis_scan_prefix';
+                $config['default']['options']['scan'] = Redis::SCAN_PREFIX;
+                break;
+            case 'phpredis_scan_noprefix':
+                $config['default']['options']['name'] = 'phpredis_scan_noprefix';
+                $config['default']['options']['scan'] = Redis::SCAN_NOPREFIX;
+                break;
+            case 'phpredis_serializer_none':
+                $config['default']['options']['name'] = 'phpredis_serializer_none';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_NONE;
+                break;
+            case 'phpredis_serializer_php':
+                $config['default']['options']['name'] = 'phpredis_serializer_php';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_PHP;
+                break;
+            case 'phpredis_serializer_igbinary':
+                $config['default']['options']['name'] = 'phpredis_serializer_igbinary';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_IGBINARY;
+                break;
+            case 'phpredis_serializer_json':
+                $config['default']['options']['name'] = 'phpredis_serializer_json';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_JSON;
+                break;
+            case 'phpredis_serializer_msgpack':
+                $config['default']['options']['name'] = 'phpredis_serializer_msgpack';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_MSGPACK;
+                break;
+            case 'phpredis_compression_lzf':
+                $config['default']['options']['name'] = 'phpredis_compression_lzf';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZF;
+                break;
+            case 'phpredis_compression_zstd':
+                $config['default']['options']['name'] = 'phpredis_compression_zstd';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
+                break;
+            case 'phpredis_compression_zstd_default':
+                $config['default']['options']['name'] = 'phpredis_compression_zstd_default';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
+                $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_DEFAULT;
+                break;
+            case 'phpredis_compression_zstd_min':
+                $config['default']['options']['name'] = 'phpredis_compression_zstd_min';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
+                $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_MIN;
+                break;
+            case 'phpredis_compression_zstd_max':
+                $config['default']['options']['name'] = 'phpredis_compression_zstd_max';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
+                $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_MAX;
+                break;
+            case 'phpredis_compression_lz4':
+                $config['default']['options']['name'] = 'phpredis_compression_lz4';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                break;
+            case 'phpredis_compression_lz4_default':
+                $config['default']['options']['name'] = 'phpredis_compression_lz4_default';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                $config['default']['options']['compression_level'] = 0;
+                break;
+            case 'phpredis_compression_lz4_min':
+                $config['default']['options']['name'] = 'phpredis_compression_lz4_min';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                $config['default']['options']['compression_level'] = 1;
+                break;
+            case 'phpredis_compression_lz4_max':
+                $config['default']['options']['name'] = 'phpredis_compression_lz4_max';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                $config['default']['options']['compression_level'] = 12;
+                break;
+            case 'phpredis_msgpack_and_lz4':
+                $config['default']['options']['name'] = 'phpredis_msgpack_and_lz4';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_MSGPACK;
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                $config['default']['options']['compression_level'] = 12;
+                break;
+            default:
+                throw new UnexpectedValueException(sprintf(
+                    'Redis manager connection configuration %s is not defined.',
+                    $connection,
+                ));
+        }
+
+        return $this->redisManagers[$connection] = $this->initializeRedisManager($driver, $config);
+    }
+
+    /**
+     * Returns a list of available redis connections.
      *
      * @return array
      */
-    public function redisDriverProvider()
+    public function getRedisConnections()
     {
         return [
-            ['predis'],
-            ['phpredis'],
+            'predis',
+            'phpredis',
         ];
     }
 
     /**
-     * Run test if redis is available.
+     * Returns an extended list of available redis connections.
      *
-     * @param  callable  $callback
-     * @return void
+     * @return array
      */
-    public function ifRedisAvailable($callback)
+    public function getExtendedRedisConnections()
     {
-        $this->setUpRedis();
+        $connections = [
+            'predis',
+            'phpredis',
+            'phpredis_url',
+            'phpredis_prefix',
+            'phpredis_persistent',
+        ];
 
-        $callback();
+        if (defined('Redis::SCAN_NORETRY')) {
+            $connections[] = 'phpredis_scan_noretry';
+        }
 
-        $this->tearDownRedis();
+        if (defined('Redis::SCAN_RETRY')) {
+            $connections[] = 'phpredis_scan_retry';
+        }
+
+        if (defined('Redis::SCAN_PREFIX')) {
+            $connections[] = 'phpredis_scan_prefix';
+        }
+
+        if (defined('Redis::SCAN_NOPREFIX')) {
+            $connections[] = 'phpredis_scan_noprefix';
+        }
+
+        if (defined('Redis::SERIALIZER_NONE')) {
+            $connections[] = 'phpredis_serializer_none';
+        }
+
+        if (defined('Redis::SERIALIZER_PHP')) {
+            $connections[] = 'phpredis_serializer_php';
+        }
+
+        if (defined('Redis::SERIALIZER_IGBINARY')) {
+            $connections[] = 'phpredis_serializer_igbinary';
+        }
+
+        if (defined('Redis::SERIALIZER_JSON')) {
+            $connections[] = 'phpredis_serializer_json';
+        }
+
+        if (defined('Redis::SERIALIZER_MSGPACK')) {
+            $connections[] = 'phpredis_serializer_msgpack';
+        }
+
+        if (defined('Redis::COMPRESSION_LZF')) {
+            $connections[] = 'phpredis_compression_lzf';
+        }
+
+        if (defined('Redis::COMPRESSION_ZSTD')) {
+            $connections[] = 'phpredis_compression_zstd';
+            $connections[] = 'phpredis_compression_zstd_default';
+            $connections[] = 'phpredis_compression_zstd_min';
+            $connections[] = 'phpredis_compression_zstd_max';
+        }
+
+        if (defined('Redis::COMPRESSION_LZ4')) {
+            $connections[] = 'phpredis_compression_lz4';
+            $connections[] = 'phpredis_compression_lz4_default';
+            $connections[] = 'phpredis_compression_lz4_min';
+            $connections[] = 'phpredis_compression_lz4_max';
+        }
+
+        if (defined('Redis::SERIALIZER_MSGPACK') && defined('Redis::COMPRESSION_LZ4')) {
+            $connections[] = 'phpredis_msgpack_and_lz4';
+        }
+
+        return $connections;
+    }
+
+    /**
+     * Data provider for tests that lists a default set of redis connections.
+     *
+     * @return array
+     */
+    public function redisConnectionDataProvider()
+    {
+        return (new Collection($this->getRedisConnections()))->mapWithKeys(function ($label) {
+            return [
+                $label => [
+                    $label,
+                ],
+            ];
+        })->all();
+    }
+
+    /**
+     * Extended data provider for tests that also lists special configurations
+     * like serialization and compression support on phpredis.
+     *
+     * @return array
+     */
+    public function extendedRedisConnectionDataProvider()
+    {
+        return (new Collection($this->getExtendedRedisConnections()))->mapWithKeys(function ($label) {
+            return [
+                $label => [
+                    $label,
+                ],
+            ];
+        })->all();
+    }
+
+    /**
+     * Initializes a new RedisManager with the given driver and config.
+     *
+     * @param  string  $driver
+     * @param  array  $config
+     * @return \Illuminate\Redis\RedisManager
+     */
+    private function initializeRedisManager($driver, $config)
+    {
+        $app = $this->app ?? new Application();
+        $redisManager = new RedisManager($app, $driver, $config);
+
+        try {
+            $redisManager->connection()->flushdb();
+        } catch (Throwable $exception) {
+            if (
+                $config['default']['host'] === '127.0.0.1' &&
+                $config['default']['port'] === 6379 &&
+                Env::get('REDIS_HOST') === null
+            ) {
+                static::$connectionFailedOnceWithDefaultsSkip = true;
+
+                $this->markTestSkipped(
+                    'Trying default host/port failed, please set environment variable '.
+                    'REDIS_HOST & REDIS_PORT to enable '.__CLASS__
+                );
+            }
+
+            throw $exception;
+        }
+
+        return $redisManager;
     }
 }

--- a/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
+++ b/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
@@ -83,6 +83,38 @@ trait PacksPhpRedisValues
     }
 
     /**
+     * Determine whether serialization and/or compression is enabled.
+     *
+     * @return bool
+     */
+    public function packed(): bool
+    {
+        return $this->serialized() || $this->compressed();
+    }
+
+    /**
+     * Determine if serialization is enabled.
+     *
+     * @return bool
+     */
+    public function serialized(): bool
+    {
+        return defined('Redis::OPT_SERIALIZER') &&
+               $this->client->getOption(Redis::OPT_SERIALIZER) !== Redis::SERIALIZER_NONE;
+    }
+
+    /**
+     * Determine if JSON serialization is enabled.
+     *
+     * @return bool
+     */
+    public function jsonSerialized(): bool
+    {
+        return defined('Redis::SERIALIZER_JSON') &&
+               $this->client->getOption(Redis::OPT_SERIALIZER) === Redis::SERIALIZER_JSON;
+    }
+
+    /**
      * Determine if compression is enabled.
      *
      * @return bool

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -270,7 +270,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
 
         foreach ($notifiables as $notifiable) {
             if (! $notification->id) {
-                $notification->id = Str::uuid()->toString();
+                $notification->id = (string) Str::uuid();
             }
 
             $notifiableChannels = $channels ?: $notification->via($notifiable);

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -64,7 +64,10 @@ class FilesystemAdapterTest extends TestCase
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('file.txt', 'пиздюк.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertSame("attachment; filename=pizdyuk.txt; filename*=utf-8''%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt", $response->headers->get('content-disposition'));
+        $this->assertContains($response->headers->get('content-disposition'), [
+            "attachment; filename=pizdyuk.txt; filename*=utf-8''%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt",
+            "attachment; filename=pizdiuk.txt; filename*=utf-8''%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt",
+        ]);
     }
 
     public function testDownloadNonAsciiEmptyFilename()
@@ -73,7 +76,10 @@ class FilesystemAdapterTest extends TestCase
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('пиздюк.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertSame('attachment; filename=pizdyuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt', $response->headers->get('content-disposition'));
+        $this->assertContains($response->headers->get('content-disposition'), [
+            'attachment; filename=pizdyuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt',
+            'attachment; filename=pizdiuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt',
+        ]);
     }
 
     public function testDownloadPercentInFilename()

--- a/tests/Integration/Cache/PhpRedisCacheLockTest.php
+++ b/tests/Integration/Cache/PhpRedisCacheLockTest.php
@@ -2,293 +2,48 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
-use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
-use Redis;
 
 class PhpRedisCacheLockTest extends TestCase
 {
     use InteractsWithRedis;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setUpRedis();
-    }
-
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
-    }
 
-    public function testRedisLockCanBeAcquiredAndReleasedWithoutSerializationAndCompression()
-    {
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    public function testRedisLockCanBeAcquiredAndReleasedWithPhpSerialization()
-    {
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    public function testRedisLockCanBeAcquiredAndReleasedWithJsonSerialization()
-    {
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_JSON);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    public function testRedisLockCanBeAcquiredAndReleasedWithIgbinarySerialization()
-    {
-        if (! defined('Redis::SERIALIZER_IGBINARY')) {
-            $this->markTestSkipped('Redis extension is not configured to support the igbinary serializer.');
-        }
-
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_IGBINARY);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    public function testRedisLockCanBeAcquiredAndReleasedWithMsgpackSerialization()
-    {
-        if (! defined('Redis::SERIALIZER_MSGPACK')) {
-            $this->markTestSkipped('Redis extension is not configured to support the msgpack serializer.');
-        }
-
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_MSGPACK);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        parent::tearDown();
     }
 
     /**
-     * @requires extension lzf
+     * @dataProvider extendedRedisConnectionDataProvider
      */
-    public function testRedisLockCanBeAcquiredAndReleasedWithLzfCompression()
+    public function testPhpRedisLockCanBeAcquiredAndReleased($connection)
     {
-        if (! defined('Redis::COMPRESSION_LZF')) {
-            $this->markTestSkipped('Redis extension is not configured to support the lzf compression.');
-        }
+        $repository = $this->getRepository($connection);
 
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZF);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
+        $repository->lock('foo')->forceRelease();
+        $this->assertNull($repository->lockConnection()->get($repository->getPrefix().'foo'));
+        $lock = $repository->lock('foo', 10);
         $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
+        $this->assertFalse($repository->lock('foo', 10)->get());
         $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $this->assertNull($repository->lockConnection()->get($repository->getPrefix().'foo'));
     }
 
     /**
-     * @requires extension zstd
+     * Builds a cache repository out of a predefined redis connection name.
+     *
+     * @param  string  $connection
+     * @return \Illuminate\Cache\Repository
      */
-    public function testRedisLockCanBeAcquiredAndReleasedWithZstdCompression()
+    private function getRepository($connection)
     {
-        if (! defined('Redis::COMPRESSION_ZSTD')) {
-            $this->markTestSkipped('Redis extension is not configured to support the zstd compression.');
-        }
+        /** @var \Illuminate\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->get('cache');
 
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_ZSTD);
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_DEFAULT);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_MIN);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_MAX);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    /**
-     * @requires extension lz4
-     */
-    public function testRedisLockCanBeAcquiredAndReleasedWithLz4Compression()
-    {
-        if (! defined('Redis::COMPRESSION_LZ4')) {
-            $this->markTestSkipped('Redis extension is not configured to support the lz4 compression.');
-        }
-
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZ4);
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 1);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 3);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 12);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    /**
-     * @requires extension Lzf
-     */
-    public function testRedisLockCanBeAcquiredAndReleasedWithSerializationAndCompression()
-    {
-        if (! defined('Redis::COMPRESSION_LZF')) {
-            $this->markTestSkipped('Redis extension is not configured to support the lzf compression.');
-        }
-
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
-        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZF);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        return $cacheManager->repository(new RedisStore($this->getRedisManager($connection)));
     }
 }

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -2,47 +2,202 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Orchestra\Testbench\TestCase;
 
 class RedisStoreTest extends TestCase
 {
     use InteractsWithRedis;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setUpRedis();
-    }
-
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
+
+        parent::tearDown();
     }
 
-    public function testItCanStoreInfinite()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanStoreInfinite($connection)
     {
-        Cache::store('redis')->clear();
+        $repository = $this->getRepository($connection);
+        /** @var \Illuminate\Cache\RedisStore $redisStore */
+        $redisStore = $repository->getStore();
+        $redisConnection = $redisStore->connection();
 
-        $result = Cache::store('redis')->put('foo', INF);
-        $this->assertTrue($result);
-        $this->assertSame(INF, Cache::store('redis')->get('foo'));
+        if ($redisConnection instanceof PhpRedisConnection && $redisConnection->jsonSerialized()) {
+            $this->markTestSkipped(
+                'JSON does not support INF or -INF. It will be serialized to null '.
+                'and as a result phpredis will store it as 0.'
+            );
+        }
 
-        $result = Cache::store('redis')->put('bar', -INF);
+        $result = $repository->put('foo', INF);
         $this->assertTrue($result);
-        $this->assertSame(-INF, Cache::store('redis')->get('bar'));
+        $this->assertSame(INF, $repository->get('foo'));
+
+        $result = $repository->put('foo', -INF);
+        $this->assertTrue($result);
+        $this->assertSame(-INF, $repository->get('foo'));
     }
 
-    public function testItCanStoreNan()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanStoreNan($connection)
     {
-        Cache::store('redis')->clear();
+        $repository = $this->getRepository($connection);
+        /** @var \Illuminate\Cache\RedisStore $redisStore */
+        $redisStore = $repository->getStore();
+        $redisConnection = $redisStore->connection();
 
-        $result = Cache::store('redis')->put('foo', NAN);
+        if ($redisConnection instanceof PhpRedisConnection && $redisConnection->jsonSerialized()) {
+            $this->markTestSkipped(
+                'JSON does not support NAN. It will be serialized to null '.
+                'and as a result phpredis will store it as 0.'
+            );
+        }
+
+        $result = $repository->put('foo', NAN);
         $this->assertTrue($result);
-        $this->assertNan(Cache::store('redis')->get('foo'));
+        $this->assertNan($repository->get('foo'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanAdd($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->add('foo', 'test test test');
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo'));
+        $result = $repository->forget('foo');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanAddWithTtl($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->add('foo', 'test test test', 10);
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo'));
+        $result = $repository->forget('foo');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanPut($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put('foo', 'test test test');
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo'));
+        $result = $repository->forget('foo');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanPutWithTtl($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put('foo', 'test test test', 10);
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo'));
+        $result = $repository->forget('foo');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanPutMany($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put([
+            'foo1' => 'test test test',
+            'foo2' => 'best best best',
+        ], null);
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo1'));
+        $result = $repository->forget('foo1');
+        $this->assertSame('best best best', $repository->get('foo2'));
+        $result = $repository->forget('foo2');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanPutManyWithTtl($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put([
+            'foo1' => 'test test test',
+            'foo2' => 'best best best',
+        ], 10);
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo1'));
+        $result = $repository->forget('foo1');
+        $this->assertSame('best best best', $repository->get('foo2'));
+        $result = $repository->forget('foo2');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanGetMany($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put([
+            'foo1' => 'test test test',
+            'foo2' => 'best best best',
+            'foo3' => 'this is the best test',
+        ], null);
+        $this->assertTrue($result);
+        $result = $repository->getMultiple(['foo1', 'foo2', 'foo3', 'foo4'], 'sure?');
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('foo1', $result);
+        $this->assertArrayHasKey('foo2', $result);
+        $this->assertArrayHasKey('foo3', $result);
+        $this->assertArrayHasKey('foo4', $result);
+        $this->assertSame('test test test', $result['foo1']);
+        $this->assertSame('best best best', $result['foo2']);
+        $this->assertSame('this is the best test', $result['foo3']);
+        $this->assertSame('sure?', $result['foo4']);
+        $result = $repository->deleteMultiple(['foo1', 'foo2', 'foo3']);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Builds a cache repository out of a predefined redis connection name.
+     *
+     * @param  string  $connection
+     * @return \Illuminate\Cache\Repository
+     */
+    private function getRepository($connection)
+    {
+        /** @var \Illuminate\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->get('cache');
+
+        return $cacheManager->repository(new RedisStore($this->getRedisManager($connection)));
     }
 }

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -15,8 +15,10 @@ class ThrottleRequestsWithRedisTest extends TestCase
 
     protected function tearDown(): void
     {
+        Carbon::setTestNow(false);
+        $this->tearDownRedis();
+
         parent::tearDown();
-        Carbon::setTestNow(null);
     }
 
     public function getEnvironmentSetUp($app)
@@ -24,38 +26,41 @@ class ThrottleRequestsWithRedisTest extends TestCase
         $app['config']->set('hashing', ['driver' => 'bcrypt']);
     }
 
-    public function testLockOpensImmediatelyAfterDecay()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testLockOpensImmediatelyAfterDecay($connection)
     {
-        $this->ifRedisAvailable(function () {
-            $now = Carbon::now();
+        $this->app['redis'] = $this->getRedisManager($connection);
 
-            Carbon::setTestNow($now);
+        $now = Carbon::now();
 
-            Route::get('/', function () {
-                return 'yes';
-            })->middleware(ThrottleRequestsWithRedis::class.':2,1');
+        Carbon::setTestNow($now);
 
-            $response = $this->withoutExceptionHandling()->get('/');
-            $this->assertSame('yes', $response->getContent());
-            $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-            $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
+        Route::get('/', function () {
+            return 'yes';
+        })->middleware(ThrottleRequestsWithRedis::class.':2,1');
 
-            $response = $this->withoutExceptionHandling()->get('/');
-            $this->assertSame('yes', $response->getContent());
-            $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-            $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertSame('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
 
-            Carbon::setTestNow($finish = $now->addSeconds(58));
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertSame('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
 
-            try {
-                $this->withoutExceptionHandling()->get('/');
-            } catch (Throwable $e) {
-                $this->assertEquals(429, $e->getStatusCode());
-                $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
-                $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-                // $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
-                // $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [$finish->getTimestamp() + 2, $finish->getTimestamp() + 3]));
-            }
-        });
+        Carbon::setTestNow($finish = $now->addSeconds(58));
+
+        try {
+            $this->withoutExceptionHandling()->get('/');
+        } catch (Throwable $e) {
+            $this->assertEquals(429, $e->getStatusCode());
+            $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            // $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
+            // $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [$finish->getTimestamp() + 2, $finish->getTimestamp() + 3]));
+        }
     }
 }

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -17,6 +17,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+        Str::createUuidsNormally();
     }
 
     public function testCanProperlyLogFailedJob()
@@ -50,8 +51,6 @@ class DynamoDbFailedJobProviderTest extends TestCase
         $provider = new DynamoDbFailedJobProvider($dynamoDbClient, 'application', 'table');
 
         $provider->log('connection', 'queue', json_encode(['uuid' => (string) $uuid]), $exception);
-
-        Str::createUuidsNormally();
     }
 
     public function testCanRetrieveAllFailedJobs()

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -26,6 +26,7 @@ class QueueBeanstalkdQueueTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+        Str::createUuidsNormally();
     }
 
     public function testPushProperlyPushesJobOntoBeanstalkd()
@@ -46,8 +47,6 @@ class QueueBeanstalkdQueueTest extends TestCase
         $this->queue->push('foo', ['data']);
 
         $this->container->shouldHaveReceived('bound')->with('events')->times(2);
-
-        Str::createUuidsNormally();
     }
 
     public function testDelayedPushProperlyPushesJobOntoBeanstalkd()
@@ -68,8 +67,6 @@ class QueueBeanstalkdQueueTest extends TestCase
         $this->queue->later(5, 'foo', ['data']);
 
         $this->container->shouldHaveReceived('bound')->with('events')->times(2);
-
-        Str::createUuidsNormally();
     }
 
     public function testPopProperlyPopsJobOffOfBeanstalkd()

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -17,6 +17,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+        Str::createUuidsNormally();
     }
 
     public function testPushProperlyPushesJobOntoDatabase()
@@ -42,8 +43,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->push('foo', ['data']);
 
         $container->shouldHaveReceived('bound')->with('events')->once();
-
-        Str::createUuidsNormally();
     }
 
     public function testDelayedPushProperlyPushesJobOntoDatabase()
@@ -73,8 +72,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->later(10, 'foo', ['data']);
 
         $container->shouldHaveReceived('bound')->with('events')->once();
-
-        Str::createUuidsNormally();
     }
 
     public function testFailureToCreatePayloadFromObject()
@@ -142,8 +139,6 @@ class QueueDatabaseQueueUnitTest extends TestCase
         });
 
         $queue->bulk(['foo', 'bar'], ['data'], 'queue');
-
-        Str::createUuidsNormally();
     }
 
     public function testBuildDatabaseRecordWithPayloadAtTheEnd()

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -17,6 +17,7 @@ class QueueRedisQueueTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+        Str::createUuidsNormally();
     }
 
     public function testPushProperlyPushesJobOntoRedis()
@@ -36,8 +37,6 @@ class QueueRedisQueueTest extends TestCase
         $id = $queue->push('foo', ['data']);
         $this->assertSame('foo', $id);
         $container->shouldHaveReceived('bound')->with('events')->once();
-
-        Str::createUuidsNormally();
     }
 
     public function testPushProperlyPushesJobOntoRedisWithCustomPayloadHook()
@@ -63,8 +62,6 @@ class QueueRedisQueueTest extends TestCase
         $container->shouldHaveReceived('bound')->with('events')->once();
 
         Queue::createPayloadUsing(null);
-
-        Str::createUuidsNormally();
     }
 
     public function testPushProperlyPushesJobOntoRedisWithTwoCustomPayloadHook()
@@ -94,8 +91,6 @@ class QueueRedisQueueTest extends TestCase
         $container->shouldHaveReceived('bound')->with('events')->once();
 
         Queue::createPayloadUsing(null);
-
-        Str::createUuidsNormally();
     }
 
     public function testDelayedPushProperlyPushesJobOntoRedis()
@@ -121,8 +116,6 @@ class QueueRedisQueueTest extends TestCase
         $id = $queue->later(1, 'foo', ['data']);
         $this->assertSame('foo', $id);
         $container->shouldHaveReceived('bound')->with('events')->once();
-
-        Str::createUuidsNormally();
     }
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
@@ -148,7 +141,5 @@ class QueueRedisQueueTest extends TestCase
 
         $queue->later($date, 'foo', ['data']);
         $container->shouldHaveReceived('bound')->with('events')->once();
-
-        Str::createUuidsNormally();
     }
 }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -3,575 +3,599 @@
 namespace Illuminate\Tests\Redis;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Redis\Connections\PhpRedisConnection;
-use Illuminate\Redis\RedisManager;
-use Mockery as m;
+use Mockery;
 use PHPUnit\Framework\TestCase;
-use Predis\Client;
 use Redis;
 
 class RedisConnectionTest extends TestCase
 {
     use InteractsWithRedis;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpRedis();
-    }
-
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
+        Mockery::close();
 
-        m::close();
+        parent::tearDown();
     }
 
-    public function testItSetsValuesWithExpiry()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSetsValuesWithExpiry($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed', 'EX', 5, 'NX');
-            $this->assertSame('mohamed', $redis->get('one'));
-            $this->assertNotEquals(-1, $redis->ttl('one'));
+        $redis = $this->getRedisManager($connection);
 
-            // It doesn't override when NX mode
-            $redis->set('one', 'taylor', 'EX', 5, 'NX');
-            $this->assertSame('mohamed', $redis->get('one'));
+        $redis->set('one', 'mohamed', 'EX', 5, 'NX');
+        $this->assertSame('mohamed', $redis->get('one'));
+        $this->assertNotEquals(-1, $redis->ttl('one'));
 
-            // It overrides when XX mode
-            $redis->set('one', 'taylor', 'EX', 5, 'XX');
-            $this->assertSame('taylor', $redis->get('one'));
+        // It doesn't override when NX mode
+        $redis->set('one', 'taylor', 'EX', 5, 'NX');
+        $this->assertSame('mohamed', $redis->get('one'));
 
-            // It fails if XX mode is on and key doesn't exist
-            $redis->set('two', 'taylor', 'PX', 5, 'XX');
-            $this->assertNull($redis->get('two'));
+        // It overrides when XX mode
+        $redis->set('one', 'taylor', 'EX', 5, 'XX');
+        $this->assertSame('taylor', $redis->get('one'));
 
-            $redis->set('three', 'mohamed', 'PX', 5000);
-            $this->assertSame('mohamed', $redis->get('three'));
-            $this->assertNotEquals(-1, $redis->ttl('three'));
-            $this->assertNotEquals(-1, $redis->pttl('three'));
+        // It fails if XX mode is on and key doesn't exist
+        $redis->set('two', 'taylor', 'PX', 5, 'XX');
+        $this->assertNull($redis->get('two'));
 
-            $redis->flushall();
+        $redis->set('three', 'mohamed', 'PX', 5000);
+        $this->assertSame('mohamed', $redis->get('three'));
+        $this->assertNotEquals(-1, $redis->ttl('three'));
+        $this->assertNotEquals(-1, $redis->pttl('three'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItDeletesKeys($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('one', 'mohamed');
+        $redis->set('two', 'mohamed');
+        $redis->set('three', 'mohamed');
+
+        $redis->del('one');
+        $this->assertNull($redis->get('one'));
+        $this->assertNotNull($redis->get('two'));
+        $this->assertNotNull($redis->get('three'));
+
+        $redis->del('two', 'three');
+        $this->assertNull($redis->get('two'));
+        $this->assertNull($redis->get('three'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItChecksForExistence($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('one', 'mohamed');
+        $redis->set('two', 'mohamed');
+
+        $this->assertEquals(1, $redis->exists('one'));
+        $this->assertEquals(0, $redis->exists('nothing'));
+        $this->assertEquals(2, $redis->exists('one', 'two'));
+        $this->assertEquals(2, $redis->exists('one', 'two', 'nothing'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItExpiresKeys($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('one', 'mohamed');
+        $this->assertEquals(-1, $redis->ttl('one'));
+        $this->assertEquals(1, $redis->expire('one', 10));
+        $this->assertNotEquals(-1, $redis->ttl('one'));
+
+        $this->assertEquals(0, $redis->expire('nothing', 10));
+
+        $redis->set('two', 'mohamed');
+        $this->assertEquals(-1, $redis->ttl('two'));
+        $this->assertEquals(1, $redis->pexpire('two', 10));
+        $this->assertNotEquals(-1, $redis->pttl('two'));
+
+        $this->assertEquals(0, $redis->pexpire('nothing', 10));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRenamesKeys($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('one', 'mohamed');
+        $redis->rename('one', 'two');
+        $this->assertNull($redis->get('one'));
+        $this->assertSame('mohamed', $redis->get('two'));
+
+        $redis->set('three', 'adam');
+        $redis->renamenx('two', 'three');
+        $this->assertSame('mohamed', $redis->get('two'));
+        $this->assertSame('adam', $redis->get('three'));
+
+        $redis->renamenx('two', 'four');
+        $this->assertNull($redis->get('two'));
+        $this->assertSame('mohamed', $redis->get('four'));
+        $this->assertSame('adam', $redis->get('three'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItAddsMembersToSortedSet($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set', 1, 'mohamed');
+        $this->assertEquals(1, $redis->zcard('set'));
+
+        $redis->zadd('set', 2, 'taylor', 3, 'adam');
+        $this->assertEquals(3, $redis->zcard('set'));
+
+        $redis->zadd('set', ['jeffrey' => 4, 'matt' => 5]);
+        $this->assertEquals(5, $redis->zcard('set'));
+
+        $redis->zadd('set', 'NX', 1, 'beric');
+        $this->assertEquals(6, $redis->zcard('set'));
+
+        $redis->zadd('set', 'NX', ['joffrey' => 1]);
+        $this->assertEquals(7, $redis->zcard('set'));
+
+        $redis->zadd('set', 'XX', ['ned' => 1]);
+        $this->assertEquals(7, $redis->zcard('set'));
+
+        $this->assertEquals(1, $redis->zadd('set', ['sansa' => 10]));
+        $this->assertEquals(0, $redis->zadd('set', 'XX', 'CH', ['arya' => 11]));
+
+        $redis->zadd('set', ['mohamed' => 100]);
+        $this->assertEquals(100, $redis->zscore('set', 'mohamed'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCountsMembersInSortedSet($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
+
+        $this->assertEquals(1, $redis->zcount('set', 1, 5));
+        $this->assertEquals(2, $redis->zcount('set', '-inf', '+inf'));
+        $this->assertEquals(2, $redis->zcard('set'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItIncrementsScoreOfSortedSet($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
+        $redis->zincrby('set', 2, 'jeffrey');
+        $this->assertEquals(3, $redis->zscore('set', 'jeffrey'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSetsKeyIfNotExists($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('name', 'mohamed');
+
+        $this->assertSame(0, $redis->setnx('name', 'taylor'));
+        $this->assertSame('mohamed', $redis->get('name'));
+
+        $this->assertSame(1, $redis->setnx('boss', 'taylor'));
+        $this->assertSame('taylor', $redis->get('boss'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSetsHashFieldIfNotExists($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->hset('person', 'name', 'mohamed');
+
+        $this->assertSame(0, $redis->hsetnx('person', 'name', 'taylor'));
+        $this->assertSame('mohamed', $redis->hget('person', 'name'));
+
+        $this->assertSame(1, $redis->hsetnx('person', 'boss', 'taylor'));
+        $this->assertSame('taylor', $redis->hget('person', 'boss'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCalculatesIntersectionOfSortedSetsAndStores($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
+        $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+
+        $redis->zinterstore('output', ['set1', 'set2']);
+        $this->assertEquals(2, $redis->zcard('output'));
+        $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
+        $this->assertEquals(5, $redis->zscore('output', 'matt'));
+
+        $redis->zinterstore('output2', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'sum',
+        ]);
+        $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
+        $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+
+        $redis->zinterstore('output3', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'min',
+        ]);
+        $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
+        $this->assertEquals(6, $redis->zscore('output3', 'matt'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCalculatesUnionOfSortedSetsAndStores($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
+        $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+
+        $redis->zunionstore('output', ['set1', 'set2']);
+        $this->assertEquals(3, $redis->zcard('output'));
+        $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
+        $this->assertEquals(5, $redis->zscore('output', 'matt'));
+        $this->assertEquals(3, $redis->zscore('output', 'taylor'));
+
+        $redis->zunionstore('output2', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'sum',
+        ]);
+        $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
+        $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+        $this->assertEquals(9, $redis->zscore('output2', 'taylor'));
+
+        $redis->zunionstore('output3', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'min',
+        ]);
+        $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
+        $this->assertEquals(6, $redis->zscore('output3', 'matt'));
+        $this->assertEquals(9, $redis->zscore('output3', 'taylor'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRangeInSortedSet($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['jeffrey', 'matt'], $redis->zrange('set', 0, 1));
+        $this->assertEquals(['jeffrey', 'matt', 'taylor'], $redis->zrange('set', 0, -1));
+
+        if ($connection === 'predis') {
+            $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, 'withscores'));
+        } else {
+            $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, true));
         }
     }
 
-    public function testItDeletesKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRevRangeInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->set('two', 'mohamed');
-            $redis->set('three', 'mohamed');
+        $redis = $this->getRedisManager($connection);
 
-            $redis->del('one');
-            $this->assertNull($redis->get('one'));
-            $this->assertNotNull($redis->get('two'));
-            $this->assertNotNull($redis->get('three'));
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['taylor', 'matt'], $redis->ZREVRANGE('set', 0, 1));
+        $this->assertEquals(['taylor', 'matt', 'jeffrey'], $redis->ZREVRANGE('set', 0, -1));
 
-            $redis->del('two', 'three');
-            $this->assertNull($redis->get('two'));
-            $this->assertNull($redis->get('three'));
-
-            $redis->flushall();
+        if ($connection === 'predis') {
+            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, 'withscores'));
+        } else {
+            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, true));
         }
     }
 
-    public function testItChecksForExistence()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRangeByScoreInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->set('two', 'mohamed');
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertEquals(1, $redis->exists('one'));
-            $this->assertEquals(0, $redis->exists('nothing'));
-            $this->assertEquals(2, $redis->exists('one', 'two'));
-            $this->assertEquals(2, $redis->exists('one', 'two', 'nothing'));
-
-            $redis->flushall();
-        }
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['jeffrey'], $redis->zrangebyscore('set', 0, 3));
+        $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
+            'withscores' => true,
+            'limit' => [
+                'offset' => 1,
+                'count' => 2,
+            ],
+        ]));
+        $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
+            'withscores' => true,
+            'limit' => [1, 2],
+        ]));
     }
 
-    public function testItExpiresKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRevRangeByScoreInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $this->assertEquals(-1, $redis->ttl('one'));
-            $this->assertEquals(1, $redis->expire('one', 10));
-            $this->assertNotEquals(-1, $redis->ttl('one'));
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertEquals(0, $redis->expire('nothing', 10));
-
-            $redis->set('two', 'mohamed');
-            $this->assertEquals(-1, $redis->ttl('two'));
-            $this->assertEquals(1, $redis->pexpire('two', 10));
-            $this->assertNotEquals(-1, $redis->pttl('two'));
-
-            $this->assertEquals(0, $redis->pexpire('nothing', 10));
-
-            $redis->flushall();
-        }
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['taylor'], $redis->ZREVRANGEBYSCORE('set', 10, 6));
+        $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
+            'withscores' => true,
+            'limit' => [
+                'offset' => 1,
+                'count' => 2,
+            ],
+        ]));
+        $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
+            'withscores' => true,
+            'limit' => [1, 2],
+        ]));
     }
 
-    public function testItRenamesKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRankInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->rename('one', 'two');
-            $this->assertNull($redis->get('one'));
-            $this->assertSame('mohamed', $redis->get('two'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->set('three', 'adam');
-            $redis->renamenx('two', 'three');
-            $this->assertSame('mohamed', $redis->get('two'));
-            $this->assertSame('adam', $redis->get('three'));
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
 
-            $redis->renamenx('two', 'four');
-            $this->assertNull($redis->get('two'));
-            $this->assertSame('mohamed', $redis->get('four'));
-            $this->assertSame('adam', $redis->get('three'));
-
-            $redis->flushall();
-        }
+        $this->assertEquals(0, $redis->zrank('set', 'jeffrey'));
+        $this->assertEquals(2, $redis->zrank('set', 'taylor'));
     }
 
-    public function testItAddsMembersToSortedSet()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsScoreInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', 1, 'mohamed');
-            $this->assertEquals(1, $redis->zcard('set'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->zadd('set', 2, 'taylor', 3, 'adam');
-            $this->assertEquals(3, $redis->zcard('set'));
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
 
-            $redis->zadd('set', ['jeffrey' => 4, 'matt' => 5]);
-            $this->assertEquals(5, $redis->zcard('set'));
-
-            $redis->zadd('set', 'NX', 1, 'beric');
-            $this->assertEquals(6, $redis->zcard('set'));
-
-            $redis->zadd('set', 'NX', ['joffrey' => 1]);
-            $this->assertEquals(7, $redis->zcard('set'));
-
-            $redis->zadd('set', 'XX', ['ned' => 1]);
-            $this->assertEquals(7, $redis->zcard('set'));
-
-            $this->assertEquals(1, $redis->zadd('set', ['sansa' => 10]));
-            $this->assertEquals(0, $redis->zadd('set', 'XX', 'CH', ['arya' => 11]));
-
-            $redis->zadd('set', ['mohamed' => 100]);
-            $this->assertEquals(100, $redis->zscore('set', 'mohamed'));
-
-            $redis->flushall();
-        }
+        $this->assertEquals(1, $redis->zscore('set', 'jeffrey'));
+        $this->assertEquals(10, $redis->zscore('set', 'taylor'));
     }
 
-    public function testItCountsMembersInSortedSet()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRemovesMembersInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertEquals(1, $redis->zcount('set', 1, 5));
-            $this->assertEquals(2, $redis->zcount('set', '-inf', '+inf'));
-            $this->assertEquals(2, $redis->zcard('set'));
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
 
-            $redis->flushall();
-        }
+        $redis->zrem('set', 'jeffrey');
+        $this->assertEquals(3, $redis->zcard('set'));
+
+        $redis->zrem('set', 'matt', 'adam');
+        $this->assertEquals(1, $redis->zcard('set'));
     }
 
-    public function testItIncrementsScoreOfSortedSet()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRemovesMembersByScoreInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
-            $redis->zincrby('set', 2, 'jeffrey');
-            $this->assertEquals(3, $redis->zscore('set', 'jeffrey'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->flushall();
-        }
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
+        $redis->ZREMRANGEBYSCORE('set', 5, '+inf');
+        $this->assertEquals(1, $redis->zcard('set'));
     }
 
-    public function testItSetsKeyIfNotExists()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRemovesMembersByRankInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('name', 'mohamed');
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertSame(0, $redis->setnx('name', 'taylor'));
-            $this->assertSame('mohamed', $redis->get('name'));
-
-            $this->assertSame(1, $redis->setnx('boss', 'taylor'));
-            $this->assertSame('taylor', $redis->get('boss'));
-
-            $redis->flushall();
-        }
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
+        $redis->ZREMRANGEBYRANK('set', 1, -1);
+        $this->assertEquals(1, $redis->zcard('set'));
     }
 
-    public function testItSetsHashFieldIfNotExists()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSetsMultipleHashFields($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->hset('person', 'name', 'mohamed');
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertSame(0, $redis->hsetnx('person', 'name', 'taylor'));
-            $this->assertSame('mohamed', $redis->hget('person', 'name'));
+        $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
+        $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash'));
 
-            $this->assertSame(1, $redis->hsetnx('person', 'boss', 'taylor'));
-            $this->assertSame('taylor', $redis->hget('person', 'boss'));
-
-            $redis->flushall();
-        }
+        $redis->hmset('hash2', 'name', 'mohamed', 'hobby', 'diving');
+        $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash2'));
     }
 
-    public function testItCalculatesIntersectionOfSortedSetsAndStores()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItGetsMultipleHashFields($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
-            $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+        $redis = $this->getRedisManager($connection);
 
-            $redis->zinterstore('output', ['set1', 'set2']);
-            $this->assertEquals(2, $redis->zcard('output'));
-            $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
-            $this->assertEquals(5, $redis->zscore('output', 'matt'));
+        $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
 
-            $redis->zinterstore('output2', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'sum',
-            ]);
-            $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
-            $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+        $this->assertEquals(['mohamed', 'diving'],
+            $redis->hmget('hash', 'name', 'hobby')
+        );
 
-            $redis->zinterstore('output3', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'min',
-            ]);
-            $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
-            $this->assertEquals(6, $redis->zscore('output3', 'matt'));
-
-            $redis->flushall();
-        }
+        $this->assertEquals(['mohamed', 'diving'],
+            $redis->hmget('hash', ['name', 'hobby'])
+        );
     }
 
-    public function testItCalculatesUnionOfSortedSetsAndStores()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItGetsMultipleKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
-            $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+        $redis = $this->getRedisManager($connection);
 
-            $redis->zunionstore('output', ['set1', 'set2']);
-            $this->assertEquals(3, $redis->zcard('output'));
-            $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
-            $this->assertEquals(5, $redis->zscore('output', 'matt'));
-            $this->assertEquals(3, $redis->zscore('output', 'taylor'));
-
-            $redis->zunionstore('output2', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'sum',
-            ]);
-            $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
-            $this->assertEquals(12, $redis->zscore('output2', 'matt'));
-            $this->assertEquals(9, $redis->zscore('output2', 'taylor'));
-
-            $redis->zunionstore('output3', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'min',
-            ]);
-            $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
-            $this->assertEquals(6, $redis->zscore('output3', 'matt'));
-            $this->assertEquals(9, $redis->zscore('output3', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRangeInSortedSet()
-    {
-        foreach ($this->connections() as $connector => $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['jeffrey', 'matt'], $redis->zrange('set', 0, 1));
-            $this->assertEquals(['jeffrey', 'matt', 'taylor'], $redis->zrange('set', 0, -1));
-
-            if ($connector === 'predis') {
-                $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, 'withscores'));
-            } else {
-                $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, true));
-            }
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRevRangeInSortedSet()
-    {
-        foreach ($this->connections() as $connector => $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['taylor', 'matt'], $redis->ZREVRANGE('set', 0, 1));
-            $this->assertEquals(['taylor', 'matt', 'jeffrey'], $redis->ZREVRANGE('set', 0, -1));
-
-            if ($connector === 'predis') {
-                $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, 'withscores'));
-            } else {
-                $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, true));
-            }
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRangeByScoreInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['jeffrey'], $redis->zrangebyscore('set', 0, 3));
-            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
-                'withscores' => true,
-                'limit' => [
-                    'offset' => 1,
-                    'count' => 2,
-                ],
-            ]));
-            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
-                'withscores' => true,
-                'limit' => [1, 2],
-            ]));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRevRangeByScoreInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['taylor'], $redis->ZREVRANGEBYSCORE('set', 10, 6));
-            $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
-                'withscores' => true,
-                'limit' => [
-                    'offset' => 1,
-                    'count' => 2,
-                ],
-            ]));
-            $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
-                'withscores' => true,
-                'limit' => [1, 2],
-            ]));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRankInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-
-            $this->assertEquals(0, $redis->zrank('set', 'jeffrey'));
-            $this->assertEquals(2, $redis->zrank('set', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsScoreInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-
-            $this->assertEquals(1, $redis->zscore('set', 'jeffrey'));
-            $this->assertEquals(10, $redis->zscore('set', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItRemovesMembersInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-
-            $redis->zrem('set', 'jeffrey');
-            $this->assertEquals(3, $redis->zcard('set'));
-
-            $redis->zrem('set', 'matt', 'adam');
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItRemovesMembersByScoreInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-            $redis->ZREMRANGEBYSCORE('set', 5, '+inf');
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItRemovesMembersByRankInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-            $redis->ZREMRANGEBYRANK('set', 1, -1);
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItSetsMultipleHashFields()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
-            $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash'));
-
-            $redis->hmset('hash2', 'name', 'mohamed', 'hobby', 'diving');
-            $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash2'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItGetsMultipleHashFields()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
-
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', 'name', 'hobby')
-            );
-
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', ['name', 'hobby'])
-            );
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItGetsMultipleKeys()
-    {
         $valueSet = ['name' => 'mohamed', 'hobby' => 'diving'];
 
-        foreach ($this->connections() as $redis) {
-            $redis->mset($valueSet);
+        $redis->mset($valueSet);
 
-            $this->assertEquals(
-                array_values($valueSet),
-                $redis->mget(array_keys($valueSet))
-            );
-
-            $redis->flushall();
-        }
+        $this->assertEquals(
+            array_values($valueSet),
+            $redis->mget(array_keys($valueSet))
+        );
     }
 
-    public function testItFlushes()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItFlushes($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('name', 'Till');
-            $this->assertSame(1, $redis->exists('name'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->flushdb();
-            $this->assertSame(0, $redis->exists('name'));
-        }
+        $redis->set('name', 'Till');
+        $this->assertSame(1, $redis->exists('name'));
+
+        $redis->flushdb();
+        $this->assertSame(0, $redis->exists('name'));
     }
 
-    public function testItFlushesAsynchronous()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItFlushesAsynchronous($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('name', 'Till');
-            $this->assertSame(1, $redis->exists('name'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->flushdb('ASYNC');
-            $this->assertSame(0, $redis->exists('name'));
-        }
+        $redis->set('name', 'Till');
+        $this->assertSame(1, $redis->exists('name'));
+
+        $redis->flushdb('ASYNC');
+        $this->assertSame(0, $redis->exists('name'));
     }
 
-    public function testItRunsEval()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRunsEval($connection)
     {
-        foreach ($this->connections() as $redis) {
-            if ($redis instanceof PhpRedisConnection) {
-                // User must decide what needs to be serialized and compressed.
-                $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', ...$redis->pack(['mohamed']));
-            } else {
-                $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
-            }
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertSame('mohamed', $redis->get('name'));
-
-            $redis->flushall();
+        if ($redis->connection() instanceof PhpRedisConnection) {
+            // User must decide what needs to be serialized and compressed.
+            $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', ...$redis->pack(['mohamed']));
+        } else {
+            $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
         }
+
+        $this->assertSame('mohamed', $redis->get('name'));
     }
 
-    public function testItRunsPipes()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRunsPipes($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $result = $redis->pipeline(function ($pipe) {
-                $pipe->set('test:pipeline:1', 1);
-                $pipe->get('test:pipeline:1');
-                $pipe->set('test:pipeline:2', 2);
-                $pipe->get('test:pipeline:2');
-            });
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertCount(4, $result);
-            $this->assertEquals(1, $result[1]);
-            $this->assertEquals(2, $result[3]);
+        $result = $redis->pipeline(function ($pipe) {
+            $pipe->set('test:pipeline:1', 1);
+            $pipe->get('test:pipeline:1');
+            $pipe->set('test:pipeline:2', 2);
+            $pipe->get('test:pipeline:2');
+        });
 
-            $redis->flushall();
-        }
+        $this->assertCount(4, $result);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[3]);
     }
 
-    public function testItRunsTransactions()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRunsTransactions($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $result = $redis->transaction(function ($pipe) {
-                $pipe->set('test:transaction:1', 1);
-                $pipe->get('test:transaction:1');
-                $pipe->set('test:transaction:2', 2);
-                $pipe->get('test:transaction:2');
-            });
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertCount(4, $result);
-            $this->assertEquals(1, $result[1]);
-            $this->assertEquals(2, $result[3]);
+        $result = $redis->transaction(function ($pipe) {
+            $pipe->set('test:transaction:1', 1);
+            $pipe->get('test:transaction:1');
+            $pipe->set('test:transaction:2', 2);
+            $pipe->get('test:transaction:2');
+        });
 
-            $redis->flushall();
-        }
+        $this->assertCount(4, $result);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[3]);
     }
 
-    public function testItRunsRawCommand()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRunsRawCommand($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->executeRaw(['SET', 'test:raw:1', '1']);
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertEquals(
-                1, $redis->executeRaw(['GET', 'test:raw:1'])
-            );
+        $redis->executeRaw(['SET', 'test:raw:1', '1']);
 
-            $redis->flushall();
-        }
+        $this->assertEquals(
+            1, $redis->executeRaw(['GET', 'test:raw:1'])
+        );
     }
 
     public function testItDispatchesQueryEvent()
     {
-        foreach ($this->connections() as $redis) {
-            $redis->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $redis = $this->getRedisManager('phpredis');
 
-            $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) {
-                $this->assertSame('get', $event->command);
-                $this->assertEquals(['foobar'], $event->parameters);
-                $this->assertSame('default', $event->connectionName);
-                $this->assertInstanceOf(Connection::class, $event->connection);
+        $redis->setEventDispatcher($events = Mockery::mock(Dispatcher::class));
 
-                return true;
-            }));
+        $events->shouldReceive('dispatch')->once()->with(Mockery::on(function ($event) {
+            $this->assertSame('get', $event->command);
+            $this->assertEquals(['foobar'], $event->parameters);
+            $this->assertSame('default', $event->connectionName);
+            $this->assertInstanceOf(Connection::class, $event->connection);
 
-            $redis->get('foobar');
+            return true;
+        }));
 
-            $redis->unsetEventDispatcher();
-        }
+        $redis->get('foobar');
+
+        $redis->unsetEventDispatcher();
     }
 
     public function testItPersistsConnection()
@@ -582,195 +606,196 @@ class RedisConnectionTest extends TestCase
 
         $this->assertSame(
             'laravel',
-            $this->connections()['persistent']->getPersistentID()
+            $this->getRedisManager('phpredis_persistent')->getPersistentID()
         );
     }
 
-    public function testItScansForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItScansForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $initialKeys = ['test:scan:1', 'test:scan:2'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($initialKeys as $k => $key) {
-                $redis->set($key, 'test');
-                $initialKeys[$k] = $this->getPrefix($redis->client()).$key;
+        $initialKeys = ['test:scan:1', 'test:scan:2'];
+
+        foreach ($initialKeys as $k => $key) {
+            $redis->set($key, 'test');
+            $initialKeys[$k] = $this->getPrefix($redis->client()).$key;
+        }
+
+        $iterator = null;
+
+        do {
+            [$cursor, $returnedKeys] = $redis->scan($iterator);
+
+            if (! is_array($returnedKeys)) {
+                $returnedKeys = [$returnedKeys];
             }
 
-            $iterator = null;
-
-            do {
-                [$cursor, $returnedKeys] = $redis->scan($iterator);
-
-                if (! is_array($returnedKeys)) {
-                    $returnedKeys = [$returnedKeys];
-                }
-
-                foreach ($returnedKeys as $returnedKey) {
-                    $this->assertContains($returnedKey, $initialKeys);
-                }
-            } while ($iterator > 0);
-
-            $redis->flushAll();
-        }
+            foreach ($returnedKeys as $returnedKey) {
+                $this->assertContains($returnedKey, $initialKeys);
+            }
+        } while ($iterator > 0);
     }
 
-    public function testItZscansForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItZscansForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $members = [100 => 'test:zscan:1', 200 => 'test:zscan:2'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($members as $score => $member) {
-                $redis->zadd('set', $score, $member);
+        $members = [100 => 'test:zscan:1', 200 => 'test:zscan:2'];
+
+        foreach ($members as $score => $member) {
+            $redis->zadd('set', $score, $member);
+        }
+
+        $iterator = null;
+        $result = [];
+
+        do {
+            [$iterator, $returnedMembers] = $redis->zscan('set', $iterator);
+
+            if (! is_array($returnedMembers)) {
+                $returnedMembers = [$returnedMembers];
             }
 
-            $iterator = null;
-            $result = [];
+            foreach ($returnedMembers as $member => $score) {
+                $this->assertArrayHasKey((int) $score, $members);
+                $this->assertContains($member, $members);
+            }
 
-            do {
-                [$iterator, $returnedMembers] = $redis->zscan('set', $iterator);
+            $result += $returnedMembers;
+        } while ($iterator > 0);
 
-                if (! is_array($returnedMembers)) {
-                    $returnedMembers = [$returnedMembers];
-                }
+        $this->assertCount(2, $result);
 
-                foreach ($returnedMembers as $member => $score) {
-                    $this->assertArrayHasKey((int) $score, $members);
-                    $this->assertContains($member, $members);
-                }
+        $iterator = null;
+        [$iterator, $returned] = $redis->zscan('set', $iterator, ['match' => 'test:unmatch:*']);
+        $this->assertEmpty($returned);
 
-                $result += $returnedMembers;
-            } while ($iterator > 0);
-
-            $this->assertCount(2, $result);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->zscan('set', $iterator, ['match' => 'test:unmatch:*']);
-            $this->assertEmpty($returned);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->zscan('set', $iterator, ['count' => 5]);
-            $this->assertCount(2, $returned);
-
-            $redis->flushAll();
-        }
+        $iterator = null;
+        [$iterator, $returned] = $redis->zscan('set', $iterator, ['count' => 5]);
+        $this->assertCount(2, $returned);
     }
 
-    public function testItHscansForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItHscansForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $fields = ['name' => 'mohamed', 'hobby' => 'diving'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($fields as $field => $value) {
-                $redis->hset('hash', $field, $value);
+        $fields = ['name' => 'mohamed', 'hobby' => 'diving'];
+
+        foreach ($fields as $field => $value) {
+            $redis->hset('hash', $field, $value);
+        }
+
+        $iterator = null;
+        $result = [];
+
+        do {
+            [$iterator, $returnedFields] = $redis->hscan('hash', $iterator);
+
+            foreach ($returnedFields as $field => $value) {
+                $this->assertArrayHasKey($field, $fields);
+                $this->assertContains($value, $fields);
             }
 
-            $iterator = null;
-            $result = [];
+            $result += $returnedFields;
+        } while ($iterator > 0);
 
-            do {
-                [$iterator, $returnedFields] = $redis->hscan('hash', $iterator);
+        $this->assertCount(2, $result);
 
-                foreach ($returnedFields as $field => $value) {
-                    $this->assertArrayHasKey($field, $fields);
-                    $this->assertContains($value, $fields);
-                }
+        $iterator = null;
+        [$iterator, $returned] = $redis->hscan('hash', $iterator, ['match' => 'test:unmatch:*']);
+        $this->assertEmpty($returned);
 
-                $result += $returnedFields;
-            } while ($iterator > 0);
-
-            $this->assertCount(2, $result);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->hscan('hash', $iterator, ['match' => 'test:unmatch:*']);
-            $this->assertEmpty($returned);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->hscan('hash', $iterator, ['count' => 5]);
-            $this->assertCount(2, $returned);
-
-            $redis->flushAll();
-        }
+        $iterator = null;
+        [$iterator, $returned] = $redis->hscan('hash', $iterator, ['count' => 5]);
+        $this->assertCount(2, $returned);
     }
 
-    public function testItSscansForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSscansForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $members = ['test:sscan:1', 'test:sscan:2'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($members as $member) {
-                $redis->sadd('set', $member);
-            }
+        $members = ['test:sscan:1', 'test:sscan:2'];
 
-            $iterator = null;
-            $result = [];
-
-            do {
-                [$iterator, $returnedMembers] = $redis->sscan('set', $iterator);
-
-                foreach ($returnedMembers as $member) {
-                    $this->assertContains($member, $members);
-                    array_push($result, $member);
-                }
-            } while ($iterator > 0);
-
-            $this->assertCount(2, $result);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->sscan('set', $iterator, ['match' => 'test:unmatch:*']);
-            $this->assertEmpty($returned);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->sscan('set', $iterator, ['count' => 5]);
-            $this->assertCount(2, $returned);
-
-            $redis->flushAll();
+        foreach ($members as $member) {
+            $redis->sadd('set', $member);
         }
+
+        $iterator = null;
+        $result = [];
+
+        do {
+            [$iterator, $returnedMembers] = $redis->sscan('set', $iterator);
+
+            foreach ($returnedMembers as $member) {
+                $this->assertContains($member, $members);
+                array_push($result, $member);
+            }
+        } while ($iterator > 0);
+
+        $this->assertCount(2, $result);
+
+        $iterator = null;
+        [$iterator, $returned] = $redis->sscan('set', $iterator, ['match' => 'test:unmatch:*']);
+        $this->assertEmpty($returned);
+
+        $iterator = null;
+        [$iterator, $returned] = $redis->sscan('set', $iterator, ['count' => 5]);
+        $this->assertCount(2, $returned);
     }
 
-    public function testItSPopsForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSPopsForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $members = ['test:spop:1', 'test:spop:2', 'test:spop:3', 'test:spop:4'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($members as $member) {
-                $redis->sadd('set', $member);
-            }
+        $members = ['test:spop:1', 'test:spop:2', 'test:spop:3', 'test:spop:4'];
 
-            $result = $redis->spop('set');
-            $this->assertIsNotArray($result);
-            $this->assertContains($result, $members);
-
-            $result = $redis->spop('set', 1);
-
-            $this->assertIsArray($result);
-            $this->assertCount(1, $result);
-
-            $result = $redis->spop('set', 2);
-
-            $this->assertIsArray($result);
-            $this->assertCount(2, $result);
-
-            $redis->flushAll();
+        foreach ($members as $member) {
+            $redis->sadd('set', $member);
         }
+
+        $result = $redis->spop('set');
+        $this->assertIsNotArray($result);
+        $this->assertContains($result, $members);
+
+        $result = $redis->spop('set', 1);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+
+        $result = $redis->spop('set', 2);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
     }
 
-    public function testPhpRedisScanOption()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testMacroable($connection)
     {
-        foreach ($this->connections() as $redis) {
-            if ($redis->client() instanceof Client) {
-                continue;
-            }
+        Connection::macro('foo', function () {
+            return 'foo';
+        });
 
-            $iterator = null;
-
-            do {
-                $returned = $redis->scan($iterator);
-
-                if ($redis->client()->getOption(Redis::OPT_SCAN) === Redis::SCAN_RETRY) {
-                    $this->assertEmpty($returned);
-                }
-            } while ($iterator > 0);
-        }
+        $this->assertSame(
+            'foo',
+            $this->getRedisManager($connection)->foo()
+        );
     }
 
     private function getPrefix($client)
@@ -780,217 +805,5 @@ class RedisConnectionTest extends TestCase
         }
 
         return $client->getOptions()->prefix;
-    }
-
-    public function testMacroable()
-    {
-        Connection::macro('foo', function () {
-            return 'foo';
-        });
-
-        foreach ($this->connections() as $redis) {
-            $this->assertSame(
-                'foo',
-                $redis->foo()
-            );
-        }
-    }
-
-    public function connections()
-    {
-        $connections = [
-            'predis' => $this->redis['predis']->connection(),
-            'phpredis' => $this->redis['phpredis']->connection(),
-        ];
-
-        $host = env('REDIS_HOST', '127.0.0.1');
-        $port = env('REDIS_PORT', 6379);
-
-        $connections[] = (new RedisManager(new Application, 'phpredis', [
-            'cluster' => false,
-            'default' => [
-                'url' => "redis://user@$host:$port",
-                'host' => 'overwrittenByUrl',
-                'port' => 'overwrittenByUrl',
-                'database' => 5,
-                'options' => ['prefix' => 'laravel:'],
-                'timeout' => 0.5,
-            ],
-        ]))->connection();
-
-        $connections['persistent'] = (new RedisManager(new Application, 'phpredis', [
-            'cluster' => false,
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'database' => 6,
-                'options' => ['prefix' => 'laravel:'],
-                'timeout' => 0.5,
-                'persistent' => true,
-                'persistent_id' => 'laravel',
-            ],
-        ]))->connection();
-
-        $connections[] = (new RedisManager(new Application, 'phpredis', [
-            'cluster' => false,
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'database' => 7,
-                'options' => ['serializer' => Redis::SERIALIZER_JSON],
-                'timeout' => 0.5,
-            ],
-        ]))->connection();
-
-        $connections[] = (new RedisManager(new Application, 'phpredis', [
-            'cluster' => false,
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'database' => 8,
-                'options' => ['scan' => Redis::SCAN_RETRY],
-                'timeout' => 0.5,
-            ],
-        ]))->connection();
-
-        if (defined('Redis::COMPRESSION_LZF')) {
-            $connections['compression_lzf'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 9,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZF,
-                        'name' => 'compression_lzf',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-        }
-
-        if (defined('Redis::COMPRESSION_ZSTD')) {
-            $connections['compression_zstd'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 10,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'name' => 'compression_zstd',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_zstd_default'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 11,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'compression_level' => Redis::COMPRESSION_ZSTD_DEFAULT,
-                        'name' => 'compression_zstd_default',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_zstd_min'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 12,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'compression_level' => Redis::COMPRESSION_ZSTD_MIN,
-                        'name' => 'compression_zstd_min',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_zstd_max'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 13,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'compression_level' => Redis::COMPRESSION_ZSTD_MAX,
-                        'name' => 'compression_zstd_max',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-        }
-
-        if (defined('Redis::COMPRESSION_LZ4')) {
-            $connections['compression_lz4'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 14,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZ4,
-                        'name' => 'compression_lz4',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_lz4_default'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 15,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZ4,
-                        'compression_level' => 0,
-                        'name' => 'compression_lz4_default',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_lz4_min'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 16,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZ4,
-                        'compression_level' => 1,
-                        'name' => 'compression_lz4_min',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_lz4_max'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 17,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZ4,
-                        'compression_level' => 12,
-                        'name' => 'compression_lz4_max',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-        }
-
-        return $connections;
     }
 }


### PR DESCRIPTION
This is a follow up of https://github.com/laravel/framework/pull/36412 and https://github.com/laravel/framework/pull/40282 which added phpredis serialization and compression support to the `redis` component.

### The Problem

Laravel's Cache component is built on top of the Redis component. The Cache component serializes on its own before sending data to the Redis component, which is a problem when we use `phpredis` with serialization enabled.

### The Solution

When `phpredis` is used together with serialization enabled, skip the serialization part on the Cache component.

### Details

This pull request adds these capabilities now to the `cache` component as there is some custom logic sitting on top of the `redis` component. The changes include prevention of double serialization/deserialization, proper eval argument packing and a reworked phpredis test suite, which lets all test that use redis run with all kind of different connection setups using data providers.

**Note: I explicitly skipped also upgrading the `queue` component in this pull request. A `queue` component upgrade pull request will follow after this one. Until then redis queues do not support phpredis compression and serialization functionality yet. I was almost done with also the queue adjustments, but noticed that we do some LUA json decoding/encoding to increment the attempt counter, which I would need to move to a different level as phpredis will serialize/compress with different set of algorithms. Can you please suggest someone who has in depth knowledge of the php redis queue implementation in laravel as I have some concrete questions regarding doing changes there.**