### PR TITLE
[8.x] Adds `Str::flushCache`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -987,7 +987,7 @@ class Str
     }
 
     /**
-     * Remove all items from the cache.
+     * Remove all strings from the casing caches.
      *
      * @return void
      */

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -985,4 +985,16 @@ class Str
     {
         static::$uuidFactory = null;
     }
+
+    /**
+     * Remove all items from the cache.
+     *
+     * @return void
+     */
+    public static function flushCache()
+    {
+        static::$snakeCache = [];
+        static::$camelCache = [];
+        static::$studlyCache = [];
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
+use ReflectionClass;
 
 class SupportStrTest extends TestCase
 {
@@ -258,6 +259,22 @@ class SupportStrTest extends TestCase
         $this->assertSame('/test/string', Str::start('test/string', '/'));
         $this->assertSame('/test/string', Str::start('/test/string', '/'));
         $this->assertSame('/test/string', Str::start('//test/string', '/'));
+    }
+
+    public function testFlushCache()
+    {
+        $reflection = new ReflectionClass(Str::class);
+        $property = $reflection->getProperty('snakeCache');
+        $property->setAccessible(true);
+
+        Str::flushCache();
+        $this->assertEmpty($property->getValue());
+
+        Str::snake('Taylor Otwell');
+        $this->assertNotEmpty($property->getValue());
+
+        Str::flushCache();
+        $this->assertEmpty($property->getValue());
     }
 
     public function testFinish()


### PR DESCRIPTION
This pull request adds `Str::flushCache` so we can flush the `Str` cache between octane requests.