### PR TITLE
[9.x] Fix default pivot attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -76,7 +76,9 @@ trait AsPivot
 
         $instance->timestamps = $instance->hasTimestampAttributes($attributes);
 
-        $instance->setRawAttributes($attributes, $exists);
+        $instance->setRawAttributes(
+            array_merge($instance->getRawOriginal(), $attributes), $exists
+        );
 
         return $instance;
     }

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -137,6 +137,17 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
         $this->assertEquals(['foo1' => 'bar1'], $project->collaborators[0]->pivot->permissions);
         $this->assertEquals(['baz2' => 'bar2'], $project->collaborators[1]->pivot->permissions);
     }
+
+    public function testDefaultAttributesAreRespectedAndCastsAreRespected()
+    {
+        $project = CustomPivotCastTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $pivot = $project->collaborators()->newPivot();
+
+        $this->assertEquals(['permissions' => ['create', 'update']], $pivot->toArray());
+    }
 }
 
 class CustomPivotCastTestUser extends Model
@@ -160,6 +171,10 @@ class CustomPivotCastTestProject extends Model
 
 class CustomPivotCastTestCollaborator extends Pivot
 {
+    protected $attributes = [
+        'permissions' => '["create", "update"]',
+    ];
+
     protected $casts = [
         'permissions' => 'json',
     ];


### PR DESCRIPTION
This PR attempts to fix an issue, when a custom pivot model is being used with default attributes. Related PR: https://github.com/laravel/framework/pull/18127

----

Let's say I have the same pivot setup as the linked PR, but also, my pivot has default attributes:

```php
class UserTeamPivot extends Pivot
{
    protected $attributes = ['permissions' => '["create_campaign"]'];

    protected $casts = ['permissions' => 'json'];
}
```

It works well, when just creating a new instance:

```php
(new UserTeamPivot())->toArray(); // ['permissions' => ['create_campaign']]
```

But fails when creating a new pivot via the relation instance, it just simply overrides the default attributes that are defined in the pivot model's `$attributes` property:

```php
$user->teams()->newPivot()->toArray(); // []
```
----

In my opinion, this is a bug, because if I want the default attributes to be empty, then I won't define them, but if they are defined, then they should be present in a fresh pivot instance.

Casting should be working as before, and I think this is not a BC.
