### PR TITLE
[8.x] Add failing test when using `Bus::chain()` with `$this->fail()`

### DIFF
--- a/tests/Integration/Bus/ChainingTest.php
+++ b/tests/Integration/Bus/ChainingTest.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Bus;
 
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Bus;
 use Orchestra\Testbench\TestCase;
 use Throwable;
@@ -18,19 +16,9 @@ class ChainingTest extends TestCase
     public function testItCanFailedTheChainUsingFailMethod()
     {
         Bus::chain([
-            new FailingJob(),
+            new Jobs\FailingJob(),
         ])->catch(function (Throwable $e) {
             //
         })->dispatch();
-    }
-}
-
-class FailingJob
-{
-    use InteractsWithQueue, Queueable;
-
-    public function handle()
-    {
-        $this->fail();
     }
 }

--- a/tests/Integration/Bus/ChainingTest.php
+++ b/tests/Integration/Bus/ChainingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Bus;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Bus;
+use Orchestra\Testbench\TestCase;
+use Throwable;
+
+class ChainingTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        $app->make('config')->set('queue.default', 'sync');
+    }
+
+    public function testItCanFailedTheChainUsingFailMethod()
+    {
+        Bus::chain([
+            new FailingJob(),
+        ])->catch(function (Throwable $e) {
+            //
+        })->dispatch();
+    }
+}
+
+class FailingJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public function handle()
+    {
+        $this->fail();
+    }
+}

--- a/tests/Integration/Bus/Jobs/FailingJob.php
+++ b/tests/Integration/Bus/Jobs/FailingJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Bus\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+
+class FailingJob
+{
+    use InteractsWithQueue, Queueable;
+
+    public function handle()
+    {
+        $this->fail();
+    }
+}


### PR DESCRIPTION
```
1) Illuminate\Tests\Integration\Bus\ChainingTest::testItCanFailedTheChainUsingFailMethod
ErrorException: Undefined array key "job"

/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Queue/Jobs/Job.php:210
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Queue/Jobs/Job.php:192
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Queue/InteractsWithQueue.php:47
/Users/crynobone/Projects/laravel/framework/8.x/tests/Integration/Bus/ChainingTest.php:34
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Container/BoundMethod.php:36
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Container/Util.php:40
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Container/BoundMethod.php:93
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Container/BoundMethod.php:37
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Container/Container.php:653
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Bus/Dispatcher.php:128
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Pipeline/Pipeline.php:128
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Pipeline/Pipeline.php:103
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Bus/Dispatcher.php:132
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Bus/Dispatcher.php:78
/Users/crynobone/Projects/laravel/framework/8.x/src/Illuminate/Foundation/Bus/PendingChain.php:163
/Users/crynobone/Projects/laravel/framework/8.x/tests/Integration/Bus/ChainingTest.php:24
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>