### PR TITLE
[10.x] Add the langPath() function to `Illuminate/Contracts/Foundation/Application`

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -46,6 +46,14 @@ interface Application extends Container
     public function databasePath($path = '');
 
     /**
+     * Get the path to the language files.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function langPath($path = '');
+
+    /**
      * Get the path to the resources directory.
      *
      * @param  string  $path


### PR DESCRIPTION
Now that the `lang` directory has changed, many developers will be updating their packages to publish translations in the correct path it would help to have that in the Contract so it is type-hinted for a better experience.
