### PR TITLE
[9.x] Remove redundant Doctrine method on schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -385,19 +385,6 @@ class Builder
     }
 
     /**
-     * Register a custom Doctrine mapping type.
-     *
-     * @param  string  $class
-     * @param  string  $name
-     * @param  string  $type
-     * @return void
-     */
-    public function registerCustomDoctrineType($class, $name, $type)
-    {
-        $this->connection->registerDoctrineType($class, $name, $type);
-    }
-
-    /**
      * Get the database connection instance.
      *
      * @return \Illuminate\Database\Connection

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -28,6 +28,7 @@ namespace Illuminate\Support\Facades;
  * @method static void enableQueryLog()
  * @method static void disableQueryLog()
  * @method static void flushQueryLog()
+ * @method static void registerDoctrineType(string $class, string $name, string $type)
  * @method static \Illuminate\Database\Connection beforeExecuting(\Closure $callback)
  * @method static void listen(\Closure $callback)
  * @method static void rollBack(int $toLevel = null)

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -17,7 +17,6 @@ namespace Illuminate\Support\Facades;
  * @method static bool dropColumns(string $table, array $columns)
  * @method static bool hasTable(string $table)
  * @method static void defaultStringLength(int $length)
- * @method static void registerCustomDoctrineType(string $class, string $name, string $type)
  * @method static array getColumnListing(string $table)
  * @method static string getColumnType(string $table, string $column)
  * @method static void morphUsingUuids()

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -50,7 +50,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $this->markTestSkipped('Test requires a SQLite connection.');
         }
 
-        Schema::registerCustomDoctrineType(TinyInteger::class, TinyInteger::NAME, 'TINYINT');
+        Schema::getConnection()->registerDoctrineType(TinyInteger::class, TinyInteger::NAME, 'TINYINT');
 
         Schema::create('test', function (Blueprint $table) {
             $table->string('test_column');
@@ -72,7 +72,7 @@ class SchemaBuilderTest extends DatabaseTestCase
             $this->markTestSkipped('Test requires a SQLite connection.');
         }
 
-        Schema::registerCustomDoctrineType(TinyInteger::class, TinyInteger::NAME, 'TINYINT');
+        Schema::getConnection()->registerDoctrineType(TinyInteger::class, TinyInteger::NAME, 'TINYINT');
 
         Schema::create('test', function (Blueprint $table) {
             $table->string('test_column');


### PR DESCRIPTION
Follow-up to #40119 and #40303. Removes `Schema::registerCustomDoctrineType()`, the correct way to register custom types is with `DB::registerDoctrineType()` or in the config, and if for some reason someone still wants to do it this way they can use `Schema::getConnection()->registerDoctrineType()`.