### PR TITLE
[9.x] Fix Support\Collection reject method type definition

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1099,7 +1099,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Create a collection of all elements that do not pass a given truth test.
      *
-     * @param  (callable(TValue): bool)|bool  $callback
+     * @param  (callable(TValue, TKey): bool)|bool  $callback
      * @return static
      */
     public function reject($callback = true);

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -788,7 +788,7 @@ trait EnumeratesValues
     /**
      * Create a collection of all elements that do not pass a given truth test.
      *
-     * @param  (callable(TValue): bool)|bool  $callback
+     * @param  (callable(TValue, TKey): bool)|bool  $callback
      * @return static
      */
     public function reject($callback = true)

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -735,6 +735,12 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->reject(funct
 
     return true;
 }));
+assertType('Illuminate\Support\Collection<int, User>', $collection->reject(function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+
+    return true;
+}));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->unique());
 assertType('Illuminate\Support\Collection<int, User>', $collection->unique(function ($user, $int) {


### PR DESCRIPTION
This PR fixes the type definition for the `reject` collection method.

The reject method also passes the `$key` to the closure as the second param.

```php
$collection = collect([1, 2, 3, 4]);
 
$filtered = $collection->reject(function ($value, $key) {
    return $value > 2;
});
 
$filtered->all();
 
// [1, 2]
```