### PR TITLE
[8.x] Fix LazyCollection::collapse() not passing along keys

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -166,8 +166,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         return new static(function () {
             foreach ($this as $values) {
                 if (is_array($values) || $values instanceof Enumerable) {
-                    foreach ($values as $value) {
-                        yield $value;
+                    foreach ($values as $key => $value) {
+                        yield $key => $value;
                     }
                 }
             }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1673,8 +1673,12 @@ class SupportCollectionTest extends TestCase
      */
     public function testCollapse($collection)
     {
-        $data = new $collection([[$object1 = new stdClass], [$object2 = new stdClass]]);
-        $this->assertEquals([$object1, $object2], $data->collapse()->all());
+        $data = new $collection([
+            ['one' => $object1 = new stdClass],
+            ['two' => $object2 = new stdClass],
+        ]);
+
+        $this->assertEquals(['one' => $object1, 'two' => $object2], $data->collapse()->all());
     }
 
     /**


### PR DESCRIPTION
Currently `LazyCollection::collapse()` is not consistent with `Collection::collapse()`, because the lazy collection does not pass along the keys within its items, while the normal collection does.

Example:

```php
>>> collect([['one' => 1], ['two' => 2]])->collapse()->all()
=> [
     "one" => 1,
     "two" => 2,
   ]
>>> collect([['one' => 1], ['two' => 2]])->lazy()->collapse()->all()
=> [
     1,
     2,
   ]

```