### PR TITLE
[8.x] Fix Stringable ucsplit

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -779,11 +779,11 @@ class Stringable implements JsonSerializable
     /**
      * Split a string by uppercase characters.
      *
-     * @return static
+     * @return array
      */
     public function ucsplit()
     {
-        return new static(Str::ucsplit($this->value));
+        return Str::ucsplit($this->value);
     }
 
     /**


### PR DESCRIPTION
This was passing an array into the constructor which causes an exception. Also, this should be the last method you call on the chain since `Str::ucsplit` returns an array.
