### PR TITLE
[8.x] Make `Illuminate\Mail\Mailable` macroable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1028,7 +1028,7 @@ class Mailable implements MailableContract, Renderable
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
         }
-        
+
         if (Str::startsWith($method, 'with')) {
             return $this->with(Str::camel(substr($method, 4)), $parameters[0]);
         }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -15,13 +15,16 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Localizable;
+use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 use ReflectionClass;
 use ReflectionProperty;
 
 class Mailable implements MailableContract, Renderable
 {
-    use Conditionable, ForwardsCalls, Localizable;
+    use Conditionable, ForwardsCalls, Localizable, Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The locale of the message.
@@ -1022,6 +1025,10 @@ class Mailable implements MailableContract, Renderable
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+        
         if (Str::startsWith($method, 'with')) {
             return $this->with(Str::camel(substr($method, 4)), $parameters[0]);
         }


### PR DESCRIPTION
This PR makes the \Illuminate\Mail\Mailable class macroable. A simple use-case is abstracting the options array when having multiple Mailables that you want to attach raw pdf data to:

```php
// Current:

Mail::send((new MyMail())->attachData($pdfData, 'filename.pdf', [
    'mime' => 'application/pdf',
]));

// Proposal:

Mailable::macro('attachPdfData', function ($data, $name) {
    return $this->attachData($data, $name, [
        'mime' => 'application/pdf',
    ]);
});

Mail::send((new MyMail())->attachPdfData($pdfData, 'filename.pdf'));
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
