### PR TITLE
[9.x] No need to implement an interface twice.

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -7,9 +7,8 @@ use Aws\Ses\SesClient;
 use Exception;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
-use Symfony\Component\Mailer\Transport\TransportInterface;
 
-class SesTransport extends AbstractTransport implements TransportInterface
+class SesTransport extends AbstractTransport
 {
     /**
      * The Amazon SES instance.

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Support;
 
-use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Mail\Mailable;
@@ -190,7 +189,7 @@ class SupportTestingMailFakeTest extends TestCase
     }
 }
 
-class MailableStub extends Mailable implements MailableContract
+class MailableStub extends Mailable
 {
     public $framework = 'Laravel';
 


### PR DESCRIPTION
There is no need mentioning that a class implements an interface, when its parent class already implements it.