### PR TITLE
[8.x] Add test to verify providing array query string can be retrieved via `$request->query()` 

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -675,11 +675,13 @@ class HttpRequestTest extends TestCase
         $all = $request->query(null);
         $this->assertSame('Taylor', $all['name']);
 
-        $request = Request::create('/', 'GET', ['user' => ['Taylor', 'Mohamed Said']]);
+        $request = Request::create('/', 'GET', ['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']]);
         $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
+        $this->assertSame(['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']], $request->query->all());
 
-        $request = Request::create('/?user[]=Taylor&user[]=Mohamed%20Said', 'GET', []);
+        $request = Request::create('/?hello=world&user[]=Taylor&user[]=Mohamed%20Said', 'GET', []);
         $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
+        $this->assertSame(['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']], $request->query->all());
     }
 
     public function testPostMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -674,6 +674,12 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Bob', $request->query('foo', 'Bob'));
         $all = $request->query(null);
         $this->assertSame('Taylor', $all['name']);
+
+        $request = Request::create('/', 'GET', ['user' => ['Taylor', 'Mohamed Said']]);
+        $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
+
+        $request = Request::create('/?user[]=Taylor&user[]=Mohamed%20Said', 'GET', []);
+        $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
     }
 
     public function testPostMethod()


### PR DESCRIPTION
Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>
