### PR TITLE
[9.x] Add Str::highlight()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -303,7 +303,7 @@ class Str
 
         $highlights = array_map(fn ($value) => preg_quote($value, '/'), (array) $highlights);
 
-        return preg_replace('/(?<![\w+])('.implode('|', $highlights).')(?![\w?+:.*^$()\[{\\}\]|])/', "<$tag>$0</$tag>", $text);
+        return preg_replace('/(?<![\w?+:.*^$()\[\{\}\]|\\])('.implode('|', $highlights).')(?![\w?+:.*^$()\[{\\}\]|])/', "<$tag>$0</$tag>", $text);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -301,7 +301,7 @@ class Str
             return $text;
         }
 
-        $highlights = array_map(fn($value) => preg_quote($value, '/'), (array)$highlights);
+        $highlights = array_map(fn ($value) => preg_quote($value, '/'), (array) $highlights);
 
         return preg_replace('/(?<![\w+])('.implode('|', $highlights).')(?![\w?+:.*^$()\[{\\}\]|])/', "<$tag>$0</$tag>", $text);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -303,7 +303,7 @@ class Str
 
         $highlights = array_map(fn ($value) => preg_quote($value, '/'), (array) $highlights);
 
-        return preg_replace('/(?<![\w?])('.implode('|', $highlights).')(?![\w?+:.*^$()\[{\\}\]|])/', "<$tag>$0</$tag>", $text);
+        return preg_replace('/(?<![\w?])('.implode('|', $highlights).')(?![\w?+:.\/*^$()\[{\\}\]|])/', "<$tag>$0</$tag>", $text);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -291,17 +291,19 @@ class Str
 
     /**
      * @param  string  $text
-     * @param  string|array  $highlight
+     * @param  string|array  $highlights
      * @param  string  $tag
      * @return string
      */
-    public static function highlight($text, $highlight, $tag = 'mark')
+    public static function highlight($text, $highlights, $tag = 'mark')
     {
-        if (empty($highlight) || $tag === '') {
+        if (empty($highlights) || $tag === '') {
             return $text;
         }
 
-        return preg_replace('/(?:'.implode('|', (array) $highlight).')/', "<$tag>$0</$tag>", $text);
+        $highlights = array_map(fn($value) => preg_quote($value, '/'), (array)$highlights);
+
+        return preg_replace('/(?<![\w+])('.implode('|', $highlights).')(?![\w?+:.*^$()\[{\\}\]|])/', "<$tag>$0</$tag>", $text);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -290,6 +290,21 @@ class Str
     }
 
     /**
+     * @param  string $text
+     * @param  string|array $highlight
+     * @param  string $tag
+     * @return string
+     */
+    public static function highlight($text, $highlight, $tag = 'mark')
+    {
+        if(empty($highlight) || $tag === '') {
+            return $text;
+        }
+
+        return preg_replace('/(?:'.implode('|', (array)$highlight).')/', "<$tag>$0</$tag>", $text);
+    }
+
+    /**
      * Cap a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -303,7 +303,7 @@ class Str
 
         $highlights = array_map(fn ($value) => preg_quote($value, '/'), (array) $highlights);
 
-        return preg_replace('/(?<![\w?+:.*^$()\[\{\}\]|\\])('.implode('|', $highlights).')(?![\w?+:.*^$()\[{\\}\]|])/', "<$tag>$0</$tag>", $text);
+        return preg_replace('/(?<![\w?])('.implode('|', $highlights).')(?![\w?+:.*^$()\[{\\}\]|])/', "<$tag>$0</$tag>", $text);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -290,18 +290,18 @@ class Str
     }
 
     /**
-     * @param  string $text
-     * @param  string|array $highlight
-     * @param  string $tag
+     * @param  string  $text
+     * @param  string|array  $highlight
+     * @param  string  $tag
      * @return string
      */
     public static function highlight($text, $highlight, $tag = 'mark')
     {
-        if(empty($highlight) || $tag === '') {
+        if (empty($highlight) || $tag === '') {
             return $text;
         }
 
-        return preg_replace('/(?:'.implode('|', (array)$highlight).')/', "<$tag>$0</$tag>", $text);
+        return preg_replace('/(?:'.implode('|', (array) $highlight).')/', "<$tag>$0</$tag>", $text);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -229,6 +229,9 @@ class SupportStrTest extends TestCase
         $this->assertSame('<mark>Laravel:</mark> a PHP framework', Str::highlight('Laravel: a PHP framework', 'Laravel:'));
         $this->assertSame('?Laravel: a PHP framework', Str::highlight('?Laravel: a PHP framework', 'Laravel'));
         $this->assertSame('<mark>?Laravel:</mark> a PHP framework', Str::highlight('?Laravel: a PHP framework', '?Laravel:'));
+
+        $this->assertSame('Laravel PHP/framework', Str::highlight('Laravel PHP/framework', 'PHP'));
+        $this->assertSame('Laravel <mark>PHP/framework</mark>', Str::highlight('Laravel PHP/framework', 'PHP/framework'));
     }
 
     public function testStrBefore()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -222,6 +222,12 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', 'Laravél'));
         $this->assertSame('<mark>Laravél</mark> PHP framework', Str::highlight('Laravél PHP framework', 'Laravél'));
+
+        $this->assertSame('Laravel PHP <mark>framework?</mark>', Str::highlight('Laravel PHP framework?', 'framework?'));
+        $this->assertSame('Laravel PHP framework?', Str::highlight('Laravel PHP framework?', 'framework'));
+        $this->assertSame('<mark>Laravel:</mark> <mark>PHP</mark> <mark>framework!</mark>', Str::highlight('Laravel: PHP framework!', ['Laravel:', 'PHP', 'framework!']));
+        $this->assertSame('Laravel: a PHP framework', Str::highlight('Laravel: a PHP framework', 'Laravel'));
+        $this->assertSame('<mark>Laravel:</mark> a PHP framework', Str::highlight('Laravel: a PHP framework', 'Laravel:'));
     }
 
     public function testStrBefore()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -202,6 +202,28 @@ class SupportStrTest extends TestCase
         $this->assertSame('João Antô...', Str::excerpt('João Antônio', 'JOÃO', ['radius' => 5]));
     }
 
