### PR TITLE
add controller helper to help us when looking for action of a specific route

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -820,6 +820,19 @@ if (! function_exists('to_route')) {
     }
 }
 
+if (! function_exists('controller')) {
+    /**
+     * Return controller action that mapped to route name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    function controller($name)
+    {
+        return app('url')->controller($name);
+    }
+}
+
 if (! function_exists('today')) {
     /**
      * Create a new Carbon instance for the current date.

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -477,6 +477,23 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Get the route name to a controller action.
+     *
+     * @param  string  $name
+     * @return string
+     *
+     * @throws \Symfony\Component\Routing\Exception\RouteNotFoundException
+     */
+    public function controller($name)
+    {
+        if (! is_null($route = $this->routes->getByName($name))) {
+            return $route->action['controller'];
+        }
+
+        throw new RouteNotFoundException("Route [{$name}] not defined.");
+    }
+
+    /**
      * Get the URL to a controller action.
      *
      * @param  string|array  $action

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1956,6 +1956,27 @@ class RoutingRouteTest extends TestCase
 
         return $router;
     }
+
+    public function testItCanReturnRelatedControllerActionForRouteName()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/bar', RouteTestControllerStub::class.'@index')->name('foo.bar');
+
+        $collection = new RouteCollection();
+
+        foreach ($router->getRoutes()->getRoutes() as $route) {
+            $collection->add($route);
+        }
+
+        $urlGenerator = new UrlGenerator($collection, new Request());
+
+        $this->assertEquals(__NAMESPACE__.'\\RouteTestControllerStub@index', $urlGenerator->controller('foo.bar'));
+
+        app()->instance('url', $urlGenerator);
+
+        $this->assertEquals(__NAMESPACE__.'\\RouteTestControllerStub@index', controller('foo.bar'));
+    }
 }
 
 class RouteTestControllerStub extends Controller


### PR DESCRIPTION
Hey @taylorotwell 
Suppose we deal with an application that has many `route()` helpers all over Tests and source code. 
When we face `route()` helpers in our code, it's hard to detect the controllers that are related to these helpers, especially when we deal with some dirty code or some huge application, it gets harder.
At the moment we must use `php artisan route:list | grep "ROUTENAME"` if we want to find the related controller but this way has more complex and even many developers don't know what they can do.
As a solution, I think if we have a `controller()` helper this help us overcome this situation.