### PR TITLE
[9.x] Improves `Support\Collection` each method type definition

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -259,7 +259,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Execute a callback over each item.
      *
-     * @param  callable(TValue): mixed  $callback
+     * @param  callable(TValue, TKey): mixed  $callback
      * @return $this
      */
     public function each(callable $callback);

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -252,7 +252,7 @@ trait EnumeratesValues
     /**
      * Execute a callback over each item.
      *
-     * @param  callable(TValue): mixed  $callback
+     * @param  callable(TValue, TKey): mixed  $callback
      * @return $this
      */
     public function each(callable $callback)

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -189,6 +189,10 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->each(functio
 assertType('Illuminate\Support\Collection<int, User>', $collection->each(function ($user) {
     assertType('User', $user);
 }));
+assertType('Illuminate\Support\Collection<int, User>', $collection->each(function ($user, $int) {
+    assertType('int', $int);
+    assertType('User', $user);
+}));
 
 assertType('Illuminate\Support\Collection<int, array{string}>', $collection::make([['string']])
     ->eachSpread(function ($int, $string) {


### PR DESCRIPTION
This pull request improves `each()` types because `each` also passes the key to the closure.

Example from Docs:

```php
$collection->each(function ($item, $key) {
    //
});
```