### PR TITLE
[9.x] Remove useless variables

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -481,7 +481,7 @@ class Gate implements GateContract
             $reflection = new ReflectionClass($class);
 
             $method = $reflection->getMethod($method);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
 

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -188,7 +188,7 @@ class Batch implements Arrayable, JsonSerializable
 
             $this->queue->connection($this->options['connection'] ?? null)->bulk(
                 $jobs->all(),
-                $data = '',
+                '',
                 $this->options['queue'] ?? null
             );
         });

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -41,7 +41,7 @@ class UniqueLock
                     : $this->cache;
 
         return (bool) $cache->lock(
-            $key = 'laravel_unique_job:'.get_class($job).$uniqueId,
+            'laravel_unique_job:'.get_class($job).$uniqueId,
             $job->uniqueFor ?? 0
         )->get();
     }

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -56,8 +56,6 @@ class DatabaseLock extends Lock
      */
     public function acquire()
     {
-        $acquired = false;
-
         try {
             $this->connection->table($this->table)->insert([
                 'key' => $this->name,
@@ -66,7 +64,7 @@ class DatabaseLock extends Lock
             ]);
 
             $acquired = true;
-        } catch (QueryException $e) {
+        } catch (QueryException) {
             $updated = $this->connection->table($this->table)
                 ->where('key', $this->name)
                 ->where(function ($query) {

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -130,7 +130,7 @@ class DatabaseStore implements LockProvider, Store
 
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));
-        } catch (Exception $e) {
+        } catch (Exception) {
             $result = $this->table()->where('key', $key)->update(compact('value', 'expiration'));
 
             return $result > 0;
@@ -153,7 +153,7 @@ class DatabaseStore implements LockProvider, Store
 
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));
-        } catch (QueryException $e) {
+        } catch (QueryException) {
             return $this->table()
                 ->where('key', $key)
                 ->where('expiration', '<=', $this->getTime())

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -102,7 +102,7 @@ class FileStore implements Store, LockProvider
 
         try {
             $file->getExclusiveLock();
-        } catch (LockTimeoutException $e) {
+        } catch (LockTimeoutException) {
             $file->close();
 
             return false;
@@ -254,7 +254,7 @@ class FileStore implements Store, LockProvider
             $expire = substr(
                 $contents = $this->files->get($path, true), 0, 10
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
             return $this->emptyPayload();
         }
 
@@ -269,7 +269,7 @@ class FileStore implements Store, LockProvider
 
         try {
             $data = unserialize(substr($contents, 10));
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->forget($key);
 
             return $this->emptyPayload();

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1369,7 +1369,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                 $ascending = Arr::get($comparison, 1, true) === true ||
                              Arr::get($comparison, 1, true) === 'asc';
 
-
                 if (! is_string($prop) && is_callable($prop)) {
                     $result = $prop($a, $b);
                 } else {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1369,7 +1369,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
                 $ascending = Arr::get($comparison, 1, true) === true ||
                              Arr::get($comparison, 1, true) === 'asc';
 
-                $result = 0;
 
                 if (! is_string($prop) && is_callable($prop)) {
                     $result = $prop($a, $b);

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -293,7 +293,7 @@ class Container implements ArrayAccess, ContainerContract
             }
 
             return $container->resolve(
-                $concrete, $parameters, $raiseEvents = false
+                $concrete, $parameters, false
             );
         };
     }

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -84,7 +84,7 @@ class EncryptCookies
                 $value = $this->decryptCookie($key, $cookie);
 
                 $request->cookies->set($key, $this->validateValue($key, $value));
-            } catch (DecryptException $e) {
+            } catch (DecryptException) {
                 $request->cookies->set($key, null);
             }
         }

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -177,7 +177,7 @@ class ConnectionFactory
     protected function createPdoResolverWithHosts(array $config)
     {
         return function () use ($config) {
-            foreach (Arr::shuffle($hosts = $this->parseHosts($config)) as $key => $host) {
+            foreach (Arr::shuffle($this->parseHosts($config)) as $host) {
                 $config['host'] = $host;
 
                 try {

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -47,7 +47,7 @@ class DumpCommand extends Command
      */
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
     {
-        $connection = $connections->connection($database = $this->input->getOption('database'));
+        $connection = $connections->connection($this->input->getOption('database'));
 
         $this->schemaState($connection)->dump(
             $connection, $path = $this->path($connection)
@@ -59,7 +59,7 @@ class DumpCommand extends Command
 
         if ($this->option('prune')) {
             (new Filesystem)->deleteDirectory(
-                database_path('migrations'), $preserve = false
+                database_path('migrations'), false
             );
 
             $this->info('Migrations pruned successfully.');

--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -24,13 +24,13 @@ class TableGuesser
     {
         foreach (self::CREATE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[1], $create = true];
+                return [$matches[1], true];
             }
         }
 
         foreach (self::CHANGE_PATTERNS as $pattern) {
             if (preg_match($pattern, $migration, $matches)) {
-                return [$matches[2], $create = false];
+                return [$matches[2], false];
             }
         }
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -563,7 +563,7 @@ class Builder implements BuilderContract
     {
         try {
             return $this->baseSole($columns);
-        } catch (RecordsNotFoundException $exception) {
+        } catch (RecordsNotFoundException) {
             throw (new ModelNotFoundException)->setModel(get_class($this->model));
         }
     }
@@ -689,7 +689,7 @@ class Builder implements BuilderContract
         $relation = Relation::noConstraints(function () use ($name) {
             try {
                 return $this->getModel()->newInstance()->$name();
-            } catch (BadMethodCallException $e) {
+            } catch (BadMethodCallException) {
                 throw RelationNotFoundException::make($this->getModel(), $name);
             }
         });

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -181,7 +181,7 @@ trait HasAttributes
         // to a DateTime / Carbon instance. This is so we will get some consistent
         // formatting while accessing attributes vs. arraying / JSONing a model.
         $attributes = $this->addDateAttributesToArray(
-            $attributes = $this->getArrayableAttributes()
+            $this->getArrayableAttributes()
         );
 
         $attributes = $this->addMutatedAttributesToArray(
@@ -1296,7 +1296,7 @@ trait HasAttributes
         // that is returned back out to the developers after we convert it here.
         try {
             $date = Date::createFromFormat($format, $value);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             $date = false;
         }
 
@@ -1712,7 +1712,7 @@ trait HasAttributes
     public function getOriginal($key = null, $default = null)
     {
         return (new static)->setRawAttributes(
-            $this->original, $sync = true
+            $this->original, true
         )->getOriginalWithoutRewindingModel($key, $default);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -476,7 +476,7 @@ trait QueriesRelationships
 
         try {
             $relationship = $this->model->{$relationshipName}();
-        } catch (BadMethodCallException $exception) {
+        } catch (BadMethodCallException) {
             throw RelationNotFoundException::make($this->model, $relationshipName);
         }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -793,7 +793,7 @@ abstract class Factory
             return Container::getInstance()
                             ->make(Application::class)
                             ->getNamespace();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return 'App\\';
         }
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1832,7 +1832,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             }
 
             if ($relation instanceof QueueableEntity) {
-                foreach ($relation->getQueueableRelations() as $entityKey => $entityValue) {
+                foreach ($relation->getQueueableRelations() as $entityValue) {
                     $relations[] = $key.'.'.$entityValue;
                 }
             }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/CanBeOneOfMany.php
@@ -76,7 +76,7 @@ trait CanBeOneOfMany
 
         $keyName = $this->query->getModel()->getKeyName();
 
-        $columns = is_string($columns = $column) ? [
+        $columns = is_string($column) ? [
             $column => $aggregate,
             $keyName => $aggregate,
         ] : $column;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -387,7 +387,7 @@ class MorphTo extends BelongsTo
         // If we tried to call a method that does not exist on the parent Builder instance,
         // we'll assume that we want to call a query macro (e.g. withTrashed) that only
         // exists on related models. We will just store the call and replay it later.
-        catch (BadMethodCallException $e) {
+        catch (BadMethodCallException) {
             $this->macroBuffer[] = compact('method', 'parameters');
 
             return $this;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -424,7 +424,7 @@ class Migrator
 
                 $this->note("<info>{$name}:</info> {$query['query']}");
             }
-        } catch (SchemaException $e) {
+        } catch (SchemaException) {
             $name = get_class($migration);
 
             $this->note("<info>{$name}:</info> failed to dump queries. This may be due to changing database columns using Doctrine, which is not supported while pretending to run migrations.");

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -888,7 +888,7 @@ class SQLiteGrammar extends Grammar
             return " as ({$storedAs}) stored";
         }
 
-        if (! is_null($storedAs = $column->storedAs)) {
+        if (! is_null($column->storedAs)) {
             return " as ({$column->storedAs}) stored";
         }
     }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -492,7 +492,7 @@ class Dispatcher implements DispatcherContract
             return (new ReflectionClass($class))->implementsInterface(
                 ShouldQueue::class
             );
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
     }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -287,7 +287,7 @@ class Filesystem
                 } else {
                     $success = false;
                 }
-            } catch (ErrorException $e) {
+            } catch (ErrorException) {
                 $success = false;
             }
         }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -235,7 +235,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             return $this->driver->read($path);
-        } catch (UnableToReadFile $e) {
+        } catch (UnableToReadFile) {
             //
         }
     }
@@ -329,7 +329,7 @@ class FilesystemAdapter implements CloudFilesystemContract
             is_resource($contents)
                 ? $this->driver->writeStream($path, $contents, $options)
                 : $this->driver->write($path, $contents, $options);
-        } catch (UnableToWriteFile $e) {
+        } catch (UnableToWriteFile) {
             return false;
         }
 
@@ -404,7 +404,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->setVisibility($path, $this->parseVisibility($visibility));
-        } catch (UnableToSetVisibility $e) {
+        } catch (UnableToSetVisibility) {
             return false;
         }
 
@@ -460,7 +460,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         foreach ($paths as $path) {
             try {
                 $this->driver->delete($path);
-            } catch (UnableToDeleteFile $e) {
+            } catch (UnableToDeleteFile) {
                 $success = false;
             }
         }
@@ -479,7 +479,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->copy($from, $to);
-        } catch (UnableToCopyFile $e) {
+        } catch (UnableToCopyFile) {
             return false;
         }
 
@@ -497,7 +497,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->move($from, $to);
-        } catch (UnableToMoveFile $e) {
+        } catch (UnableToMoveFile) {
             return false;
         }
 
@@ -544,7 +544,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             return $this->driver->readStream($path);
-        } catch (UnableToReadFile $e) {
+        } catch (UnableToReadFile) {
             //
         }
     }
@@ -556,7 +556,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->writeStream($path, $resource, $options);
-        } catch (UnableToWriteFile $e) {
+        } catch (UnableToWriteFile) {
             return false;
         }
 
@@ -752,7 +752,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->createDirectory($path);
-        } catch (UnableToCreateDirectory $e) {
+        } catch (UnableToCreateDirectory) {
             return false;
         }
 
