### PR TITLE
Adds attempt helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -677,6 +677,21 @@ if (! function_exists('rescue')) {
     }
 }
 
+if (! function_exists('attempt')) {
+    /**
+     * Attempt a callable, ignore any exceptions and return a default value.
+     *
+     * @param  callable  $callback
+     * @param  mixed  $rescue
+     * @param  bool  $report
+     * @return mixed
+     */
+    function attempt(callable $callback, $rescue = null)
+    {
+        return rescue($callback, $rescue, false);
+    }
+}
+
 if (! function_exists('resolve')) {
     /**
      * Resolve a service from the container.

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -51,6 +51,47 @@ class FoundationHelpersTest extends TestCase
         );
     }
 
+    public function testAttempt()
+    {
+        $this->assertEquals(
+            'attempted!',
+            attempt(function () {
+                throw new Exception;
+            }, 'attempted!')
+        );
+
+        $this->assertEquals(
+            'attempted!',
+            attempt(function () {
+                throw new Exception;
+            }, function () {
+                return 'attempted!';
+            })
+        );
+
+        $this->assertEquals(
+            'no need to rescue',
+            attempt(function () {
+                return 'no need to rescue';
+            }, 'attempted!')
+        );
+
+        $testClass = new class
+        {
+            public function test(int $a)
+            {
+                return $a;
+            }
+        };
+
+        $this->assertEquals(
+            'attempted!',
+            attempt(function () use ($testClass) {
+                $testClass->test([]);
+            }, 'attempted!')
+        );
+    }
+
     public function testMixReportsExceptionWhenAssetIsMissingFromManifest()
     {
         $handler = new FakeHandler;


### PR DESCRIPTION
Adds `attempt` helper.
It attempts to execute a callback, but if it fails, it simply ignores it.

The `rescue` helper is nice, but I always need to set the `$report` argument to `false`.