### PR TITLE
[8.x] Avoid `undefined array key 0` error

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -13,7 +13,7 @@ class PhpRedisClusterConnection extends PhpRedisConnection
     {
         $arguments = func_get_args();
 
-        $async = strtoupper((string) $arguments[0] ?? null) === 'ASYNC';
+        $async = strtoupper((string) ($arguments[0] ?? null)) === 'ASYNC';
 
         foreach ($this->client->_masters() as $master) {
             $async

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -500,7 +500,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $arguments = func_get_args();
 
-        if (strtoupper((string) $arguments[0] ?? null) === 'ASYNC') {
+        if (strtoupper((string) ($arguments[0] ?? null)) === 'ASYNC') {
             return $this->command('flushdb', [true]);
         }
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -467,6 +467,28 @@ class RedisConnectionTest extends TestCase
         }
     }
 
+    public function testItFlushes()
+    {
+        foreach ($this->connections() as $redis) {
+            $redis->set('name', 'Till');
+            $this->assertSame(1, $redis->exists('name'));
+
+            $redis->flushdb();
+            $this->assertSame(0, $redis->exists('name'));
+        }
+    }
+
+    public function testItFlushesAsynchronous()
+    {
+        foreach ($this->connections() as $redis) {
+            $redis->set('name', 'Till');
+            $this->assertSame(1, $redis->exists('name'));
+
+            $redis->flushdb('ASYNC');
+            $this->assertSame(0, $redis->exists('name'));
+        }
+    }
+
     public function testItRunsEval()
     {
         foreach ($this->connections() as $redis) {


### PR DESCRIPTION
Followup to #40544 to avoid `Undefined array key 0` notices.

Added tests to ensure `ASYNC` parameter is accepted.