### PR TITLE
[9.x] Add keyBy() method to Arr helpers

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -744,4 +744,34 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Indexes the array according to a specified key.
+     *
+     * @param iterable $array
+     * @param string|int|null $key
+     * @return array the indexed array
+     */
+    public static function index($array, $key)
+    {
+        $results = [];
+
+        foreach ($array as $item) {
+
+            $keyValue = data_get($item, $key);
+
+            if (is_null($keyValue)) {
+                $results[] = $item;
+                continue;
+            }
+
+            if (is_object($keyValue) && method_exists($keyValue, '__toString')) {
+                $keyValue = (string)$keyValue;
+            }
+
+            $results[$keyValue] = $item;
+        }
+
+        return $results;
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -757,7 +757,6 @@ class Arr
         $results = [];
 
         foreach ($array as $item) {
-
             $keyValue = data_get($item, $key);
 
             if (is_null($keyValue)) {

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -746,31 +746,13 @@ class Arr
     }
 
     /**
-     * Indexes the array according to a specified key.
+     * Key an associative array by a field or using a callback.
      *
-     * @param  iterable  $array
-     * @param  string|int|null  $key
-     * @return array the indexed array
+     * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
+     * @return array
      */
-    public static function index($array, $key)
+    public static function keyBy($array, $keyBy)
     {
-        $results = [];
-
-        foreach ($array as $item) {
-            $keyValue = data_get($item, $key);
-
-            if (is_null($keyValue)) {
-                $results[] = $item;
-                continue;
-            }
-
-            if (is_object($keyValue) && method_exists($keyValue, '__toString')) {
-                $keyValue = (string) $keyValue;
-            }
-
-            $results[$keyValue] = $item;
-        }
-
-        return $results;
+        return Collection::make($array)->keyBy($keyBy)->all();
     }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -748,8 +748,8 @@ class Arr
     /**
      * Indexes the array according to a specified key.
      *
-     * @param iterable $array
-     * @param string|int|null $key
+     * @param  iterable  $array
+     * @param  string|int|null  $key
      * @return array the indexed array
      */
     public static function index($array, $key)
@@ -766,7 +766,7 @@ class Arr
             }
 
             if (is_object($keyValue) && method_exists($keyValue, '__toString')) {
-                $keyValue = (string)$keyValue;
+                $keyValue = (string) $keyValue;
             }
 
             $results[$keyValue] = $item;

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -424,6 +424,18 @@ class Arr
     }
 
     /**
+     * Key an associative array by a field or using a callback.
+     *
+     * @param  array  $array
+     * @param  callable|array|string
+     * @return array
+     */
+    public static function keyBy($array, $keyBy)
+    {
+        return Collection::make($array)->keyBy($keyBy)->all();
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array
@@ -743,16 +755,5 @@ class Arr
         }
 
         return is_array($value) ? $value : [$value];
-    }
-
-    /**
-     * Key an associative array by a field or using a callback.
-     *
-     * @param  (callable(TValue, TKey): array-key)|array|string  $keyBy
-     * @return array
-     */
-    public static function keyBy($array, $keyBy)
-    {
-        return Collection::make($array)->keyBy($keyBy)->all();
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1032,7 +1032,7 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals([
             '123' => ['id' => '123', 'data' => 'abc'],
-            '345' => ['id' => '345', 'data' => 'hgi'],
+            '345' => ['id' => '345', 'data' => 'def'],
             '498' => ['id' => '498', 'data' => 'hgi'],
         ], Arr::index($array, 'id'));
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1022,7 +1022,7 @@ class SupportArrTest extends TestCase
         ], $sortedWithCallable);
     }
 
-    public function testIndex()
+    public function testKeyBy()
     {
         $array = [
             ['id' => '123', 'data' => 'abc'],
@@ -1034,6 +1034,6 @@ class SupportArrTest extends TestCase
             '123' => ['id' => '123', 'data' => 'abc'],
             '345' => ['id' => '345', 'data' => 'def'],
             '498' => ['id' => '498', 'data' => 'hgi'],
-        ], Arr::index($array, 'id'));
+        ], Arr::keyBy($array, 'id'));
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1021,4 +1021,19 @@ class SupportArrTest extends TestCase
             ['name' => 'John', 'age' => 8,  'meta' => ['key' => 3]],
         ], $sortedWithCallable);
     }
+
+    public function testIndex()
+    {
+        $array = [
+            ['id' => '123', 'data' => 'abc'],
+            ['id' => '345', 'data' => 'def'],
+            ['id' => '498', 'data' => 'hgi'],
+        ];
+
+        $this->assertEquals([
+            '123' => ['id' => '123', 'data' => 'abc'],
+            '345' => ['id' => '345', 'data' => 'hgi'],
+            '498' => ['id' => '498', 'data' => 'hgi'],
+        ], Arr::index($array, 'id'));
+    }
 }


### PR DESCRIPTION
Hi guys, this is my first PR. Please let me know if you have anything to change or improve. This method was inspired by the [ArrayHelper::index of the Yii2 framework](https://www.yiiframework.com/doc/api/2.0/yii-helpers-basearrayhelper#index()-detail). I used this method a lot to format arrays and I would really like laravel to have it too


Indexes the array according to a specified key.

use case
```
$array = [
    ['id' => '123', 'data' => 'abc', 'device' => 'laptop'],
    ['id' => '345', 'data' => 'def', 'device' => 'tablet'],
    ['id' => '345', 'data' => 'hgi', 'device' => 'smartphone'],
];
$result = Arr::index($array, 'id');
```

The result will be an associative array, where the key is the value of id attribute
```
[
    '123' => ['id' => '123', 'data' => 'abc', 'device' => 'laptop'],
    '345' => ['id' => '345', 'data' => 'hgi', 'device' => 'smartphone']
    // The second element of an original array is overwritten by the last element because of the same id
]
```

- Renamed Arr:index to Arr:keyBy
