### PR TITLE
[8.x] Add test for cache Repository@add

### DIFF
--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -205,6 +205,36 @@ class CacheRepositoryTest extends TestCase
         $this->assertTrue($repository->add('k', 'v', 60));
     }
 
+    public function testAddMethodCanAcceptDateIntervals()
+    {
+        $storeWithAdd = m::mock(RedisStore::class);
+        $storeWithAdd->shouldReceive('add')->once()->with('k', 'v', 61)->andReturn(true);
+        $repository = new Repository($storeWithAdd);
+        $this->assertTrue($repository->add('k', 'v', DateInterval::createFromDateString('61 seconds')));
+
+        $storeWithoutAdd = m::mock(ArrayStore::class);
+        $this->assertFalse(method_exists(ArrayStore::class, 'add'), 'This store should not have add method on it.');
+        $storeWithoutAdd->shouldReceive('get')->once()->with('k')->andReturn(null);
+        $storeWithoutAdd->shouldReceive('put')->once()->with('k', 'v', 60)->andReturn(true);
+        $repository = new Repository($storeWithoutAdd);
+        $this->assertTrue($repository->add('k', 'v', DateInterval::createFromDateString('60 seconds')));
+    }
+
+    public function testAddMethodCanAcceptDateTimeInterface()
+    {
+        $withAddStore = m::mock(RedisStore::class);
+        $withAddStore->shouldReceive('add')->once()->with('k', 'v', 61)->andReturn(true);
+        $repository = new Repository($withAddStore);
+        $this->assertTrue($repository->add('k', 'v', Carbon::now()->addSeconds(61)));
+
+        $noAddStore = m::mock(ArrayStore::class);
+        $this->assertFalse(method_exists(ArrayStore::class, 'add'), 'This store should not have add method on it.');
+        $noAddStore->shouldReceive('get')->once()->with('k')->andReturn(null);
+        $noAddStore->shouldReceive('put')->once()->with('k', 'v', 62)->andReturn(true);
+        $repository = new Repository($noAddStore);
+        $this->assertTrue($repository->add('k', 'v', Carbon::now()->addSeconds(62)));
+    }
+
     public function testAddWithNullTTLRemembersItemForever()
     {
         $repo = $this->getRepository();
@@ -220,6 +250,8 @@ class CacheRepositoryTest extends TestCase
         $result = $repo->add('foo', 'bar', Carbon::now()->subMinutes(10));
         $this->assertFalse($result);
         $result = $repo->add('foo', 'bar', Carbon::now());
+        $this->assertFalse($result);
+        $result = $repo->add('foo', 'bar', -1);
         $this->assertFalse($result);
     }
 


### PR DESCRIPTION
The `add` method on the repository class should have tests for cases in which it accepts objects as ttl.
to check that they are successfully converted to raw int as seconds before it calls the underlying store object.
