### PR TITLE
[8.x] Add forceMake to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -147,6 +147,19 @@ class Builder
     }
 
     /**
+     * Create and return an un-saved model instance. Allow mass-assignment.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function forceMake(array $attributes = [])
+    {
+        return $this->model->unguarded(function () use ($attributes) {
+            return $this->newModelInstance($attributes);
+        });
+    }
+
+    /**
      * Register a new global scope.
      *
      * @param  string  $identifier

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -338,6 +338,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(21, $model->id);
     }
 
+    public function testForceMakeMethodSavesNewModelWithGuardedAttributes()
+    {
+        $_SERVER['__eloquent.saved'] = false;
+        $model = EloquentModelSaveStub::forceMake(['id' => 21]);
+        $this->assertFalse($_SERVER['__eloquent.saved']);
+        $this->assertEquals(21, $model->id);
+    }
+
     public function testFindMethodUseWritePdo()
     {
         EloquentModelFindWithWritePdoStub::onWriteConnection()->find(1);


### PR DESCRIPTION
Hello,

the original Problem was already mentioned in this Issue some years ago:
https://github.com/laravel/ideas/issues/825

Sadly no-one submitted a PR for this.

So this PR adds a new forceMake method to the Eloquent Builder. Which simplifies the DX when creating unsaved Model instances.

Before:

```PHP
$user = new User();
$user->forceFill(['email'=>'taylor@laravel.com']);
```

and After:
```PHP
$user = User::forceMake(['email'=>'taylor@laravel.com']);
```

Thank you and have a nice weekend!