### PR TITLE
[8.x] Fix in rule

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -254,7 +254,7 @@ class ValidationRuleParser
             return [$parameter];
         }
 
-        return str_getcsv($parameter, ',', '', '');
+        return str_getcsv($parameter, ',', '', '"');
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -254,7 +254,7 @@ class ValidationRuleParser
             return [$parameter];
         }
 
-        return str_getcsv($parameter);
+        return str_getcsv($parameter, ',', '', '');
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -501,13 +501,6 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertSame('type must be included in Short, Long.', $v->messages()->first('type'));
-        $valueWithTrailingBackslash = 'foo\\';
-        $v = new Validator(
-            $trans,
-            ['type' => $valueWithTrailingBackslash],
-            ['type' => \Illuminate\Validation\Rule::in($valueWithTrailingBackslash)]
-        );
-        $this->assertTrue($v->passes());
 
         // date_equals:tomorrow
         $trans = $this->getIlluminateArrayTranslator();
@@ -2752,6 +2745,14 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['name' => ['foo', []]], ['name' => 'Array|In:foo,bar']);
         $this->assertFalse($v->passes());
+
+        $valueWithTrailingBackslash = 'foo\\';
+        $v = new Validator(
+            $trans,
+            ['name' => $valueWithTrailingBackslash],
+            ['name' => \Illuminate\Validation\Rule::in([$valueWithTrailingBackslash])]
+        );
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateNotIn()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -501,6 +501,13 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertSame('type must be included in Short, Long.', $v->messages()->first('type'));
+        $valueWithTrailingBackslash = 'foo\\';
+        $v = new Validator(
+            $trans,
+            ['type' => $valueWithTrailingBackslash],
+            ['type' => \Illuminate\Validation\Rule::in($valueWithTrailingBackslash)]
+        );
+        $this->assertTrue($v->passes());
 
         // date_equals:tomorrow
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
The In Rule fails, if the value has a trailing backslash.