+    public function testStrHighlight()
+    {
+        $this->assertSame('Laravel PHP <mark>framework</mark>', Str::highlight('Laravel PHP framework', 'framework'));
+        $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', 'laravel'));
+        $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', 'xxx'));
+
+        $this->assertSame('Laravel <mark>PHP</mark> <mark>framework</mark>', Str::highlight('Laravel PHP framework', ['PHP', 'framework']));
+        $this->assertSame('Laravel PHP <mark>framework</mark>', Str::highlight('Laravel PHP framework', ['framework', 'xxx']));
+
+        $this->assertSame('Laravel PHP <b>framework</b>', Str::highlight('Laravel PHP framework', 'framework', 'b'));
+        $this->assertSame('Laravel <b>PHP</b> <b>framework</b>', Str::highlight('Laravel PHP framework', ['PHP', 'framework'], 'b'));
+        $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', 'Laravel', ''));
+
+        $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', ''));
+        $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', []));
+
+        $this->assertSame('', Str::highlight('', 'Laravel'));
+
+        $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', 'Laravél'));
+        $this->assertSame('<mark>Laravél</mark> PHP framework', Str::highlight('Laravél PHP framework', 'Laravél'));
+    }
+
     public function testStrBefore()
     {
         $this->assertSame('han', Str::before('hannah', 'nah'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -217,7 +217,6 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', ''));
         $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', []));
-
         $this->assertSame('', Str::highlight('', 'Laravel'));
 
         $this->assertSame('Laravel PHP framework', Str::highlight('Laravel PHP framework', 'Laravél'));
@@ -228,6 +227,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('<mark>Laravel:</mark> <mark>PHP</mark> <mark>framework!</mark>', Str::highlight('Laravel: PHP framework!', ['Laravel:', 'PHP', 'framework!']));
         $this->assertSame('Laravel: a PHP framework', Str::highlight('Laravel: a PHP framework', 'Laravel'));
         $this->assertSame('<mark>Laravel:</mark> a PHP framework', Str::highlight('Laravel: a PHP framework', 'Laravel:'));
+        $this->assertSame('?Laravel: a PHP framework', Str::highlight('?Laravel: a PHP framework', 'Laravel'));
+        $this->assertSame('<mark>?Laravel:</mark> a PHP framework', Str::highlight('?Laravel: a PHP framework', '?Laravel:'));
     }
 
     public function testStrBefore()


### PR DESCRIPTION
After seeing #41000, I got inspired to also add the highlight feature, the original idea also coming from [Rails](https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-highlight)

This pull requests adds the ability to easily highlight words in a string:
```php
public static function highlight($text, $highlight, $tag = 'mark')
```

Usage:
```php
Str::highlight('Laravel, The PHP Framework for Web Artisans', 'Laravel');
// <mark>Laravel</mark>, The PHP Framework for Web Artisans

Str::highlight('Laravel, The PHP Framework for Web Artisans', ['Laravel', 'Framework', 'Artisans']);
// <mark>Laravel</mark>, The PHP <mark>Framework</mark> for Web <mark>Artisans</mark>
```
Or with custom tags:
```php
Str::highlight('Laravel, The PHP Framework for Web Artisans', ['Laravel', 'Framework', 'Artisans'], 'b');
// <b>Laravel</b>, The PHP <b>Framework</b> for Web <b>Artisans</b>
```
If no `$highlight` or an empty `$tag` is given, the string is returned as-is, because there is nothing to highlight
```php
Str::highlight('Laravel, The PHP Framework for Web Artisans', '');
Str::highlight('Laravel, The PHP Framework for Web Artisans', []);
Str::highlight('Laravel, The PHP Framework for Web Artisans', 'Laravel', '');
// Laravel, The PHP Framework for Web Artisans
```