### PR TITLE
[9.x] Add instantiate method to collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1220,6 +1220,20 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Turns class names into objects of that class.
+     *
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function instantiate()
+    {
+        return $this->map(function($item) {
+            return new $item;
+        });
+    }
+
+    /**
      * Get the first item in the collection but throw an exception if no matching items exist.
      *
      * @param  (callable(TValue, TKey): bool)|string  $key

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1226,7 +1226,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function instantiate()
     {
-        return $this->map(function($item) {
+        return $this->map(function ($item) {
             return new $item;
         });
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1223,8 +1223,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Turns class names into objects of that class.
      *
      * @return TValue
-     *
-     * @throws \Illuminate\Support\ItemNotFoundException
      */
     public function instantiate()
     {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1167,7 +1167,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function instantiate()
     {
-        return $this->map(function($item) {
+        return $this->map(function ($item) {
             return new $item;
         });
     }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1161,6 +1161,20 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Turns class names into objects of that class.
+     *
+     * @return TValue
+     *
+     * @throws \Illuminate\Support\ItemNotFoundException
+     */
+    public function instantiate()
+    {
+        return $this->map(function($item) {
+            return new $item;
+        });
+    }
+
+    /**
      * Get the first item in the collection but throw an exception if no matching items exist.
      *
      * @param  (callable(TValue, TKey): bool)|string  $key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1164,8 +1164,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Turns class names into objects of that class.
      *
      * @return TValue
-     *
-     * @throws \Illuminate\Support\ItemNotFoundException
      */
     public function instantiate()
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5000,6 +5000,17 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testInstantiate($collection) {
+        $data = new $collection([Collection::class]);
+
+        $object = $data->instantiate()->first();
+
+        $this->assertTrue(is_a($object, Collection::class));
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5002,7 +5002,8 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testInstantiate($collection) {
+    public function testInstantiate($collection)
+    {
         $data = new $collection([Collection::class]);
 
         $object = $data->instantiate()->first();


### PR DESCRIPTION
I often add classes to an array which I then later want to instantiate using a collection.

For example, I want to scrape these news websites.

```php
$sites = [
    NYTimes::class,
    BuzzFeed::class,
    TheTelegraph::class,
];

// Before
collect($sites)->map(function($class) {
    return new $class;
});

// Now
collect($sites)->instantiate();
```

The new collections now have an object of each class.

**For reviewers:**
- Please check if the DocBlocks are correct .
- Maybe you know an easier name for the method.