### PR TITLE
[8.x] Local providers

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -667,8 +667,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
 
         $providers = Collection::make($this->config['app.local_providers']);
-        $providers->each(function ($p) {
-            $this->register($p, true);
+        $providers->each(function ($provider) {
+            $this->register($provider, true);
         });
     }
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -665,7 +665,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
      **/
     public function registerLocalProviders()
     {
-
         $providers = Collection::make($this->config['app.local_providers']);
         $providers->each(function ($provider) {
             $this->register($provider, true);

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -663,7 +663,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      * Register all of the local only configured providers.
      *
      * @return void
-     **/
+     */
     public function registerLocalProviders()
     {
         $providers = Collection::make($this->config['app.local_providers']);
@@ -671,7 +671,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             $this->register($provider, true);
         });
     }
-    
+
     /**
      * Register a service provider with the application.
      *

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -658,7 +658,19 @@ class Application extends Container implements ApplicationContract, CachesConfig
         (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
                     ->load($providers->collapse()->toArray());
     }
+    /**
+     * Register all of the local only configured providers.
+     *
+     * @return void
+     **/
+    public function registerLocalProviders()
+    {
 
+        $providers = Collection::make($this->config['app.local_providers']);
+        $providers->each(function ($p) {
+            $this->register($p, true);
+        });
+    }
     /**
      * Register a service provider with the application.
      *

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -658,6 +658,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         (new ProviderRepository($this, new Filesystem, $this->getCachedServicesPath()))
                     ->load($providers->collapse()->toArray());
     }
+
     /**
      * Register all of the local only configured providers.
      *
@@ -670,6 +671,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             $this->register($provider, true);
         });
     }
+    
     /**
      * Register a service provider with the application.
      *

--- a/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php
@@ -15,5 +15,9 @@ class RegisterProviders
     public function bootstrap(Application $app)
     {
         $app->registerConfiguredProviders();
+
+        if ($app->isLocal()) {
+            $app->registerLocalProviders();
+        }
     }
 }


### PR DESCRIPTION
I've added support for local only providers support.
**local_providers** key will be in **config/app.php** and framework checks if there is any provider there, registers them. Something like require-dev for development.

It happens a lot to me that in development I need to make some changes to framework. For all local only things I need to ckeck isLocal, then register. Here we have in one place and they will not be registered in production.