### PR TITLE
[9.x] Add test for the cacheManager purge and etc

### DIFF
--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -172,7 +172,7 @@ class CacheFileStoreTest extends TestCase
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
         $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents))->willReturn(strlen($contents));
         $store = new FileStore($files, __DIR__);
-        $result = $store->forever('foo', 'Hello World', 10);
+        $result = $store->forever('foo', 'Hello World');
         $this->assertTrue($result);
     }
 

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -92,6 +92,104 @@ class CacheManagerTest extends TestCase
         $this->assertNotNull($repo->getEventDispatcher());
     }
 
+    public function testItRefreshesDispatcherOnAllStores()
+    {
+        $userConfig = [
+            'cache' => [
+                'stores' => [
+                    'store_1' => [
+                        'driver' => 'array',
+                    ],
+                    'store_2' => [
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
+        $repo1 = $cacheManager->store('store_1');
+        $repo2 = $cacheManager->store('store_2');
+
+        $this->assertNull($repo1->getEventDispatcher());
+        $this->assertNull($repo2->getEventDispatcher());
+
+        $dispatcher = new Event;
+        $app->bind(Dispatcher::class, fn () => $dispatcher);
+
+        $cacheManager->refreshEventDispatcher();
+
+        $this->assertNotSame($repo1, $repo2);
+        $this->assertSame($dispatcher, $repo1->getEventDispatcher());
+        $this->assertSame($dispatcher, $repo2->getEventDispatcher());
+    }
+
+    public function testItSetsDefaultDriverChangesGlobalConfig()
+    {
+        $userConfig = [
+            'cache' => [
+                'default' => 'store_1',
+                'stores' => [
+                    'store_1' => [
+                        'driver' => 'array',
+                    ],
+                    'store_2' => [
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
+
+        $cacheManager->setDefaultDriver('><((((@>');
+
+        $this->assertEquals('><((((@>', $app->get('config')->get('cache.default'));
+    }
+
+    public function testItCachesStoreObjects()
+    {
+        $userConfig = [
+            'cache' => [
+                'stores' => [
+                    'store_1' => [
+                        'driver' => 'array',
+                    ],
+                    'store_2' => [
+                        'driver' => 'null',
+                    ],
+                ],
+            ],
+        ];
+
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
+
+        $repo1 = $cacheManager->store('store_1');
+        $repo2 = $cacheManager->store('store_1');
+
+        $repo3 = $cacheManager->store('store_2');
+        $repo4 = $cacheManager->store('store_2');
+        $repo5 = $cacheManager->store('store_2');
+
+        $this->assertSame($repo1, $repo2);
+        $this->assertSame($repo3, $repo4);
+        $this->assertSame($repo3, $repo5);
+        $this->assertNotSame($repo1, $repo5);
+
+        $cacheManager->purge('store_1');
+
+        // Make sure a now object is built this time.
+        $repo6 = $cacheManager->store('store_1');
+        $this->assertNotSame($repo1, $repo6);
+
+        // Make sure Purge does not delete all objects.
+        $repo7 = $cacheManager->store('store_2');
+        $this->assertSame($repo3, $repo7);
+    }
+
     public function testForgetDriver()
     {
         $cacheManager = m::mock(CacheManager::class)
@@ -182,7 +280,7 @@ class CacheManagerTest extends TestCase
     protected function getApp(array $userConfig)
     {
         $app = Container::getInstance();
-        $app->bind('config', fn () => new Repository($userConfig));
+        $app->singleton('config', fn () => new Repository($userConfig));
 
         return $app;
     }


### PR DESCRIPTION
These methods on the `CacheManager` still have no tests at all:
- `setDefaultDriver`
- `refreshEventDispatcher`
- `purge`

Memoization behavior also has no tests.

It also removes a redundant extra argument passed to the `forever` method, seemingly copy/pasted from the previous test.