@@ -769,7 +769,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->deleteDirectory($directory);
-        } catch (UnableToDeleteDirectory $e) {
+        } catch (UnableToDeleteDirectory) {
             return false;
         }
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -92,7 +92,7 @@ class HandleExceptions
 
         try {
             $logger = static::$app->make(LogManager::class);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -99,7 +99,7 @@ class DownCommand extends Command
     {
         try {
             return $this->laravel->make(PreventRequestsDuringMaintenance::class)->getExcludedPaths();
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return [];
         }
     }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -259,7 +259,7 @@ class RouteListCommand extends Command
     {
         $results = [];
 
-        foreach ($columns as $i => $column) {
+        foreach ($columns as $column) {
             if (str_contains($column, ',')) {
                 $results = array_merge($results, explode(',', $column));
             } else {

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -56,7 +56,7 @@ class DiscoverEvents
                 $listener = new ReflectionClass(
                     static::classFromFile($listener, $basePath)
                 );
-            } catch (ReflectionException $e) {
+            } catch (ReflectionException) {
                 continue;
             }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -237,7 +237,7 @@ class Handler implements ExceptionHandlerContract
 
         try {
             $logger = $this->container->make(LoggerInterface::class);
-        } catch (Exception $ex) {
+        } catch (Exception) {
             throw $e;
         }
 
@@ -304,7 +304,7 @@ class Handler implements ExceptionHandlerContract
                 'userId' => Auth::id(),
                 // 'email' => optional(Auth::user())->email,
             ]);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return [];
         }
     }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -155,7 +155,7 @@ class VerifyCsrfToken
         if (! $token && $header = $request->header('X-XSRF-TOKEN')) {
             try {
                 $token = CookieValuePrefix::remove($this->encrypter->decrypt($header, static::serialized()));
-            } catch (DecryptException $e) {
+            } catch (DecryptException) {
                 $token = '';
             }
         }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -89,7 +89,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
         });
 
         Request::macro('hasValidRelativeSignature', function () {
-            return URL::hasValidSignature($this, $absolute = false);
+            return URL::hasValidSignature($this, false);
         });
 
         Request::macro('hasValidSignatureWhileIgnoring', function ($ignoreQuery = [], $absolute = true) {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -60,7 +60,7 @@ trait InteractsWithRedis
 
         try {
             $this->redis['phpredis']->connection()->flushdb();
-        } catch (Exception $e) {
+        } catch (Exception) {
             if ($host === '127.0.0.1' && $port === 6379 && Env::get('REDIS_HOST') === null) {
                 static::$connectionFailedOnceWithDefaultsSkip = true;
 

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -38,6 +38,6 @@ class RequestException extends HttpClientException
             ? \GuzzleHttp\Psr7\Message::bodySummary($response->toPsrResponse())
             : \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
 
-        return is_null($summary) ? $message : $message .= ":\n{$summary}\n";
+        return is_null($summary) ? $message : $message.":\n{$summary}\n";
     }
 }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -92,7 +92,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
     public function resolve($request = null)
     {
         $data = $this->toArray(
-            $request = $request ?: Container::getInstance()->make('request')
+            $request ?: Container::getInstance()->make('request')
         );
 
         if ($data instanceof Arrayable) {

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -52,7 +52,7 @@ class PruneBatchesCommand extends Command
 
         $this->info("{$count} entries deleted!");
 
-        if ($unfinished = $this->option('unfinished')) {
+        if ( $this->option('unfinished')) {
             $count = 0;
 
             if ($repository instanceof DatabaseBatchRepository) {

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -52,7 +52,7 @@ class PruneBatchesCommand extends Command
 
         $this->info("{$count} entries deleted!");
 
-        if ( $this->option('unfinished')) {
+        if ($this->option('unfinished')) {
             $count = 0;
 
             if ($repository instanceof DatabaseBatchRepository) {

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -41,7 +41,6 @@ class PruneFailedJobsCommand extends Command
     {
         $failer = $this->laravel['queue.failer'];
 
-
         if ($failer instanceof PrunableFailedJobProvider) {
             $count = $failer->prune(Carbon::now()->subHours($this->option('hours')));
         } else {

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -41,7 +41,6 @@ class PruneFailedJobsCommand extends Command
     {
         $failer = $this->laravel['queue.failer'];
 
-        $count = 0;
 
         if ($failer instanceof PrunableFailedJobProvider) {
             $count = $failer->prune(Carbon::now()->subHours($this->option('hours')));

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -212,7 +212,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
         }
 
         if (! $name) {
-            $route->name($name = $this->generateRouteName());
+            $route->name( $this->generateRouteName());
 
             $this->add($route);
         } elseif (! is_null($symfonyRoutes->get($name))) {

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -212,7 +212,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
         }
 
         if (! $name) {
-            $route->name( $this->generateRouteName());
+            $route->name($this->generateRouteName());
 
             $this->add($route);
         } elseif (! is_null($symfonyRoutes->get($name))) {

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -121,10 +121,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
             if ($result = $matcher->matchRequest($trimmedRequest)) {
                 $route = $this->getByName($result['_route']);
             }
-        } catch (ResourceNotFoundException|MethodNotAllowedException $e) {
+        } catch (ResourceNotFoundException|MethodNotAllowedException) {
             try {
                 return $this->routes->match($request);
-            } catch (NotFoundHttpException $e) {
+            } catch (NotFoundHttpException) {
                 //
             }
         }
@@ -136,7 +136,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
                 if (! $dynamicRoute->isFallback) {
                     $route = $dynamicRoute;
                 }
-            } catch (NotFoundHttpException|MethodNotAllowedHttpException $e) {
+            } catch (NotFoundHttpException|MethodNotAllowedHttpException) {
                 //
             }
         }

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -81,7 +81,7 @@ class RouteUrlGenerator
         // has been constructed, we'll make sure we don't have any missing parameters or we
         // will need to throw the exception to let the developers know one was not given.
         $uri = $this->addQueryString($this->url->format(
-            $root = $this->replaceRootParameters($route, $domain, $parameters),
+            $this->replaceRootParameters($route, $domain, $parameters),
             $this->replaceRouteParameters($route->uri(), $parameters),
             $route
         ), $parameters);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -621,7 +621,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $route->setAction($this->mergeWithLastGroup(
             $route->getAction(),
-            $prependExistingPrefix = false
+            false
         ));
     }
 

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -156,7 +156,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     {
         try {
             return $this->getQuery()->insert(Arr::set($payload, 'id', $sessionId));
-        } catch (QueryException $e) {
+        } catch (QueryException) {
             $this->performUpdate($sessionId, $payload);
         }
     }

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -42,7 +42,7 @@ class EncryptedStore extends Store
     {
         try {
             return $this->encrypter->decrypt($data);
-        } catch (DecryptException $e) {
+        } catch (DecryptException) {
             return $this->serialization === 'json' ? json_encode([]) : serialize([]);
         }
     }

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -189,7 +189,7 @@ class SessionManager extends Manager
                 : new Store(
                     $this->config->get('session.cookie'),
                     $handler,
-                    $id = null,
+                    null,
                     $this->config->get('session.serialization', 'php')
                 );
     }
@@ -206,7 +206,7 @@ class SessionManager extends Manager
             $this->config->get('session.cookie'),
             $handler,
             $this->container['encrypter'],
-            $id = null,
+            null,
             $this->config->get('session.serialization', 'php'),
         );
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -760,8 +760,8 @@ class Str
         $parts = explode(' ', $value);
 
         $parts = count($parts) > 1
-            ? $parts = array_map([static::class, 'title'], $parts)
-            : $parts = array_map([static::class, 'title'], static::ucsplit(implode('_', $parts)));
+            ? array_map([static::class, 'title'], $parts)
+            : array_map([static::class, 'title'], static::ucsplit(implode('_', $parts)));
 
         $collapsed = static::replace(['-', '_', ' '], '_', implode('_', $parts));
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -204,7 +204,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject)
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $key => $value) {
+            foreach ($replacements as $value) {
                 return array_shift($replacements);
             }
         }, $subject);

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -77,7 +77,7 @@ trait TestDatabases
             $this->usingDatabase($testDatabase, function () {
                 Schema::hasTable('dummy');
             });
-        } catch (QueryException $e) {
+        } catch (QueryException) {
             $this->usingDatabase($database, function () use ($testDatabase) {
                 Schema::dropDatabaseIfExists($testDatabase);
                 Schema::createDatabase($testDatabase);

--- a/src/Illuminate/Testing/ParallelTesting.php
+++ b/src/Illuminate/Testing/ParallelTesting.php
@@ -261,7 +261,7 @@ class ParallelTesting
      */
     public function token()
     {
-        return $token = $this->tokenResolver
+        return $this->tokenResolver
             ? call_user_func($this->tokenResolver)
             : ($_SERVER['TEST_TOKEN'] ?? false);
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1159,8 +1159,6 @@ EOF;
 
         $this->assertSessionHas('errors');
 
-        $keys = (array) $errors;
-
         $sessionErrors = $this->session()->get('errors')->getBag($errorBag)->getMessages();
 
         $errorMessage = $sessionErrors

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -119,7 +119,7 @@ trait ValidatesAttributes
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
                 return count(dns_get_record($url.'.', DNS_A | DNS_AAAA)) > 0;
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return false;
             }
         }
@@ -301,7 +301,7 @@ trait ValidatesAttributes
     {
         try {
             return @Date::parse($value) ?: null;
-        } catch (Exception $e) {
+        } catch (Exception) {
             //
         }
     }
@@ -476,7 +476,7 @@ trait ValidatesAttributes
             if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
                 return false;
             }
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
 

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -40,7 +40,7 @@ class Enum implements Rule
 
         try {
             return ! is_null($this->type::tryFrom($value));
-        } catch (TypeError $e) {
+        } catch (TypeError) {
             return false;
         }
     }

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -222,7 +222,7 @@ class ComponentTagCompiler
         if (! class_exists($class)) {
             $parameters = [
                 'view' => "'$class'",
-                'data' => '['.$this->attributesToString($data->all(), $escapeBound = false).']',
+                'data' => '['.$this->attributesToString($data->all(), false).']',
             ];
 
             $class = AnonymousComponent::class;
@@ -230,11 +230,11 @@ class ComponentTagCompiler
             $parameters = $data->all();
         }
 
-        return "##BEGIN-COMPONENT-CLASS##@component('{$class}', '{$component}', [".$this->attributesToString($parameters, $escapeBound = false).'])
+        return "##BEGIN-COMPONENT-CLASS##@component('{$class}', '{$component}', [".$this->attributesToString($parameters, false).'])
 <?php if (isset($attributes) && $constructor = (new ReflectionClass('.$class.'::class))->getConstructor()): ?>
 <?php $attributes = $attributes->except(collect($constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php $component->withAttributes(['.$this->attributesToString($attributes->all(), $escapeAttributes = $class !== DynamicComponent::class).']); ?>';
+<?php $component->withAttributes(['.$this->attributesToString($attributes->all(), $class !== DynamicComponent::class).']); ?>';
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -313,7 +313,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
 
             unset($attributes['attributes']);
 
-            $attributes = $parentBag->merge($attributes, $escape = false)->getAttributes();
+            $attributes = $parentBag->merge($attributes, false)->getAttributes();
         }
 
         $this->attributes = $attributes;

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -283,7 +283,7 @@ class Factory implements FactoryContract
     {
         try {
             $this->finder->find($view);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             return false;
         }
 

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -41,7 +41,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => hash('sha256', 'foo')])->andReturn($user);
         $request = Request::create('/', 'GET', ['api_token' => 'foo']);
 
-        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token',  true);
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', true);
 
         $user = $guard->user();
 

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -41,7 +41,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => hash('sha256', 'foo')])->andReturn($user);
         $request = Request::create('/', 'GET', ['api_token' => 'foo']);
 
-        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token', $hash = true);
+        $guard = new TokenGuard($provider, $request, 'api_token', 'api_token',  true);
 
         $user = $guard->user();
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -172,7 +172,7 @@ class BusBatchTest extends TestCase
     {
         $queue = m::mock(Factory::class);
 
-        $batch = $this->createTestBatch($queue,  false);
+        $batch = $this->createTestBatch($queue, false);
 
         $job = new class
         {
@@ -213,7 +213,7 @@ class BusBatchTest extends TestCase
     {
         $queue = m::mock(Factory::class);
 
-        $batch = $this->createTestBatch($queue,  true);
+        $batch = $this->createTestBatch($queue, true);
 
         $job = new class
         {
@@ -378,7 +378,7 @@ class BusBatchTest extends TestCase
         $connection = m::spy(PostgresConnection::class);
 
         $connection->shouldReceive('table->where->first')
-            ->andReturn( (object) [
+            ->andReturn((object) [
                 'id' => '',
                 'name' => '',
                 'total_jobs' => '',

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -172,7 +172,7 @@ class BusBatchTest extends TestCase
     {
         $queue = m::mock(Factory::class);
 
-        $batch = $this->createTestBatch($queue, $allowFailures = false);
+        $batch = $this->createTestBatch($queue,  false);
 
         $job = new class
         {
@@ -213,7 +213,7 @@ class BusBatchTest extends TestCase
     {
         $queue = m::mock(Factory::class);
 
-        $batch = $this->createTestBatch($queue, $allowFailures = true);
+        $batch = $this->createTestBatch($queue,  true);
 
         $job = new class
         {
@@ -378,7 +378,7 @@ class BusBatchTest extends TestCase
         $connection = m::spy(PostgresConnection::class);
 
         $connection->shouldReceive('table->where->first')
-            ->andReturn($m = (object) [
+            ->andReturn( (object) [
                 'id' => '',
                 'name' => '',
                 'total_jobs' => '',

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -52,7 +52,7 @@ class BusPendingBatchTest extends TestCase
 
         $repository = m::mock(BatchRepository::class);
         $repository->shouldReceive('store')->once()->with($pendingBatch)->andReturn($batch = m::mock(stdClass::class));
-        $batch->shouldReceive('add')->once()->with(m::type(Collection::class))->andReturn($batch = m::mock(Batch::class));
+        $batch->shouldReceive('add')->once()->with(m::type(Collection::class))->andReturn( m::mock(Batch::class));
 
         $container->instance(BatchRepository::class, $repository);
 

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -52,7 +52,7 @@ class BusPendingBatchTest extends TestCase
 
         $repository = m::mock(BatchRepository::class);
         $repository->shouldReceive('store')->once()->with($pendingBatch)->andReturn($batch = m::mock(stdClass::class));
-        $batch->shouldReceive('add')->once()->with(m::type(Collection::class))->andReturn( m::mock(Batch::class));
+        $batch->shouldReceive('add')->once()->with(m::type(Collection::class))->andReturn(m::mock(Batch::class));
 
         $container->instance(BatchRepository::class, $repository);
 

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -198,7 +198,7 @@ class CacheArrayStoreTest extends TestCase
 
     public function testValuesAreNotStoredByReference()
     {
-        $store = new ArrayStore( true);
+        $store = new ArrayStore(true);
         $object = new stdClass;
         $object->foo = true;
 

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -198,7 +198,7 @@ class CacheArrayStoreTest extends TestCase
 
     public function testValuesAreNotStoredByReference()
     {
-        $store = new ArrayStore($serialize = true);
+        $store = new ArrayStore( true);
         $object = new stdClass;
         $object->foo = true;
 

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -53,8 +53,8 @@ class ConsoleApplicationTest extends TestCase
     public function testCallFullyStringCommandLine()
     {
         $app = new Application(
-            $app = m::mock(ApplicationContract::class, ['version' => '6.0']),
-            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            m::mock(ApplicationContract::class, ['version' => '6.0']),
+            m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
             'testing'
         );
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -115,7 +115,7 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('A driver must be specified.');
 
-        $factory = new ConnectionFactory($container = m::mock(Container::class));
+        $factory = new ConnectionFactory( m::mock(Container::class));
         $factory->createConnector(['foo']);
     }
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -115,7 +115,7 @@ class DatabaseConnectionFactoryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('A driver must be specified.');
 
-        $factory = new ConnectionFactory( m::mock(Container::class));
+        $factory = new ConnectionFactory(m::mock(Container::class));
         $factory->createConnector(['foo']);
     }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -146,7 +146,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection([], $pdo);
         try {
             $connection->beginTransaction();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->assertEquals(0, $connection->transactionLevel());
         }
     }
@@ -189,7 +189,7 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(1, $connection->transactionLevel());
         try {
             $connection->beginTransaction();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->assertEquals(1, $connection->transactionLevel());
         }
     }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -816,7 +816,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('from');
         $builder->getQuery()->shouldReceive('where')->once()->with('foo', 'bar');
-        $builder->setModel( new EloquentBuilderTestScopeStub);
+        $builder->setModel(new EloquentBuilderTestScopeStub);
         $result = $builder->approved();
 
         $this->assertEquals($builder, $result);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -816,7 +816,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('from');
         $builder->getQuery()->shouldReceive('where')->once()->with('foo', 'bar');
-        $builder->setModel($model = new EloquentBuilderTestScopeStub);
+        $builder->setModel( new EloquentBuilderTestScopeStub);
         $result = $builder->approved();
 
         $this->assertEquals($builder, $result);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -207,7 +207,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_has_many_relationship()
     {
-        $users = FactoryTestUserFactory::times(10)
+        FactoryTestUserFactory::times(10)
             ->has(
                 FactoryTestPostFactory::times(3)
                     ->state(function ($attributes, $user) {
@@ -282,7 +282,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_morph_to_relationship()
     {
-        $posts = FactoryTestCommentFactory::times(3)
+        FactoryTestCommentFactory::times(3)
             ->for(FactoryTestPostFactory::new(['title' => 'Test Title']), 'commentable')
             ->create();
 
@@ -296,7 +296,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_morph_to_relationship_with_existing_model_instance()
     {
         $post = FactoryTestPostFactory::new(['title' => 'Test Title'])->create();
-        $posts = FactoryTestCommentFactory::times(3)
+        FactoryTestCommentFactory::times(3)
             ->for($post, 'commentable')
             ->create();
 
@@ -309,7 +309,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_belongs_to_many_relationship()
     {
-        $users = FactoryTestUserFactory::times(3)
+        FactoryTestUserFactory::times(3)
             ->hasAttached(
                 FactoryTestRoleFactory::times(3)->afterCreating(function ($role, $user) {
                     $_SERVER['__test.role.creating-role'] = $role;

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -153,7 +153,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
     public function testItGetsCorrectResults()
     {
         $user = HasOneOfManyTestUser::create();
-         $user->logins()->create();
+        $user->logins()->create();
         $latestLogin = $user->logins()->create();
 
         $result = $user->latest_login()->getResults();
@@ -174,7 +174,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
     public function testItGetsCorrectResultsUsingShortcutMethod()
     {
         $user = HasOneOfManyTestUser::create();
-         $user->logins()->create();
+        $user->logins()->create();
         $latestLogin = $user->logins()->create();
 
         $result = $user->latest_login_with_shortcut()->getResults();
@@ -408,7 +408,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
 
     public function testWithExists()
     {
-         HasOneOfManyTestUser::create();
+        HasOneOfManyTestUser::create();
 
         $user = HasOneOfManyTestUser::withExists('latest_login')->first();
         $this->assertFalse($user->latest_login_exists);
@@ -420,7 +420,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
 
     public function testWithExistsWithConstraintsInJoinSubSelect()
     {
-         HasOneOfManyTestUser::create();
+        HasOneOfManyTestUser::create();
 
         $user = HasOneOfManyTestUser::withExists('foo_state')->first();
 

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -153,7 +153,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
     public function testItGetsCorrectResults()
     {
         $user = HasOneOfManyTestUser::create();
-        $previousLogin = $user->logins()->create();
+         $user->logins()->create();
         $latestLogin = $user->logins()->create();
 
         $result = $user->latest_login()->getResults();
@@ -174,7 +174,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
     public function testItGetsCorrectResultsUsingShortcutMethod()
     {
         $user = HasOneOfManyTestUser::create();
-        $previousLogin = $user->logins()->create();
+         $user->logins()->create();
         $latestLogin = $user->logins()->create();
 
         $result = $user->latest_login_with_shortcut()->getResults();
@@ -408,7 +408,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
 
     public function testWithExists()
     {
-        $user = HasOneOfManyTestUser::create();
+         HasOneOfManyTestUser::create();
 
         $user = HasOneOfManyTestUser::withExists('latest_login')->first();
         $this->assertFalse($user->latest_login_exists);
@@ -420,7 +420,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
 
     public function testWithExistsWithConstraintsInJoinSubSelect()
     {
-        $user = HasOneOfManyTestUser::create();
+         HasOneOfManyTestUser::create();
 
         $user = HasOneOfManyTestUser::withExists('foo_state')->first();
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1215,7 +1215,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
                     $user->save();
                     throw new Exception;
                 });
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // ignore the exception
             }
             $user = EloquentTestUser::first();
@@ -1230,7 +1230,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             try {
                 $user->email = 'otwell@laravel.com';
                 $user->saveOrFail();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // ignore the exception
             }
 
@@ -1248,7 +1248,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $user->id = 'invalid';
                 $user->email = 'otwell@laravel.com';
                 $user->saveOrFail();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // ignore the exception
             }
 
@@ -1365,7 +1365,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestOrder::create(['id' => 1, 'item_type' => EloquentTestItem::class, 'item_id' => 1]);
         try {
             $item = EloquentTestOrder::first()->item;
-        } catch (Exception $e) {
+        } catch (Exception) {
             // ignore the exception
         }
 
@@ -1773,7 +1773,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($user->updated_at));
         $this->assertTrue($before->isSameDay($post->updated_at));
 
-        Carbon::setTestNow($future = $before->copy()->addDays(3));
+        Carbon::setTestNow( $before->copy()->addDays(3));
 
         EloquentTouchingUser::withoutTouching(function () use ($post) {
             $post->delete();
@@ -1838,7 +1838,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($user->updated_at));
         $this->assertTrue($before->isSameDay($post->updated_at));
 
-        Carbon::setTestNow($future = $before->copy()->addDays(3));
+        Carbon::setTestNow( $before->copy()->addDays(3));
 
         EloquentTouchingUser::withoutTouching(function () {
             EloquentTouchingPost::withoutTouching(function () {
@@ -1862,7 +1862,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($user->updated_at));
         $this->assertTrue($before->isSameDay($post->updated_at));
 
-        Carbon::setTestNow($future = $before->copy()->addDays(3));
+        Carbon::setTestNow( $before->copy()->addDays(3));
 
         Model::withoutTouchingOn([EloquentTouchingUser::class, EloquentTouchingPost::class], function () {
             EloquentTouchingComment::create(['content' => 'Comment content', 'post_id' => 1]);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1773,7 +1773,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($user->updated_at));
         $this->assertTrue($before->isSameDay($post->updated_at));
 
-        Carbon::setTestNow( $before->copy()->addDays(3));
+        Carbon::setTestNow($before->copy()->addDays(3));
 
         EloquentTouchingUser::withoutTouching(function () use ($post) {
             $post->delete();
@@ -1838,7 +1838,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($user->updated_at));
         $this->assertTrue($before->isSameDay($post->updated_at));
 
-        Carbon::setTestNow( $before->copy()->addDays(3));
+        Carbon::setTestNow($before->copy()->addDays(3));
 
         EloquentTouchingUser::withoutTouching(function () {
             EloquentTouchingPost::withoutTouching(function () {
@@ -1862,7 +1862,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($before->isSameDay($user->updated_at));
         $this->assertTrue($before->isSameDay($post->updated_at));
 
-        Carbon::setTestNow( $before->copy()->addDays(3));
+        Carbon::setTestNow($before->copy()->addDays(3));
 
         Model::withoutTouchingOn([EloquentTouchingUser::class, EloquentTouchingPost::class], function () {
             EloquentTouchingComment::create(['content' => 'Comment content', 'post_id' => 1]);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1246,7 +1246,7 @@ class DatabaseEloquentModelTest extends TestCase
             Model::unguarded(function () {
                 throw new Exception;
             });
-        } catch (Exception $e) {
+        } catch (Exception) {
             // ignore the exception
         }
         $this->assertFalse(Model::isUnguarded());

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -117,7 +117,7 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
 
     public function testWithExists()
     {
-        $product = MorphOneOfManyTestProduct::create();
+        MorphOneOfManyTestProduct::create();
 
         $product = MorphOneOfManyTestProduct::withExists('current_state')->first();
         $this->assertFalse($product->current_state_exists);
@@ -131,7 +131,7 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
 
     public function testWithExistsWithConstraintsInJoinSubSelect()
     {
-        $product = MorphOneOfManyTestProduct::create();
+         MorphOneOfManyTestProduct::create();
 
         $product = MorphOneOfManyTestProduct::withExists('current_foo_state')->first();
         $this->assertFalse($product->current_foo_state_exists);

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -131,7 +131,7 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
 
     public function testWithExistsWithConstraintsInJoinSubSelect()
     {
-         MorphOneOfManyTestProduct::create();
+        MorphOneOfManyTestProduct::create();
 
         $product = MorphOneOfManyTestProduct::withExists('current_foo_state')->first();
         $this->assertFalse($product->current_foo_state_exists);

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -27,7 +27,7 @@ class DatabaseEloquentMorphToTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->addEagerConstraints([
-            $one = (object) ['morph_type' => 'morph_type_2', 'foreign_key' => TestEnum::test],
+             (object) ['morph_type' => 'morph_type_2', 'foreign_key' => TestEnum::test],
         ]);
         $dictionary = $relation->getDictionary();
         $relation->getDictionary();

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -27,7 +27,7 @@ class DatabaseEloquentMorphToTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->addEagerConstraints([
-             (object) ['morph_type' => 'morph_type_2', 'foreign_key' => TestEnum::test],
+            (object) ['morph_type' => 'morph_type_2', 'foreign_key' => TestEnum::test],
         ]);
         $dictionary = $relation->getDictionary();
         $relation->getDictionary();

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -25,8 +25,8 @@ class DatabaseEloquentPivotTest extends TestCase
         $parent->shouldReceive('getConnectionName')->twice()->andReturn('connection');
         $parent->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($connection = m::mock(Connection::class));
-        $connection->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
-        $connection->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
+        $connection->shouldReceive('getQueryGrammar')->andReturn( m::mock(Grammar::class));
+        $connection->shouldReceive('getPostProcessor')->andReturn( m::mock(Processor::class));
         $parent->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $parent->setDateFormat('Y-m-d H:i:s');
         $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar', 'created_at' => '2015-09-12'], 'table', true);

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -25,8 +25,8 @@ class DatabaseEloquentPivotTest extends TestCase
         $parent->shouldReceive('getConnectionName')->twice()->andReturn('connection');
         $parent->setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($connection = m::mock(Connection::class));
-        $connection->shouldReceive('getQueryGrammar')->andReturn( m::mock(Grammar::class));
-        $connection->shouldReceive('getPostProcessor')->andReturn( m::mock(Processor::class));
+        $connection->shouldReceive('getQueryGrammar')->andReturn(m::mock(Grammar::class));
+        $connection->shouldReceive('getPostProcessor')->andReturn(m::mock(Processor::class));
         $parent->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $parent->setDateFormat('Y-m-d H:i:s');
         $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar', 'created_at' => '2015-09-12'], 'table', true);

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -204,7 +204,7 @@ class DatabaseEloquentRelationTest extends TestCase
             });
 
             $this->fail('Exception was not thrown');
-        } catch (Exception $exception) {
+        } catch (Exception) {
             // Does nothing.
         }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -222,7 +222,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         try {
             $user->forceDelete();
-        } catch (Exception $exception) {
+        } catch (Exception) {
         }
 
         $this->assertTrue($user->exists);

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -22,7 +22,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testBasicMigrationsCallMigratorWithProperArguments()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), m::mock(Dispatcher::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -87,7 +87,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheCommandMayBePretended()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), m::mock(Dispatcher::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -105,7 +105,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheDatabaseMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), m::mock(Dispatcher::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -123,7 +123,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testStepMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class), m::mock(Dispatcher::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -22,7 +22,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testBasicMigrationsCallMigratorWithProperArguments()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -67,7 +67,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testMigrationRepositoryCreatedWhenNecessary()
     {
-        $params = [$migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class)];
+        $params = [$migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class)];
         $command = $this->getMockBuilder(MigrateCommand::class)->onlyMethods(['call'])->setConstructorArgs($params)->getMock();
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
@@ -87,7 +87,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheCommandMayBePretended()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -105,7 +105,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheDatabaseMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -123,7 +123,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testStepMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class),  m::mock(Dispatcher::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -27,7 +27,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $command = new RefreshCommand;
 
         $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
-        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
+        $dispatcher = $app->instance(Dispatcher::class,  m::mock());
         $console = m::mock(ConsoleApplication::class)->makePartial();
         $console->__construct();
         $command->setLaravel($app);
@@ -52,7 +52,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $command = new RefreshCommand;
 
         $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
-        $dispatcher = $app->instance(Dispatcher::class, $events = m::mock());
+        $dispatcher = $app->instance(Dispatcher::class,  m::mock());
         $console = m::mock(ConsoleApplication::class)->makePartial();
         $console->__construct();
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -27,7 +27,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $command = new RefreshCommand;
 
         $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
-        $dispatcher = $app->instance(Dispatcher::class,  m::mock());
+        $dispatcher = $app->instance(Dispatcher::class, m::mock());
         $console = m::mock(ConsoleApplication::class)->makePartial();
         $console->__construct();
         $command->setLaravel($app);
@@ -52,7 +52,7 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
         $command = new RefreshCommand;
 
         $app = new ApplicationDatabaseRefreshStub(['path.database' => __DIR__]);
-        $dispatcher = $app->instance(Dispatcher::class,  m::mock());
+        $dispatcher = $app->instance(Dispatcher::class, m::mock());
         $console = m::mock(ConsoleApplication::class)->makePartial();
         $console->__construct();
         $command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -36,7 +36,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
     {
         $repo = $this->getMockBuilder(DatabaseMigrationRepository::class)->onlyMethods(['getLastBatchNumber'])->setConstructorArgs([
-             m::mock(ConnectionResolverInterface::class), 'migrations',
+            m::mock(ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->willReturn(1);
         $query = m::mock(stdClass::class);

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -36,7 +36,7 @@ class DatabaseMigrationRepositoryTest extends TestCase
     public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
     {
         $repo = $this->getMockBuilder(DatabaseMigrationRepository::class)->onlyMethods(['getLastBatchNumber'])->setConstructorArgs([
-            $resolver = m::mock(ConnectionResolverInterface::class), 'migrations',
+             m::mock(ConnectionResolverInterface::class), 'migrations',
         ])->getMock();
         $repo->expects($this->once())->method('getLastBatchNumber')->willReturn(1);
         $query = m::mock(stdClass::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3303,7 +3303,7 @@ SQL;
         $this->assertSame('select * from [users] order by [email] desc offset 11 rows fetch next 10 rows only', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
-        $subQueryBuilder = $this->getSqlServerBuilder();
+        $this->getSqlServerBuilder();
         $subQuery = function ($query) {
             return $query->select('created_at')->from('logins')->where('users.name', 'nameBinding')->whereColumn('user_id', 'users.id')->limit(1);
         };

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -61,7 +61,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('withTrashed');
         $givenBuilder = m::mock(EloquentBuilder::class);
-        $givenBuilder->shouldReceive('getModel')->andReturn( m::mock(Model::class));
+        $givenBuilder->shouldReceive('getModel')->andReturn(m::mock(Model::class));
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $result = $callback($givenBuilder);
 
@@ -81,7 +81,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('onlyTrashed');
         $givenBuilder = m::mock(EloquentBuilder::class);
-        $givenBuilder->shouldReceive('getQuery')->andReturn( m::mock(stdClass::class));
+        $givenBuilder->shouldReceive('getQuery')->andReturn(m::mock(stdClass::class));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
@@ -104,7 +104,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('withoutTrashed');
         $givenBuilder = m::mock(EloquentBuilder::class);
-        $givenBuilder->shouldReceive('getQuery')->andReturn( m::mock(stdClass::class));
+        $givenBuilder->shouldReceive('getQuery')->andReturn(m::mock(stdClass::class));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -61,7 +61,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('withTrashed');
         $givenBuilder = m::mock(EloquentBuilder::class);
-        $givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock(Model::class));
+        $givenBuilder->shouldReceive('getModel')->andReturn( m::mock(Model::class));
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $result = $callback($givenBuilder);
 
@@ -81,7 +81,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('onlyTrashed');
         $givenBuilder = m::mock(EloquentBuilder::class);
-        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(stdClass::class));
+        $givenBuilder->shouldReceive('getQuery')->andReturn( m::mock(stdClass::class));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
@@ -104,7 +104,7 @@ class DatabaseSoftDeletingScopeTest extends TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('withoutTrashed');
         $givenBuilder = m::mock(EloquentBuilder::class);
-        $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock(stdClass::class));
+        $givenBuilder->shouldReceive('getQuery')->andReturn( m::mock(stdClass::class));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $givenBuilder->shouldReceive('withoutGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');

--- a/tests/Database/DatabaseTransactionsTest.php
+++ b/tests/Database/DatabaseTransactionsTest.php
@@ -180,7 +180,7 @@ class DatabaseTransactionsTest extends TestCase
 
                 throw new Exception;
             });
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
     }
 
@@ -235,7 +235,7 @@ class DatabaseTransactionsTest extends TestCase
                     throw new Exception;
                 });
             });
-        } catch (Throwable $e) {
+        } catch (Throwable) {
         }
     }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -38,7 +38,7 @@ class FilesystemTest extends TestCase
         m::close();
 
         $files = new Filesystem;
-        $files->deleteDirectory(self::$tempDir,  true);
+        $files->deleteDirectory(self::$tempDir, true);
     }
 
     public function testGetRetrievesFiles()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -38,7 +38,7 @@ class FilesystemTest extends TestCase
         m::close();
 
         $files = new Filesystem;
-        $files->deleteDirectory(self::$tempDir, $preserve = true);
+        $files->deleteDirectory(self::$tempDir,  true);
     }
 
     public function testGetRetrievesFiles()

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -74,7 +74,7 @@ class FileCacheLockTest extends TestCase
             $firstLock->block(1, function () {
                 throw new Exception('failed');
             });
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Not testing the exception, just testing the lock
             // is released regardless of the how the exception
             // thrown by the callback was handled.

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -87,7 +87,7 @@ class RedisCacheLockTest extends TestCase
             $firstLock->block(1, function () {
                 throw new Exception('failed');
             });
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Not testing the exception, just testing the lock
             // is released regardless of the how the exception
             // thrown by the callback was handled.

--- a/tests/Integration/Console/CallbackSchedulingTest.php
+++ b/tests/Integration/Console/CallbackSchedulingTest.php
@@ -54,7 +54,7 @@ class CallbackSchedulingTest extends TestCase
 
     public function testExecutionOrder()
     {
-        $event = $this->app->make(Schedule::class)
+        $this->app->make(Schedule::class)
             ->call($this->logger('call'))
             ->after($this->logger('after 1'))
             ->before($this->logger('before 1'))

--- a/tests/Integration/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Integration/Console/Scheduling/CallbackEventTest.php
@@ -64,7 +64,7 @@ class CallbackEventTest extends TestCase
 
         try {
             $event->run($this->app);
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
 
         $this->assertFalse($success);

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -45,7 +45,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
             $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
             $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
 
-            Carbon::setTestNow( $now->addSeconds(58));
+            Carbon::setTestNow($now->addSeconds(58));
 
             try {
                 $this->withoutExceptionHandling()->get('/');

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -45,7 +45,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
             $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
             $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
 
-            Carbon::setTestNow($finish = $now->addSeconds(58));
+            Carbon::setTestNow( $now->addSeconds(58));
 
             try {
                 $this->withoutExceptionHandling()->get('/');

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -57,7 +57,7 @@ class CallQueuedHandlerTest extends TestCase
         $job->shouldReceive('delete')->once();
 
         $instance->call($job, [
-            'command' => serialize($command = new CallQueuedHandlerTestJobWithMiddleware),
+            'command' => serialize( new CallQueuedHandlerTestJobWithMiddleware),
         ]);
 
         $this->assertInstanceOf(CallQueuedHandlerTestJobWithMiddleware::class, CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand);
@@ -79,7 +79,7 @@ class CallQueuedHandlerTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
         $job->shouldReceive('delete')->once();
 
-        $command = $command = new CallQueuedHandlerTestJobWithMiddleware;
+        $command =  new CallQueuedHandlerTestJobWithMiddleware;
         $command->through([new TestJobMiddleware]);
 
         $instance->call($job, [

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -57,7 +57,7 @@ class CallQueuedHandlerTest extends TestCase
         $job->shouldReceive('delete')->once();
 
         $instance->call($job, [
-            'command' => serialize( new CallQueuedHandlerTestJobWithMiddleware),
+            'command' => serialize(new CallQueuedHandlerTestJobWithMiddleware),
         ]);
 
         $this->assertInstanceOf(CallQueuedHandlerTestJobWithMiddleware::class, CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand);
@@ -79,7 +79,7 @@ class CallQueuedHandlerTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
         $job->shouldReceive('delete')->once();
 
-        $command =  new CallQueuedHandlerTestJobWithMiddleware;
+        $command = new CallQueuedHandlerTestJobWithMiddleware;
         $command->through([new TestJobMiddleware]);
 
         $instance->call($job, [

--- a/tests/Integration/Queue/QueueConnectionTest.php
+++ b/tests/Integration/Queue/QueueConnectionTest.php
@@ -49,7 +49,7 @@ class QueueConnectionTest extends TestCase
 
         try {
             Bus::dispatch((new QueueConnectionTestJob)->beforeCommit());
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             // This job was dispatched
         }
     }
@@ -67,7 +67,7 @@ class QueueConnectionTest extends TestCase
 
         try {
             Bus::dispatch((new QueueConnectionTestJob)->afterCommit());
-        } catch (SqsException $e) {
+        } catch (SqsException) {
             // This job was dispatched
         }
     }

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -67,7 +67,7 @@ class RateLimitedTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
 
         $instance->call($job, [
-            'command' => serialize( new RateLimitedTestJob),
+            'command' => serialize(new RateLimitedTestJob),
         ]);
 
         $this->assertFalse(RateLimitedTestJob::$handled);
@@ -145,7 +145,7 @@ class RateLimitedTest extends TestCase
         $job->shouldReceive('delete')->once();
 
         $instance->call($job, [
-            'command' => serialize( new $class),
+            'command' => serialize(new $class),
         ]);
 
         $this->assertTrue($class::$handled);
@@ -164,7 +164,7 @@ class RateLimitedTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
 
         $instance->call($job, [
-            'command' => serialize( new $class),
+            'command' => serialize(new $class),
         ]);
 
         $this->assertFalse($class::$handled);
@@ -183,7 +183,7 @@ class RateLimitedTest extends TestCase
         $job->shouldReceive('delete')->once();
 
         $instance->call($job, [
-            'command' => serialize( new $class),
+            'command' => serialize(new $class),
         ]);
 
         $this->assertFalse($class::$handled);

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -67,7 +67,7 @@ class RateLimitedTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
 
         $instance->call($job, [
-            'command' => serialize($command = new RateLimitedTestJob),
+            'command' => serialize( new RateLimitedTestJob),
         ]);
 
         $this->assertFalse(RateLimitedTestJob::$handled);
@@ -145,7 +145,7 @@ class RateLimitedTest extends TestCase
         $job->shouldReceive('delete')->once();
 
         $instance->call($job, [
-            'command' => serialize($command = new $class),
+            'command' => serialize( new $class),
         ]);
 
         $this->assertTrue($class::$handled);
@@ -164,7 +164,7 @@ class RateLimitedTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
 
         $instance->call($job, [
-            'command' => serialize($command = new $class),
+            'command' => serialize( new $class),
         ]);
 
         $this->assertFalse($class::$handled);
@@ -183,7 +183,7 @@ class RateLimitedTest extends TestCase
         $job->shouldReceive('delete')->once();
 
         $instance->call($job, [
-            'command' => serialize($command = new $class),
+            'command' => serialize( new $class),
         ]);
 
         $this->assertFalse($class::$handled);

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -58,7 +58,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 
         $instance->call($job, [
-            'command' => serialize($command = new $class),
+            'command' => serialize( new $class),
         ]);
 
         $this->assertTrue($class::$handled);
@@ -80,7 +80,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 
         $instance->call($job, [
-            'command' => serialize($command = new $class),
+            'command' => serialize( new $class),
         ]);
 
         $this->assertFalse($class::$handled);
@@ -100,7 +100,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 
         $instance->call($job, [
-            'command' => serialize($command = new $class),
+            'command' => serialize( new $class),
         ]);
 
         $this->assertTrue($class::$handled);

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -58,7 +58,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 
         $instance->call($job, [
-            'command' => serialize( new $class),
+            'command' => serialize(new $class),
         ]);
 
         $this->assertTrue($class::$handled);
@@ -80,7 +80,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 
         $instance->call($job, [
-            'command' => serialize( new $class),
+            'command' => serialize(new $class),
         ]);
 
         $this->assertFalse($class::$handled);
@@ -100,7 +100,7 @@ class ThrottlesExceptionsTest extends TestCase
         $job->shouldReceive('uuid')->andReturn('simple-test-uuid');
 
         $instance->call($job, [
-            'command' => serialize( new $class),
+            'command' => serialize(new $class),
         ]);
 
         $this->assertTrue($class::$handled);

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -70,7 +70,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
 
         $instance->call($job, [
-            'command' => serialize( new $class($key)),
+            'command' => serialize(new $class($key)),
         ]);
 
         $this->assertTrue($class::$handled);
@@ -91,7 +91,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
 
         $instance->call($job, [
-            'command' => serialize( new $class($key)),
+            'command' => serialize(new $class($key)),
         ]);
 
         $this->assertFalse($class::$handled);
@@ -110,7 +110,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $job->shouldReceive('delete')->once();
 
         $instance->call($job, [
-            'command' => serialize( new $class($key)),
+            'command' => serialize(new $class($key)),
         ]);
 
         $this->assertTrue($class::$handled);

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -70,7 +70,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
 
         $instance->call($job, [
-            'command' => serialize($command = new $class($key)),
+            'command' => serialize( new $class($key)),
         ]);
 
         $this->assertTrue($class::$handled);
@@ -91,7 +91,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $job->shouldReceive('isDeletedOrReleased')->once()->andReturn(true);
 
         $instance->call($job, [
-            'command' => serialize($command = new $class($key)),
+            'command' => serialize( new $class($key)),
         ]);
 
         $this->assertFalse($class::$handled);
@@ -110,7 +110,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
         $job->shouldReceive('delete')->once();
 
         $instance->call($job, [
-            'command' => serialize($command = new $class($key)),
+            'command' => serialize( new $class($key)),
         ]);
 
         $this->assertTrue($class::$handled);

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -114,7 +114,7 @@ class CompiledRouteCollectionTest extends TestCase
 
     public function testRouteCollectionCanGetIteratorWhenRoutesAreAdded()
     {
-        $this->routeCollection->add($routeIndex = $this->newRoute('GET', 'foo/index', [
+        $this->routeCollection->add( $this->newRoute('GET', 'foo/index', [
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
@@ -123,7 +123,7 @@ class CompiledRouteCollectionTest extends TestCase
 
         $this->assertCount(1, $routes);
 
-        $this->routeCollection->add($routeShow = $this->newRoute('GET', 'bar/show', [
+        $this->routeCollection->add( $this->newRoute('GET', 'bar/show', [
             'uses' => 'BarController@show',
             'as' => 'bar_show',
         ]));
@@ -306,7 +306,7 @@ class CompiledRouteCollectionTest extends TestCase
     public function testMatchingRouteWithSameDynamicallyAddedRouteAlwaysMatchesCachedOneFirst()
     {
         $this->routeCollection->add(
-            $route = $this->newRoute('GET', '/', ['uses' => 'FooController@index', 'as' => 'foo'])
+             $this->newRoute('GET', '/', ['uses' => 'FooController@index', 'as' => 'foo'])
         );
 
         $routes = $this->collection();
@@ -330,7 +330,7 @@ class CompiledRouteCollectionTest extends TestCase
     public function testMatchingWildcardFromCompiledRoutesAlwaysTakesPrecedent()
     {
         $this->routeCollection->add(
-            $route = $this->newRoute('GET', '{wildcard}', ['uses' => 'FooController@index', 'as' => 'foo'])
+             $this->newRoute('GET', '{wildcard}', ['uses' => 'FooController@index', 'as' => 'foo'])
                 ->where('wildcard', '.*')
         );
 
@@ -424,7 +424,7 @@ class CompiledRouteCollectionTest extends TestCase
     public function testGroupGenerateNameForDuplicateRouteNamesThatEndWithDot()
     {
         $this->routeCollection->add($this->newRoute('GET', 'foo', ['uses' => 'FooController@index'])->name('foo.'));
-        $this->routeCollection->add($route = $this->newRoute('GET', 'bar', ['uses' => 'BarController@index'])->name('foo.'));
+        $this->routeCollection->add( $this->newRoute('GET', 'bar', ['uses' => 'BarController@index'])->name('foo.'));
 
         $routes = $this->collection();
 
@@ -448,7 +448,7 @@ class CompiledRouteCollectionTest extends TestCase
     public function testMatchingSlashedRoutes()
     {
         $this->routeCollection->add(
-            $route = $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
+             $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
         );
 
         $this->assertSame('foo', $this->collection()->match(Request::create('/foo/bar/'))->getName());
@@ -457,7 +457,7 @@ class CompiledRouteCollectionTest extends TestCase
     public function testMatchingUriWithQuery()
     {
         $this->routeCollection->add(
-            $route = $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
+             $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
         );
 
         $this->assertSame('foo', $this->collection()->match(Request::create('/foo/bar/?foo=bar'))->getName());
@@ -466,7 +466,7 @@ class CompiledRouteCollectionTest extends TestCase
     public function testMatchingRootUri()
     {
         $this->routeCollection->add(
-            $route = $this->newRoute('GET', '/', ['uses' => 'FooController@index', 'as' => 'foo'])
+             $this->newRoute('GET', '/', ['uses' => 'FooController@index', 'as' => 'foo'])
         );
 
         $this->assertSame('foo', $this->collection()->match(Request::create('http://example.com'))->getName());

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -114,7 +114,7 @@ class CompiledRouteCollectionTest extends TestCase
 
     public function testRouteCollectionCanGetIteratorWhenRoutesAreAdded()
     {
-        $this->routeCollection->add( $this->newRoute('GET', 'foo/index', [
+        $this->routeCollection->add($this->newRoute('GET', 'foo/index', [
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
@@ -123,7 +123,7 @@ class CompiledRouteCollectionTest extends TestCase
 
         $this->assertCount(1, $routes);
 
-        $this->routeCollection->add( $this->newRoute('GET', 'bar/show', [
+        $this->routeCollection->add($this->newRoute('GET', 'bar/show', [
             'uses' => 'BarController@show',
             'as' => 'bar_show',
         ]));
@@ -424,7 +424,7 @@ class CompiledRouteCollectionTest extends TestCase
     public function testGroupGenerateNameForDuplicateRouteNamesThatEndWithDot()
     {
         $this->routeCollection->add($this->newRoute('GET', 'foo', ['uses' => 'FooController@index'])->name('foo.'));
-        $this->routeCollection->add( $this->newRoute('GET', 'bar', ['uses' => 'BarController@index'])->name('foo.'));
+        $this->routeCollection->add($this->newRoute('GET', 'bar', ['uses' => 'BarController@index'])->name('foo.'));
 
         $routes = $this->collection();
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -235,10 +235,10 @@ class UrlSigningTest extends TestCase
     public function testSignedMiddlewareWithRelativePath()
     {
         Route::get('/foo/relative', function (Request $request) {
-            return $request->hasValidSignature( false) ? 'valid' : 'invalid';
+            return $request->hasValidSignature(false) ? 'valid' : 'invalid';
         })->name('foo')->middleware('signed:relative');
 
-        $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', [], null,  false));
+        $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', [], null, false));
         $this->assertSame('valid', $this->get($url)->original);
 
         $response = $this->get('/foo/relative');

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -235,10 +235,10 @@ class UrlSigningTest extends TestCase
     public function testSignedMiddlewareWithRelativePath()
     {
         Route::get('/foo/relative', function (Request $request) {
-            return $request->hasValidSignature($absolute = false) ? 'valid' : 'invalid';
+            return $request->hasValidSignature( false) ? 'valid' : 'invalid';
         })->name('foo')->middleware('signed:relative');
 
-        $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', [], null, $absolute = false));
+        $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', [], null,  false));
         $this->assertSame('valid', $this->get($url)->original);
 
         $response = $this->get('/foo/relative');

--- a/tests/Integration/Support/MultipleInstanceManagerTest.php
+++ b/tests/Integration/Support/MultipleInstanceManagerTest.php
@@ -29,6 +29,6 @@ class MultipleInstanceManagerTest extends TestCase
 
         $manager = new MultipleInstanceManager($this->app);
 
-         $manager->instance('missing');
+        $manager->instance('missing');
     }
 }

--- a/tests/Integration/Support/MultipleInstanceManagerTest.php
+++ b/tests/Integration/Support/MultipleInstanceManagerTest.php
@@ -29,6 +29,6 @@ class MultipleInstanceManagerTest extends TestCase
 
         $manager = new MultipleInstanceManager($this->app);
 
-        $instance = $manager->instance('missing');
+         $manager->instance('missing');
     }
 }

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -124,7 +124,7 @@ class ArtisanCommandTest extends TestCase
         } finally {
             try {
                 Mockery::close();
-            } catch (InvalidCountException $e) {
+            } catch (InvalidCountException) {
                 // Ignore mock exception from PendingCommand::expectsOutput().
             }
         }

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -29,7 +29,7 @@ class NotificationChannelManagerTest extends TestCase
     {
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
-        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Bus::class, m::mock());
         $container->instance(Dispatcher::class, $events = m::mock());
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
@@ -45,7 +45,7 @@ class NotificationChannelManagerTest extends TestCase
     {
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
-        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Bus::class, m::mock());
         $container->instance(Dispatcher::class, $events = m::mock());
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
@@ -62,7 +62,7 @@ class NotificationChannelManagerTest extends TestCase
     {
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
-        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Bus::class, m::mock());
         $container->instance(Dispatcher::class, $events = m::mock());
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
@@ -77,7 +77,7 @@ class NotificationChannelManagerTest extends TestCase
     {
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
-        $container->instance(Bus::class, $bus = m::mock());
+        $container->instance(Bus::class, m::mock());
         $container->instance(Dispatcher::class, $events = m::mock());
         Container::setInstance($container);
         $manager = m::mock(ChannelManager::class.'[driver]', [$container]);
@@ -93,7 +93,7 @@ class NotificationChannelManagerTest extends TestCase
     {
         $container = new Container;
         $container->instance('config', ['app.name' => 'Name', 'app.logo' => 'Logo']);
-        $container->instance(Dispatcher::class, $events = m::mock());
+        $container->instance(Dispatcher::class, m::mock());
         $container->instance(Bus::class, $bus = m::mock());
         $bus->shouldReceive('dispatch')->with(m::type(SendQueuedNotifications::class));
         Container::setInstance($container);

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -10,7 +10,7 @@ class CursorPaginatorTest extends TestCase
 {
     public function testReturnsRelevantContextInformation()
     {
-        $p = new CursorPaginator($array = [['id' => 1], ['id' => 2], ['id' => 3]], 2, null, [
+        $p = new CursorPaginator( [['id' => 1], ['id' => 2], ['id' => 3]], 2, null, [
             'parameters' => ['id'],
         ]);
 
@@ -31,7 +31,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testPaginatorRemovesTrailingSlashes()
     {
-        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
             ['path' => 'http://website.com/test/', 'parameters' => ['id']]);
 
         $this->assertSame('http://website.com/test?cursor='.$this->getCursor(['id' => 5]), $p->nextPageUrl());
@@ -39,7 +39,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
     {
-        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
             ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
         $this->assertSame('http://website.com/test?cursor='.$this->getCursor(['id' => 5]), $p->nextPageUrl());
@@ -47,7 +47,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testItRetrievesThePaginatorOptions()
     {
-        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
             $options = ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
         $this->assertSame($p->getOptions(), $options);
@@ -55,16 +55,16 @@ class CursorPaginatorTest extends TestCase
 
     public function testPaginatorReturnsPath()
     {
-        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
-            $options = ['path' => 'http://website.com/test', 'parameters' => ['id']]);
+        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+             ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
         $this->assertSame($p->path(), 'http://website.com/test');
     }
 
     public function testCanTransformPaginatorItems()
     {
-        $p = new CursorPaginator($array = [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
-            $options = ['path' => 'http://website.com/test', 'parameters' => ['id']]);
+        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+             ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
         $p->through(function ($item) {
             $item['id'] = $item['id'] + 2;

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -10,7 +10,7 @@ class CursorPaginatorTest extends TestCase
 {
     public function testReturnsRelevantContextInformation()
     {
-        $p = new CursorPaginator( [['id' => 1], ['id' => 2], ['id' => 3]], 2, null, [
+        $p = new CursorPaginator([['id' => 1], ['id' => 2], ['id' => 3]], 2, null, [
             'parameters' => ['id'],
         ]);
 
@@ -31,7 +31,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testPaginatorRemovesTrailingSlashes()
     {
-        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+        $p = new CursorPaginator([['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
             ['path' => 'http://website.com/test/', 'parameters' => ['id']]);
 
         $this->assertSame('http://website.com/test?cursor='.$this->getCursor(['id' => 5]), $p->nextPageUrl());
@@ -39,7 +39,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
     {
-        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+        $p = new CursorPaginator([['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
             ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
         $this->assertSame('http://website.com/test?cursor='.$this->getCursor(['id' => 5]), $p->nextPageUrl());
@@ -47,7 +47,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testItRetrievesThePaginatorOptions()
     {
-        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+        $p = new CursorPaginator([['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
             $options = ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
         $this->assertSame($p->getOptions(), $options);
@@ -55,7 +55,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testPaginatorReturnsPath()
     {
-        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+        $p = new CursorPaginator([['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
              ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
         $this->assertSame($p->path(), 'http://website.com/test');
@@ -63,7 +63,7 @@ class CursorPaginatorTest extends TestCase
 
     public function testCanTransformPaginatorItems()
     {
-        $p = new CursorPaginator( [['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
+        $p = new CursorPaginator([['id' => 4], ['id' => 5], ['id' => 6]], 2, null,
              ['path' => 'http://website.com/test', 'parameters' => ['id']]);
 
         $p->through(function ($item) {

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -20,7 +20,7 @@ class LengthAwarePaginatorTest extends TestCase
     protected function setUp(): void
     {
         $this->options = ['onEachSide' => 5];
-        $this->p = new LengthAwarePaginator( ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
+        $this->p = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
     }
 
     protected function tearDown(): void

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -20,7 +20,7 @@ class LengthAwarePaginatorTest extends TestCase
     protected function setUp(): void
     {
         $this->options = ['onEachSide' => 5];
-        $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
+        $this->p = new LengthAwarePaginator( ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
     }
 
     protected function tearDown(): void

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -9,7 +9,7 @@ class PaginatorTest extends TestCase
 {
     public function testSimplePaginatorReturnsRelevantContextInformation()
     {
-        $p = new Paginator( ['item3', 'item4', 'item5'], 2, 2);
+        $p = new Paginator(['item3', 'item4', 'item5'], 2, 2);
 
         $this->assertEquals(2, $p->currentPage());
         $this->assertTrue($p->hasPages());
@@ -33,7 +33,7 @@ class PaginatorTest extends TestCase
 
     public function testPaginatorRemovesTrailingSlashes()
     {
-        $p = new Paginator( ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator(['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test/']);
 
         $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
@@ -41,7 +41,7 @@ class PaginatorTest extends TestCase
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
     {
-        $p = new Paginator( ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator(['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);
 
         $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
@@ -49,7 +49,7 @@ class PaginatorTest extends TestCase
 
     public function testItRetrievesThePaginatorOptions()
     {
-        $p = new Paginator( ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator(['item1', 'item2', 'item3'], 2, 2,
             $options = ['path' => 'http://website.com/test']);
 
         $this->assertSame($p->getOptions(), $options);
@@ -57,7 +57,7 @@ class PaginatorTest extends TestCase
 
     public function testPaginatorReturnsPath()
     {
-        $p = new Paginator( ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator(['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);
 
         $this->assertSame($p->path(), 'http://website.com/test');
@@ -65,7 +65,7 @@ class PaginatorTest extends TestCase
 
     public function testCanTransformPaginatorItems()
     {
-        $p = new Paginator( ['item1', 'item2', 'item3'], 3, 1,
+        $p = new Paginator(['item1', 'item2', 'item3'], 3, 1,
                                     ['path' => 'http://website.com/test']);
 
         $p->through(function ($item) {

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -9,7 +9,7 @@ class PaginatorTest extends TestCase
 {
     public function testSimplePaginatorReturnsRelevantContextInformation()
     {
-        $p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2);
+        $p = new Paginator( ['item3', 'item4', 'item5'], 2, 2);
 
         $this->assertEquals(2, $p->currentPage());
         $this->assertTrue($p->hasPages());
@@ -33,7 +33,7 @@ class PaginatorTest extends TestCase
 
     public function testPaginatorRemovesTrailingSlashes()
     {
-        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator( ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test/']);
 
         $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
@@ -41,7 +41,7 @@ class PaginatorTest extends TestCase
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
     {
-        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator( ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);
 
         $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
@@ -49,7 +49,7 @@ class PaginatorTest extends TestCase
 
     public function testItRetrievesThePaginatorOptions()
     {
-        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator( ['item1', 'item2', 'item3'], 2, 2,
             $options = ['path' => 'http://website.com/test']);
 
         $this->assertSame($p->getOptions(), $options);
@@ -57,7 +57,7 @@ class PaginatorTest extends TestCase
 
     public function testPaginatorReturnsPath()
     {
-        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+        $p = new Paginator( ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);
 
         $this->assertSame($p->path(), 'http://website.com/test');
@@ -65,7 +65,7 @@ class PaginatorTest extends TestCase
 
     public function testCanTransformPaginatorItems()
     {
-        $p = new Paginator($array = ['item1', 'item2', 'item3'], 3, 1,
+        $p = new Paginator( ['item1', 'item2', 'item3'], 3, 1,
                                     ['path' => 'http://website.com/test']);
 
         $p->through(function ($item) {

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -10,14 +10,14 @@ class UrlWindowTest extends TestCase
 {
     public function testPresenterCanDetermineIfThereAreAnyPagesToShow()
     {
-        $p = new LengthAwarePaginator( ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
+        $p = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
         $this->assertTrue($window->hasPages());
     }
 
     public function testPresenterCanGetAUrlRangeForASmallNumberOfUrls()
     {
-        $p = new LengthAwarePaginator( ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
+        $p = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
         $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
     }

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -10,14 +10,14 @@ class UrlWindowTest extends TestCase
 {
     public function testPresenterCanDetermineIfThereAreAnyPagesToShow()
     {
-        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
+        $p = new LengthAwarePaginator( ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
         $this->assertTrue($window->hasPages());
     }
 
     public function testPresenterCanGetAUrlRangeForASmallNumberOfUrls()
     {
-        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
+        $p = new LengthAwarePaginator( ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
         $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
     }

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -22,7 +22,7 @@ class QueueManagerTest extends TestCase
                 'queue.default' => 'sync',
                 'queue.connections.sync' => ['driver' => 'sync'],
             ],
-            'encrypter' => $encrypter = m::mock(Encrypter::class),
+            'encrypter' =>  m::mock(Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
@@ -45,7 +45,7 @@ class QueueManagerTest extends TestCase
                 'queue.default' => 'sync',
                 'queue.connections.foo' => ['driver' => 'bar'],
             ],
-            'encrypter' => $encrypter = m::mock(Encrypter::class),
+            'encrypter' =>  m::mock(Encrypter::class),
         ];
 
         $manager = new QueueManager($app);
@@ -67,7 +67,7 @@ class QueueManagerTest extends TestCase
             'config' => [
                 'queue.default' => 'null',
             ],
-            'encrypter' => $encrypter = m::mock(Encrypter::class),
+            'encrypter' =>  m::mock(Encrypter::class),
         ];
 
         $manager = new QueueManager($app);

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -51,7 +51,7 @@ class QueueSyncQueueTest extends TestCase
 
         try {
             $sync->push(FailingSyncQueueTestHandler::class, ['foo' => 'bar']);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->assertTrue($_SERVER['__sync.failed']);
         }
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -305,7 +305,7 @@ class QueueWorkerTest extends TestCase
             $worker->daemon('default', 'queue', $this->workerOptions());
 
             $this->fail('Expected LoopBreakerException to be thrown');
-        } catch (LoopBreakerException $e) {
+        } catch (LoopBreakerException) {
             $this->assertSame(1, $firstJob->attempts);
 
             $this->assertSame(0, $secondJob->attempts);

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -148,7 +148,7 @@ class ConcurrentLimiterTest extends TestCase
             $lock->block(1, function () {
                 throw new Error;
             });
-        } catch (Error $e) {
+        } catch (Error) {
         }
 
         $lock = new ConcurrencyLimiter($this->redis(), 'key', 1, 5);

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -82,13 +82,13 @@ class RouteCollectionTest extends TestCase
 
     public function testRouteCollectionCanGetIteratorWhenRouteAreAdded()
     {
-        $this->routeCollection->add( new Route('GET', 'foo/index', [
+        $this->routeCollection->add(new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
         $this->assertCount(1, $this->routeCollection);
 
-        $this->routeCollection->add( new Route('GET', 'bar/show', [
+        $this->routeCollection->add(new Route('GET', 'bar/show', [
             'uses' => 'BarController@show',
             'as' => 'bar_show',
         ]));

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -82,13 +82,13 @@ class RouteCollectionTest extends TestCase
 
     public function testRouteCollectionCanGetIteratorWhenRouteAreAdded()
     {
-        $this->routeCollection->add($routeIndex = new Route('GET', 'foo/index', [
+        $this->routeCollection->add( new Route('GET', 'foo/index', [
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
         $this->assertCount(1, $this->routeCollection);
 
-        $this->routeCollection->add($routeShow = new Route('GET', 'bar/show', [
+        $this->routeCollection->add( new Route('GET', 'bar/show', [
             'uses' => 'BarController@show',
             'as' => 'bar_show',
         ]));

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -609,7 +609,7 @@ class RoutingUrlGeneratorTest extends TestCase
     public function testForceRootUrl()
     {
         $url = new UrlGenerator(
-            $routes = new RouteCollection,
+             new RouteCollection,
             Request::create('http://www.foo.com/')
         );
 
@@ -671,7 +671,7 @@ class RoutingUrlGeneratorTest extends TestCase
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
-            $request = Request::create('http://www.foo.com/')
+             Request::create('http://www.foo.com/')
         );
         $url->setKeyResolver(function () {
             return 'secret';
@@ -695,7 +695,7 @@ class RoutingUrlGeneratorTest extends TestCase
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
-            $request = Request::create('http://www.foo.com/')
+             Request::create('http://www.foo.com/')
         );
         $url->setKeyResolver(function () {
             return 'secret';
@@ -717,7 +717,7 @@ class RoutingUrlGeneratorTest extends TestCase
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
-            $request = Request::create('http://www.foo.com/')
+             Request::create('http://www.foo.com/')
         );
         $url->setKeyResolver(function () {
             return 'secret';
@@ -743,7 +743,7 @@ class RoutingUrlGeneratorTest extends TestCase
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
-            $request = Request::create('http://www.foo.com/')
+             Request::create('http://www.foo.com/')
         );
         $url->setKeyResolver(function () {
             return 'secret';
@@ -764,7 +764,7 @@ class RoutingUrlGeneratorTest extends TestCase
     {
         $url = new UrlGenerator(
             $routes = new RouteCollection,
-            $request = Request::create('http://www.foo.com/')
+             Request::create('http://www.foo.com/')
         );
         $url->setKeyResolver(function () {
             return 'secret';

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -704,19 +704,19 @@ class SupportArrTest extends TestCase
 
         try {
             Arr::random([]);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             $exceptions++;
         }
 
         try {
             Arr::random([], 1);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             $exceptions++;
         }
 
         try {
             Arr::random([], 2);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             $exceptions++;
         }
 

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -37,7 +37,7 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+        $this->assertInstanceOf(MockInterface::class,  FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
         $this->assertSame('baz', $app['foo']->foo('bar'));
     }
 
@@ -59,8 +59,8 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
-        $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
+        $this->assertInstanceOf(MockInterface::class,  FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+        $this->assertInstanceOf(MockInterface::class,  FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
         $this->assertSame('baz', $app['foo']->foo('bar'));
         $this->assertSame('baz2', $app['foo']->foo2('bar2'));
     }
@@ -77,7 +77,7 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::expects('foo')->with('bar')->andReturn('baz')->getMock());
+        $this->assertInstanceOf(MockInterface::class,  FacadeStub::expects('foo')->with('bar')->andReturn('baz')->getMock());
         $this->assertSame('baz', $app['foo']->foo('bar'));
     }
 }

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -37,7 +37,7 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf(MockInterface::class,  FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+        $this->assertInstanceOf(MockInterface::class, FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
         $this->assertSame('baz', $app['foo']->foo('bar'));
     }
 
@@ -59,8 +59,8 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf(MockInterface::class,  FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
-        $this->assertInstanceOf(MockInterface::class,  FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
+        $this->assertInstanceOf(MockInterface::class, FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+        $this->assertInstanceOf(MockInterface::class, FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
         $this->assertSame('baz', $app['foo']->foo('bar'));
         $this->assertSame('baz2', $app['foo']->foo2('bar2'));
     }
@@ -77,7 +77,7 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => new stdClass]);
         FacadeStub::setFacadeApplication($app);
 
-        $this->assertInstanceOf(MockInterface::class,  FacadeStub::expects('foo')->with('bar')->andReturn('baz')->getMock());
+        $this->assertInstanceOf(MockInterface::class, FacadeStub::expects('foo')->with('bar')->andReturn('baz')->getMock());
         $this->assertSame('baz', $app['foo']->foo('bar'));
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -373,7 +373,7 @@ class SupportHelpersTest extends TestCase
         $this->assertInstanceOf(Stringable::class, $stringable);
         $this->assertSame('string-value', (string) $stringable);
 
-        $stringable = str( null);
+        $stringable = str(null);
         $this->assertInstanceOf(Stringable::class, $stringable);
         $this->assertTrue($stringable->isEmpty());
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -373,7 +373,7 @@ class SupportHelpersTest extends TestCase
         $this->assertInstanceOf(Stringable::class, $stringable);
         $this->assertSame('string-value', (string) $stringable);
 
-        $stringable = str($name = null);
+        $stringable = str( null);
         $this->assertInstanceOf(Stringable::class, $stringable);
         $this->assertTrue($stringable->isEmpty());
 

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -285,7 +285,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
 
         $this->assertEnumerates(5, function ($collection) {
-            foreach ($collection as $key => $value) {
+            foreach ($collection as  $value) {
                 if ($value == 5) {
                     return false;
                 }
@@ -293,7 +293,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
 
         $this->assertEnumeratesOnce(function ($collection) {
-            foreach ($collection as $key => $value) {
+            foreach ($collection as  $value) {
                 // Silence is golden!
             }
         });
@@ -1040,7 +1040,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
                 $collection->firstOrFail(function ($item) {
                     return $item === 101;
                 });
-            } catch (ItemNotFoundException $e) {
+            } catch (ItemNotFoundException) {
                 //
             }
         });
@@ -1072,7 +1072,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         $this->assertEnumerates(2, function ($collection) {
             try {
                 $collection->sole();
-            } catch (MultipleItemsFoundException $e) {
+            } catch (MultipleItemsFoundException) {
                 //
             }
         });
@@ -1088,7 +1088,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
                 $collection->sole(function ($item) {
                     return $item % 2 === 0;
                 });
-            } catch (MultipleItemsFoundException $e) {
+            } catch (MultipleItemsFoundException) {
                 //
             }
         });
@@ -1595,7 +1595,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         try {
             $callback();
-        } catch (Exception $e) {
+        } catch (Exception) {
             // Silence is golden
         }
     }

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -88,7 +88,7 @@ class SupportReflectsClosuresTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-         ReflectsClosuresClass::reflectFirstAll(function ($a, $b) {
+        ReflectsClosuresClass::reflectFirstAll(function ($a, $b) {
             //
         });
     }
@@ -97,7 +97,7 @@ class SupportReflectsClosuresTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-         ReflectsClosuresClass::reflectFirstAll(function () {
+        ReflectsClosuresClass::reflectFirstAll(function () {
             //
         });
     }

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -88,7 +88,7 @@ class SupportReflectsClosuresTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $types = ReflectsClosuresClass::reflectFirstAll(function ($a, $b) {
+         ReflectsClosuresClass::reflectFirstAll(function ($a, $b) {
             //
         });
     }
@@ -97,7 +97,7 @@ class SupportReflectsClosuresTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $types = ReflectsClosuresClass::reflectFirstAll(function () {
+         ReflectsClosuresClass::reflectFirstAll(function () {
             //
         });
     }

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -35,7 +35,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
 
     public function testApiResponseGoesWrong()
     {
-        $httpFactory = m::mock(HttpFactory::class);
+         m::mock(HttpFactory::class);
         $response = m::mock(Response::class);
 
         $httpFactory = m::mock(HttpFactory::class);

--- a/tests/Validation/ValidationNotPwnedVerifierTest.php
+++ b/tests/Validation/ValidationNotPwnedVerifierTest.php
@@ -35,7 +35,7 @@ class ValidationNotPwnedVerifierTest extends TestCase
 
     public function testApiResponseGoesWrong()
     {
-         m::mock(HttpFactory::class);
+        m::mock(HttpFactory::class);
         $response = m::mock(Response::class);
 
         $httpFactory = m::mock(HttpFactory::class);

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -32,20 +32,20 @@ class ValidationRequiredIfTest extends TestCase
 
     public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
     {
-        $rule = new RequiredIf(false);
+         new RequiredIf(false);
 
-        $rule = new RequiredIf(true);
+         new RequiredIf(true);
 
         $this->expectException(\InvalidArgumentException::class);
 
-        $rule = new RequiredIf('phpinfo');
+         new RequiredIf('phpinfo');
     }
 
     public function testItReturnedRuleIsNotSerializable()
     {
         $this->expectException(\Exception::class);
 
-        $rule = serialize(new RequiredIf(function () {
+         serialize(new RequiredIf(function () {
             return true;
         }));
     }

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -32,20 +32,20 @@ class ValidationRequiredIfTest extends TestCase
 
     public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
     {
-         new RequiredIf(false);
+        new RequiredIf(false);
 
-         new RequiredIf(true);
+        new RequiredIf(true);
 
         $this->expectException(\InvalidArgumentException::class);
 
-         new RequiredIf('phpinfo');
+        new RequiredIf('phpinfo');
     }
 
     public function testItReturnedRuleIsNotSerializable()
     {
         $this->expectException(\Exception::class);
 
-         serialize(new RequiredIf(function () {
+        serialize(new RequiredIf(function () {
             return true;
         }));
     }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -48,7 +48,8 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
     {
         $string = "@php(\$data = ['test' => ')'])";
 
-        $expected = "<?php (\$data = ['test' => ')']); ?>";
+        //
+        /*$expected = "<?php (\$data = ['test' => ')']); ?>";*/
 
         $actual = "<?php (\$data = ['test' => '); ?>'])";
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -76,7 +76,7 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testCompileSetAndGetThePath()
     {
-        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
         $compiler->setPath('foo');
         $this->assertSame('foo', $compiler->getPath());
     }
@@ -189,7 +189,7 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testShouldStartFromStrictTypesDeclaration()
     {
-        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
         $strictTypeDecl = "<?php\ndeclare(strict_types = 1);";
         $this->assertSame(substr($compiler->compileString("<?php\ndeclare(strict_types = 1);\nHello World"),
             0, strlen($strictTypeDecl)), $strictTypeDecl);
@@ -197,22 +197,22 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testComponentAliasesCanBeConventionallyDetermined()
     {
-        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
 
         $compiler->component('App\Foo\Bar');
         $this->assertEquals(['bar' => 'App\Foo\Bar'], $compiler->getClassComponentAliases());
 
-        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
 
         $compiler->component('App\Foo\Bar', null, 'prefix');
         $this->assertEquals(['prefix-bar' => 'App\Foo\Bar'], $compiler->getClassComponentAliases());
 
-        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
 
         $compiler->component('App\View\Components\Forms\Input');
         $this->assertEquals(['forms:input' => 'App\View\Components\Forms\Input'], $compiler->getClassComponentAliases());
 
-        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
 
         $compiler->component('App\View\Components\Forms\Input', null, 'prefix');
         $this->assertEquals(['prefix-forms:input' => 'App\View\Components\Forms\Input'], $compiler->getClassComponentAliases());

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -76,7 +76,7 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testCompileSetAndGetThePath()
     {
-        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $compiler->setPath('foo');
         $this->assertSame('foo', $compiler->getPath());
     }
@@ -189,7 +189,7 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testShouldStartFromStrictTypesDeclaration()
     {
-        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $strictTypeDecl = "<?php\ndeclare(strict_types = 1);";
         $this->assertSame(substr($compiler->compileString("<?php\ndeclare(strict_types = 1);\nHello World"),
             0, strlen($strictTypeDecl)), $strictTypeDecl);
@@ -197,22 +197,22 @@ class ViewBladeCompilerTest extends TestCase
 
     public function testComponentAliasesCanBeConventionallyDetermined()
     {
-        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
 
         $compiler->component('App\Foo\Bar');
         $this->assertEquals(['bar' => 'App\Foo\Bar'], $compiler->getClassComponentAliases());
 
-        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
 
         $compiler->component('App\Foo\Bar', null, 'prefix');
         $this->assertEquals(['prefix-bar' => 'App\Foo\Bar'], $compiler->getClassComponentAliases());
 
-        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
 
         $compiler->component('App\View\Components\Forms\Input');
         $this->assertEquals(['forms:input' => 'App\View\Components\Forms\Input'], $compiler->getClassComponentAliases());
 
-        $compiler = new BladeCompiler( $this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
 
         $compiler->component('App\View\Components\Forms\Input', null, 'prefix');
         $this->assertEquals(['prefix-forms:input' => 'App\View\Components\Forms\Input'], $compiler->getClassComponentAliases());

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -103,7 +103,7 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andThrow(InvalidArgumentException::class);
         $factory->getFinder()->shouldReceive('find')->once()->with('bar')->andThrow(InvalidArgumentException::class);
-        $factory->getEngineResolver()->shouldReceive('resolve')->with('php')->andReturn($engine = m::mock(Engine::class));
+        $factory->getEngineResolver()->shouldReceive('resolve')->with('php')->andReturn( m::mock(Engine::class));
         $factory->getFinder()->shouldReceive('addExtension')->with('php');
         $factory->addExtension('php', 'php');
         $factory->first(['bar', 'view'], ['foo' => 'bar'], ['baz' => 'boom']);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -103,7 +103,7 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->once()->with('view')->andThrow(InvalidArgumentException::class);
         $factory->getFinder()->shouldReceive('find')->once()->with('bar')->andThrow(InvalidArgumentException::class);
-        $factory->getEngineResolver()->shouldReceive('resolve')->with('php')->andReturn( m::mock(Engine::class));
+        $factory->getEngineResolver()->shouldReceive('resolve')->with('php')->andReturn(m::mock(Engine::class));
         $factory->getFinder()->shouldReceive('addExtension')->with('php');
         $factory->addExtension('php', 'php');
         $factory->first(['bar', 'view'], ['foo' => 'bar'], ['baz' => 'boom']);


### PR DESCRIPTION
In many places in the code are useless variables set.
It sometimes make sense for understanding, but very often it feels like refactoring where those variables have been left untouched.

This PR fixes that.