### PR TITLE
[8.x] Allows enums as morphed model type in QueryBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -462,7 +462,7 @@ abstract class Relation
      */
     public static function getMorphedModel($alias)
     {
-        $key = is_string($alias) ? $alias : (isset($alias->value) ? $alias->value : '');
+        $key = $alias instanceof \BackedEnum ? $alias->value : $alias;
         return static::$morphMap[$key] ?? null;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -457,12 +457,13 @@ abstract class Relation
     /**
      * Get the model associated with a custom polymorphic type.
      *
-     * @param  string  $alias
+     * @param  string|object  $alias
      * @return string|null
      */
     public static function getMorphedModel($alias)
     {
-        return static::$morphMap[$alias] ?? null;
+        $key = is_string($alias) ? $alias : (isset($alias->value) ? $alias->value : '');
+        return static::$morphMap[$key] ?? null;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -25,7 +25,7 @@ class DatabaseEloquentRelationTest extends TestCase
         if (version_compare(PHP_VERSION, '8.1') < 0) {
             $this->markTestSkipped('PHP 8.1 is required');
         } else {
-            Relation::$morphMap['test'] = 'TestModel';
+            Relation::morphMap(['test' => 'TestModel']);
             $enumKey = TestEnum::test;
             $this->assertEquals('TestModel',Relation::getMorphedModel('test'));
             $this->assertEquals('TestModel',Relation::getMorphedModel($enumKey));
@@ -227,7 +227,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
     public function testSettingMorphMapWithNumericArrayUsesTheTableNames()
     {
-        Relation::morphMap([EloquentRelationResetModelStub::class]);
+        Relation::morphMap([EloquentRelationResetModelStub::class], false);
 
         $this->assertEquals([
             'reset' => EloquentRelationResetModelStub::class,
@@ -238,7 +238,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
     public function testSettingMorphMapWithNumericKeys()
     {
-        Relation::morphMap([1 => 'App\User']);
+        Relation::morphMap([1 => 'App\User'], false);
 
         $this->assertEquals([
             1 => 'App\User',

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -11,12 +11,25 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Tests\Database\stubs\TestEnum;
 
 class DatabaseEloquentRelationTest extends TestCase
 {
     protected function tearDown(): void
     {
         m::close();
+    }
+
+    public function testGetMorphedModelWithEnum()
+    {
+        if (version_compare(PHP_VERSION, '8.1') < 0) {
+            $this->markTestSkipped('PHP 8.1 is required');
+        } else {
+            Relation::$morphMap['test'] = 'TestModel';
+            $enumKey = TestEnum::test;
+            $this->assertEquals('TestModel',Relation::getMorphedModel('test'));
+            $this->assertEquals('TestModel',Relation::getMorphedModel($enumKey));
+        }
     }
 
     public function testSetRelationFail()

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -20,16 +20,15 @@ class DatabaseEloquentRelationTest extends TestCase
         m::close();
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
     public function testGetMorphedModelWithEnum()
     {
-        if (version_compare(PHP_VERSION, '8.1') < 0) {
-            $this->markTestSkipped('PHP 8.1 is required');
-        } else {
-            Relation::morphMap(['test' => 'TestModel']);
-            $enumKey = TestEnum::test;
-            $this->assertEquals('TestModel',Relation::getMorphedModel('test'));
-            $this->assertEquals('TestModel',Relation::getMorphedModel($enumKey));
-        }
+        Relation::morphMap(['test' => 'TestModel']);
+        $enumKey = TestEnum::test;
+        $this->assertEquals('TestModel',Relation::getMorphedModel('test'));
+        $this->assertEquals('TestModel',Relation::getMorphedModel($enumKey));
     }
 
     public function testSetRelationFail()


### PR DESCRIPTION
Consider following model and an enum
```
enum MyTypes: string
{
    case type1 = 'Type1';
    case type2 = 'Type2';
}
class MyModel extends Model
{
    public $casts [
         'item_type' => MyTypes::class
    ];

    public function item(): MorphTo
    {
        return $this->morphTo();
    }
}
```
In AppServiceProvider custom morph types are set (#40375 allowed this)
```
    public function boot()
    {
        Relation::morphMap(
            [
                'Type1' => \App\Models\ModelTypeOne::class,
                'Type2' => \App\Models\ModelTypeTwo::class
            ]
        );
    }
```
and when I try to get models with the query
`MyModel::query()->whereHasMorph('item', [MyTypes::type2 ])->get()`

instead of models I get
```
TypeError
Illegal offset type
```
This happens because a BakedEnum cannot be an array key

This pr allows BakedEnum to be used in `whereHasMorph` method and the key is either string key or enum's value
