### PR TITLE
[8.x] Allow to push and prepend config values on new keys

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -99,7 +99,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function prepend($key, $value)
     {
-        $array = $this->get($key);
+        $array = $this->get($key, []);
 
         array_unshift($array, $value);
 
@@ -115,7 +115,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function push($key, $value)
     {
-        $array = $this->get($key);
+        $array = $this->get($key, []);
 
         $array[] = $value;
 

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -143,6 +143,18 @@ class RepositoryTest extends TestCase
         $this->assertSame('xxx', $this->repository->get('array.2'));
     }
 
+    public function testPrependWithNewKey()
+    {
+        $this->repository->prepend('new_key', 'xxx');
+        $this->assertSame(['xxx'], $this->repository->get('new_key'));
+    }
+
+    public function testPushWithNewKey()
+    {
+        $this->repository->push('new_key', 'xxx');
+        $this->assertSame(['xxx'], $this->repository->get('new_key'));
+    }
+
     public function testAll()
     {
         $this->assertSame($this->config, $this->repository->all());


### PR DESCRIPTION
The current behavior with config `prepend` and `push` is inconsistent when used with new/undefined keys:

```php
config()->push('new_key', 'foobar');
```
seems to work fine.
However,
```php
config()->prepend('new_key2', 'foobar');
```
throws:

`TypeError: array_unshift(): Argument #1 ($array) must be of type array, null given`

This PR addresses this issue.

Regards.