### PR TITLE
[10.x] Add redirectToRoute to router

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -22,6 +22,7 @@ use ReflectionClass;
 use ReflectionProperty;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 
 class Mailable implements MailableContract, Renderable
@@ -675,6 +676,8 @@ class Mailable implements MailableContract, Renderable
             return (object) $recipient;
         } elseif (is_string($recipient)) {
             return (object) ['email' => $recipient];
+        } elseif ($recipient instanceof Address) {
+            return (object) ['email' => $recipient->getAddress(), 'name' => $recipient->getName()];
         }
 
         return $recipient;

--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -27,8 +27,7 @@ class RedirectController extends Controller
             $parameters->forget('status')->forget('route');
 
             $route = \Route::getRoutes()->getByName($route)->bind($request);
-        }
-        else {
+        } else {
             $destination = $parameters->get('destination');
 
             $parameters->forget('status')->forget('destination');

--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -21,13 +21,22 @@ class RedirectController extends Controller
 
         $status = $parameters->get('status');
 
-        $destination = $parameters->get('destination');
+        if ($parameters->has('route')) {
+            $route = $parameters->get('route');
 
-        $parameters->forget('status')->forget('destination');
+            $parameters->forget('status')->forget('route');
 
-        $route = (new Route('GET', $destination, [
-            'as' => 'laravel_route_redirect_destination',
-        ]))->bind($request);
+            $route = \Route::getRoutes()->getByName($route)->bind($request);
+        }
+        else {
+            $destination = $parameters->get('destination');
+
+            $parameters->forget('status')->forget('destination');
+
+            $route = (new Route('GET', $destination, [
+                'as' => 'laravel_route_redirect_destination',
+            ]))->bind($request);
+        }
 
         $parameters = $parameters->only(
             $route->getCompiled()->getPathVariables()

--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -26,7 +26,7 @@ class RedirectController extends Controller
 
             $parameters->forget('status')->forget('route');
 
-            $route = \Route::getRoutes()->getByName($route)->bind($request);
+            $route = Route::getRoutes()->getByName($route)->bind($request);
         } else {
             $destination = $parameters->get('destination');
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -250,6 +250,21 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Create a redirect from one URI to a route.
+     *
+     * @param  string  $uri
+     * @param  string  $route
+     * @param  int  $status
+     * @return \Illuminate\Routing\Route
+     */
+    public function redirectToRoute($uri, $route, $status = 302)
+    {
+        return $this->any($uri, '\Illuminate\Routing\RedirectController')
+                ->defaults('route', $route)
+                ->defaults('status', $status);
+    }
+
+    /**
      * Create a permanent redirect from one URI to another.
      *
      * @param  string  $uri


### PR DESCRIPTION
so that you can do `Route::redirectToRoute('route.name')` in `routes/web.php` for instance instead of
```
Route::any('uri', function() {
    return redirect()->route('route.name');
});
```
or
`Route::redirect('uri', 'destination-uri');`
