### PR TITLE
[8.x] Add ability to generate URL's with query strings using `url()->query()`

### DIFF
--- a/src/Illuminate/Routing/GeneratesQueryStrings.php
+++ b/src/Illuminate/Routing/GeneratesQueryStrings.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Support\Arr;
+
+trait GeneratesQueryStrings
+{
+    /**
+     * Generate a query string with the given parameters.
+     *
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function makeQueryString(array $parameters)
+    {
+        if (count($parameters) === 0) {
+            return '';
+        }
+
+        $query = Arr::query(
+            $keyed = $this->getStringParameters($parameters)
+        );
+
+        // If there happens to be more parameters remaining, we will fetch the numeric
+        // parameters that are in the array and add them to the query string or we
+        // will make the initial query string if it wasn't started with strings.
+        if (count($keyed) < count($parameters)) {
+            $query .= '&'.implode(
+                '&', $this->getNumericParameters($parameters)
+            );
+        }
+
+        $query = trim($query, '&');
+
+        return $query === '' ? '' : "?{$query}";
+    }
+
+    /**
+     * Get the string parameters from a given list.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function getStringParameters(array $parameters)
+    {
+        return array_filter($parameters, 'is_string', ARRAY_FILTER_USE_KEY);
+    }
+
+    /**
+     * Get the numeric parameters from a given list.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function getNumericParameters(array $parameters)
+    {
+        return array_filter($parameters, 'is_numeric', ARRAY_FILTER_USE_KEY);
+    }
+}

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Str;
 
 class RouteUrlGenerator
 {
+    use GeneratesQueryStrings;
+
     /**
      * The URL generator instance.
      *
@@ -259,51 +261,7 @@ class RouteUrlGenerator
      */
     protected function getRouteQueryString(array $parameters)
     {
-        // First we will get all of the string parameters that are remaining after we
-        // have replaced the route wildcards. We'll then build a query string from
-        // these string parameters then use it as a starting point for the rest.
-        if (count($parameters) === 0) {
-            return '';
-        }
-
-        $query = Arr::query(
-            $keyed = $this->getStringParameters($parameters)
-        );
-
-        // Lastly, if there are still parameters remaining, we will fetch the numeric
-        // parameters that are in the array and add them to the query string or we
-        // will make the initial query string if it wasn't started with strings.
-        if (count($keyed) < count($parameters)) {
-            $query .= '&'.implode(
-                '&', $this->getNumericParameters($parameters)
-            );
-        }
-
-        $query = trim($query, '&');
-
-        return $query === '' ? '' : "?{$query}";
-    }
-
-    /**
-     * Get the string parameters from a given list.
-     *
-     * @param  array  $parameters
-     * @return array
-     */
-    protected function getStringParameters(array $parameters)
-    {
-        return array_filter($parameters, 'is_string', ARRAY_FILTER_USE_KEY);
-    }
-
-    /**
-     * Get the numeric parameters from a given list.
-     *
-     * @param  array  $parameters
-     * @return array
-     */
-    protected function getNumericParameters(array $parameters)
-    {
-        return array_filter($parameters, 'is_numeric', ARRAY_FILTER_USE_KEY);
+        return $this->makeQueryString($parameters);
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class UrlGenerator implements UrlGeneratorContract
 {
-    use InteractsWithTime, Macroable;
+    use InteractsWithTime, GeneratesQueryStrings, Macroable;
 
     /**
      * The route collection.
@@ -209,6 +209,26 @@ class UrlGenerator implements UrlGeneratorContract
         return $this->format(
             $root, '/'.trim($path.'/'.$tail, '/')
         ).$query;
+    }
+
+    /**
+     * Generate an absolute URL with query parameters.
+     *
+     * @param  string  $path
+     * @param  array  $parameters
+     * @param  array  $extra
+     * @param  bool|null  $secure
+     * @return string
+     */
+    public function query($path, $parameters = [], $extra = [], $secure = null)
+    {
+        [$path, $query] = $this->extractQueryString($path);
+
+        parse_str(Str::remove('?', $query), $output);
+
+        $query = $this->makeQueryString(array_merge($output, $parameters));
+
+        return $this->to($path.$query, $extra, $secure);
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -216,7 +216,7 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @param  string  $path
      * @param  array  $parameters
-     * @param  array  $extra
+     * @param  array|bool  $extra
      * @param  bool|null  $secure
      * @return string
      */
@@ -228,7 +228,9 @@ class UrlGenerator implements UrlGeneratorContract
 
         $query = $this->makeQueryString(array_merge($output, $parameters));
 
-        return $this->to($path.$query, $extra, $secure);
+        $args = is_bool($extra) ? [[], $extra] : [$extra, $secure];
+
+        return $this->to($path.$query, ...$args);
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -58,6 +58,8 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         $this->assertSame('http://www.foo.com/foo/bar', $url->query('foo/bar'));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->query('foo/bar', [], false));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->query('foo/bar', [], true));
         $this->assertSame('https://www.foo.com/foo/bar', $url->query('foo/bar', [], [], true));
         $this->assertSame('https://www.foo.com/foo/bar/baz/boom', $url->query('foo/bar', [], ['baz', 'boom'], true));
         $this->assertSame('https://www.foo.com/foo/bar/baz?foo=bar&baz=boom', $url->query('foo/bar?foo=bar', ['baz' => 'boom'], ['baz'], true));

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -50,6 +50,20 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
     }
 
+    public function testBasicQueryGeneration()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $this->assertSame('http://www.foo.com/foo/bar', $url->query('foo/bar'));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->query('foo/bar', [], [], true));
+        $this->assertSame('https://www.foo.com/foo/bar/baz/boom', $url->query('foo/bar', [], ['baz', 'boom'], true));
+        $this->assertSame('https://www.foo.com/foo/bar/baz?foo=bar&baz=boom', $url->query('foo/bar?foo=bar', ['baz' => 'boom'], ['baz'], true));
+        $this->assertSame('https://www.foo.com/foo/bar/baz?foo=bar&baz=boom&zal', $url->query('foo/bar?foo=bar', ['baz' => 'boom', 'zal'], ['baz'], true));
+    }
+
     public function testBasicGenerationWithHostFormatting()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
