### PR TITLE
[8.x] Server command: Allow xdebug auto-connect to listener feature

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -104,9 +104,9 @@ class ServeCommand extends Command
                 'APP_ENV',
                 'LARAVEL_SAIL',
                 'PHP_CLI_SERVER_WORKERS',
+                'PHP_IDE_CONFIG',
                 'XDEBUG_CONFIG',
                 'XDEBUG_MODE',
-                'PHP_IDE_CONFIG',
                 'XDEBUG_SESSION',
             ]) ? [$key => $value] : [$key => false];
         })->all());

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -106,6 +106,8 @@ class ServeCommand extends Command
                 'PHP_CLI_SERVER_WORKERS',
                 'XDEBUG_CONFIG',
                 'XDEBUG_MODE',
+                'PHP_IDE_CONFIG',
+                'XDEBUG_SESSION',
             ]) ? [$key => $value] : [$key => false];
         })->all());
 


### PR DESCRIPTION
👋

To allow xdebug to auto-connect PHPStorms listener we need to pass env variables from the docker container to the PHP process.  

We need to pass 2 ENV VARIABLES: 

- PHP_IDE_CONFIG - setups which mapping the PHPStorm will use
- XDEBUG_SESSION - starts the xdebug session

This PR is connected with [laravel-sail PR](https://github.com/laravel/sail/pull/324).
