### PR TITLE
Add `whereDistinctFrom` and `whereDistinctFromColumn`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1473,6 +1473,44 @@ class Builder
         return $this;
     }
 
+    public function whereDistinctFrom($column, $value, $boolean = 'and')
+    {
+        $type = 'distinctFrom';
+
+        $this->wheres[] = compact('type', 'column', 'value', 'boolean');
+        $this->addBinding($value);
+
+        return $this;
+    }
+
+    public function orWhereDistinctFrom($column, $value, $boolean = 'or')
+    {
+        $type = 'distinctFrom';
+
+        $this->wheres[] = compact('type', 'column', 'value', 'boolean');
+        $this->addBinding($value);
+
+        return $this;
+    }
+
+    public function whereDistinctFromColumn($first, $second, $boolean = 'and')
+    {
+        $type = 'distinctFromColumn';
+
+        $this->wheres[] = compact('type', 'first', 'second', 'boolean');
+
+        return $this;
+    }
+
+    public function orWhereDistinctFromColumn($first, $second, $boolean = 'or')
+    {
+        $type = 'distinctFromColumn';
+
+        $this->wheres[] = compact('type', 'first', 'second', 'boolean');
+
+        return $this;
+    }
+
     /**
      * Add a nested where statement to the query.
      *

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -576,6 +576,20 @@ class Grammar extends BaseGrammar
         );
     }
 
+    protected function whereDistinctFrom(Builder $query, $where)
+    {
+        $column = $this->wrap($where['column']);
+
+        return '('.$column.' != '.$this->parameter($where['value']).' or '.$column.' is null)';
+    }
+
+    protected function whereDistinctFromColumn(Builder $query, $where)
+    {
+        $first = $this->wrap($where['first']);
+
+        return '('.$first.' != '.$this->wrap($where['second']).' or '.$first.' is null)';
+    }
+
     /**
      * Compile a "JSON contains" statement into SQL.
      *

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -117,6 +117,16 @@ class PostgresGrammar extends Grammar
         return "({$columns}) @@ {$mode}('{$language}', {$this->parameter($where['value'])})";
     }
 
+    protected function whereDistinctFrom(Builder $query, $where)
+    {
+        return $this->wrap($where['column']).' is distinct from '.$this->parameter($where['value']);
+    }
+
+    protected function whereDistinctFromColumn(Builder $query, $where)
+    {
+        return $this->wrap($where['first']).' is distinct from '.$this->wrap($where['second']);
+    }
+
     /**
      * Get an array of valid full text languages.
      *

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -18,6 +18,7 @@ class QueryBuilderTest extends DatabaseTestCase
             $table->increments('id');
             $table->string('title');
             $table->text('content');
+            $table->string('og')->nullable();
             $table->timestamp('created_at');
         });
 
@@ -196,6 +197,46 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereTime('created_at', '03:04:05')->count());
         $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereTime('created_at', new Carbon('2018-01-02 03:04:05'))->count());
+    }
+
+    public function testWhereDistinctFrom()
+    {
+        DB::table('posts')->insert([
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'og' => 'foo',  'created_at' => new Carbon('2017-11-12 13:14:15')],
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'og' => 'bar',  'created_at' => new Carbon('2017-11-12 13:14:15')],
+        ]);
+
+        $this->assertSame(3, DB::table('posts')->whereDistinctFrom('og', 'foo')->count());
+    }
+
+    public function testOrWhereDistinctFrom()
+    {
+        DB::table('posts')->insert([
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'og' => 'foo',  'created_at' => new Carbon('2017-11-12 13:14:15')],
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'og' => 'bar',  'created_at' => new Carbon('2017-11-12 13:14:15')],
+        ]);
+
+        $this->assertSame(4, DB::table('posts')->where('id', 3)->orWhereDistinctFrom('og', 'foo')->count());
+    }
+
+    public function testWhereDistinctFromColumn()
+    {
+        DB::table('posts')->insert([
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'og' => 'foo',  'created_at' => new Carbon('2017-11-12 13:14:15')],
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'og' => 'Lorem Ipsum.',  'created_at' => new Carbon('2017-11-12 13:14:15')],
+        ]);
+
+        $this->assertSame(3, DB::table('posts')->whereDistinctFromColumn('og', 'content')->count());
+    }
+
+    public function testOrWhereDistinctFromColumn()
+    {
+        DB::table('posts')->insert([
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'og' => 'Lorem Ipsum.',  'created_at' => new Carbon('2017-11-12 13:14:15')],
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'og' => 'bar',  'created_at' => new Carbon('2017-11-12 13:14:15')],
+        ]);
+
+        $this->assertSame(4, DB::table('posts')->where('id', 3)->orWhereDistinctFromColumn('og', 'content')->count());
     }
 
     public function testPaginateWithSpecificColumns()


### PR DESCRIPTION
Postgresql has `is distinct from` operator which will treat `null` values as known - meaning if you say

```sql
select * from "posts" where "og"  is distinct from 'foo'
```

it will return all values where `og` is not equal to `'foo'` or where `og` is `null`.
If we simply use `!=` operator `null` values will not be returned.

Mysql works the same way, except there is no `is distinct from` operator. So for it and other grammars, we need to simulate this by building the `!= or null` query ourselves.

Mysql example: https://www.db-fiddle.com/f/q74q6Q5RQ6vM6N3cMdNYfW/3
Postgresql example: https://www.db-fiddle.com/f/s88JcDQn6wg8FZJH6KoAMU/0

This should ease building queries to cater for this case and maybe even bring more awareness that `!=` operator works that way.