### PR TITLE
[9.x] Added dropForeignIdFor method to match foreignIdFor method

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -401,6 +401,22 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given foreign key should be dropped.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param  string|null  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropForeignIdFor($model, $column = null)
+    {
+        if (is_string($model)) {
+            $model = new $model;
+        }
+
+        return $this->dropConstrainedForeignId($column ?: $model->getForeignKey());
+    }
+
+    /**
      * Indicate that the given column and foreign key should be dropped.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -401,6 +401,19 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given column and foreign key should be dropped.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropConstrainedForeignId($column)
+    {
+        $this->dropForeign([$column]);
+
+        return $this->dropColumn($column);
+    }
+
+    /**
      * Indicate that the given foreign key should be dropped.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $model
@@ -430,19 +443,6 @@ class Blueprint
         }
 
         return $this->dropConstrainedForeignId($column ?: $model->getForeignKey());
-    }
-
-    /**
-     * Indicate that the given column and foreign key should be dropped.
-     *
-     * @param  string  $column
-     * @return \Illuminate\Support\Fluent
-     */
-    public function dropConstrainedForeignId($column)
-    {
-        $this->dropForeign([$column]);
-
-        return $this->dropColumn($column);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -413,6 +413,22 @@ class Blueprint
             $model = new $model;
         }
 
+        return $this->dropForeign([$column ?: $model->getForeignKey()]);
+    }
+
+    /**
+     * Indicate that the given foreign key should be dropped.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $model
+     * @param  string|null  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropConstrainedForeignIdFor($model, $column = null)
+    {
+        if (is_string($model)) {
+            $model = new $model;
+        }
+
         return $this->dropConstrainedForeignId($column ?: $model->getForeignKey());
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -342,7 +342,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testDropConstrainedRelationshipColumnWithUuidModel()
     {
-        require_once __DIR__ . '/stubs/EloquentModelUuidStub.php';
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
 
         $base = new Blueprint('posts', function ($table) {
             $table->dropConstrainedForeignIdFor('EloquentModelUuidStub');

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -292,6 +292,40 @@ class DatabaseSchemaBlueprintTest extends TestCase
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
+    public function testDropRelationshipColumnWithIncrementalModel()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->dropForeignIdFor('Illuminate\Foundation\Auth\User');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` drop foreign key `posts_user_id_foreign`',
+            'alter table `posts` drop `user_id`',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
+    public function testDropRelationshipColumnWithUuidModel()
+    {
+        require_once __DIR__ . '/stubs/EloquentModelUuidStub.php';
+
+        $base = new Blueprint('posts', function ($table) {
+            $table->dropForeignIdFor('EloquentModelUuidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` drop foreign key `posts_eloquent_model_uuid_stub_id_foreign`',
+            'alter table `posts` drop `eloquent_model_uuid_stub_id`',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
     public function testTinyTextColumn()
     {
         $base = new Blueprint('posts', function ($table) {

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -304,7 +304,6 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals([
             'alter table `posts` drop foreign key `posts_user_id_foreign`',
-            'alter table `posts` drop `user_id`',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 
@@ -314,6 +313,39 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $base = new Blueprint('posts', function ($table) {
             $table->dropForeignIdFor('EloquentModelUuidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` drop foreign key `posts_eloquent_model_uuid_stub_id_foreign`',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
+    public function testDropConstrainedRelationshipColumnWithIncrementalModel()
+    {
+        $base = new Blueprint('posts', function ($table) {
+            $table->dropConstrainedForeignIdFor('Illuminate\Foundation\Auth\User');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` drop foreign key `posts_user_id_foreign`',
+            'alter table `posts` drop `user_id`',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
+    public function testDropConstrainedRelationshipColumnWithUuidModel()
+    {
+        require_once __DIR__ . '/stubs/EloquentModelUuidStub.php';
+
+        $base = new Blueprint('posts', function ($table) {
+            $table->dropConstrainedForeignIdFor('EloquentModelUuidStub');
         });
 
         $connection = m::mock(Connection::class);

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -309,7 +309,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testDropRelationshipColumnWithUuidModel()
     {
-        require_once __DIR__ . '/stubs/EloquentModelUuidStub.php';
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
 
         $base = new Blueprint('posts', function ($table) {
             $table->dropForeignIdFor('EloquentModelUuidStub');


### PR DESCRIPTION
Hi All

So i recently started using these foreignIdFor methods to make my migrations look so much nicer. But i found that the down() method of the migration didn't look as nice

Currently i'm writing

`$table->foreignIdFor(\App\Models\Item::class);`

and then to drop 

`$table->dropForeign('item_id')`

This change introduces 

`$table->dropForeignIdFor(\App\Models\Item::class);`

And also the constrained scenario

`$table->foreignIdFor(\App\Models\Item::class)->constrained();`

This change introduces 

`$table->dropConstrainedForeignIdFor(\App\Models\Item::class);`

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
