### PR TITLE
[9.x] Fix Carbon::setTestNow usage

### DIFF
--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -13,19 +13,11 @@ use stdClass;
 
 class AuthDatabaseTokenRepositoryTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Carbon::setTestNow(Carbon::now());
-    }
-
     protected function tearDown(): void
     {
         parent::tearDown();
 
         m::close();
-        Carbon::setTestNow(null);
     }
 
     public function testCreateInsertsNewRecordIntoTable()

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -9,6 +9,13 @@ use stdClass;
 
 class CacheArrayStoreTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
+
     public function testItemsCanBeSetAndRetrieved()
     {
         $store = new ArrayStore;
@@ -37,7 +44,6 @@ class CacheArrayStoreTest extends TestCase
 
     public function testItemsCanExpire()
     {
-        Carbon::setTestNow(Carbon::now());
         $store = new ArrayStore;
 
         $store->put('foo', 'bar', 10);
@@ -45,7 +51,6 @@ class CacheArrayStoreTest extends TestCase
         $result = $store->get('foo');
 
         $this->assertNull($result);
-        Carbon::setTestNow(null);
     }
 
     public function testStoreItemForeverProperlyStoresInArray()
@@ -77,7 +82,6 @@ class CacheArrayStoreTest extends TestCase
 
     public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
     {
-        Carbon::setTestNow(Carbon::now());
         $store = new ArrayStore;
 
         $store->put('foo', 999, 10);
@@ -85,7 +89,6 @@ class CacheArrayStoreTest extends TestCase
         $result = $store->increment('foo');
 
         $this->assertEquals(1, $result);
-        Carbon::setTestNow(null);
     }
 
     public function testValuesCanBeDecremented()
@@ -134,7 +137,6 @@ class CacheArrayStoreTest extends TestCase
 
     public function testCanAcquireLockAgainAfterExpiry()
     {
-        Carbon::setTestNow(Carbon::now());
         $store = new ArrayStore;
         $lock = $store->lock('foo', 10);
         $lock->acquire();
@@ -146,6 +148,7 @@ class CacheArrayStoreTest extends TestCase
     public function testLockExpirationLowerBoundary()
     {
         Carbon::setTestNow(Carbon::now());
+
         $store = new ArrayStore;
         $lock = $store->lock('foo', 10);
         $lock->acquire();
@@ -156,7 +159,6 @@ class CacheArrayStoreTest extends TestCase
 
     public function testLockWithNoExpirationNeverExpires()
     {
-        Carbon::setTestNow(Carbon::now());
         $store = new ArrayStore;
         $lock = $store->lock('foo');
         $lock->acquire();

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -11,20 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 class CacheFileStoreTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Carbon::setTestNow(Carbon::now());
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        Carbon::setTestNow(null);
-    }
-
     public function testNullIsReturnedIfFileDoesntExist()
     {
         $files = $this->mockFilesystem();

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -66,7 +66,7 @@ class CacheMemcachedStoreTest extends TestCase
         $store = new MemcachedStore($memcache);
         $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
-        Carbon::setTestNow();
+        Carbon::setTestNow(null);
     }
 
     public function testIncrementMethodProperlyCallsMemcache()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -23,7 +23,8 @@ class CacheRepositoryTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
-        Carbon::setTestNow();
+
+        Carbon::setTestNow(null);
     }
 
     public function testGetReturnsValueFromCache()
@@ -95,11 +96,6 @@ class CacheRepositoryTest extends TestCase
             return 'bar';
         });
         $this->assertSame('bar', $result);
-
-        /*
-         * Use Carbon object...
-         */
-        Carbon::setTestNow(Carbon::now());
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->times(2)->andReturn(null);

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -17,7 +17,7 @@ class FrequencyTest extends TestCase
 
     protected function setUp(): void
     {
-        Carbon::setTestNow();
+
 
         $this->event = new Event(
             m::mock(EventMutex::class),
@@ -102,6 +102,8 @@ class FrequencyTest extends TestCase
         Carbon::setTestNow('2020-10-10 10:10:10');
 
         $this->assertSame('0 0 31 * *', $this->event->lastDayOfMonth()->getExpression());
+
+        Carbon::setTestNow(null);
     }
 
     public function testTwiceMonthly()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -17,8 +17,6 @@ class FrequencyTest extends TestCase
 
     protected function setUp(): void
     {
-
-
         $this->event = new Event(
             m::mock(EventMutex::class),
             'php foo'

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -26,6 +26,10 @@ class DatabaseEloquentBuilderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+
         m::close();
     }
 
@@ -1665,8 +1669,6 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->update(['foo' => 'bar']);
         $this->assertEquals(1, $result);
-
-        Carbon::setTestNow(null);
     }
 
     public function testUpdateWithTimestampValue()
@@ -1711,8 +1713,6 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $result = $builder->from('table as alias')->update(['foo' => 'bar']);
         $this->assertEquals(1, $result);
-
-        Carbon::setTestNow(null);
     }
 
     public function testUpsert()
