### PR TITLE
[9.x] Adds `carry()` method to Enumerable

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -180,6 +180,34 @@ trait EnumeratesValues
     }
 
     /**
+     * Reduce the collection using an aggregate value.
+     *
+     * @param  callable(int|float|\Countable, TValue, TKey): \Countable|int|float|bool|null|void  $callback
+     * @param  \Countable|int|float||null  $initial
+     * @return \Illuminate\Support\Collection<TKey, TValue>
+     */
+    public function carry(callable $callback, $initial = null)
+    {
+        $cumulative = $initial;
+
+        $collection = new Collection();
+
+        foreach ($this as $key => $value) {
+            $result = $callback($cumulative, $value, $key);
+
+            if ($result === null || $result === false) {
+                break;
+            }
+
+            $cumulative = $result;
+
+            $collection->put($key, $value);
+        }
+
+        return $collection;
+    }
+
+    /**
      * Alias for the "contains" method.
      *
      * @param  (callable(TValue, TKey): bool)|TValue|string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -843,6 +843,52 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testCarryOverCountable($collection)
+    {
+        $data = new $collection([
+            [1, 2, 3],
+            [1, 2, 3],
+            [1, 2, 3],
+            [1, 2, 3],
+        ]);
+
+        $this->assertCount(2, $data->carry(8));
+        $this->assertCount(3, $data->carry(9));
+        $this->assertCount(3, $data->carry(10));
+
+        $data = new $collection([
+            ['array' => [1, 2, 3]],
+            ['array' => [1, 2, 3]],
+            ['array' => [1, 2, 3]],
+            ['array' => [1, 2, 3]],
+        ]);
+
+        $this->assertCount(2, $data->carry('array', 8));
+        $this->assertCount(3, $data->carry('array', 9));
+        $this->assertCount(3, $data->carry('array', 10));
+
+        $data = new $collection([
+            ['array' => [1, 2, 3]],
+            ['array' => [1, 2, 3]],
+            ['array' => false],
+            ['array' => [1, 2, 3]],
+        ]);
+
+        $this->assertCount(2, $data->carry('array', PHP_INT_MAX));
+
+        $data = new $collection([
+            ['array' => [1, 2, 3]],
+            ['array' => [1, 2, 3]],
+            ['array' => null],
+            ['array' => [1, 2, 3]],
+        ]);
+
+        $this->assertCount(2, $data->carry('array', PHP_INT_MAX));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testCountByWithKey($collection)
     {
         $c = new $collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -793,33 +793,51 @@ class SupportCollectionTest extends TestCase
      */
     public function testCarry($collection)
     {
+        $data = new $collection([
+            ['value' => -1],
+            ['value' => 0],
+            ['value' => 1],
+            ['value' => 2],
+            ['value' => 3],
+            ['value' => 4],
+            ['value' => 5],
+        ]);
+
+        $this->assertCount(7, $data->carry('value', PHP_INT_MAX));
+        $this->assertEquals(14, $data->carry('value', PHP_INT_MAX)->sum('value'));
+
+        $this->assertCount(6, $data->carry('value', 9));
+        $this->assertEquals(9, $data->carry('value', 9)->sum('value'));
+
+        $this->assertCount(3, $data->carry('value', 0));
+
+        $this->assertEmpty($data->carry('value', -10));
+
+        $this->assertEmpty($data->carry('not-found', 10));
+
+        $this->assertCount(5, $data->carry('value', 9, 1));
+
+        $this->assertCount(4, $data->carry(function ($carry, $item) {
+            return $item['value'] < 3
+                ? $item['value']
+                : false;
+        }));
+
         $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);
 
-        $new = $data->carry(function ($sum, $value, $key) {
-            $sum += $value;
+        $this->assertCount(7, $data->carry(PHP_INT_MAX));
+        $this->assertEquals(14, $data->carry(PHP_INT_MAX)->sum());
 
-            if ($sum < 6) {
-                return $sum;
-            }
-        });
-        $this->assertNotEquals($data, $new);
-        $this->assertCount(5, $new);
-        $this->assertEquals(5, $new->sum());
+        $this->assertCount(6, $data->carry(9));
+        $this->assertEquals(9, $data->carry(9)->sum());
 
-        $new = $data->carry(function ($sum) {
-            return $sum !== 0;
-        }, 0);
-        $this->assertEmpty($new);
+        $this->assertCount(3, $data->carry(0));
 
