### PR TITLE
[8.x] Define route redirection when model is missing

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -12,6 +12,7 @@ use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
 use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\SerializableClosure\SerializableClosure;
@@ -980,6 +981,21 @@ class Route
                 'C:32:"Opis\\Closure\\SerializableClosure',
                 'O:47:"Laravel\\SerializableClosure\\SerializableClosure',
             ]) ? unserialize($missing) : $missing;
+    }
+
+    /**
+     * Define the redirection that should be performed on a missing model exception.
+     *
+     * @param  string  $route
+     * @param  mixed  $parameters
+     * @param  array  $headers
+     * @return $this
+     */
+    public function redirectMissing($route, $parameters = [], $headers = [])
+    {
+        return $this->missing(function () use ($route, $parameters, $headers) {
+            return Redirect::route($route, $parameters, 301, $headers);
+        });
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -7,8 +7,9 @@ use FooController;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Route;
+use Illuminate\Routing\Redirector;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Redirect;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Stringable;
@@ -531,6 +532,23 @@ class RouteRegistrarTest extends TestCase
         $this->assertNull($this->router->getRoutes()->getByName('users.index')->getMissing());
         $this->assertNull($this->router->getRoutes()->getByName('users.create')->getMissing());
         $this->assertNull($this->router->getRoutes()->getByName('users.store')->getMissing());
+    }
+
+    public function testRedirectionOnMissingModel()
+    {
+        Redirect::swap($redirector = m::mock(Redirector::class));
+
+        $redirector
+            ->shouldReceive('route')
+            ->with('redirection', ['foo' => 'bar'], 301, ['header' => 'zzz'])
+            ->andReturn('redirected');
+
+        $this->router->get('foo')->redirectMissing('redirection', ['foo' => 'bar'], ['header' => 'zzz']);
+
+        $missing = $this->getRoute()->getMissing();
+
+        $this->assertIsCallable($missing);
+        $this->assertSame('redirected', $missing());
     }
 
     public function testCanAccessRegisteredResourceRoutesAsRouteCollection()


### PR DESCRIPTION
This PR introduces a papercut to define the route that a user should be redirected to when a model is missing:

```php
// before
Route::get('posts/{post}', [PostsController::class, 'show'])->missing(function() {
    return Redirect::route('posts.index', status: 301);
});

// after
Route::get('posts/{post}', [PostsController::class, 'show'])->redirectMissing('posts.index');
```