### PR TITLE
[8.x] Remove commented code

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -886,10 +886,6 @@ class Container implements ArrayAccess, ContainerContract
             return $this->notInstantiable($concrete);
         }
 
-        // if (in_array($concrete, $this->buildStack)) {
-        //     throw new CircularDependencyException("Circular dependency detected while resolving [{$concrete}].");
-        // }
-
         $this->buildStack[] = $concrete;
 
         $constructor = $reflector->getConstructor();


### PR DESCRIPTION
I found this commented code in the `src/Illuminate/Container/Container.php` when I got the error `Illuminate\Contracts\Container\BindingResolutionException`