### PR TITLE
[8.x] Accept 'on' as a valid boolean

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -420,7 +420,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 0, 1, '0', '1', 'on'];
 
         return in_array($value, $acceptable, true);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2170,6 +2170,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 0], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'on'], ['foo' => 'Boolean']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateBool()


### PR DESCRIPTION
This PR will accept ``on`` as a valid boolean when the validation rule [boolean](https://laravel.com/docs/8.x/validation#rule-boolean) is set for an input field.
Browsers will sent ``on`` if a checkbox is checked that doesn't have a defined value.

``on`` is already accepted as a valid boolean in the [accepted](https://laravel.com/docs/8.x/validation#rule-accepted) and [acceptedIf](https://laravel.com/docs/8.x/validation#rule-accepted-if) validation rules.

It's also accepted in ``Illuminate\Http\Concerns\InteractsWithInput`` when you do ``request()->boolean('demo')``, as the underlying PHP function ``filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN)`` is called.

According to https://www.php.net/manual/en/filter.filters.validate.php, even ``yes`` should be accepted.

> Returns true for "1", "true", "on" and "yes". Returns false otherwise. 

If accepted, the documentation needs to be updated as well:
https://github.com/laravel/docs/blob/8.x/validation.md#rule-boolean

Looking forward to any feedback and suggestions regarding this PR.
Perhaps ``on`` was left out intentionally in the past for some (edge) cases?

Thanks!