### PR TITLE
[8.x] Fix Not override actionList

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -102,7 +102,11 @@ class RouteCollection extends AbstractRouteCollection
      */
     protected function addToActionList($action, $route)
     {
-        $this->actionList[trim($action['controller'], '\\')] = $route;
+        $key = trim($action['controller'], '\\');
+
+        if (! isset($this->actionList[$key])) {
+            $this->actionList[$key] = $route;
+        }
     }
 
     /**

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -539,6 +539,26 @@ class CompiledRouteCollectionTest extends TestCase
         ], $this->collection()->getRoutesByMethod());
     }
 
+    public function testRouteCollectionDuplicateControllerAction()
+    {
+        $routeA = $this->newRoute('GET', 'foo', [
+            'uses' => 'View@view',
+            'as' => 'routeA',
+        ]);
+
+        $routeB = $this->newRoute('GET', 'foo.csv', [
+            'uses' => 'View@view',
+            'as' => 'routeB',
+        ]);
+
+        $this->routeCollection->add($routeA);
+        $this->routeCollection->add($routeB);
+
+        $routes = $this->collection();
+
+        $this->assertEquals($routeA, $routes->getByAction('View@view'));
+    }
+
     /**
      * Create a new Route object.
      *

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -281,4 +281,15 @@ class RouteCollectionTest extends TestCase
         );
         $this->routeCollection->match($request);
     }
+
+    public function testRouteCollectionDuplicateControllerAction()
+    {
+        $routeA = new Route('GET', 'foo', ['controller' => 'View@view', 'as' => 'routeA']);
+        $routeB = new Route('GET', 'foo.csv', ['controller' => 'View@view', 'as' => 'routeB']);
+
+        $this->routeCollection->add($routeA);
+        $this->routeCollection->add($routeB);
+
+        $this->assertEquals($routeA, $this->routeCollection->getByAction('View@view'));
+    }
 }


### PR DESCRIPTION
If you define the same action for multiple routes, I think the route you created earlier will take precedence.
The reality is different: the non-cached RouteCollection overwrites the ActionList key, giving priority to routes added later.
This fix corrects the differences with the CompiledRouteCollection.