### PR TITLE
[9.x] Add support for nested having in queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1549,6 +1549,33 @@ class Builder
         return $this;
     }
 
+    public function havingNested(Closure $callback, $boolean = 'and')
+    {
+        call_user_func($callback, $query = $this->forNestedWhere());
+
+        return $this->addNestedHavingQuery($query, $boolean);
+    }
+
+    /**
+     * Add another query builder as a nested where to the query builder.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function addNestedHavingQuery($query, $boolean = 'and')
+    {
+        if (count($query->havings)) {
+            $type = 'Nested';
+
+            $this->havings[] = compact('type', 'query', 'boolean');
+
+            $this->addBinding($query->getRawBindings()['having'], 'having');
+        }
+
+        return $this;
+    }
+
     /**
      * Add a full sub-select to the query.
      *
@@ -1923,7 +1950,7 @@ class Builder
     /**
      * Add a "having" clause to the query.
      *
-     * @param  string  $column
+     * @param  \Closure|string  $column
      * @param  string|null  $operator
      * @param  string|null  $value
      * @param  string  $boolean
@@ -1939,6 +1966,13 @@ class Builder
         [$value, $operator] = $this->prepareValueAndOperator(
             $value, $operator, func_num_args() === 2
         );
+
+        // If the columns is actually a Closure instance, we will assume the developer
+        // wants to begin a nested having statement which is wrapped in parenthesis.
+        // We'll add that Closure to the query then return back out immediately.
+        if ($column instanceof Closure && is_null($operator)) {
+            return $this->havingNested($column, $boolean);
+        }
 
         // If the given operator is not found in the list of valid operators we will
         // assume that the developer is just short-cutting the '=' operators and
@@ -1963,7 +1997,7 @@ class Builder
     /**
      * Add an "or having" clause to the query.
      *
-     * @param  string  $column
+     * @param  \Closure|string  $column
      * @param  string|null  $operator
      * @param  string|null  $value
      * @return $this


### PR DESCRIPTION
## Description

This PR implements nested having queries for the query builder, in the same way that wheres work. This means you can now group together "having" queries like the example below. Currently you are forced to make the query using `havingRaw` which could potentially introduce the possibility for SQL injections.

This shouldn't have an impact on existing applications as closure's where never supported in the first place.

## Example
```php
DB::table('product_data')
    ->having(function (Builder $query) {
        $query->having('column_one', 'foo')
            ->having('column_two', 'bar');
    })
    ->orHaving('column_three', 'biz')
    ->get();
```

Translates to: `select * from "product_data" having ("column_one" = "foo" and "column_two" = "bar") or "column_three" = "biz"`

This follows the current way of creating nested wheres.
```php
DB::table('product_data')
    ->where(function (Builder $query) {
        $query->where('column_one', 'foo')
            ->where('column_two', 'bar');
    })
    ->orWhere('column_three', 'biz')
    ->get();
```