### PR TITLE
[9.x] Added the ability to use the uniqueFor method for Jobs

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -36,13 +36,17 @@ class UniqueLock
                     ? $job->uniqueId()
                     : ($job->uniqueId ?? '');
 
+        $uniqueFor = method_exists($job, 'uniqueFor')
+                    ? $job->uniqueFor()
+                    : ($job->uniqueFor ?? 0);
+
         $cache = method_exists($job, 'uniqueVia')
                     ? $job->uniqueVia()
                     : $this->cache;
 
         return (bool) $cache->lock(
             $key = 'laravel_unique_job:'.get_class($job).$uniqueId,
-            $job->uniqueFor ?? 0
+            $uniqueFor
         )->get();
     }
 }


### PR DESCRIPTION
Currently, you can specify the duration of the job uniqueness check either by explicitly specifying the value in the variable, or by creating your own method, for example:

```php
public function __constructor()
{
    $this->uniqueFor = $this->uniqueFor();
}

protected function uniqueFor()
{
    return now()->diffInRealSeconds($this->delay);
}
```

In my case, the job is created with a delayed start and there is a need to check the uniqueness during this time.

This means that you need to dynamically calculate the duration.

By adding the ability to use the "uniqueFor" method like the "uniqueId" method, we reduce the amount of code:

```php
protected function uniqueFor()
{
    return now()->diffInRealSeconds($this->delay);
}
```

This will allow more flexible control over the uniqueness time.