### PR TITLE
[9.x] Widen the type of `Collection::unique` `$key` parameter

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1528,7 +1528,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Return only unique items from the collection array.
      *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|null  $key
      * @param  bool  $strict
      * @return static
      */

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1114,7 +1114,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Return only unique items from the collection array.
      *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|null  $key
      * @param  bool  $strict
      * @return static
      */
@@ -1123,7 +1123,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Return only unique items from the collection array using strict comparison.
      *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|null  $key
      * @return static
      */
     public function uniqueStrict($key = null);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1464,7 +1464,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Return only unique items from the collection array.
      *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|null  $key
      * @param  bool  $strict
      * @return static
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -818,7 +818,7 @@ trait EnumeratesValues
     /**
      * Return only unique items from the collection array.
      *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|null  $key
      * @param  bool  $strict
      * @return static
      */
@@ -840,7 +840,7 @@ trait EnumeratesValues
     /**
      * Return only unique items from the collection array using strict comparison.
      *
-     * @param  (callable(TValue, TKey): bool)|string|null  $key
+     * @param  (callable(TValue, TKey): mixed)|string|null  $key
      * @return static
      */
     public function uniqueStrict($key = null)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -458,7 +458,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Return only unique items from the collection.
      *
-     * @param  (callable(TModel, TKey): bool)|string|null  $key
+     * @param  (callable(TModel, TKey): mixed)|string|null  $key
      * @param  bool  $strict
      * @return static<int, TModel>
      */

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -135,7 +135,7 @@ assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->un
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->primaryKey;
+    return $user->getTable();
 }));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->unique('string'));
 

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -135,7 +135,7 @@ assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->un
     assertType('User', $user);
     assertType('int', $int);
 
-    return true;
+    return $user->id;
 }));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->unique('string'));
 

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -135,7 +135,7 @@ assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->un
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->id;
+    return $user->primaryKey;
 }));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->unique('string'));
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -747,7 +747,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->unique(funct
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->primaryKey;
+    return $user->getTable();
 }));
 assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
     assertType('string', $stringA);
@@ -761,7 +761,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->uniqueStrict
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->primaryKey;
+    return $user->getTable();
 }));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->values());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -747,13 +747,13 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->unique(funct
     assertType('User', $user);
     assertType('int', $int);
 
-    return true;
+    return $user->id;
 }));
 assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
     assertType('string', $stringA);
-    assertType('string', $stringA);
+    assertType('string', $stringB);
 
-    return false;
+    return $stringA;
 }, true));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->uniqueStrict());
@@ -761,7 +761,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->uniqueStrict
     assertType('User', $user);
     assertType('int', $int);
 
-    return true;
+    return $user->id;
 }));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->values());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -747,7 +747,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->unique(funct
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->id;
+    return $user->primaryKey;
 }));
 assertType('Illuminate\Support\Collection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
     assertType('string', $stringA);
@@ -761,7 +761,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->uniqueStrict
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->id;
+    return $user->primaryKey;
 }));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->values());

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -745,13 +745,13 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->unique(f
     assertType('User', $user);
     assertType('int', $int);
 
-    return true;
+    return $user->id;
 }));
 assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
     assertType('string', $stringA);
-    assertType('string', $stringA);
+    assertType('string', $stringB);
 
-    return false;
+    return $stringA;
 }, true));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->uniqueStrict());
@@ -759,7 +759,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->uniqueSt
     assertType('User', $user);
     assertType('int', $int);
 
-    return true;
+    return $user->id;
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->values());

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -745,7 +745,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->unique(f
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->id;
+    return $user->primaryKey;
 }));
 assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
     assertType('string', $stringA);
@@ -759,7 +759,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->uniqueSt
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->id;
+    return $user->primaryKey;
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->values());

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -745,7 +745,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->unique(f
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->primaryKey;
+    return $user->getTable();
 }));
 assertType('Illuminate\Support\LazyCollection<string, string>', $collection->make(['string' => 'string'])->unique(function ($stringA, $stringB) {
     assertType('string', $stringA);
@@ -759,7 +759,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->uniqueSt
     assertType('User', $user);
     assertType('int', $int);
 
-    return $user->primaryKey;
+    return $user->getTable();
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->values());


### PR DESCRIPTION
This was narrowed down to bool, but the docs and implementation
actually support arbitrary values.

As suggested in https://github.com/laravel/framework/issues/40897 I PRed the changes to `Collection` and other related classes like `LazyCollection`.

### Description:

Currently the [`$key` parameter](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/Collection.php#L1531) of the `Collection::unique` method has the following type annotation:

```php
    /**
     * Return only unique items from the collection array.
     *
     * @param  (callable(TValue, TKey): bool)|string|null  $key
     * @param  bool  $strict
     * @return static
     */
    public function unique($key = null, $strict = false)
```

So basically it can be
- a function that returns bool
- a string
- nothing at all

I think the first one is a little bit too strict. Looking at https://laravel.com/docs/9.x/collections#method-unique I should be able to return any value to determine uniqueness:

> Finally, you may also pass your own closure to the unique method to specify which value should determine an item's uniqueness:
```php
$unique = $collection->unique(function ($item) {
    return $item['brand'].$item['type'];
});
 
$unique->values()->all();
 
/*
    [
        ['name' => 'iPhone 6', 'brand' => 'Apple', 'type' => 'phone'],
        ['name' => 'Apple Watch', 'brand' => 'Apple', 'type' => 'watch'],
        ['name' => 'Galaxy S6', 'brand' => 'Samsung', 'type' => 'phone'],
        ['name' => 'Galaxy Gear', 'brand' => 'Samsung', 'type' => 'watch'],
    ]
*/
```