### PR TITLE
[9.x] Fix Queue Failed_jobs insert issue with Exception contain UNICODE

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -57,7 +57,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface, PrunableF
     {
         $failed_at = Date::now();
 
-        $exception = (string) $exception;
+        $exception = (string) mb_convert_encoding($exception, 'UTF-8');
 
         return $this->getTable()->insertGetId(compact(
             'connection', 'queue', 'payload', 'exception', 'failed_at'

--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -60,7 +60,7 @@ class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface, Pruna
             'connection' => $connection,
             'queue' => $queue,
             'payload' => $payload,
-            'exception' => (string) $exception,
+            'exception' => (string) mb_convert_encoding($exception, 'UTF-8'),
             'failed_at' => Date::now(),
         ]);
 

--- a/tests/Queue/DatabaseFailedJobProviderTest.php
+++ b/tests/Queue/DatabaseFailedJobProviderTest.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Tests\Queue;
 
+use Exception;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseFailedJobProviderTest extends TestCase
@@ -38,5 +40,35 @@ class DatabaseFailedJobProviderTest extends TestCase
         $db->getConnection()->table('failed_jobs')->insert(['failed_at' => Date::now()->subDays(10)]);
         $provider->flush(10 * 24);
         $this->assertSame(0, $db->getConnection()->table('failed_jobs')->count());
+    }
+
+    public function testCanProperlyLogFailedJob()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->getConnection()->getSchemaBuilder()->create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+
+        $uuid = Str::uuid();
+
+        $exception = new Exception(utf8_decode('ÐÑÙ0E\xE2\x�98\xA0World��7B¹!þÿ'));
+        $provider = new DatabaseFailedJobProvider($db->getDatabaseManager(), 'default', 'failed_jobs');
+
+        $provider->log('database', 'default', json_encode(['uuid' => (string) $uuid]), $exception);
+
+        $exception = (string) mb_convert_encoding($exception, 'UTF-8');
+
+        $this->assertSame(1, $db->getConnection()->table('failed_jobs')->count());
+        $this->assertSame($exception, $db->getConnection()->table('failed_jobs')->first()->exception);
     }
 }


### PR DESCRIPTION
Can't Insert failed job  exception with UNICODE character. 
Add an "utf8_encode" front of exception.

If you have a better way, my ears is open
I deal manually with this case from laravel 5.5

Issues : 
https://github.com/laravel/framework/issues/24263
https://github.com/laravel/framework/issues/41016


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
