### PR TITLE
[9.x] Add ability to supply HTTP client methods with `JsonSerializable` instances

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use JsonSerializable;
 use Psr\Http\Message\MessageInterface;
 use Symfony\Component\VarDumper\VarDumper;
 
@@ -832,11 +833,11 @@ class PendingRequest
             $laravelData = is_array($parsedData) ? $parsedData : [];
         }
 
-        if (!is_array($laravelData)) {
-            $laravelData = [];
+        if ($laravelData instanceof JsonSerializable) {
+            $laravelData = $laravelData->jsonSerialize();
         }
 
-        return $laravelData;
+        return is_array($laravelData) ? $laravelData : [];
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -832,6 +832,10 @@ class PendingRequest
             $laravelData = is_array($parsedData) ? $parsedData : [];
         }
 
+        if (!is_array($laravelData)) {
+            $laravelData = [];
+        }
+
         return $laravelData;
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -18,6 +18,7 @@ use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
+use JsonSerializable;
 use Mockery as m;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
@@ -195,6 +196,28 @@ class HttpClientTest extends TestCase
             return $request->url() === 'http://foo.com/form' &&
                    $request->hasHeader('Content-Type', 'application/x-www-form-urlencoded') &&
                    $request['name'] === 'Taylor';
+        });
+    }
+
+    public function testCanSendJsonSerializableData()
+    {
+        $this->factory->fake();
+
+        $this->factory->asJson()->post('http://foo.com/form', new class implements JsonSerializable
+        {
+            public function jsonSerialize()
+            {
+                return [
+                    'name' => 'Taylor',
+                    'title' => 'Laravel Developer',
+                ];
+            }
+        });
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/form' &&
+                $request->hasHeader('Content-Type', 'application/json') &&
+                $request['name'] === 'Taylor';
         });
     }
 


### PR DESCRIPTION
## Problem

Guzzle supports ["any PHP type that can be operated on by PHP's json_encode() function"](https://docs.guzzlephp.org/en/stable/request-options.html#json) as JSON body format, but the current implementation prevents using anything other than a string or an array (or `Arrayable`). This is because the logic that parses the request data for assertions assumes it's always either of those types.

## Description

This PR introduces the ability – or fixes the bug, depends how you see it – to supply `JsonSerializable` instances into the Laravel HTTP Client for more convenient use.

## Usage

### Before
``` php
$user = new User(['name' => 'Taylor']); // Some class implementing JsonSerializable.

Http::withBody(json_encode($user), 'application/json')->post('/users');
```

### After
``` php
$user = new User(['name' => 'Taylor']); // Some class implementing JsonSerializable.

Http::post('/users', $user);
```

This example uses a class that implements `JsonSerializable`, but it can be anything that `json_encode` can handle.