### PR TITLE
[9.x] Add auto discovery controller to API Resource Routes

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -277,6 +277,16 @@ class CompiledRouteCollection extends AbstractRouteCollection
     }
 
     /**
+     * Get the route action by route name.
+     *
+     * @return array
+     */
+    public function getRouteAction($name)
+    {
+        return $this->routes->getRouteAction($name);
+    }
+
+    /**
      * Resolve an array of attributes to a Route instance.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -237,6 +237,16 @@ class RouteCollection extends AbstractRouteCollection
     }
 
     /**
+     * Get the route action by route name.
+     *
+     * @return array
+     */
+    public function getRouteAction($name)
+    {
+        return $this->getByName($name)->action ?? [];
+    }
+
+    /**
      * Convert the collection to a Symfony RouteCollection instance.
      *
      * @return \Symfony\Component\Routing\RouteCollection

--- a/src/Illuminate/Routing/RouteCollectionInterface.php
+++ b/src/Illuminate/Routing/RouteCollectionInterface.php
@@ -95,4 +95,11 @@ interface RouteCollectionInterface
      * @return \Illuminate\Routing\Route[]
      */
     public function getRoutesByName();
+
+    /**
+     * Get the route action by route name.
+     *
+     * @return array
+     */
+    public function getRouteAction($name);
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -353,12 +353,18 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  array  $options
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
-    public function apiResource($name, $controller, array $options = [])
+    public function apiResource($name, $controller = null, array $options = [])
     {
         $only = ['index', 'show', 'store', 'update', 'destroy'];
 
         if (isset($options['except'])) {
             $only = array_diff($only, (array) $options['except']);
+        }
+        
+        if (!$controller) {
+            $group = end($this->groupStack);
+
+            $controller = $group['controller'] ?? null;
         }
 
         return $this->resource($name, $controller, array_merge([

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -361,7 +361,7 @@ class Router implements BindingRegistrar, RegistrarContract
             $only = array_diff($only, (array) $options['except']);
         }
         
-        if (!$controller) {
+        if (! $controller) {
             $group = end($this->groupStack);
 
             $controller = $group['controller'] ?? null;

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -188,6 +188,20 @@ class RouteCollectionTest extends TestCase
         $this->assertSame($routesByName, $this->routeCollection->getRoutesByName());
     }
 
+    public function testRouteCollectionCanGetRouteActionByName()
+    {
+        $routesByName = [
+            'foo_index' => new Route('GET', 'foo/index', [
+                'uses' => 'FooController@index',
+                'as' => 'foo_index',
+            ]),
+        ];
+
+        $this->routeCollection->add($routesByName['foo_index']);
+
+        $this->assertSame($routesByName['foo_index']->action, $this->routeCollection->getRouteAction('foo_index'));
+    }
+
     public function testRouteCollectionCanGetRoutesByMethod()
     {
         $routes = [

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -720,6 +720,22 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.show'));
     }
 
+    public function testUserCanRegisterApiResourceWithGroupController()
+    {
+        $this->router->controller(RouteRegistrarControllerStub::class)->group(function () {
+            $this->router->apiResource('users')->only('index');
+        });
+
+        $this->assertCount(1, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.index'));
+        
+        $this->assertEquals(
+            RouteRegistrarControllerStub::class . '@index',
+            $this->router->getRoutes()->getRouteAction('users.index')['controller']
+        );
+    }
+
     public function testCanNameRoutesOnRegisteredResource()
     {
         $this->router->resource('comments', RouteRegistrarControllerStub::class)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -731,7 +731,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.index'));
         
         $this->assertEquals(
-            RouteRegistrarControllerStub::class . '@index',
+            RouteRegistrarControllerStub::class.'@index',
             $this->router->getRoutes()->getRouteAction('users.index')['controller']
         );
     }


### PR DESCRIPTION
This PR allows users to add the API Resource Routes inside the Controller Route Groups without adding the controller.

E.g.

```php
Route::controller(GoalsController::class)->group(function () {
    Route::apiResource('/goals')->only('index');
});
```

This is usefull when you want to add a different route name for an api resource method, but keeping inside the controller group.

Tests added