### PR TITLE
[9.x] Patch regex rule parsing due to `Rule::forEach()`

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -88,7 +88,9 @@ class ValidationRuleParser
             [$name] = static::parseStringRule($rule);
 
             return explode('|', $rule, ...array_filter([static::ruleIsRegex($name)]));
-        } elseif (is_object($rule)) {
+        }
+
+        if (is_object($rule)) {
             return Arr::wrap($this->prepareRule($rule, $attribute));
         }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -87,7 +87,7 @@ class ValidationRuleParser
         if (is_string($rule)) {
             [$name] = static::parseStringRule($rule);
 
-            return explode('|', $rule, ...array_filter([static::ruleIsRegex($name)]));
+            return static::ruleIsRegex($name) ? [$rule] : explode('|', $rule);
         }
 
         if (is_object($rule)) {

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -276,11 +276,7 @@ class ValidationRuleParser
      */
     protected static function parseParameters($rule, $parameter)
     {
-        if (static::ruleIsRegex($rule)) {
-            return [$parameter];
-        }
-
-        return str_getcsv($parameter);
+        return static::ruleIsRegex($rule) ? [$parameter] : str_getcsv($parameter);
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -156,7 +156,7 @@ class ValidationRuleParser
                     } else {
                         $this->implicitAttributes[$attribute][] = $key;
 
-                        $results = $this->mergeRules($results, $key, $rule);
+                        $results = $this->mergeRules($results, $key, Arr::wrap($rule));
                     }
                 }
             }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -85,7 +85,9 @@ class ValidationRuleParser
     protected function explodeExplicitRule($rule, $attribute)
     {
         if (is_string($rule)) {
-            return explode('|', $rule, ...array_filter([str_contains($rule, 'regex')]));
+            [$name] = static::parseStringRule($rule);
+
+            return explode('|', $rule, ...array_filter([static::ruleIsRegex($name)]));
         } elseif (is_object($rule)) {
             return Arr::wrap($this->prepareRule($rule, $attribute));
         }
@@ -272,13 +274,22 @@ class ValidationRuleParser
      */
     protected static function parseParameters($rule, $parameter)
     {
-        $rule = strtolower($rule);
-
-        if (in_array($rule, ['regex', 'not_regex', 'notregex'], true)) {
+        if (static::ruleIsRegex($rule)) {
             return [$parameter];
         }
 
         return str_getcsv($parameter);
+    }
+
+    /**
+     * Determine if the rule is a regular expression.
+     *
+     * @param  string  $rule
+     * @return bool
+     */
+    protected static function ruleIsRegex($rule)
+    {
+        return in_array(strtolower($rule), ['regex', 'not_regex', 'notregex'], true);
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -85,7 +85,7 @@ class ValidationRuleParser
     protected function explodeExplicitRule($rule, $attribute)
     {
         if (is_string($rule)) {
-            return explode('|', $rule);
+            return explode('|', $rule, ...array_filter([str_contains($rule, 'regex')]));
         } elseif (is_object($rule)) {
             return Arr::wrap($this->prepareRule($rule, $attribute));
         }
@@ -156,7 +156,7 @@ class ValidationRuleParser
                     } else {
                         $this->implicitAttributes[$attribute][] = $key;
 
-                        $results = $this->mergeRules($results, $key, Arr::wrap($rule));
+                        $results = $this->mergeRules($results, $key, $rule);
                     }
                 }
             }

--- a/tests/Validation/ValidationForEachTest.php
+++ b/tests/Validation/ValidationForEachTest.php
@@ -200,7 +200,7 @@ class ValidationForEachTest extends TestCase
             'items.1.discounts.0.discount' => ['validation.numeric'],
         ], $v->getMessageBag()->toArray());
     }
-    
+
     public function testNestedCallbacksDoNotBreakRegexRules()
     {
         $data = [

--- a/tests/Validation/ValidationForEachTest.php
+++ b/tests/Validation/ValidationForEachTest.php
@@ -200,6 +200,32 @@ class ValidationForEachTest extends TestCase
             'items.1.discounts.0.discount' => ['validation.numeric'],
         ], $v->getMessageBag()->toArray());
     }
+    
+    public function testNestedCallbacksDoNotBreakRegexRules()
+    {
+        $data = [
+            'items' => [
+                ['users' => [['type' => 'super'], ['type' => 'admin']]],
+            ],
+        ];
+
+        $rules = [
+            'items.*' => Rule::forEach(function () {
+                return ['users.*.type' => 'regex:/^(super|admin)$/i'];
+            }),
+        ];
+
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, $data, $rules);
+
+        $this->assertFalse($v->passes());
+
+        $this->assertEquals([
+            'items.0.users.0.type' => ['validation.regex'],
+            'items.0.users.1.type' => ['validation.regex'],
+        ], $v->getMessageBag()->toArray());
+    }
 
     protected function getTranslator()
     {

--- a/tests/Validation/ValidationForEachTest.php
+++ b/tests/Validation/ValidationForEachTest.php
@@ -205,7 +205,7 @@ class ValidationForEachTest extends TestCase
     {
         $data = [
             'items' => [
-                ['users' => [['type' => 'super'], ['type' => 'admin']]],
+                ['users' => [['type' => 'super'], ['type' => 'invalid']]],
             ],
         ];
 
@@ -222,7 +222,6 @@ class ValidationForEachTest extends TestCase
         $this->assertFalse($v->passes());
 
         $this->assertEquals([
-            'items.0.users.0.type' => ['validation.regex'],
             'items.0.users.1.type' => ['validation.regex'],
         ], $v->getMessageBag()->toArray());
     }

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -137,6 +137,18 @@ class ValidationRuleParserTest extends TestCase
         $this->assertEquals('bar)$/i', $exploded->rules['items.0.type'][2]);
     }
 
