### PR TITLE
[9.x] Support `callables` in `value()` helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -184,6 +184,14 @@ if (! function_exists('value')) {
      */
     function value($value, ...$args)
     {
-        return $value instanceof Closure ? $value(...$args) : $value;
+        if ($value instanceof Closure) {
+            return $value(...$args);
+        }
+
+        if (is_callable($value)) {
+            return value(Closure::fromCallable($value), ...$args);
+        }
+
+        return $value;
     }
 }

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -188,7 +188,7 @@ if (! function_exists('value')) {
             return $value(...$args);
         }
 
-        if (is_callable($value)) {
+        if (is_array($value) && is_callable($value)) {
             return value(Closure::fromCallable($value), ...$args);
         }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -47,6 +47,16 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('foo', value(function ($arg) {
             return $arg;
         }, 'foo'));
+
+        $foo = new class {
+            function bar($arg) {
+                return $arg;
+            }
+        };
+        
+        $this->assertSame('baz', value([$foo, 'bar'], 'baz'));
+
+        $this->assertSame([$foo, 'baz'], value([$foo, 'baz']));
     }
 
     public function testObjectGet()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -50,7 +50,7 @@ class SupportHelpersTest extends TestCase
 
         $foo = new class
         {
-            function bar($arg)
+            public function bar($arg)
             {
                 return $arg;
             }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -48,12 +48,14 @@ class SupportHelpersTest extends TestCase
             return $arg;
         }, 'foo'));
 
-        $foo = new class {
-            function bar($arg) {
+        $foo = new class
+        {
+            function bar($arg)
+            {
                 return $arg;
             }
         };
-        
+
         $this->assertSame('baz', value([$foo, 'bar'], 'baz'));
 
         $this->assertSame([$foo, 'baz'], value([$foo, 'baz']));


### PR DESCRIPTION
## Description

This PR provides the ability to provide callables in the `value()` helper. Ex:

```php
value([$object, 'method'], 'arg');
```

This adds some additional simplicity when allowing various data types in method parameters:

```php
value($var); // $var
value(fn () => true); // true
value([$object, 'method']); // method return
```