### PR TITLE
[9.x] Add "getChunk" method to Filesystem

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -50,8 +50,24 @@ class Filesystem
      */
     public function get($path, $lock = false)
     {
+        return $this->getChunk($path, $lock);
+    }
+
+    /**
+     * Get the contents of a file.
+     *
+     * @param  string  $path
+     * @param  bool  $lock
+     * @param  int  $offset
+     * @param  int|null  $length
+     * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function getChunk($path, $lock = false, $offset = 0, $length = null)
+    {
         if ($this->isFile($path)) {
-            return $lock ? $this->sharedGet($path) : file_get_contents($path);
+            return $lock ? $this->sharedGet($path) : file_get_contents($path, false, null, $offset, $length);
         }
 
         throw new FileNotFoundException("File does not exist at path {$path}.");


### PR DESCRIPTION
The `get` method is a wrapper around the `file_get_contents` but it does not give the option of reading a portion of a big file.
So the getChuck method can be useful.

### Backward Compatibility:
Adding more parameters to `get` method is not backward compatible in case someone overrides the method in a subclass.
so I decided to implement a new method. This is still theoretically a breaking change in case someone has implemented a `getChunck` method in a subclass with a different signature, which is very unlikely.

- The `get` method reuses the new method to avoid duplication of logic.
