### PR TITLE
[9.x] Add terminating method to Application interface

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -215,6 +215,14 @@ interface Application extends Container
     public function shouldSkipMiddleware();
 
     /**
+     * Register a terminating callback with the application.
+     *
+     * @param  callable|string  $callback
+     * @return \Illuminate\Contracts\Foundation\Application
+     */
+    public function terminating($callback);
+
+    /**
      * Terminate the application.
      *
      * @return void


### PR DESCRIPTION
While working on https://github.com/laravel/framework/pull/40639 I've spotted that while the `terminate` method is part of the interface the `terminating` method is not so there's no way to add any terminating callbacks from the interface perspective. This PR adds that method to the interface.

Technically it's a breaking change (so that's why I've sent it to 9.x branch) but I doubt that anyone implements this huge interface and does not have the `terminating` method too.