### PR TITLE
[8.x] Fix ResourceCollection::jsonOptions when it collects Model

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Resources;
 
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
@@ -64,7 +65,7 @@ trait CollectsResources
     {
         $collects = $this->collects();
 
-        if (! $collects) {
+        if (! $collects || ! is_subclass_of($collects, JsonResource::class)) {
             return 0;
         }
 

--- a/tests/Integration/Http/Fixtures/PostCollectionResourceCollectingModel.php
+++ b/tests/Integration/Http/Fixtures/PostCollectionResourceCollectingModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostCollectionResourceCollectingModel extends ResourceCollection
+{
+    public $collects = Post::class;
+
+    public function toArray($request)
+    {
+        return ['ids' => $this->collection->pluck('id')];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -20,6 +20,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\ObjectResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResource;
+use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResourceCollectingModel;
 use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResourceWithPaginationInformation;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithAnonymousResourceCollectionWithPaginationInformation;
@@ -572,6 +573,25 @@ class ResourceTest extends TestCase
 
         $this->assertEquals(
             '{"data":{"id":5,"title":"Test Title","reading_time":3.0}}',
+            $response->baseResponse->content()
+        );
+    }
+
+    public function testResourcesCollectionMayCollectModels()
+    {
+        Route::get('/', function () {
+            return new PostCollectionResourceCollectingModel(collect([
+                new Post(['id' => 5]),
+                new Post(['id' => 7]),
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $this->assertEquals(
+            '{"data":{"ids":[5,7]}}',
             $response->baseResponse->content()
         );
     }


### PR DESCRIPTION
It appears that some developers are defining `$collects` of `ResourceCollection` with a model class to bypass the auto-discovery of the underlying resource class.

PR #40208 breaks this usage as the model does not have the `jsonOptions` method. (see https://github.com/laravel/framework/pull/40208#issuecomment-1027833288)

This PR fixes it returning 0 as json options when the collected class is not a `JsonResource`.