### PR TITLE
[9.x] Fixes `Foundation\Application` instance leaking between feature tests

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -26,7 +26,7 @@ class HandleExceptions
      *
      * @var \Illuminate\Contracts\Foundation\Application
      */
-    protected $app;
+    protected static $app;
 
     /**
      * Bootstrap the given application.
@@ -38,15 +38,15 @@ class HandleExceptions
     {
         self::$reservedMemory = str_repeat('x', 10240);
 
-        $this->app = $app;
+        static::$app = $app;
 
         error_reporting(-1);
 
-        set_error_handler([$this, 'handleError']);
+        set_error_handler($this->forwardsTo('handleError'));
 
-        set_exception_handler([$this, 'handleException']);
+        set_exception_handler($this->forwardsTo('handleException'));
 
-        register_shutdown_function([$this, 'handleShutdown']);
+        register_shutdown_function($this->forwardsTo('handleShutdown'));
 
         if (! $app->environment('testing')) {
             ini_set('display_errors', 'Off');
@@ -91,7 +91,7 @@ class HandleExceptions
         }
 
         try {
-            $logger = $this->app->make(LogManager::class);
+            $logger = static::$app->make(LogManager::class);
         } catch (Exception $e) {
             return;
         }
@@ -112,7 +112,7 @@ class HandleExceptions
      */
     protected function ensureDeprecationLoggerIsConfigured()
     {
-        with($this->app['config'], function ($config) {
+        with(static::$app['config'], function ($config) {
             if ($config->get('logging.channels.deprecations')) {
                 return;
             }
@@ -132,7 +132,7 @@ class HandleExceptions
      */
     protected function ensureNullLogDriverIsConfigured()
     {
-        with($this->app['config'], function ($config) {
+        with(static::$app['config'], function ($config) {
             if ($config->get('logging.channels.null')) {
                 return;
             }
@@ -164,7 +164,7 @@ class HandleExceptions
             //
         }
 
-        if ($this->app->runningInConsole()) {
+        if (static::$app->runningInConsole()) {
             $this->renderForConsole($e);
         } else {
             $this->renderHttpResponse($e);
@@ -190,7 +190,7 @@ class HandleExceptions
      */
     protected function renderHttpResponse(Throwable $e)
     {
-        $this->getExceptionHandler()->render($this->app['request'], $e)->send();
+        $this->getExceptionHandler()->render(static::$app['request'], $e)->send();
     }
 
     /**
@@ -215,6 +215,18 @@ class HandleExceptions
     protected function fatalErrorFromPhpError(array $error, $traceOffset = null)
     {
         return new FatalError($error['message'], 0, $error, $traceOffset);
+    }
+
+    /**
+     * Forward a method call to the given method, if an app instance exists.
+     *
+     * @return callable
+     */
+    protected function forwardsTo($method)
+    {
+        return fn (...$arguments) => static::$app
+            ? $this->{$method}(...$arguments)
+            : false;
     }
 
     /**
@@ -246,6 +258,16 @@ class HandleExceptions
      */
     protected function getExceptionHandler()
     {
-        return $this->app->make(ExceptionHandler::class);
+        return static::$app->make(ExceptionHandler::class);
+    }
+
+    /**
+     * Clears the app instance.
+     *
+     * @return void
+     */
+    public static function forgetApp()
+    {
+        static::$app = null;
     }
 }

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -218,7 +218,7 @@ class HandleExceptions
     }
 
     /**
-     * Forward a method call to the given method, if an app instance exists.
+     * Forward a method call to the given method if an application instance exists.
      *
      * @return callable
      */
@@ -262,7 +262,7 @@ class HandleExceptions
     }
 
     /**
-     * Clears the app instance.
+     * Clear the local application instance from memory.
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -201,9 +201,7 @@ abstract class TestCase extends BaseTestCase
         $this->beforeApplicationDestroyedCallbacks = [];
 
         Artisan::forgetBootstrappers();
-
         Queue::createPayloadUsing(null);
-
         HandleExceptions::forgetApp();
 
         if ($this->callbackException) {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
@@ -202,6 +203,8 @@ abstract class TestCase extends BaseTestCase
         Artisan::forgetBootstrappers();
 
         Queue::createPayloadUsing(null);
+
+        HandleExceptions::forgetApp();
 
         if ($this->callbackException) {
             throw $this->callbackException;


### PR DESCRIPTION
After hours of investigation, here is a pull request that fixes https://github.com/laravel/framework/pull/40592 yet takes a different approach from https://github.com/laravel/framework/pull/40639.

So, to be clear, as described here https://github.com/laravel/framework/pull/40639, this pull request attempts to fix a memory leak between Laravel feature tests.

```php
// 10,000 feature tests:
Time: 00:32.837, Memory: 114.00 MB // Before
Time: 00:32.797, Memory: 100.00 MB // After
```

This issue relies on the `Foundation\Application` instance that never gets clean from memory by PHP's garbage collector, as the `HandleExceptions::$app` property gets used by `set_error_handler`, `set_exception_handler`, and `register_shutdown_function` as described on `HandleExceptions::bootstrap`:

```php
// $this contains a $this->app property that points to the `Foundation\Application` instance
set_exception_handler([$this, 'handleException']); 
```

Now, the solution proposed in this pull request is simply about making the `HandleExceptions::$app` a static property in `HandleExceptions`. And this way, the previous `HandleExceptions::$app` gets overridden every new Laravel test and, of course, collected by PHP's garbage collector.

In addition, this pull request offers an  `HandleExceptions::forgetApp` that gets used by our own `TestCase` feature test class, to ensure the error handler set by the framework never gets used even if PHPUnit doesn't set its own error handler - it may happen on certain PHPUnit options.

With this solution, on the contrary of https://github.com/laravel/framework/pull/40639, we don't play with `set_error_handler`, `set_exception_handler`, `register_shutdown_function` handlers. These internal handlers are used by multiple vendors, and PHPUnit itself depends on the PHPUnit options. Making this pull request, a simpler and less error-prone solution compared with https://github.com/laravel/framework/pull/40639.

Going to debate this pull request with the original authors, and Taylor. If we agree on this solution, here are the remaining tasks:

- [x] Write tests
- [x] Pull request `HandleExceptions::forgetApp` to TestBench. (https://github.com/orchestral/testbench-core/pull/75)

Closes https://github.com/laravel/framework/pull/40639.