### PR TITLE
[9.x] Add .gitattributes to components

### DIFF
--- a/src/Illuminate/Auth/.gitattributes
+++ b/src/Illuminate/Auth/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Broadcasting/.gitattributes
+++ b/src/Illuminate/Broadcasting/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Bus/.gitattributes
+++ b/src/Illuminate/Bus/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Cache/.gitattributes
+++ b/src/Illuminate/Cache/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Collections/.gitattributes
+++ b/src/Illuminate/Collections/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Conditionable/.gitattributes
+++ b/src/Illuminate/Conditionable/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Config/.gitattributes
+++ b/src/Illuminate/Config/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Console/.gitattributes
+++ b/src/Illuminate/Console/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Container/.gitattributes
+++ b/src/Illuminate/Container/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Contracts/.gitattributes
+++ b/src/Illuminate/Contracts/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Cookie/.gitattributes
+++ b/src/Illuminate/Cookie/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Database/.gitattributes
+++ b/src/Illuminate/Database/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Encryption/.gitattributes
+++ b/src/Illuminate/Encryption/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Events/.gitattributes
+++ b/src/Illuminate/Events/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Filesystem/.gitattributes
+++ b/src/Illuminate/Filesystem/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Hashing/.gitattributes
+++ b/src/Illuminate/Hashing/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Http/.gitattributes
+++ b/src/Illuminate/Http/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Log/.gitattributes
+++ b/src/Illuminate/Log/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Macroable/.gitattributes
+++ b/src/Illuminate/Macroable/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Mail/.gitattributes
+++ b/src/Illuminate/Mail/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Notifications/.gitattributes
+++ b/src/Illuminate/Notifications/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Pagination/.gitattributes
+++ b/src/Illuminate/Pagination/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Pipeline/.gitattributes
+++ b/src/Illuminate/Pipeline/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Queue/.gitattributes
+++ b/src/Illuminate/Queue/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Redis/.gitattributes
+++ b/src/Illuminate/Redis/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Routing/.gitattributes
+++ b/src/Illuminate/Routing/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Session/.gitattributes
+++ b/src/Illuminate/Session/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Support/.gitattributes
+++ b/src/Illuminate/Support/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Testing/.gitattributes
+++ b/src/Illuminate/Testing/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Translation/.gitattributes
+++ b/src/Illuminate/Translation/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/Validation/.gitattributes
+++ b/src/Illuminate/Validation/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore

--- a/src/Illuminate/View/.gitattributes
+++ b/src/Illuminate/View/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+.gitattributes export-ignore


### PR DESCRIPTION
When I sent in #39318 I forgot to add a .gitattributes file to each component to filter out the .github directory when installing the components separately.
