### PR TITLE
[8.x] fix HandleExceptions memory leak in tests

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -42,11 +42,7 @@ class HandleExceptions
 
         error_reporting(-1);
 
-        set_error_handler([$this, 'handleError']);
-
-        set_exception_handler([$this, 'handleException']);
-
-        register_shutdown_function([$this, 'handleShutdown']);
+        HandleExceptionsGlobal::register($this);
 
         if (! $app->environment('testing')) {
             ini_set('display_errors', 'Off');

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptionsGlobal.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptionsGlobal.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Foundation\Bootstrap;
+
+use Throwable;
+
+class HandleExceptionsGlobal
+{
+    protected static $instance;
+
+    /**
+     * @var \Illuminate\Foundation\Bootstrap\HandleExceptions
+     */
+    protected $handler;
+
+    protected function __construct()
+    {
+        set_error_handler([$this, 'handleError']);
+        set_exception_handler([$this, 'handleException']);
+        register_shutdown_function([$this, 'handleShutdown']);
+    }
+
+    /**
+     * Register a global exception handler.
+     *
+     * @param  \Illuminate\Foundation\Bootstrap\HandleExceptions  $handler
+     * @return void
+     */
+    public static function register(HandleExceptions $handler)
+    {
+        if (! self::$instance) {
+            self::$instance = new self;
+        }
+
+        self::$instance->handler = $handler;
+    }
+
+    /**
+     * Report PHP deprecations, or convert PHP errors to ErrorException instances.
+     *
+     * @param  int  $level
+     * @param  string  $message
+     * @param  string  $file
+     * @param  int  $line
+     * @param  array  $context
+     * @return void
+     *
+     * @throws \ErrorException
+     */
+    public function handleError($level, $message, $file = '', $line = 0, $context = [])
+    {
+        $this->handler->handleError($level, $message, $file, $line, $context);
+    }
+
+    /**
+     * Handle an uncaught exception from the application.
+     *
+     * Note: Most exceptions can be handled via the try / catch block in
+     * the HTTP and Console kernels. But, fatal error exceptions must
+     * be handled differently since they are not normal exceptions.
+     *
+     * @param  \Throwable  $e
+     * @return void
+     */
+    public function handleException(Throwable $e)
+    {
+        $this->handler->handleException($e);
+    }
+
+    /**
+     * Handle the PHP shutdown event.
+     *
+     * @return void
+     */
+    public function handleShutdown()
+    {
+        $this->handler->handleShutdown();
+    }
+}

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -53,7 +53,7 @@ class SupportJsTest extends TestCase
 
             public $bar = 'not world';
 
-            public function jsonSerialize()
+            public function jsonSerialize(): array
             {
                 return ['foo' => 'hello', 'bar' => 'world'];
             }
@@ -85,7 +85,7 @@ class SupportJsTest extends TestCase
                 return json_encode(['foo' => 'hello', 'bar' => 'world'], $options);
             }
 
-            public function jsonSerialize()
+            public function jsonSerialize(): array
             {
                 return ['foo' => 'not hello', 'bar' => 'not world'];
             }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fix for https://github.com/laravel/framework/issues/40554 . By introducing a separate global handler we can avoid keeping every HandleExceptions with its own Application instance in memory and it can be cleaned up after each test instead of after all tests are done.

Couldn't think of any other way to deal with it without introducing a separate class.