### PR TITLE
Add generic hints to Cache

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -84,9 +84,11 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
+     * @template TCached of mixed
+     *
      * @param  array|string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  null|TCached  $default
+     * @return null|TCached
      */
     public function get($key, $default = null): mixed
     {
@@ -175,9 +177,11 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache and delete it.
      *
+     * @template TCached of mixed
+     *
      * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  TCached  $default
+     * @return null|TCached
      */
     public function pull($key, $default = null)
     {
@@ -372,10 +376,12 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get an item from the cache, or execute the given Closure and store the result.
      *
+     * @template TCached of mixed
+     *
      * @param  string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCached  $callback
+     * @return TCached
      */
     public function remember($key, $ttl, Closure $callback)
     {
@@ -396,9 +402,11 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCached of mixed
+     *
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCached  $callback
+     * @return TCached
      */
     public function sear($key, Closure $callback)
     {
@@ -408,9 +416,11 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCached of mixed
+     *
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCached  $callback
+     * @return TCached
      */
     public function rememberForever($key, Closure $callback)
     {

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -10,9 +10,11 @@ interface Repository extends CacheInterface
     /**
      * Retrieve an item from the cache and delete it.
      *
+     * @template TCached of mixed
+     *
      * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  null|TCached  $default
+     * @return null|TCached
      */
     public function pull($key, $default = null);
 
@@ -66,28 +68,34 @@ interface Repository extends CacheInterface
     /**
      * Get an item from the cache, or execute the given Closure and store the result.
      *
+     * @template TCached of mixed
+     *
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCached  $callback
+     * @return TCached
      */
     public function remember($key, $ttl, Closure $callback);
 
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCached of mixed
+     *
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCached  $callback
+     * @return TCached
      */
     public function sear($key, Closure $callback);
 
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCached of mixed
+     *
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCached  $callback
+     * @return TCached
      */
     public function rememberForever($key, Closure $callback);
 

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @template TCached of mixed
+ *
  * @method static \Illuminate\Cache\TaggedCache tags(array|mixed $names)
  * @method static \Illuminate\Contracts\Cache\Lock lock(string $name, int $seconds = 0, mixed $owner = null)
  * @method static \Illuminate\Contracts\Cache\Lock restoreLock(string $name, string $owner)
@@ -17,11 +19,11 @@ namespace Illuminate\Support\Facades;
  * @method static bool put(array|string $key, $value, \DateTimeInterface|\DateInterval|int $ttl = null)
  * @method static int|bool decrement(string $key, $value = 1)
  * @method static int|bool increment(string $key, $value = 1)
- * @method static mixed get(array|string $key, mixed $default = null)
- * @method static mixed pull(string $key, mixed $default = null)
- * @method static mixed remember(string $key, \DateTimeInterface|\DateInterval|int $ttl, \Closure $callback)
- * @method static mixed rememberForever(string $key, \Closure $callback)
- * @method static mixed sear(string $key, \Closure $callback)
+ * @method static null|TCached get(array|string $key, TCached $default = null)
+ * @method static null|TCached pull(string $key, TCached $default = null)
+ * @method static TCached remember(string $key, \DateTimeInterface|\DateInterval|int $ttl, \Closure(): TCached $callback)
+ * @method static TCached rememberForever(string $key, \Closure(): TCached $callback)
+ * @method static TCached sear(string $key, \Closure(): TCached $callback)
  *
  * @see \Illuminate\Cache\CacheManager
  * @see \Illuminate\Cache\Repository

--- a/types/Support/Cache.php
+++ b/types/Support/Cache.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\Repository as RepositoryInterface;
+use function PHPStan\Testing\assertType;
+
+/** @var RepositoryInterface $cache */
+$cache = resolve(RepositoryInterface::class);
+
+assertType('int|null', $cache->pull('cache', 10));
+assertType('int', $cache->sear('cache', function (): int {
+    return 12;
+}));
+assertType('int', $cache->rememberForever('cache', function (): int {
+    return 15;
+}));
+
+/** @var Repository $cache */
+$cache = resolve(Repository::class);
+
+assertType('int|null', $cache->get('cache', 21));
+assertType('int|null', $cache->pull('cache', 22));
+assertType('int', $cache->sear('cache', function (): int {
+    return 24;
+}));
+assertType('int', $cache->rememberForever('cache', function (): int {
+    return 27;
+}));


### PR DESCRIPTION
This provides a way for IDEs and other analyzer tools to reason about the value returned by the cache and there by not cause lose of context when ever it is used. See https://github.com/laravel/framework/pull/38257 for a general discussions about this topic.