### PR TITLE
[10.x] Improves `Support\Collection` reduce method type definition

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -805,7 +805,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TReduceInitial
      * @template TReduceReturnType
      *
-     * @param  callable(TReduceInitial|TReduceReturnType, TValue): TReduceReturnType  $callback
+     * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType  $callback
      * @param  TReduceInitial  $initial
      * @return TReduceReturnType
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -744,7 +744,7 @@ trait EnumeratesValues
      * @template TReduceInitial
      * @template TReduceReturnType
      *
-     * @param  callable(TReduceInitial|TReduceReturnType, TValue): TReduceReturnType  $callback
+     * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType  $callback
      * @param  TReduceInitial  $initial
      * @return TReduceReturnType
      */
@@ -808,7 +808,7 @@ trait EnumeratesValues
      * @template TReduceWithKeysInitial
      * @template TReduceWithKeysReturnType
      *
-     * @param  callable(TReduceWithKeysInitial|TReduceWithKeysReturnType, TValue): TReduceWithKeysReturnType  $callback
+     * @param  callable(TReduceWithKeysInitial|TReduceWithKeysReturnType, TValue, TKey): TReduceWithKeysReturnType  $callback
      * @param  TReduceWithKeysInitial  $initial
      * @return TReduceWithKeysReturnType
      */

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -546,6 +546,14 @@ assertType('int', $collection
 
         return 1;
     }, 0));
+assertType('int', $collection
+    ->reduce(function ($int, $user, $key) {
+        assertType('User', $user);
+        assertType('int', $int);
+        assertType('int', $key);
+
+        return 1;
+    }, 0));
 
 assertType('int', $collection
     ->reduceWithKeys(function ($null, $user) {
@@ -558,6 +566,14 @@ assertType('int', $collection
     ->reduceWithKeys(function ($int, $user) {
         assertType('User', $user);
         assertType('int', $int);
+
+        return 1;
+    }, 0));
+assertType('int', $collection
+    ->reduceWithKeys(function ($int, $user, $key) {
+        assertType('User', $user);
+        assertType('int', $int);
+        assertType('int', $key);
 
         return 1;
     }, 0));


### PR DESCRIPTION
Following the improvements made by @nunomaduro on #38538, this pull request updates the type definition of `reduce` and `reduceWithKeys` methods to consider the `$callback` key parameter.

Whenever the reduce callback expects the third parameter static analysis fail because the type is not defined which produces the following error.
![image](https://user-images.githubusercontent.com/1761690/152578949-712d7a2c-fbbd-4911-a585-3cf570f2fa7e.png)
