### PR TITLE
[9.x] Add @pushOnce and @prependOnce

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -36,10 +36,9 @@ trait CompilesStacks
      */
     protected function compilePushOnce($expression)
     {
-        $parts = explode(',', $this->stripParentheses($expression));
+        $parts = explode(',', $this->stripParentheses($expression), 2);
 
-        $stack = $parts[0];
-        $id = $parts[1] ?? null;
+        [$stack, $id] = [$parts[0], $parts[1] ?? null];
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
 
@@ -86,10 +85,9 @@ $__env->startPush('.$stack.'); ?>';
      */
     protected function compilePrependOnce($expression)
     {
-        $parts = explode(',', $this->stripParentheses($expression));
+        $parts = explode(',', $this->stripParentheses($expression), 2);
 
-        $stack = $parts[0];
-        $id = $parts[1] ?? null;
+        [$stack, $id] = [$parts[0], $parts[1] ?? null];
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -43,9 +43,8 @@ trait CompilesStacks
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
 
-        return '<?php $__env->startPush('.$stack.');
-if (! $__env->hasRenderedOnce('.$id.')):
-$__env->markAsRenderedOnce('.$id.'); ?>';
+        return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
+$__env->startPush('.$stack.'); ?>';
     }
 
     /**
@@ -65,7 +64,7 @@ $__env->markAsRenderedOnce('.$id.'); ?>';
      */
     protected function compileEndpushOnce()
     {
-        return '<?php endif; $__env->stopPush(); ?>';
+        return '<?php $__env->stopPush(); endif; ?>';
     }
 
     /**
@@ -94,9 +93,8 @@ $__env->markAsRenderedOnce('.$id.'); ?>';
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
 
-        return '<?php $__env->startPrepend('.$stack.');
-if (! $__env->hasRenderedOnce('.$id.')):
-$__env->markAsRenderedOnce('.$id.'); ?>';
+        return '<?php if (! $__env->hasRenderedOnce('.$id.')): $__env->markAsRenderedOnce('.$id.');
+$__env->startPrepend('.$stack.'); ?>';
     }
 
     /**
@@ -116,6 +114,6 @@ $__env->markAsRenderedOnce('.$id.'); ?>';
      */
     protected function compileEndprependOnce()
     {
-        return '<?php endif; $__env->stopPrepend(); ?>';
+        return '<?php $__env->stopPrepend(); endif; ?>';
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -37,7 +37,7 @@ trait CompilesStacks
     protected function compilePushOnce($expression)
     {
         $parts = explode(',', $this->stripParentheses($expression));
-        
+
         $stack = $parts[0];
         $id = $parts[1] ?? null;
 
@@ -88,7 +88,7 @@ $__env->markAsRenderedOnce('.$id.'); ?>';
     protected function compilePrependOnce($expression)
     {
         $parts = explode(',', $this->stripParentheses($expression));
-        
+
         $stack = $parts[0];
         $id = $parts[1] ?? null;
 
@@ -108,7 +108,7 @@ $__env->markAsRenderedOnce('.$id.'); ?>';
     {
         return '<?php $__env->stopPrepend(); ?>';
     }
-    
+
     /**
      * Compile the end-prepend-once statements into valid PHP.
      *

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -43,7 +43,7 @@ trait CompilesStacks
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
 
-        return '<?php \$__env->startPush('.$stack.');
+        return '<?php $__env->startPush('.$stack.');
 if (! $__env->hasRenderedOnce('.$id.')):
 $__env->markAsRenderedOnce('.$id.'); ?>';
     }
@@ -94,7 +94,7 @@ $__env->markAsRenderedOnce('.$id.'); ?>';
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
 
-        return '<?php \$__env->startPrepend('.$stack.');
+        return '<?php $__env->startPrepend('.$stack.');
 if (! $__env->hasRenderedOnce('.$id.')):
 $__env->markAsRenderedOnce('.$id.'); ?>';
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
+use Illuminate\Support\Str;
+
 trait CompilesStacks
 {
     /**
@@ -27,6 +29,26 @@ trait CompilesStacks
     }
 
     /**
+     * Compile the push-once statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePushOnce($expression)
+    {
+        $parts = explode(',', $this->stripParentheses($expression));
+        
+        $stack = $parts[0];
+        $id = $parts[1] ?? null;
+
+        $id = trim($id) ?: "'".(string) Str::uuid()."'";
+
+        return '<?php \$__env->startPush('.$stack.');
+if (! $__env->hasRenderedOnce('.$id.')):
+$__env->markAsRenderedOnce('.$id.'); ?>';
+    }
+
+    /**
      * Compile the end-push statements into valid PHP.
      *
      * @return string
@@ -34,6 +56,16 @@ trait CompilesStacks
     protected function compileEndpush()
     {
         return '<?php $__env->stopPush(); ?>';
+    }
+
+    /**
+     * Compile the end-push-once statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndpushOnce()
+    {
+        return '<?php endif; $__env->stopPush(); ?>';
     }
 
     /**
@@ -48,6 +80,26 @@ trait CompilesStacks
     }
 
     /**
+     * Compile the prepend-once statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePrependOnce($expression)
+    {
+        $parts = explode(',', $this->stripParentheses($expression));
+        
+        $stack = $parts[0];
+        $id = $parts[1] ?? null;
+
+        $id = trim($id) ?: "'".(string) Str::uuid()."'";
+
+        return '<?php \$__env->startPrepend('.$stack.');
+if (! $__env->hasRenderedOnce('.$id.')):
+$__env->markAsRenderedOnce('.$id.'); ?>';
+    }
+
+    /**
      * Compile the end-prepend statements into valid PHP.
      *
      * @return string
@@ -55,5 +107,15 @@ trait CompilesStacks
     protected function compileEndprepend()
     {
         return '<?php $__env->stopPrepend(); ?>';
+    }
+    
+    /**
+     * Compile the end-prepend-once statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndprependOnce()
+    {
+        return '<?php endif; $__env->stopPrepend(); ?>';
     }
 }

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -22,7 +22,7 @@ bar
 test
 @endprependOnce';
 
-        $expected = '<?php \$__env->startPrepend(\'foo\');
+        $expected = '<?php $__env->startPrepend(\'foo\');
 if (! $__env->hasRenderedOnce(\'bar\')):
 $__env->markAsRenderedOnce(\'bar\'); ?>
 test

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -15,4 +15,19 @@ bar
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testPushOnceIsCompiled()
+    {
+        $string = '@prependOnce(\'foo\', \'bar\')
+test
+@endprependOnce';
+
+        $expected = '<?php \$__env->startPrepend(\'foo\');
+if (! $__env->hasRenderedOnce(\'bar\')):
+$__env->markAsRenderedOnce(\'bar\'); ?>
+test
+<?php endif; $__env->stopPrepend(); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -16,7 +16,7 @@ bar
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testPushOnceIsCompiled()
+    public function testPrependOnceIsCompiled()
     {
         $string = '@prependOnce(\'foo\', \'bar\')
 test

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -22,11 +22,10 @@ bar
 test
 @endprependOnce';
 
-        $expected = '<?php $__env->startPrepend(\'foo\');
-if (! $__env->hasRenderedOnce(\'bar\')):
-$__env->markAsRenderedOnce(\'bar\'); ?>
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
+$__env->startPrepend(\'foo\'); ?>
 test
-<?php endif; $__env->stopPrepend(); ?>';
+<?php $__env->stopPrepend(); endif; ?>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -20,7 +20,7 @@ bar
     {
         $string = '@prependOnce(\'foo\', \'bar\')
 test
-@endprependOnce';
+@endPrependOnce';
 
         $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
 $__env->startPrepend(\'foo\'); ?>

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -14,4 +14,19 @@ test
 <?php $__env->stopPush(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testPushOnceIsCompiled()
+    {
+        $string = '@pushOnce(\'foo\', \'bar\')
+test
+@endpushOnce';
+
+        $expected = '<?php \$__env->startPush(\'foo\');
+if (! $__env->hasRenderedOnce(\'bar\')):
+$__env->markAsRenderedOnce(\'bar\'); ?>
+test
+<?php endif; $__env->stopPush(); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -21,11 +21,10 @@ test
 test
 @endpushOnce';
 
-        $expected = '<?php $__env->startPush(\'foo\');
-if (! $__env->hasRenderedOnce(\'bar\')):
-$__env->markAsRenderedOnce(\'bar\'); ?>
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
+$__env->startPush(\'foo\'); ?>
 test
-<?php endif; $__env->stopPush(); ?>';
+<?php $__env->stopPush(); endif; ?>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -21,7 +21,7 @@ test
 test
 @endpushOnce';
 
-        $expected = '<?php \$__env->startPush(\'foo\');
+        $expected = '<?php $__env->startPush(\'foo\');
 if (! $__env->hasRenderedOnce(\'bar\')):
 $__env->markAsRenderedOnce(\'bar\'); ?>
 test

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -19,7 +19,7 @@ test
     {
         $string = '@pushOnce(\'foo\', \'bar\')
 test
-@endpushOnce';
+@endPushOnce';
 
         $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
 $__env->startPush(\'foo\'); ?>


### PR DESCRIPTION
## Problem
I almost always combine `@push` and `@once` and writing both out feels verbose:

```html
@push('scripts')
@once
    <script src="https://cdn.jsdelivr.net/npm/pikaday/pikaday.js"></script>
@endonce
@endpush
```

## Solution
A new directive: `@pushOnce` to combine them both:

```html
@pushOnce('scripts')
    <script src="https://cdn.jsdelivr.net/npm/pikaday/pikaday.js"></script>
@endpushOnce
```

(I added `@prependOnce` as well, though I personally never use it)