### PR TITLE
[9.x] Use null safe operator in cache Repository class

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -583,9 +583,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     protected function event($event)
     {
-        if (isset($this->events)) {
-            $this->events->dispatch($event);
-        }
+        $this->events?->dispatch($event);
     }
 
     /**


### PR DESCRIPTION
As laravel 9.x requires PHP 8.0.x I think we can refactor the situation to a more sugary one if there is not a subtle difference there.