### PR TITLE
[8.x] Support cursor pagination with union query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -865,9 +865,7 @@ class Builder
      */
     protected function ensureOrderForCursorPagination($shouldReverse = false)
     {
-        $orders = collect($this->query->orders);
-
-        if ($orders->count() === 0) {
+        if (empty($this->query->orders) && empty($this->query->unionOrders)) {
             $this->enforceOrderBy();
         }
 
@@ -877,6 +875,10 @@ class Builder
 
                 return $order;
             })->toArray();
+        }
+
+        if ($this->query->unionOrders) {
+            return collect($this->query->unionOrders);
         }
 
         return collect($this->query->orders);

--- a/tests/Integration/Database/EloquentCursorPaginateTest.php
+++ b/tests/Integration/Database/EloquentCursorPaginateTest.php
@@ -36,6 +36,23 @@ class EloquentCursorPaginateTest extends DatabaseTestCase
         $this->assertCount(15, TestPost::cursorPaginate(15, ['id', 'title']));
     }
 
+    public function testPaginationWithUnion()
+    {
+        TestPost::create(['title' => 'Hello world', 'user_id' => 1]);
+        TestPost::create(['title' => 'Goodbye world', 'user_id' => 2]);
+        TestPost::create(['title' => 'Howdy', 'user_id' => 3]);
+        TestPost::create(['title' => '4th', 'user_id' => 4]);
+
+        $table1 = TestPost::query()->whereIn('user_id', [1, 2]);
+        $table2 = TestPost::query()->whereIn('user_id', [3, 4]);
+
+        $result = $table1->unionAll($table2)
+            ->orderBy('user_id', 'desc')
+            ->cursorPaginate(1);
+
+        self::assertSame(['user_id'], $result->getOptions()['parameters']);
+    }
+
     public function testPaginationWithDistinct()
     {
         for ($i = 1; $i <= 3; $i++) {


### PR DESCRIPTION
When doing unionAll() queries, cursorPaginate doesn't work because it thinks there is no orderBy on the query