### PR TITLE
[8.x] Throw an event when a relation is loaded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Events\RelationLoadedEvent;
 use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -542,9 +543,13 @@ trait HasAttributes
             ));
         }
 
-        return tap($relation->getResults(), function ($results) use ($method) {
+        $results = tap($relation->getResults(), function ($results) use ($method) {
             $this->setRelation($method, $results);
         });
+
+        static::$dispatcher->dispatch(new RelationLoadedEvent($this, $method, $results));
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Database/Events/RelationLoadedEvent.php
+++ b/src/Illuminate/Database/Events/RelationLoadedEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RelationLoadedEvent
+{
+    /**
+     * The model that is loading a relation.
+     *
+     * @var Model
+     */
+    private $model;
+
+    /**
+     * The name of the relation.
+     *
+     * @var string
+     */
+    private $relation;
+
+    /**
+     * The results of the relation query.
+     *
+     * @var mixed
+     */
+    private $results;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param Model $model
+     * @param string $relation
+     * @param mixed $results
+     */
+    public function __construct(Model $model, string $relation, $results)
+    {
+        $this->model = $model;
+        $this->relation = $relation;
+        $this->results = $results;
+    }
+}


### PR DESCRIPTION
Right now, when you use eloquent models you have to be mindful on what are the relations you need to eager load. 

Code is a living thing, continuously changing. As a result, one can easily forget to add/remove relations that are/aren't needed. 

By listening and counting, on a per model basis, what relations were called and how many times we can detect:

- relations that are used but not eager loaded
- relations that are eager loaded but not used