### PR TITLE
[9.x] Expose next and previous cursor of cursor paginator

### DIFF
--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -132,7 +132,9 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
             'data' => $this->items->toArray(),
             'path' => $this->path(),
             'per_page' => $this->perPage(),
+            'next_page' => $this->nextCursor()?->encode(),
             'next_page_url' => $this->nextPageUrl(),
+            'prev_page' => $this->previousCursor()?->encode(),
             'prev_page_url' => $this->previousPageUrl(),
         ];
     }

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -132,9 +132,9 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
             'data' => $this->items->toArray(),
             'path' => $this->path(),
             'per_page' => $this->perPage(),
-            'next_page' => $this->nextCursor()?->encode(),
+            'next_cursor' => $this->nextCursor()?->encode(),
             'next_page_url' => $this->nextPageUrl(),
-            'prev_page' => $this->previousCursor()?->encode(),
+            'prev_cursor' => $this->previousCursor()?->encode(),
             'prev_page_url' => $this->previousPageUrl(),
         ];
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -799,6 +799,8 @@ class ResourceTest extends TestCase
             'meta' => [
                 'path' => '/',
                 'per_page' => 1,
+                'next_page' => (new Cursor(['id' => 5]))->encode(),
+                'prev_page' => null,
             ],
         ]);
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -799,8 +799,8 @@ class ResourceTest extends TestCase
             'meta' => [
                 'path' => '/',
                 'per_page' => 1,
-                'next_page' => (new Cursor(['id' => 5]))->encode(),
-                'prev_page' => null,
+                'next_cursor' => (new Cursor(['id' => 5]))->encode(),
+                'prev_cursor' => null,
             ],
         ]);
     }

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -22,9 +22,9 @@ class CursorPaginatorTest extends TestCase
             'data' => [['id' => 1], ['id' => 2]],
             'path' => '/',
             'per_page' => 2,
-            'next_page' => $this->getCursor(['id' => 2]),
+            'next_cursor' => $this->getCursor(['id' => 2]),
             'next_page_url' => '/?cursor='.$this->getCursor(['id' => 2]),
-            'prev_page' => null,
+            'prev_cursor' => null,
             'prev_page_url' => null,
         ];
 

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -22,7 +22,9 @@ class CursorPaginatorTest extends TestCase
             'data' => [['id' => 1], ['id' => 2]],
             'path' => '/',
             'per_page' => 2,
+            'next_page' => $this->getCursor(['id' => 2]),
             'next_page_url' => '/?cursor='.$this->getCursor(['id' => 2]),
+            'prev_page' => null,
             'prev_page_url' => null,
         ];
 


### PR DESCRIPTION
The json response of a `CursorPaginator` does currently not expose the raw values of the next cursor and previous cursor (it only exposes full URLs), while that is something that should be exposed by default in my opinion. This is similar to the `LengthAwarePaginator`, where the values of the current / next / last page are also exposed.