### PR TITLE
[8.x] `getOrFail` for the Translator

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -134,6 +134,24 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // from the application's language files. Otherwise we can return the line.
         return $this->makeReplacements($line ?: $key, $replace);
     }
+    
+    /**
+     * Get the translation for the given key or fail
+     * 
+     * @param  $key
+     * @param  array $replace
+     * @param  null $locale
+     * @param  bool $fallback
+     * @return array|string|null
+     */
+    public function getOrFail($key, array $replace = [], $locale = null, $fallback = true)
+    {
+        if (! $this->has($key)) {
+            throw new InvalidArgumentException("Lang Key '$key' Not Defined");
+        }
+
+        return $this->get($key, $replace, $locale, $fallback);
+    }
 
     /**
      * Get a translation according to an integer value.


### PR DESCRIPTION
Almost all of my projects need `Translator`, Its important to me to 'translate' but sometimes i forget to translate  some keys in some languages, Translator return string no matter the key was defined or not So here it is.

If merged i add tests and facades method