### PR TITLE
[8.x] Automated response for edit permissions

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,64 @@
+name: Pull Requests
+
+# Credit: https://github.com/github/docs/blob/main/.github/workflows/notify-when-maintainers-cannot-edit.yaml
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  uneditable:
+    if: github.repository == 'laravel/framework'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@2b34a689ec86a68d8ab9478298f91d5401337b7d
+        with:
+          script: |
+            const query = `
+              query($number: Int!) {
+                repository(owner: "laravel", name: "framework") {
+                  pullRequest(number: $number) {
+                    headRepositoryOwner {
+                      login
+                    }
+                    maintainerCanModify
+                  }
+                }
+              }
+            `;
+
+            const pullNumber = context.issue.number;
+            const variables = { number: pullNumber };
+
+            try {
+              console.log(`Check laravel/framework#${pullNumber} for maintainer edit access ...`);
+
+              const result = await github.graphql(query, variables);
+
+              console.log(JSON.stringify(result, null, 2));
+
+              const pullRequest = result.repository.pullRequest;
+
+              if (pullRequest.headRepositoryOwner.login === 'laravel') {
+                console.log('PR owned by laravel');
+
+                return;
+              }
+
+              if (!pullRequest.maintainerCanModify) {
+                console.log('PR not owned by Laravel and does not have maintainer edits enabled');
+
+                await github.issues.createComment({
+                  issue_number: pullNumber,
+                  owner: 'laravel',
+                  repo: 'framework',
+                  body: "Thanks for submitting a PR!\n\nIn order to review and merge PRs most efficiently, we require that all PRs grant maintainer edit access before we review them. For information on how to do this, [see the relevant GitHub documentation](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)."
+                });
+              }
+            } catch(e) {
+              console.log(e);
+            }


### PR DESCRIPTION
This action will post a message each time a PR is sent in when no edit permissions are given. 

In the future we could extend this action by also putting PR's in draft until the author has changed permissions.