### PR TITLE
Add hasHeaders() method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -35,6 +35,25 @@ trait InteractsWithInput
     }
 
     /**
+     * Determine if a headers is set on the request.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function hasHeaders($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $key) {
+            if (!$this->hasHeader($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Retrieve a header from the request.
      *
      * @param  string|null  $key


### PR DESCRIPTION
## Description
You may want to check request has multiple headers, but there is no method to use.
Here i've added new method for that.

## Files changed
`\Illuminate\Http\Concerns\InteractsWithInput.php:37`
## More
Wrong commit message "add hasHeaders() Method*"