### PR TITLE
[9.x] Adds `Str::excerpt`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -266,7 +266,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match('/^(.*?)('.preg_quote((string) $phrase).')(.*)$/i', (string) $text, $matches);
+        preg_match('/^(.*?)('.preg_quote((string) $phrase).')(.*)$/iu', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -266,7 +266,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match("/^(.*?)(".preg_quote((string) $phrase).")(.*)$/i", (string) $text, $matches);
+        preg_match('/^(.*?)('.preg_quote((string) $phrase).')(.*)$/i', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -254,6 +254,42 @@ class Str
     }
 
     /**
+     * Extracts an excerpt from text that matches the first instance of phrase.
+     *
+     * @param  string  $text
+     * @param  string  $phrase
+     * @param  array  $options
+     * @return string|null
+     */
+    public static function excerpt($text, $phrase = '', $options = [])
+    {
+        $radius = $options['radius'] ?? 100;
+        $omission = $options['omission'] ?? '...';
+
+        preg_match_all("/^(\W*|.*)(".preg_quote((string) $phrase).")(.*\W*)$/i", (string) $text, $matches);
+
+        if (is_null($middle = collect($matches[2])->first())) {
+            return null;
+        }
+
+        $start = ltrim((string) collect($matches[1])->first());
+
+        $start = str(substr($start, max(mb_strlen($start) - $radius, 0), $radius))->ltrim()->unless(
+            fn ($startWithRadius) => $startWithRadius->exactly($start),
+            fn ($startWithRadius) => $startWithRadius->prepend($omission),
+        );
+
+        $end = rtrim((string) collect($matches[3])->first());
+
+        $end = str(substr($end, 0, $radius))->rtrim()->unless(
+            fn ($endWithRadius) => $endWithRadius->exactly($end),
+            fn ($endWithRadius) => $endWithRadius->append($omission),
+        );
+
+        return $start->append($middle, $end)->toString();
+    }
+
+    /**
      * Cap a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -266,27 +266,27 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match_all("/^(\W*|.*)(".preg_quote((string) $phrase).")(.*\W*)$/i", (string) $text, $matches);
+        preg_match("/^(.*?)(".preg_quote((string) $phrase).")(.*)$/i", (string) $text, $matches);
 
-        if (is_null($middle = collect($matches[2])->first())) {
+        if (empty($matches)) {
             return null;
         }
 
-        $start = ltrim((string) collect($matches[1])->first());
+        $start = ltrim($matches[1]);
 
-        $start = str(substr($start, max(mb_strlen($start) - $radius, 0), $radius))->ltrim()->unless(
+        $start = str(mb_substr($start, max(mb_strlen($start, 'UTF-8') - $radius, 0), $radius, 'UTF-8'))->ltrim()->unless(
             fn ($startWithRadius) => $startWithRadius->exactly($start),
             fn ($startWithRadius) => $startWithRadius->prepend($omission),
         );
 
-        $end = rtrim((string) collect($matches[3])->first());
+        $end = rtrim($matches[3]);
 
-        $end = str(substr($end, 0, $radius))->rtrim()->unless(
+        $end = str(mb_substr($end, 0, $radius, 'UTF-8'))->rtrim()->unless(
             fn ($endWithRadius) => $endWithRadius->exactly($end),
             fn ($endWithRadius) => $endWithRadius->append($omission),
         );
 
-        return $start->append($middle, $end)->toString();
+        return $start->append($matches[2], $end)->toString();
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -254,7 +254,7 @@ class Str
     }
 
     /**
-     * Extracts an excerpt from text that matches the first instance of phrase.
+     * Extracts an excerpt from text that matches the first instance of a phrase.
      *
      * @param  string  $text
      * @param  string  $phrase

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -196,6 +196,18 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Extracts an excerpt from text that matches the first instance of phrase.
+     *
+     * @param  string  $phrase
+     * @param  array  $options
+     * @return string|null
+     */
+    public function excerpt($phrase = '', $options = [])
+    {
+        return Str::excerpt($this->value, $phrase, $options);
+    }
+
+    /**
      * Explode the string into an array.
      *
      * @param  string  $delimiter

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -196,7 +196,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Extracts an excerpt from text that matches the first instance of phrase.
+     * Extracts an excerpt from text that matches the first instance of a phrase.
      *
      * @param  string  $phrase
      * @param  array  $options

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -155,11 +155,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('This is a...', Str::excerpt('This is a beautiful morning', 'this', ['radius' => 5]));
         $this->assertSame('...iful morning', Str::excerpt('This is a beautiful morning', 'morning', ['radius' => 5]));
         $this->assertNull(Str::excerpt('This is a beautiful morning', 'day'));
-        $this->assertSame('...is a beautiful! mor...', Str::excerpt('This is a beautiful! morning', 'beautiful', ['radius' => 5]));
+        $this->assertSame('...is a beautiful! mor...', Str::excerpt('This is a beautiful! morning', 'Beautiful', ['radius' => 5]));
         $this->assertSame('...is a beautiful? mor...', Str::excerpt('This is a beautiful? morning', 'beautiful', ['radius' => 5]));
         $this->assertSame('', Str::excerpt('', '', ['radius' => 0]));
         $this->assertSame('a', Str::excerpt('a', 'a', ['radius' => 0]));
-        $this->assertSame('...b...', Str::excerpt('abc', 'b', ['radius' => 0]));
+        $this->assertSame('...b...', Str::excerpt('abc', 'B', ['radius' => 0]));
         $this->assertSame('abc', Str::excerpt('abc', 'b', ['radius' => 1]));
         $this->assertSame('abc...', Str::excerpt('abcd', 'b', ['radius' => 1]));
         $this->assertSame('...abc', Str::excerpt('zabc', 'b', ['radius' => 1]));
@@ -175,7 +175,7 @@ class SupportStrTest extends TestCase
         ));
 
         $this->assertSame('...y...', Str::excerpt('taylor', 'y', ['radius' => 0]));
-        $this->assertSame('...ayl...', Str::excerpt('taylor', 'y', ['radius' => 1]));
+        $this->assertSame('...ayl...', Str::excerpt('taylor', 'Y', ['radius' => 1]));
         $this->assertSame('<div> The article description </div>', Str::excerpt('<div> The article description </div>', 'article'));
         $this->assertSame('...The article desc...', Str::excerpt('<div> The article description </div>', 'article', ['radius' => 5]));
         $this->assertSame('The article description', Str::excerpt(strip_tags('<div> The article description </div>'), 'article'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -196,7 +196,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('åèö - 二 sān 大åèö', Str::excerpt('åèö - 二 sān 大åèö', 'åèö - 二 sān 大åèö', ['radius' => 4]));
         $this->assertSame('...༼...', Str::excerpt('㏗༼㏗', '༼', ['radius' => 0]));
         $this->assertSame('...༼...', Str::excerpt('㏗༼㏗', '༼', ['radius' => 0]));
+        $this->assertSame('...ocê e...', Str::excerpt('Como você está', 'ê', ['radius' => 2]));
         $this->assertSame('...ocê e...', Str::excerpt('Como você está', 'Ê', ['radius' => 2]));
+        $this->assertSame('João...', Str::excerpt('João Antônio ', 'jo', ['radius' => 2]));
+        $this->assertSame('João Antô...', Str::excerpt('João Antônio', 'JOÃO', ['radius' => 5]));
     }
 
     public function testStrBefore()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -191,6 +191,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('What i?', Str::excerpt('What is the article?', 'What', ['radius' => 2, 'omission' => '?']));
 
         $this->assertSame('...ö - 二 sān 大åè...', Str::excerpt('åèö - 二 sān 大åèö', '二 sān', ['radius' => 4]));
+        $this->assertSame('åèö - 二...', Str::excerpt('åèö - 二 sān 大åèö', 'åèö', ['radius' => 4]));
+        $this->assertSame('åèö - 二 sān 大åèö', Str::excerpt('åèö - 二 sān 大åèö', 'åèö - 二 sān 大åèö', ['radius' => 4]));
+        $this->assertSame('åèö - 二 sān 大åèö', Str::excerpt('åèö - 二 sān 大åèö', 'åèö - 二 sān 大åèö', ['radius' => 4]));
+        $this->assertSame('...༼...', Str::excerpt('㏗༼㏗', '༼', ['radius' => 0]));
+        $this->assertSame('...༼...', Str::excerpt('㏗༼㏗', '༼', ['radius' => 0]));
     }
 
     public function testStrBefore()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -196,6 +196,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('åèö - 二 sān 大åèö', Str::excerpt('åèö - 二 sān 大åèö', 'åèö - 二 sān 大åèö', ['radius' => 4]));
         $this->assertSame('...༼...', Str::excerpt('㏗༼㏗', '༼', ['radius' => 0]));
         $this->assertSame('...༼...', Str::excerpt('㏗༼㏗', '༼', ['radius' => 0]));
+        $this->assertSame('...ocê e...', Str::excerpt('Como você está', 'Ê', ['radius' => 2]));
     }
 
     public function testStrBefore()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -149,6 +149,48 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith('你好', 'a'));
     }
 
+    public function testStrExcerpt()
+    {
+        $this->assertSame('...is a beautiful morn...', Str::excerpt('This is a beautiful morning', 'beautiful', ['radius' => 5]));
+        $this->assertSame('This is a...', Str::excerpt('This is a beautiful morning', 'this', ['radius' => 5]));
+        $this->assertSame('...iful morning', Str::excerpt('This is a beautiful morning', 'morning', ['radius' => 5]));
+        $this->assertNull(Str::excerpt('This is a beautiful morning', 'day'));
+        $this->assertSame('...is a beautiful! mor...', Str::excerpt('This is a beautiful! morning', 'beautiful', ['radius' => 5]));
+        $this->assertSame('...is a beautiful? mor...', Str::excerpt('This is a beautiful? morning', 'beautiful', ['radius' => 5]));
+        $this->assertSame('', Str::excerpt('', '', ['radius' => 0]));
+        $this->assertSame('a', Str::excerpt('a', 'a', ['radius' => 0]));
+        $this->assertSame('...b...', Str::excerpt('abc', 'b', ['radius' => 0]));
+        $this->assertSame('abc', Str::excerpt('abc', 'b', ['radius' => 1]));
+        $this->assertSame('abc...', Str::excerpt('abcd', 'b', ['radius' => 1]));
+        $this->assertSame('...abc', Str::excerpt('zabc', 'b', ['radius' => 1]));
+        $this->assertSame('...abc...', Str::excerpt('zabcd', 'b', ['radius' => 1]));
+        $this->assertSame('zabcd', Str::excerpt('zabcd', 'b', ['radius' => 2]));
+        $this->assertSame('zabcd', Str::excerpt('  zabcd  ', 'b', ['radius' => 4]));
+        $this->assertSame('...abc...', Str::excerpt('z  abc  d', 'b', ['radius' => 1]));
+        $this->assertSame('[...]is a beautiful morn[...]', Str::excerpt('This is a beautiful morning', 'beautiful', ['omission' => '[...]', 'radius' => 5]));
+        $this->assertSame(
+              'This is the ultimate supercalifragilisticexpialidoceous very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome tempera[...]',
+              Str::excerpt('This is the ultimate supercalifragilisticexpialidoceous very looooooooooooooooooong looooooooooooong beautiful morning with amazing sunshine and awesome temperatures. So what are you gonna do about it?', 'very',
+              ['omission' => '[...]'],
+        ));
+
+        $this->assertSame('...y...', Str::excerpt('taylor', 'y', ['radius' => 0]));
+        $this->assertSame('...ayl...', Str::excerpt('taylor', 'y', ['radius' => 1]));
+        $this->assertSame('<div> The article description </div>', Str::excerpt('<div> The article description </div>', 'article'));
+        $this->assertSame('...The article desc...', Str::excerpt('<div> The article description </div>', 'article', ['radius' => 5]));
+        $this->assertSame('The article description', Str::excerpt(strip_tags('<div> The article description </div>'), 'article'));
+        $this->assertSame('', Str::excerpt(null));
+        $this->assertSame('', Str::excerpt(''));
+        $this->assertSame('', Str::excerpt(null, ''));
+        $this->assertSame('T...', Str::excerpt('The article description', null, ['radius' => 1]));
+        $this->assertSame('The arti...', Str::excerpt('The article description', '', ['radius' => 8]));
+        $this->assertSame('', Str::excerpt(' '));
+        $this->assertSame('...icle desc...', Str::excerpt('The article description', ' ', ['radius' => 4]));
+        $this->assertSame('...cle description', Str::excerpt('The article description', 'description', ['radius' => 4]));
+        $this->assertSame('T...', Str::excerpt('The article description', 'T', ['radius' => 0]));
+        $this->assertSame('What i?', Str::excerpt('What is the article?', 'What', ['radius' => 2, 'omission' => '?']));
+    }
+
     public function testStrBefore()
     {
         $this->assertSame('han', Str::before('hannah', 'nah'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -185,10 +185,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('T...', Str::excerpt('The article description', null, ['radius' => 1]));
         $this->assertSame('The arti...', Str::excerpt('The article description', '', ['radius' => 8]));
         $this->assertSame('', Str::excerpt(' '));
-        $this->assertSame('...icle desc...', Str::excerpt('The article description', ' ', ['radius' => 4]));
+        $this->assertSame('The arti...', Str::excerpt('The article description', ' ', ['radius' => 4]));
         $this->assertSame('...cle description', Str::excerpt('The article description', 'description', ['radius' => 4]));
         $this->assertSame('T...', Str::excerpt('The article description', 'T', ['radius' => 0]));
         $this->assertSame('What i?', Str::excerpt('What is the article?', 'What', ['radius' => 2, 'omission' => '?']));
+
+        $this->assertSame('...ö - 二 sān 大åè...', Str::excerpt('åèö - 二 sān 大åèö', '二 sān', ['radius' => 4]));
     }
 
     public function testStrBefore()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -474,6 +474,11 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('Malmö')->endsWith('mo'));
     }
 
+    public function testExcerpt()
+    {
+        $this->assertSame('...is a beautiful morn...', (string) $this->stringable('This is a beautiful morning')->excerpt('beautiful', ['radius' => 5]));
+    }
+
     public function testBefore()
     {
         $this->assertSame('han', (string) $this->stringable('hannah')->before('nah'));


### PR DESCRIPTION
This pull request adds the `Str::excerpt` method to Laravel 9.

The original idea comes from Rails [`ActionView::Helpers::TextHelper::excerpt`](https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-excerpt), and extracts an excerpt from the given `$text` that matches the first instance of `$phrase`.

```php
public static function excerpt($text, $phrase = '', $options = [])
```

In other words, it just creates a relevant excerpt that contains the given `$phrase`:

```php
// Description: Laravel is a web application framework with expressive, elegant syntax.
// Search: Framework
$article = Article::search($request->search)->get()->first();

// Excerpt: ...plication framework with expr...
$excerpt = str($article->description)->excerpt($request->search, [
    'radius' => 10,
]);
```

The `radius` option expands the excerpt on each side of the first occurrence of `$phrase` by the number of characters defined in `radius` (which defaults to 100). If the excerpt radius overflows the beginning or end of the `$text`, then the `$omission` option (which defaults to "...") will be prepended/appended accordingly:
```php
// Excerpt: ...on framework wi...
// The left side with radius is: "on ".
// The right side with radius is: " wi".
$excerpt = str($article->description)->excerpt($request->search, [
    'radius' => 3,
]);

// Excerpt: ???on framework wi???
$excerpt = str($article->description)->excerpt($request->search, [
    'radius' => 3,
    'omission' => '?'
]);
```

Of course, if the excerpt radius does not overflows the beginning or end of the `$text`, the no omission is applied:
```
// Excerpt: '......el  Framework'
$excerpt = str('Laravel Framework')->excerpt('Framework', [
    'radius' => 3,
    'omission' => '......'
]);
```

If the `$phrase` isn't found, `null` is returned:

```php
// Excerpt: null
$excerpt = str($article->description)->excerpt('This does not exist on text');
```

