### PR TITLE
[9.x] Adds `carry()` method to Collection.

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -180,6 +180,34 @@ trait EnumeratesValues
     }
 
     /**
+     * Reduce the collection using an aggregate value.
+     *
+     * @param  callable(int|float|\Countable, TValue, TKey): \Countable|int|float|bool|null|void  $callback
+     * @param  \Countable|int|float||null  $initial
+     * @return \Illuminate\Support\Collection<TKey, TValue>
+     */
+    public function carry(callable $callback, $initial = null)
+    {
+        $cumulative = $initial;
+
+        $collection = new Collection();
+
+        foreach ($this as $key => $value) {
+            $result = $callback($cumulative, $value, $key);
+
+            if ($result === null || $result === false) {
+                break;
+            }
+
+            $cumulative = $result;
+
+            $collection->put($key, $value);
+        }
+
+        return $collection;
+    }
+
+    /**
      * Alias for the "contains" method.
      *
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -791,6 +791,40 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testCarry($collection)
+    {
+        $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);
+
+        $new = $data->carry(function ($sum, $value, $key) {
+            $sum += $value;
+
+            if ($sum < 6) {
+                return $sum;
+            }
+        });
+        $this->assertNotEquals($data, $new);
+        $this->assertCount(5, $new);
+        $this->assertEquals(5, $new->sum());
+
+        $new = $data->carry(function ($sum) {
+            return $sum !== 0;
+        }, 0);
+        $this->assertEmpty($new);
+
+        $new = $data->carry(function () {
+            return true;
+        });
+        $this->assertEquals(14, $new->sum());
+
+        $new = $data->carry(function () {
+            return false;
+        });
+        $this->assertEmpty($new);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testCountByWithKey($collection)
     {
         $c = new $collection([

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -39,6 +39,31 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testCarryIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->carry(function ($sum, $value, $key) {
+                $sum += $key;
+
+                if ($sum < 10) {
+                    return $sum + $key;
+                }
+            });
+        });
+
+        $this->assertEnumerates(1, function ($collection) {
+            $collection->carry(function () {
+                return false;
+            });
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->carry(function () {
+                return true;
+            });
+        });
+    }
+
     public function testChunkIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
## What?

The `carry()` method works as a "takeUntil" using a carry value. A callback returns the carried value, and if it returns `null` or `false`, the iteration is stopped.

```php
$collection = collect([1, 2, 3, 4]);

$collection->carry(function ($carry, $item) {
    if ($carry > 3) {
        return false;
    }

    return $carry + 1;
});
```

Instead of a more verbose approach.

```php
$collection = collect([1, 2, 3, 4]);

$cumulative = 0;

$collection->takeUntil(function ($item) use (&$cumulative) {
    $cumulative++;

    return $cumulative > 2;
});
```
