### PR TITLE
Prevent application Requests that extend FormRequest.php from unnecessarily defining authorize method unless overriding with some logic

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -271,4 +271,14 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         return $this;
     }
+
+    /**
+     *  Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Currently, app Requests extending FormRequest.php often define the `authorize` method even when it explicitly returns `true`;
```
public function authorize(): bool
{
   return true;
}
```
To avoid the compulsion of unnecessarily doing so, the `authorize` method can now be declare in the parent `FormRequest` class so that child classes can override it only when there's compelling logic to do so.
This change will not break things because the child classes are already overriding it