### PR TITLE
[9.x] Support AWS SES with IAM Assume Role

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,6 +143,9 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
+        env:
+          AWS_ACCESS_KEY_ID: random_key
+          AWS_SECRET_ACCESS_KEY: random_secret
 
       - name: Store artifacts
         uses: actions/upload-artifact@v2

--- a/composer.json
+++ b/composer.json
@@ -92,8 +92,8 @@
         "phpstan/phpstan": "^1.0",
         "predis/predis": "^1.1.9",
         "phpunit/phpunit": "^9.5.8",
-        "symfony/cache": "^6.0",
-        "symfony/amazon-mailer": "^6.0"
+        "symfony/amazon-mailer": "^6.0",
+        "symfony/cache": "^6.0"
     },
     "provide": {
         "psr/container-implementation": "1.1|2.0",

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,8 @@
         "phpstan/phpstan": "^1.0",
         "predis/predis": "^1.1.9",
         "phpunit/phpunit": "^9.5.8",
-        "symfony/cache": "^6.0"
+        "symfony/cache": "^6.0",
+        "symfony/amazon-mailer": "^6.0"
     },
     "provide": {
         "psr/container-implementation": "1.1|2.0",

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -243,8 +243,8 @@ class MailManager implements FactoryContract
         return $factory->create(new Dsn(
             'ses+api',
             'default',
-            $config['key'],
-            $config['secret'],
+            $config['key'] ?? null,
+            $config['secret'] ?? null,
             $config['port'] ?? null,
             $config
         ));

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -25,6 +25,6 @@ class MailSesTransportTest extends TestCase
 
         $transport = $manager->createSymfonyTransport(['transport' => 'ses']);
 
-        $this->assertSame('ses+api://@us-east-1', $transport->__toString());
+        $this->assertSame('ses+api://random_key@us-east-1', $transport->__toString());
     }
 }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -16,8 +16,6 @@ class MailSesTransportTest extends TestCase
         $container->singleton('config', function () {
             return new Repository([
                 'services.ses' => [
-                    'key' => 'foo',
-                    'secret' => 'bar',
                     'region' => 'us-east-1',
                 ],
             ]);
@@ -27,6 +25,6 @@ class MailSesTransportTest extends TestCase
 
         $transport = $manager->createSymfonyTransport(['transport' => 'ses']);
 
-        $this->assertSame('ses+api://foo@us-east-1', $transport->__toString());
+        $this->assertSame('ses+api://@us-east-1', $transport->__toString());
     }
 }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Mail\MailManager;
+use PHPUnit\Framework\TestCase;
+
+class MailSesTransportTest extends TestCase
+{
+    public function testGetTransport()
+    {
+        $container = new Container;
+
+        $container->singleton('config', function () {
+            return new Repository([
+                'services.ses' => [
+                    'key' => 'foo',
+                    'secret' => 'bar',
+                    'region' => 'us-east-1',
+                ],
+            ]);
+        });
+
+        $manager = new MailManager($container);
+
+        $transport = $manager->createSymfonyTransport(['transport' => 'ses']);
+
+        $this->assertSame('ses+api://foo@us-east-1', $transport->__toString());
+    }
+}


### PR DESCRIPTION
On PR https://github.com/laravel/framework/pull/38481, the file https://github.com/laravel/framework/blob/3234a8dfecbb12140e1ce980e415fcd0363f320a/tests/Mail/MailSesTransportTest.php was removed and with it 3 features were lost:

- Ability to let SES Assume Role through AWS SDK
- Ability to configure SES ConfigurationSet
- Ability to define Email tags

This PR addresses point 1. Upon closer look at item 2), it looks quite complex to get that functionality back because it must be configured at Mail Sending time (see https://github.com/symfony/symfony/pull/37897) and during the Mailable build we would end up needing some sort of `if (... instanceof Ses)`.

Item 3) seem to not even be supported by Symfony and is not clearly documented by AsyncAws (see https://async-aws.com/clients/ses.html).