@@ -1736,8 +1736,6 @@ class DatabaseEloquentBuilderTest extends TestCase
         $result = $builder->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], ['email']);
 
         $this->assertEquals(2, $result);
-
-        Carbon::setTestNow(null);
     }
 
     public function testWithCastsMethod()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1631,7 +1631,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is not touching model own timestamps.');
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is not touching models related timestamps.');
-
     }
 
     public function testMultiLevelTouchingWorks()
@@ -1650,7 +1649,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is not touching models related timestamps.');
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is not touching models related timestamps.');
-
     }
 
     public function testDeletingChildModelTouchesParentTimestamps()
@@ -1668,7 +1666,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $post->delete();
 
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is not touching models related timestamps.');
-
     }
 
     public function testTouchingChildModelUpdatesParentsTimestamps()
@@ -1687,7 +1684,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is not touching model own timestamps.');
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is not touching models related timestamps.');
-
     }
 
     public function testTouchingChildModelRespectsParentNoTouching()
@@ -1715,7 +1711,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $before->isSameDay($user->fresh()->updated_at),
             'It is touching model own timestamps in withoutTouching scope, when it should not.'
         );
-
     }
 
     public function testUpdatingChildPostRespectsNoTouchingDefinition()
@@ -1736,7 +1731,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is not touching model own timestamps when it should.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models relationships when it should be disabled.');
-
     }
 
     public function testUpdatingModelInTheDisabledScopeTouchesItsOwnTimestamps()
@@ -1757,7 +1751,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
-
     }
 
     public function testDeletingChildModelRespectsTheNoTouchingRule()
@@ -1777,7 +1770,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
 
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
-
     }
 
     public function testRespectedMultiLevelTouchingChain()
@@ -1798,7 +1790,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
-
     }
 
     public function testTouchesGreatParentEvenWhenParentIsInNoTouchScope()
@@ -1819,7 +1810,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($before->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
-
     }
 
     public function testCanNestCallsOfNoTouching()
@@ -1842,7 +1832,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($before->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
-
     }
 
     public function testCanPassArrayOfModelsToIgnore()
@@ -1863,7 +1852,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($before->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
-
     }
 
     public function testWhenBaseModelIsIgnoredAllChildModelsAreIgnored()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -155,6 +155,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->drop('users');
             $this->schema($connection)->drop('friends');
@@ -165,6 +167,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Relation::morphMap([], false);
         Eloquent::unsetConnectionResolver();
