### PR TITLE
[9.x] Fix middleware not running when HTTP client is faked

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -898,11 +898,12 @@ class PendingRequest
         return tap($handlerStack, function ($stack) {
             $stack->push($this->buildBeforeSendingHandler());
             $stack->push($this->buildRecorderHandler());
-            $stack->push($this->buildStubHandler());
 
             $this->middleware->each(function ($middleware) use ($stack) {
                 $stack->push($middleware);
             });
+
+            $stack->push($this->buildStubHandler());
         });
     }
 


### PR DESCRIPTION
HTTP middleware does not run when the HTTP client is faked. This is because the `stubHandler` short-circuits the middleware onion.

After figuring out how to fix this problem, I found [this previous PR](https://github.com/laravel/framework/pull/34666) with the exact same solution. Could have saved myself some work if I found it earlier. I don't agree with the reasoning behind why it was rejected, I hope my example will make you reconsider.

In my case, I'm using [Guzzle's standard `History` middleware](https://docs.guzzlephp.org/en/stable/testing.html#history-middleware). This works especially well because in combination with the `Http::retry()` method. Each HTTP call can contain one or multiple request/response pairs (depending on if it had to retry). I use the history to store the HTTP calls on disk. I then display them in the front-end. Very useful for debugging, especially when working with troublesome external APIs.

The issue is that all of this works great in production. But doesn't work at all in my Dusk or PHPUnit tests. The middleware gets skipped, the history is always empty. This makes it very difficult to test my code in a meaningful way.

The previous PR attempt was rejected with the reason that middleware should be tested separately. I don't agree with this. The only thing that the HTTP client should fake is the actual response from the remote server. How middleware transforms or records this response should be identical in both production and testing.

I've targeted 9.x because this PR will break some tests. Anyone that is using work-arounds to imitate middleware will have to remove the work-arounds.

---

Fixes https://github.com/laravel/framework/issues/34505