### PR TITLE
[8.x] Document `excludeUnvalidatedArrayKeys()` on `Validator` facade

### DIFF
--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Contracts\Validation\Validator make(array $data, array $rules, array $messages = [], array $customAttributes = [])
+ * @method static void excludeUnvalidatedArrayKeys()
  * @method static void extend(string $rule, \Closure|string $extension, string $message = null)
  * @method static void extendImplicit(string $rule, \Closure|string $extension, string $message = null)
  * @method static void replacer(string $rule, \Closure|string $replacer)


### PR DESCRIPTION
`excludeUnvalidatedArrayKeys()` was added in #37943, but the facade doesn't document this method. I've added this method to the facade's PHPDoc to help with IDE autocompletion and static analysis.
