### PR TITLE
[9.x] Fix publishing visibility

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Str;
 use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\Local\LocalFilesystemAdapter as LocalAdapter;
 use League\Flysystem\MountManager;
+use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
+use League\Flysystem\Visibility;
 
 class VendorPublishCommand extends Command
 {
@@ -243,9 +245,11 @@ class VendorPublishCommand extends Command
      */
     protected function publishDirectory($from, $to)
     {
+        $visibility = PortableVisibilityConverter::fromArray([], Visibility::PUBLIC);
+
         $this->moveManagedFiles(new MountManager([
             'from' => new Flysystem(new LocalAdapter($from)),
-            'to' => new Flysystem(new LocalAdapter($to)),
+            'to' => new Flysystem(new LocalAdapter($to, $visibility)),
         ]));
 
         $this->status($from, $to, 'Directory');


### PR DESCRIPTION
This PR fixes the vendor:publish command to set a public visibility for directories when publishing views or assets. The default behavior in Flysystem got changed to private. 