+
+        Carbon::setTestNow(null);
     }
 
     /**
@@ -1628,7 +1632,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is not touching model own timestamps.');
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is not touching models related timestamps.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testMultiLevelTouchingWorks()
@@ -1648,7 +1651,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is not touching models related timestamps.');
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is not touching models related timestamps.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testDeletingChildModelTouchesParentTimestamps()
@@ -1667,7 +1669,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is not touching models related timestamps.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testTouchingChildModelUpdatesParentsTimestamps()
@@ -1687,7 +1688,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is not touching model own timestamps.');
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is not touching models related timestamps.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testTouchingChildModelRespectsParentNoTouching()
@@ -1716,7 +1716,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
             'It is touching model own timestamps in withoutTouching scope, when it should not.'
         );
 
-        Carbon::setTestNow($before);
     }
 
     public function testUpdatingChildPostRespectsNoTouchingDefinition()
@@ -1738,7 +1737,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is not touching model own timestamps when it should.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models relationships when it should be disabled.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testUpdatingModelInTheDisabledScopeTouchesItsOwnTimestamps()
@@ -1760,7 +1758,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testDeletingChildModelRespectsTheNoTouchingRule()
@@ -1781,7 +1778,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testRespectedMultiLevelTouchingChain()
@@ -1803,7 +1799,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($future->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testTouchesGreatParentEvenWhenParentIsInNoTouchScope()
@@ -1825,7 +1820,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($future->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testCanNestCallsOfNoTouching()
@@ -1849,7 +1843,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testCanPassArrayOfModelsToIgnore()
@@ -1871,7 +1864,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($post->fresh()->updated_at), 'It is touching models when it should be disabled.');
         $this->assertTrue($before->isSameDay($user->fresh()->updated_at), 'It is touching models when it should be disabled.');
 
-        Carbon::setTestNow($before);
     }
 
     public function testWhenBaseModelIsIgnoredAllChildModelsAreIgnored()

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -55,9 +55,13 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         $this->schema()->drop('irregular_plural_tokens');
         $this->schema()->drop('irregular_plural_humans');
         $this->schema()->drop('irregular_plural_human_irregular_plural_token');
+
+        Carbon::setTestNow(null);
     }
 
     protected function schema()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2051,7 +2051,6 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
 
-
         $scopes = [
             'published',
             'category' => 'Laravel',

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -42,13 +42,6 @@ class DatabaseEloquentModelTest extends TestCase
 {
     use InteractsWithTime;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Carbon::setTestNow(Carbon::now());
-    }
-
     protected function tearDown(): void
     {
         parent::tearDown();
@@ -2058,7 +2051,6 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
 
-        Carbon::setTestNow();
 
         $scopes = [
             'published',

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -18,7 +18,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
-        Carbon::setTestNow(Carbon::now());
+        parent::setUp();
 
         $db = new DB;
 

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -11,6 +11,8 @@ class DatabaseEloquentTimestampsTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         $db = new DB;
 
         $db->addConnection([
@@ -22,7 +24,6 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $db->setAsGlobal();
 
         $this->createSchema();
-        Carbon::setTestNow(Carbon::now());
     }
 
     /**

--- a/tests/Database/DatabaseSoftDeletingTest.php
+++ b/tests/Database/DatabaseSoftDeletingTest.php
@@ -19,7 +19,6 @@ class DatabaseSoftDeletingTest extends TestCase
 
     public function testDeletedAtIsCastToCarbonInstance()
     {
-        Carbon::setTestNow(Carbon::now());
         $expected = Carbon::createFromFormat('Y-m-d H:i:s', '2018-12-29 13:59:39');
         $model = new SoftDeletingModel(['deleted_at' => $expected->format('Y-m-d H:i:s')]);
 

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Cache;
 
 use Exception;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -37,8 +37,6 @@ class FileCacheLockTest extends TestCase
 
     public function testLocksCanBlockForSeconds()
     {
-        Carbon::setTestNow();
-
         Cache::lock('foo')->forceRelease();
         $this->assertSame('taylor', Cache::lock('foo', 10)->block(1, function () {
             return 'taylor';

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Cache;
 
 use Illuminate\Contracts\Cache\LockTimeoutException;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 
 /**

--- a/tests/Integration/Cache/MemcachedCacheLockTestCase.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTestCase.php
@@ -24,8 +24,6 @@ class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
 
     public function testMemcachedLocksCanBlockForSeconds()
     {
-        Carbon::setTestNow();
-
         Cache::store('memcached')->lock('foo')->forceRelease();
         $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
             return 'taylor';
@@ -46,8 +44,6 @@ class MemcachedCacheLockTestCase extends MemcachedIntegrationTestCase
     public function testLocksThrowTimeoutIfBlockExpires()
     {
         $this->expectException(LockTimeoutException::class);
-
-        Carbon::setTestNow();
 
         Cache::store('memcached')->lock('foo')->release();
         Cache::store('memcached')->lock('foo', 5)->get();

--- a/tests/Integration/Cache/NoLockTest.php
+++ b/tests/Integration/Cache/NoLockTest.php
@@ -38,8 +38,6 @@ class NoLockTest extends TestCase
 
     public function testLocksCanBlockForSeconds()
     {
-        Carbon::setTestNow();
-
         Cache::lock('foo')->forceRelease();
         $this->assertSame('taylor', Cache::lock('foo', 10)->block(1, function () {
             return 'taylor';

--- a/tests/Integration/Cache/NoLockTest.php
+++ b/tests/Integration/Cache/NoLockTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -50,8 +50,6 @@ class RedisCacheLockTest extends TestCase
 
     public function testRedisLocksCanBlockForSeconds()
     {
-        Carbon::setTestNow();
-
         Cache::store('redis')->lock('foo')->forceRelease();
         $this->assertSame('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
             return 'taylor';

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Exception;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 

--- a/tests/Integration/Cookie/CookieTest.php
+++ b/tests/Integration/Cookie/CookieTest.php
@@ -36,7 +36,6 @@ class CookieTest extends TestCase
             return 'hello world';
         })->middleware('web');
 
-        Carbon::setTestNow(Carbon::now());
         $response = $this->get('/');
         $this->assertCount(2, $response->headers->getCookies());
         $this->assertEquals(Carbon::now()->getTimestamp() + 60, ($response->headers->getCookies()[1])->getExpiresTime());

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -15,6 +15,13 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentBelongsToManyTest extends DatabaseTestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
+
     protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
     {
         Schema::create('users', function (Blueprint $table) {

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Integration\Database\EloquentMorphManyTest;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -26,8 +26,6 @@ class EloquentMorphManyTest extends DatabaseTestCase
             $table->string('commentable_type');
             $table->timestamps();
         });
-
-        Carbon::setTestNow(null);
     }
 
     public function testUpdateModelWithDefaultWithCount()

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -79,6 +79,8 @@ class SendingMailWithLocaleTest extends TestCase
         );
 
         $this->assertSame('en', Carbon::getLocale());
+
+        Carbon::setTestNow(null);
     }
 
     public function testLocaleIsSentWithModelPreferredLocale()

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -145,6 +145,8 @@ class SendingNotificationsWithLocaleTest extends TestCase
         $this->assertTrue($this->app->isLocale('en'));
 
         $this->assertSame('en', Carbon::getLocale());
+
+        Carbon::setTestNow(null);
     }
 
     public function testLocaleIsSentWithNotifiablePreferredLocale()

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -13,6 +13,13 @@ use Orchestra\Testbench\TestCase;
 
 class UrlSigningTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
+
     public function testSigningUrl()
     {
         Route::get('/foo/{id}', function (Request $request, $id) {

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -27,7 +27,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
             return $uuid;
         });
 
-        Carbon::setTestNow($now = CarbonImmutable::now());
+        $now = CarbonImmutable::now();
 
         $exception = new Exception('Something went wrong.');
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -37,6 +37,10 @@ class QueueWorkerTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+
         Container::setInstance(null);
     }
 

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -30,15 +30,16 @@ class RedisQueueIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
-        Carbon::setTestNow(Carbon::now());
         parent::setUp();
+
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow(null);
         parent::tearDown();
+
+        Carbon::setTestNow(null);
         $this->tearDownRedis();
         m::close();
     }

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -9,6 +9,13 @@ use SessionHandlerInterface;
 
 class ArraySessionHandlerTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
+
     public function test_it_implements_the_session_handler_interface()
     {
         $this->assertInstanceOf(SessionHandlerInterface::class, new ArraySessionHandler(10));
@@ -45,7 +52,6 @@ class ArraySessionHandlerTest extends TestCase
 
         Carbon::setTestNow(Carbon::now()->addMinutes(10));
         $this->assertSame('bar', $handler->read('foo'));
-        Carbon::setTestNow();
     }
 
     public function test_it_reads_data_from_an_expired_session()
@@ -56,7 +62,6 @@ class ArraySessionHandlerTest extends TestCase
 
         Carbon::setTestNow(Carbon::now()->addMinutes(10)->addSecond());
         $this->assertSame('', $handler->read('foo'));
-        Carbon::setTestNow();
     }
 
     public function test_it_reads_data_from_a_non_existing_session()
@@ -109,6 +114,5 @@ class ArraySessionHandlerTest extends TestCase
         $this->assertSame('', $handler->read('foo'));
         $this->assertSame('qux', $handler->read('baz'));
 
-        Carbon::setTestNow();
     }
 }

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -113,6 +113,5 @@ class ArraySessionHandlerTest extends TestCase
         $this->assertSame(1, $handler->gc(300));
         $this->assertSame('', $handler->read('foo'));
         $this->assertSame('qux', $handler->read('baz'));
-
     }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -25,7 +25,7 @@ class SupportCarbonTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
+        Carbon::setTestNow(null);
         Carbon::serializeUsing(null);
 
         parent::tearDown();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -36,7 +36,8 @@ class ValidationValidatorTest extends TestCase
 {
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
+        parent::tearDown();
+
         m::close();
     }
 
@@ -4019,6 +4020,8 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => new Carbon('2018-01-01')], ['x' => 'date_equals:tomorrow']);
         $this->assertTrue($v->fails());
+
+        Carbon::setTestNow(null);
     }
 
     public function testBeforeAndAfter()


### PR DESCRIPTION
In many place in the tests, the usage of Carbon::setTestNow does not make sense or is not used properly.
This PR fixes that.

See PR code comments.

---

In a ideal world, a way to go would be to have an abstract test class that every other test (excepted integration) class could  extend, this abstract class would close Mockery and reset Carbon in its tearDown method.