### PR TITLE
[8.x] Fix replacing request options

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -319,7 +319,7 @@ class PendingRequest
     public function withHeaders(array $headers)
     {
         return tap($this, function ($request) use ($headers) {
-            return $this->options = array_replace_recursive($this->options, [
+            return $this->options = array_merge_recursive($this->options, [
                 'headers' => $headers,
             ]);
         });
@@ -390,7 +390,7 @@ class PendingRequest
     public function withCookies(array $cookies, string $domain)
     {
         return tap($this, function ($request) use ($cookies, $domain) {
-            return $this->options = array_replace_recursive($this->options, [
+            return $this->options = array_merge_recursive($this->options, [
                 'cookies' => CookieJar::fromArray($cookies, $domain),
             ]);
         });

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -319,7 +319,7 @@ class PendingRequest
     public function withHeaders(array $headers)
     {
         return tap($this, function ($request) use ($headers) {
-            return $this->options = array_merge_recursive($this->options, [
+            return $this->options = array_replace_recursive($this->options, [
                 'headers' => $headers,
             ]);
         });
@@ -390,7 +390,7 @@ class PendingRequest
     public function withCookies(array $cookies, string $domain)
     {
         return tap($this, function ($request) use ($cookies, $domain) {
-            return $this->options = array_merge_recursive($this->options, [
+            return $this->options = array_replace_recursive($this->options, [
                 'cookies' => CookieJar::fromArray($cookies, $domain),
             ]);
         });
@@ -464,7 +464,7 @@ class PendingRequest
     }
 
     /**
-     * Merge new options into the client.
+     * Replace new options into the client.
      *
      * @param  array  $options
      * @return $this
@@ -472,7 +472,7 @@ class PendingRequest
     public function withOptions(array $options)
     {
         return tap($this, function ($request) use ($options) {
-            return $this->options = array_merge_recursive($this->options, $options);
+            return $this->options = array_replace_recursive($this->options, $options);
         });
     }
 
@@ -980,14 +980,14 @@ class PendingRequest
     }
 
     /**
-     * Merge the given options with the current request options.
+     * Replace the given options with the current request options.
      *
      * @param  array  $options
      * @return array
      */
     public function mergeOptions(...$options)
     {
-        return array_merge_recursive($this->options, ...$options);
+        return array_replace_recursive($this->options, ...$options);
     }
 
     /**
@@ -1092,5 +1092,15 @@ class PendingRequest
         );
 
         return $this;
+    }
+
+    /**
+     * Get the pending request options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -464,7 +464,7 @@ class PendingRequest
     }
 
     /**
-     * Replace new options into the client.
+     * Replace the specified options on the request.
      *
      * @param  array  $options
      * @return $this

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -941,6 +941,15 @@ class HttpClientTest extends TestCase
         $this->assertSame($client, $request->buildClient());
     }
 
+    public function testRequestsCanReplaceOptions()
+    {
+        $request = new PendingRequest($this->factory);
+
+        $request = $request->withOptions(['http_errors' => true]);
+
+        $this->assertSame(['http_errors' => true], $request->getOptions());
+    }
+
     public function testMultipleRequestsAreSentInThePool()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -945,9 +945,13 @@ class HttpClientTest extends TestCase
     {
         $request = new PendingRequest($this->factory);
 
-        $request = $request->withOptions(['http_errors' => true]);
+        $request = $request->withOptions(['http_errors' => true, 'connect_timeout' => 10]);
 
-        $this->assertSame(['http_errors' => true], $request->getOptions());
+        $this->assertSame(['http_errors' => true, 'connect_timeout' => 10], $request->getOptions());
+
+        $request = $request->withOptions(['connect_timeout' => 20]);
+
+        $this->assertSame(['http_errors' => true, 'connect_timeout' => 20], $request->getOptions());
     }
 
     public function testMultipleRequestsAreSentInThePool()


### PR DESCRIPTION
This is an attempt at fixing https://github.com/laravel/framework/issues/40952. Right now, when using `array_merge_recursive`, options which already exist will be merged into a new array. See the behavior here: https://3v4l.org/joqh9

It seems to be this is always unwanted as you'd simply want to replace the previous option that was present. I've added a test for the new behavior. As you can see it verifies the originally set option of `http_errors` stays set properly and doesn't gets converted to an array.

This issue was uncovered in Laravel 9 where we now set the default `connect_timeout`. Apps that were overriding this with `withOptions` saw their apps and integrations break because `connect_timeout` was suddenly an array instead of an integer.

I sent this in to 8.x because Laravel 8 also suffers from this. I have to admit that I don't know of any situation where the behavior is wanted but that couldn't mean it's not used. Therefor I'm not 100% if this will break anything. But the current behavior definitely isn't the correct one either.

After merging this this will need to be merged into 9.x as well by merging the 8.x branch into the 9.x branch.

Fixes https://github.com/laravel/framework/issues/40952