### PR TITLE
[9.x] Implement Responsable on query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1562,7 +1562,7 @@ class Builder implements BuilderContract, Responsable
     }
 
     /**
-     * Return the results of the query as a response
+     * Return the results of the query as a response.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Database\Eloquent\Collection|static[]

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -7,6 +7,7 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Concerns\QueriesRelationships;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -25,7 +26,7 @@ use ReflectionMethod;
  *
  * @mixin \Illuminate\Database\Query\Builder
  */
-class Builder implements BuilderContract
+class Builder implements BuilderContract, Responsable
 {
     use BuildsQueries, ForwardsCalls, QueriesRelationships {
         BuildsQueries::sole as baseSole;
@@ -1558,6 +1559,17 @@ class Builder implements BuilderContract
     public function qualifyColumns($columns)
     {
         return $this->model->qualifyColumns($columns);
+    }
+
+    /**
+     * Return the results of the query as a response
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
+    public function toResponse($request)
+    {
+        return $this->get();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3588,7 +3588,7 @@ class Builder implements BuilderContract, Responsable
     }
 
     /**
-     * Return the results of the query as a response
+     * Return the results of the query as a response.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Database\Eloquent\Collection|static[]

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -8,6 +8,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
@@ -26,7 +27,7 @@ use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 
-class Builder implements BuilderContract
+class Builder implements BuilderContract, Responsable
 {
     use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;
@@ -3584,6 +3585,17 @@ class Builder implements BuilderContract
     public function dd()
     {
         dd($this->toSql(), $this->getBindings());
+    }
+
+    /**
+     * Return the results of the query as a response
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
+    public function toResponse($request)
+    {
+        return $this->get();
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request implements the `Responsable` interface on the Query Builder.

**Before:**

```php
Route::get('/users', function () {
    return User::where('id', '>', 7)->get();
});
```

**After:**

```php
Route::get('/users', function () {
    return User::where('id', '>', 7);
});
```

This allows the user to return a query builder object as a response directly, which automatically calls `->get()`.

### Why?

This is one of the small paper-cuts I've found in the framework that hinders the developer experience, and potentially confuses new developers with this error:

> Symfony\Component\HttpFoundation\Response::setContent(): Argument #1 ($content) must be of type ?string, Illuminate\Database\Eloquent\Builder given, called in [...]

Additionally, a [relevant question on Stack Overflow](https://stackoverflow.com/q/64094886/2544756) has been viewed over 22 thousand times.

### Tests

I have started work on the tests for this feature, but may need help from someone in the community, as the framework is quite complex and I'm not sure exactly how to test this interaction between the query builder and router.

### Why 9.x?

This feature does not break existing behavior. This functionality is additive.
