### PR TITLE
[9.x] Use correct collection class

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -729,7 +729,7 @@ trait EnumeratesValues
      */
     public function pipeThrough($pipes)
     {
-        return static::make($pipes)->reduce(
+        return Collection::make($pipes)->reduce(
             function ($carry, $pipe) {
                 return $pipe($carry);
             },

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -724,14 +724,14 @@ trait EnumeratesValues
     /**
      * Pass the collection through a series of callable pipes and return the result.
      *
-     * @param  array<callable>  $pipes
+     * @param  array<callable>  $callbacks
      * @return mixed
      */
-    public function pipeThrough($pipes)
+    public function pipeThrough($callbacks)
     {
-        return Collection::make($pipes)->reduce(
-            function ($carry, $pipe) {
-                return $pipe($carry);
+        return Collection::make($callbacks)->reduce(
+            function ($carry, $callback) {
+                return $callback($carry);
             },
             $this,
         );


### PR DESCRIPTION
When using a collection as a utility within a method, we should always use the base collection.

For example in this case, it doesn't make sense to create an Eloquent Collection instance with a list of closures.