### PR TITLE
[8.x] Add helper to retrieve namespaces

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -97,6 +97,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Get the namespace of the class path.
+     *
+     * @return static
+     */
+    public function classNamespace()
+    {
+        return new static(class_namespace($this->value));
+    }
+
+    /**
      * Get the portion of a string before the first occurrence of a given value.
      *
      * @param  string  $search

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -76,7 +76,7 @@ if (! function_exists('class_basename')) {
 
 if (! function_exists('class_namespace')) {
     /**
-     * Get the class "basename" of the given object / class.
+     * Get the class "namespace" of the given object / class.
      *
      * @param  string|object  $class
      * @return string

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -74,6 +74,21 @@ if (! function_exists('class_basename')) {
     }
 }
 
+if (! function_exists('class_namespace')) {
+    /**
+     * Get the class "basename" of the given object / class.
+     *
+     * @param  string|object  $class
+     * @return string
+     */
+    function class_namespace($class)
+    {
+        $class = is_object($class) ? get_class($class) : $class;
+
+        return substr($class, 0, strrpos($class, '\\'));
+    }
+}
+
 if (! function_exists('class_uses_recursive')) {
     /**
      * Returns all traits used by a class, its parent classes and trait of their traits.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -34,6 +34,12 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('Baz', class_basename('Baz'));
     }
 
+    public function testClassNamespace()
+    {
+        $this->assertSame('Foo\Bar', class_namespace('Foo\Bar\Baz'));
+        $this->assertSame('', class_namespace('Baz'));
+    }
+
     public function testValue()
     {
         $this->assertSame('foo', value('foo'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -26,6 +26,14 @@ class SupportStringableTest extends TestCase
         );
     }
 
+    public function testClassNamespace()
+    {
+        $this->assertEquals(
+            class_namespace(static::class),
+            $this->stringable(static::class)->classNamespace()
+        );
+    }
+
     public function testIsAscii()
     {
         $this->assertTrue($this->stringable('A')->isAscii());


### PR DESCRIPTION
This PR introduces:
- the helper `class_namespace()`
- the Stringable method `classNamespace()`

Those are complementary helpers for `class_basename()`:

```php
// all the following lines will return 'Illuminate\Foundation'
$namespace = class_namespace('Illuminate\Foundation\Application');
$namespace = Str::of('Illuminate\Foundation\Application')->classNamespace();
$namespace = class_namespace(app());
$namespace = Str::of(app())->classNamespace();
```