### PR TITLE
[8.x] Catch suppressed deprecation logs

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -67,11 +67,11 @@ class HandleExceptions
      */
     public function handleError($level, $message, $file = '', $line = 0, $context = [])
     {
-        if (error_reporting() & $level) {
-            if ($this->isDeprecation($level)) {
-                return $this->handleDeprecation($message, $file, $line);
-            }
+        if ($this->isDeprecation($level)) {
+            return $this->handleDeprecation($message, $file, $line);
+        }
 
+        if (error_reporting() & $level) {
             throw new ErrorException($message, 0, $level, $file, $line);
         }
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDeprecationHandling.php
@@ -38,7 +38,7 @@ trait InteractsWithDeprecationHandling
     {
         if ($this->originalDeprecationHandler == null) {
             $this->originalDeprecationHandler = set_error_handler(function ($level, $message, $file = '', $line = 0) {
-                if (error_reporting() & $level) {
+                if (in_array($level, [E_DEPRECATED, E_USER_DEPRECATED]) || (error_reporting() & $level)) {
                     throw new ErrorException($message, 0, $level, $file, $line);
                 }
             });


### PR DESCRIPTION
This pull requests closes https://github.com/laravel/framework/issues/40854 by making Laravel's deprecation handler catch suppressed deprecations.

The motivation behind this pull request is the way Symfony manages deprecations, as they use the `@` operator like so:

```
@trigger_error('idn_to_utf8(): INTL_IDNA_VARIANT_2003 is deprecated', \E_USER_DEPRECATED);
```