+    public function testExplodeProperlyFlattensRuleArraysOfArrays()
+    {
+        $data = ['items' => [['type' => 'foo']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['items.*.type' => ['in:foo', [[['regex:/^(foo|bar)$/i']]]]]
+        );
+
+        $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
+        $this->assertEquals('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][1]);
+    }
+
     public function testExplodeGeneratesNestedRules()
     {
         $parser = (new ValidationRuleParser([

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -89,6 +89,42 @@ class ValidationRuleParserTest extends TestCase
         ], $rules);
     }
 
+    public function testExplodeProperlyParsesSingleRegexRule()
+    {
+        $data = ['items' => [['type' => 'foo']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['items.*.type' => 'regex:/^(super|admin)$/i']
+        );
+
+        $this->assertEquals('regex:/^(super|admin)$/i', $exploded->rules['items.0.type'][0]);
+    }
+
+    public function testExplodeProperlyParsesRegexWithArrayOfRules()
+    {
+        $data = ['items' => [['type' => 'foo']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['items.*.type' => ['in:foo', 'regex:/^(super|admin)$/i']]
+        );
+
+        $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
+        $this->assertEquals('regex:/^(super|admin)$/i', $exploded->rules['items.0.type'][1]);
+    }
+
+    public function testExplodeFailsParsingRegexWithOtherRulesInSingleString()
+    {
+        $data = ['items' => [['type' => 'foo']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['items.*.type' => 'in:foo|regex:/^(super|admin)$/i']
+        );
+
+        $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
+        $this->assertEquals('regex:/^(super', $exploded->rules['items.0.type'][1]);
+        $this->assertEquals('admin)$/i', $exploded->rules['items.0.type'][2]);
+    }
+
     public function testExplodeGeneratesNestedRules()
     {
         $parser = (new ValidationRuleParser([

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -94,10 +94,10 @@ class ValidationRuleParserTest extends TestCase
         $data = ['items' => [['type' => 'foo']]];
 
         $exploded = (new ValidationRuleParser($data))->explode(
-            ['items.*.type' => 'regex:/^(super|admin)$/i']
+            ['items.*.type' => 'regex:/^(foo|bar)$/i']
         );
 
-        $this->assertEquals('regex:/^(super|admin)$/i', $exploded->rules['items.0.type'][0]);
+        $this->assertEquals('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][0]);
     }
 
     public function testExplodeProperlyParsesRegexWithArrayOfRules()
@@ -105,11 +105,23 @@ class ValidationRuleParserTest extends TestCase
         $data = ['items' => [['type' => 'foo']]];
 
         $exploded = (new ValidationRuleParser($data))->explode(
-            ['items.*.type' => ['in:foo', 'regex:/^(super|admin)$/i']]
+            ['items.*.type' => ['in:foo', 'regex:/^(foo|bar)$/i']]
         );
 
         $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
-        $this->assertEquals('regex:/^(super|admin)$/i', $exploded->rules['items.0.type'][1]);
+        $this->assertEquals('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][1]);
+    }
+
+    public function testExplodeProperlyParsesRegexThatDoesNotContainPipe()
+    {
+        $data = ['items' => [['type' => 'foo']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['items.*.type' => 'in:foo|regex:/^(bar)$/i']
+        );
+
+        $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
+        $this->assertEquals('regex:/^(bar)$/i', $exploded->rules['items.0.type'][1]);
     }
 
     public function testExplodeFailsParsingRegexWithOtherRulesInSingleString()
@@ -117,12 +129,12 @@ class ValidationRuleParserTest extends TestCase
         $data = ['items' => [['type' => 'foo']]];
 
         $exploded = (new ValidationRuleParser($data))->explode(
-            ['items.*.type' => 'in:foo|regex:/^(super|admin)$/i']
+            ['items.*.type' => 'in:foo|regex:/^(foo|bar)$/i']
         );
 
         $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
-        $this->assertEquals('regex:/^(super', $exploded->rules['items.0.type'][1]);
-        $this->assertEquals('admin)$/i', $exploded->rules['items.0.type'][2]);
+        $this->assertEquals('regex:/^(foo', $exploded->rules['items.0.type'][1]);
+        $this->assertEquals('bar)$/i', $exploded->rules['items.0.type'][2]);
     }
 
     public function testExplodeGeneratesNestedRules()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3820,6 +3820,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => 12], ['x' => 'Regex:/^12$/i']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ['y' => ['z' => 'james']]], ['x.*.z' => ['Regex:/^(taylor|james)$/i']]);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateNotRegex()


### PR DESCRIPTION
## Description

This PR fixes https://github.com/laravel/framework/issues/40924.

This also allows the ability to supply a regex validation rule inside of a single string-based rule, instead of requiring it to be an array.

**Before**:

This would previously fail in Laravel:

```php
$data = ['items' => [['type' => 'admin']]]

// Fails. preg_match throws malformed regex exception.
$rules = ['items.*' => 'regex:/^(super|admin)$/i'];

// Passes.
$rules = ['items.*' => ['regex:/^(super|admin)$/i']];

Validator::make($data, $rules)->passes();
```

**After**:

```php
$data = ['items' => [['type' => 'admin']]]

// Passes.
$rules = ['items.*' => 'regex:/^(super|admin)$/i'];

// Passes.
$rules = ['items.*' => ['regex:/^(super|admin)$/i']];

Validator::make($data, $rules)->passes();
```

## Notes

I've added various test cases to ensure parsing is done properly. However, maybe we should introduce an exception when `preg_match()` throws an exception due to a malformed regex which would indicate to the developer they must wrap the regex rule in an array when using multiple rules?

Let me know your thoughts. If you like the idea, I will update my PR to include this exception.