### PR TITLE
[9.x] Makes `ExceptionHandler::renderForConsole` internal on contract

### DIFF
--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -41,6 +41,8 @@ interface ExceptionHandler
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  \Throwable  $e
      * @return void
+     *
+     * @internal This method is not meant to be used or overwritten outside the framework.
      */
     public function renderForConsole($output, Throwable $e);
 }


### PR DESCRIPTION
Same as https://github.com/laravel/framework/pull/40936, but also on contract.