### PR TITLE
[9.x] Share HTTP client when faking

### DIFF
--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Client\Factory;
 
 /**
  * @method static \GuzzleHttp\Promise\PromiseInterface response($body = null, $status = 200, $headers = [])
- * @method static \Illuminate\Http\Client\Factory fake($callback = null)
  * @method static \Illuminate\Http\Client\PendingRequest accept(string $contentType)
  * @method static \Illuminate\Http\Client\PendingRequest acceptJson()
  * @method static \Illuminate\Http\Client\PendingRequest asForm()
@@ -43,7 +42,6 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Response post(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response put(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response send(string $method, string $url, array $options = [])
- * @method static \Illuminate\Http\Client\ResponseSequence fakeSequence(string $urlPattern = '*')
  * @method static void assertSent(callable $callback)
  * @method static void assertSentInOrder(array $callbacks)
  * @method static void assertNotSent(callable $callback)
@@ -63,5 +61,47 @@ class Http extends Facade
     protected static function getFacadeAccessor()
     {
         return Factory::class;
+    }
+
+    /**
+     * Register a stub callable that will intercept requests and be able to return stub responses.
+     *
+     * @param  \Closure|array  $callback
+     * @return \Illuminate\Http\Client\Factory
+     */
+    public static function fake($callback = null)
+    {
+        return tap(static::getFacadeRoot(), function ($fake) use ($callback) {
+            static::swap($fake->fake($callback));
+        });
+    }
+
+    /**
+     * Register a response sequence for the given URL pattern.
+     *
+     * @param  string  $urlPattern
+     * @return \Illuminate\Http\Client\ResponseSequence
+     */
+    public static function fakeSequence(string $urlPattern = '*')
+    {
+        $fake = tap(static::getFacadeRoot(), function ($fake) {
+            static::swap($fake);
+        });
+
+        return $fake->fakeSequence($urlPattern);
+    }
+
+    /**
+     * Stub the given URL using the given callback.
+     *
+     * @param  string  $url
+     * @param  \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface|callable  $callback
+     * @return \Illuminate\Http\Client\Factory
+     */
+    public static function stubUrl($url, $callback)
+    {
+        return tap(static::getFacadeRoot(), function ($fake) use ($url, $callback) {
+            static::swap($fake->stubUrl($url, $callback));
+        });
     }
 }

--- a/tests/Support/SupportFacadesHttpTest.php
+++ b/tests/Support/SupportFacadesHttpTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Container\Container;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\TestCase;
+
+class SupportFacadesHttpTest extends TestCase
+{
+    protected $app;
+
+    protected function setUp(): void
+    {
+        $this->app = new Container;
+        Facade::setFacadeApplication($this->app);
+    }
+
+    public function testFacadeRootIsNotSharedByDefault(): void
+    {
+        $this->assertNotSame(Http::getFacadeRoot(), $this->app->make(Factory::class));
+    }
+
+    public function testFacadeRootIsSharedWhenFaked(): void
+    {
+        Http::fake([
+            'https://laravel.com' => Http::response('OK!'),
+        ]);
+
+        $factory = $this->app->make(Factory::class);
+        $this->assertSame('OK!', $factory->get('https://laravel.com')->body());
+    }
+
+    public function testFacadeRootIsSharedWhenFakedWithSequence(): void
+    {
+        Http::fakeSequence('laravel.com/*')->push('OK!');
+
+        $factory = $this->app->make(Factory::class);
+        $this->assertSame('OK!', $factory->get('https://laravel.com')->body());
+    }
+
+    public function testFacadeRootIsSharedWhenStubbingUrls(): void
+    {
+        Http::stubUrl('laravel.com', Http::response('OK!'));
+
+        $factory = $this->app->make(Factory::class);
+        $this->assertSame('OK!', $factory->get('https://laravel.com')->body());
+    }
+}


### PR DESCRIPTION
Laravel's HTTP client allows you to stub responses and prevent requests by calling the `fake()` method. However this faking is done on an instance level, and the underlying `Factory` instance isn't registered as a singleton. This means any classes that get the HTTP client via dependency injection cannot be tested using the faked responses on the facade.

This PR aims to change this by registering the facade's underlying HTTP client as a singleton whenever faking HTTP calls.

Because this PR only changes behavior when faking responses, breaking changes (if any) should be limited to tests.

