### PR TITLE
[9.x] ability to add tags/metadata to Emails/Notifications

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -874,6 +874,33 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Add a tag header to the message when supported by the underlying transport.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function tag($value)
+    {
+        return $this->withSymfonyMessage(function (Email $message) use ($value) {
+            $message->getHeaders()->add(new TagHeader($value));
+        });
+    }
+
+    /**
+     * Add a metadata header to the message when supported by the underlying transport.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+    public function metadata($key, $value)
+    {
+        return $this->withSymfonyMessage(function (Email $message) use ($key, $value) {
+            $message->getHeaders()->add(new MetadataHeader($key, $value));
+        });
+    }
+
+    /**
      * Assert that the given text is present in the HTML email body.
      *
      * @param  string  $string
@@ -1022,33 +1049,6 @@ class Mailable implements MailableContract, Renderable
         $this->mailer = $mailer;
 
         return $this;
-    }
-
-    /**
-     * Add a tag to the email (for drivers that support).
-     *
-     * @param  string  $value
-     * @return $this
-     */
-    public function tag($value)
-    {
-        return $this->withSymfonyMessage(function (Email $message) use ($value) {
-            $message->getHeaders()->add(new TagHeader($value));
-        });
-    }
-
-    /**
-     * Add metadata to the email (for drivers that support).
-     *
-     * @param  string  $key
-     * @param  string  $value
-     * @return $this
-     */
-    public function metadata($key, $value)
-    {
-        return $this->withSymfonyMessage(function (Email $message) use ($key, $value) {
-            $message->getHeaders()->add(new MetadataHeader($key, $value));
-        });
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -20,6 +20,9 @@ use Illuminate\Testing\Constraints\SeeInOrder;
 use PHPUnit\Framework\Assert as PHPUnit;
 use ReflectionClass;
 use ReflectionProperty;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mime\Email;
 
 class Mailable implements MailableContract, Renderable
 {
@@ -1019,6 +1022,33 @@ class Mailable implements MailableContract, Renderable
         $this->mailer = $mailer;
 
         return $this;
+    }
+
+    /**
+     * Add a tag to the email (for drivers that support).
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function tag($value)
+    {
+        return $this->withSymfonyMessage(function (Email $message) use ($value) {
+            $message->getHeaders()->add(new TagHeader($value));
+        });
+    }
+
+    /**
+     * Add metadata to the email (for drivers that support).
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+    public function metadata($key, $value)
+    {
+        return $this->withSymfonyMessage(function (Email $message) use ($key, $value) {
+            $message->getHeaders()->add(new MetadataHeader($key, $value));
+        });
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -257,6 +257,33 @@ class MailMessage extends SimpleMessage implements Renderable
     }
 
     /**
+     * Add a tag header to the message when supported by the underlying transport.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function tag($value)
+    {
+        return $this->withSymfonyMessage(function (Email $message) use ($value) {
+            $message->getHeaders()->add(new TagHeader($value));
+        });
+    }
+
+    /**
+     * Add a metadata header to the message when supported by the underlying transport.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+    public function metadata($key, $value)
+    {
+        return $this->withSymfonyMessage(function (Email $message) use ($key, $value) {
+            $message->getHeaders()->add(new MetadataHeader($key, $value));
+        });
+    }
+
+    /**
      * Set the priority of this message.
      *
      * The value is an integer where 1 is the highest priority and 5 is the lowest.
@@ -322,33 +349,6 @@ class MailMessage extends SimpleMessage implements Renderable
 
         return $markdown->theme($this->theme ?: $markdown->getTheme())
                 ->render($this->markdown, $this->data());
-    }
-
-    /**
-     * Add a tag to the email (for drivers that support).
-     *
-     * @param  string  $value
-     * @return $this
-     */
-    public function tag($value)
-    {
-        return $this->withSymfonyMessage(function (Email $message) use ($value) {
-            $message->getHeaders()->add(new TagHeader($value));
-        });
-    }
-
-    /**
-     * Add metadata to the email (for drivers that support).
-     *
-     * @param  string  $key
-     * @param  string  $value
-     * @return $this
-     */
-    public function metadata($key, $value)
-    {
-        return $this->withSymfonyMessage(function (Email $message) use ($key, $value) {
-            $message->getHeaders()->add(new MetadataHeader($key, $value));
-        });
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -7,6 +7,9 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Mail\Markdown;
 use Illuminate\Support\Traits\Conditionable;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mime\Email;
 
 class MailMessage extends SimpleMessage implements Renderable
 {
@@ -319,6 +322,33 @@ class MailMessage extends SimpleMessage implements Renderable
 
         return $markdown->theme($this->theme ?: $markdown->getTheme())
                 ->render($this->markdown, $this->data());
+    }
+
+    /**
+     * Add a tag to the email (for drivers that support).
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function tag($value)
+    {
+        return $this->withSymfonyMessage(function (Email $message) use ($value) {
+            $message->getHeaders()->add(new TagHeader($value));
+        });
+    }
+
+    /**
+     * Add metadata to the email (for drivers that support).
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return $this
+     */
+    public function metadata($key, $value)
+    {
+        return $this->withSymfonyMessage(function (Email $message) use ($key, $value) {
+            $message->getHeaders()->add(new MetadataHeader($key, $value));
+        });
     }
 
     /**


### PR DESCRIPTION
`symfony/mailer` has a special `TagHeader` and `MetadataHeader` for [adding tags/metadata to emails](https://symfony.com/doc/current/mailer.html#adding-tags-and-metadata-to-emails) in a generic way. All the transports/drivers you document support these with the slight exception of SES: it doesn't have tags in the way Symfony defines them but does have metadata. SES calls these tags so it's a bit confusing. Symfony's SES transport will [support metadata in 6.1](https://github.com/symfony/symfony/pull/45222) but I see you created your own [SESTransport](https://github.com/laravel/framework/pull/40696). I can add support to your transport if desired.

Here's how [tags](https://postmarkapp.com/blog/tags-support-for-smtp#what-are-tags) and [metadata](https://postmarkapp.com/blog/feature-announcement-custom-metadata-for-your-emails) are used with Postmark - all services are similar I believe.

I thought it would be nice to have helpers to add this data in `Mailable`/`MailMessage`:

```php
// in your mailable:
public function build()
{
    return $this->from('example@example.com', 'Example')
                ->tag('shipment')
                ->metadata('order_id', $this->order->id)
                ->view('emails.orders.shipped');
}

// in your notification:
public function toMail($notifiable)
{
    return (new MailMessage)
                ->from('barrett@example.com', 'Barrett Blair')
                ->tag('upvote')
                ->metadata('comment_id', $this->comment->id)
                ->line('...');
}
```

If this is of interest, I can add tests/docs. Maybe you'd want the methods in a trait or done a different way - let me know!