### PR TITLE
[8.x] Add a BladeCompiler::renderComponent() method to render a component instance

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -9,6 +9,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool check(string $name, array ...$parameters)
  * @method static string compileString(string $value)
  * @method static string render(string $string, array $data = [], bool $deleteCachedView = false)
+ * @method static string renderComponent(\Illuminate\View\Component $component)
  * @method static string getPath()
  * @method static string stripParentheses(string $expression)
  * @method static void aliasComponent(string $path, string|null $alias = null)

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -3,7 +3,9 @@
 namespace Illuminate\View\Compilers;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
@@ -304,6 +306,30 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 unlink($view->getPath());
             }
         });
+    }
+
+    /**
+     * Render a component instance to HTML.
+     *
+     * @param  Component  $component
+     * @return string
+     */
+    public static function renderComponent(Component $component)
+    {
+        $data = $component->data();
+
+        $view = value($component->resolveView(), $data);
+
+        if ($view instanceof View) {
+            return $view->with($data)->render();
+        } elseif ($view instanceof Htmlable) {
+            return $view->toHtml();
+        } else {
+            return Container::getInstance()
+                ->make(ViewFactory::class)
+                ->make($view, $data)
+                ->render();
+        }
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -311,7 +311,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     /**
      * Render a component instance to HTML.
      *
-     * @param  Component  $component
+     * @param  \Illuminate\View\Component  $component
      * @return string
      */
     public static function renderComponent(Component $component)

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\View;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
 use Orchestra\Testbench\TestCase;
 
 class BladeTest extends TestCase
@@ -11,6 +12,13 @@ class BladeTest extends TestCase
     public function test_rendering_blade_string()
     {
         $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor']));
+    }
+
+    public function test_rendering_blade_component_instance()
+    {
+        $component = new HelloComponent('Taylor');
+
+        $this->assertSame('Hello Taylor', Blade::renderComponent($component));
     }
 
     public function test_basic_blade_rendering()
@@ -108,5 +116,20 @@ class BladeTest extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('view.paths', [__DIR__.'/templates']);
+    }
+}
+
+class HelloComponent extends Component
+{
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function render()
+    {
+        return 'Hello {{ $name }}';
     }
 }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -121,7 +121,7 @@ class BladeTest extends TestCase
 
 class HelloComponent extends Component
 {
-    private $name;
+    public $name;
 
     public function __construct(string $name)
     {


### PR DESCRIPTION
This PR is similar to the functionality introduced in #40425.

This new method allows you to call `BladeCompiler::renderComponent($component)`, where `$component` is an instance of `Illuminate\View\Component`, and get the HTML of the rendered component returned. Alternatively you may call the `renderComponent` method from the Blade facade: `Blade::renderComponent($component)`.

## Example

```php
class HelloComponent extends Component
{
    private $name;

    public function __construct(string $name)
    {
        $this->name = $name;
    }

    public function render()
    {
        return "Hello, $this->name";
    }
}

Blade::renderComponent(new HelloComponent('Claire'));

// Returns 'Hello, Claire'
```

## Rationale

Components are a great way to encapsulate parts of the view. Rendering a component programatically is useful if you want to render a component's HTML directly into a response. For example, if you wanted to dynamically update a component via XMLHttpRequest.

Currently to achieve this you would need to create a new view partial to return in the response, for the sole purpose of rendering the component:

```html
<x-hello-component :name="$name"/>
```

```php
return view('partials.hello-component', ['name' => 'Claire']);
```

The `Blade::render()` function makes this a bit easier, as you could render the component as a Blade string into the response, rather than needing to resort to a partial:

```php
return Blade::render('<x-hello-component :name="$name"/>', ['name' => 'Claire']);
```

However, this still doesn't have optimal ergonomics, especially with increasing numbers of properties. The `renderComponent` method cuts out the intermediate step and makes this simple:

```php
return Blade::renderComponent(new HelloComponent('Claire'));
```

Note that if needed, attributes can be set on the component instance like so:

```php
return Blade::renderComponent((new HelloComponent('Claire'))->withAttributes(['class' => 'red']));
```

## Implementation

The implementation is based on the `renderComponent` method of the `Illuminate\View\Concerns\ManagesComponents` trait.