## Description

This PR adds the ability to generate absolute URL's with query strings using `url()->query()`.

## Purpose

Currently, there is no built-in way of generating an absolute URL with query string parameters. You will have to assemble it yourself. It is currently possible using the `route()` and `action()` helpers, but not with `url()`.

**Before**:
```php
$query = Arr::query(['brand' => 'Samsung', 'model' => 'Galaxy']);

// http://localhost/products?brand=Samsung&model=Galaxy
url()->to('/products?'.$query);
```

**After**:

```php
// http://localhost/products?brand=Samsung&model=Galaxy
url()->query('/products', ['brand' => 'Samsung', 'model' => 'Galaxy']));
```

---

**Extra Parameters**:

You can also add extra parameters as you would with `url()->to()`:

```php
// http://www.localhost.com/products/samsung?model=Galaxy
url()->query('/products', ['model' => 'Galaxy'], ['samsung']);
```

**Secure URL**:

As with `url()->to()`, we may also provide a `$secure` parameter to generate an HTTPS URL:

```php
// https://www.localhost.com/products/samsung?model=Galaxy
url()->query('/products', ['model' => 'Galaxy'], ['samsung'], $secure = true);
```

**Developer Shortcut**:

We may also provide a boolean into the `$extra` parameter argument as a shortcut to generate a secure URL:

```php
// https://www.localhost.com/products?model=Galaxy
url()->query('/products', ['model' => 'Galaxy'], $secure = true)
``` 

---

Thanks for your time! ❤️  Let me know your thoughts 🙏 