### PR TITLE
[9.x] Return status code on `view:cache` error

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Symfony\Component\Finder\Finder;
@@ -39,13 +40,19 @@ class ViewCacheCommand extends Command
      */
     public function handle()
     {
-        $this->call('view:clear');
+        try {
+            $this->call('view:clear');
 
-        $this->paths()->each(function ($path) {
-            $this->compileViews($this->bladeFilesIn([$path]));
-        });
+            $this->paths()->each(function ($path) {
+                $this->compileViews($this->bladeFilesIn([$path]));
+            });
 
-        $this->info('Blade templates cached successfully!');
+            $this->info('Blade templates cached successfully!');
+        } catch (Exception $e) {
+            $this->error($e->getMessage());
+
+            return 1;
+        }
     }
 
     /**


### PR DESCRIPTION
Hi,

We have run into a few situations where deployments have completed successfully, even though one of the `artisan` commands has failed.

I don't know if there is a reason these commands don't already return a status (`artisan:up` and `down` already return status codes), hence I am submitting this PR as a `draft` just to get feedback on why this may be the case.

I have only edited the `view:cache` command at the moment, but other artisan commands that potentially should return a status code are...

- config:cache
- config:clear
- event:cache
- event:clear
- optimize:cache
- optimize:clear
- route:cache
- route:clear
- view:cache
- view:clear

Looking forward to hearing your thoughts 👍 