### PR TITLE
[9.x] Fix mails with tags and metadata are not queuable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -172,11 +172,11 @@ class Mailable implements MailableContract, Renderable
     protected $metadata = [];
 
     /**
-     * The tag for the message.
+     * The tags for the message.
      *
-     * @var string
+     * @var array
      */
-    protected $tag;
+    protected $tags = [];
 
     /**
      * The callback that should be invoked while building the view data.
@@ -204,7 +204,7 @@ class Mailable implements MailableContract, Renderable
                 $this->buildFrom($message)
                      ->buildRecipients($message)
                      ->buildSubject($message)
-                     ->buildTag($message)
+                     ->buildTags($message)
                      ->buildMetadata($message)
                      ->runCallbacks($message)
                      ->buildAttachments($message);
@@ -422,15 +422,17 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
-     * Set the tag for the message.
+     * Set the tags for the message.
      *
      * @param  \Illuminate\Mail\Message  $message
      * @return $this
      */
-    protected function buildTag($message)
+    protected function buildTags($message)
     {
-        if ($this->tag) {
-            $message->getHeaders()->add(new TagHeader($this->tag));
+        if ($this->tags) {
+            foreach ($this->tags as $tag) {
+                $message->getHeaders()->add(new TagHeader($tag));
+            }
         }
 
         return $this;
@@ -932,7 +934,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function tag($value)
     {
-        $this->tag = $value;
+        array_push($this->tags, $value);
         return $this;
     }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -165,6 +165,20 @@ class Mailable implements MailableContract, Renderable
     protected $assertionableRenderStrings;
 
     /**
+     * The metadata for the message.
+     *
+     * @var array
+     */
+    protected $metadata = [];
+
+    /**
+     * The tag for the message.
+     *
+     * @var string
+     */
+    protected $tag;
+
+    /**
      * The callback that should be invoked while building the view data.
      *
      * @var callable
@@ -190,6 +204,8 @@ class Mailable implements MailableContract, Renderable
                 $this->buildFrom($message)
                      ->buildRecipients($message)
                      ->buildSubject($message)
+                     ->buildTag($message)
+                     ->buildMetadata($message)
                      ->runCallbacks($message)
                      ->buildAttachments($message);
             });
@@ -400,6 +416,38 @@ class Mailable implements MailableContract, Renderable
             $message->subject($this->subject);
         } else {
             $message->subject(Str::title(Str::snake(class_basename($this), ' ')));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the tag for the message.
+     *
+     * @param  \Illuminate\Mail\Message  $message
+     * @return $this
+     */
+    protected function buildTag($message)
+    {
+        if ($this->tag) {
+            $message->getHeaders()->add(new TagHeader($this->tag));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the tag for the message.
+     *
+     * @param  \Illuminate\Mail\Message  $message
+     * @return $this
+     */
+    protected function buildMetadata($message)
+    {
+        if ($this->metadata) {
+            foreach ($this->metadata as $key => $value) {
+                $message->getHeaders()->add(new MetadataHeader($key, $value));
+            }
         }
 
         return $this;
@@ -884,9 +932,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function tag($value)
     {
-        return $this->withSymfonyMessage(function (Email $message) use ($value) {
-            $message->getHeaders()->add(new TagHeader($value));
-        });
+        $this->tag = $value;
+        return $this;
     }
 
     /**
@@ -898,9 +945,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function metadata($key, $value)
     {
-        return $this->withSymfonyMessage(function (Email $message) use ($key, $value) {
-            $message->getHeaders()->add(new MetadataHeader($key, $value));
-        });
+        $this->metadata[$key] = $value;
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -137,6 +137,20 @@ class Mailable implements MailableContract, Renderable
     public $diskAttachments = [];
 
     /**
+     * The tags for the message.
+     *
+     * @var array
+     */
+    protected $tags = [];
+
+    /**
+     * The metadata for the message.
+     *
+     * @var array
+     */
+    protected $metadata = [];
+
+    /**
      * The callbacks for the message.
      *
      * @var array
@@ -163,20 +177,6 @@ class Mailable implements MailableContract, Renderable
      * @var array
      */
     protected $assertionableRenderStrings;
-
-    /**
-     * The metadata for the message.
-     *
-     * @var array
-     */
-    protected $metadata = [];
-
-    /**
-     * The tags for the message.
-     *
-     * @var array
-     */
-    protected $tags = [];
 
     /**
      * The callback that should be invoked while building the view data.
@@ -422,40 +422,6 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
-     * Set the tags for the message.
-     *
-     * @param  \Illuminate\Mail\Message  $message
-     * @return $this
-     */
-    protected function buildTags($message)
-    {
-        if ($this->tags) {
-            foreach ($this->tags as $tag) {
-                $message->getHeaders()->add(new TagHeader($tag));
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Set the tag for the message.
-     *
-     * @param  \Illuminate\Mail\Message  $message
-     * @return $this
-     */
-    protected function buildMetadata($message)
-    {
-        if ($this->metadata) {
-            foreach ($this->metadata as $key => $value) {
-                $message->getHeaders()->add(new MetadataHeader($key, $value));
-            }
-        }
-
-        return $this;
-    }
-
-    /**
      * Add all of the attachments to the message.
      *
      * @param  \Illuminate\Mail\Message  $message
@@ -497,6 +463,40 @@ class Mailable implements MailableContract, Renderable
                 array_merge(['mime' => $storage->mimeType($attachment['path'])], $attachment['options'])
             );
         }
+    }
+
+    /**
+     * Add all defined tags to the message.
+     *
+     * @param  \Illuminate\Mail\Message  $message
+     * @return $this
+     */
+    protected function buildTags($message)
+    {
+        if ($this->tags) {
+            foreach ($this->tags as $tag) {
+                $message->getHeaders()->add(new TagHeader($tag));
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add all defined metadata to the message.
+     *
+     * @param  \Illuminate\Mail\Message  $message
+     * @return $this
+     */
+    protected function buildMetadata($message)
+    {
+        if ($this->metadata) {
+            foreach ($this->metadata as $key => $value) {
+                $message->getHeaders()->add(new MetadataHeader($key, $value));
+            }
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -935,6 +935,7 @@ class Mailable implements MailableContract, Renderable
     public function tag($value)
     {
         array_push($this->tags, $value);
+
         return $this;
     }
 
@@ -948,6 +949,7 @@ class Mailable implements MailableContract, Renderable
     public function metadata($key, $value)
     {
         $this->metadata[$key] = $value;
+
         return $this;
     }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -9,6 +9,8 @@ use Illuminate\Mail\Markdown;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
 
 class MailChannel
 {
@@ -142,6 +144,16 @@ class MailChannel
 
         if (! is_null($message->priority)) {
             $mailMessage->setPriority($message->priority);
+        }
+
+        if ($message->tag) {
+            $mailMessage->getHeaders()->add(new TagHeader($this->tag));
+        }
+
+        if ($message->metadata) {
+            foreach ($message->metadata as $key => $value) {
+                $mailMessage->getHeaders()->add(new MetadataHeader($key, $value));
+            }
         }
 
         $this->runCallbacks($mailMessage, $message);

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -146,8 +146,10 @@ class MailChannel
             $mailMessage->setPriority($message->priority);
         }
 
-        if ($message->tag) {
-            $mailMessage->getHeaders()->add(new TagHeader($this->tag));
+        if ($message->tags) {
+            foreach ($message->tags as $tag) {
+                $mailMessage->getHeaders()->add(new TagHeader($tag));
+            }
         }
 
         if ($message->metadata) {

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -7,9 +7,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Mail\Markdown;
 use Illuminate\Support\Traits\Conditionable;
-use Symfony\Component\Mailer\Header\MetadataHeader;
-use Symfony\Component\Mailer\Header\TagHeader;
-use Symfony\Component\Mime\Email;
 
 class MailMessage extends SimpleMessage implements Renderable
 {
@@ -98,6 +95,20 @@ class MailMessage extends SimpleMessage implements Renderable
      * @var array
      */
     public $callbacks = [];
+
+    /**
+     * The metadata for the message.
+     *
+     * @var array
+     */
+    public $metadata = [];
+
+    /**
+     * The tag for the message.
+     *
+     * @var string
+     */
+    public $tag;
 
     /**
      * Set the view for the mail message.
@@ -264,9 +275,8 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function tag($value)
     {
-        return $this->withSymfonyMessage(function (Email $message) use ($value) {
-            $message->getHeaders()->add(new TagHeader($value));
-        });
+        $this->tag = $value;
+        return $this;
     }
 
     /**
@@ -278,9 +288,8 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function metadata($key, $value)
     {
-        return $this->withSymfonyMessage(function (Email $message) use ($key, $value) {
-            $message->getHeaders()->add(new MetadataHeader($key, $value));
-        });
+        $this->metadata[$key] = $value;
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -104,11 +104,11 @@ class MailMessage extends SimpleMessage implements Renderable
     public $metadata = [];
 
     /**
-     * The tag for the message.
+     * The tags for the message.
      *
-     * @var string
+     * @var array
      */
-    public $tag;
+    public $tags = [];
 
     /**
      * Set the view for the mail message.
@@ -275,7 +275,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function tag($value)
     {
-        $this->tag = $value;
+        array_push($this->tags, $value);
         return $this;
     }
 

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -276,6 +276,7 @@ class MailMessage extends SimpleMessage implements Renderable
     public function tag($value)
     {
         array_push($this->tags, $value);
+
         return $this;
     }
 
@@ -289,6 +290,7 @@ class MailMessage extends SimpleMessage implements Renderable
     public function metadata($key, $value)
     {
         $this->metadata[$key] = $value;
+
         return $this;
     }
 

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -83,6 +83,20 @@ class MailMessage extends SimpleMessage implements Renderable
     public $rawAttachments = [];
 
     /**
+     * The tags for the message.
+     *
+     * @var array
+     */
+    public $tags = [];
+
+    /**
+     * The metadata for the message.
+     *
+     * @var array
+     */
+    public $metadata = [];
+
+    /**
      * Priority level of the message.
      *
      * @var int
@@ -95,20 +109,6 @@ class MailMessage extends SimpleMessage implements Renderable
      * @var array
      */
     public $callbacks = [];
-
-    /**
-     * The metadata for the message.
-     *
-     * @var array
-     */
-    public $metadata = [];
-
-    /**
-     * The tags for the message.
-     *
-     * @var array
-     */
-    public $tags = [];
 
     /**
      * Set the view for the mail message.

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -445,6 +445,46 @@ class MailMailableTest extends TestCase
         $this->assertSame('hello@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
         $this->assertStringContainsString('X-Priority: 1 (Highest)', $sentMessage->toString());
     }
+
+    public function testMailableMetadataGetsSent()
+    {
+        $view = m::mock(Factory::class);
+
+        $mailer = new Mailer('array', $view, new ArrayTransport);
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->to('hello@laravel.com');
+        $mailable->from('taylor@laravel.com');
+        $mailable->html('test content');
+
+        $mailable->metadata('origin', 'test-suite');
+        $mailable->metadata('user_id', 1);
+
+        $sentMessage = $mailer->send($mailable);
+
+        $this->assertSame('hello@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
+        $this->assertStringContainsString('X-Metadata-origin: test-suite', $sentMessage->toString());
+        $this->assertStringContainsString('X-Metadata-user_id: 1', $sentMessage->toString());
+    }
+
+    public function testMailableTagGetsSent()
+    {
+        $view = m::mock(Factory::class);
+
+        $mailer = new Mailer('array', $view, new ArrayTransport);
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->to('hello@laravel.com');
+        $mailable->from('taylor@laravel.com');
+        $mailable->html('test content');
+
+        $mailable->tag('test');
+
+        $sentMessage = $mailer->send($mailable);
+
+        $this->assertSame('hello@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
+        $this->assertStringContainsString('X-Tag: test', $sentMessage->toString());
+    }
 }
 
 class WelcomeMailableStub extends Mailable

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -479,11 +479,13 @@ class MailMailableTest extends TestCase
         $mailable->html('test content');
 
         $mailable->tag('test');
+        $mailable->tag('foo');
 
         $sentMessage = $mailer->send($mailable);
 
         $this->assertSame('hello@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
         $this->assertStringContainsString('X-Tag: test', $sentMessage->toString());
+        $this->assertStringContainsString('X-Tag: foo', $sentMessage->toString());
     }
 }
 

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -138,7 +138,7 @@ class NotificationMailMessageTest extends TestCase
         $message = new MailMessage;
         $message->tag('test');
 
-        $this->assertSame('test', $message->tag);
+        $this->assertContains('test', $message->tags);
     }
 
     public function testCallbackIsSetCorrectly()

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -121,6 +121,26 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame([['test@example.com', null], ['test@example.com', 'Test']], $message->replyTo);
     }
 
+    public function testMetadataIsSetCorrectly()
+    {
+        $message = new MailMessage;
+        $message->metadata('origin', 'test-suite');
+        $message->metadata('user_id', 1);
+
+        $this->assertArrayHasKey('origin', $message->metadata);
+        $this->assertSame('test-suite', $message->metadata['origin']);
+        $this->assertArrayHasKey('user_id', $message->metadata);
+        $this->assertSame(1, $message->metadata['user_id']);
+    }
+
+    public function testTagIsSetCorrectly()
+    {
+        $message = new MailMessage;
+        $message->tag('test');
+
+        $this->assertSame('test', $message->tag);
+    }
+
     public function testCallbackIsSetCorrectly()
     {
         $callback = function () {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In PR #40783 functionality is added to mails to add tags en metadata to supported mail drivers. However, this is not working when queuing mails, because `Serialization of 'Closure' is not allowed`. This PR fixes that problem and is adding some unit tests for this functionality.