### PR TITLE
[8.x] Fix `isRelation()` failing to check an `Attribute`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -499,6 +499,10 @@ trait HasAttributes
      */
     public function isRelation($key)
     {
+        if ($this->hasAttributeMutator($key)) {
+            return false;
+        }
+
         return method_exists($this, $key) ||
             (static::$relationResolvers[get_class($this)][$key] ?? null);
     }

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -281,6 +282,14 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertInstanceOf(EloquentResolverRelationStub::class, $model->customer());
         $this->assertSame(['key' => 'value'], $model->customer);
     }
+
+    public function testIsRelationIgnoresAttribute()
+    {
+        $model = new EloquentRelationAndAtrributeModelStub;
+
+        $this->assertTrue($model->isRelation('parent'));
+        $this->assertFalse($model->isRelation('field'));
+    }
 }
 
 class EloquentRelationResetModelStub extends Model
@@ -349,5 +358,27 @@ class EloquentResolverRelationStub extends EloquentRelationStub
     public function getResults()
     {
         return ['key' => 'value'];
+    }
+}
+
+class EloquentRelationAndAtrributeModelStub extends Model
+{
+    protected $table = 'one_more_table';
+
+    public function field(): Attribute
+    {
+        return new Attribute(
+            function ($value) {
+                return $value;
+            },
+            function ($value) {
+                return $value;
+            },
+        );
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo(self::class);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

If an Eloquent model has a attribute defined using the new Attribute class, `Model@isRelation(...)` returns true when checking for the attribute name,

This PR:

- Adds a `if` clause at `Model@isRelation(...)` to check if a attribute is defined with the same name
- Adds a test that would fail prior to the changes proposed

Note: I am sending this to 8.x as it seems to be a bugfix from the related issue's description.

Closes #40966 