### PR TITLE
[9.x] Fix fetching array parameters from the InputBag on Symfony 6

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
 use SplFileInfo;
 use stdClass;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\VarDumper\VarDumper;
 
 trait InteractsWithInput
@@ -505,6 +506,10 @@ trait InteractsWithInput
     {
         if (is_null($key)) {
             return $this->$source->all();
+        }
+
+        if ($this->$source instanceof InputBag) {
+            return $this->$source->all()[$key] ?? $default;
         }
 
         return $this->$source->get($key, $default);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -676,6 +676,14 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Bob', $request->query('foo', 'Bob'));
         $all = $request->query(null);
         $this->assertSame('Taylor', $all['name']);
+
+        $request = Request::create('/', 'GET', ['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']]);
+        $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
+        $this->assertSame(['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']], $request->query->all());
+
+        $request = Request::create('/?hello=world&user[]=Taylor&user[]=Mohamed%20Said', 'GET', []);
+        $this->assertSame(['Taylor', 'Mohamed Said'], $request->query('user'));
+        $this->assertSame(['hello' => 'world', 'user' => ['Taylor', 'Mohamed Said']], $request->query->all());
     }
 
     public function testPostMethod()


### PR DESCRIPTION
Due to the following deprecation https://github.com/symfony/symfony/blob/v5.4.2/src/Symfony/Component/HttpFoundation/InputBag.php#L39 (which was added via https://github.com/symfony/symfony/pull/34363) which became an exception on Symfony 6, fetching array params from the request now fails on Laravel 9. This PR fixes that.
