### PR TITLE
Add generic hints to Cache

### DIFF
--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -71,7 +71,7 @@ interface Repository extends CacheInterface
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCached  $callback
-     * @return mixed
+     * @return TCached
      */
     public function remember($key, $ttl, Closure $callback);
 
@@ -91,7 +91,7 @@ interface Repository extends CacheInterface
      * @template TCached of mixed
      * @param  string  $key
      * @param  \Closure(): TCached  $callback
-     * @return mixed
+     * @return TCached
      */
     public function rememberForever($key, Closure $callback);
 

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -11,6 +11,7 @@ interface Repository extends CacheInterface
      * Retrieve an item from the cache and delete it.
      *
      * @template TCached of mixed
+     *
      * @param  string  $key
      * @param  null|TCached  $default
      * @return null|TCached
@@ -68,6 +69,7 @@ interface Repository extends CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result.
      *
      * @template TCached of mixed
+     *
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @param  \Closure(): TCached  $callback
@@ -79,6 +81,7 @@ interface Repository extends CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
      * @template TCached of mixed
+     *
      * @param  string  $key
      * @param  \Closure(): TCached  $callback
      * @return TCached
@@ -89,6 +92,7 @@ interface Repository extends CacheInterface
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
      * @template TCached of mixed
+     *
      * @param  string  $key
      * @param  \Closure(): TCached  $callback
      * @return TCached

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -10,9 +10,10 @@ interface Repository extends CacheInterface
     /**
      * Retrieve an item from the cache and delete it.
      *
+     * @template TCached of mixed
      * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  null|TCached  $default
+     * @return null|TCached
      */
     public function pull($key, $default = null);
 
@@ -66,9 +67,10 @@ interface Repository extends CacheInterface
     /**
      * Get an item from the cache, or execute the given Closure and store the result.
      *
+     * @template TCached of mixed
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
-     * @param  \Closure  $callback
+     * @param  \Closure(): TCached  $callback
      * @return mixed
      */
     public function remember($key, $ttl, Closure $callback);
@@ -76,17 +78,19 @@ interface Repository extends CacheInterface
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCached of mixed
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCached  $callback
+     * @return TCached
      */
     public function sear($key, Closure $callback);
 
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCached of mixed
      * @param  string  $key
-     * @param  \Closure  $callback
+     * @param  \Closure(): TCached  $callback
      * @return mixed
      */
     public function rememberForever($key, Closure $callback);

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @template TCached of mixed
+ *
  * @method static \Illuminate\Cache\TaggedCache tags(array|mixed $names)
  * @method static \Illuminate\Contracts\Cache\Lock lock(string $name, int $seconds = 0, mixed $owner = null)
  * @method static \Illuminate\Contracts\Cache\Lock restoreLock(string $name, string $owner)
@@ -17,11 +19,11 @@ namespace Illuminate\Support\Facades;
  * @method static bool put(string $key, $value, \DateTimeInterface|\DateInterval|int $ttl = null)
  * @method static int|bool decrement(string $key, $value = 1)
  * @method static int|bool increment(string $key, $value = 1)
- * @method static mixed get(string $key, mixed $default = null)
- * @method static mixed pull(string $key, mixed $default = null)
- * @method static mixed remember(string $key, \DateTimeInterface|\DateInterval|int $ttl, \Closure $callback)
- * @method static mixed rememberForever(string $key, \Closure $callback)
- * @method static mixed sear(string $key, \Closure $callback)
+ * @method static null|TCached get(string $key, TCached $default = null)
+ * @method static null|TCached pull(string $key, TCached $default = null)
+ * @method static TCached remember(string $key, \DateTimeInterface|\DateInterval|int $ttl, \Closure(): TCached $callback)
+ * @method static TCached rememberForever(string $key, \Closure(): TCached $callback)
+ * @method static TCached sear(string $key, \Closure(): TCached $callback)
  *
  * @see \Illuminate\Cache\CacheManager
  * @see \Illuminate\Cache\Repository


### PR DESCRIPTION
This provides a way for IDEs and other analyzer tools to reason about the value returned by the cache and there by not cause lose of context when ever it is used. See https://github.com/laravel/framework/pull/38257 for a general discussions about this topic.