### PR TITLE
[8.x] Define multiple foreign model IDs in table Blueprint at once

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -886,6 +886,55 @@ class Blueprint
         ]));
     }
 
+    /**
+     * Creates a collection of foreign ID columns for the given array of models. A convenient shorthand for when you
+     * need to reference a number of foreign models from this table. Where necessary, you may also specify the
+     * column name, and / or a closure to process the resulting ForeignIdColumnDefinition.
+     *
+     * E.g. Array of models - conventional column names will be used.
+     * $table->foreignIdsFor([
+     *      User::model,
+     *      Post::model
+     * ]);
+     *
+     * E.g. Since the method returns a Collection, you can use the HigherOrderCollectionProxy methods to set defaults
+     * that will apply to all columns (individual column definitions can also be configured - see below).
+     * $table->foreignIdsFor([
+     *      User::model,
+     *      Post::model
+     * ])->each->nullable();
+     *
+     * E.g. Use the array key to specify the model, and the value for the column name.
+     *
+     * $table->foreignIdsFor([
+     *      User::model => 'author_id',
+     *      Post::model
+     * ]);
+     *
+     * E.g. Use the array value as a callback function to modify the column definition.
+     *
+     * $table->foreignIdsFor([
+     *      User::model => 'author_id',
+     *      Post::model => function(ForeignIdColumnDefinition $def) {
+     *          $def->nullable()
+     *      })
+     * ]);
+     *
+     * E.g. If you need to provide a specific column name for the foreign ID, and handle the column definition, set the
+     * value in the array to an array where the first item is the string column name, and the second is the callback
+     * $table->foreignIdsFor([
+     *      User::model,
+     *      Post::model => [
+     *         'featured_post_id',
+     *         function(ForeignIdColumnDefinition $def) {
+     *              $def->nullable()
+     *         }
+     *      ]
+     * ]);
+     *
+     * @param string[] $models|
+     * @return \Illuminate\Support\Collection|\Illuminate\Database\Schema\ForeignIdColumnDefinition[]
+     */
     public function foreignIdsFor($models) {
         if (!is_array($models))
             $models = [$models];

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -935,23 +935,23 @@ class Blueprint
      *      ]
      * ]);
      *
