### PR TITLE
[9.x] Add filtering of route:list by domain

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -212,9 +212,10 @@ class RouteListCommand extends Command
      */
     protected function filterRoute(array $route)
     {
-        if (($this->option('name') && ! str_contains($route['name'], $this->option('name'))) ||
-            $this->option('path') && ! str_contains($route['uri'], $this->option('path')) ||
-            $this->option('method') && ! str_contains($route['method'], strtoupper($this->option('method')))) {
+        if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
+            ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
+            ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
+            ($this->option('domain') && ! Str::contains($route['domain'], $this->option('domain')))) {
             return;
         }
 
@@ -418,6 +419,7 @@ class RouteListCommand extends Command
             ['json', null, InputOption::VALUE_NONE, 'Output the route list as JSON'],
             ['method', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by method'],
             ['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name'],
+            ['domain', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by domain'],
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],


### PR DESCRIPTION
Further to the discussion in #40815, I have broken out the domain filtering part. It's a very simple addition that lets you filter the route list by domain, much as you can for paths:

    php artisan route:list --domain=example.com

The only other change is a minor cleanup to make all the filtering options use the same syntax (without any functional changes), as it was inconsistent and potentially ambiguous, causing it to be flagged by static analysis tools.