### PR TITLE
[8.x] Implement the file cache purge command

### DIFF
--- a/src/Illuminate/Foundation/Console/CachePurgeCommand.php
+++ b/src/Illuminate/Foundation/Console/CachePurgeCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Carbon;
+use Symfony\Component\Finder\Finder;
+
+class CachePurgeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:purge';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'cache:purge';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove the obsolete cached items in file system.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(Filesystem $filesystem)
+    {
+        $config = config('cache');
+        $store = $config['default'];
+
+        $storeConfigs = $config['stores'][$store] ?? [];
+
+        if (($storeConfigs['driver'] ?? '') !== 'file') {
+            $this->info('Your store driver is not set to the "file" driver!');
+
+            return;
+        }
+
+        $cacheFiles = Finder::create()->in($storeConfigs['path'])->files();
+
+        foreach ($cacheFiles as $cacheFile) {
+            $contents = $cacheFile->getContents();
+            $expire = substr($contents, 0, 10);
+
+            if (Carbon::now()->getTimestamp() >= $expire) {
+                $path = $cacheFile->getPath();
+                $filesystem->deleteDirectory(dirname($path));
+            }
+        }
+
+        $this->info('Your Filesystem cache successfully purged!');
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Foundation\Console\CachePurgeCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
@@ -135,6 +136,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Up' => 'command.up',
         'ViewCache' => 'command.view.cache',
         'ViewClear' => 'command.view.clear',
+        'PurgeFileCache' => CachePurgeCommand::class,
     ];
 
     /**
@@ -1111,6 +1113,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.view.clear', function ($app) {
             return new ViewClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerPurgeFileCacheCommand()
+    {
+        $this->app->singleton(CachePurgeCommand::class, function ($app) {
+            return new CachePurgeCommand();
         });
     }
 


### PR DESCRIPTION
This command (`php artisan cache:purge`) tries to free up disk space by removing the obsolete cached items on the local file system.
The idea is simple, iterate over all the files in the cache folder and check the expiration date and delete the file if the expiration date has passed.