### PR TITLE
[9.x] Sent message alternative

### DIFF
--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -11,7 +11,7 @@ use Illuminate\Mail\SentMessage;
 class MessageSent
 {
     /**
-     * The Illuminate SentMessage instance.
+     * The message that was sent.
      *
      * @var \Illuminate\Mail\SentMessage
      */
@@ -33,8 +33,8 @@ class MessageSent
      */
     public function __construct(SentMessage $message, array $data = [])
     {
-        $this->data = $data;
         $this->sent = $message;
+        $this->data = $data;
     }
 
     /**
@@ -88,6 +88,6 @@ class MessageSent
             return $this->sent->getOriginalMessage();
         }
 
-        throw new Exception('Undefined property on '.__CLASS__.': '.$key);
+        throw new Exception('Unable to access undefined property on '.__CLASS__.': '.$key);
     }
 }

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -2,14 +2,14 @@
 
 namespace Illuminate\Mail\Events;
 
-use Symfony\Component\Mime\Email;
+use Illuminate\Mail\SentMessage;
 
 class MessageSent
 {
     /**
-     * The Symfony Email instance.
+     * The Illuminate SentMessage instance.
      *
-     * @var \Symfony\Component\Mime\Email
+     * @var \Illuminate\Mail\SentMessage
      */
     public $message;
 
@@ -23,14 +23,24 @@ class MessageSent
     /**
      * Create a new event instance.
      *
-     * @param  \Symfony\Component\Mime\Email  $message
+     * @param  \Illuminate\Mail\SentMessage  $message
      * @param  array  $data
      * @return void
      */
-    public function __construct(Email $message, array $data = [])
+    public function __construct(SentMessage $message, array $data = [])
     {
         $this->data = $data;
         $this->message = $message;
+    }
+
+    /**
+     * Get the original sent email message.
+     *
+     * @return \Symfony\Component\Mime\Email
+     */
+    public function original()
+    {
+        return $this->message->getOriginalMessage();
     }
 
     /**
@@ -40,7 +50,7 @@ class MessageSent
      */
     public function __serialize()
     {
-        $hasAttachments = collect($this->message->getAttachments())->isNotEmpty();
+        $hasAttachments = collect($this->original()->getAttachments())->isNotEmpty();
 
         return $hasAttachments ? [
             'message' => base64_encode(serialize($this->message)),

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -44,14 +44,14 @@ class MessageSent
      */
     public function __serialize()
     {
-        $hasAttachments = collect($this->sent->getAttachments())->isNotEmpty();
+        $hasAttachments = collect($this->message->getAttachments())->isNotEmpty();
 
         return $hasAttachments ? [
-            'message' => base64_encode(serialize($this->sent)),
+            'sent' => base64_encode(serialize($this->sent)),
             'data' => base64_encode(serialize($this->data)),
             'hasAttachments' => true,
         ] : [
-            'message' => $this->sent,
+            'sent' => $this->sent,
             'data' => $this->data,
             'hasAttachments' => false,
         ];
@@ -66,10 +66,10 @@ class MessageSent
     public function __unserialize(array $data)
     {
         if (isset($data['hasAttachments']) && $data['hasAttachments'] === true) {
-            $this->sent = unserialize(base64_decode($data['message']));
+            $this->sent = unserialize(base64_decode($data['sent']));
             $this->data = unserialize(base64_decode($data['data']));
         } else {
-            $this->sent = $data['message'];
+            $this->sent = $data['sent'];
             $this->data = $data['data'];
         }
     }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -282,11 +282,15 @@ class Mailer implements MailerContract, MailQueueContract
         $symfonyMessage = $message->getSymfonyMessage();
 
         if ($this->shouldSendMessage($symfonyMessage, $data)) {
-            $sentMessage = $this->sendSymfonyMessage($symfonyMessage);
+            $symfonySentMessage = $this->sendSymfonyMessage($symfonyMessage);
 
-            $this->dispatchSentEvent($message, $data);
+            if ($symfonySentMessage) {
+                $sentMessage = new SentMessage($symfonySentMessage);
 
-            return $sentMessage === null ? null : new SentMessage($sentMessage);
+                $this->dispatchSentEvent($sentMessage, $data);
+
+                return $sentMessage;
+            }
         }
     }
 
@@ -520,7 +524,7 @@ class Mailer implements MailerContract, MailQueueContract
 
     /**
      * Determines if the email can be sent.
-     *
+    *
      * @param  \Symfony\Component\Mime\Email  $message
      * @param  array  $data
      * @return bool
@@ -539,7 +543,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Dispatch the message sent event.
      *
-     * @param  \Illuminate\Mail\Message  $message
+     * @param  \Illuminate\Mail\SentMessage  $message
      * @param  array  $data
      * @return void
      */
@@ -547,7 +551,7 @@ class Mailer implements MailerContract, MailQueueContract
     {
         if ($this->events) {
             $this->events->dispatch(
-                new MessageSent($message->getSymfonyMessage(), $data)
+                new MessageSent($message, $data)
             );
         }
     }

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -524,7 +524,7 @@ class Mailer implements MailerContract, MailQueueContract
 
     /**
      * Determines if the email can be sent.
-    *
+     *
      * @param  \Symfony\Component\Mime\Email  $message
      * @param  array  $data
      * @return bool


### PR DESCRIPTION
Alternative for https://github.com/laravel/framework/pull/40962

We use a dynamic call to preserve BC and keep the event payload to a minimum when serialized.

I'm still not 100% sure on the serialized keys... 