### PR TITLE
[8.x] Improves `Support\Reflector` to support checking interfaces

### DIFF
--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -136,7 +136,8 @@ class Reflector
         $paramClassName = static::getParameterClassName($parameter);
 
         return $paramClassName
-            && class_exists($paramClassName)
+            && (class_exists($paramClassName) ||
+                interface_exists($paramClassName))
             && (new ReflectionClass($paramClassName))->isSubclassOf($className);
     }
 }

--- a/tests/Support/SupportReflectorTest.php
+++ b/tests/Support/SupportReflectorTest.php
@@ -48,6 +48,13 @@ class SupportReflectorTest extends TestCase
         $this->assertSame(A::class, Reflector::getParameterClassName($method->getParameters()[0]));
     }
 
+    public function testParameterSubclassOfInterface()
+    {
+        $method = (new ReflectionClass(TestClassWithInterfaceSubclassParameter::class))->getMethod('f');
+
+        $this->assertTrue(Reflector::isParameterSubclassOf($method->getParameters()[0], IA::class));
+    }
+
     /**
      * @requires PHP >= 8
      */
@@ -95,8 +102,7 @@ class C
     {
         //
     }
-}'
-    );
+}');
 }
 
 class TestClassWithCall
@@ -110,6 +116,22 @@ class TestClassWithCall
 class TestClassWithCallStatic
 {
     public static function __callStatic($method, $parameters)
+    {
+        //
+    }
+}
+
+interface IA
+{
+}
+
+interface IB extends IA
+{
+}
+
+class TestClassWithInterfaceSubclassParameter
+{
+    public function f(IB $x)
     {
         //
     }


### PR DESCRIPTION
Since `ReflectionClass` already may represent an interface, we may check for interface existence as part of checking parameter subclass.

`isParameterSubclassOf` is used in two places for model route binding:

- `Routing\RouteSignatureParameters`
- `Broadcasting\Broadcasters\Broadcaster`

This improvement helps with implicit binding when the parameter is an interface served from the container
```php

use Illuminate\Contracts\Routing\UrlRoutable;

interface MyUrlRoutableModel extends UrlRoutable {
 //
}

Route::get('/{model}', function (MyUrlRoutableModel $model) {
   // $model binds correctly
});
```
Fixes #11791