### PR TITLE
[10.x] Fix ensure that the visibility of the local driver is taken into account

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -169,7 +169,8 @@ class FilesystemManager implements FactoryContract
     public function createLocalDriver(array $config)
     {
         $visibility = PortableVisibilityConverter::fromArray(
-            $config['permissions'] ?? []
+            $config['permissions'] ?? [],
+            $config['visibility'] ?? Visibility::PRIVATE
         );
 
         $links = ($config['links'] ?? null) === 'skip'


### PR DESCRIPTION
When uploading files, the permissions of the directory to be created have changed after updating laravel 9.x.
I'm setting `visibility` to `public`.
I assume this is a bug.

![2022-02-01_15h22_32](https://user-images.githubusercontent.com/14008307/151939577-7acdcdbd-b25c-4722-9259-9f319d5a03a7.png)

I was not so sure how to make tests, so I didn't.
