### PR TITLE
[9.x] Fix the error message when no routes are detected

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -98,7 +98,7 @@ class RouteListCommand extends Command
     {
         $this->router->flushMiddlewareGroups();
 
-        if (!$this->router->getRoutes()->count()) {
+        if (! $this->router->getRoutes()->count()) {
             return $this->error("Your application doesn't have any routes.");
         }
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -98,7 +98,7 @@ class RouteListCommand extends Command
     {
         $this->router->flushMiddlewareGroups();
 
-        if (empty($this->router->getRoutes())) {
+        if (!$this->router->getRoutes()->count()) {
             return $this->error("Your application doesn't have any routes.");
         }
 


### PR DESCRIPTION
This fixes the error message that's displayed when Laravel can't find any routes to list. Router->getRoutes() returns a RouteCollectionInterface, not an array.