### PR TITLE
[8.x] Default schema value accepts Enum

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -297,6 +297,14 @@ abstract class Grammar extends BaseGrammar
             return $value;
         }
 
+        // Test if the object is "enum" - at this moment we have not found a method to
+        // check if a valid enum
+        if (is_object($value) &&
+            method_exists($value, '__toString') === false
+            && property_exists($value, 'value')) {
+            $value = $value->value;
+        }
+
         return is_bool($value)
                     ? "'".(int) $value."'"
                     : "'".(string) $value."'";

--- a/tests/Database/DatabaseAbstractSchemaGrammarDefaultValueTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarDefaultValueTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Carbon\Carbon;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Grammars\Grammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
+use Illuminate\Tests\Database\stubs\TestIntEnum;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class DatabaseAbstractSchemaGrammarDefaultValueTest extends TestCase
+{
+    /**
+     * @var Grammar
+     */
+    protected $grammar;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->grammar = new class extends Grammar {
+            public function testGetDefaultValue ($value) {
+                return $this->getDefaultValue($value);
+            }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testString(): void
+    {
+        $this->assertValue('laravel', 'laravel');
+    }
+
+    public function testExpression(): void
+    {
+        $result = $this->grammar->testGetDefaultValue(new Expression('it'));
+        $this->assertEquals("it", $result);
+    }
+
+    public function testObjectWithToString(): void
+    {
+        $value = new class extends stdClass {
+            public function __toString()
+            {
+                return 'just';
+            }
+        };
+
+        $this->assertValue('just', $value);
+    }
+
+    public function testEnumWithString(): void
+    {
+        $this->assertValue('test', TestEnum::test);
+    }
+
+    public function testEnumWithInt(): void
+    {
+        $this->assertValue('1', TestIntEnum::test);
+    }
+
+    public function testCarbon(): void
+    {
+        $this->assertValue('2022-01-27 00:00:00', Carbon::create(2022, 1,27));
+    }
+
+    public function testObjectWithoutToStringMethodFails(): void
+    {
+        $this->expectExceptionMessage('bject of class stdClass could not be converted to string');
+        $this->grammar->testGetDefaultValue(new stdClass());
+    }
+
+    protected function assertValue(string $expected, $value): void
+    {
+        $result = $this->grammar->testGetDefaultValue($value);
+
+        $this->assertEquals("'".$expected."'", $result);
+    }
+}

--- a/tests/Database/DatabaseAbstractSchemaGrammarDefaultValueTest.php
+++ b/tests/Database/DatabaseAbstractSchemaGrammarDefaultValueTest.php
@@ -23,7 +23,8 @@ class DatabaseAbstractSchemaGrammarDefaultValueTest extends TestCase
         parent::setUp();
 
         $this->grammar = new class extends Grammar {
-            public function testGetDefaultValue ($value) {
+            public function testGetDefaultValue($value)
+            {
                 return $this->getDefaultValue($value);
             }
         };
@@ -42,7 +43,7 @@ class DatabaseAbstractSchemaGrammarDefaultValueTest extends TestCase
     public function testExpression(): void
     {
         $result = $this->grammar->testGetDefaultValue(new Expression('it'));
-        $this->assertEquals("it", $result);
+        $this->assertEquals('it', $result);
     }
 
     public function testObjectWithToString(): void
@@ -57,11 +58,17 @@ class DatabaseAbstractSchemaGrammarDefaultValueTest extends TestCase
         $this->assertValue('just', $value);
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
     public function testEnumWithString(): void
     {
         $this->assertValue('test', TestEnum::test);
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
     public function testEnumWithInt(): void
     {
         $this->assertValue('1', TestIntEnum::test);
@@ -69,12 +76,12 @@ class DatabaseAbstractSchemaGrammarDefaultValueTest extends TestCase
 
     public function testCarbon(): void
     {
-        $this->assertValue('2022-01-27 00:00:00', Carbon::create(2022, 1,27));
+        $this->assertValue('2022-01-27 00:00:00', Carbon::create(2022, 1, 27));
     }
 
     public function testObjectWithoutToStringMethodFails(): void
     {
-        $this->expectExceptionMessage('bject of class stdClass could not be converted to string');
+        $this->expectExceptionMessage('Object of class stdClass could not be converted to string');
         $this->grammar->testGetDefaultValue(new stdClass());
     }
 
@@ -82,6 +89,6 @@ class DatabaseAbstractSchemaGrammarDefaultValueTest extends TestCase
     {
         $result = $this->grammar->testGetDefaultValue($value);
 
-        $this->assertEquals("'".$expected."'", $result);
+        $this->assertEquals("'" . $expected . "'", $result);
     }
 }

--- a/tests/Database/stubs/TestIntEnum.php
+++ b/tests/Database/stubs/TestIntEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\Database\stubs;
+
+enum TestIntEnum: int
+{
+    case test = 1;
+
+}


### PR DESCRIPTION
👋

In our migration we can now use PHP 8.1 Enum.

**Instead of using**

```php
$table->tinyInteger('x')->default(MyEnum::WAITING->value);
```

**we can use**

```php
$table->tinyInteger('x')->default(MyEnum::WAITING);
```

Also I've added tests to cover other values than Enum. I've not found a method that could tests if variable is enum. I've implemented a different approach. 

**FYI:**

As my first contribution it was little bit challenging to find out:

- can I use PHP 8.1(8.0) syntax in tests? __answer is no - we need to run tests agains 7.3 and lower -> maybe update docs with tests section?__
- how can I setup full tests suite (to run redis / mysql tests), i can see docker-compose.yml but it does not contain PHP runtime.

Probably we can make docker-compose.yml that contains PHP runtime + php-unit.xml that can be ready for to use by anyone with full test suite support. Probably it is possible to run multiple PHP runtimes?

Thanks for everything,
Martin.
