### PR TITLE
[9.x] Do not render exceptions in streamed download

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -369,10 +369,8 @@ class Handler implements ExceptionHandlerContract
      */
     protected function mapException(Throwable $e)
     {
-        if (
-            method_exists($e, 'getInnerException') &&
-            ($inner = $e->getInnerException()) instanceof Throwable
-        ) {
+        if (method_exists($e, 'getInnerException') &&
+            ($inner = $e->getInnerException()) instanceof Throwable) {
             return $inner;
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -369,6 +369,13 @@ class Handler implements ExceptionHandlerContract
      */
     protected function mapException(Throwable $e)
     {
+        if (
+            method_exists($e, 'getInnerException') &&
+            ($inner = $e->getInnerException()) instanceof Throwable
+        ) {
+            return $inner;
+        }
+
         foreach ($this->exceptionMap as $class => $mapper) {
             if (is_a($e, $class)) {
                 return $mapper($e);

--- a/src/Illuminate/Routing/Exceptions/StreamedResponseException.php
+++ b/src/Illuminate/Routing/Exceptions/StreamedResponseException.php
@@ -35,9 +35,6 @@ class StreamedResponseException extends RuntimeException
      */
     public function render()
     {
-        // Since we are in the process of streaming a file download,
-        // we don't actually want it to render anything into the
-        // file being downloaded. We return an empty response.
         return new Response('');
     }
 

--- a/src/Illuminate/Routing/Exceptions/StreamedResponseException.php
+++ b/src/Illuminate/Routing/Exceptions/StreamedResponseException.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Routing\Exceptions;
+
+use Illuminate\Http\Response;
+use RuntimeException;
+use Throwable;
+
+class StreamedResponseException extends RuntimeException
+{
+    /**
+     * The actual exception thrown during the stream.
+     *
+     * @var \Throwable
+     */
+    public $originalException;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  \Throwable  $originalException
+     * @return void
+     */
+    public function __construct(Throwable $originalException)
+    {
+        $this->originalException = $originalException;
+
+        parent::__construct($originalException->message);
+    }
+
+    /**
+     * Render the exception.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function render()
+    {
+        // Since we are in the process of streaming a file download,
+        // we don't actually want it to render anything into the
+        // file being downloaded. We return an empty response.
+        return new Response('');
+    }
+
+    /**
+     * Get the actual exception thrown during the stream.
+     *
+     * @return \Throwable
+     */
+    public function getInnerException()
+    {
+        return $this->originalException;
+    }
+}


### PR DESCRIPTION
# Problem

When streaming a download using `response()->streamDownload(...)`, if an exception is thrown in the middle of the stream, the HTML of the error ends up in the downloaded file.

To test it, paste this code block into your `routes/web.php` file:

```php
Route::get('/', function () {
    return response()->streamDownload(function () {
        echo "Line Number, Value\n";

        collect()->times(1000)->each(function ($number) {
            echo "{$number}, Value {$number}\n";
        });

        throw new Exception('I do not want to see this in my CSV file');
    }, 'stream-error-test.csv');
});
```

When you visit that route, it'll download the CSV file. Open it, and you'll see the HTML of the message directly in the file:

![image](https://user-images.githubusercontent.com/1403741/151598971-f622f834-1a5e-4dc0-90a3-88a698b4ef83.png)

This is clearly not what anyone wants. We want the error to be logged (AKA reported), but not rendered.

# Solution

Wrap the provided callback in our own closure. Within that closure, we can wrap the original callback in a `try`/`catch` block, and return a custom exception that indicates that it was thrown from within a stream. Then we'll pass the wrapped closure to the `StreamedResponse` constructor:
```php
public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment')
{
    $withWrappedException = function () use ($callback) {
        try {
            $callback();
        } catch (Throwable $e) {
            throw new StreamedResponseException($e);
        }
    };

    $response = new StreamedResponse($withWrappedException, 200, $headers);

    //...

    return $response;
}
```

### Note about mapping inner exceptions

For logging purposes (AKA reporting) we're not interested in the special `StreamedResponseException`. We want to log the original exception as is.

In C# and in JS, there's an official way to wrap exceptions, and to then get back to the original exception. C# uses [the `InnerException` property](https://docs.microsoft.com/en-us/dotnet/api/system.exception.innerexception?view=net-6.0), and JS uses [the `cause` property](https://github.com/tc39/proposal-error-cause).

Alas, PHP does not have a built-in mechanism for this. Instead, what this PR does is add a new convention: just like we already respect `render` and `report` methods directly on the exception class, we'll now also respect a `getInnerException` method, and use that in the `mapException` logic in the `Handler`. This way, we can map the `StreamedResponseException` back to the original exception for logging purposes.