### PR TITLE
Fix UndefinedDocblockClass error

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Doctrine\DBAL\Driver\PDOConnection getPdo()
+ * @method static \Doctrine\DBAL\Driver\PDO\Connection getPdo()
  * @method static \Illuminate\Database\ConnectionInterface connection(string $name = null)
  * @method static \Illuminate\Database\Query\Builder table(string $table, string $as = null)
  * @method static \Illuminate\Database\Query\Expression raw($value)


### PR DESCRIPTION
On a PSALM check, there is an error:
UndefinedDocblockClass - *** - Docblock-defined class, interface or enum named Doctrine\DBAL\Driver\PDOConnection does not exist (see https://psalm.dev/200) DB::getPdo()->lastInsertId());

Fixed to the current Doctrine structure