### PR TITLE
[9.x] Add array_keys_in validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -219,6 +219,24 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the array_keys_in rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceArrayKeysIn($message, $attribute, $rule, $parameters)
+    {
+        foreach ($parameters as &$parameter) {
+            $parameter = $this->getDisplayableValue($attribute, $parameter);
+        }
+
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
+
+    /**
      * Replace all place-holders for the mimetypes rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -395,6 +395,29 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an array has any of the given keys.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    public function validateArrayKeysIn($attribute, $value, $parameters)
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        foreach (array_keys($value) as $key) {
+            if (!in_array($key, $parameters)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Validate the size of an attribute is between a set of values.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -409,7 +409,7 @@ trait ValidatesAttributes
         }
 
         foreach (array_keys($value) as $key) {
-            if (!in_array($key, $parameters)) {
+            if (! in_array($key, $parameters)) {
                 return false;
             }
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7051,6 +7051,102 @@ class ValidationValidatorTest extends TestCase
         );
     }
 
+    public function testArrayKeysInValidationPassedWhenHasKeys()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $data = [
+            'baz' => [
+                'foo' => 'bar',
+                'fee' => 'faa',
+                'laa' => 'lee',
+            ],
+        ];
+
+        $rules = [
+            'baz' => [
+                'array',
+                'array_keys_in:foo,fee,laa',
+            ],
+        ];
+
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testArrayKeysInValidationFailsWithPartialMatch()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $data = [
+            'baz' => [
+                'foo' => 'bar',
+                'fee' => 'faa',
+                'laa' => 'lee',
+            ],
+        ];
+
+        $rules = [
+            'baz' => [
+                'array',
+                'array_keys_in:foo,fee',
+            ],
+        ];
+
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertFalse($validator->passes());
+
+        $this->assertSame(
+            'validation.array_keys_in',
+            $validator->messages()->first('baz')
+        );
+    }
+
+    public function testArrayKeysInPassesWithMissingKey()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $data = [
+            'baz' => [
+                'foo' => 'bar',
+                'fee' => 'faa',
+                'laa' => 'lee',
+            ],
+        ];
+
+        $rules = [
+            'baz' => [
+                'array',
+                'array_keys_in:foo,fee,laa,boo,bar',
+            ],
+        ];
+
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testArrayKeysInFailsWithNotAnArray()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $data = [
+            'baz' => 'no an array',
+        ];
+
+        $rules = [
+            'baz' => [
+                'array_keys_in:foo,fee,boo,bar',
+            ],
+        ];
+
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertFalse($validator->passes());
+        $this->assertSame(
+            'validation.array_keys_in',
+            $validator->messages()->first('baz')
+        );
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);


### PR DESCRIPTION
### Example Code

```php

// request data 
[
     'bag' => [
        'foo' => 1,
        'bar' => 2,
        'baz' => 3,
     ]
]

$request->validate(['bag' => 'array_keys_in:foo,bar,baz'); //passes

$request->validate(['bag' => 'array_keys_in:foo,bar'); //fails

$request->validate(['bag' => 'array_keys_in:foo,bar,baz,fee,lee'); //passes
```
### Motivation
since we have introduced **required_array_keys** I felt that **array_keys_in** should be a convenient method. as some times not all of the array keys are required

### Real World Example
```php
// let's imagine a form where it submits list of users configurations 
// and we need to make sure that user ids exist in db
// request data
[
     'users_configurations' => [
        '1' => ['config_1' => [],...etc],
        '2' => ['config_2' => [],...etc],
        '3' => ['config_3' => [],..etc],
     ]
]

$request->validate(['users_configurations' => 'array_keys_in:' . User::pluck('id')->implode('id',',')
```
