### PR TITLE
[8.x] Get item of array as int and float.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -744,4 +744,32 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Returns the item value converted to integer.
+     *
+     * @param      $array
+     * @param      $key
+     * @param null $default
+     *
+     * @return int
+     */
+    public static function getInt($array, $key, $default = null): int
+    {
+        return (int) self::get($array, $key, $default);
+    }
+
+    /**
+     * Returns the item value converted to float.
+     *
+     * @param      $array
+     * @param      $key
+     * @param null $default
+     *
+     * @return float
+     */
+    public static function getFloat($array, $key, $default = null): float
+    {
+        return (float) self::get($array, $key, $default);
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -751,7 +751,6 @@ class Arr
      * @param      $array
      * @param      $key
      * @param null $default
-     *
      * @return int
      */
     public static function getInt($array, $key, $default = null): int
@@ -765,7 +764,6 @@ class Arr
      * @param      $array
      * @param      $key
      * @param null $default
-     *
      * @return float
      */
     public static function getFloat($array, $key, $default = null): float

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -748,9 +748,9 @@ class Arr
     /**
      * Returns the item value converted to integer.
      *
-     * @param      $array
-     * @param      $key
-     * @param null $default
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  mixed  $default
      * @return int
      */
     public static function getInt($array, $key, $default = null): int
@@ -761,9 +761,9 @@ class Arr
     /**
      * Returns the item value converted to float.
      *
-     * @param      $array
-     * @param      $key
-     * @param null $default
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  mixed  $default
      * @return float
      */
     public static function getFloat($array, $key, $default = null): float


### PR DESCRIPTION
Often in projects I see: `(int) Arr::get($item, 'brand.id');` or `(float) Arr::get($item, 'discountTotal')` I suggest doing this instead `Arr::getInt($item, 'brand.id')` or `Arr::getFloat($item, 'discountTotal')`
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
