### PR TITLE
[9.x] Cursor pagination: convert original column to expression

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -13,6 +13,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use InvalidArgumentException;
 use RuntimeException;
@@ -344,7 +345,7 @@ trait BuildsQueries
                     $originalColumn = $this->getOriginalColumnNameForCursorPagination($this, $previousColumn);
 
                     $builder->where(
-                        str_starts_with($originalColumn, '(') && str_ends_with($originalColumn, ')') ? new Expression($originalColumn) : $originalColumn,
+                        Str::contains($originalColumn, ['(', ')']) ? new Expression($originalColumn) : $originalColumn,
                         '=',
                         $cursor->parameter($previousColumn)
                     );
@@ -356,7 +357,7 @@ trait BuildsQueries
                     $originalColumn = $this->getOriginalColumnNameForCursorPagination($this, $column);
 
                     $builder->where(
-                        str_starts_with($originalColumn, '(') && str_ends_with($originalColumn, ')') ? new Expression($originalColumn) : $originalColumn,
+                        Str::contains($originalColumn, ['(', ')']) ? new Expression($originalColumn) : $originalColumn,
                         $direction === 'asc' ? '>' : '<',
                         $cursor->parameter($column)
                     );

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Concerns;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\MultipleRecordsFoundException;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
@@ -341,7 +342,7 @@ trait BuildsQueries
             $addCursorConditions = function (self $builder, $previousColumn, $i) use (&$addCursorConditions, $cursor, $orders) {
                 if (! is_null($previousColumn)) {
                     $builder->where(
-                        $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
+                        new Expression($this->getOriginalColumnNameForCursorPagination($this, $previousColumn)),
                         '=',
                         $cursor->parameter($previousColumn)
                     );
@@ -351,7 +352,7 @@ trait BuildsQueries
                     ['column' => $column, 'direction' => $direction] = $orders[$i];
 
                     $builder->where(
-                        $this->getOriginalColumnNameForCursorPagination($this, $column),
+                        new Expression($this->getOriginalColumnNameForCursorPagination($this, $column)),
                         $direction === 'asc' ? '>' : '<',
                         $cursor->parameter($column)
                     );

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3906,7 +3906,7 @@ SQL;
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
-                'select * from "foobar" where ("test" > ?) order by "test" asc limit 17',
+                'select * from "foobar" where (test > ?) order by "test" asc limit 17',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
 
@@ -3944,7 +3944,7 @@ SQL;
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
-                'select * from "foobar" where ("test" > ? or ("test" = ? and ("another" > ?))) order by "test" asc, "another" asc limit 17',
+                'select * from "foobar" where (test > ? or (test = ? and (another > ?))) order by "test" asc, "another" asc limit 17',
                 $builder->toSql()
             );
             $this->assertEquals(['bar', 'bar', 'foo'], $builder->bindings['where']);
@@ -3982,7 +3982,7 @@ SQL;
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
-                'select * from "foobar" where ("test" > ?) order by "test" asc limit 16',
+                'select * from "foobar" where (test > ?) order by "test" asc limit 16',
                 $builder->toSql());
             $this->assertEquals(['bar'], $builder->bindings['where']);
 
@@ -4052,7 +4052,7 @@ SQL;
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
-                'select * from "foobar" where ("id" > ?) order by "id" asc limit 17',
+                'select * from "foobar" where (id > ?) order by "id" asc limit 17',
                 $builder->toSql());
             $this->assertEquals([2], $builder->bindings['where']);
 
@@ -4090,7 +4090,7 @@ SQL;
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results) {
             $this->assertEquals(
-                'select * from "foobar" where ("foo" > ? or ("foo" = ? and ("bar" < ? or ("bar" = ? and ("baz" > ?))))) order by "foo" asc, "bar" desc, "baz" asc limit 17',
+                'select * from "foobar" where (foo > ? or (foo = ? and (bar < ? or (bar = ? and (baz > ?))))) order by "foo" asc, "bar" desc, "baz" asc limit 17',
                 $builder->toSql()
             );
             $this->assertEquals([1, 1, 2, 2, 3], $builder->bindings['where']);


### PR DESCRIPTION
Imagine you write the following query:
```php
User::query()
    ->select('*')
    ->selectSub('CONCAT(firstname, \' \', lastname)', 'fullname')
    ->orderBy('fullname')
    ->orderBy('id')
    ->cursorPaginate()
```
According to the [documentation](https://laravel.com/docs/8.x/pagination#cursor-vs-offset-pagination), this should work:
> Query expressions in "order by" clauses are supported only if they are aliased and added to the "select" clause as well.

But this query will only work when fetching the first page. When you fetch the users of the second page / next cursor, you will get the following error:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'CONCAT(firstname, ' ', lastname)' in 'where clause'
```
This is caused by the fact that the raw output of the `getOriginalColumnNameForCursorPagination` method is provided to a `where` method. This means that the original column value is interpreted as a real column name. That is not the case when aliasing a dynamic column.

By wrapping the result of the `getOriginalColumnNameForCursorPagination` method in an `\Illuminate\Database\Query\Expression` object, we ensure that the original column value is correctly interpreted.