### PR TITLE
[9.x] Use array_key_first

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -141,9 +141,7 @@ class EloquentUserProvider implements UserProvider
      */
     protected function firstCredentialKey(array $credentials)
     {
-        foreach ($credentials as $key => $value) {
-            return $key;
-        }
+        return array_key_first($credentials);
     }
 
     /**


### PR DESCRIPTION
Since PHP 7.3 there is a native function for retreiving the first key of the given array: https://www.php.net/manual/en/function.array-key-first.php

So a small refactoring can be done here. The behavior is exactly the same, actually the polyfill for this function is the current implementation.

Related PRs: #35147 and #32550. 

I don't think this has any feelable affect on the performance in real Laravel applications, as it was discussed. My point of view is just, why not to use native stuff where we can.