### PR TITLE
[9.x] change artisan migrate command option --database to --connection

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -18,7 +18,7 @@ class DumpCommand extends Command
      * @var string
      */
     protected $signature = 'schema:dump
-                {--database= : The database connection to use}
+                {--connection= : The database connection to use}
                 {--path= : The path where the schema dump file should be stored}
                 {--prune : Delete all existing migration files}';
 

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -40,14 +40,14 @@ class FreshCommand extends Command
         $database = $this->input->getOption('database');
 
         $this->call('db:wipe', array_filter([
-            '--database' => $database,
+            '--connection' => $database,
             '--drop-views' => $this->option('drop-views'),
             '--drop-types' => $this->option('drop-types'),
             '--force' => true,
         ]));
 
         $this->call('migrate', array_filter([
-            '--database' => $database,
+            '--connection' => $database,
             '--path' => $this->input->getOption('path'),
             '--realpath' => $this->input->getOption('realpath'),
             '--schema-path' => $this->input->getOption('schema-path'),
@@ -87,7 +87,7 @@ class FreshCommand extends Command
     protected function runSeeder($database)
     {
         $this->call('db:seed', array_filter([
-            '--database' => $database,
+            '--connection' => $database,
             '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
             '--force' => true,
         ]));

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -17,7 +17,7 @@ class MigrateCommand extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'migrate {--database= : The database connection to use}
+    protected $signature = 'migrate {--connection= : The database connection to use}
                 {--force : Force the operation to run when in production}
                 {--path=* : The path(s) to the migrations files to be executed}
                 {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
@@ -105,7 +105,7 @@ class MigrateCommand extends BaseCommand
     {
         if (! $this->migrator->repositoryExists()) {
             $this->call('migrate:install', array_filter([
-                '--database' => $this->option('database'),
+                '--connection' => $this->option('database'),
             ]));
         }
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -59,7 +59,7 @@ class RefreshCommand extends Command
         // the migration commands and just provides a convenient wrapper to execute
         // them in succession. We'll also see if we need to re-seed the database.
         $this->call('migrate', array_filter([
-            '--database' => $database,
+            '--connection' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
             '--force' => true,
@@ -89,7 +89,7 @@ class RefreshCommand extends Command
     protected function runRollback($database, $path, $step)
     {
         $this->call('migrate:rollback', array_filter([
-            '--database' => $database,
+            '--connection' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
             '--step' => $step,
@@ -107,7 +107,7 @@ class RefreshCommand extends Command
     protected function runReset($database, $path)
     {
         $this->call('migrate:reset', array_filter([
-            '--database' => $database,
+            '--connection' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
             '--force' => true,
@@ -133,7 +133,7 @@ class RefreshCommand extends Command
     protected function runSeeder($database)
     {
         $this->call('db:seed', array_filter([
-            '--database' => $database,
+            '--connection' => $database,
             '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
             '--force' => true,
         ]));

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -69,7 +69,7 @@ class MySqlSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $command = 'mysql '.$this->connectionString().' --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
+        $command = 'mysql '.$this->connectionString().' --connection="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"';
 
         $process = $this->makeProcess($command)->setTimeout(null);
 

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -24,7 +24,7 @@ class DatabaseMigrationInstallCommandTest extends TestCase
         $repo->shouldReceive('setSource')->once()->with('foo');
         $repo->shouldReceive('createRepository')->once();
 
-        $this->runCommand($command, ['--database' => 'foo']);
+        $this->runCommand($command, ['--connection' => 'foo']);
     }
 
     protected function runCommand($command, $options = [])

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -118,7 +118,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
-        $this->runCommand($command, ['--database' => 'foo']);
+        $this->runCommand($command, ['--connection' => 'foo']);
     }
 
     public function testStepMayBeSet()

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -49,7 +49,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('reset')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
 
-        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
+        $this->runCommand($command, ['--pretend' => true, '--connection' => 'foo']);
     }
 
     protected function runCommand($command, $input = [])

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -62,7 +62,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
 
-        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
+        $this->runCommand($command, ['--pretend' => true, '--connection' => 'foo']);
     }
 
     public function testRollbackCommandCanBePretendedWithStepOption()
@@ -78,7 +78,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
         $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2]);
 
-        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
+        $this->runCommand($command, ['--pretend' => true, '--connection' => 'foo', '--step' => 2]);
     }
 
     protected function runCommand($command, $input = [])

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -21,7 +21,7 @@ class SeedCommandTest extends TestCase
 {
     public function testHandle()
     {
-        $input = new ArrayInput(['--force' => true, '--database' => 'sqlite']);
+        $input = new ArrayInput(['--force' => true, '--connection' => 'sqlite']);
         $output = new NullOutput;
 
         $seeder = m::mock(Seeder::class);
@@ -55,7 +55,7 @@ class SeedCommandTest extends TestCase
     {
         $input = new ArrayInput([
             '--force' => true,
-            '--database' => 'sqlite',
+            '--connection' => 'sqlite',
             '--class' => UserWithoutModelEventsSeeder::class,
         ]);
         $output = new NullOutput;


### PR DESCRIPTION
Benefit to end users
This change better describes the option as referring to the connection to be used rather than the rather confusing name of database.

This will not break existing laravel features but may break some third party packages.