### PR TITLE
[9.x] Handle unicode characters on TrimStrings middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -53,7 +53,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return is_string($value) ? trim($value, "  \t\n\r\0\x0B") : $value;
+        return is_string($value) ? preg_replace('~^\s+|\s+$~iu', '', $value) : $value;
     }
 
     /**

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -35,12 +35,20 @@ class TrimStringsTest extends TestCase
         $symfonyRequest = new SymfonyRequest([
             // Here has some NBSP, but it still display to space.
             'abc' => '   123    ',
+            'xyz' => 'だ',
+            'foo' => 'ム',
+            'bar' => '   だ    ',
+            'baz' => '   ム    ',
         ]);
         $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
             $this->assertSame('123', $request->get('abc'));
+            $this->assertSame('だ', $request->get('xyz'));
+            $this->assertSame('ム', $request->get('foo'));
+            $this->assertSame('だ', $request->get('bar'));
+            $this->assertSame('ム', $request->get('baz'));
         });
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

PR #38117 introduced the ability to other space unicode characters to the `TrimStrings` middleware.

As issue #40577 stated the current implementation conflicts with some other unicode characters which end with the same escape sequence as the NBSP character.

In particular these japanese characters:

- だ (unicode `E381A0`)
- ム (unicode `E383A0`)

The implementation from PR #38117 causes the `A0` sequence to be trimmed, which converts the sequence to an invalid one.

This PR:

- Changes the implementation to use `preg_replace` to trim the spaces using the proper modifiers
- Add additional test cases that failed with the previous implementation and passed with the proposed one


Closes #40577 