### PR TITLE
[10.x] Route list urifilter

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -126,6 +126,7 @@ class RouteListCommand extends Command
             'name' => $route->getName(),
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
+            'route' => $route,
         ]);
     }
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -191,7 +191,7 @@ class RouteListCommand extends Command
      * Filter the route by URI and / or name.
      *
      * @param  array  $route
-     * @return array|null
+     * @return array|void
      */
     protected function filterRoute(array $route)
     {

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -197,15 +197,15 @@ class RouteListCommand extends Command
     protected function filterRoute(array $route)
     {
         if (
-            ($this->option('name') && !Str::contains($route['name'], $this->option('name'))) ||
-            ($this->option('path') && !Str::contains($route['uri'], $this->option('path'))) ||
-            ($this->option('method') && !Str::contains($route['method'], strtoupper($this->option('method'))))
+            ($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
+            ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
+            ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method'))))
         ) {
             return;
         }
         //The domain option behaves differently depending on whether the uri option is also provided
         if ($this->option('uri')) {
-            if (!$route['route']->matches(
+            if (! $route['route']->matches(
                 Request::create(
                     ($this->option('domain') ? 'https://' . $this->option('domain') : '') . $this->option('uri'),
                     $this->option('method') ?: 'GET'
@@ -213,7 +213,7 @@ class RouteListCommand extends Command
             )) {
                 return;
             }
-        } elseif ($this->option('domain') && !Str::contains($route['domain'], $this->option('domain'))) {
+        } elseif ($this->option('domain') && ! Str::contains($route['domain'], $this->option('domain'))) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -207,7 +207,7 @@ class RouteListCommand extends Command
         if ($this->option('uri')) {
             if (! $route['route']->matches(
                 Request::create(
-                    ($this->option('domain') ? 'https://' . $this->option('domain') : '') . $this->option('uri'),
+                    ($this->option('domain') ? 'https://'.$this->option('domain') : '').$this->option('uri'),
                     $this->option('method') ?: 'GET'
                 )
             )) {


### PR DESCRIPTION
This PR adds two new features to the `route:list` artisan command, to address shortcomings in the existing filtering options available in there.

Firstly, it adds filtering by domain. For example, if you have two routes that are identical, but in different domains, there is no way to separate them in the route list. The domain column is already present in the output, so this simply adds the ability to filter on it, just like the other supported columns do.

The second feature is more advanced: filtering by URI matching on resolved routes. This addresses a major shortcoming of the existing `path` filter, which only supports simple string matching on the path pattern itself, not URIs that match it. Since it's very common to have routes *that do not contain the literal path*, such as regex routes, or ones with parameters, a more thorough approach is needed.

If I want to find out which route will handle a URI like `/posts/1`, I could search using `--path=posts`, however, this would likely find several false positives, such as `/posts`. If the route is using model binding, it will be defined as `/posts/{post}`, which will fail to match a search for the URI in the path param `--path=/posts/1`.

This extension works like this:

    ./artisan route:list --uri="https://www.example.com/posts/1"

and you can also use all the other route:list options with it:

    ./artisan route:list --uri="https://www.example.com/posts/1" --method=PATCH --middleware=auth --columns=uri,method,middleware

The `uri` param interacts with the `domain` param, so you can provide the domain and pass a relative path in`uri` separately, like this:

    --domain=www.example.com --uri=/posts/1

and internally it will construct a URL of `https://www.example.com/posts/1`, and resolve that against the routes.

It's especially useful for debugging, for example the common scenario of inadvertently putting API resource routes before other routes will often mean that a request is sent to the wrong controller; a path query would fail to spot that, but a URI match would identify it immediately and precisely. In practice, I find that filtering by `path` often tells you what *should be* happening, but matching the URI tells you what is *actually* happening.

> In short, given a full application URL, it will unambiguously and accurately tell you exactly which route will handle the request; this functionality is not currently available through the existing params.

The implementation makes one internal change which is to pass the route itself to the `filterRoute` method, allowing future filtering options to do anything they like with the route without having to add yet more options to the method.

I'm submitting this as a PR against `framework` rather than creating a standalone extension because it is a small extension to existing functionality, and it interacts with the existing route:list params. Since there is no way to extend built-in commands like this, I would either have to clone the entire functionality of the existing command just to add this one feature, or lose all the other existing functionality it integrates with.