### PR TITLE
[9.x] MySQL driver might modify custom casted date

### DIFF
--- a/tests/Integration/Database/MySql/EloquentCustomDateCastingRetrivalTest.php
+++ b/tests/Integration/Database/MySql/EloquentCustomDateCastingRetrivalTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentCustomDateCastingRetrivalTest extends MySqlTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('test_models', function (Blueprint $table) {
+            $table->id('id');
+            $table->date('custom_date');
+        });
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('test_models');
+    }
+
+    public function testCustomDateMatchesGivenDateBeforeSave()
+    {
+        TestModel::create(['custom_date' => '26.01.2022']);
+
+        $this->assertEquals('26.01.2022', TestModel::first()->custom_date->format('d.m.Y'));
+    }
+}
+
+class TestModel extends Model
+{
+    public $timestamps = false;
+    protected $guarded = [];
+
+    protected $casts = [
+        'custom_date' => 'date:d.m.Y'
+    ];
+}


### PR DESCRIPTION
This PR only shows that the custom date formatting is not working in all cases. **it does not implement a fix**, because I am not 100% sure where to fix this issue and why it occurs in the first place or whether it should be fixed on the config level of the MySQL driver.

## Explanation
Setting a custom date format which does not follow the American approach and list the year first, will be altered when the related model is saved to the MySQL DB driver.

```php
class TestModel extends Model
{
    protected $casts = [
        'custom_date' => 'date:d.m.Y'
    ];
}

TestModel::create(['custom_date' => '26.01.2022']);

//  custom_date is set to 20.01.2026 instead of the expected date
TestModel::first()->custom_date->format('d.m.Y') === '26.01.2022'; // false
```

## Attempted fixes
```php
// Illuminate\Database\Eloquent\Concerns\HasAttributes

public function setAttribute($key, $value)
{
    //...

    elseif ($value && ($this->isDateAttribute($key)  || $this->isDateCastableWithCustomFormat($key))) { // added last statement
        $value = $this->fromDateTime($value);
    }

    //...
}
```
**or**
```php
// Illuminate\Database\Eloquent\Concerns\HasAttributes

protected function isDateAttribute($key)
{
    return in_array($key, $this->getDates(), true) ||
        $this->isDateCastable($key) ||
        $this->isDateCastableWithCustomFormat($key); // added that line
}
```

Both attempts fixed the issue, however they resulted in the failing of `EloquentModelDateCastingTest::testDatesFormattedAttributeBindings` test

```
1) Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest\EloquentModelDateCastingTest::testDatesFormattedAttributeBindings
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
-    0 => '2019-10-01'
+    0 => '2019-10-01 00:00:00'
     1 => '2019-10-01 10:15:20'
-    2 => '2019-10-01'
-    3 => '2019-10-01 10:15'
+    2 => '2019-10-01 00:00:00'
+    3 => '2019-10-01 10:15:00'
 )
```