### PR TITLE
[9.x] Add failing tests `$request->query()` no longer can retrieve array query string

### DIFF
--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -677,11 +677,13 @@ class HttpRequestTest extends TestCase
         $all = $request->query(null);
         $this->assertSame('Taylor', $all['name']);
 
-        $request = Request::create('/', 'GET', ['user' => ['Taylor', 'Mohamed Said']]);
+        $request = Request::create('/', 'GET', ['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']]);
         $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
+        $this->assertSame(['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']], $request->query->all());
 
-        $request = Request::create('/?user[]=Taylor&user[]=Mohamed%20Said', 'GET', []);
+        $request = Request::create('/?hello=world&user[]=Taylor&user[]=Mohamed%20Said', 'GET', []);
         $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
+        $this->assertSame(['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']], $request->query->all());
     }
 
     public function testPostMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -676,6 +676,12 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Bob', $request->query('foo', 'Bob'));
         $all = $request->query(null);
         $this->assertSame('Taylor', $all['name']);
+
+        $request = Request::create('/', 'GET', ['user' => ['Taylor', 'Mohamed Said']]);
+        $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
+
+        $request = Request::create('/?user[]=Taylor&user[]=Mohamed%20Said', 'GET', []);
+        $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
     }
 
     public function testPostMethod()


### PR DESCRIPTION
Exact same code from #40598 for Laravel 9

```
1) Illuminate\Tests\Http\HttpRequestTest::testQueryMethod
Symfony\Component\HttpFoundation\Exception\BadRequestException: Input value "user" contains a non-scalar value.

/home/runner/work/framework/framework/vendor/symfony/http-foundation/InputBag.php:37
/home/runner/work/framework/framework/src/Illuminate/Http/Concerns/InteractsWithInput.php:510
/home/runner/work/framework/framework/src/Illuminate/Http/Concerns/InteractsWithInput.php:383
/home/runner/work/framework/framework/tests/Http/HttpRequestTest.php:681
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>
