### PR TITLE
[9.x] Switch to null coalescing operator in Conditionable

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -26,9 +26,9 @@ trait Conditionable
         }
 
         if ($value) {
-            return $callback($this, $value) ?: $this;
+            return $callback($this, $value) ?? $this;
         } elseif ($default) {
-            return $default($this, $value) ?: $this;
+            return $default($this, $value) ?? $this;
         }
 
         return $this;
@@ -53,9 +53,9 @@ trait Conditionable
         }
 
         if (! $value) {
-            return $callback($this, $value) ?: $this;
+            return $callback($this, $value) ?? $this;
         } elseif ($default) {
-            return $default($this, $value) ?: $this;
+            return $default($this, $value) ?? $this;
         }
 
         return $this;


### PR DESCRIPTION
This fixes #40877 but is technically a breaking change. Generally, I think this leads to more expected behavior, but it could be an issue for someone who currently expects that returning a falsy value will result in the conditionable object to be returned.

A more backwards-compatible approach might be to do an `is_null($result) || $result === false` check instead. I personally think the null coalesce is fine, but I just wanted to point it out.