### PR TITLE
[9.x] Fix static return type of Collection sort function callback parameter

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1283,7 +1283,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Sort through each item with a callback.
      *
-     * @param  (callable(TValue, TValue): bool)|null|int  $callback
+     * @param  (callable(TValue, TValue): int)|null|int  $callback
      * @return static
      */
     public function sort($callback = null)

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -964,7 +964,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Sort through each item with a callback.
      *
-     * @param  (callable(TValue, TValue): bool)|null|int  $callback
+     * @param  (callable(TValue, TValue): int)|null|int  $callback
      * @return static
      */
     public function sort($callback = null);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1274,7 +1274,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Sort through each item with a callback.
      *
-     * @param  (callable(TValue, TValue): bool)|null|int  $callback
+     * @param  (callable(TValue, TValue): int)|null|int  $callback
      * @return static
      */
     public function sort($callback = null)

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -632,7 +632,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->sort(functio
     assertType('User', $userA);
     assertType('User', $userB);
 
-    return true;
+    return 1;
 }));
 assertType('Illuminate\Support\Collection<int, User>', $collection->sort());
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -627,7 +627,7 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sort(fun
     assertType('User', $userA);
     assertType('User', $userB);
 
-    return true;
+    return 1;
 }));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->sort());
 


### PR DESCRIPTION
Unless my morning brain is playing tricks with me, the return type of the `Illuminate\Support\Collection` `sort` method is incorrectly set to `bool` but should be `int`. Larastan gave me a warning about my return type being incorrect.

The callback is passed to the php builtin `uasort` which has the signature `callback(mixed $a, mixed $b): int`, and it's the parity (positive, negative or 0) of the return value that determines the sort order.