### PR TITLE
[9.x] Add isolatedTransaction() method for transactions

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -65,6 +65,23 @@ trait ManagesTransactions
     }
 
     /**
+     * Execute a transaction using isolation level
+     *
+     * @param  string  $isolationLevel
+     * @param  \Closure  $callback
+     * @param  int  $attempts
+     * @return mixed
+     *
+     * @throws \Throwable
+     */
+    public function isolatedTransaction($isolationLevel, Closure $callback, $attempts = 1)
+    {
+        $this->prepareIsolationLevel($isolationLevel);
+
+        return $this->transaction($callback, $attempts);
+    }
+
+    /**
      * Handle an exception encountered when running a transacted statement.
      *
      * @param  \Throwable  $e
@@ -330,5 +347,23 @@ trait ManagesTransactions
         }
 
         throw new RuntimeException('Transactions Manager has not been set.');
+    }
+
+
+    /**
+     * Set isolation level for current transaction
+     *
+     * @param string $isolationLevel
+     * @return void
+     */
+    protected function prepareIsolationLevel($isolationLevel)
+    {
+        if($this->getDriverName() == 'sqlite'){
+            return;
+        }
+
+        $query = $this->getQueryGrammar()->compileIsolationLevel($isolationLevel);
+
+        $this->getPdo()->prepare($query)->execute();
     }
 }

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -65,7 +65,7 @@ trait ManagesTransactions
     }
 
     /**
-     * Execute a transaction using isolation level
+     * Execute a transaction using isolation level.
      *
      * @param  string  $isolationLevel
      * @param  \Closure  $callback
@@ -349,16 +349,15 @@ trait ManagesTransactions
         throw new RuntimeException('Transactions Manager has not been set.');
     }
 
-
     /**
-     * Set isolation level for current transaction
+     * Set isolation level for current transaction.
      *
-     * @param string $isolationLevel
+     * @param  string  $isolationLevel
      * @return void
      */
     protected function prepareIsolationLevel($isolationLevel)
     {
-        if($this->getDriverName() == 'sqlite'){
+        if ($this->getDriverName() == 'sqlite') {
             return;
         }
 

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -357,7 +357,7 @@ trait ManagesTransactions
      */
     protected function prepareIsolationLevel($isolationLevel)
     {
-        if ($this->getDriverName() == 'sqlite') {
+        if ($this->getDriverName() === 'sqlite') {
             return;
         }
 

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -357,7 +357,7 @@ trait ManagesTransactions
      */
     protected function prepareIsolationLevel($isolationLevel)
     {
-        if ($this->getDriverName() === 'sqlite') {
+        if (! in_array($this->getDriverName(), ['mysql', 'pgsql', 'sqlsrv'])) {
             return;
         }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1366,9 +1366,9 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * Compile a SQL query to set isolation level for current transaction
+     * Compile a SQL query to set isolation level for current transaction.
      *
-     * @param string $isolationLevel
+     * @param  string  $isolationLevel
      * @return string
      */
     public function compileIsolationLevel($isolationLevel)

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1364,4 +1364,15 @@ class Grammar extends BaseGrammar
     {
         return $this->bitOperators;
     }
+
+    /**
+     * Compile a SQL query to set isolation level for current transaction
+     *
+     * @param string $isolationLevel
+     * @return string
+     */
+    public function compileIsolationLevel($isolationLevel)
+    {
+        return "SET TRANSACTION ISOLATION LEVEL {$isolationLevel}";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -590,4 +590,15 @@ class PostgresGrammar extends Grammar
                         : "'$attribute'";
         }, $path);
     }
+
+    /**
+     * Compile a SQL query to set isolation level for current transaction.
+     *
+     * @param  string  $isolationLevel
+     * @return string
+     */
+    public function compileIsolationLevel($isolationLevel)
+    {
+        return "START TRANSACTION ISOLATION LEVEL {$isolationLevel}";
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class SQLiteGrammar extends Grammar
 {
@@ -345,10 +346,10 @@ class SQLiteGrammar extends Grammar
      *
      * @param  string  $isolationLevel
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public function compileIsolationLevel($isolationLevel)
     {
-        throw new \RuntimeException('SQLite database engine does not support isolation level.');
+        throw new RuntimeException('SQLite database engine does not support isolation level.');
     }
 }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -341,12 +341,11 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Compile a SQL query to set isolation level for current transaction
+     * Compile a SQL query to set isolation level for current transaction.
      *
-     * @param string $isolationLevel
+     * @param  string  $isolationLevel
      *
      * @throws \RuntimeException
-     *
      */
     public function compileIsolationLevel($isolationLevel)
     {

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -339,4 +339,17 @@ class SQLiteGrammar extends Grammar
 
         return 'json_extract('.$field.$path.')';
     }
+
+    /**
+     * Compile a SQL query to set isolation level for current transaction
+     *
+     * @param string $isolationLevel
+     *
+     * @throws \RuntimeException
+     *
+     */
+    public function compileIsolationLevel($isolationLevel)
+    {
+        throw new \RuntimeException('SQLite database engine does not support isolation level.');
+    }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4273,7 +4273,7 @@ SQL;
 
     public function testIsolationLevelIsNotSupportedInSQLite()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $builder = $this->getSQLiteBuilder();
         $builder->getGrammar()->compileIsolationLevel('SERIALIZABLE');
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4264,6 +4264,20 @@ SQL;
         $this->assertEquals([1], $builder->getBindings());
     }
 
+    public function testIsolationLevelCompiled()
+    {
+        $builder = $this->getBuilder();
+        $result = $builder->getGrammar()->compileIsolationLevel('SERIALIZABLE');
+        $this->assertEquals('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE', $result);
+    }
+
+    public function testIsolationLevelIsNotSupportedInSQLite()
+    {
+        $this->expectException(\RuntimeException::class);
+        $builder = $this->getSQLiteBuilder();
+        $builder->getGrammar()->compileIsolationLevel('SERIALIZABLE');
+    }
+
     public function testWhereJsonLengthMySql()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseTransactionsTest.php
+++ b/tests/Database/DatabaseTransactionsTest.php
@@ -98,6 +98,25 @@ class DatabaseTransactionsTest extends TestCase
         $this->connection()->commit();
     }
 
+    public function testIsolatedTransactionWorksProperly()
+    {
+        $transactionManager = m::mock(new DatabaseTransactionsManager);
+        $transactionManager->shouldReceive('begin')->once()->with('default', 1);
+        $transactionManager->shouldReceive('commit')->once()->with('default');
+
+        $this->connection()->setTransactionManager($transactionManager);
+
+        $this->connection()->table('users')->insert([
+            'name' => 'Reza', 'value' => 1,
+        ]);
+
+        $this->connection()->isolatedTransaction('SERIALIZABLE', function () {
+            $this->connection()->table('users')->where(['name' => 'Reza'])->update([
+                'value' => 2,
+            ]);
+        });
+    }
+
     public function testNestedTransactionIsRecordedAndCommitted()
     {
         $transactionManager = m::mock(new DatabaseTransactionsManager);


### PR DESCRIPTION
Now we can't use a specific isolation level for our transaction.
We can just set a default isolation level in our configs.
With this new `isolatedTransaction()` method, we can easily pass our isolation level without touching config files and customize them.

These new methods don't have any breaking changes, and they work separately.

Also, SQLite cannot support ISOLATION LEVEL unlike SQL Server, MySQL, and PostgreSQL.

Because of that, we skip the isolation level for SQLite, but if we use `SQLite` in our test environment everything works properly!

Example: 
```php

DB::isolatedTransaction('SERIALIZABLE', function(){
    DB::table('users')->update([
        'transaction_count' => $user->transaction_count++,
    ]);
    
    DB::table('transaction')->insert([
        'user_id' => 1,
        'price' => 999.99
    ]);

    return DB::table('transactions')->count('id');
});

```

There are some documentations to set the isolation level for the current transaction:
[SQL Server](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15) 
[MySQL](https://dev.mysql.com/doc/refman/5.6/en/set-transaction.html)
[PostgreSQL](https://www.postgresql.org/docs/9.3/sql-set-transaction.html)