### PR TITLE
[8.x] Add a console command to get and display a config value

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigGetCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigGetCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+
+class ConfigGetCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'config:get {key : The key of the config value to retrieve}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Returns the value of the given configuration key';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->info(json_encode(config($this->argument('key')), JSON_PRETTY_PRINT));
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -26,6 +26,7 @@ use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\ComponentMakeCommand;
 use Illuminate\Foundation\Console\ConfigCacheCommand;
 use Illuminate\Foundation\Console\ConfigClearCommand;
+use Illuminate\Foundation\Console\ConfigGetCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
@@ -94,6 +95,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'CacheForget' => 'command.cache.forget',
         'ClearCompiled' => 'command.clear-compiled',
         'ClearResets' => 'command.auth.resets.clear',
+        'ConfigGet' => 'command.config.get',
         'ConfigCache' => 'command.config.cache',
         'ConfigClear' => 'command.config.clear',
         'Db' => DbCommand::class,
@@ -297,6 +299,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.component.make', function ($app) {
             return new ComponentMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerConfigGetCommand()
+    {
+        $this->app->singleton('command.config.get', function ($app) {
+            return new ConfigGetCommand();
         });
     }
 


### PR DESCRIPTION
This pull request adds a new command to retrieve and display a given config value. The reason I'd like to add this functionality is because there are times when I want to pull a config value from a deployed environment, and running tinker is sometimes a pain (Vapor, Heroku, etc). This would help with debugging and ensuring the correct environment variables are deployed.

This is a completely new command, so should have no impact on any existing functionality.

Usage:

```
php artisan config:get app.name
"Laravel"

php artisan config:get database.connections.sqlite
{
    "driver": "sqlite",
    "url": null,
    "database": "laravel",
    "prefix": "",
    "foreign_key_constraints": true
}
```