### PR TITLE
[8.x] Fix error handling

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
@@ -29,6 +29,7 @@ trait InteractsWithDeprecationHandling
                 $this->beforeApplicationDestroyed(function () use ($previousHandler) {
                     if (null !== $previousHandler) {
                         restore_error_handler();
+                        $this->originalDeprecationHandler = null;
                     }
                 });
             }
@@ -55,6 +56,7 @@ trait InteractsWithDeprecationHandling
                 $this->beforeApplicationDestroyed(function () {
                     if (null !== $this->originalDeprecationHandler) {
                         restore_error_handler();
+                        $this->originalDeprecationHandler = null;
                     }
                 });
             }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -88,6 +88,7 @@ abstract class TestCase extends BaseTestCase
             ParallelTesting::callSetUpTestCaseCallbacks($this);
         }
 
+        $this->deprecationHandling();
         $this->setUpTraits();
 
         foreach ($this->afterApplicationCreatedCallbacks as $callback) {
@@ -97,6 +98,16 @@ abstract class TestCase extends BaseTestCase
         Model::setEventDispatcher($this->app['events']);
 
         $this->setUpHasRun = true;
+    }
+
+    /**
+     * Hook to setup whether or not to handle deprecations.
+     *
+     * @return void
+     */
+    protected function deprecationHandling(): void
+    {
+        $this->withoutDeprecationHandling();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -159,6 +159,8 @@ abstract class TestCase extends BaseTestCase
 
             ParallelTesting::callTearDownTestCaseCallbacks($this);
 
+            $this->app->terminate();
+
             $this->app->flush();
 
             $this->app = null;


### PR DESCRIPTION
Fixes problems described in https://github.com/laravel/framework/pull/40592#issuecomment-1021554516

TLDR; Laravel never cleaned up its handlers, resulting in the PHPUnit error handler never firing for unit tests that came after Laravel's integration tests, plus since the handlers were never cleaned it resulted in a memory leak.

In order to avoid having to call `$this->withoutDeprecationHandling()` in every Laravel integration test I've added that call in the `protected function deprecationHandling()` hook method which is now called from the base test class `setUp` method (users can override it in their base class if they want to change the behavior).

The changes made in the base test class here should also be ported over to Testbench, after which I can fix all the deprecation exceptions that will pop up on CI, before this PR can be merged.

Also note that this PR makes use of a terminating callback to restore the handlers, which also meant having to manually call `$this->app->terminate()` in the test teardown (it's weird that this was not already called as `terminate` is always called in a real HTTP request).

Fixes https://github.com/laravel/framework/issues/40554