### PR TITLE
[9.x] Adds `expectsOutputToContain` to the `PendingCommand`.

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -23,6 +23,13 @@ trait InteractsWithConsole
     public $expectedOutput = [];
 
     /**
+     * All of the expected text to be present on the output.
+     *
+     * @var array
+     */
+    public $expectedOutputToContain = [];
+
+    /**
      * All of the output lines that aren't expected to be displayed.
      *
      * @var array

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -27,7 +27,7 @@ trait InteractsWithConsole
      *
      * @var array
      */
-    public $expectedOutputToContain = [];
+    public $expectedOutputSubstrings = [];
 
     /**
      * All of the output lines that aren't expected to be displayed.

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -155,6 +155,19 @@ class PendingCommand
     }
 
     /**
+     * Specifies that a given text is present when the command runs.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    public function expectsOutputToContain($text)
+    {
+        $this->test->expectedOutputToContain[] = $text;
+
+        return $this;
+    }
+
+    /**
      * Specify a table that should be printed when the command runs.
      *
      * @param  array  $headers
@@ -311,6 +324,10 @@ class PendingCommand
             $this->test->fail('Output "'.Arr::first($this->test->expectedOutput).'" was not printed.');
         }
 
+        if (count($this->test->expectedOutputToContain)) {
+            $this->test->fail('Output does not contain "'.Arr::first($this->test->expectedOutputToContain).'".');
+        }
+
         if ($output = array_search(true, $this->test->unexpectedOutput)) {
             $this->test->fail('Output "'.$output.'" was printed.');
         }
@@ -373,6 +390,14 @@ class PendingCommand
                 });
         }
 
+        foreach ($this->test->expectedOutputToContain as $i => $text) {
+            $mock->shouldReceive('doWrite')
+                ->withArgs(fn ($output) => str_contains($output, $text))
+                ->andReturnUsing(function () use ($i) {
+                    unset($this->test->expectedOutputToContain[$i]);
+                });
+        }
+
         foreach ($this->test->unexpectedOutput as $output => $displayed) {
             $mock->shouldReceive('doWrite')
                 ->ordered()
@@ -393,6 +418,7 @@ class PendingCommand
     protected function flushExpectations()
     {
         $this->test->expectedOutput = [];
+        $this->test->expectedOutputToContain = [];
         $this->test->unexpectedOutput = [];
         $this->test->expectedTables = [];
         $this->test->expectedQuestions = [];

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -155,14 +155,14 @@ class PendingCommand
     }
 
     /**
-     * Specifies that a given text is present when the command runs.
+     * Specify that the given string should be contained in the command output.
      *
-     * @param  string  $text
+     * @param  string  $string
      * @return $this
      */
-    public function expectsOutputToContain($text)
+    public function expectsOutputToContain($string)
     {
-        $this->test->expectedOutputToContain[] = $text;
+        $this->test->expectedOutputSubstrings[] = $string;
 
         return $this;
     }
@@ -324,8 +324,8 @@ class PendingCommand
             $this->test->fail('Output "'.Arr::first($this->test->expectedOutput).'" was not printed.');
         }
 
-        if (count($this->test->expectedOutputToContain)) {
-            $this->test->fail('Output does not contain "'.Arr::first($this->test->expectedOutputToContain).'".');
+        if (count($this->test->expectedOutputSubstrings)) {
+            $this->test->fail('Output does not contain "'.Arr::first($this->test->expectedOutputSubstrings).'".');
         }
 
         if ($output = array_search(true, $this->test->unexpectedOutput)) {
@@ -390,11 +390,11 @@ class PendingCommand
                 });
         }
 
-        foreach ($this->test->expectedOutputToContain as $i => $text) {
+        foreach ($this->test->expectedOutputSubstrings as $i => $text) {
             $mock->shouldReceive('doWrite')
                 ->withArgs(fn ($output) => str_contains($output, $text))
                 ->andReturnUsing(function () use ($i) {
-                    unset($this->test->expectedOutputToContain[$i]);
+                    unset($this->test->expectedOutputSubstrings[$i]);
                 });
         }
 
@@ -418,7 +418,7 @@ class PendingCommand
     protected function flushExpectations()
     {
         $this->test->expectedOutput = [];
-        $this->test->expectedOutputToContain = [];
+        $this->test->expectedOutputSubstrings = [];
         $this->test->unexpectedOutput = [];
         $this->test->expectedTables = [];
         $this->test->expectedQuestions = [];

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -32,6 +32,10 @@ class ArtisanCommandTest extends TestCase
             $this->line($this->ask('What?'));
             $this->line($this->ask('Huh?'));
         });
+
+        Artisan::command('contains', function () {
+            $this->line('My name is Taylor Otwell');
+        });
     }
 
     public function test_console_command_that_passes()
@@ -106,6 +110,25 @@ class ArtisanCommandTest extends TestCase
                  ->expectsOutput('Taylor')
                  ->expectsOutput('Otwell')
                  ->expectsOutput('Danger')
+                 ->assertExitCode(0);
+        });
+    }
+
+    public function test_console_command_that_passes_if_the_output_contains()
+    {
+        $this->artisan('contains')
+             ->expectsOutputToContain('Taylor Otwell')
+             ->assertExitCode(0);
+    }
+
+    public function test_console_command_that_fails_if_the_output_does_not_contain()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Output does not contain "Otwell Taylor".');
+
+        $this->ignoringMockOnceExceptions(function () {
+            $this->artisan('contains')
+                 ->expectsOutputToContain('Otwell Taylor')
                  ->assertExitCode(0);
         });
     }


### PR DESCRIPTION
Hey guys,

This PR adds a method to the `PendingCommand` to be used for testing.

The main reason is to test if the output contains a text, I found this really helpful, to use for the CLI output, its like the `assertSee` method from the `Http` response.

## Example

```php

$this->artisan('Hello World')
      ->expectsOutputToContain('Hello');
```

Hope that helps,

Thanks,
Francisco.