### PR TITLE
[8.x] Add Transliterate shortcut to the Str helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -100,6 +100,19 @@ class Str
     }
 
     /**
+     * Transliterate a string to its closest ASCII representation.
+     *
+     * @param  string  $string
+     * @param  string|null  $unknown
+     * @param  bool|null  $strict
+     * @return string
+     */
+    public static function transliterate($string, $unknown = '?', $strict = false)
+    {
+        return ASCII::to_transliterate($string, $unknown, $strict);
+    }
+
+    /**
      * Get the portion of a string before the first occurrence of a given value.
      *
      * @param  string  $subject
@@ -984,19 +997,6 @@ class Str
     public static function createUuidsNormally()
     {
         static::$uuidFactory = null;
-    }
-
-    /**
-     * Transliterate a string into it's closest ASCII representation.
-     *
-     * @param  string  $string
-     * @param  string|null  $unknown
-     * @param  bool|null  $strict
-     * @return string
-     */
-    public static function transliterate($string, $unknown = '?', $strict = false)
-    {
-        return ASCII::to_transliterate($string, $unknown, $strict);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -987,6 +987,20 @@ class Str
     }
 
     /**
+     * Transliterate a string into it's closest ASCII representation.
+     *
+     * @param  string  $string
+     * @param  string|null  $unkown
+     * @param  bool|null  $strict
+     * @return string
+     */
+    public static function transliterate($string, $unkown = '?', $strict = false)
+    {
+        return ASCII::to_transliterate($string, $unkown, $strict);
+    }
+
+
+    /**
      * Remove all strings from the casing caches.
      *
      * @return void

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -990,13 +990,13 @@ class Str
      * Transliterate a string into it's closest ASCII representation.
      *
      * @param  string  $string
-     * @param  string|null  $unkown
+     * @param  string|null  $unknown
      * @param  bool|null  $strict
      * @return string
      */
-    public static function transliterate($string, $unkown = '?', $strict = false)
+    public static function transliterate($string, $unknown = '?', $strict = false)
     {
-        return ASCII::to_transliterate($string, $unkown, $strict);
+        return ASCII::to_transliterate($string, $unknown, $strict);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -999,7 +999,6 @@ class Str
         return ASCII::to_transliterate($string, $unkown, $strict);
     }
 
-
     /**
      * Remove all strings from the casing caches.
      *

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -672,6 +672,42 @@ class SupportStrTest extends TestCase
         $this->assertSame('aaaaa', Str::repeat('a', 5));
         $this->assertSame('', Str::repeat('', 5));
     }
+
+    /**
+     * @dataProvider specialCharacterProvider
+     */
+    public function testTransliterate(string $value, string $expected): void
+    {
+        $this->assertSame($expected, Str::transliterate($value));
+    }
+
+    public function specialCharacterProvider(): array
+    {
+        return [
+            ['ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ', 'abcdefghijklmnopqrstuvwxyz'],
+            ['⓪①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳', '01234567891011121314151617181920'],
+            ['⓵⓶⓷⓸⓹⓺⓻⓼⓽⓾', '12345678910'],
+            ['⓿⓫⓬⓭⓮⓯⓰⓱⓲⓳⓴', '011121314151617181920'],
+            ['ⓣⓔⓢⓣ@ⓛⓐⓡⓐⓥⓔⓛ.ⓒⓞⓜ', 'test@laravel.com'],
+            ['🎂', '?'],
+            ['abcdefghijklmnopqrstuvwxyz', 'abcdefghijklmnopqrstuvwxyz'],
+            ['0123456789', '0123456789'],
+        ];
+    }
+
+    public function testTransliterateOverrideUnknown(): void
+    {
+        $this->assertSame('HHH', Str::transliterate('🎂🚧🏆', 'H'));
+        $this->assertSame('Hello', Str::transliterate('🎂', 'Hello'));
+    }
+
+    /**
+     * @dataProvider specialCharacterProvider
+     */
+    public function testTransliterateStrict(string $value, string $expected): void
+    {
+        $this->assertSame($expected, Str::transliterate($value, '?', true));
+    }
 }
 
 class StringableObjectStub


### PR DESCRIPTION
### Description

Add a transliterate shortcut to the String helper. 

I've added the by recommendation on [a recent PR](https://github.com/laravel/ui/pull/216) around fixing security exploit in the UI package. 

In short, MYSQL and other DB hosts will transliterate special characters in queries, making it possible to bypass security checks and throttles.

In the case of the UI security exploit, by default, Laravel throttles login attempts by the applications email/username. However, if I use special characters to replace standard characters in my email when the email gets to the Database, the query parameters will transliterate. This means that `ⓣⓔⓢⓣ@ⓛⓐⓡⓐⓥⓔⓛ.ⓒⓞⓜ` will be read as `test@laravel.com` by the Database. This made it was possible for a user to brute force a password by bypassing the login throttle.

Adding this shortcut will make it easier to implement a more elegant solution to the current UI fix while also making it easier for users to improve the security of their application or similar functionality by adding transliteration directly from the helper without needing prior knowledge of the ASCII package. 
