### PR TITLE
[8.x] Use `Test\TestCase` rather than `PHPUnit\Framework\TestCase` for unit test stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.unit.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class {{ class }} extends TestCase
 {


### PR DESCRIPTION
This PR changes the namespace of `PHPUnit\Framework\TestCase` to `Test\TestCase` on unit tests so that it matches the same as the feature tests.

This evening I noticed that I was getting an error on a new project with a unit test. The error was below:

```
Call to a member function connection() on null

  at vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1653
    1649▕      * @return \Illuminate\Database\Connection
    1650▕      */
    1651▕     public static function resolveConnection($connection = null)
    1652▕     {
  ➜ 1653▕         return static::$resolver->connection($connection);
    1654▕     }
    1655▕ 
    1656▕     /**
    1657▕      * Get the connection resolver instance.
```

I did some debugging and found that the issue was caused by the wrong namespace for the `TestCase` class, and [there are others which have experienced this issue](https://laracasts.com/discuss/channels/laravel/call-to-a-member-function-connection-on-null). 

Changing the namespace seems to resolve the issue. This only looks to be the case for unit tests, feature tests already had the correct namespace.

If merging this PR the [example](https://github.com/laravel/laravel/blob/8.x/tests/Unit/ExampleTest.php) on the `laravel/laravel` repository may also need updating to reflect this change.