### PR TITLE
[8.x] Temporarily limit voku/portable-ascii <1.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/var-dumper": "^5.4",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
         "vlucas/phpdotenv": "^5.4.1",
-        "voku/portable-ascii": "^1.4.8"
+        "voku/portable-ascii": "^1.4.8|<1.6.0"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/var-dumper": "^5.4",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
         "vlucas/phpdotenv": "^5.4.1",
-        "voku/portable-ascii": "^1.4.8|<1.6.0"
+        "voku/portable-ascii": "^1.4.8 <1.6.0"
     },
     "replace": {
         "illuminate/auth": "self.version",


### PR DESCRIPTION
To circumvent the failing builds across the framework and PR's until https://github.com/voku/portable-ascii/issues/74 is fixed.