### PR TITLE
[8.x] Update docblocks of NullStore cache driver class

### DIFF
--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -12,7 +12,7 @@ class NullStore extends TaggableStore implements LockProvider
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @return mixed
+     * @return void
      */
     public function get($key)
     {
@@ -37,7 +37,7 @@ class NullStore extends TaggableStore implements LockProvider
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return int|bool
+     * @return bool
      */
     public function increment($key, $value = 1)
     {
@@ -49,7 +49,7 @@ class NullStore extends TaggableStore implements LockProvider
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return int|bool
+     * @return bool
      */
     public function decrement($key, $value = 1)
     {


### PR DESCRIPTION
It does not make sense for a class to just copy its interface doc-blocks. As I know according to L in SOLID it is perfectly fine for an implementation to return only a subset of possible return types declared by the interface.
