### PR TITLE
[9.x] JSON Session Option

### DIFF
--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -22,13 +22,14 @@ class EncryptedStore extends Store
      * @param  \SessionHandlerInterface  $handler
      * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
      * @param  string|null  $id
+     * @param  string  $serialization
      * @return void
      */
-    public function __construct($name, SessionHandlerInterface $handler, EncrypterContract $encrypter, $id = null)
+    public function __construct($name, SessionHandlerInterface $handler, EncrypterContract $encrypter, $id = null, $serialization = 'php')
     {
         $this->encrypter = $encrypter;
 
-        parent::__construct($name, $handler, $id);
+        parent::__construct($name, $handler, $id, $serialization);
     }
 
     /**
@@ -42,7 +43,7 @@ class EncryptedStore extends Store
         try {
             return $this->encrypter->decrypt($data);
         } catch (DecryptException $e) {
-            return serialize([]);
+            return $this->serialization === 'json' ? json_encode([]) : serialize([]);
         }
     }
 

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -186,7 +186,12 @@ class SessionManager extends Manager
     {
         return $this->config->get('session.encrypt')
                 ? $this->buildEncryptedSession($handler)
-                : new Store($this->config->get('session.cookie'), $handler);
+                : new Store(
+                    $this->config->get('session.cookie'),
+                    $handler,
+                    $id = null,
+                    $this->config->get('session.serialization', 'php')
+                );
     }
 
     /**
@@ -198,7 +203,11 @@ class SessionManager extends Manager
     protected function buildEncryptedSession($handler)
     {
         return new EncryptedStore(
-            $this->config->get('session.cookie'), $handler, $this->container['encrypter']
+            $this->config->get('session.cookie'),
+            $handler,
+            $this->container['encrypter'],
+            $id = null,
+            $this->config->get('session.serialization', 'php'),
         );
     }
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -40,6 +40,13 @@ class Store implements Session
     protected $handler;
 
     /**
+     * The session store's serialization strategy.
+     *
+     * @var string
+     */
+    protected $serialization = 'php';
+
+    /**
      * Session store started status.
      *
      * @var bool
@@ -52,13 +59,15 @@ class Store implements Session
      * @param  string  $name
      * @param  \SessionHandlerInterface  $handler
      * @param  string|null  $id
+     * @param  string  $serialization
      * @return void
      */
-    public function __construct($name, SessionHandlerInterface $handler, $id = null)
+    public function __construct($name, SessionHandlerInterface $handler, $id = null, $serialization = 'php')
     {
         $this->setId($id);
         $this->name = $name;
         $this->handler = $handler;
+        $this->serialization = $serialization;
     }
 
     /**
@@ -95,7 +104,11 @@ class Store implements Session
     protected function readFromHandler()
     {
         if ($data = $this->handler->read($this->getId())) {
-            $data = @unserialize($this->prepareForUnserialize($data));
+            if ($this->serialization === 'json') {
+                $data = json_decode($this->prepareForUnserialize($data), true);
+            } else {
+                $data = @unserialize($this->prepareForUnserialize($data));
+            }
 
             if ($data !== false && ! is_null($data) && is_array($data)) {
                 return $data;
@@ -126,7 +139,7 @@ class Store implements Session
         $this->ageFlashData();
 
         $this->handler->write($this->getId(), $this->prepareForStorage(
-            serialize($this->attributes)
+            $this->serialization === 'json' ? json_encode($this->attributes) : serialize($this->attributes)
         ));
 
         $this->started = false;


### PR DESCRIPTION
This pull requests allows developers to choose to serialize session data in storage using PHP or JSON. Over the years, several people have expressed concerns with deserializing sessions using PHP's `unserialize` function, as this could lead to security problems (including remote code execution) if the application's encryption key is leaked.

However, all known ways to exploit this require the attacker to know the application's encryption key, which if known, could already be used to craft authenticated cookies for the application, etc. Nevertheless, offering this an option to those who would prefer to use JSON to serialize sessions in storage.