### PR TITLE
[9.x] Restrict route:list command to minimum required width

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -308,7 +308,20 @@ class RouteListCommand extends Command
 
         $terminalWidth = $this->getTerminalWidth();
 
-        return $routes->map(function ($route) use ($maxMethod, $terminalWidth) {
+        $maxWidth = 0;
+        foreach ($routes as $route) {
+            [
+                'action' => $action,
+                'method' => $method,
+                'uri' => $uri,
+            ] = $route;
+            $thisWidth = max($maxMethod + 6 - mb_strlen($method), 0) + mb_strlen($method.$uri.$action) + 10;
+            $maxWidth = max($maxWidth, $thisWidth);
+        }
+
+        $maxWidth = min($maxWidth, $terminalWidth);
+
+        return $routes->map(function ($route) use ($maxMethod, $terminalWidth, $maxWidth) {
             [
                 'action' => $action,
                 'domain' => $domain,
@@ -326,7 +339,7 @@ class RouteListCommand extends Command
             $spaces = str_repeat(' ', max($maxMethod + 6 - mb_strlen($method), 0));
 
             $dots = str_repeat('.', max(
-                $terminalWidth - mb_strlen($method.$spaces.$uri.$action) - 6 - ($action ? 1 : 0), 0
+                $maxWidth - mb_strlen($method.$spaces.$uri.$action) - 6 - ($action ? 1 : 0), 0
             ));
 
             $dots = empty($dots) ? $dots : " $dots";

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -28,21 +28,21 @@ class RouteListCommandTest extends TestCase
 
         $this->router = $this->app->make(Registrar::class);
 
-        RouteListCommand::resolveTerminalWidthUsing(function () {
+        RouteListCommand::resolveTerminalWidthUsing(function() {
             return 70;
         });
     }
 
     public function testDisplayRoutesForCli()
     {
-        $this->router->get('closure', function () {
+        $this->router->get('closure', function() {
             return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
         });
 
         $this->router->get('controller-method/{user}', [FooController::class, 'show']);
         $this->router->post('controller-invokable', FooController::class);
-        $this->router->domain('{account}.example.com')->group(function () {
-            $this->router->get('user/{id}', function ($account, $id) {
+        $this->router->domain('{account}.example.com')->group(function() {
+            $this->router->get('user/{id}', function($account, $id) {
                 //
             })->name('user.show')->middleware('web');
         });
@@ -57,16 +57,43 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('');
     }
 
-    public function testDisplayRoutesForCliInVerboseMode()
+    public function testDisplayRoutesForCliOnWidescreen()
     {
-        $this->router->get('closure', function () {
+        RouteListCommand::resolveTerminalWidthUsing(function() {
+            return 700;
+        });
+        $this->router->get('closure', function() {
             return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
         });
 
         $this->router->get('controller-method/{user}', [FooController::class, 'show']);
         $this->router->post('controller-invokable', FooController::class);
-        $this->router->domain('{account}.example.com')->group(function () {
-            $this->router->get('user/{id}', function ($account, $id) {
+        $this->router->domain('{account}.example.com')->group(function() {
+            $this->router->get('user/{id}', function($account, $id) {
+                //
+            })->name('user.show')->middleware('web');
+        });
+
+        $this->artisan(RouteListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('')
+            ->expectsOutput('  GET|HEAD   closure ........................................................................ ')
+            ->expectsOutput('  POST       controller-invokable ............ Illuminate\Tests\Testing\Console\FooController')
+            ->expectsOutput('  GET|HEAD   controller-method/{user} ... Illuminate\Tests\Testing\Console\FooController@show')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ...................................... user.show')
+            ->expectsOutput('');
+    }
+
+    public function testDisplayRoutesForCliInVerboseMode()
+    {
+        $this->router->get('closure', function() {
+            return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
+        });
+
+        $this->router->get('controller-method/{user}', [FooController::class, 'show']);
+        $this->router->post('controller-invokable', FooController::class);
+        $this->router->domain('{account}.example.com')->group(function() {
+            $this->router->get('user/{id}', function($account, $id) {
                 //
             })->name('user.show')->middleware('web');
         });


### PR DESCRIPTION
Currently the new `route:list` command occupies all of the terminal width, which makes it hard to read. This PR shrinks output to minimum required width to fit all of the lines.

Kept all the code as is, only added `$maxWidth` local variable and corresponding math. Comes with a test.

Previously:

![image](https://user-images.githubusercontent.com/181486/153085124-8b929c17-1444-4e99-9d3f-d0e613c837d1.png)

This PR:

![image](https://user-images.githubusercontent.com/181486/153085073-9c0089ea-4e57-4cb6-a52a-c3e9158f5ac2.png)
