### PR TITLE
[8.x] Add array_keys validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -613,13 +613,13 @@ trait ReplacesAttributes
     /**
      * Replace all place-holders for the contains_all rule.
      *
-     * @param string  $message
-     * @param string  $attribute
-     * @param string  $rule
-     * @param array  $parameters
-     * @return string
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return  string
      */
-    protected function replaceContainsAll($message, $attribute, $rule, $parameters)
+    protected function replaceArrayKeys($message, $attribute, $rule, $parameters)
     {
         foreach ($parameters as &$parameter) {
             $parameter = $this->getDisplayableValue($attribute, $parameter);

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -201,6 +201,24 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the array_keys rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceArrayKeys($message, $attribute, $rule, $parameters)
+    {
+        foreach ($parameters as &$parameter) {
+            $parameter = $this->getDisplayableValue($attribute, $parameter);
+        }
+
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
+
+    /**
      * Replace all place-holders for the mimetypes rule.
      *
      * @param  string  $message
@@ -602,24 +620,6 @@ trait ReplacesAttributes
      * @return string
      */
     protected function replaceStartsWith($message, $attribute, $rule, $parameters)
-    {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
-    }
-
-    /**
-     * Replace all place-holders for the contains_all rule.
-     *
-     * @param  string  $message
-     * @param  string  $attribute
-     * @param  string  $rule
-     * @param  array  $parameters
-     * @return string
-     */
-    protected function replaceArrayKeys($message, $attribute, $rule, $parameters)
     {
         foreach ($parameters as &$parameter) {
             $parameter = $this->getDisplayableValue($attribute, $parameter);

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -613,10 +613,10 @@ trait ReplacesAttributes
     /**
      * Replace all place-holders for the contains_all rule.
      *
-     * @param string $message
-     * @param string $attribute
-     * @param string $rule
-     * @param array $parameters
+     * @param string  $message
+     * @param string  $attribute
+     * @param string  $rule
+     * @param array  $parameters
      * @return string
      */
     protected function replaceContainsAll($message, $attribute, $rule, $parameters)
@@ -626,7 +626,5 @@ trait ReplacesAttributes
         }
 
         return str_replace(':values', implode(', ', $parameters), $message);
-
-
     }
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -201,7 +201,7 @@ trait ReplacesAttributes
     }
 
     /**
-     * Replace all place-holders for the array_keys rule.
+     * Replace all place-holders for the required_array_keys rule.
      *
      * @param  string  $message
      * @param  string  $attribute
@@ -209,7 +209,7 @@ trait ReplacesAttributes
      * @param  array  $parameters
      * @return string
      */
-    protected function replaceArrayKeys($message, $attribute, $rule, $parameters)
+    protected function replaceRequiredArrayKeys($message, $attribute, $rule, $parameters)
     {
         foreach ($parameters as &$parameter) {
             $parameter = $this->getDisplayableValue($attribute, $parameter);

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -610,23 +610,23 @@ trait ReplacesAttributes
         return str_replace(':values', implode(', ', $parameters), $message);
     }
 
-	/**
-	 * Replace all place-holders for the contains_all rule.
-	 *
-	 * @param string $message
-	 * @param string $attribute
-	 * @param string $rule
-	 * @param array $parameters
-	 * @return string
-	 */
-	protected function replaceContainsAll($message, $attribute, $rule, $parameters)
-	{
-		foreach ($parameters as &$parameter) {
+    /**
+     * Replace all place-holders for the contains_all rule.
+     *
+     * @param string $message
+     * @param string $attribute
+     * @param string $rule
+     * @param array $parameters
+     * @return string
+     */
+    protected function replaceContainsAll($message, $attribute, $rule, $parameters)
+    {
+        foreach ($parameters as &$parameter) {
             $parameter = $this->getDisplayableValue($attribute, $parameter);
         }
 
-		return str_replace(':values', implode(', ', $parameters), $message);
+        return str_replace(':values', implode(', ', $parameters), $message);
 
 
-	}
+    }
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -609,4 +609,24 @@ trait ReplacesAttributes
 
         return str_replace(':values', implode(', ', $parameters), $message);
     }
+
+	/**
+	 * Replace all place-holders for the contains_all rule.
+	 *
+	 * @param string $message
+	 * @param string $attribute
+	 * @param string $rule
+	 * @param array $parameters
+	 * @return string
+	 */
+	protected function replaceContainsAll($message, $attribute, $rule, $parameters)
+	{
+		foreach ($parameters as &$parameter) {
+            $parameter = $this->getDisplayableValue($attribute, $parameter);
+        }
+
+		return str_replace(':values', implode(', ', $parameters), $message);
+
+
+	}
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -617,7 +617,7 @@ trait ReplacesAttributes
      * @param  string  $attribute
      * @param  string  $rule
      * @param  array  $parameters
-     * @return  string
+     * @return string
      */
     protected function replaceArrayKeys($message, $attribute, $rule, $parameters)
     {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -372,24 +372,24 @@ trait ValidatesAttributes
     }
 
     /**
-     * @param string  $attribute
-     * @param mixed  $value
-     * @param array  $parameters
-     * @return bool
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return  bool
      */
-    public function validateContainsAll($attribute, $value, $parameters)
+    public function validateArrayKeys($attribute, $value, $parameters)
     {
-        if (is_array($value)) {
-            foreach ($parameters as $param) {
-                if (! Arr::exists($value, $param)) {
-                    return false;
-                }
-            }
+		if (! is_array($value)) {
+			return false;
+		}
 
-            return true;
+        foreach ($parameters as $param) {
+            if (! Arr::exists($value, $param)) {
+                return false;
+            }
         }
 
-        return Str::containsAll($value, $parameters);
+        return true;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -379,7 +379,7 @@ trait ValidatesAttributes
      * @param  array  $parameters
      * @return bool
      */
-    public function validateArrayKeys($attribute, $value, $parameters)
+    public function validateRequiredArrayKeys($attribute, $value, $parameters)
     {
         if (! is_array($value)) {
             return false;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -371,20 +371,26 @@ trait ValidatesAttributes
         return empty(array_diff_key($value, array_fill_keys($parameters, '')));
     }
 
-	public function validateContainsAll($attribute, $value, $parameters)
-	{
-		if (is_array($value)) {
-			foreach($parameters as $param) {
-				if (!Arr::exists($value, $param)) {
-					return false;
-				}
-			}
+    /**
+     * @param string $attribute
+     * @param mixed $value
+     * @param array $parameters
+     * @return bool
+     */
+    public function validateContainsAll($attribute, $value, $parameters)
+    {
+        if (is_array($value)) {
+            foreach ($parameters as $param) {
+                if (!Arr::exists($value, $param)) {
+                    return false;
+                }
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		return Str::containsAll($value, $parameters);
-	}
+        return Str::containsAll($value, $parameters);
+    }
 
     /**
      * Validate the size of an attribute is between a set of values.

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -372,6 +372,8 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an array has all of the given keys.
+     *
      * @param  string  $attribute
      * @param  mixed  $value
      * @param  array  $parameters

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -375,13 +375,13 @@ trait ValidatesAttributes
      * @param  string  $attribute
      * @param  mixed  $value
      * @param  array  $parameters
-     * @return  bool
+     * @return bool
      */
     public function validateArrayKeys($attribute, $value, $parameters)
     {
-		if (! is_array($value)) {
-			return false;
-		}
+        if (! is_array($value)) {
+            return false;
+        }
 
         foreach ($parameters as $param) {
             if (! Arr::exists($value, $param)) {

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -372,16 +372,16 @@ trait ValidatesAttributes
     }
 
     /**
-     * @param string $attribute
-     * @param mixed $value
-     * @param array $parameters
+     * @param string  $attribute
+     * @param mixed  $value
+     * @param array  $parameters
      * @return bool
      */
     public function validateContainsAll($attribute, $value, $parameters)
     {
         if (is_array($value)) {
             foreach ($parameters as $param) {
-                if (!Arr::exists($value, $param)) {
+                if (! Arr::exists($value, $param)) {
                     return false;
                 }
             }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -371,6 +371,21 @@ trait ValidatesAttributes
         return empty(array_diff_key($value, array_fill_keys($parameters, '')));
     }
 
+	public function validateContainsAll($attribute, $value, $parameters)
+	{
+		if (is_array($value)) {
+			foreach($parameters as $param) {
+				if (!Arr::exists($value, $param)) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return Str::containsAll($value, $parameters);
+	}
+
     /**
      * Validate the size of an attribute is between a set of values.
      *

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7034,7 +7034,7 @@ class ValidationValidatorTest extends TestCase
         $rules = [
             'baz' => [
                 'array',
-                'array_keys:foo,fee,laa',
+                'required_array_keys:foo,fee,laa',
             ],
         ];
 
@@ -7057,7 +7057,7 @@ class ValidationValidatorTest extends TestCase
         $rules = [
             'baz' => [
                 'array',
-                'array_keys:foo,fee',
+                'required_array_keys:foo,fee',
             ],
         ];
 
@@ -7068,7 +7068,7 @@ class ValidationValidatorTest extends TestCase
     public function testArrayKeysValidationFailsWithMissingKey()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.array_keys' => 'The :attribute field must contain entries for :values'], 'en');
+        $trans->addLines(['validation.required_array_keys' => 'The :attribute field must contain entries for :values'], 'en');
 
         $data = [
             'baz' => [
@@ -7081,7 +7081,7 @@ class ValidationValidatorTest extends TestCase
         $rules = [
             'baz' => [
                 'array',
-                'array_keys:foo,fee,boo,bar',
+                'required_array_keys:foo,fee,boo,bar',
             ],
         ];
 
@@ -7096,7 +7096,7 @@ class ValidationValidatorTest extends TestCase
     public function testArrayKeysValidationFailsWithNotAnArray()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.array_keys' => 'The :attribute field must contain entries for :values'], 'en');
+        $trans->addLines(['validation.required_array_keys' => 'The :attribute field must contain entries for :values'], 'en');
 
         $data = [
             'baz' => 'no an array',
@@ -7104,7 +7104,7 @@ class ValidationValidatorTest extends TestCase
 
         $rules = [
             'baz' => [
-                'array_keys:foo,fee,boo,bar',
+                'required_array_keys:foo,fee,boo,bar',
             ],
         ];
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7019,111 +7019,113 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals($expectedFailOnFirstErrorEnableResult, $failOnFirstErrorEnable->getMessageBag()->getMessages());
     }
 
-	public function testArrayContainsValidationPassedWhenHasKeys()
-	{
-		$trans = $this->getIlluminateArrayTranslator();
+    public function testArrayContainsValidationPassedWhenHasKeys()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
 
-		$data = [
-			'baz' => [
-				'foo' => 'bar',
-				'fee' => 'faa',
-				'laa' => 'lee',
-			],
-		];
+        $data = [
+            'baz' => [
+                'foo' => 'bar',
+                'fee' => 'faa',
+                'laa' => 'lee',
+            ],
+        ];
 
-		$rules = [
-			'baz' => [
-				'array',
-				'containsAll:foo,fee,laa'
-			],
-		];
+        $rules = [
+            'baz' => [
+                'array',
+                'containsAll:foo,fee,laa',
+            ],
+        ];
 
-		$validator = new Validator($trans, $data, $rules, [], []);
-		$this->assertTrue($validator->passes());
-	}
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertTrue($validator->passes());
+    }
 
-	public function testArrayContainsValidationPassedWithPartialMatch()
-	{
-		$trans = $this->getIlluminateArrayTranslator();
+    public function testArrayContainsValidationPassedWithPartialMatch()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
 
-		$data = [
-			'baz' => [
-				'foo' => 'bar',
-				'fee' => 'faa',
-				'laa' => 'lee',
-			],
-		];
+        $data = [
+            'baz' => [
+                'foo' => 'bar',
+                'fee' => 'faa',
+                'laa' => 'lee',
+            ],
+        ];
 
-		$rules = [
-			'baz' => [
-				'array',
-				'containsAll:foo,fee'
-			],
-		];
+        $rules = [
+            'baz' => [
+                'array',
+                'containsAll:foo,fee',
+            ],
+        ];
 
-		$validator = new Validator($trans, $data, $rules, [], []);
-		$this->assertTrue($validator->passes());
-	}
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertTrue($validator->passes());
+    }
 
-	public function testArrayContainsValidationFailsWithMissingKey()
-	{
-		$trans = $this->getIlluminateArrayTranslator();
-		$trans->addLines(['validation.contains_all' => 'The :attribute field must contain entries for :values'], 'en');
+    public function testArrayContainsValidationFailsWithMissingKey()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.contains_all' => 'The :attribute field must contain entries for :values'], 'en');
 
-		$data = [
-			'baz' => [
-				'foo' => 'bar',
-				'fee' => 'faa',
-				'laa' => 'lee',
-			],
-		];
+        $data = [
+            'baz' => [
+                'foo' => 'bar',
+                'fee' => 'faa',
+                'laa' => 'lee',
+            ],
+        ];
 
-		$rules = [
-			'baz' => [
-				'array',
-				'containsAll:foo,fee,boo,bar'
-			],
-		];
+        $rules = [
+            'baz' => [
+                'array',
+                'containsAll:foo,fee,boo,bar',
+            ],
+        ];
 
-		$validator = new Validator($trans, $data, $rules, [], []);
-		$this->assertFalse($validator->passes());
-		$this->assertSame(
-			'The baz field must contain entries for foo, fee, boo, bar',
-			$validator->messages()->first('baz')
-		);
-	}
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertFalse($validator->passes());
+        $this->assertSame(
+            'The baz field must contain entries for foo, fee, boo, bar',
+            $validator->messages()->first('baz')
+        );
+    }
 
-	public function testContainsValidationPassesWithStrings() {
-		$trans = $this->getIlluminateArrayTranslator();
+    public function testContainsValidationPassesWithStrings()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
 
-		$data = ['invoice_number' => 'INV-123456789'];
+        $data = ['invoice_number' => 'INV-123456789'];
 
-		$rules = [
-			'invoice_number' => [
-				'required',
-				'containsAll:INV',
-			],
-		];
+        $rules = [
+            'invoice_number' => [
+                'required',
+                'containsAll:INV',
+            ],
+        ];
 
-		$validator = new Validator($trans, $data, $rules, [], []);
-		$this->assertTrue($validator->passes());
-	}
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertTrue($validator->passes());
+    }
 
-	public function testContainsValidationFailsWithInvalidStrings() {
-		$trans = $this->getIlluminateArrayTranslator();
+    public function testContainsValidationFailsWithInvalidStrings()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
 
-		$data = ['invoice_number' => 'PO-987654321'];
+        $data = ['invoice_number' => 'PO-987654321'];
 
-		$rules = [
-			'invoice_number' => [
-				'required',
-				'containsAll:INV',
-			],
-		];
+        $rules = [
+            'invoice_number' => [
+                'required',
+                'containsAll:INV',
+            ],
+        ];
 
-		$validator = new Validator($trans, $data, $rules, [], []);
-		$this->assertFalse($validator->passes());
-	}
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertFalse($validator->passes());
+    }
 
     protected function getTranslator()
     {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7019,6 +7019,112 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals($expectedFailOnFirstErrorEnableResult, $failOnFirstErrorEnable->getMessageBag()->getMessages());
     }
 
+	public function testArrayContainsValidationPassedWhenHasKeys()
+	{
+		$trans = $this->getIlluminateArrayTranslator();
+
+		$data = [
+			'baz' => [
+				'foo' => 'bar',
+				'fee' => 'faa',
+				'laa' => 'lee',
+			],
+		];
+
+		$rules = [
+			'baz' => [
+				'array',
+				'containsAll:foo,fee,laa'
+			],
+		];
+
+		$validator = new Validator($trans, $data, $rules, [], []);
+		$this->assertTrue($validator->passes());
+	}
+
+	public function testArrayContainsValidationPassedWithPartialMatch()
+	{
+		$trans = $this->getIlluminateArrayTranslator();
+
+		$data = [
+			'baz' => [
+				'foo' => 'bar',
+				'fee' => 'faa',
+				'laa' => 'lee',
+			],
+		];
+
+		$rules = [
+			'baz' => [
+				'array',
+				'containsAll:foo,fee'
+			],
+		];
+
+		$validator = new Validator($trans, $data, $rules, [], []);
+		$this->assertTrue($validator->passes());
+	}
+
+	public function testArrayContainsValidationFailsWithMissingKey()
+	{
+		$trans = $this->getIlluminateArrayTranslator();
+		$trans->addLines(['validation.contains_all' => 'The :attribute field must contain entries for :values'], 'en');
+
+		$data = [
+			'baz' => [
+				'foo' => 'bar',
+				'fee' => 'faa',
+				'laa' => 'lee',
+			],
+		];
+
+		$rules = [
+			'baz' => [
+				'array',
+				'containsAll:foo,fee,boo,bar'
+			],
+		];
+
+		$validator = new Validator($trans, $data, $rules, [], []);
+		$this->assertFalse($validator->passes());
+		$this->assertSame(
+			'The baz field must contain entries for foo, fee, boo, bar',
+			$validator->messages()->first('baz')
+		);
+	}
+
+	public function testContainsValidationPassesWithStrings() {
+		$trans = $this->getIlluminateArrayTranslator();
+
+		$data = ['invoice_number' => 'INV-123456789'];
+
+		$rules = [
+			'invoice_number' => [
+				'required',
+				'containsAll:INV',
+			],
+		];
+
+		$validator = new Validator($trans, $data, $rules, [], []);
+		$this->assertTrue($validator->passes());
+	}
+
+	public function testContainsValidationFailsWithInvalidStrings() {
+		$trans = $this->getIlluminateArrayTranslator();
+
+		$data = ['invoice_number' => 'PO-987654321'];
+
+		$rules = [
+			'invoice_number' => [
+				'required',
+				'containsAll:INV',
+			],
+		];
+
+		$validator = new Validator($trans, $data, $rules, [], []);
+		$this->assertFalse($validator->passes());
+	}
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7019,7 +7019,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals($expectedFailOnFirstErrorEnableResult, $failOnFirstErrorEnable->getMessageBag()->getMessages());
     }
 
-    public function testArrayContainsValidationPassedWhenHasKeys()
+    public function testArrayKeysValidationPassedWhenHasKeys()
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -7034,7 +7034,7 @@ class ValidationValidatorTest extends TestCase
         $rules = [
             'baz' => [
                 'array',
-                'containsAll:foo,fee,laa',
+                'array_keys:foo,fee,laa',
             ],
         ];
 
@@ -7042,7 +7042,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($validator->passes());
     }
 
-    public function testArrayContainsValidationPassedWithPartialMatch()
+    public function testArrayKeysValidationPassedWithPartialMatch()
     {
         $trans = $this->getIlluminateArrayTranslator();
 
@@ -7057,7 +7057,7 @@ class ValidationValidatorTest extends TestCase
         $rules = [
             'baz' => [
                 'array',
-                'containsAll:foo,fee',
+                'array_keys:foo,fee',
             ],
         ];
 
@@ -7065,10 +7065,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($validator->passes());
     }
 
-    public function testArrayContainsValidationFailsWithMissingKey()
+    public function testArrayKeysValidationFailsWithMissingKey()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $trans->addLines(['validation.contains_all' => 'The :attribute field must contain entries for :values'], 'en');
+        $trans->addLines(['validation.array_keys' => 'The :attribute field must contain entries for :values'], 'en');
 
         $data = [
             'baz' => [
@@ -7081,7 +7081,7 @@ class ValidationValidatorTest extends TestCase
         $rules = [
             'baz' => [
                 'array',
-                'containsAll:foo,fee,boo,bar',
+                'array_keys:foo,fee,boo,bar',
             ],
         ];
 
@@ -7093,38 +7093,27 @@ class ValidationValidatorTest extends TestCase
         );
     }
 
-    public function testContainsValidationPassesWithStrings()
+    public function testArrayKeysValidationFailsWithNotAnArray()
     {
         $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.array_keys' => 'The :attribute field must contain entries for :values'], 'en');
 
-        $data = ['invoice_number' => 'INV-123456789'];
-
-        $rules = [
-            'invoice_number' => [
-                'required',
-                'containsAll:INV',
-            ],
+        $data = [
+            'baz' => 'no an array',
         ];
 
-        $validator = new Validator($trans, $data, $rules, [], []);
-        $this->assertTrue($validator->passes());
-    }
-
-    public function testContainsValidationFailsWithInvalidStrings()
-    {
-        $trans = $this->getIlluminateArrayTranslator();
-
-        $data = ['invoice_number' => 'PO-987654321'];
-
         $rules = [
-            'invoice_number' => [
-                'required',
-                'containsAll:INV',
+            'baz' => [
+                'array_keys:foo,fee,boo,bar',
             ],
         ];
 
         $validator = new Validator($trans, $data, $rules, [], []);
         $this->assertFalse($validator->passes());
+        $this->assertSame(
+            'The baz field must contain entries for foo, fee, boo, bar',
+            $validator->messages()->first('baz')
+        );
     }
 
     protected function getTranslator()


### PR DESCRIPTION
I have recently been finding it more common to have to validate that certain items are available in an array. However, the items that are required are usually dynamically driven and then stored as JSON in a DB column.

A really simple example of this might be shifts for a team. Each team has working days which are pre-defined and stored in a database. There is then a dynamically generated form which asks for the shift times for these days.

The required data for each shift would be the same, a start time and an end time and would be required. Typically, to validate this dynamic data, you might do something such as:

```php
public function rules() {

$dayRules = BusinessHourDay::sameCompany()->get()->map(function ($businessHourDay) {  
  return [  
  'days.' . $businessHourDay->day . '.start_time' => 'required',  
  'days.' . $businessHourDay->day . '.end_time' => 'required',  
  // more rules  
  ];  
});  
  
return [  
  'name' => 'required',  
  'description' => 'required'
  'days' => 'array',
  ...$dayRules,  
];
```

This allows us to validate the days that the user has configured in the database are present in the dynamically generated form.

This proposed change would allow this instead:

```php
public function rules() {

$dayRules = BusinessHourDay::sameCompany()->get()->pluck('day');  
return [  
  'name' => 'required',  
  'description' => 'required',  
  'days' => [  
  'bail',
  'array',  
  'contains_all,' . $dayRules->implode(','),  
  ],  
  'days.*.start_time' => 'required',  
  'days.*.end_time' => 'required',
  // more rules  
];
```

This would simplify the validation in the cases where mapping a list of validation rules, which would have the same rules for each entry, but we still want to assert that all the required data was present.

The rule could also be applied to a string field to make sure a part or parts of it given match a particular structure, for example, a form where you might enter an invoice "number" something like "INV:12345-WEB"

```php
public function rules() {

return [
	'invoice_id' = [
		'required',
		'contains_all:INV,WEB',
	],
];
```

Would be grateful for any feedback or thought you have on this :)

Thanks guys.

