### PR TITLE
[8.x] Do not set SYSTEMROOT to false

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -105,6 +105,7 @@ class ServeCommand extends Command
                 'LARAVEL_SAIL',
                 'PHP_CLI_SERVER_WORKERS',
                 'PHP_IDE_CONFIG',
+                'SYSTEMROOT',
                 'XDEBUG_CONFIG',
                 'XDEBUG_MODE',
                 'XDEBUG_SESSION',


### PR DESCRIPTION
For some reason, if the ```SYSTEMROOT``` environment variable is set to false.  The serve command will fail with ```(reason: ?)``` on Windows using ```8.x```.   Preserve the original value in the command.