### PR TITLE
[9.x] Adds `whereIn` helpers for querying relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1660,7 +1660,7 @@ class Builder implements BuilderContract
             return $this->callNamedScope($method, $parameters);
         }
 
-        if (in_array($method, ['whereRelation', 'orWhereRelation', 'whereMorphRelation', 'orWhereMorphRelation', 'whereRelationIn', 'orWhereRelationIn', 'whereMorphRelationIn', 'orWhereMorphRelationIn', 'whereRelationNotIn', 'orWhereRelationNotIn'])) {
+        if (in_array($method, ['whereRelation', 'orWhereRelation', 'whereMorphRelation', 'orWhereMorphRelation', 'whereRelationIn', 'orWhereRelationIn', 'whereMorphRelationIn', 'orWhereMorphRelationIn', 'whereRelationNotIn', 'orWhereRelationNotIn', 'whereMorphRelationNotIn', 'orWhereMorphRelationNotIn'])) {
             return match ($method) {
                 'whereRelation' => $this->dynamicWhereRelation(...$parameters),
                 'orWhereRelation' => $this->dynamicWhereRelation(...array_merge($parameters, ['or' => true])),
@@ -1676,6 +1676,9 @@ class Builder implements BuilderContract
 
                 'whereRelationNotIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['not' => true])),
                 'orWhereRelationNotIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['or' => true, 'not' => true])),
+
+                'whereMorphRelationNotIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['not' => true])),
+                'orWhereMorphRelationNotIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['or' => true, 'not' => true])),
             };
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -111,6 +111,21 @@ class Builder implements BuilderContract
         'toSql',
     ];
 
+    protected $dynamicWhereRelations = [
+        'whereRelation',
+        'orWhereRelation',
+        'whereMorphRelation',
+        'orWhereMorphRelation',
+        'whereRelationIn',
+        'orWhereRelationIn',
+        'whereMorphRelationIn',
+        'orWhereMorphRelationIn',
+        'whereRelationNotIn',
+        'orWhereRelationNotIn',
+        'whereMorphRelationNotIn',
+        'orWhereMorphRelationNotIn',
+    ];
+
     /**
      * Applied global scopes.
      *
@@ -1226,6 +1241,29 @@ class Builder implements BuilderContract
         }, $parameters);
     }
 
+    protected function isDynamicWhereRelation($method)
+    {
+        return in_array($method, $this->dynamicWhereRelations);
+    }
+
+    protected function callDynamicWhereRelation($method, $parameters)
+    {
+        return match ($method) {
+            'whereRelation' => $this->dynamicWhereRelation(...$parameters),
+            'orWhereRelation' => $this->dynamicWhereRelation(...array_merge($parameters, ['or' => true])),
+            'whereRelationIn' => $this->dynamicWhereRelationIn(...$parameters),
+            'orWhereRelationIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['or' => true])),
+            'whereRelationNotIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['not' => true])),
+            'orWhereRelationNotIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['or' => true, 'not' => true])),
+            'whereMorphRelation' => $this->dynamicWhereMorphRelation(...$parameters),
+            'orWhereMorphRelation' => $this->dynamicWhereMorphRelation(...array_merge($parameters, ['or' => true])),
+            'whereMorphRelationIn' => $this->dynamicWhereMorphRelationIn(...$parameters),
+            'orWhereMorphRelationIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['or' => true])),
+            'whereMorphRelationNotIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['not' => true])),
+            'orWhereMorphRelationNotIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['or' => true, 'not' => true])),
+        };
+    }
+
     /**
      * Nest where conditions by slicing them at the given where count.
      *
@@ -1660,26 +1698,8 @@ class Builder implements BuilderContract
             return $this->callNamedScope($method, $parameters);
         }
 
-        if (in_array($method, ['whereRelation', 'orWhereRelation', 'whereMorphRelation', 'orWhereMorphRelation', 'whereRelationIn', 'orWhereRelationIn', 'whereMorphRelationIn', 'orWhereMorphRelationIn', 'whereRelationNotIn', 'orWhereRelationNotIn', 'whereMorphRelationNotIn', 'orWhereMorphRelationNotIn'])) {
-            return match ($method) {
-                'whereRelation' => $this->dynamicWhereRelation(...$parameters),
-                'orWhereRelation' => $this->dynamicWhereRelation(...array_merge($parameters, ['or' => true])),
-
-                'whereMorphRelation' => $this->dynamicWhereMorphRelation(...$parameters),
-                'orWhereMorphRelation' => $this->dynamicWhereMorphRelation(...array_merge($parameters, ['or' => true])),
-
-                'whereRelationIn' => $this->dynamicWhereRelationIn(...$parameters),
-                'orWhereRelationIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['or' => true])),
-
-                'whereMorphRelationIn' => $this->dynamicWhereMorphRelationIn(...$parameters),
-                'orWhereMorphRelationIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['or' => true])),
-
-                'whereRelationNotIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['not' => true])),
-                'orWhereRelationNotIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['or' => true, 'not' => true])),
-
-                'whereMorphRelationNotIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['not' => true])),
-                'orWhereMorphRelationNotIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['or' => true, 'not' => true])),
-            };
+        if ($this->isDynamicWhereRelation($method)) {
+            return $this->callDynamicWhereRelation($method, $parameters);
         }
 
         if (in_array($method, $this->passthru)) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -114,14 +114,14 @@ class Builder implements BuilderContract
     protected $dynamicWhereRelations = [
         'whereRelation',
         'orWhereRelation',
-        'whereMorphRelation',
-        'orWhereMorphRelation',
         'whereRelationIn',
         'orWhereRelationIn',
-        'whereMorphRelationIn',
-        'orWhereMorphRelationIn',
         'whereRelationNotIn',
         'orWhereRelationNotIn',
+        'whereMorphRelation',
+        'orWhereMorphRelation',
+        'whereMorphRelationIn',
+        'orWhereMorphRelationIn',
         'whereMorphRelationNotIn',
         'orWhereMorphRelationNotIn',
     ];
@@ -1241,11 +1241,24 @@ class Builder implements BuilderContract
         }, $parameters);
     }
 
+    /**
+     * Determine if method is a dynamic where relation.
+     *
+     * @param  string  $method
+     * @return bool
+     */
     protected function isDynamicWhereRelation($method)
     {
         return in_array($method, $this->dynamicWhereRelations);
     }
 
+    /**
+     * Apply the correct dynamic where relation on the current builder instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
     protected function callDynamicWhereRelation($method, $parameters)
     {
         return match ($method) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1660,14 +1660,22 @@ class Builder implements BuilderContract
             return $this->callNamedScope($method, $parameters);
         }
 
-        if (in_array($method, ['whereRelation', 'orWhereRelation', 'whereMorphRelation', 'orWhereMorphRelation', 'whereRelationIn', 'orWhereRelationIn'])) {
+        if (in_array($method, ['whereRelation', 'orWhereRelation', 'whereMorphRelation', 'orWhereMorphRelation', 'whereRelationIn', 'orWhereRelationIn', 'whereMorphRelationIn', 'orWhereMorphRelationIn', 'whereRelationNotIn', 'orWhereRelationNotIn'])) {
             return match ($method) {
                 'whereRelation' => $this->dynamicWhereRelation(...$parameters),
                 'orWhereRelation' => $this->dynamicWhereRelation(...array_merge($parameters, ['or' => true])),
+
                 'whereMorphRelation' => $this->dynamicWhereMorphRelation(...$parameters),
                 'orWhereMorphRelation' => $this->dynamicWhereMorphRelation(...array_merge($parameters, ['or' => true])),
+
                 'whereRelationIn' => $this->dynamicWhereRelationIn(...$parameters),
                 'orWhereRelationIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['or' => true])),
+
+                'whereMorphRelationIn' => $this->dynamicWhereMorphRelationIn(...$parameters),
+                'orWhereMorphRelationIn' => $this->dynamicWhereMorphRelationIn(...array_merge($parameters, ['or' => true])),
+
+                'whereRelationNotIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['not' => true])),
+                'orWhereRelationNotIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['or' => true, 'not' => true])),
             };
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1660,6 +1660,17 @@ class Builder implements BuilderContract
             return $this->callNamedScope($method, $parameters);
         }
 
+        if (in_array($method, ['whereRelation', 'orWhereRelation', 'whereMorphRelation', 'orWhereMorphRelation', 'whereRelationIn', 'orWhereRelationIn'])) {
+            return match ($method) {
+                'whereRelation' => $this->dynamicWhereRelation(...$parameters),
+                'orWhereRelation' => $this->dynamicWhereRelation(...array_merge($parameters, ['or' => true])),
+                'whereMorphRelation' => $this->dynamicWhereMorphRelation(...$parameters),
+                'orWhereMorphRelation' => $this->dynamicWhereMorphRelation(...array_merge($parameters, ['or' => true])),
+                'whereRelationIn' => $this->dynamicWhereRelationIn(...$parameters),
+                'orWhereRelationIn' => $this->dynamicWhereRelationIn(...array_merge($parameters, ['or' => true])),
+            };
+        }
+
         if (in_array($method, $this->passthru)) {
             return $this->toBase()->{$method}(...$parameters);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -352,39 +352,44 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a basic where clause to a relationship query.
+     * Add a basic where or an "or where" clause to a relationship query.
      *
      * @param  string  $relation
      * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
+     * @param  bool  $or
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereRelation($relation, $column, $operator = null, $value = null)
+    public function dynamicWhereRelation($relation, $column, $operator = null, $value = null, $or = false)
     {
-        return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
+        $method = $or ? 'orWhereHas' : 'whereHas';
+
+        return $this->$method($relation, function ($query) use ($column, $operator, $value) {
             $query->where($column, $operator, $value);
         });
     }
 
     /**
-     * Add an "or where" clause to a relationship query.
+     * Add a basic "where in" or an "or where in " clause to a relationship query.
      *
      * @param  string  $relation
      * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  mixed  $values
+     * @param  bool  $or
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function orWhereRelation($relation, $column, $operator = null, $value = null)
+    public function dynamicWhereRelationIn($relation, $column, $values, $or = false)
     {
-        return $this->orWhereHas($relation, function ($query) use ($column, $operator, $value) {
-            $query->where($column, $operator, $value);
+        $method = $or ? 'orWhereHas' : 'whereHas';
+
+        return $this->$method($relation, function ($query) use ($column, $values) {
+            $query->whereIn($column, $values);
         });
     }
 
     /**
-     * Add a polymorphic relationship condition to the query with a where clause.
+     * Add a polymorphic relationship condition to the query with a where or an "or where" clause.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
      * @param  string|array  $types
@@ -393,27 +398,12 @@ trait QueriesRelationships
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereMorphRelation($relation, $types, $column, $operator = null, $value = null)
+    public function dynamicWhereMorphRelation($relation, $types, $column, $operator = null, $value = null, $or = false, $in = false)
     {
-        return $this->whereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
-            $query->where($column, $operator, $value);
-        });
-    }
+        $method = $or ? 'orWhereHasMorph' : 'whereHasMorph';
 
-    /**
-     * Add a polymorphic relationship condition to the query with an "or where" clause.
-     *
-     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
-     * @param  string|array  $types
-     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Builder|static
-     */
-    public function orWhereMorphRelation($relation, $types, $column, $operator = null, $value = null)
-    {
-        return $this->orWhereHasMorph($relation, $types, function ($query) use ($column, $operator, $value) {
-            $query->where($column, $operator, $value);
+        return $this->$method($relation, $types, function ($query) use ($column, $operator, $value, $in) {
+            $in ? $query->whereIn($column, $value) : $query->where($column, $operator, $value);
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -385,9 +385,7 @@ trait QueriesRelationships
         $method = $or ? 'orWhereHas' : 'whereHas';
 
         return $this->$method($relation, function ($query) use ($column, $values, $not) {
-            $method = $not ? 'whereNotIn' : 'whereIn';
-
-            $query->$method($column, $values);
+            $query->whereIn($column, $values, not:$not);
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -371,20 +371,23 @@ trait QueriesRelationships
     }
 
     /**
-     * Add a basic "where in" or an "or where in " clause to a relationship query.
+     * Add a basic "where in" or an "or where in" clause to a relationship query.
      *
      * @param  string  $relation
      * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $values
      * @param  bool  $or
+     * @param  bool  $not
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function dynamicWhereRelationIn($relation, $column, $values, $or = false)
+    public function dynamicWhereRelationIn($relation, $column, $values, $or = false, $not = false)
     {
         $method = $or ? 'orWhereHas' : 'whereHas';
 
-        return $this->$method($relation, function ($query) use ($column, $values) {
-            $query->whereIn($column, $values);
+        return $this->$method($relation, function ($query) use ($column, $values, $not) {
+            $method = $not ? 'whereNotIn' : 'whereIn';
+
+            $query->$method($column, $values);
         });
     }
 
@@ -398,12 +401,34 @@ trait QueriesRelationships
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function dynamicWhereMorphRelation($relation, $types, $column, $operator = null, $value = null, $or = false, $in = false)
+    public function dynamicWhereMorphRelation($relation, $types, $column, $operator = null, $value = null, $or = false)
     {
         $method = $or ? 'orWhereHasMorph' : 'whereHasMorph';
 
-        return $this->$method($relation, $types, function ($query) use ($column, $operator, $value, $in) {
-            $in ? $query->whereIn($column, $value) : $query->where($column, $operator, $value);
+        return $this->$method($relation, $types, function ($query) use ($column, $operator, $value) {
+            $query->where($column, $operator, $value);
+        });
+    }
+
+    /**
+     * Add a polymorphic relationship condition to the query with a where or an "or where" clause.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $values
+     * @param  bool  $or
+     * @param  bool  $not
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function dynamicWhereMorphRelationIn($relation, $types, $column, $values, $or = false, $not = false)
+    {
+        $method = $or ? 'orWhereHasMorph' : 'whereHasMorph';
+
+        return $this->$method($relation, $types, function ($query) use ($column, $values, $not) {
+            $method = $not ? 'whereNotIn' : 'whereIn';
+
+            $query->$method($column, $values);
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -385,7 +385,7 @@ trait QueriesRelationships
         $method = $or ? 'orWhereHas' : 'whereHas';
 
         return $this->$method($relation, function ($query) use ($column, $values, $not) {
-            $query->whereIn($column, $values, not:$not);
+            $query->whereIn($column, $values, not: $not);
         });
     }
 
@@ -424,9 +424,7 @@ trait QueriesRelationships
         $method = $or ? 'orWhereHasMorph' : 'whereHasMorph';
 
         return $this->$method($relation, $types, function ($query) use ($column, $values, $not) {
-            $method = $not ? 'whereNotIn' : 'whereIn';
-
-            $query->$method($column, $values);
+            $query->whereIn($column, $values, not: $not);
         });
     }
 

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -139,9 +139,23 @@ class EloquentWhereHasTest extends DatabaseTestCase
 
     public function testOrWhereMorphRelationIn()
     {
-        $comments = Comment::whereMorphRelation('commentable', Text::class, 'content', '')->orWhereMorphRelationIn('commentable', '*', 'public', [true])->get();
+        $comments = Comment::whereMorphRelation('commentable', '*', 'public', true)->orWhereMorphRelationIn('commentable', '*', 'public', [false])->get();
+
+        $this->assertEquals([1, 2], $comments->pluck('id')->all());
+    }
+
+    public function testWhereMorphRelationNotIn()
+    {
+        $comments = Comment::whereMorphRelationNotIn('commentable', '*', 'public', [false])->get();
 
         $this->assertEquals([1], $comments->pluck('id')->all());
+    }
+
+    public function testOrWhereMorphRelationNotIn()
+    {
+        $comments = Comment::whereMorphRelation('commentable', '*', 'public', true)->orWhereMorphRelationNotIn('commentable', '*', 'public', [true])->get();
+
+        $this->assertEquals([1, 2], $comments->pluck('id')->all());
     }
 
     public function testWithCount()

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -72,6 +72,20 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
+    public function testWhereRelationNotIn()
+    {
+        $users = User::whereRelationNotIn('posts', 'id', [42])->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
+    public function testOrWhereRelationNotIn()
+    {
+        $users = User::whereRelationIn('posts', 'id', [1])->orWhereRelationNotIn('posts', 'id', [42])->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
     public function testNestedWhereRelationIn()
     {
         $users = User::whereRelationIn('posts.texts', 'content', ['test', 'something'])->get();
@@ -114,6 +128,20 @@ class EloquentWhereHasTest extends DatabaseTestCase
             ->get();
 
         $this->assertEquals([1, 2], $comments->pluck('id')->all());
+    }
+
+    public function testWhereMorphRelationIn()
+    {
+        $comments = Comment::whereMorphRelationIn('commentable', '*', 'public', [true])->get();
+
+        $this->assertEquals([1], $comments->pluck('id')->all());
+    }
+
+    public function testOrWhereMorphRelationIn()
+    {
+        $comments = Comment::whereMorphRelation('commentable', Text::class, 'content', '')->orWhereMorphRelationIn('commentable', '*', 'public', [true])->get();
+
+        $this->assertEquals([1], $comments->pluck('id')->all());
     }
 
     public function testWithCount()

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -86,6 +86,20 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
+    public function testNestedWhereRelation()
+    {
+        $texts = User::whereRelation('posts.texts', 'content', 'test')->get();
+
+        $this->assertEquals([1], $texts->pluck('id')->all());
+    }
+
+    public function testNestedOrWhereRelation()
+    {
+        $texts = User::whereRelation('posts.texts', 'content', 'test')->orWhereRelation('posts.texts', 'content', 'test2')->get();
+
+        $this->assertEquals([1, 2], $texts->pluck('id')->all());
+    }
+
     public function testNestedWhereRelationIn()
     {
         $users = User::whereRelationIn('posts.texts', 'content', ['test', 'something'])->get();
@@ -100,18 +114,18 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
-    public function testNestedWhereRelation()
+    public function testNestedWhereRelationNotIn()
     {
-        $texts = User::whereRelation('posts.texts', 'content', 'test')->get();
+        $users = User::whereRelationNotIn('posts.texts', 'content', ['something'])->get();
 
-        $this->assertEquals([1], $texts->pluck('id')->all());
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
-    public function testNestedOrWhereRelation()
+    public function testNestedOrWhereRelationNotIn()
     {
-        $texts = User::whereRelation('posts.texts', 'content', 'test')->orWhereRelation('posts.texts', 'content', 'test2')->get();
+        $users = User::whereRelationIn('posts.texts', 'content', ['test', 'something'])->orWhereRelationNotIn('posts.texts', 'content', ['something'])->get();
 
-        $this->assertEquals([1, 2], $texts->pluck('id')->all());
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
     public function testWhereMorphRelation()

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -58,6 +58,34 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
+    public function testWhereRelationIn()
+    {
+        $users = User::whereRelationIn('posts', 'id', [1])->get();
+
+        $this->assertEquals([1], $users->pluck('id')->all());
+    }
+
+    public function testOrWhereRelationIn()
+    {
+        $users = User::whereRelationIn('posts', 'id', [1])->orWhereRelationIn('posts', 'id', [2])->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
+    public function testNestedWhereRelationIn()
+    {
+        $users = User::whereRelationIn('posts.texts', 'content', ['test', 'something'])->get();
+
+        $this->assertEquals([1], $users->pluck('id')->all());
+    }
+
+    public function testNestedOrWhereRelationIn()
+    {
+        $users = User::whereRelationIn('posts.texts', 'content', ['test', 'something'])->orWhereRelationIn('posts.texts', 'content', ['test2', 'something'])->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
     public function testNestedWhereRelation()
     {
         $texts = User::whereRelation('posts.texts', 'content', 'test')->get();


### PR DESCRIPTION
Adds additional `whereIn` helpers for simplified relation querying.

Example:
```php
// Before
User::whereHas('posts', function ($query) {
    $query->whereIn('status', ['live', 'draft']);
})->get();

// After
User::whereRelationIn('posts', 'status', ['live', 'draft'])->get();
```

Helpers Added:
```php
Model::whereRelationIn();
Model::orWhereRelationIn();

Model::whereRelationNotIn();
Model::orWhereRelationNotIn();

Model::whereMorphRelationIn();
Model::orWhereMorphRelationIn();

Model::whereMorphRelationNotIn();
Model::orWhereMorphRelationNotIn();
```

Rather than creating additional helper methods, which would have been a large amount of redundant code, the existing methods were refactored to consolidate the implementation of simplified relation querying.

Although methods have been removed, there are no breaking changes to affordances or backwards compatibility as they have been re-implemented via dynamic magic methods.

Contributors: @Orrison @jrseliga