### PR TITLE
[9.x] Improve type hints in ModelNotFoundException

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -10,22 +10,22 @@ class ModelNotFoundException extends RecordsNotFoundException
     /**
      * Name of the affected Eloquent model.
      *
-     * @var string
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
      */
     protected $model;
 
     /**
      * The affected model IDs.
      *
-     * @var int|array
+     * @var array<int>|array<string>
      */
     protected $ids;
 
     /**
      * Set the affected Eloquent model and instance ids.
      *
-     * @param  string  $model
-     * @param  int|array  $ids
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $model
+     * @param  int|array<int>|string|array<string>  $ids
      * @return $this
      */
     public function setModel($model, $ids = [])
@@ -47,7 +47,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     /**
      * Get the affected Eloquent model.
      *
-     * @return string
+     * @return class-string<\Illuminate\Database\Eloquent\Model>
      */
     public function getModel()
     {
@@ -57,7 +57,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     /**
      * Get the affected Eloquent model IDs.
      *
-     * @return int|array
+     * @return array<int>|array<string>
      */
     public function getIds()
     {

--- a/types/Database/Eloquent/ModelNotFoundException.php
+++ b/types/Database/Eloquent/ModelNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use function PHPStan\Testing\assertType;
+
+class Foo extends Model {}
+
+$modelNotFound = new ModelNotFoundException();
+
+assertType('array<int|string>', $modelNotFound->getIds());
+assertType('class-string<Illuminate\Database\Eloquent\Model>', $modelNotFound->getModel());
+assertType('Illuminate\Database\Eloquent\Model', new ($modelNotFound->getModel()));
+
+$modelNotFound->setModel(Foo::class, 1);
+$modelNotFound->setModel(Foo::class, [1]);
+$modelNotFound->setModel(Foo::class, '1');
+$modelNotFound->setModel(Foo::class, ['1']);

--- a/types/Database/Eloquent/ModelNotFoundException.php
+++ b/types/Database/Eloquent/ModelNotFoundException.php
@@ -4,7 +4,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use function PHPStan\Testing\assertType;
 
-class Foo extends Model {}
+class Foo extends Model
+{
+}
 
 $modelNotFound = new ModelNotFoundException();
 


### PR DESCRIPTION
I am using this class in my unit tests to build up an exception I expect
to be thrown in the code under test. My model is using string keys, so
both my IDE and static analysis tooling complain about passing its ID.

Additional work on this could be done by:
- introducing generic types for both the model and its ID
- using strong type hints
I kept it light and simple for now and only changed the type hints.
