### PR TITLE
[9.x] Add `defaultOrderBy` property to model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -84,6 +84,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected $withCount = [];
 
     /**
+     * The columns to order by when none were specified in the query.
+     *
+     * @var string[]|null
+     */
+    public $defaultOrderBy;
+
+    /**
      * Indicates whether lazy loading will be prevented on this model.
      *
      * @var bool

--- a/tests/Integration/Database/EloquentModelDefaultOrderByTest.php
+++ b/tests/Integration/Database/EloquentModelDefaultOrderByTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentModelDefaultOrderByTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('slug');
+        });
+    }
+
+    public function testUsesDefaultOrderByWhenNoOrderHasNotBeenSet()
+    {
+        $post1 = PostOrdered::create(['title' => 'Post 1', 'slug' => 'post-1']);
+        $post2 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-2']);
+        $post3 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-22']);
+
+        $posts = PostOrdered::all();
+
+        $this->assertCount(3, $posts);
+        $this->assertTrue($posts->get(0)->is($post1));
+        $this->assertTrue($posts->get(1)->is($post3));
+        $this->assertTrue($posts->get(2)->is($post2));
+    }
+
+    public function testItDoesNotUseDefaultOrderByWhenOrderHasBeenSet()
+    {
+        $post1 = PostOrdered::create(['title' => 'Post 1', 'slug' => 'post-1']);
+        $post2 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-2']);
+        $post3 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-22']);
+
+        $posts = PostOrdered::orderBy('id')->get();
+
+        $this->assertCount(3, $posts);
+        $this->assertTrue($posts->get(0)->is($post1));
+        $this->assertTrue($posts->get(1)->is($post2));
+        $this->assertTrue($posts->get(2)->is($post3));
+    }
+
+    public function testItDoesNotUseDefaultOrderByWhenWithoutDefaultOrderByIsUsed()
+    {
+        $this->assertStringNotContainsString('order by', PostOrdered::withoutDefaultOrderBy()->toSql());
+    }
+
+    public function testItDoesNotUseDefaultOrderByWhenOrderByIsAppliedViaScope()
+    {
+        $post1 = PostOrdered::create(['title' => 'Post 1', 'slug' => 'post-1']);
+        $post2 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-2']);
+        $post3 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-22']);
+
+        $this->assertSame([1, 2, 3], PostOrdered::orderBySlugAscending()->pluck('id')->toArray());
+    }
+
+    public function testCursorRespectDefaultOrderBy()
+    {
+        $post1 = PostOrdered::create(['title' => 'Post 1', 'slug' => 'post-1']);
+        $post2 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-2']);
+        $post3 = PostOrdered::create(['title' => 'Post 2', 'slug' => 'post-22']);
+
+        $this->assertSame([1, 3, 2], PostOrdered::cursor()->pluck('id')->toArray());
+    }
+
+    public function testFirstRespectDefaultOrderBy()
+    {
+        PostOrdered::create(['title' => 'Test Post', 'slug' => 'post-1']);
+        $expected = PostOrdered::create(['title' => 'Test Post', 'slug' => 'post-2']);
+
+        $this->assertTrue(PostOrdered::first()->is($expected));
+    }
+
+    public function testValueRespectsDefaultOrderBy()
+    {
+        PostOrdered::create(['title' => 'Test Post', 'slug' => 'post-1']);
+        PostOrdered::create(['title' => 'Test Post', 'slug' => 'post-2']);
+
+        $this->assertSame('post-2', PostOrdered::value('slug'));
+    }
+}
+
+class PostOrdered extends Model
+{
+    public $table = 'posts';
+    public $timestamps = false;
+    public $defaultOrderBy = [
+        'title',
+        'slug' => 'DESC',
+    ];
+    protected $guarded = [];
+
+    public function scopeOrderBySlugAscending($query)
+    {
+        return $query->orderBy('slug', 'asc');
+    }
+}


### PR DESCRIPTION
Builds on @jasonmccreary's previous PR at https://github.com/laravel/framework/pull/40678 .. with some tweaks/additions:

### Naming

Feels as though simply `$orderBy` as the name of the property could be confusing for devs, as they may think that either (a) this is the place to always specify ordering for your queries, instead of using `orderBy()` within queries/scopes directly, or (b) that this default ordering always gets applied _in addition_ to any ordering from `orderBy()` calls, which it does not - the default ordering only gets applied when there is no other ordering specified for the query.

It's a little more verbose, but hopefully much clearer and unambiguous.

### Applying in query builder methods

Previously, the call to `applyOrderBy()` (now `applyDefaultOrderBy()`) was chained _before_ `applyScopes()` in the Eloquent builder methods. This meant that any scopes which themselves included an `orderBy()` call would have been applied to the query _in addition to_ and _after_ the default ordering, which would be incorrect/ambiguous. This method-chaining order has been corrected. Thanks to @crynobone who spotted this in the previous PR thread.

### Removal of the default ordering

Eloquent allows any modification or constraint applied to queries via model configuration to also be _removed_, enabling a query to return to simply `select * from {table}` as the compiled SQL. For example, even if a `boot()` method applies a global scope, this can be removed for a certain query scenario via `withoutGlobalScope()` or `withoutGlobalScopes()`. This new default ordering functionality should also be removable in the same way, so I've added a `$useDefaultOrderBy = true` property to the Eloquent builder and a `withoutDefaultOrderBy()` method which prevents the default ordering from being applied by setting this property to `false`. This allows the model to still be queried without the default ordering when required, and I feel this provides consistency with other similar mechanisms the query builders provide.

### Tests

I've added additional tests. One to verify that chaining `withoutDefaultOrderBy()` into a query prevents the default ordering from being applied, and one to verify that the default ordering does not get applied if a local scope method added to the query contains an `orderBy()` call. All tests passing.