### PR TITLE
[8.x] Fixes attempt to log deprecations on mocks

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -86,7 +86,10 @@ class HandleExceptions
      */
     public function handleDeprecation($message, $file, $line)
     {
-        if (! class_exists(LogManager::class)) {
+        if (! class_exists(LogManager::class)
+            || ! $this->app->hasBeenBootstrapped()
+            || $this->app->runningUnitTests()
+        ) {
             return;
         }
 


### PR DESCRIPTION
This pull request fixes an issue that may happen when testing code looks like so:

```php
    public function test_example()
    {
        Log::spy();

        // Error: Call to a member function warning() on null
        str_contains(null, null);
    }
```

In other words, the framework, and the attempt to log the deprecation, tries to resolve the Log instance that is a mock in this case. Now, because in tests, we only want to raise deprecations as errors when using the `withoutDeprecationHandling`, we can safely disable deprecation logs on unit tests.

This needs to be included on L9 too.

Fixes https://github.com/laravel/framework/pull/40942#issuecomment-1041436442, and Mior's issue on Nova this morning:

<img width="519" alt="Screenshot 2022-02-16 at 16 19 47" src="https://user-images.githubusercontent.com/5457236/154309156-cebdcc66-be47-4398-8628-951b2e14c043.png">

