### PR TITLE
[9.x] Add test for CacheManager

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -328,7 +328,7 @@ class CacheManager implements FactoryContract
      * Get the cache connection configuration.
      *
      * @param  string  $name
-     * @return array
+     * @return array|null
      */
     protected function getConfig($name)
     {


### PR DESCRIPTION
It adds tests to cover "unknown driver" and  "unknown store" behaviors.

**Why Docblock is modified?**
Since the `config` implements the `ArrayAccess` and may return `null` in case of a missing key, this method can also return `null` alongside arrays.

