### PR TITLE
[9.x] Add more additional info for assertDatabaseHas

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -85,6 +85,16 @@ class HasInDatabase extends Constraint
 
         if ($similarResults->isNotEmpty()) {
             $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT);
+
+            if ($similarResults->count() === 1) {
+                $firstData = (array)$similarResults->first();
+
+                array_walk_recursive($firstData, fn(&$value) => $value = $value ?? '<NULL>');
+
+                $diff = array_diff_assoc($this->data, $firstData);
+
+                $description .= sprintf("\n\nYou might want to check these:\n%s", json_encode($diff, JSON_PRETTY_PRINT));
+            }
         } else {
             $query = $this->database->table($table);
 


### PR DESCRIPTION
When `assertDatabaseHas` test fails, it shows you similar results.
While it's useful, sometimes database result or query conditions have many attributes.
And it makes hard to distinguish the differences.
This pull request tries to solve this problem.

### Before
![2022-02-14_18h35_05](https://user-images.githubusercontent.com/14008307/153863706-1783d1cf-b86e-4401-8f2e-835cb93c5e05.png)

### After
![2022-02-14_18h38_57](https://user-images.githubusercontent.com/14008307/153863735-a7a8cd5f-4469-4708-b4e3-94721010e6bb.png)

Before diffing, `null`s are converted to '&lt;NULL&gt;'.
I did so because `array_diff_assoc` cannot distinguish them.
https://www.php.net/manual/en/function.array-diff-assoc.php#example-4909

Example.
```
$db = [
    'first_name' => 'John',
    'last_name' => 'Doe',
    'nickname' => null,
];

$payload = [
    'first_name' => 'John',
    'last_name' => 'Doe',
    'nickname' => '',
];

array_diff_assoc($db, $payload); // result is an empty array.
```

This shows diffs only when single similar result is found.
That way we can keep simple code and existing tests can pass.