### PR TITLE
[9.x] Add `orderBy` property for default model sorting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -84,6 +84,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected $withCount = [];
 
     /**
+     * The columns to order by when none were specified in the query.
+     *
+     * @var string[]|null
+     */
+    public $orderBy;
+
+    /**
      * Indicates whether lazy loading will be prevented on this model.
      *
      * @var bool

--- a/tests/Integration/Database/EloquentModelHasOrderTest.php
+++ b/tests/Integration/Database/EloquentModelHasOrderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentModelHasOrderTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('slug');
+        });
+    }
+
+    public function testUsesDefaultOrderByWhenNoOrderHasNotBeenSet()
+    {
+        $post1 = PostOrdered::create(['title' => 'Post 1', 'slug' => 'post-1']);
+        $post2 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-2']);
+        $post3 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-22']);
+
+        $posts = PostOrdered::all();
+
+        $this->assertCount(3, $posts);
+        $this->assertTrue($posts->get(0)->is($post1));
+        $this->assertTrue($posts->get(1)->is($post3));
+        $this->assertTrue($posts->get(2)->is($post2));
+    }
+
+    public function testItDoesNotUseDefaultOrderByWhenOrderHasBeenSet()
+    {
+        $post1 = PostOrdered::create(['title' => 'Post 1', 'slug' => 'post-1']);
+        $post2 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-2']);
+        $post3 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-22']);
+
+        $posts = PostOrdered::orderBy('id')->get();
+
+        $this->assertCount(3, $posts);
+        $this->assertTrue($posts->get(0)->is($post1));
+        $this->assertTrue($posts->get(1)->is($post2));
+        $this->assertTrue($posts->get(2)->is($post3));
+    }
+
+    public function testCursorRespectDefaultOrderBy()
+    {
+        $post1 = PostOrdered::create(['title' => 'Post 1', 'slug' => 'post-1']);
+        $post2 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-2']);
+        $post3 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-22']);
+
+        $this->assertSame([1, 3, 2], PostOrdered::cursor()->pluck('id')->toArray());
+    }
+
+    public function testFirstRespectDefaultOrderBy()
+    {
+        PostOrdered::create(['title' => 'Test Post', 'slug' => 'post-1']);
+        $expected = PostOrdered::create(['title' => 'Test Post', 'slug' => 'post-2']);
+
+        $this->assertTrue(PostOrdered::first()->is($expected));
+    }
+
+    public function testValueRespectsDefaultOrderBy()
+    {
+        PostOrdered::create(['title' => 'Test Post', 'slug' => 'post-1']);
+        PostOrdered::create(['title' => 'Test Post', 'slug' => 'post-2']);
+
+        $this->assertSame('post-2', PostOrdered::value('slug'));
+    }
+}
+
+class PostOrdered extends Model
+{
+    public $table = 'posts';
+    public $timestamps = false;
+    public $orderBy = [
+        'title',
+        'slug' => 'DESC',
+    ];
+    protected $guarded = [];
+}


### PR DESCRIPTION
This adds an optional `orderBy` property to Eloquent models which allows the developer to easily add **default sorting** to any model.

**Why**
I believe this is a common enough use case where having something built-in adds to that "comes with everything right out-of-the-box" feel Laravel has.

While this may be done currently, it's a rather cumbersome experience: overwriting the `boot` method, registering a global scope, writing your own logic.

**How**
Instead, you may simply set the `orderBy` property with the column (or columns) and direction (optional) you want your Eloquent queries to be ordered by. For example:

```php
class Post extends Model
{
    public $orderBy = [
        'published_at' => 'DESC',
        'title',
    ];
}
```

**Note:** To avoid this feature being a "foot gun" with the complexity of merging default and runtime orders, this is only applied when `orderBy` was not called in the Eloquent query. Calling `orderBy` in an Eloquent query assumes the developer wants full control over the sorting.
