### PR TITLE
[9.x] Add `assertClientError` to `TestResponse`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -126,6 +126,21 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has a client error status code.
+     *
+     * @return $this
+     */
+    public function assertClientError()
+    {
+        PHPUnit::assertTrue(
+            $this->isClientError(),
+            $this->statusMessageWithDetails('>=400, <500', $this->getStatusCode())
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has a not found status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -488,6 +488,22 @@ class TestResponseTest extends TestCase
         $response->assertUnprocessable();
     }
 
+    public function testAssertClientError()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Expected response status code');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertClientError();
+    }
+
     public function testAssertNoContentAsserts204StatusCodeByDefault()
     {
         $statusCode = 500;


### PR DESCRIPTION
I have added support for asserting that a test response has a client side error status code (>= 400, <500). Similar to how `assertSuccessful` uses the Symfony response class' `isSuccessful`, this assertion uses `isClientError`.

This allows for asserting that responses are caused by a client error, not necessarily needing to test which specific status code it has returned.

```php
$response->assertClientError();
```