### PR TITLE
[9.x] fix: bring back old behaviour 

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -869,6 +869,7 @@ class Connection implements ConnectionInterface
             'beganTransaction' => new TransactionBeginning($this),
             'committed' => new TransactionCommitted($this),
             'rollingBack' => new TransactionRolledBack($this),
+            default => null,
         });
     }
 

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -46,6 +46,7 @@ trait RoutesNotifications
         return match ($driver) {
             'database' => $this->notifications(),
             'mail' => $this->email,
+            default => null,
         };
     }
 }

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -171,6 +171,7 @@ class RedisManager implements Factory
         return match ($this->driver) {
             'predis' => new PredisConnector,
             'phpredis' => new PhpRedisConnector,
+            default => null,
         };
     }
 


### PR DESCRIPTION
Hi,

This PR bring back old behavior, since this can be a breaking change for many.

```php
$notifiable->routeNotificationFor('MethodWhichIsNotImplemented', $notification);

// Larval 8.x and before => null
// Larval v9.x => throws UnhandledMatchError
```

The routeNotificationFor() method should return `null` if the method is not implemented on Notifiable.

Tip: the `match` expression does not return `null` when there is no match.

PS - This PR adds `default` case to some more `match` expressions.


