### PR TITLE
[8.x] Make `Str::swap()` first argument the string value

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -911,11 +911,11 @@ class Str
     /**
      * Swap multiple keywords in a string with other keywords.
      *
-     * @param  array  $map
      * @param  string  $subject
+     * @param  array  $map
      * @return string
      */
-    public static function swap(array $map, $subject)
+    public static function swap($subject, array $map)
     {
         return str_replace(array_keys($map), array_values($map), $subject);
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -627,17 +627,17 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame(
             'PHP 8 is fantastic',
-            Str::swap([
+            Str::swap('PHP is awesome', [
                 'PHP' => 'PHP 8',
                 'awesome' => 'fantastic',
-            ], 'PHP is awesome')
+            ])
         );
 
         $this->assertSame(
             'foo bar baz',
-            Str::swap([
+            Str::swap('foo bar ⓐⓑ', [
                 'ⓐⓑ' => 'baz',
-            ], 'foo bar ⓐⓑ')
+            ])
         );
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/laravel/framework/pull/40831 before new method `Str::swap()` is release-tagged tomorrow.

`Str::is()` is the only method in its class that doesn't accept the string subject as the first argument. Ensure consistency with other `Str` methods and PHP standard library `strtr()` that this aliases with a better name.