### PR TITLE
[9.x] Fix dispatch_now behavior for fail call

### DIFF
--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Queue;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
 use Orchestra\Testbench\TestCase;
 
 class JobDispatchingTest extends TestCase
@@ -20,6 +21,13 @@ class JobDispatchingTest extends TestCase
 
         $this->assertTrue(Job::$ran);
         $this->assertSame('new-test', Job::$value);
+    }
+
+    public function testJobCanFailManuallyAfterDispatchNow()
+    {
+        JobDispatchingTestFailingJob::dispatchNow();
+
+        $this->assertTrue(JobDispatchingTestFailingJob::$failed);
     }
 }
 
@@ -45,5 +53,22 @@ class Job implements ShouldQueue
     public function replaceValue($value)
     {
         static::$value = $value;
+    }
+}
+
+class JobDispatchingTestFailingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public static $failed = false;
+
+    public function handle(): void
+    {
+        $this->fail();
+    }
+
+    public function failed()
+    {
+        static::$failed = true;
     }
 }


### PR DESCRIPTION
At the moment when you call dispatch_now on a job and that job contains a manual `->fail()` call [(documented here)](https://laravel.com/docs/9.x/queues#manually-failing-a-job), the app will break and an Undefined array key "job" error is thrown.

This is because of this line that passes an empty array as the job payload: https://github.com/laravel/framework/blob/9.x/src/Illuminate/Bus/Dispatcher.php#L115

I'm not sure what the correct solution here is... Haven't investigated yet if this is also the case on Laravel v8.

See https://github.com/laravel/lumen-framework/issues/1217