### PR TITLE
[9.x] Solve exception error: Undefined array key "", in artisan route:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -122,7 +122,7 @@ class RouteListCommand extends Command
 
         if (($sort = $this->option('sort')) !== null) {
             $routes = $this->sortRoutes($sort, $routes);
-        }else {
+        } else {
             $routes = $this->sortRoutes('uri', $routes);
         }
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -120,8 +120,10 @@ class RouteListCommand extends Command
             return $this->getRouteInformation($route);
         })->filter()->all();
 
-        if (($sort = $this->option('sort')) !== 'precedence') {
+        if (($sort = $this->option('sort')) !== null) {
             $routes = $this->sortRoutes($sort, $routes);
+        }else {
+            $routes = $this->sortRoutes('uri', $routes);
         }
 
         if ($this->option('reverse')) {


### PR DESCRIPTION
If you run php artisan route:list --sort without any param you get an exception.

 ```
$ php artisan route:list --sort
```
   ErrorException 

  Undefined array key ""

  at vendor/laravel/framework/src/Illuminate/Foundation/Console/RouteListCommand.php:162

But by default routes would be sorted by uri, based on help on this command.



<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
