### PR TITLE
[9.x] Add new `ConvertStringBooleansToBoolean` middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/ConvertStringBooleansToBoolean.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertStringBooleansToBoolean.php
@@ -40,7 +40,7 @@ class ConvertStringBooleansToBoolean extends TransformsRequest
      */
     protected function transform($key, $value)
     {
-        return match($value) {
+        return match ($value) {
             'true' => true,
             'false' => false,
             default => $value

--- a/src/Illuminate/Foundation/Http/Middleware/ConvertStringBooleansToBoolean.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertStringBooleansToBoolean.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+
+class ConvertStringBooleansToBoolean extends TransformsRequest
+{
+    /**
+     * All of the registered skip callbacks.
+     *
+     * @var array
+     */
+    protected static $skipCallbacks = [];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach (static::$skipCallbacks as $callback) {
+            if ($callback($request)) {
+                return $next($request);
+            }
+        }
+
+        return parent::handle($request, $next);
+    }
+
+    /**
+     * Transform the given value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function transform($key, $value)
+    {
+        return match($value) {
+            'true' => true,
+            'false' => false,
+            default => $value
+        };
+    }
+
+    /**
+     * Register a callback that instructs the middleware to be skipped.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function skipWhen(Closure $callback)
+    {
+        static::$skipCallbacks[] = $callback;
+    }
+}

--- a/tests/Foundation/Http/Middleware/ConvertStringBooleansToBooleanTest.php
+++ b/tests/Foundation/Http/Middleware/ConvertStringBooleansToBooleanTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\ConvertStringBooleansToBoolean;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+class ConvertStringBooleansToBooleanTest extends TestCase
+{
+    public function testConvertsStringBooleansToTrueBooleans()
+    {
+        $middleware = new ConvertStringBooleansToBoolean;
+        $symfonyRequest = new SymfonyRequest([
+            'foo' => 'value',
+            'bar' => 1,
+            'baz' => 'true',
+            'qux' => 'false',
+        ]);
+        $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertSame('value', $request->get('foo'));
+            $this->assertSame(1, $request->get('bar'));
+            $this->assertTrue($request->get('baz'));
+            $this->assertFalse($request->get('qux'));
+        });
+    }
+}


### PR DESCRIPTION
## What

This PR adds a new `ConvertStringBooleansToBoolean` middleware to the frameworks. This middleware converts string-like booleans `"true"` or `"false"` into their true `boolean` type.

Upon acceptance, and merge, of this PR I would want to add a follow up PR to `laravel/laravel` to include this new middleware as part of the default stack - like `ConvertEmptyStringsToNull`.

## Why

In my recent Laravel adventures I was building a filtering system to a GET endpoint and sending these filters via a query string. I found that when validating these inputs that `booleans` were treated as strings, this prevented me from using the 'boolean' validation rule.

e.g; `/invoices?approved=true`

```php
// ...
public function rules()
{
    return [
        'approved' => ['boolean'],
    ];
}
// ...
```

The above pseudo-code  would result in a validation error being thrown as within the request object `'approved' => 'true'`. 

This new middleware resolves what I believe to be a developer inconvenience and normalises expectations when passing booleans in a query string.