### PR TITLE
[9.x] Add inline slot name syntax (<x-slot:name>)

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -438,9 +438,9 @@ class ComponentTagCompiler
         /x";
 
         $value = preg_replace_callback($pattern, function ($matches) {
-            $name = $this->stripQuotes($matches['inlineName'] ?? $matches['name']);
+            $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name']);
 
-            if ($matches[1] !== ':') {
+            if ($matches[2] !== ':') {
                 $name = "'{$name}'";
             }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -406,8 +406,8 @@ class ComponentTagCompiler
             <
                 \s*
                 x[\-\:]slot
-                \s+
-                (:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+))
+                (?:\:(?<inlineName>\w+))?
+                (?:\s+(:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
                 (?<attributes>
                     (?:
                         \s+
@@ -438,7 +438,9 @@ class ComponentTagCompiler
         /x";
 
         $value = preg_replace_callback($pattern, function ($matches) {
-            $name = $this->stripQuotes($matches['name']);
+            $name = $matches['inlineName'] !== ''
+                ? $matches['inlineName']
+                : $this->stripQuotes($matches['name']);
 
             if ($matches[1] !== ':') {
                 $name = "'{$name}'";

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -438,9 +438,7 @@ class ComponentTagCompiler
         /x";
 
         $value = preg_replace_callback($pattern, function ($matches) {
-            $name = $matches['inlineName'] !== ''
-                ? $matches['inlineName']
-                : $this->stripQuotes($matches['name']);
+            $name = $this->stripQuotes($matches['inlineName'] ?? $matches['name']);
 
             if ($matches[1] !== ':') {
                 $name = "'{$name}'";

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -28,6 +28,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("@slot('foo', null, []) \n".' @endslot', trim($result));
     }
 
+    public function testInlineSlotsCanBeCompiled()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot:foo>
+</x-slot>');
+
+        $this->assertSame("@slot('foo', null, []) \n".' @endslot', trim($result));
+    }
+
     public function testDynamicSlotsCanBeCompiled()
     {
         $result = $this->compiler()->compileSlots('<x-slot :name="$foo">
@@ -39,6 +47,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testSlotsWithAttributesCanBeCompiled()
     {
         $result = $this->compiler()->compileSlots('<x-slot name="foo" class="font-bold">
+</x-slot>');
+
+        $this->assertSame("@slot('foo', null, ['class' => 'font-bold']) \n".' @endslot', trim($result));
+    }
+
+    public function testInlineSlotsWithAttributesCanBeCompiled()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot:foo class="font-bold">
 </x-slot>');
 
         $this->assertSame("@slot('foo', null, ['class' => 'font-bold']) \n".' @endslot', trim($result));


### PR DESCRIPTION
This PR allows for a slightly sleeker inline syntax for named slots:

```html
<!-- Before: -->
<x-modal>
    <x-slot name="trigger">
        ...
    </x-slot>
    ...
</x-modal>

<!-- After: -->
<x-modal>
    <x-slot:trigger>
        ...
    </x-slot>
    ...
</x-modal>
```

If people wish, Blade is tolerant to these inline names existing in closing tags like so:

`<x-slot:trigger>...</x-slot:trigger>`