### PR TITLE
[9.x] Fix notification email recipient

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -200,7 +200,11 @@ class Message
         if (is_array($address)) {
             $type = lcfirst($type);
 
-            $addresses = collect($address)->map(function (string|array $address) {
+            $addresses = collect($address)->map(function (string|array $address, $key) {
+                if (is_string($key) && is_string($address)) {
+                    return new Address($key, $address);
+                }
+
                 if (is_array($address)) {
                     return new Address($address['email'] ?? $address['address'], $address['name'] ?? null);
                 }

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -41,8 +41,11 @@ class MailMessageTest extends TestCase
 
     public function testToMethod()
     {
-        $this->assertInstanceOf(Message::class, $message = $this->message->to('foo@bar.baz', 'Foo', false));
+        $this->assertInstanceOf(Message::class, $message = $this->message->to('foo@bar.baz', 'Foo'));
         $this->assertEquals(new Address('foo@bar.baz', 'Foo'), $message->getSymfonyMessage()->getTo()[0]);
+
+        $this->assertInstanceOf(Message::class, $message = $this->message->to(['bar@bar.baz' => 'Bar']));
+        $this->assertEquals(new Address('bar@bar.baz', 'Bar'), $message->getSymfonyMessage()->getTo()[0]);
     }
 
     public function testToMethodWithOverride()


### PR DESCRIPTION
This PR fixes an issue where the address of a notifiable for email sending is returned as a key/value array. Fixes #40895
