### PR TITLE
[9.x] Use proper temporaryUrl method

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -640,6 +640,10 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function temporaryUrl($path, $expiration, array $options = [])
     {
+        if (method_exists($this->adapter, 'temporaryUrl')) {
+            return $this->adapter->temporaryUrl($path, $expiration, $options);
+        }
+
         if (method_exists($this->adapter, 'getTemporaryUrl')) {
             return $this->adapter->getTemporaryUrl($path, $expiration, $options);
         }


### PR DESCRIPTION
In Laravel v8 we checked for a `getTemporaryUrl` method on an adapter even though the main Filesystem used a `temporaryUrl` method. But the new S3 adapter we ship uses a `temporaryUrl`. This PR adds a check for `temporaryUrl` so both are supported.

To be fair, we could remove the `getTemporaryUrl` check and add that to the upgrade guide. Or leave it in. Doesn't matter that much.