### PR TITLE
[9.x] Allow key as second argument for Collection#filter

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -363,7 +363,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Run a filter over each of the items.
      *
-     * @param (callable(TValue): bool)|null  $callback
+     * @param (callable(TValue, TKey): bool)|null  $callback
      * @return static
      */
     public function filter(callable $callback = null)


### PR DESCRIPTION
See #40621 

Did not realise that a 9.x branch was created now, my bad!