### PR TITLE
[8.x] Add getLineLoaded Function

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -137,11 +137,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     /**
      * Get the translation of the key.
      *
-     * @param  array $lineLoaded
-     * @param  string|null $key
+     * @param  array  $lineLoaded
+     * @param  string|null  $key
      * @return string|null
      */
-    private function getLineLoaded( $lineLoaded, $key )
+    private function getLineLoaded($lineLoaded, $key)
     {
         $key = explode('.', $key, 2);
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -133,20 +133,21 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // from the application's language files. Otherwise we can return the line.
         return $this->makeReplacements($line ?: $key, $replace);
     }
-    
+
     /**
      * Get the translation of the key.
      *
-     * @param array $lineLoaded
-     * @param string|null $key
+     * @param  array $lineLoaded
+     * @param  string|null $key
      * @return string|null
      */
-    private function getLineLoaded( $lineLoaded, $key ) {
-        $key = explode(".", $key, 2);
+    private function getLineLoaded( $lineLoaded, $key )
+    {
+        $key = explode('.', $key, 2);
 
-        if ( !isset($lineLoaded[$key[0]]) ) {
+        if (! isset($lineLoaded[$key[0]])) {
             return null;
-        } elseif ( is_array($lineLoaded[$key[0]]) ) {
+        } elseif (is_array($lineLoaded[$key[0]])) {
             return $this->getLineLoaded($lineLoaded[$key[0]], $key[1]);
         } else {
             return $lineLoaded[$key[0]];

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -103,11 +103,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $locale = $locale ?: $this->locale;
 
         // For JSON translations, there is only one file per locale, so we will simply load
-        // that file and then we will be ready to check the array for the key. These are
-        // only one level deep so we do not need to do any fancy searching through it.
+        // that file and then we will be ready to check the array for the key.
         $this->load('*', '*', $locale);
-
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        
+        $line = $this->getLineLoaded($this->loaded['*']['*'][$locale], $key);
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a
@@ -134,6 +133,25 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // from the application's language files. Otherwise we can return the line.
         return $this->makeReplacements($line ?: $key, $replace);
     }
+    
+    /**
+	 * Get the translation of the key.
+	 *
+	 * @param array $lineLoaded
+	 * @param string|null $key
+	 * @return string|null
+	 */
+	private function getLineLoaded( $lineLoaded, $key ) {
+		$key = explode(".", $key, 2);
+
+		if ( !isset($lineLoaded[$key[0]]) ) {
+			return null;
+		} elseif ( is_array($lineLoaded[$key[0]]) ) {
+			return $this->getLineLoaded($lineLoaded[$key[0]], $key[1]);
+		} else {
+			return $lineLoaded[$key[0]];
+		}
+	}
 
     /**
      * Get a translation according to an integer value.

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -105,7 +105,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // For JSON translations, there is only one file per locale, so we will simply load
         // that file and then we will be ready to check the array for the key.
         $this->load('*', '*', $locale);
-        
+
         $line = $this->getLineLoaded($this->loaded['*']['*'][$locale], $key);
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
@@ -135,23 +135,23 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
     
     /**
-	 * Get the translation of the key.
-	 *
-	 * @param array $lineLoaded
-	 * @param string|null $key
-	 * @return string|null
-	 */
-	private function getLineLoaded( $lineLoaded, $key ) {
-		$key = explode(".", $key, 2);
+     * Get the translation of the key.
+     *
+     * @param array $lineLoaded
+     * @param string|null $key
+     * @return string|null
+     */
+    private function getLineLoaded( $lineLoaded, $key ) {
+        $key = explode(".", $key, 2);
 
-		if ( !isset($lineLoaded[$key[0]]) ) {
-			return null;
-		} elseif ( is_array($lineLoaded[$key[0]]) ) {
-			return $this->getLineLoaded($lineLoaded[$key[0]], $key[1]);
-		} else {
-			return $lineLoaded[$key[0]];
-		}
-	}
+        if ( !isset($lineLoaded[$key[0]]) ) {
+            return null;
+        } elseif ( is_array($lineLoaded[$key[0]]) ) {
+            return $this->getLineLoaded($lineLoaded[$key[0]], $key[1]);
+        } else {
+            return $lineLoaded[$key[0]];
+        }
+    }
 
     /**
      * Get a translation according to an integer value.


### PR DESCRIPTION
JSON Provides a hierarchy style for the key value. This means that value can be an array too.
For some organizing work, you would need to write __("foo.bar") and load it from the JSON file.
This function provides you with the ability to assign the value of the key "foo" to be an array
that contains a key called "bar" with a string value.
It doesn't affect the old style of writing and processing the function.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
