### PR TITLE
[9.x] Support --ssl-ca on schema load and dump

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -105,7 +105,7 @@ class MySqlSchemaState extends SchemaState
 
         $value .= $this->connection->getConfig()['unix_socket'] ?? false
                         ? ' --socket="${:LARAVEL_LOAD_SOCKET}"'
-                        : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"';
+                        : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
 
         return $value;
     }
@@ -127,6 +127,7 @@ class MySqlSchemaState extends SchemaState
             'LARAVEL_LOAD_USER' => $config['username'],
             'LARAVEL_LOAD_PASSWORD' => $config['password'] ?? '',
             'LARAVEL_LOAD_DATABASE' => $config['database'],
+            'LARAVEL_LOAD_SSL_CA' => $config['options'][\PDO::MYSQL_ATTR_SSL_CA] ?? '',
         ];
     }
 


### PR DESCRIPTION
When using SSL with MySql php artisan migrate will fail with 

```
In Process.php line 272:
                                                                               
  [Symfony\Component\Process\Exception\ProcessFailedException]                 
  The command "mysql  --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_L  
  OAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}  
  " --database="${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"" failed.  
                                                                               
  Exit Code: 5(Unknown error)                                                  
                                           