### PR TITLE
[8.x] Expand Full-Text Search capabilities

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -296,6 +296,23 @@ class Builder
     }
 
     /**
+     * @param  string|string[]  $columns
+     * @param  string  $value
+     * @param  string  $as
+     * @return $this
+     */
+    public function selectFullText($columns, $value, $as, array $options = [])
+    {
+        $columns = (array) $columns;
+
+        $query = $this->grammar->compileFullText($columns, $value, $options);
+
+        return $this->selectRaw(
+            '('.$query.') as '.$this->grammar->wrap($as), [$value]
+        );
+    }
+
+    /**
      * Makes "from" fetch from a subquery.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
@@ -411,6 +428,31 @@ class Builder
                 $this->columns[] = $column;
             }
         }
+
+        return $this;
+    }
+
+    /**
+     * Add a fulltext select to the query.
+     *
+     * @param  string|string[]  $columns
+     * @param  string  $value
+     * @param  string  $as
+     * @return $this
+     */
+    public function addSelectFullText($columns, $value, $as, array $options = [])
+    {
+        if (is_null($this->columns)) {
+            $this->select($this->from.'.*');
+        }
+
+        $columns = (array) $columns;
+
+        $query = $this->grammar->compileFullText($columns, $value, $options);
+
+        $this->selectSub($query, $as);
+
+        $this->addBinding([$value], 'select');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -668,6 +668,21 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "fulltext" clause.
+     *
+     * @param  array  $columns
+     * @param  string  $value
+     * @param  array  $options
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileFullText($columns, $value, $options)
+    {
+        throw new RuntimeException('This database engine does not support fulltext search operations.');
+    }
+
+    /**
      * Compile the "group by" portions of the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -51,7 +51,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Compile a "where fulltext" clause.
+     * Add a "where fulltext" clause to the query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $where
@@ -59,15 +59,28 @@ class MySqlGrammar extends Grammar
      */
     public function whereFullText(Builder $query, $where)
     {
-        $columns = $this->columnize($where['columns']);
+        return $this->compileFullText($where['columns'], $where['value'], $where['options']);
+    }
 
-        $value = $this->parameter($where['value']);
+    /**
+     * Compile a "fulltext" clause.
+     *
+     * @param  array  $columns
+     * @param  string  $value
+     * @param  array  $options
+     * @return string
+     */
+    public function compileFullText($columns, $value, $options)
+    {
+        $columns = $this->columnize($columns);
 
-        $mode = ($where['options']['mode'] ?? []) === 'boolean'
+        $value = $this->parameter($value);
+
+        $mode = ($options['mode'] ?? []) === 'boolean'
             ? ' in boolean mode'
             : ' in natural language mode';
 
-        $expanded = ($where['options']['expanded'] ?? []) && ($where['options']['mode'] ?? []) !== 'boolean'
+        $expanded = ($options['expanded'] ?? []) && ($options['mode'] ?? []) !== 'boolean'
             ? ' with query expansion'
             : '';
 


### PR DESCRIPTION
Following on from @driesvints' excellent work in https://github.com/laravel/framework/pull/40129, this adds selectFullText() and addSelectFullText() methods.

Whilst whereFullText() is useful in itself, an arguably more practical use-case for fulltext search queries involves being able to select the relevance score in the query, filter to only results with > 0 relevance score using a having clause, and ordering the results by relevance).

This is a scenario used in the fulltext search lesson of @reinink's Eloquent Performance Patterns video course, except there the MATCH()..AGAINST() is used in with select and where clauses, which isn't actually necessary .. see 'Ordering By Result Relevance' section here https://www.cloudsavvyit.com/10172/how-to-use-full-text-searches-in-mysql/

Example (assuming a fulltext index exists on 'bio,resume' (both `string`) fields):
```
$users = \App\Models\User::addSelectFullText(['bio', 'resume'], 'my previous work', 'relevance', ['mode' => 'boolean'])
->having('relevance', '>', 0);
->orderBy('relevance', 'desc')
->get();
```

TODO:
- Postgres version (I'm out of my depth there) .. hoping @tpetry can help
- Add more tests, specific to selectFullText() and addSelectFullText()