### PR TITLE
Make `PendingRequest` `Conditionable`

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -13,13 +13,14 @@ use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Psr\Http\Message\MessageInterface;
 use Symfony\Component\VarDumper\VarDumper;
 
 class PendingRequest
 {
-    use Macroable;
+    use Conditionable, Macroable;
 
     /**
      * The factory instance.


### PR DESCRIPTION
This pull request makes `PendingRequest` `Conditionable`.

It will let you use when() and unless() to make the code a bit more readable.
Example where I would have used it:
```
$this->http = Http::withBasicAuth(
            $username,
            $password
        );

        if (app()->environment('local')) {
            $this->http->withoutVerifying();
        }
        
        if ($baseUrl !== null) {
            $this->http->baseUrl($baseUrl);
        }
```
becomes
```
$this->http = Http::withBasicAuth(
            $username,
            $password
        )->when(app()->environment('local'), function (PendingRequest $request) {
            $request->withoutVerifying();
        })->when($baseUrl !== null, function (PendingRequest $request) {
            $request->baseUrl($baseUrl);
        });
```
