### PR TITLE
Allow enums in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1000,11 +1000,15 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array  $allowed
+     * @param  array|string  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, array|string $allowed)
     {
+        if (is_string($allowed) && function_exists('enum_exists') && enum_exists($allowed)) {
+            $allowed = array_column($allowed::cases(), 'value');
+        }
+
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Tests\Database\Fixtures\Enums\Roles;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -761,6 +762,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
+    }
+
+    public function testAllowingBackedEnumDefinition()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', Roles::class);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -768,6 +768,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
     public function testAllowingBackedEnumDefinition()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -580,6 +580,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
     public function testAllowingBackedEnumDefinition()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Tests\Database\Fixtures\Enums\Roles;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -573,6 +574,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+    }
+
+    public function testAllowingBackedEnumDefinition()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', Roles::class);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -501,6 +501,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
     public function testAllowingBackedEnumDefinition()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
+use Illuminate\Tests\Database\Fixtures\Enums\Roles;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -494,6 +495,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $blueprint->enum('role', ['member', 'admin']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+    }
+
+    public function testAllowingBackedEnumDefinition()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', Roles::class);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);

--- a/tests/Database/Fixtures/Enums/Roles.php
+++ b/tests/Database/Fixtures/Enums/Roles.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Tests\Database\Fixtures\Enums;
+
+enum Roles: string
+{
+    case Member = 'member';
+    case Admin = 'admin';
+}


### PR DESCRIPTION
This change allows enums to be used during column creation, in migrations:

```php
enum Difficulty: string
{
    case Easy = 'easy';
    case Hard = 'hard';
}

$table->enum('difficulty', Difficulty::class);
```