### PR TITLE
[9.x] Adds `Attribute::with`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -47,10 +47,7 @@ class Attribute
      */
     public static function make(callable $get = null, callable $set = null): static
     {
-        return new static(
-            get: $get,
-            set: $set
-        );
+        return new static($get, $set);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -45,7 +45,7 @@ class Attribute
      * @param  callable|null  $set
      * @return static
      */
-    public static function with(callable $get = null, callable $set = null): static
+    public static function make(callable $get = null, callable $set = null): static
     {
         return new static(
             get: $get,

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -39,6 +39,21 @@ class Attribute
     }
 
     /**
+     * Create a new attribute accessor / mutator.
+     *
+     * @param  callable|null  $get
+     * @param  callable|null  $set
+     * @return static
+     */
+    public static function with(callable $get = null, callable $set = null): static
+    {
+        return new static(
+            get: $get,
+            set: $set
+        );
+    }
+
+    /**
      * Create a new attribute accessor.
      *
      * @param  callable  $get

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -280,7 +280,7 @@ class TestEloquentModelWithAttributeCast extends Model
 
     public function uppercase(): Attribute
     {
-        return Attribute::with(
+        return Attribute::make(
             function ($value) {
                 return strtoupper($value);
             },

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -280,7 +280,7 @@ class TestEloquentModelWithAttributeCast extends Model
 
     public function uppercase(): Attribute
     {
-        return new Attribute(
+        return Attribute::with(
             function ($value) {
                 return strtoupper($value);
             },


### PR DESCRIPTION

- This PR adds the possibility to create `Attribute` using static `with` method to Laravel 9.


**Why?**

Laravel has a very expressive syntax, but I think the current syntax of `Attributes` isn't like other parts of laravel. So I made this PR with a cleaner and more readable way to create them, significantly when disabling object caching.

Current approach:

```

    public function uppercase(): Attribute
    {
        return (new Attribute(
            get: fn ($value) => strtoupper($value),
            set: fn ($value) => strtoupper($value)
        ))->withoutObjectCaching();
    }


```
New approach:

```

    public function uppercase(): Attribute
    {
        return Attribute::with(
            get: fn ($value) => strtoupper($value),
            set: fn ($value) => strtoupper($value)
        )->withoutObjectCaching();
    }


```