### PR TITLE
[8.x] Add firstOr() function to BelongsToMany relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -750,6 +751,28 @@ class BelongsToMany extends Relation
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->related));
+    }
+
+    /**
+     * Execute the query and get the first result or call a callback.
+     *
+     * @param  \Closure|array  $columns
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Model|static|mixed
+     */
+    public function firstOr($columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        if (! is_null($model = $this->first($columns))) {
+            return $model;
+        }
+
+        return $callback();
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

- It adds the `firstOr()` function to the `BelongsToMany::class` relationship.
- Adds tests to support this addition ☝🏼.

## Why do we need this?
### Before this PR
The 'firstOr()' function was being executed via the `__call()` method of the `BelongsToMany::class` which forwarded the call to the `Eloquent\Builder::class`. When the `firstOr()` function found a `first()` record it returned the relationship instance, but didn't add the necessary select columns (`$this->shouldSelect($columns)`) to the query builder object.
```
SELECT * 
FROM `posts` 
INNER JOIN `users_posts` ON `posts`.`uuid` = `users_posts`.`post_uuid` 
WHERE `users_posts`.`user_uuid` = ? 
ORDER BY RAND() 
LIMIT 1;
```

### With this PR

By adding the `firstOr()` function to the `BelongsToMany::class` itself, the `get()` that executes the select query statement is now the one that lives in the `BelongsToMany::class` and defines the columns that should be selected.
```
SELECT `posts`.*, `users_posts`.`user_uuid` AS `pivot_user_uuid`, `users_posts`.`post_uuid` AS `pivot_post_uuid`, `users_posts`.`is_draft` AS `pivot_is_draft`, `users_posts`.`created_at` AS `pivot_created_at`, `users_posts`.`updated_at` AS `pivot_updated_at` 
FROM `posts` 
INNER JOIN `users_posts` ON `posts`.`uuid` = `users_posts`.`post_uuid` 
WHERE `users_posts`.`user_uuid` = ? 
ORDER BY RAND() 
LIMIT 1;
```
Thanks to the `get()` function being executed directly on the `BelongsToMany::class`'s relation, it adds the select columns, and prevents the `Post::class`'s model from inheriting the wrong `id` and/or any other pivot table (`users_posts`) column with the same name as any of the columns in the `posts` table. 

