### PR TITLE
Improve type hints in ModelNotFoundException

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -10,22 +10,22 @@ class ModelNotFoundException extends RecordsNotFoundException
     /**
      * Name of the affected Eloquent model.
      *
-     * @var string
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
      */
     protected $model;
 
     /**
      * The affected model IDs.
      *
-     * @var int|array
+     * @var array<int>|array<string>
      */
     protected $ids;
 
     /**
      * Set the affected Eloquent model and instance ids.
      *
-     * @param  string  $model
-     * @param  int|array  $ids
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $model
+     * @param  int|array<int>|string|array<string>  $ids
      * @return $this
      */
     public function setModel($model, $ids = [])
@@ -47,7 +47,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     /**
      * Get the affected Eloquent model.
      *
-     * @return string
+     * @return class-string<\Illuminate\Database\Eloquent\Model>
      */
     public function getModel()
     {
@@ -57,7 +57,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     /**
      * Get the affected Eloquent model IDs.
      *
-     * @return int|array
+     * @return array<int>|array<string>
      */
     public function getIds()
     {


### PR DESCRIPTION
I am using this class in my unit tests to build up an exception I expect
to be thrown in the code under test. My model is using string keys, so
both my IDE and static analysis tooling complain about passing its ID.

Additional work on this could be done by introducing generic types for both the model and its ID. However, this would most likely require moving the hydration of the exception into `__construct()` and thus breaking the interface. I kept it light and simple for now and only changed the type hints.