-        $new = $data->carry(function () {
-            return true;
-        });
-        $this->assertEquals(14, $new->sum());
+        $this->assertEmpty($data->carry(-10));
 
-        $new = $data->carry(function () {
-            return false;
-        });
-        $this->assertEmpty($new);
+        $this->assertEmpty($data->carry('doesnt-exists', PHP_INT_MAX));
+
+        $this->assertCount(5, $data->carry(9, null, 1));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -791,6 +791,40 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testCarry($collection)
+    {
+        $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);
+
+        $new = $data->carry(function ($sum, $value, $key) {
+            $sum += $value;
+
+            if ($sum < 6) {
+                return $sum;
+            }
+        });
+        $this->assertNotEquals($data, $new);
+        $this->assertCount(5, $new);
+        $this->assertEquals(5, $new->sum());
+
+        $new = $data->carry(function ($sum) {
+            return $sum !== 0;
+        }, 0);
+        $this->assertEmpty($new);
+
+        $new = $data->carry(function () {
+            return true;
+        });
+        $this->assertEquals(14, $new->sum());
+
+        $new = $data->carry(function () {
+            return false;
+        });
+        $this->assertEmpty($new);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testCountByWithKey($collection)
     {
         $c = new $collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -798,9 +798,7 @@ class SupportCollectionTest extends TestCase
         $new = $data->carry(function ($sum, $value, $key) {
             $sum += $value;
 
-            if ($sum < 6) {
-                return $sum;
-            }
+            return $sum < 6 ? $sum : false;
         });
         $this->assertNotEquals($data, $new);
         $this->assertCount(5, $new);
@@ -819,6 +817,68 @@ class SupportCollectionTest extends TestCase
         $new = $data->carry(function () {
             return false;
         });
+        $this->assertEmpty($new);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCarryUntil($collection)
+    {
+        $data = new $collection([
+            ['value' => -1],
+            ['value' => 0],
+            ['value' => 1],
+            ['value' => 2],
+            ['value' => 3],
+            ['value' => 4],
+            ['value' => 5],
+        ]);
+
+        $new = $data->carryUntil('value', PHP_INT_MAX);
+
+        $this->assertCount(7, $new);
+        $this->assertEquals(14, $new->sum('value'));
+
+        $new = $data->carryUntil('value', 9);
+
+        $this->assertCount(6, $new);
+        $this->assertEquals(9, $new->sum('value'));
+
+        $new = $data->carryUntil('value', 0);
+
+        $this->assertCount(3, $new);
+
+        $new = $data->carryUntil('value', -10);
+
+        $this->assertEmpty($new);
+
+        $new = $data->carryUntil('not-found', 10);
+
+        $this->assertEmpty($new);
+
+        $data = new $collection([-1, 0, 1, 2, 3, 4, 5]);
+
+        $new = $data->carryUntil(PHP_INT_MAX);
+
+        $this->assertCount(7, $new);
+        $this->assertEquals(14, $new->sum());
+
+        $new = $data->carryUntil(9);
+
+        $this->assertCount(6, $new);
+        $this->assertEquals(9, $new->sum());
+
+        $new = $data->carryUntil(0);
+
+        $this->assertCount(3, $new);
+
+        $new = $data->carryUntil(-10);
+
+        $this->assertEmpty($new);
+
+        $new = $data->carryUntil('doesnt-exists', PHP_INT_MAX);
+
         $this->assertEmpty($new);
     }
 

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -64,6 +64,21 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testCarryUntilIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->carryUntil(10);
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->carryUntil(1);
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->carryUntil(PHP_INT_MAX);
+        });
+    }
+
     public function testChunkIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -41,23 +41,21 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testCarryIsLazy()
     {
-        $this->assertEnumerates(5, function ($collection) {
-            $collection->carry(function ($sum, $value, $key) {
-                $sum += $key;
-
-                if ($sum < 10) {
-                    return $sum + $key;
-                }
-            });
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->carry(20);
         });
 
-        $this->assertEnumerates(1, function ($collection) {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->carry('value', 20);
+        });
+
+        $this->assertDoesNotEnumerate(function ($collection) {
             $collection->carry(function () {
                 return false;
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertDoesNotEnumerate(function ($collection) {
             $collection->carry(function () {
                 return true;
             });

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -39,6 +39,31 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testCarryIsLazy()
+    {
+        $this->assertEnumerates(5, function ($collection) {
+            $collection->carry(function ($sum, $value, $key) {
+                $sum += $key;
+
+                if ($sum < 10) {
+                    return $sum + $key;
+                }
+            });
+        });
+
+        $this->assertEnumerates(1, function ($collection) {
+            $collection->carry(function () {
+                return false;
+            });
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->carry(function () {
+                return true;
+            });
+        });
+    }
+
     public function testChunkIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -62,21 +62,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
-    public function testCarryUntilIsLazy()
-    {
-        $this->assertEnumerates(5, function ($collection) {
-            $collection->carryUntil(10);
-        });
-
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->carryUntil(1);
-        });
-
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->carryUntil(PHP_INT_MAX);
-        });
-    }
-
     public function testChunkIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
## What?

Allows retrieving items from a Collection until reaching a numeric/countable threshold.

Remember [the `reduceSpread()` example?](https://laravel.com/docs/8.x/collections#method-reduce-spread). Here is with `carry()` instead:

```php
$batch = Image::where('status', 'unprocessed')
    ->lazy()
    ->carry(function ($creditsRemaining, $image) {
        if ($image->creditsRequired() > $creditsRemaining) {
            return false;
        }
        
        return $creditsRemaining - $image->creditsRequired();
    }, $creditsRemaining);
```

And if it `creditsRequired()` was a dynamic property, much, much better:

```php
$batch = Image::where('status', 'unprocessed')->lazy()->carry('credits_required', $creditsRemaining);
```

- It will stop once the threshold is reached, or `false` is returned by the function, avoiding looping over an entire collection (or database).
- It allows to use a function or a simple _dot.value_ and a limit.
- It also works over countable values, like arrays or Collections.
- It supports using an initial value on both syntaxes.

## Why?

It's useful for lazy collections where you want to retrieve data but stop once a certain threshold is reached. Without these methods, some verbose code is needed to replicate the same example.

The easy way is to name the property to carry over, and the threshold to stop.

```php
$images = collect([
    ['name' => 'avatar.jpg', 'kb' => 112], 
    ['name' => 'matrix.jpg', 'kb' => 245], 
    ['name' => 'antman.jpg', 'kb' => 548], 
]) 

$limited = $images->carry('kb', 500);
//    [ 
//        ['name' => 'avatar.jpg', 'kb' => 112], 
//        ['name' => 'matrix.jpg', 'kb' => 245]
//    ]
```

And waaaay better than using even `takeWhile()`;

```php
$cumulative = 0;

$limited = $images->takeWhile(function ($image) use (&$cumulative) {
    $cumulative += $image['kb'];
    
    return $cumulative < 500;
});
```

Additionally, you can set a starting initial value as third parameter.

```php
$images = collect([
    ['name' => 'avatar.jpg', 'kb' => 112], 
    ['name' => 'matrix.jpg', 'kb' => 245], 
    ['name' => 'antman.jpg', 'kb' => 548], 
]);

$cumulative = 0; 

$limited = $images->carry('kb', 500, 100));
```

Finally, it works over countable items, like arrays or other collections.

```php
$numbers = collect([
    ['name' => 'maria', 'lucky_numbers' => [8, 2]],
    ['name' => 'adam',  'lucky_numbers' => [4, 1, 2]],
    ['name' => 'eve',   'lucky_numbers' => [5, 8, 9, 3]],
]);

$limited = $numbers->carry('lucky_numbers', 5));

//    [ 
//        ['name' => 'maria', 'lucky_numbers' => [8, 2]],
//        ['name' => 'adam',  'lucky_numbers' => [4, 1, 2]],
//    ]
```

## Caveats

Since by default it expects data to carry, if the value is `null` or `false` it will stop automatically. For that reason, the developer may want to use a function instead.

```php
$items = collect([1, 2, 3, false , 5]);

$carry = $items->carry(11);

//    [1, 2, 3]
```

Second, it will always get N+1 items. This is because it always need to check the next item value. For example, the fifth value is retrieved since it's the item value that goes above the threshold, signaling to stop.

```php
$items = collect([1, 2, 3, 0, 4, 5]);

$carry = $items->carry(6);

// [1, 2, 3, 0];
```` 

## BC?

Nope, only additive.

## Naming suggestions?

I tried `carryUntil()`, `pour()`, `takeBefore()`, `below()`, and `reduceUntil()`. Suggestions are welcomed.