### PR TITLE
[8.x] Fix enum casts arrayable behaviour

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -296,7 +296,7 @@ trait HasAttributes
                 $attributes[$key] = $this->serializeClassCastableAttribute($key, $attributes[$key]);
             }
 
-            if ($this->isEnumCastable($key)) {
+            if ($this->isEnumCastable($key) && (! ($attributes[$key] ?? null) instanceof Arrayable)) {
                 $attributes[$key] = isset($attributes[$key]) ? $attributes[$key]->value : null;
             }
 

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -22,6 +22,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             $table->increments('id');
             $table->string('string_status', 100)->nullable();
             $table->integer('integer_status')->nullable();
+            $table->string('arrayable_status')->nullable();
         });
     }
 
@@ -30,12 +31,14 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         DB::table('enum_casts')->insert([
             'string_status' => 'pending',
             'integer_status' => 1,
+            'arrayable_status' => 'pending',
         ]);
 
         $model = EloquentModelEnumCastingTestModel::first();
 
         $this->assertEquals(StringStatus::pending, $model->string_status);
         $this->assertEquals(IntegerStatus::pending, $model->integer_status);
+        $this->assertEquals(ArrayableStatus::pending, $model->arrayable_status);
     }
 
     public function testEnumsReturnNullWhenNull()
@@ -43,12 +46,14 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         DB::table('enum_casts')->insert([
             'string_status' => null,
             'integer_status' => null,
+            'arrayable_status' => null,
         ]);
 
         $model = EloquentModelEnumCastingTestModel::first();
 
         $this->assertEquals(null, $model->string_status);
         $this->assertEquals(null, $model->integer_status);
+        $this->assertEquals(null, $model->arrayable_status);
     }
 
     public function testEnumsAreCastableToArray()
@@ -56,11 +61,17 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => StringStatus::pending,
             'integer_status' => IntegerStatus::pending,
+            'arrayable_status' => ArrayableStatus::pending,
         ]);
 
         $this->assertEquals([
             'string_status' => 'pending',
             'integer_status' => 1,
+            'arrayable_status' => [
+                'name' => 'pending',
+                'value' => 'pending',
+                'description' => 'pending status description',
+            ],
         ], $model->toArray());
     }
 
@@ -69,11 +80,13 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => null,
             'integer_status' => null,
+            'arrayable_status' => null,
         ]);
 
         $this->assertEquals([
             'string_status' => null,
             'integer_status' => null,
+            'arrayable_status' => null,
         ], $model->toArray());
     }
 
@@ -82,6 +95,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => StringStatus::pending,
             'integer_status' => IntegerStatus::pending,
+            'arrayable_status' => ArrayableStatus::pending,
         ]);
 
         $model->save();
@@ -90,6 +104,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'id' => $model->id,
             'string_status' => 'pending',
             'integer_status' => 1,
+            'arrayable_status' => 'pending',
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
 
@@ -98,6 +113,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => null,
             'integer_status' => null,
+            'arrayable_status' => null,
         ]);
 
         $model->save();
@@ -106,6 +122,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'id' => $model->id,
             'string_status' => null,
             'integer_status' => null,
+            'arrayable_status' => null,
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
 
@@ -114,6 +131,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => 'pending',
             'integer_status' => 1,
+            'arrayable_status' => 'pending',
         ]);
 
         $model->save();
@@ -122,6 +140,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
 
         $this->assertEquals(StringStatus::pending, $model->string_status);
         $this->assertEquals(IntegerStatus::pending, $model->integer_status);
+        $this->assertEquals(ArrayableStatus::pending, $model->arrayable_status);
     }
 
     public function testFirstOrNew()
@@ -129,6 +148,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         DB::table('enum_casts')->insert([
             'string_status' => 'pending',
             'integer_status' => 1,
+            'arrayable_status' => 'pending',
         ]);
 
         $model = EloquentModelEnumCastingTestModel::firstOrNew([
@@ -176,5 +196,6 @@ class EloquentModelEnumCastingTestModel extends Model
     public $casts = [
         'string_status' => StringStatus::class,
         'integer_status' => IntegerStatus::class,
+        'arrayable_status' => ArrayableStatus::class,
     ];
 }

--- a/tests/Integration/Database/Enums.php
+++ b/tests/Integration/Database/Enums.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Contracts\Support\Arrayable;
+
 enum StringStatus: string
 {
     case pending = 'pending';
@@ -12,4 +14,27 @@ enum IntegerStatus: int
 {
     case pending = 1;
     case done = 2;
+}
+
+enum ArrayableStatus: string implements Arrayable
+{
+    case pending = 'pending';
+    case done = 'done';
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::pending => 'pending status description',
+            self::done => 'done status description'
+        };
+    }
+
+    public function toArray()
+    {
+        return [
+            'name' => $this->name,
+            'value' => $this->value,
+            'description' => $this->description(),
+        ];
+    }
 }


### PR DESCRIPTION
This is the same fix from #40885

"fix a wrong behavoiur when an attribute is casted to an enum implementig Arrayable in comparision to the behavoiur when the same thing is done on a collection object."