### PR TITLE
[9.x] Rename `Rule::nested` to `Rule::forEach`

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -87,7 +87,7 @@ class Rule
      * @param  callable  $callback
      * @return \Illuminate\Validation\NestedRules
      */
-    public static function nested($callback)
+    public static function forEach($callback)
     {
         return new NestedRules($callback);
     }

--- a/tests/Validation/ValidationForEachTest.php
+++ b/tests/Validation/ValidationForEachTest.php
@@ -9,9 +9,9 @@ use Illuminate\Validation\Validator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
-class ValidationNestedRulesTest extends TestCase
+class ValidationForEachTest extends TestCase
 {
-    public function testNestedCallbacksCanProperlySegmentRules()
+    public function testForEachCallbacksCanProperlySegmentRules()
     {
         $data = [
             'items' => [
@@ -22,7 +22,7 @@ class ValidationNestedRulesTest extends TestCase
         ];
 
         $rules = [
-            'items.*' => Rule::nested(function () {
+            'items.*' => Rule::forEach(function () {
                 return ['discounts.*.id' => 'distinct'];
             }),
         ];
@@ -39,7 +39,7 @@ class ValidationNestedRulesTest extends TestCase
         ], $v->getMessageBag()->toArray());
     }
 
-    public function testNestedCallbacksCanBeRecursivelyNested()
+    public function testForEachCallbacksCanBeRecursivelyNested()
     {
         $data = [
             'items' => [
@@ -50,9 +50,9 @@ class ValidationNestedRulesTest extends TestCase
         ];
 
         $rules = [
-            'items.*' => Rule::nested(function () {
+            'items.*' => Rule::forEach(function () {
                 return [
-                    'discounts.*.id' => Rule::nested(function () {
+                    'discounts.*.id' => Rule::forEach(function () {
                         return 'distinct';
                     }),
                 ];
@@ -71,7 +71,7 @@ class ValidationNestedRulesTest extends TestCase
         ], $v->getMessageBag()->toArray());
     }
 
-    public function testNestedCallbacksCanReturnMultipleValidationRules()
+    public function testForEachCallbacksCanReturnMultipleValidationRules()
     {
         $data = [
             'items' => [
@@ -92,10 +92,10 @@ class ValidationNestedRulesTest extends TestCase
             ],
         ];
         $rules = [
-            'items.*' => Rule::nested(function () {
+            'items.*' => Rule::forEach(function () {
                 return [
                     'discounts.*.id' => 'distinct',
-                    'discounts.*' => Rule::nested(function () {
+                    'discounts.*' => Rule::forEach(function () {
                         return [
                             'id' => 'distinct',
                             'percent' => 'numeric|min:0|max:100',
@@ -124,7 +124,7 @@ class ValidationNestedRulesTest extends TestCase
         ], $v->getMessageBag()->toArray());
     }
 
-    public function testNestedCallbacksCanReturnArraysOfValidationRules()
+    public function testForEachCallbacksCanReturnArraysOfValidationRules()
     {
         $data = [
             'items' => [
@@ -135,7 +135,7 @@ class ValidationNestedRulesTest extends TestCase
         ];
 
         $rules = [
-            'items.*' => Rule::nested(function () {
+            'items.*' => Rule::forEach(function () {
                 return ['discounts.*.id' => ['distinct', 'numeric']];
             }),
         ];
@@ -153,7 +153,7 @@ class ValidationNestedRulesTest extends TestCase
         ], $v->getMessageBag()->toArray());
     }
 
-    public function testNestedCallbacksCanReturnDifferentRules()
+    public function testForEachCallbacksCanReturnDifferentRules()
     {
         $data = [
             'items' => [
@@ -174,11 +174,11 @@ class ValidationNestedRulesTest extends TestCase
         ];
 
         $rules = [
-            'items.*' => Rule::nested(function () {
+            'items.*' => Rule::forEach(function () {
                 return [
                     'discounts.*.id' => 'distinct',
                     'discounts.*.type' => 'in:percent,absolute',
-                    'discounts.*' => Rule::nested(function ($value) {
+                    'discounts.*' => Rule::forEach(function ($value) {
                         return $value['type'] === 'percent'
                             ? ['discount' => 'numeric|min:0|max:100']
                             : ['discount' => 'numeric'];

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -90,7 +90,7 @@ class ValidationRuleParserTest extends TestCase
         ]));
 
         $results = $parser->explode([
-            'users.*.name' => Rule::nested(function ($value, $attribute, $data) {
+            'users.*.name' => Rule::forEach(function ($value, $attribute, $data) {
                 $this->assertEquals('Taylor Otwell', $value);
                 $this->assertEquals('users.0.name', $attribute);
                 $this->assertEquals($data['users.0.name'], 'Taylor Otwell');
@@ -110,7 +110,7 @@ class ValidationRuleParserTest extends TestCase
         ]));
 
         $results = $parser->explode([
-            'name' => Rule::nested(function ($value, $attribute, $data = null) {
+            'name' => Rule::forEach(function ($value, $attribute, $data = null) {
                 $this->assertEquals('Taylor Otwell', $value);
                 $this->assertEquals('name', $attribute);
                 $this->assertEquals(['name' => 'Taylor Otwell'], $data);
@@ -134,7 +134,7 @@ class ValidationRuleParserTest extends TestCase
 
         $results = $parser->explode([
             'users.*.name' => [
-                Rule::nested(function ($value, $attribute, $data) {
+                Rule::forEach(function ($value, $attribute, $data) {
                     $this->assertEquals([
                         'users.0.name' => 'Taylor Otwell',
                         'users.1.name' => 'Abigail Otwell',
@@ -142,7 +142,7 @@ class ValidationRuleParserTest extends TestCase
 
                     return [Rule::requiredIf(true)];
                 }),
-                Rule::nested(function ($value, $attribute, $data) {
+                Rule::forEach(function ($value, $attribute, $data) {
                     $this->assertEquals([
                         'users.0.name' => 'Taylor Otwell',
                         'users.1.name' => 'Abigail Otwell',
@@ -180,17 +180,17 @@ class ValidationRuleParserTest extends TestCase
 
         $results = $parser->explode([
             'users.*.name' => [
-                Rule::nested(function ($value, $attribute, $data) {
+                Rule::forEach(function ($value, $attribute, $data) {
                     $this->assertEquals('Taylor Otwell', $value);
                     $this->assertEquals('users.0.name', $attribute);
                     $this->assertEquals(['users.0.name' => 'Taylor Otwell'], $data);
 
-                    return Rule::nested(function ($value, $attribute, $data) {
+                    return Rule::forEach(function ($value, $attribute, $data) {
                         $this->assertNull($value);
                         $this->assertEquals('users.0.name', $attribute);
                         $this->assertEquals(['users.0.name' => 'Taylor Otwell'], $data);
 
-                        return Rule::nested(function ($value, $attribute, $data) {
+                        return Rule::forEach(function ($value, $attribute, $data) {
                             $this->assertNull($value);
                             $this->assertEquals('users.0.name', $attribute);
                             $this->assertEquals(['users.0.name' => 'Taylor Otwell'], $data);
@@ -216,7 +216,7 @@ class ValidationRuleParserTest extends TestCase
         ]));
 
         $rules = [
-            'items.*' => Rule::nested(function () {
+            'items.*' => Rule::forEach(function () {
                 return ['discounts.*.id' => 'distinct'];
             }),
         ];


### PR DESCRIPTION
## Description

Renames `Rule::nested()` to `Rule::forEach()` as discussed in https://github.com/laravel/framework/pull/40498.

