### PR TITLE
[9.x] Add support for passing array as the second parameter for the group method.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -369,10 +369,28 @@ class Router implements BindingRegistrar, RegistrarContract
      * Create a route group with shared attributes.
      *
      * @param  array  $attributes
-     * @param  \Closure|string  $routes
+     * @param  \Closure|array|string  $routes
      * @return void
      */
     public function group(array $attributes, $routes)
+    { 
+        if (is_array($routes)) {
+            foreach ($routes as $route) {
+                $this->applyGroup($attributes, $route);
+            }
+        } else {
+            $this->applyGroup($attributes, $routes);
+        }
+    }
+
+    /**
+     * Apply the given group.
+     * 
+     * @param  array  $attributes
+     * @param  \Closure|string  $routes
+     * @return void
+     */
+    protected function applyGroup(array $attributes, $routes)
     {
         $this->updateGroupStack($attributes);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -16,6 +16,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
@@ -374,32 +375,16 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function group(array $attributes, $routes)
     { 
-        if (is_array($routes)) {
-            foreach ($routes as $route) {
-                $this->applyGroup($attributes, $route);
-            }
-        } else {
-            $this->applyGroup($attributes, $routes);
+        foreach (Arr::wrap($routes) as $groupRoutes) {
+            $this->updateGroupStack($attributes);
+
+            // Once we have updated the group stack, we'll load the provided routes and
+            // merge in the group's attributes when the routes are created. After we
+            // have created the routes, we will pop the attributes off the stack.
+            $this->loadRoutes($groupRoutes);
+
+            array_pop($this->groupStack);
         }
-    }
-
-    /**
-     * Apply the given group.
-     * 
-     * @param  array  $attributes
-     * @param  \Closure|string  $routes
-     * @return void
-     */
-    protected function applyGroup(array $attributes, $routes)
-    {
-        $this->updateGroupStack($attributes);
-
-        // Once we have updated the group stack, we'll load the provided routes and
-        // merge in the group's attributes when the routes are created. After we
-        // have created the routes, we will pop the attributes off the stack.
-        $this->loadRoutes($routes);
-
-        array_pop($this->groupStack);
     }
 
     /**


### PR DESCRIPTION
Hi.

**What's this PR for? (example):**
in the `RouteServiceProvider` file:
```php
Route::middleware('web')
   ->namespace($this->namespace)
      ->group(base_path('routes/account/web.php'));

Route::middleware('web')
   ->namespace($this->namespace)
      ->group(base_path('routes/account/staff.php'));
```
can be written as follows
```php
Route::middleware('web')
   ->namespace($this->namespace)
      ->group([
         base_path('routes/account/web.php'),
         base_path('routes/account/staff.php')
       ]);
```
Both of them with the same middleware and namespace in just an array.

**Reasons why this PR won't break other features:**
1. The original `group` method only accepts `\Closure|string` as the second parameter which is `$routes`, so passing an array won't mess around.

    **The original group:**
    ```php
    /**
      * Create a route group with shared attributes.
     *
     * @param  array  $attributes
     * @param  \Closure|string  $routes
     * @return void
     */
    public function group(array $attributes, $routes)
    ```

2. It's only one simple commit, I also tested it on a real/ready project.

I ❤ Laravel