### PR TITLE
[10.x] Fix Redis store set int value, but get returns string

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -335,11 +335,11 @@ class RedisStore extends TaggableStore implements LockProvider
             return $value;
         }
 
-        if (is_float($value) && !in_array($value, [\INF, -\INF], true) && !is_nan($value)) {
+        if (is_float($value) && ! in_array($value, [\INF, -\INF], true) && ! is_nan($value)) {
             // Note that float like "1.0" will be converted to string "1"
             $value = (string) $value;
             // Append missing ".", because we use "." to detect float (trailing 0 could be ignored)
-            return str_contains($value, '.') ? $value : ($value . '.');
+            return str_contains($value, '.') ? $value : ($value.'.');
         }
 
         return serialize($value);
@@ -356,6 +356,7 @@ class RedisStore extends TaggableStore implements LockProvider
         if (is_numeric($value)) {
             return str_contains($value, '.') ? (float) $value : (int) $value;
         }
+
         return unserialize($value);
     }
 }

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -4,9 +4,9 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
+use const INF;
 use Orchestra\Testbench\TestCase;
 use stdClass;
-use const INF;
 
 class RedisStoreTest extends TestCase
 {
@@ -63,7 +63,7 @@ class RedisStoreTest extends TestCase
             ['bool', true],
             ['bool-false', false],
             ['int', 1],
-            ['float', 1.2,],
+            ['float', 1.2],
             ['float-int', 1.0],
             ['float-e', 7E+20],
             ['float-ne', 7E-20],


### PR DESCRIPTION
Fix the issues in #31345

```php
Cache::put('test', 1);
Cache::get('test'); // expected: 1, actual: "1"
Cache::put('test', 1.0);
Cache::get('test'); // expected: 1.0, actual: "1"

//  throws an error on the second call
function foo(): int
{
    return Cache::remember('foo', 60, function() {
        return 1;
    });
}
```

## Implement 

- Store raw value of int and float to Redis
- Use "." to distinguish int and float
- Serialize other type(including string) before store to Redis

## BREAKING CHANGES

- Reading existing numeric values in Redis will be converted from string to int or float
- Increment new stored string value wont work, use int instead

```php
Cache::set('test', '1'); // store "s:1:"1";" in Redis
Cache::increment('test');  // (error) ERR value is not an integer or out of range
```

To avoid breaking changes, we can add option like `keepNumeric`/`keepType` ? to enable this feature.

