### PR TITLE
[9.x] Add make:subscriber command

### DIFF
--- a/src/Illuminate/Foundation/Console/SubscriberMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/SubscriberMakeCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+
+class SubscriberMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:subscriber';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'make:subscriber';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new event subscriber class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Subscriber';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/subscriber.stub';
+    }
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return class_exists($rawName);
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Listeners';
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/subscriber.stub
+++ b/src/Illuminate/Foundation/Console/stubs/subscriber.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Queue\InteractsWithQueue;
+
+class {{ class }}
+{
+    public function subscribe(Dispatcher $events): array
+    {
+        return [
+            //
+        ];
+    }
+}


### PR DESCRIPTION
I think event subscribers are useful and having a make-command to generate them will be nice.
