### PR TITLE
[8.x] Mail - Add missing test coverage for global "reply_to" and "to"

### DIFF
--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -128,7 +128,17 @@ class MailMailerTest extends TestCase
         unset($_SERVER['__mailer.test']);
     }
 
-    public function testGlobalFromIsRespectedOnAllMessages()
+    public function globalAddressesDataProvider()
+    {
+        return [
+            'from' => ['setter' => 'alwaysFrom', 'getter' => 'getFrom'],
+            'reply_to' => ['setter' => 'alwaysReplyTo', 'getter' => 'getReplyTo'],
+            'to' => ['setter' => 'alwaysTo', 'getter' => 'getTo'],
+        ];
+    }
+
+    /** @dataProvider globalAddressesDataProvider */
+    public function testGlobalAddressesAreRespectedOnAllMessages(string $setter, string $getter)
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
@@ -136,9 +146,9 @@ class MailMailerTest extends TestCase
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
-        $mailer->alwaysFrom('taylorotwell@gmail.com', 'Taylor Otwell');
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
-            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->getFrom());
+        $mailer->{$setter}('taylorotwell@gmail.com', 'Taylor Otwell');
+        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) use ($getter) {
+            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->{$getter}());
         });
         $mailer->send('foo', ['data'], function ($m) {
             //


### PR DESCRIPTION
This is just adding some test coverage for something which feels like should be covered.

Before
```
Mail Mailer (Illuminate\Tests\Mail\MailMailer)
 ✔ Global from is respected on all messages  2 ms
```

After
```
Mail Mailer (Illuminate\Tests\Mail\MailMailer)
 ✔ Global addresses are respected on all messages with from  2 ms
 ✔ Global addresses are respected on all messages with reply_to  1 ms
 ✔ Global addresses are respected on all messages with to  1 ms
```

See [laravel/docs #7620](https://github.com/laravel/docs/pull/7620) for context.