### PR TITLE
[9.x] Makes `ExceptionHandler::renderForConsole` internal

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -692,6 +692,8 @@ class Handler implements ExceptionHandlerContract
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  \Throwable  $e
      * @return void
+     *
+     * @internal This method is not meant to be used or overwritten outside the framework itself.
      */
     public function renderForConsole($output, Throwable $e)
     {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -693,7 +693,7 @@ class Handler implements ExceptionHandlerContract
      * @param  \Throwable  $e
      * @return void
      *
-     * @internal This method is not meant to be used or overwritten outside the framework itself.
+     * @internal This method is not meant to be used or overwritten outside the framework.
      */
     public function renderForConsole($output, Throwable $e)
     {


### PR DESCRIPTION
This pull request makes the `ExceptionHandler::renderForConsole` internal. **For years**, Collision overrides the method with its own logic, and as consequence, `App\Exceptions\ExceptionHandler::renderForConsole` never gets called.

Adding the flag `@internal` will instruct people that this method is not meant to be overwritten.

Closes https://github.com/laravel/framework/issues/40935.