### PR TITLE
Use PHP enums in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1036,7 +1036,7 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array|class-string  $allowed List of allowed cases or the class-string of a backed enum
+     * @param  array|class-string  $allowed  List of allowed cases or the class-string of a backed enum
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
     public function enum($column, array|string $allowed)
@@ -1051,18 +1051,18 @@ class Blueprint
     /**
      * Returns a list of all values of a backed enum.
      * 
-     * @param class-string $enum_class_name
+     * @param  class-string  $enum_class_name
      * @return int[]|string[]
      */
     protected function getEnumValues(string $enum_class_name): array
     {
         $enum = new ReflectionEnum($enum_class_name);
-        if (!$enum->isBacked()) {
-            throw new BadMethodCallException("An enum needs to be backed in order to be used in a Blueprint");
+        if (! $enum->isBacked()) {
+            throw new BadMethodCallException('An enum needs to be backed in order to be used in a Blueprint');
         }
 
         return array_map(
-            fn(ReflectionEnumBackedCase $case) => $case->getBackingValue(),
+            fn (ReflectionEnumBackedCase $case) => $case->getBackingValue(),
             $enum->getCases()
         );
     }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -765,6 +766,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
+    }
+
+    public function testAddingNativeEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `role` enum(\'test\', \'test2\') not null', $statements[0]);
     }
 
     public function testAddingSet()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -577,6 +578,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+    }
+
+    public function testAddingNativeEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'test\', \'test2\')) not null', $statements[0]);
     }
 
     public function testAddingDate()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -498,6 +499,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+    }
+
+    public function testAddingNativeEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'test\', \'test2\')) not null', $statements[0]);
     }
 
     public function testAddingJson()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -543,6 +544,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
+    }
+
+    public function testAddingNativeEnum()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'test\', N\'test2\')) not null', $statements[0]);
     }
 
     public function testAddingJson()

--- a/tests/Database/stubs/TestEnum.php
+++ b/tests/Database/stubs/TestEnum.php
@@ -5,5 +5,5 @@ namespace Illuminate\Tests\Database\stubs;
 enum TestEnum: string
 {
     case test = 'test';
-
+    case another = 'test2';
 }


### PR DESCRIPTION
Currently, when I have a migration, I can create an enum column by writing:

```php
$table->enum('user_role', ['admin', 'member']);
```

Since PHP 8.1 supports now native enums, it would be great if I could do the following:

```php
enum UserRole: string
{
    case Admin = 'admin';
    case Member = 'member';
}
```
```php
$table->enum('user_role', UserRole::class);
```

This pull requests adds this functionality.