### PR TITLE
[9.x] Collection find first key from a collection by testing the values

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -390,6 +390,26 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get the first key from the collection where the value passes the given truth test.
+     *
+     * @template TFirstDefault
+     *
+     * @param  (callable(TValue, TKey): bool)  $callback
+     * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
+     * @return TValue|TFirstDefault
+     */
+    public function firstKeyWhereValue(callable $callback, $default = null)
+    {
+        foreach ($this->items as $key => $value) {
+            if ($callback($value)) {
+                return $key;
+            }
+        }
+
+        return value($default);
+    }
+
+    /**
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -449,6 +449,28 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Get the first key from the collection where the value passes the given truth test.
+     *
+     * @template TFirstDefault
+     *
+     * @param  (callable(TValue, TKey): bool)|null  $callback
+     * @param  TFirstDefault|(\Closure(): TFirstDefault)  $default
+     * @return TValue|TFirstDefault
+     */
+    public function firstKeyWhereValue(callable $callback, $default = null)
+    {
+        $iterator = $this->getIterator();
+
+        foreach ($iterator as $key => $value) {
+            if ($callback($value, $key)) {
+                return $key;
+            }
+        }
+
+        return value($default);
+    }
+
+    /**
      * Get a flattened list of the items in the collection.
      *
      * @param  int  $depth

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -72,6 +72,30 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testFirstKeyWhereValue($collection)
+    {
+        $data = new $collection(['foo' => 'bar']);
+        $result = $data->firstKeyWhereValue(function ($value) {
+            return $value === 'bar';
+        }, 'default');
+        $this->assertSame('foo', $result);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFirstKeyWhereValueAndDefault($collection)
+    {
+        $data = new $collection(['foo' => 'bar']);
+        $result = $data->firstKeyWhereValue(function ($value) {
+            return $value === 'baz';
+        }, 'default');
+        $this->assertSame('default', $result);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSoleReturnsFirstItemInCollectionIfOnlyOneExists($collection)
     {
         $collection = new $collection([


### PR DESCRIPTION
This PR adds support to find the first key from a collection by testing the values.
I couldn't find a good way to achieve this with the currently available methods and I thought this could be a nice addition to the framework.

Example:

```php
$data = new Collection(['john' => 'doe', 'foo' => 'bar']);
$result = $data->firstKeyWhereValue(fn ($value) => $value === 'bar', 'default');
// foo
```

I am not sure if this method name is the best but it's a descriptive one and I think it doesn't raise any doubts of what it does. You don't need to go to the docs to understand how to use it.
I also considered `firstKeyWhere` as it is shorter but you don't know what you test with the callback.

Additionally I think adding the key to the callback is probably useful if you want to test both the value and the key but I am not sure about that. 
```php
if ($callback($value, $key)) {...
```

I'm looking for feedback.