### PR TITLE
[9.x] Fix FTP root config

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -192,6 +192,10 @@ class FilesystemManager implements FactoryContract
      */
     public function createFtpDriver(array $config)
     {
+        if (! isset($config['root'])) {
+            $config['root'] = '/';
+        }
+
         $adapter = new FtpAdapter(FtpConnectionOptions::fromArray($config));
 
         return new FilesystemAdapter($this->createFlysystem($adapter, $config), $adapter, $config);

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -193,7 +193,7 @@ class FilesystemManager implements FactoryContract
     public function createFtpDriver(array $config)
     {
         if (! isset($config['root'])) {
-            $config['root'] = '/';
+            $config['root'] = '';
         }
 
         $adapter = new FtpAdapter(FtpConnectionOptions::fromArray($config));


### PR DESCRIPTION
With Flysystem v2, the `root` setting is now required. We'll need to add a sensible default.