### PR TITLE
findOrFail with array of ids throws ModelNotFound with all ids instead of only the missing ones

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -434,16 +434,22 @@ class Builder
         $id = $id instanceof Arrayable ? $id->toArray() : $id;
 
         if (is_array($id)) {
-            if (count($result) === count(array_unique($id))) {
-                return $result;
+            if (count($result) !== count(array_unique($id))) {
+                throw (new ModelNotFoundException)->setModel(
+                    get_class($this->model), array_diff($id, $result->modelKeys())
+                );
             }
-        } elseif (! is_null($result)) {
+
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(
-            get_class($this->model), $id
-        );
+        if (is_null($result)) {
+            throw (new ModelNotFoundException)->setModel(
+                get_class($this->model), $id
+            );
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -126,10 +126,13 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKey')->andReturn(1);
+
         $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
-        $builder->setModel($this->getMockModel());
+        $builder->setModel($model);
         $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
-        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([1]));
+        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model]));
         $builder->findOrFail([1, 2], ['column']);
     }
 
@@ -137,10 +140,13 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
 
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKey')->andReturn(1);
+
         $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
-        $builder->setModel($this->getMockModel());
+        $builder->setModel($model);
         $builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
-        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([1]));
+        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model]));
         $builder->findOrFail(new Collection([1, 2]), ['column']);
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -612,6 +612,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
     {
         $this->expectException(ModelNotFoundException::class);
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1');
+        $this->expectExceptionObject(
+            (new ModelNotFoundException())->setModel(EloquentTestUser::class, [1]),
+        );
 
         EloquentTestUser::findOrFail(1);
     }
@@ -619,19 +622,25 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1, 2');
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
+        $this->expectExceptionObject(
+            (new ModelNotFoundException())->setModel(EloquentTestUser::class, [2, 3]),
+        );
 
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
-        EloquentTestUser::findOrFail([1, 2]);
+        EloquentTestUser::findOrFail([1, 2, 3]);
     }
 
     public function testFindOrFailWithMultipleIdsUsingCollectionThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 1, 2');
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\EloquentTestUser] 2, 3');
+        $this->expectExceptionObject(
+            (new ModelNotFoundException())->setModel(EloquentTestUser::class, [2, 3]),
+        );
 
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
-        EloquentTestUser::findOrFail(new Collection([1, 2]));
+        EloquentTestUser::findOrFail(new Collection([1, 1, 2, 3]));
     }
 
     public function testOneToOneRelationship()


### PR DESCRIPTION
```php
try {
  Model::findOrFail([1, 2, 3]);
} catch (ModelNotFoundException $e) {
  dd($e->ids);
}
```

If only id=3 is missing, this will throw a `ModelNotFound` with the `ids = [1, 2, 3]`.

The ideal behaviour should be using only the missing models `ids = [3]`.

*Note:* I did not know if this is a proper bug or what, so I didn't pick the LTS just in case. Please let me know how to proceed.