### PR TITLE
[8.x] `@checked` Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -304,4 +304,15 @@ trait CompilesConditionals
     {
         return '<?php endif; ?>';
     }
+
+    /**
+     * Compile a checked block into valid PHP.
+     *
+     * @param string $condition
+     * @return string
+     */
+    protected function compileChecked($condition)
+    {
+        return "<?php if{$condition}: echo 'checked'; endif; ?>";
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -308,7 +308,7 @@ trait CompilesConditionals
     /**
      * Compile a checked block into valid PHP.
      *
-     * @param string $condition
+     * @param  string  $condition
      * @return string
      */
     protected function compileChecked($condition)

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -6,8 +6,8 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 {
     public function testCheckedStatementsAreCompiled()
     {
-        $string = '@checked(name(foo(bar)))';
-        $expected = "<?php if(name(foo(bar))): echo 'checked'; endif; ?>";
+        $string = '<input @checked(name(foo(bar)))/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'checked'; endif; ?>/>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeCheckedStatementsTest extends AbstractBladeTestCase
+{
+    public function testCheckedStatementsAreCompiled()
+    {
+        $string = '@checked(name(foo(bar)))';
+        $expected = "<?php if(name(foo(bar))): echo 'checked'; endif; ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
Hi! This PR's only a small one, but something that I thought might be useful. It adds a new `@checked` Blade directive that can be used in views.

In almost every project I've worked on, I always see this type of approach used for determining whether 'checked' should be placed on a radio button or checkbox:

```blade
<input type="radio" name="active" value="1" {{ old('active', $user->active)) ? 'checked' : '' }}/>

<input type="radio" name="active" value="0" {{ old('active', $user->active)) ? '' : 'checked' }}/>
```

With `@checked`, you could pass the condition straight to the directive and let it handle it for you. As a quick example, say you had the following Blade in a form that you can use to update a user model:

```blade
<input type="radio" name="active" value="1" @checked(old('active', $user->active))/>

<input type="radio" name="active" value="0" @checked(!old('active', $user->active))/>
```

If the condition resolved as a truthy result, `checked` would be added to the input field (making the radio button checked as a result). But, if it's a falsey result, nothing will be output.

Of course, this isn't exactly adding any new functionality, but I thought it could be some pretty nice syntactic sugar to neaten up our views.

If it's anything you'd consider merging, please let me know if any changes need making to it 😄