### PR TITLE
[8.x] Revert Bit operators

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -204,15 +204,6 @@ class Builder
     ];
 
     /**
-     * All of the available bit operators.
-     *
-     * @var string[]
-     */
-    public $bitOperators = [
-        '&', '|', '^', '<<', '>>', '&~',
-    ];
-
-    /**
      * Whether to use write pdo for the select.
      *
      * @var bool
@@ -763,10 +754,6 @@ class Builder
             }
         }
 
-        if ($this->isBitOperator($operator)) {
-            $type = 'Bit';
-        }
-
         // Now that we are working with just a simple query we can put the elements
         // in our array and add the query binding to our array of bindings that
         // will be bound to each SQL statements when it is finally executed.
@@ -848,18 +835,6 @@ class Builder
     {
         return ! in_array(strtolower($operator), $this->operators, true) &&
                ! in_array(strtolower($operator), $this->grammar->getOperators(), true);
-    }
-
-    /**
-     * Determine if the operator is a bit operator.
-     *
-     * @param  string  $operator
-     * @return bool
-     */
-    protected function isBitOperator($operator)
-    {
-        return in_array(strtolower($operator), $this->bitOperators, true) ||
-               in_array(strtolower($operator), $this->grammar->getBitOperators(), true);
     }
 
     /**
@@ -1938,10 +1913,6 @@ class Builder
         // we will set the operators to '=' and set the values appropriately.
         if ($this->invalidOperator($operator)) {
             [$value, $operator] = [$operator, '='];
-        }
-
-        if ($this->isBitOperator($operator)) {
-            $type = 'bit';
         }
 
         $this->havings[] = compact('type', 'column', 'operator', 'value', 'boolean');

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -19,13 +19,6 @@ class Grammar extends BaseGrammar
     protected $operators = [];
 
     /**
-     * The grammar specific bit operators.
-     *
-     * @var array
-     */
-    protected $bitOperators = [];
-
-    /**
      * The components that make up a select clause.
      *
      * @var string[]
@@ -260,22 +253,6 @@ class Grammar extends BaseGrammar
         $operator = str_replace('?', '??', $where['operator']);
 
         return $this->wrap($where['column']).' '.$operator.' '.$value;
-    }
-
-    /**
-     * Compile a bit operator where clause.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereBit(Builder $query, $where)
-    {
-        $value = $this->parameter($where['value']);
-
-        $operator = str_replace('?', '??', $where['operator']);
-
-        return '('.$this->wrap($where['column']).' '.$operator.' '.$value.') != 0';
     }
 
     /**
@@ -708,8 +685,6 @@ class Grammar extends BaseGrammar
             return $having['boolean'].' '.$having['sql'];
         } elseif ($having['type'] === 'between') {
             return $this->compileHavingBetween($having);
-        } elseif ($having['type'] === 'bit') {
-            return $this->compileHavingBit($having);
         }
 
         return $this->compileBasicHaving($having);
@@ -747,21 +722,6 @@ class Grammar extends BaseGrammar
         $max = $this->parameter(last($having['values']));
 
         return $having['boolean'].' '.$column.' '.$between.' '.$min.' and '.$max;
-    }
-
-    /**
-     * Compile a having clause involving a bit operator.
-     *
-     * @param  array  $having
-     * @return string
-     */
-    protected function compileHavingBit($having)
-    {
-        $column = $this->wrap($having['column']);
-
-        $parameter = $this->parameter($having['value']);
-
-        return $having['boolean'].' ('.$column.' '.$having['operator'].' '.$parameter.') != 0';
     }
 
     /**
@@ -1338,15 +1298,5 @@ class Grammar extends BaseGrammar
     public function getOperators()
     {
         return $this->operators;
-    }
-
-    /**
-     * Get the grammar specific bit operators.
-     *
-     * @return array
-     */
-    public function getBitOperators()
-    {
-        return $this->bitOperators;
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -22,15 +22,6 @@ class PostgresGrammar extends Grammar
     ];
 
     /**
-     * The grammar specific bit operators.
-     *
-     * @var array
-     */
-    protected $bitOperators = [
-        '~', '&', '|', '#', '<<', '>>', '<<=', '>>=',
-    ];
-
-    /**
      * {@inheritdoc}
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2153,7 +2153,6 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($connection = m::mock(Connection::class));
         $connection->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
-        $grammar->shouldReceive('getBitOperators')->andReturn([]);
         $connection->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
@@ -2441,7 +2440,6 @@ class EloquentModelSaveStub extends Model
     {
         $mock = m::mock(Connection::class);
         $mock->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
-        $grammar->shouldReceive('getBitOperators')->andReturn([]);
         $mock->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
         $mock->shouldReceive('getName')->andReturn('name');
         $mock->shouldReceive('query')->andReturnUsing(function () use ($mock, $grammar, $processor) {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3209,25 +3209,6 @@ SQL;
         $this->assertEquals(['John Doe'], $builder->getBindings());
     }
 
-    public function testBitOperators()
-    {
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->where('bar', '&', 1);
-        $this->assertSame('select * from "users" where ("bar" & ?) != 0', $builder->toSql());
-
-        $builder = $this->getPostgresBuilder();
-        $builder->select('*')->from('users')->where('bar', '#', 1);
-        $this->assertSame('select * from "users" where ("bar" # ?) != 0', $builder->toSql());
-
-        $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->having('bar', '&', 1);
-        $this->assertSame('select * from "users" having ("bar" & ?) != 0', $builder->toSql());
-
-        $builder = $this->getPostgresBuilder();
-        $builder->select('*')->from('users')->having('bar', '#', 1);
-        $this->assertSame('select * from "users" having ("bar" # ?) != 0', $builder->toSql());
-    }
-
     public function testMergeWheresCanMergeWheresAndBindings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR reverts https://github.com/laravel/framework/pull/40529 & https://github.com/laravel/framework/commit/def671d4902d9cdd315aee8249199b45fcc2186b because breaking changes were introduced. 

@Arzaroth if you figure out how to solve with avoiding breaking changes we can reconsider a new PR.

Fixes https://github.com/laravel/framework/issues/40757#