### PR TITLE
[9.x] Fix session decorator typehint

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -516,7 +516,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Get the session associated with the request.
      *
-     * @return \Illuminate\Session\Store
+     * @return \Illuminate\Contracts\Session\Session
      *
      * @throws \RuntimeException
      */

--- a/src/Illuminate/Session/SymfonySessionDecorator.php
+++ b/src/Illuminate/Session/SymfonySessionDecorator.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session;
 
 use BadMethodCallException;
+use Illuminate\Contracts\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
@@ -19,10 +20,10 @@ class SymfonySessionDecorator implements SessionInterface
     /**
      * Create a new session decorator.
      *
-     * @param  \Illuminate\Session\Store  $store
+     * @param  \Illuminate\Contracts\Session\Session  $store
      * @return void
      */
-    public function __construct(Store $store)
+    public function __construct(Session $store)
     {
         $this->store = $store;
     }


### PR DESCRIPTION
`\Illuminate\Http\Request::setLaravelSession` has the session interface typehint for the session param which in turn means that the `\Illuminate\Http\Request::session`docblock was wrong as the concrete implementation class was in it instead of the interface which also means that the session decorator constructor typehint was wrong and had to be changed so this PR fixes that.
