### PR TITLE
[7.x][6.x] Fix PHP requirements in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^7.2.5|<8.1",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",


### PR DESCRIPTION
Fixes #40601 

7.x is not included because it is already EOL, but will be added if necessary.