### PR TITLE
[9.x] Enhance Container flush method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1365,6 +1365,9 @@ class Container implements ArrayAccess, ContainerContract
         $this->aliases = [];
         $this->resolved = [];
         $this->bindings = [];
+        $this->contextual = [];
+        $this->tags = [];
+        $this->with = [];
         $this->instances = [];
         $this->abstractAliases = [];
         $this->scopedInstances = [];


### PR DESCRIPTION
I did not find a precise definition for the `flush` method of the container.
But it seems that when we remove all the binding, we should also remove the `contextual binding` and the `tags` for its bindings as well because they are very close to each other.

These three properties are flushed nowhere. neither in the `Container` flush nor in the `Application` flush method.

- Let me mention that this is important for `swoole` or `road-runner` style, since we may want to simulate a restart from scratch.