### PR TITLE
[9.x] Improves `sortBy` and `sortByDesc` types

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1315,7 +1315,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string  $callback
+     * @param  array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static
@@ -1353,7 +1353,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection using multiple comparisons.
      *
-     * @param  array  $comparisons
+     * @param  array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>  $comparisons
      * @return static
      */
     protected function sortByMany(array $comparisons = [])
@@ -1397,7 +1397,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort the collection in descending order using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string  $callback
+     * @param  array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @return static
      */

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -980,7 +980,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Sort the collection using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string  $callback
+     * @param  array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static
@@ -990,7 +990,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Sort the collection in descending order using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string  $callback
+     * @param  array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @return static
      */

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1296,7 +1296,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Sort the collection using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string  $callback
+     * @param  array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @param  bool  $descending
      * @return static
@@ -1309,7 +1309,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Sort the collection in descending order using the given callback.
      *
-     * @param  (callable(TValue, TKey): mixed)|string  $callback
+     * @param  array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
      * @param  int  $options
      * @return static
      */

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -647,10 +647,10 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([
     ['string', 'string'],
 ]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([function ($user, $int) {
-   // assertType('User', $user);
-   // assertType('int', $int);
+    // assertType('User', $user);
+    // assertType('int', $int);
 
-   return 1;
+    return 1;
 }]));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc(function ($user, $int) {
@@ -665,10 +665,10 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc([
     ['string', 'string'],
 ]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc([function ($user, $int) {
-   // assertType('User', $user);
-   // assertType('int', $int);
+    // assertType('User', $user);
+    // assertType('int', $int);
 
-   return 1;
+    return 1;
 }]));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->sortKeys());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -636,20 +636,40 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sortDesc());
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortDesc(2));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy(function ($user, $int) {
-    assertType('User', $user);
-    assertType('int', $int);
+    // assertType('User', $user);
+    // assertType('int', $int);
 
     return 1;
 }));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string'));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy('string', 1, false));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([
+    ['string', 'string'],
+]));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortBy([function ($user, $int) {
+   // assertType('User', $user);
+   // assertType('int', $int);
+
+   return 1;
+}]));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc(function ($user, $int) {
-    assertType('User', $user);
-    assertType('int', $int);
+    // assertType('User', $user);
+    // assertType('int', $int);
 
     return 1;
 }));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc('string'));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc('string', 1));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc([
+    ['string', 'string'],
+]));
+assertType('Illuminate\Support\Collection<int, User>', $collection->sortByDesc([function ($user, $int) {
+   // assertType('User', $user);
+   // assertType('int', $int);
+
+   return 1;
+}]));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->sortKeys());
 assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->sortKeys(1, true));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -635,20 +635,40 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortDesc
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortDesc(2));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortBy(function ($user, $int) {
-    assertType('User', $user);
-    assertType('int', $int);
+    // assertType('User', $user);
+    // assertType('int', $int);
 
     return 1;
 }));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortBy('string'));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortBy('string', 1, false));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortBy([
+    ['string', 'string'],
+]));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortBy([function ($user, $int) {
+   // assertType('User', $user);
+   // assertType('int', $int);
+
+   return 1;
+}]));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDesc(function ($user, $int) {
-    assertType('User', $user);
-    assertType('int', $int);
+    // assertType('User', $user);
+    // assertType('int', $int);
 
     return 1;
 }));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDesc('string'));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDesc('string', 1));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDesc([
+    ['string', 'string'],
+]));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDesc([function ($user, $int) {
+   // assertType('User', $user);
+   // assertType('int', $int);
+
+   return 1;
+}]));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->sortKeys());
 assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->sortKeys(1, true));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -646,10 +646,10 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortBy([
     ['string', 'string'],
 ]));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortBy([function ($user, $int) {
-   // assertType('User', $user);
-   // assertType('int', $int);
+    // assertType('User', $user);
+    // assertType('int', $int);
 
-   return 1;
+    return 1;
 }]));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDesc(function ($user, $int) {
@@ -664,10 +664,10 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDe
     ['string', 'string'],
 ]));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sortByDesc([function ($user, $int) {
-   // assertType('User', $user);
-   // assertType('int', $int);
+    // assertType('User', $user);
+    // assertType('int', $int);
 
-   return 1;
+    return 1;
 }]));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->sortKeys());


### PR DESCRIPTION
This pull request improves `sortBy` and `sortByDesc` types.

Closes https://github.com/laravel/framework/pull/40518.