### PR TITLE
[8.x] Bump voku/portable-ascii to v1.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/var-dumper": "^5.4",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
         "vlucas/phpdotenv": "^5.4.1",
-        "voku/portable-ascii": "^1.4.8 <1.6.0"
+        "voku/portable-ascii": "^1.6.1"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -22,7 +22,7 @@
         "illuminate/contracts": "^8.0",
         "illuminate/macroable": "^8.0",
         "nesbot/carbon": "^2.53.1",
-        "voku/portable-ascii": "^1.4.8"
+        "voku/portable-ascii": "^1.6.1"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"


### PR DESCRIPTION
Bumps `voku/portable-ascii` to v1.6.1 that reverts the breaking changes from 2.0. I'll send in a PR to 9.x after this is merged into 9.x to update the package to 2.0