### PR TITLE
[9.x] Fix Duplicate Route Namespace

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -544,7 +544,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $group = end($this->groupStack);
 
-        return isset($group['namespace']) && ! str_starts_with($class, '\\')
+        return isset($group['namespace']) && ! str_starts_with($class, '\\') && ! str_starts_with($class, $group['namespace'])
                 ? $group['namespace'].'\\'.$class : $class;
     }
 


### PR DESCRIPTION
When you are using group namespaces you cannot use the group controller method or single action controllers. 
Also you cannot use the controller class as a parameter on your route

```
Route::namespace($module->namespace().'\App\Http\Controllers')->group($module->getRoutes());
```

This works

```
Route::get('/', 'FrameworkController@index')->name('index');
```

The following scenarios are not working

Controller group
```
use Modules/Foo/App/Http/Controllers/FooController;
Route::prefix('foo')
    ->controller(FooController::class)
    ->group(function () {
        Route::get('/foo', 'foo');
    });
```

Single Action Controller
```
use Modules/Foo/App/Http/Controllers/InvokableController;
Route::prefix('foo')->group(function () {
        Route::get('/foo', InvokableController::class);
    });
```

```
use Modules/Foo/App/Http/Controllers/FooController;

Route::prefix('foo')->group(function () {
        Route::get('/', [FooController::class, 'index']);
    });
```


The solution I came up with is to not prepend the group namespace if the controller class starts with the same namespace
