### PR TITLE
[9.x] Fix loadAggregate not correctly applying casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -92,7 +92,7 @@ class Collection extends BaseCollection implements QueueableCollection
         $this->each(function ($model) use ($models, $attributes) {
             $extraAttributes = Arr::only($models->get($model->getKey())->getAttributes(), $attributes);
 
-            $model->forceFill($extraAttributes)->syncOriginalAttributes($attributes);
+            $model->forceFill($extraAttributes)->syncOriginalAttributes($attributes)->mergeCasts($models->get($model->getKey())->getCasts());
         });
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -92,7 +92,9 @@ class Collection extends BaseCollection implements QueueableCollection
         $this->each(function ($model) use ($models, $attributes) {
             $extraAttributes = Arr::only($models->get($model->getKey())->getAttributes(), $attributes);
 
-            $model->forceFill($extraAttributes)->syncOriginalAttributes($attributes)->mergeCasts($models->get($model->getKey())->getCasts());
+            $model->forceFill($extraAttributes)
+                ->syncOriginalAttributes($attributes)
+                ->mergeCasts($models->get($model->getKey())->getCasts());
         });
 
         return $this;

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Support\Collection as BaseCollection;
 use LogicException;
 use Mockery as m;
@@ -13,8 +15,53 @@ use stdClass;
 
 class DatabaseEloquentCollectionTest extends TestCase
 {
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+
+            $this->schema()->create('users', function ($table) {
+                $table->increments('id');
+                $table->string('email')->unique();
+            });
+
+            $this->schema()->create('articles', function ($table) {
+                $table->increments('id');
+                $table->integer('user_id');
+                $table->string('title');
+            });
+
+            $this->schema()->create('comments', function ($table) {
+                $table->increments('id');
+                $table->integer('article_id');
+                $table->string('content');
+            });
+
+    }
+
     protected function tearDown(): void
     {
+        $this->schema()->drop('users');
+        $this->schema()->drop('articles');
+        $this->schema()->drop('comments');
         m::close();
     }
 
@@ -536,6 +583,56 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c = new Collection;
         $c->toQuery();
     }
+
+    public function testLoadExistsShouldCastBool()
+    {
+        $this->seedData();
+        $user = EloquentTestUserModel::with('articles')->first();
+        $user->articles->loadExists("comments");
+        $commentsExists = $user->articles->pluck('comments_exists')->toArray();
+        $this->assertContainsOnly('bool',$commentsExists);
+    }
+
+    /**
+     * Helpers...
+     */
+    protected function seedData()
+    {
+        $user = EloquentTestUserModel::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        EloquentTestArticleModel::query()->insert([
+            ['user_id' => 1, 'title' => 'Another title'],
+            ['user_id' => 1, 'title' => 'Another title'],
+            ['user_id' => 1, 'title' => 'Another title'],
+        ]);
+
+        EloquentTestCommentModel::query()->insert([
+            ['article_id' => 1, 'content' => 'Another comment'],
+            ['article_id' => 2, 'content' => 'Another comment'],
+        ]);
+
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
 }
 
 class TestEloquentCollectionModel extends Model
@@ -547,4 +644,35 @@ class TestEloquentCollectionModel extends Model
     {
         return 'test';
     }
+}
+
+class EloquentTestUserModel extends Model
+{
+    protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function articles()
+    {
+        return $this->hasMany(EloquentTestArticleModel::class,'user_id');
+    }
+}
+
+class EloquentTestArticleModel extends Model
+{
+    protected $table = 'articles';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function comments()
+    {
+        return $this->hasMany(EloquentTestCommentModel::class,'article_id');
+    }
+}
+
+class EloquentTestCommentModel extends Model
+{
+    protected $table = 'comments';
+    protected $guarded = [];
+    public $timestamps = false;
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -37,24 +37,22 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     protected function createSchema()
     {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
 
-            $this->schema()->create('users', function ($table) {
-                $table->increments('id');
-                $table->string('email')->unique();
-            });
+        $this->schema()->create('articles', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->string('title');
+        });
 
-            $this->schema()->create('articles', function ($table) {
-                $table->increments('id');
-                $table->integer('user_id');
-                $table->string('title');
-            });
-
-            $this->schema()->create('comments', function ($table) {
-                $table->increments('id');
-                $table->integer('article_id');
-                $table->string('content');
-            });
-
+        $this->schema()->create('comments', function ($table) {
+            $table->increments('id');
+            $table->integer('article_id');
+            $table->string('content');
+        });
     }
 
     protected function tearDown(): void
@@ -588,9 +586,9 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $this->seedData();
         $user = EloquentTestUserModel::with('articles')->first();
-        $user->articles->loadExists("comments");
+        $user->articles->loadExists('comments');
         $commentsExists = $user->articles->pluck('comments_exists')->toArray();
-        $this->assertContainsOnly('bool',$commentsExists);
+        $this->assertContainsOnly('bool', $commentsExists);
     }
 
     /**
@@ -610,7 +608,6 @@ class DatabaseEloquentCollectionTest extends TestCase
             ['article_id' => 1, 'content' => 'Another comment'],
             ['article_id' => 2, 'content' => 'Another comment'],
         ]);
-
     }
 
     /**
@@ -632,7 +629,6 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         return $this->connection()->getSchemaBuilder();
     }
-
 }
 
 class TestEloquentCollectionModel extends Model
@@ -654,7 +650,7 @@ class EloquentTestUserModel extends Model
 
     public function articles()
     {
-        return $this->hasMany(EloquentTestArticleModel::class,'user_id');
+        return $this->hasMany(EloquentTestArticleModel::class, 'user_id');
     }
 }
 
@@ -666,7 +662,7 @@ class EloquentTestArticleModel extends Model
 
     public function comments()
     {
-        return $this->hasMany(EloquentTestCommentModel::class,'article_id');
+        return $this->hasMany(EloquentTestCommentModel::class, 'article_id');
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Reopening #41025 with tests and better explanation about the bug. 

There's a bug in `loadAggregate` in Eloquent Collections specefically when running `LoadExists` where running something like

`$user->articles->loadExists("comments")`  will add `comments_exists` to all existing articles but only the first model will have bool `casts` automatically added to it. Resulting in something similar to:

    .. "comments_exists" => true
    .. "comments_exists" => '1'
    .. "comments_exists" => '1'  

This PR fixes that and adds casts to all items instead of only the first one. I highly doubt it'll be breaking change to anyone.