-     * @param string[] $models|
+     * @param  string[]  $models
      * @return \Illuminate\Support\Collection|\Illuminate\Database\Schema\ForeignIdColumnDefinition[]
      */
     public function foreignIdsFor($models) {
-        if (!is_array($models))
+        if (! is_array($models)) {
             $models = [$models];
+        }
 
         $definitions = collect();
-        foreach($models as $index => $value) {
+        foreach ($models as $index => $value) {
             $model = is_int($index) ? $value : $index;
 
             if (is_array($value)) {
                 $column = $value[0];
                 $callback = $value[1];
-            }
-            else {
-                $column = !is_int($index) && is_string($value) ? $value : null;
+            } else {
+                $column = ! is_int($index) && is_string($value) ? $value : null;
                 $callback = $value instanceof Closure ? $value : null;
             }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -888,43 +888,46 @@ class Blueprint
 
     /**
      * Creates a collection of foreign ID columns for the given array of models. A convenient shorthand for when you
-     * need to reference a number of foreign models from this table. Where necessary, you may also specify the
-     * column name, and / or a closure to process the resulting ForeignIdColumnDefinition.
+     * need to reference a number of foreign models from this table. Where necessary, you may also specify
+     * the column name, and / or a closure to process the resulting ForeignIdColumnDefinition.
      *
      * E.g. Array of models - conventional column names will be used.
      * $table->foreignIdsFor([
-     *      User::model,
-     *      Post::model
+     *      User::class,
+     *      Project::class,
+     *      State::class
      * ]);
      *
-     * E.g. Since the method returns a Collection, you can use the HigherOrderCollectionProxy methods to set defaults
+     * E.g. Since the method returns a Collection, you may use the HigherOrderCollectionProxy methods to set defaults
      * that will apply to all columns (individual column definitions can also be configured - see below).
      * $table->foreignIdsFor([
-     *      User::model,
-     *      Post::model
+     *      User::class,
+     *      Project::class,
      * ])->each->nullable();
      *
      * E.g. Use the array key to specify the model, and the value for the column name.
      *
      * $table->foreignIdsFor([
-     *      User::model => 'author_id',
-     *      Post::model
+     *      User::class => 'author_id',
+     *      Project::class
      * ]);
      *
      * E.g. Use the array value as a callback function to modify the column definition.
      *
      * $table->foreignIdsFor([
-     *      User::model => 'author_id',
-     *      Post::model => function(ForeignIdColumnDefinition $def) {
+     *      User::class => 'author_id',
+     *      Project::class => function(ForeignIdColumnDefinition $def) {
      *          $def->nullable()
      *      })
      * ]);
      *
-     * E.g. If you need to provide a specific column name for the foreign ID, and handle the column definition, set the
-     * value in the array to an array where the first item is the string column name, and the second is the callback
+     * E.g. If you need to provide a specific column name for the foreign ID, and handle the column definition,
+     * set the value in the models array to an array where the first item is the string column name,
+     * and the second is the callback to handle the ForeignIdColumnDefinition.
+     *
      * $table->foreignIdsFor([
-     *      User::model,
-     *      Post::model => [
+     *      User::class,
+     *      Post::class => [
      *         'featured_post_id',
      *         function(ForeignIdColumnDefinition $def) {
      *              $def->nullable()

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -938,7 +938,8 @@ class Blueprint
      * @param  string[]  $models
      * @return \Illuminate\Support\Collection|\Illuminate\Database\Schema\ForeignIdColumnDefinition[]
      */
-    public function foreignIdsFor($models) {
+    public function foreignIdsFor($models)
+    {
         if (! is_array($models)) {
             $models = [$models];
         }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -886,6 +886,33 @@ class Blueprint
         ]));
     }
 
+    public function foreignIdsFor($models) {
+        if (!is_array($models))
+            $models = [$models];
+
+        $definitions = collect();
+        foreach($models as $index => $value) {
+            $model = is_int($index) ? $value : $index;
+
+            if (is_array($value)) {
+                $column = $value[0];
+                $callback = $value[1];
+            }
+            else {
+                $column = !is_int($index) && is_string($value) ? $value : null;
+                $callback = $value instanceof Closure ? $value : null;
+            }
+
+            $definitions->add($definition = $this->foreignIdFor($model, $column));
+
+            if ($callback) {
+                $callback($definition);
+            }
+        }
+
+        return $definitions;
+    }
+
     /**
      * Create a foreign ID column for the given model.
      *

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -303,6 +303,15 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ]);
     }
 
+    public function testGenerateMultipleRelationshipColumnsWithHigherOrderCallback()
+    {
+        $this->runBlueprintAssertions('some_table', function (Blueprint $table) {
+            $table->foreignIdsFor([User::class])->each->nullable();
+        }, [
+            'alter table `some_table` add `user_id` bigint unsigned null',
+        ]);
+    }
+
     public function testGenerateMultipleRelationshipColumnsWithCallbackAndColumnDefinition()
     {
         $this->runBlueprintAssertions('some_table', function (Blueprint $table) {

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -338,7 +338,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals($statements, $blueprint->toSql($connection, new MySqlGrammar));
     }
-    
+
     public function testGenerateRelationshipColumnWithUuidModel()
     {
         require_once __DIR__.'/stubs/EloquentModelUuidStub.php';

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -296,7 +296,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             $table->foreignIdsFor([
                 DatabaseNotification::class => function (ForeignIdColumnDefinition $definition) {
                     $definition->nullable();
-                }
+                },
             ]);
         }, [
             'alter table `some_table` add `database_notification_id` char(36) null',
@@ -321,8 +321,8 @@ class DatabaseSchemaBlueprintTest extends TestCase
                     'author_id',
                     function (ForeignIdColumnDefinition $definition) {
                         $definition->nullable();
-                    }
-                ]
+                    },
+                ],
             ]);
         }, [
             'alter table `some_table` add `user_id` bigint unsigned not null, add `author_id` bigint unsigned null',

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -338,8 +338,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals($statements, $blueprint->toSql($connection, new MySqlGrammar));
     }
-
-
+    
     public function testGenerateRelationshipColumnWithUuidModel()
     {
         require_once __DIR__.'/stubs/EloquentModelUuidStub.php';


### PR DESCRIPTION
The PR exposes a convenience method of defining multiple foreign ID columns for related models. 

### Backwards compatability

Since it sits on top of the existing $table->foreignIdFor(...) method and does not modify the existing behaviour of that method, it does not present any breaking changes or backwards incompatability.

### Benefit to users

Currently, users are able to define foreign Ids tied to models using the existing 'foreignIdFor(Model::class)' method. This new method enables users to more succinctly define tables that relate to multiple foreign models. All resulting ForeignIdColumnDefinitions remain accessible for additional individual configuration or handling. Furthermore, since the method returns a Collection, the use of HigherOrderCollectionProxy methods, or 'each' Collection callbacks can also be used to apply settings to the entire collection.

### Unit tests

Tests accompany this PR. See the additional tests in tests/Database/DatabaseSchemaBlueprintTest.php. Since the tests are named with a similar base, they can all be ran with the following command: 
`php .\vendor\bin\phpunit --filter='testGenerateMultipleRelationshipColumns'`

### Example usages

Typically from within a migration:


Conventional column names will be used (user_id, project_id, state_id):
```php
Schema::table('uploads', function (Blueprint $table) {
    $table->foreignIdsFor([
        User::class,
        Project::class,
        State::class
    ]);
});
```

Conventional column names will be used (user_id, project_id, state_id), all columns made nullable.
```php
Schema::table('uploads', function (Blueprint $table) {
    $table->foreignIdsFor([
        User::class,
        Project::class,
        State::class
    ])->each->nullable();
});

// Or without the use of HigherOrderCollectionProxy
Schema::table('uploads', function (Blueprint $table) {
    $table->foreignIdsFor([
        User::class,
        Project::class,
        State::class
    ])->each( fn($def) => $def->nullable() );
});
```

Note - to express the same schema with the existing API, the following code is necessary - 215 chars vs 160 chars with the proposed change.
```php
Schema::table('uploads', function (Blueprint $table) {
    $table->foreignIdFor(User::class)->nullable();
    $table->foreignIdFor(Project::class)->nullable();
    $table->foreignIdFor(State::class)->nullable();
});
```

To provide a specific column name, or handle the ForeignIdColumnDefinition, the $table may configured in the following way. Assuming no other conventions are changed in model class definitions, the resulting columns created will be: 'post_id', 'uploader_id', 'project_id', and 'status_id;'
```php
Schema::table('uploads', function (Blueprint $table) {
    $table->foreignIdsFor([
        Post::class,
        User::class => 'uploader_id',
        Project::class => fn(ForeignIdColumnDefinition $definition) => $definition->nullable(),
        State::class => ['status_id', fn(ForeignIdColumnDefinition $definition) => $definition->after('id')]
    ]);
});
```
