### PR TITLE
[8.x] Fix : `strtotime` Epoch doesn't fit in PHP int (laravel#40686)

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -449,7 +449,11 @@ trait ValidatesAttributes
             return true;
         }
 
-        if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
+        try {
+            if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
+                return false;
+            }
+        } catch (Exception $e) {
             return false;
         }
 


### PR DESCRIPTION
`strtotime` produces errors on some edge cases, to completely shut down the validation routine within the `ValidateAttributes` concern. During my testing, I found out that the error is consistently faced in x86 builds of apache + PHP.

This PR attempts to address that minor edge-case. Thanks for your time, and feel free to let me know if there are any requested changes I should address.