### PR TITLE
[9.x] Use SentMessage instead of original message in event

### DIFF
--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -34,7 +34,7 @@ class MessageSent
     }
 
     /**
-     * Get the original sent email message.
+     * Get the original email message.
      *
      * @return \Symfony\Component\Mime\Email
      */

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -2,14 +2,14 @@
 
 namespace Illuminate\Mail\Events;
 
-use Symfony\Component\Mime\Email;
+use Illuminate\Mail\SentMessage;
 
 class MessageSent
 {
     /**
-     * The Symfony Email instance.
+     * The Illuminate SentMessage instance.
      *
-     * @var \Symfony\Component\Mime\Email
+     * @var \Illuminate\Mail\SentMessage
      */
     public $message;
 
@@ -23,14 +23,24 @@ class MessageSent
     /**
      * Create a new event instance.
      *
-     * @param  \Symfony\Component\Mime\Email  $message
+     * @param  \Illuminate\Mail\SentMessage  $message
      * @param  array  $data
      * @return void
      */
-    public function __construct(Email $message, array $data = [])
+    public function __construct(SentMessage $message, array $data = [])
     {
         $this->data = $data;
         $this->message = $message;
+    }
+
+    /**
+     * Get the original sent email message.
+     *
+     * @return \Symfony\Component\Mime\Email
+     */
+    public function original()
+    {
+        return $this->message->getOriginalMessage();
     }
 
     /**
@@ -40,7 +50,7 @@ class MessageSent
      */
     public function __serialize()
     {
-        $hasAttachments = collect($this->message->getAttachments())->isNotEmpty();
+        $hasAttachments = collect($this->original()->getAttachments())->isNotEmpty();
 
         return $hasAttachments ? [
             'message' => base64_encode(serialize($this->message)),

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -7,7 +7,7 @@ use Illuminate\Mail\SentMessage;
 class MessageSent
 {
     /**
-     * The Illuminate SentMessage instance.
+     * The sent message instance.
      *
      * @var \Illuminate\Mail\SentMessage
      */

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -29,8 +29,8 @@ class MessageSent
      */
     public function __construct(SentMessage $message, array $data = [])
     {
-        $this->data = $data;
         $this->message = $message;
+        $this->data = $data;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -282,11 +282,15 @@ class Mailer implements MailerContract, MailQueueContract
         $symfonyMessage = $message->getSymfonyMessage();
 
         if ($this->shouldSendMessage($symfonyMessage, $data)) {
-            $sentMessage = $this->sendSymfonyMessage($symfonyMessage);
+            $symfonySentMessage = $this->sendSymfonyMessage($symfonyMessage);
 
-            $this->dispatchSentEvent($message, $data);
+            if ($symfonySentMessage) {
+                $sentMessage = new SentMessage($symfonySentMessage);
 
-            return $sentMessage === null ? null : new SentMessage($sentMessage);
+                $this->dispatchSentEvent($sentMessage, $data);
+
+                return $sentMessage;
+            }
         }
     }
 
@@ -520,7 +524,7 @@ class Mailer implements MailerContract, MailQueueContract
 
     /**
      * Determines if the email can be sent.
-     *
+    *
      * @param  \Symfony\Component\Mime\Email  $message
      * @param  array  $data
      * @return bool
@@ -539,7 +543,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Dispatch the message sent event.
      *
-     * @param  \Illuminate\Mail\Message  $message
+     * @param  \Illuminate\Mail\SentMessage  $message
      * @param  array  $data
      * @return void
      */
@@ -547,7 +551,7 @@ class Mailer implements MailerContract, MailQueueContract
     {
         if ($this->events) {
             $this->events->dispatch(
-                new MessageSent($message->getSymfonyMessage(), $data)
+                new MessageSent($message, $data)
             );
         }
     }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -524,7 +524,7 @@ class Mailer implements MailerContract, MailQueueContract
 
     /**
      * Determines if the email can be sent.
-    *
+     *
      * @param  \Symfony\Component\Mime\Email  $message
      * @param  array  $data
      * @return bool


### PR DESCRIPTION
This PR changes the type of the message on the `MessageSent` event to the Illuminate `SentMessage` class. Instead of placing the original message on the event, we place the actual sent message instance. The original message can still be retrieved with the new `original` method.

This also changes the behavior of sending events to only send events when a message is returned from the transport as that's the only reference we have that the message was sent out properly.