### PR TITLE
[8.x] Fix autoresolving model name from factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -675,7 +675,9 @@ abstract class Factory
     public function modelName()
     {
         $resolver = static::$modelNameResolver ?: function (self $factory) {
-            $factoryBasename = Str::replaceLast('Factory', '', class_basename($factory));
+            $factoryBasename = Str::replaceLast(
+                'Factory', '', Str::replaceFirst(static::$namespace, '', get_class($factory))
+            );
 
             $appNamespace = static::appNamespace();
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -675,14 +675,16 @@ abstract class Factory
     public function modelName()
     {
         $resolver = static::$modelNameResolver ?: function (self $factory) {
-            $factoryBasename = Str::replaceLast(
+            $namespacedFactoryBasename = Str::replaceLast(
                 'Factory', '', Str::replaceFirst(static::$namespace, '', get_class($factory))
             );
 
+            $factoryBasename = Str::replaceLast('Factory', '', class_basename($factory));
+
             $appNamespace = static::appNamespace();
 
-            return class_exists($appNamespace.'Models\\'.$factoryBasename)
-                        ? $appNamespace.'Models\\'.$factoryBasename
+            return class_exists($appNamespace.'Models\\'.$namespacedFactoryBasename)
+                        ? $appNamespace.'Models\\'.$namespacedFactoryBasename
                         : $appNamespace.$factoryBasename;
         };
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -427,6 +428,18 @@ class DatabaseEloquentFactoryTest extends TestCase
         foreach ($resolves as $model => $factory) {
             $this->assertEquals($factory, Factory::resolveFactoryName($model));
         }
+    }
+
+    public function test_resolve_nested_model_name_from_factory()
+    {
+        Container::getInstance()->instance(Application::class, $app = Mockery::mock(Application::class));
+        $app->shouldReceive('getNamespace')->andReturn('Illuminate\\Tests\\Database\\Fixtures\\');
+
+        Factory::useNamespace('Illuminate\\Tests\\Database\\Fixtures\\Factories\\');
+
+        $factory = Price::factory();
+
+        $this->assertSame(Price::class, $factory->modelName());
     }
 
     public function test_resolve_non_app_nested_model_factories()

--- a/tests/Database/Fixtures/Factories/Money/PriceFactory.php
+++ b/tests/Database/Fixtures/Factories/Money/PriceFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Factories\Money;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PriceFactory extends Factory
+{
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+        ];
+    }
+}

--- a/tests/Database/Fixtures/Models/Money/Price.php
+++ b/tests/Database/Fixtures/Models/Money/Price.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Models\Money;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Database\Fixtures\Factories\Money\PriceFactory;
+
+class Price extends Model
+{
+    use HasFactory;
+
+    protected $table = 'prices';
+
+    public static function factory()
+    {
+        return PriceFactory::new();
+    }
+}


### PR DESCRIPTION
At the moment, a factory can't auto-resolve namespaced models which are nested inside the models directory and have coresponding Factory classes at the same location. You can reproduce this with the issue at https://github.com/laravel/framework/issues/40614

By changing the code here to take into account the nested namespace for factory classes, we can auto resort the model name without having to define the `$model` class on the factory.

One thing I'm not sure off is that if we should just fallback on the model classname without the namespace for the last part here (as it was before):

```
: $appNamespace.$factoryBasename;
```

I can adjust the code for that if you like.

Fixes https://github.com/laravel/framework/issues/40614