### PR TITLE
[8.x] Add test coverage for Mail::alwaysTo() and Mail::alwaysReplyTo()

### DIFF
--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -128,17 +128,7 @@ class MailMailerTest extends TestCase
         unset($_SERVER['__mailer.test']);
     }
 
-    public function globalAddressesDataProvider()
-    {
-        return [
-            'from' => ['setter' => 'alwaysFrom', 'getter' => 'getFrom'],
-            'reply_to' => ['setter' => 'alwaysReplyTo', 'getter' => 'getReplyTo'],
-            'to' => ['setter' => 'alwaysTo', 'getter' => 'getTo'],
-        ];
-    }
-
-    /** @dataProvider globalAddressesDataProvider */
-    public function testGlobalAddressesAreRespectedOnAllMessages(string $setter, string $getter)
+    public function testGlobalFromIsRespectedOnAllMessages()
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
@@ -146,9 +136,43 @@ class MailMailerTest extends TestCase
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
-        $mailer->{$setter}('taylorotwell@gmail.com', 'Taylor Otwell');
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) use ($getter) {
-            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->{$getter}());
+        $mailer->alwaysFrom('taylorotwell@gmail.com', 'Taylor Otwell');
+        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
+            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->getFrom());
+        });
+        $mailer->send('foo', ['data'], function ($m) {
+            //
+        });
+    }
+
+    public function testGlobalReplyToIsRespectedOnAllMessages()
+    {
+        unset($_SERVER['__mailer.test']);
+        $mailer = $this->getMailer();
+        $view = m::mock(stdClass::class);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
+        $view->shouldReceive('render')->once()->andReturn('rendered.view');
+        $this->setSwiftMailer($mailer);
+        $mailer->alwaysReplyTo('taylorotwell@gmail.com', 'Taylor Otwell');
+        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
+            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->getReplyTo());
+        });
+        $mailer->send('foo', ['data'], function ($m) {
+            //
+        });
+    }
+
+    public function testGlobalToIsRespectedOnAllMessages()
+    {
+        unset($_SERVER['__mailer.test']);
+        $mailer = $this->getMailer();
+        $view = m::mock(stdClass::class);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
+        $view->shouldReceive('render')->once()->andReturn('rendered.view');
+        $this->setSwiftMailer($mailer);
+        $mailer->alwaysTo('taylorotwell@gmail.com', 'Taylor Otwell');
+        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
+            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->getTo());
         });
         $mailer->send('foo', ['data'], function ($m) {
             //

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -128,7 +128,17 @@ class MailMailerTest extends TestCase
         unset($_SERVER['__mailer.test']);
     }
 
-    public function testGlobalFromIsRespectedOnAllMessages()
+    public function globalAddressesDataProvider()
+    {
+        return [
+            'from' => ['setter' => 'alwaysFrom', 'getter' => 'getFrom'],
+            'reply_to' => ['setter' => 'alwaysReplyTo', 'getter' => 'getReplyTo'],
+            'to' => ['setter' => 'alwaysTo', 'getter' => 'getTo'],
+        ];
+    }
+
+    /** @dataProvider globalAddressesDataProvider */
+    public function testGlobalAddressesAreRespectedOnAllMessages(string $setter, string $getter)
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
@@ -136,9 +146,9 @@ class MailMailerTest extends TestCase
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
-        $mailer->alwaysFrom('taylorotwell@gmail.com', 'Taylor Otwell');
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
-            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->getFrom());
+        $mailer->{$setter}('taylorotwell@gmail.com', 'Taylor Otwell');
+        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) use ($getter) {
+            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->{$getter}());
         });
         $mailer->send('foo', ['data'], function ($m) {
             //


### PR DESCRIPTION
Just adding some test coverage.

Before
```
Mail Mailer (Illuminate\Tests\Mail\MailMailer)
 ✔ Global from is respected on all messages  2 ms
 ✔ Global return path is respected on all messages  2 ms
```

After
```
Mail Mailer (Illuminate\Tests\Mail\MailMailer)
 ✔ Global from is respected on all messages  2 ms
 ✔ Global reply to is respected on all messages  1 ms
 ✔ Global to is respected on all messages  1 ms
 ✔ Global return path is respected on all messages  2 ms
```

Linked to [laravel/docs #7620](https://github.com/laravel/docs/pull/7620) and #40561 