### PR TITLE
[8.x] Return collection from ucsplit

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -779,11 +779,11 @@ class Stringable implements JsonSerializable
     /**
      * Split a string by uppercase characters.
      *
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     public function ucsplit()
     {
-        return Str::ucsplit($this->value);
+        return collect(Str::ucsplit($this->value));
     }
 
     /**


### PR DESCRIPTION
As suggested in my previous PR (#40694), other methods like `explode` return a collection, so why not this one?