### PR TITLE
[9.x] Add "assertRelationLoaded"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -784,6 +785,19 @@ trait HasRelationships
     public function relationLoaded($key)
     {
         return array_key_exists($key, $this->relations);
+    }
+
+    /**
+     * Assert that the given relation is loaded.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function assertRelationLoaded($key)
+    {
+        if (! $this->relationLoaded($key)) {
+            throw new LazyLoadingViolationException($this, $key);
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Support\Carbon;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -289,6 +290,26 @@ class DatabaseEloquentRelationTest extends TestCase
 
         $this->assertTrue($model->isRelation('parent'));
         $this->assertFalse($model->isRelation('field'));
+    }
+
+    public function testAssertRelationLoadedThrowsIfNotLoaded()
+    {
+        $this->expectException(LazyLoadingViolationException::class);
+
+        $model = new EloquentRelationResetModelStub;
+
+        $model->assertRelationLoaded('foo');
+    }
+
+    public function testAssertRelationLoadedDoesNotThrowIfLoaded()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $model = new EloquentRelationResetModelStub;
+
+        $model->setRelation('foo', []);
+
+        $model->assertRelationLoaded('foo');
     }
 }
 


### PR DESCRIPTION
I have some big projects that were created before `Model::preventLazyLoading()` existed. I'm not mentally prepared yet to fix every instance of lazy loading in the whole application, so instead, for new code that I write, I do something like this:

```php
public function perfectCommentsCount(): Attribute
{
    throw_unless($this->relationLoaded('comments'), '"perfectCommentsCount" used, but "comments" relation is not loaded.');

    return new Attribute(
        get: fn () => $this->comments->where('is_perfect', true)->count(),
    );
}
```

This PR adds a `assertRelationLoaded` method so that I can do this instead:

```php
public function perfectCommentsCount(): Attribute
{
    $this->assertRelationLoaded('comments');

    return new Attribute(
        get: fn () => $this->comments->where('is_perfect', true)->count(),
    );
}
```

It seemed fitting to throw the existing `LazyLoadingViolationException` exception, but the exception message isn't exactly correct:

https://github.com/laravel/framework/blob/4b478a60d629861244aa8242abc2d376d9ece6e7/src/Illuminate/Database/LazyLoadingViolationException.php#L34

I think changing the exception message might be a breaking change? We could leave it be for now and change the message in Laravel 10, or we could throw a `LogicException` instead.
