### PR TITLE
Default options for Http requests

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Http\Client\ResponseSequence;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
@@ -1158,5 +1159,27 @@ class HttpClientTest extends TestCase
         $this->assertSame('Fake', tap($history[0]['response']->getBody())->rewind()->getContents());
 
         $this->assertSame(['hyped-for' => 'laravel-movie'], json_decode(tap($history[0]['request']->getBody())->rewind()->getContents(), true));
+    }
+
+    public function testDefaultOptionsAreSet()
+    {
+        $this->factory->defaultOptions([
+            'proxy' => 'localhost:9090',
+            'verify' => false,
+        ]);
+
+        $request = $this->factory->withOptions(['allow_redirects' => true]);
+
+        $this->assertSame(
+            ['proxy' => 'localhost:9090', 'verify' => false, 'allow_redirects' => true],
+            Arr::only($request->getOptions(), ['proxy', 'verify', 'allow_redirects'])
+        );
+
+        $request = $request->withOptions(['proxy' => 'http://foo.com:9090', 'allow_redirects' => false]);
+
+        $this->assertSame(
+            ['proxy' => 'http://foo.com:9090', 'verify' => false, 'allow_redirects' => false],
+            Arr::only($request->getOptions(), ['proxy', 'verify', 'allow_redirects'])
+        );
     }
 }


### PR DESCRIPTION
This adds a defaultOptions() method to the Http\Client\Factory class, that can be called in the AppServiceProvider to set some Guzzle options that should be applied to each and every request that follow.

The most relatable use-case that comes to my mind are proxy options that should apply to all upcoming requests.

You can use it in your AppServiceProvider like this
```php
Http::defaultOptions([
	'proxy'  => 'localhost:9090',
	'verify' => false
]);
```

And every request created through the Factory should get the same options automatically.

`Http::get('http://foo.com')` gets automatically send through the proxy.

If you need another setting for a specific request you still can overwrite the options with the `Http::withOptions(['verify' => true])->get('http://bar.com')`.

This does not break any existing features, because in `newPendingRequest()` we pass an empty array to `withOptions()` when `defaultOptions()` is never called before. With the current array_merge_recursively implementation in withOptions nothing is changed.

It's backwards compatible too, because it's one additional function that has no effect if not called.

This implementation makes it a little easier to have an app specific proxy setting or other Guzzle settings, that should apply to every request. Before you would have to create a macro and call it on every request. But 3rd-party libraries using the Http Factory would not be affected by this since they would not use the user-created Macro. Another solution would be to overwrite the Factory class to implement this functionality on a project basis. A direct implementation in the Factory class has the benefit that everyone can use it out of the box.