### PR TITLE
[9.x] Retrieve the underlying string value in Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -32,6 +32,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Retrieve the underlying string value.
+     *
+     * @return string
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
      * @param  string  $search

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -32,16 +32,6 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Retrieve the underlying string value.
-     *
-     * @return string
-     */
-    public function get()
-    {
-        return $this->value;
-    }
-
-    /**
      * Return the remainder of a string after the first occurrence of a given value.
      *
      * @param  string  $search
@@ -989,6 +979,26 @@ class Stringable implements JsonSerializable
         $this->dump();
 
         exit(1);
+    }
+
+    /**
+     * Get the underlying string value.
+     *
+     * @return string
+     */
+    public function value()
+    {
+        return $this->toString();
+    }
+
+    /**
+     * Get the underlying string value.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->value;
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -938,6 +938,7 @@ class SupportStringableTest extends TestCase
 
     public function testGet()
     {
-        $this->assertSame('foo', $this->stringable('foo')->get());
+        $this->assertSame('foo', $this->stringable('foo')->value());
+        $this->assertSame('foo', $this->stringable('foo')->toString());
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -935,4 +935,9 @@ class SupportStringableTest extends TestCase
         $this->assertSame(['Otwell', 'Taylor'], $this->stringable('Otwell, Taylor')->scan('%[^,],%s')->toArray());
         $this->assertSame(['filename', 'jpg'], $this->stringable('filename.jpg')->scan('%[^.].%s')->toArray());
     }
+
+    public function testGet()
+    {
+        $this->assertSame('foo', $this->stringable('foo')->get());
+    }
 }


### PR DESCRIPTION
This PR adds the method `get()` to `Illuminate/Support/Stringable`. This can be useful to quickly retrieve the underlying string value without the need of casting:

```php
// before
return (string) Str::of('foo')->uppercase()->append('!');

// after
return Str::of('foo')->uppercase()->append('!')->get();
```