### PR TITLE
[9.x] Add ability to supply additional callbacks in Rule::when

### DIFF
--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -51,7 +51,7 @@ class ConditionalRules
     public function passes(array $data = [])
     {
         return is_callable($this->condition)
-                    ? value($this->condition, new Fluent($data))
+                    ? call_user_func($this->condition, new Fluent($data))
                     : $this->condition;
     }
 

--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -51,27 +51,33 @@ class ConditionalRules
     public function passes(array $data = [])
     {
         return is_callable($this->condition)
-                    ? call_user_func($this->condition, new Fluent($data))
+                    ? value($this->condition, new Fluent($data))
                     : $this->condition;
     }
 
     /**
      * Get the rules.
-     *
+     * 
+     * @param  array  $data
      * @return array
      */
-    public function rules()
+    public function rules(array $data = [])
     {
-        return is_string($this->rules) ? explode('|', $this->rules) : $this->rules;
+        return is_string($this->rules)
+                    ? explode('|', $this->rules)
+                    : value($this->rules, new Fluent($data));
     }
 
     /**
      * Get the default rules.
      *
+     * @param  array  $data
      * @return array
      */
-    public function defaultRules()
+    public function defaultRules(array $data = [])
     {
-        return is_string($this->defaultRules) ? explode('|', $this->defaultRules) : $this->defaultRules;
+        return is_string($this->defaultRules)
+                    ? explode('|', $this->defaultRules)
+                    : value($this->defaultRules, new Fluent($data));
     }
 }

--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -57,7 +57,7 @@ class ConditionalRules
 
     /**
      * Get the rules.
-     * 
+     *
      * @param  array  $data
      * @return array
      */

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -313,8 +313,8 @@ class ValidationRuleParser
 
             if ($attributeRules instanceof ConditionalRules) {
                 return [$attribute => $attributeRules->passes($data)
-                                ? array_filter($attributeRules->rules())
-                                : array_filter($attributeRules->defaultRules()), ];
+                                ? array_filter($attributeRules->rules($data))
+                                : array_filter($attributeRules->defaultRules($data)), ];
             }
 
             return [$attribute => collect($attributeRules)->map(function ($rule) use ($data) {
@@ -322,7 +322,7 @@ class ValidationRuleParser
                     return [$rule];
                 }
 
-                return $rule->passes($data) ? $rule->rules() : $rule->defaultRules();
+                return $rule->passes($data) ? $rule->rules($data) : $rule->defaultRules($data);
             })->filter()->flatten(1)->values()->all()];
         })->all();
     }

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -20,6 +20,12 @@ class ValidationRuleParserTest extends TestCase
             'city' => ['required', Rule::when(function (Fluent $input) {
                 return true;
             }, ['min:2'])],
+            'state' => ['required', Rule::when(true, function (Fluent $input) {
+                return 'min:2';
+            })],
+            'zip' => ['required', Rule::when(false, [], function (Fluent $input) {
+                return ['min:2'];
+            })],
         ]);
 
         $this->assertEquals([
@@ -29,6 +35,8 @@ class ValidationRuleParserTest extends TestCase
             'username' => ['required', 'min:2'],
             'address' => ['required'],
             'city' => ['required', 'min:2'],
+            'state' => ['required', 'min:2'],
+            'zip' => ['required', 'min:2'],
         ], $rules);
     }
 


### PR DESCRIPTION
## Description

This PR provides the ability to pass callbacks into the `$rules` and `$defaultRules` arguments in the `Rule::when()` method, providing the access to the input data for generating rules.

Also, since the `$condition` argument supports a callback, I feel it also makes sense to allow the other arguments to support callbacks. I initially assumed this was the case until I was met with an exception.

## Purpose

This allows us to delay instantiation of rules and/or objects when the `$condition` is truthy, preventing these instances from being created if they don't need to be:

```php
// In Form Request...

use App\Rules\HasPermission;

public function rules()
{
    return [
        'role' => [
            Rule::when($this->route('company'), function ($input) {
                // Ensure the user can assign the role in the company.
                return new CanAssignRole($input->role, $this->route('company'));
            }),
        ],
        // ...
    ];
}
```

## Breaking Changes

Both method signatures of the `rules()` and `defaultRules()` have been altered.