### PR TITLE
[9.x] logoutOtherDevices for Sanctum SPA Authentication

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSanctumSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSanctumSession.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Session\Middleware;
+
+use Closure;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+
+class AuthenticateSanctumSession
+{
+    /**
+     * The sanctum driver.
+     *
+     * @var string
+     */
+    protected $driver = 'sanctum';
+
+    /**
+     * The authentication factory implementation.
+     *
+     * @var \Illuminate\Contracts\Auth\Factory
+     */
+    protected $auth;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Factory  $auth
+     * @return void
+     */
+    public function __construct(AuthFactory $auth)
+    {
+        $this->auth = $auth;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (! $request->hasSession() || ! $request->user()) {
+            return $next($request);
+        }
+
+        if ($this->guard()->viaRemember()) {
+            $passwordHash = explode('|', $request->cookies->get($this->auth->getRecallerName()))[2] ?? null;
+
+            if (! $passwordHash || $passwordHash != $request->user()->getAuthPassword()) {
+                $this->logout($request);
+            }
+        }
+
+        if (! $request->session()->has('password_hash_'.$this->driver)) {
+            $this->storePasswordHashInSession($request);
+        }
+
+        if ($request->session()->get('password_hash_'.$this->driver) !== $request->user()->getAuthPassword()) {
+            $this->logout($request);
+        }
+
+        return tap($next($request), function () use ($request) {
+            if (! is_null($this->guard()->user())) {
+                $this->storePasswordHashInSession($request);
+            }
+        });
+    }
+
+    /**
+     * Store the user's current password hash in the session.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function storePasswordHashInSession($request)
+    {
+        if (! $request->user()) {
+            return;
+        }
+
+        $request->session()->put([
+            'password_hash_'.$this->driver => $request->user()->getAuthPassword(),
+        ]);
+    }
+
+    /**
+     * Log the user out of the application.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    protected function logout($request)
+    {
+        $this->guard()->logoutCurrentDevice();
+
+        $request->session()->flush();
+
+        throw new AuthenticationException('Unauthenticated.', [$this->driver]);
+    }
+
+    /**
+     * Get the guard instance that should be used by the middleware.
+     *
+     * @return \Illuminate\Contracts\Auth\Factory|\Illuminate\Contracts\Auth\Guard
+     */
+    protected function guard()
+    {
+        return $this->auth;
+    }
+}


### PR DESCRIPTION
I guess the feature I want to add here is to allow `Auth::logoutOtherDevices($password)` to be used on Sanctum's SPA Authentication since it looks like this feature is not available (unless you use Sanctum tokens).

After searching online I came to [this youtube video.](https://www.youtube.com/watch?v=iwq5YrNND0k&t=686s) To summarize:
1.  Create a new middleware (ie. AuthenticateSanctumSession.php)
2.  Copy everything in AuthenticateSession.php middleware and paste in new middleware
3.  Create a variable for sanctum driver `protected $driver = 'sanctum';`
4.  Replace all instance of `$this->auth->getDefaultDriver()` with `$this->driver`, basically the sanctum driver is hardcoded.

And that's it, the features of AuthenticateSession is now available for Sanctum SPA Authentication. 

I would like to hear other people's opinion **especially** if there is a right way of doing this since I basically just copy-pasted the AuthenticateSession middleware... The main goal is just to allow the use of logoutOtherDevices... I also tried to just directly use the AuthenticateSession in api middleware and it doesn't work..