### PR TITLE
[9.x] Allow base JsonResource class to be collected

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -57,7 +57,7 @@ trait CollectsResources
             $collects = $class;
         }
 
-        if (! $collects || is_subclass_of($collects, JsonResource::class)) {
+        if (! $collects || $collects === JsonResource::class || is_subclass_of($collects, JsonResource::class)) {
             return $collects;
         }
 

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -57,7 +57,7 @@ trait CollectsResources
             $collects = $class;
         }
 
-        if (! $collects || $collects === JsonResource::class || is_subclass_of($collects, JsonResource::class)) {
+        if (! $collects || is_a($collects, JsonResource::class, true)) {
             return $collects;
         }
 


### PR DESCRIPTION
In some cases, my app is just using the base JsonResource like so:

```php
return JsonResource::collection(User::take(10)->get());
```

This fails as the `collects()` method is only checking if the class is a subclass. It does not allow the base JsonResource class.