### PR TITLE
[8.x] Consistent `Stringable::swap()` & `Str::swap()` implementations

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -741,7 +741,7 @@ class Stringable implements JsonSerializable
      */
     public function swap(array $map)
     {
-        return new static(str_replace(array_keys($map), array_values($map), $this->value));
+        return new static(strtr($this->value, $map));
     }
 
     /**


### PR DESCRIPTION
Commit https://github.com/laravel/framework/commit/609351ca3021b97746ba2be51e248585b626e276 missed that `Stringable::swap()` doesn't invoke `Str::swap()`.

Make both methods use `strtr()`.