### PR TITLE
Eager-load Eloquent relationships via getter functions, allowing for more dynamic optimisations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1997,7 +1997,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         return static::$modelsShouldPreventLazyLoading;
     }
-    
+
     /**
      * Get the relations to eager load on every query.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1376,8 +1376,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public function newQueryWithoutScopes()
     {
         return $this->newModelQuery()
-                    ->with($this->with)
-                    ->withCount($this->withCount);
+                    ->with($this->getWith())
+                    ->withCount($this->getWithCount());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1997,6 +1997,52 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         return static::$modelsShouldPreventLazyLoading;
     }
+    
+    /**
+     * Get the relations to eager load on every query.
+     *
+     * @return array
+     */
+    public function getWith()
+    {
+        return $this->with;
+    }
+
+    /**
+     * Set the relations to eager load on every query.
+     *
+     * @param  array  $with
+     * @return $this
+     */
+    public function setWith($with)
+    {
+        $this->with = $with;
+
+        return $this;
+    }
+
+    /**
+     * Get the relationship counts that should be eager loaded on every query.
+     *
+     * @return array
+     */
+    public function getWithCount()
+    {
+        return $this->withCount;
+    }
+
+    /**
+     * Set the relationship counts that should be eager loaded on every query.
+     *
+     * @param  array  $withCount
+     * @return $this
+     */
+    public function setWithCount($withCount)
+    {
+        $this->withCount = $withCount;
+
+        return $this;
+    }
 
     /**
      * Get the broadcast channel route definition that is associated with the given entity.


### PR DESCRIPTION
Eloquent allows us to eager-load relationships by defining the `protected $with = [];` property on a Model. This works great if you always want to eager-load the same relationships globally — but for more complex apps, it would be good to have a bit more control over this.

For example, the `User` models in my app have many different relationships defined for several distinct areas of the platform. I want to be able to eager-load different relations by default, depending on which route/controller they're visiting. Whilst we could just use `User::with([...])`, this becomes hard to keep track of and maintain in larger projects.

This PR adds new getter/setter functions for `$with` and `$withCount`. The only place these property values are loaded is in `newQueryWithoutScopes()`, so this should be nicely backwards-compatible. Developers are then free to override the `getWith()` function for their own purposes, if needed.

Hopefully this helps some people with more complex Eloquent use cases. Thanks in advance!