### PR TITLE
[9.x] Add disabled directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -326,4 +326,15 @@ trait CompilesConditionals
     {
         return "<?php if{$condition}: echo 'checked'; endif; ?>";
     }
+
+    /**
+     * Compile a disabled block into valid PHP.
+     *
+     * @param  string  $condition
+     * @return string
+     */
+    protected function compileDisabled($condition)
+    {
+        return "<?php if{$condition}: echo 'disabled'; endif; ?>";
+    }
 }

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -19,4 +19,12 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testDisabledStatementsAreCompiled()
+    {
+        $string = '<button @disabled(name(foo(bar)))>Foo</button>';
+        $expected = "<button <?php if(name(foo(bar))): echo 'disabled'; endif; ?>>Foo</button>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR provides the use of the common HTML directive `disabled` through a shorthand syntax via a Blade directive. Allowing developers to have a more enjoyable method of disabling a button, for example, could improve the smooth flow that we Laravel developers are consistently being treated too. Simple yet, effective.

```blade
<button type="submit" @disabled($errors->isNotEmpty())>Submit</button>
```

Editing for documentation PR: https://github.com/laravel/docs/pull/7690