### PR TITLE
[9.x] Throw exception when ResourceCollection collects something else than …

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Http\Resources;
 
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use RuntimeException;
 use Traversable;
 
 trait CollectsResources
@@ -45,15 +47,21 @@ trait CollectsResources
      */
     protected function collects()
     {
-        if ($this->collects) {
-            return $this->collects;
-        }
+        $collects = null;
 
-        if (str_ends_with(class_basename($this), 'Collection') &&
+        if ($this->collects) {
+            $collects =  $this->collects;
+        } elseif (str_ends_with(class_basename($this), 'Collection') &&
             (class_exists($class = Str::replaceLast('Collection', '', get_class($this))) ||
              class_exists($class = Str::replaceLast('Collection', 'Resource', get_class($this))))) {
-            return $class;
+            $collects = $class;
         }
+
+        if (!$collects || is_subclass_of($collects, JsonResource::class)) {
+            return $collects;
+        }
+
+        throw new RuntimeException('ResourceCollection must collect JsonResources.');
     }
 
     /**

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -61,7 +61,7 @@ trait CollectsResources
             return $collects;
         }
 
-        throw new LogicException('ResourceCollection must collect JsonResources.');
+        throw new LogicException('Resource collections must collect instances of '.JsonResource::class.'.');
     }
 
     /**

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -50,14 +50,14 @@ trait CollectsResources
         $collects = null;
 
         if ($this->collects) {
-            $collects =  $this->collects;
+            $collects = $this->collects;
         } elseif (str_ends_with(class_basename($this), 'Collection') &&
             (class_exists($class = Str::replaceLast('Collection', '', get_class($this))) ||
              class_exists($class = Str::replaceLast('Collection', 'Resource', get_class($this))))) {
             $collects = $class;
         }
 
-        if (!$collects || is_subclass_of($collects, JsonResource::class)) {
+        if (! $collects || is_subclass_of($collects, JsonResource::class)) {
             return $collects;
         }
 

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -7,8 +7,8 @@ use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use LogicException;
 use ReflectionClass;
-use RuntimeException;
 use Traversable;
 
 trait CollectsResources
@@ -61,7 +61,7 @@ trait CollectsResources
             return $collects;
         }
 
-        throw new RuntimeException('ResourceCollection must collect JsonResources.');
+        throw new LogicException('ResourceCollection must collect JsonResources.');
     }
 
     /**

--- a/tests/Integration/Http/Fixtures/PostModelCollectionResource.php
+++ b/tests/Integration/Http/Fixtures/PostModelCollectionResource.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class PostModelCollectionResource extends ResourceCollection
+{
+    public $collects = Post::class;
+
+    public function toArray($request)
+    {
+        return ['data' => $this->collection];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -21,6 +21,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\ObjectResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResourceWithPaginationInformation;
+use Illuminate\Tests\Integration\Http\Fixtures\PostModelCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithAnonymousResourceCollectionWithPaginationInformation;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithExtraData;
@@ -38,6 +39,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Subscription;
 use Mockery;
 use Orchestra\Testbench\TestCase;
+use RuntimeException;
 
 class ResourceTest extends TestCase
 {
@@ -1041,6 +1043,19 @@ class ResourceTest extends TestCase
 
         $this->assertCount(2, $collection);
         $this->assertCount(2, $collection);
+    }
+
+    public function testCollectionResourcesMustCollectResources()
+    {
+        $posts = collect([
+            new Post(['id' => 1, 'title' => 'Test title']),
+            new Post(['id' => 2, 'title' => 'Test title 2']),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('ResourceCollection must collect JsonResources.');
+
+        new PostModelCollectionResource($posts);
     }
 
     public function testKeysArePreservedIfTheResourceIsFlaggedToPreserveKeys()

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -37,9 +37,9 @@ use Illuminate\Tests\Integration\Http\Fixtures\ReallyEmptyPostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\ResourceWithPreservedKeys;
 use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Subscription;
+use LogicException;
 use Mockery;
 use Orchestra\Testbench\TestCase;
-use RuntimeException;
 
 class ResourceTest extends TestCase
 {
@@ -1052,7 +1052,7 @@ class ResourceTest extends TestCase
             new Post(['id' => 2, 'title' => 'Test title 2']),
         ]);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('ResourceCollection must collect JsonResources.');
 
         new PostModelCollectionResource($posts);

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1053,7 +1053,7 @@ class ResourceTest extends TestCase
         ]);
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('ResourceCollection must collect JsonResources.');
+        $this->expectExceptionMessage('must collect');
 
         new PostModelCollectionResource($posts);
     }


### PR DESCRIPTION
…JsonResource

This PR is a follow up of https://github.com/laravel/framework/pull/40799 and discussions on https://github.com/laravel/framework/pull/40208

I set taget to 9.x as to me it is a breaking change but feel free to change it if you want.

Not sure about the implementation nor the exception, I let you adjust this the way you prefer.