### PR TITLE
[8.x] Don't add duplicate callbacks

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -64,6 +64,8 @@ class TrimStrings extends TransformsRequest
      */
     public static function skipWhen(Closure $callback)
     {
-        static::$skipCallbacks[] = $callback;
+        if (! in_array($callback, static::$skipCallbacks)) {
+            static::$skipCallbacks[] = $callback;
+        }
     }
 }


### PR DESCRIPTION
While troubleshooting a semi-related problem with tests, Livewire, and the `TrimStrings` middleware, I noticed that while running a batch of tests, callbacks will "stack up"....that is, they will keep being added.

I'm not sure that this behavior is necessarily bad, and it may actually be a good thing under some circumstances...I'm not sure.  But, it seemed to me that it would generally be considered something worth avoiding.

To test this, I simply dumped the count of `static::$skipCallbacks` at the end of `skipWhen()` and, when running my tests normally, the value just continues to increase.

So...I put this little change in anticipating that it might make tests a little more efficient.  🤓 

Please let me know if there are any questions/concerns...or let me know if I've missed something.  😜 

Thx.  🚀

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
