### PR TITLE
[9.x] Add test for cache increment

### DIFF
--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -70,6 +70,33 @@ class CacheArrayStoreTest extends TestCase
         $result = $store->increment('foo');
         $this->assertEquals(2, $result);
         $this->assertEquals(2, $store->get('foo'));
+
+        $result = $store->increment('foo', 2);
+        $this->assertEquals(4, $result);
+        $this->assertEquals(4, $store->get('foo'));
+    }
+
+    public function testValuesGetCastedByIncrementOrDecrement()
+    {
+        $store = new ArrayStore;
+        $store->put('foo', '1', 10);
+        $result = $store->increment('foo');
+        $this->assertEquals(2, $result);
+        $this->assertEquals(2, $store->get('foo'));
+
+        $store->put('bar', '1', 10);
+        $result = $store->decrement('bar');
+        $this->assertEquals(0, $result);
+        $this->assertEquals(0, $store->get('bar'));
+    }
+
+    public function testIncrementNonNumericValues()
+    {
+        $store = new ArrayStore;
+        $store->put('foo', 'I am string', 10);
+        $result = $store->increment('foo');
+        $this->assertEquals(1, $result);
+        $this->assertEquals(1, $store->get('foo'));
     }
 
     public function testNonExistingKeysCanBeIncremented()
@@ -77,6 +104,10 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
         $result = $store->increment('foo');
         $this->assertEquals(1, $result);
+        $this->assertEquals(1, $store->get('foo'));
+
+        // Will be there forever
+        Carbon::setTestNow(Carbon::now()->addYears(10));
         $this->assertEquals(1, $store->get('foo'));
     }
 
@@ -98,6 +129,10 @@ class CacheArrayStoreTest extends TestCase
         $result = $store->decrement('foo');
         $this->assertEquals(0, $result);
         $this->assertEquals(0, $store->get('foo'));
+
+        $result = $store->decrement('foo', 2);
+        $this->assertEquals(-2, $result);
+        $this->assertEquals(-2, $store->get('foo'));
     }
 
     public function testItemsCanBeRemoved()

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use Exception;
 use Illuminate\Cache\FileStore;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
@@ -186,17 +187,80 @@ class CacheFileStoreTest extends TestCase
         $this->assertSame('Hello World', $store->get('foo'));
     }
 
+    public function testIncrementExpiredKeys()
+    {
+        $filePath = $this->getCachePath('foo');
+        $files = $this->mockFilesystem();
+        $now = Carbon::now()->getTimestamp();
+        $initialValue = ($now - 10).serialize(77);
+        $valueAfterIncrement = '9999999999'.serialize(3);
+        $store = new FileStore($files, __DIR__);
+
+        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willReturn($initialValue);
+        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+
+        $result = $store->increment('foo', 3);
+    }
+
     public function testIncrementCanAtomicallyJump()
     {
+        $filePath = $this->getCachePath('foo');
         $files = $this->mockFilesystem();
         $initialValue = '9999999999'.serialize(1);
         $valueAfterIncrement = '9999999999'.serialize(4);
         $store = new FileStore($files, __DIR__);
-        $files->expects($this->once())->method('get')->willReturn($initialValue);
-        $hash = sha1('foo');
-        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($valueAfterIncrement));
-        $store->increment('foo', 3);
+
+        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willReturn($initialValue);
+        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+
+        $result = $store->increment('foo', 3);
+        $this->assertEquals(4, $result);
+    }
+
+    public function testDecrementCanAtomicallyJump()
+    {
+        $filePath = $this->getCachePath('foo');
+
+        $files = $this->mockFilesystem();
+        $initialValue = '9999999999'.serialize(2);
+        $valueAfterIncrement = '9999999999'.serialize(0);
+        $store = new FileStore($files, __DIR__);
+
+        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willReturn($initialValue);
+        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+
+        $result = $store->decrement('foo', 2);
+        $this->assertEquals(0, $result);
+    }
+
+    public function testIncrementNonNumericValues()
+    {
+        $filePath = $this->getCachePath('foo');
+
+        $files = $this->mockFilesystem();
+        $initialValue = '1999999909'.serialize('foo');
+        $valueAfterIncrement = '1999999909'.serialize(1);
+        $store = new FileStore($files, __DIR__);
+        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willReturn($initialValue);
+        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+        $result = $store->increment('foo');
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIncrementNonExistentKeys()
+    {
+        $filePath = $this->getCachePath('foo');
+
+        $files = $this->mockFilesystem();
+        $valueAfterIncrement = '9999999999'.serialize(1);
+        $store = new FileStore($files, __DIR__);
+        // simulates a missing item in file store by the exception
+        $files->expects($this->once())->method('get')->with($this->equalTo($filePath), $this->equalTo(true))->willThrowException(new Exception);
+        $files->expects($this->once())->method('put')->with($this->equalTo($filePath), $this->equalTo($valueAfterIncrement));
+        $result = $store->increment('foo');
+        $this->assertIsInt($result);
+        $this->assertEquals(1, $result);
     }
 
     public function testIncrementDoesNotExtendCacheLife()
@@ -272,5 +336,13 @@ class CacheFileStoreTest extends TestCase
     protected function mockFilesystem()
     {
         return $this->createMock(Filesystem::class);
+    }
+
+    protected function getCachePath($key)
+    {
+        $hash = sha1($key);
+        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+
+        return __DIR__.'/'.$cache_dir.'/'.$hash;
     }
 }


### PR DESCRIPTION
The `increment` and `decrement` methods lack these tests.
I used the `getCachePath()` helper method to make my tests tidier and cleaner.