### PR TITLE
[9.x] Add --view flag to make:component command

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -46,6 +46,14 @@ class ComponentMakeCommand extends GeneratorCommand
      */
     public function handle()
     {
+        if ($this->option('view')) {
+            $this->writeView(function () {
+                $this->info($this->type.' created successfully.');
+            });
+
+            return;
+        }
+        
         if (parent::handle() === false && ! $this->option('force')) {
             return false;
         }
@@ -58,9 +66,10 @@ class ComponentMakeCommand extends GeneratorCommand
     /**
      * Write the view for the component.
      *
+     * @param  callable|null $onSuccess
      * @return void
      */
-    protected function writeView()
+    protected function writeView($onSuccess = null)
     {
         $path = $this->viewPath(
             str_replace('.', '/', 'components.'.$this->getView()).'.blade.php'
@@ -82,6 +91,10 @@ class ComponentMakeCommand extends GeneratorCommand
     <!-- '.Inspiring::quote().' -->
 </div>'
         );
+
+        if ($onSuccess) {
+            $onSuccess();
+        }
     }
 
     /**
@@ -167,6 +180,7 @@ class ComponentMakeCommand extends GeneratorCommand
         return [
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the component already exists'],
             ['inline', null, InputOption::VALUE_NONE, 'Create a component that renders an inline view'],
+            ['view', null, InputOption::VALUE_NONE, 'Create an anonymous component with only a view'],
         ];
     }
 }


### PR DESCRIPTION
I almost exclusively use anonymous Blade components, so because the `artisan make:component` command generates both a class and a view, I never use it.

This PR adds a `--view` flag to opt-out of generating a class for a component:
<img width="577" alt="Screen Shot 2022-02-01 at 3 59 03 PM" src="https://user-images.githubusercontent.com/3670578/152051154-ab8898fd-c19c-4f8c-98d8-6395c3545d91.png">

Here is the command when a view already exists:
<img width="554" alt="Screen Shot 2022-02-01 at 3 59 11 PM" src="https://user-images.githubusercontent.com/3670578/152051162-886e3f51-fd30-4fdb-b65f-16289d6f1e7e.png">

Here is the definition of the command (with the `--view` flag added):
<img width="1177" alt="Screen Shot 2022-02-01 at 4 01 27 PM" src="https://user-images.githubusercontent.com/3670578/152051223-f3538f0c-1f37-4fe9-9aca-eb1de0411232.png">

I chose `--view` over `--anonymous`, because it's shorter and easier to type therefore I'm more likely to use it. If writing out the full `--anonymous` was required, I might not use this command at all as generating simple view is fairly easy anyways.

I'm open to opinions.