### PR TITLE
[9.x] Expose pusher() and ably()

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -207,12 +207,12 @@ class BroadcastManager implements FactoryContract
     }
 
     /**
-     * Create an instance of the driver.
+     * Get the Pusher instance associated to the config.
      *
      * @param  array  $config
-     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
+     * @return \Pusher\Pusher
      */
-    protected function createPusherDriver(array $config)
+    public function pusher(array $config)
     {
         $pusher = new Pusher(
             $config['key'],
@@ -228,7 +228,29 @@ class BroadcastManager implements FactoryContract
             $pusher->setLogger($this->app->make(LoggerInterface::class));
         }
 
-        return new PusherBroadcaster($pusher);
+        return $pusher;
+    }
+
+    /**
+     * Create an instance of the driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
+     */
+    protected function createPusherDriver(array $config)
+    {
+        return new PusherBroadcaster($this->pusher($config));
+    }
+
+    /**
+     * Get the Ably instance associated to the config.
+     *
+     * @param  array  $config
+     * @return \Ably\AblyRest
+     */
+    public function ably(array $config)
+    {
+        return new AblyRest($config);
     }
 
     /**
@@ -239,7 +261,7 @@ class BroadcastManager implements FactoryContract
      */
     protected function createAblyDriver(array $config)
     {
-        return new AblyBroadcaster(new AblyRest($config));
+        return new AblyBroadcaster($this->ably($config));
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -207,7 +207,18 @@ class BroadcastManager implements FactoryContract
     }
 
     /**
-     * Get the Pusher instance associated to the config.
+     * Create an instance of the driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
+     */
+    protected function createPusherDriver(array $config)
+    {
+        return new PusherBroadcaster($this->pusher($config));
+    }
+
+    /**
+     * Get a Pusher instance for the given configuration.
      *
      * @param  array  $config
      * @return \Pusher\Pusher
@@ -237,13 +248,13 @@ class BroadcastManager implements FactoryContract
      * @param  array  $config
      * @return \Illuminate\Contracts\Broadcasting\Broadcaster
      */
-    protected function createPusherDriver(array $config)
+    protected function createAblyDriver(array $config)
     {
-        return new PusherBroadcaster($this->pusher($config));
+        return new AblyBroadcaster($this->ably($config));
     }
 
     /**
-     * Get the Ably instance associated to the config.
+     * Get an Ably instance for the given configuration.
      *
      * @param  array  $config
      * @return \Ably\AblyRest
@@ -251,17 +262,6 @@ class BroadcastManager implements FactoryContract
     public function ably(array $config)
     {
         return new AblyRest($config);
-    }
-
-    /**
-     * Create an instance of the driver.
-     *
-     * @param  array  $config
-     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
-     */
-    protected function createAblyDriver(array $config)
-    {
-        return new AblyBroadcaster($this->ably($config));
     }
 
     /**


### PR DESCRIPTION
For a quick change, it seems like it would have been much easier to access the underlying Pusher or Ably drivers by calling the Broadcasting directly with the given configuration:

```php
$pusher = Broadcast::pusher(config('broadcasting.connections.pusher'));

$pusher->get_channel_info(...);
```

Not sure how to work around the config parameter better, but it should do the job in initializing the SDK instead of manually creating one.