### PR TITLE
[8.x] Receive an attribute through a callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -938,6 +938,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                         ? $models->all() : [$models];
 
             foreach (array_filter($models) as $model) {
+
+                // Attributes with a callback are only available after saving the linked model
+                $model->attributes = array_map('value', $model->attributes);
+
                 if (! $model->push()) {
                     return false;
                 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -805,7 +805,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $related1 = $this->getMockBuilder(EloquentModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
         $query = m::mock(Builder::class);
-        $query->shouldReceive('insertGetId')->once()->with(['relation_one_id' => 1] ,'id')->andReturn(2);
+        $query->shouldReceive('insertGetId')->once()->with(['relation_one_id' => 1], 'id')->andReturn(2);
         $query->shouldReceive('getConnection')->once();
         $related1->expects($this->once())->method('newModelQuery')->willReturn($query);
         $related1->expects($this->once())->method('updateTimestamps');


### PR DESCRIPTION
I cannot store `hasMany` relationships beautifully. Take the following example:
```php
        $product = ProductFactory::new()->make();

        $pricing = PricingFactory::new()->make();
        $product->setRelation('pricing', $pricing);

        $product->push();
```
In this case pricing has no product_id. As a result, we get the following error:
`Illuminate\Database\QueryException : SQLSTATE[23000]: Integrity constraint violation: 19 NOT NULL constraint failed: pricing.product_id`

Therefore, we need to save the object first and use the id to store it in pricing:
```php
        $product = ProductFactory::new()->make();
        $pricing = PricingFactory::new()->make();

        $product->setRelation('pricing', $pricing);
        $product->save();
        $pricing->product_id = $product->id;
        $product->push();

        $this->assertEquals(1, Pricing::first()->product_id);
```
- I build relationships in another method, but I need to pass it through so I can save it for the push.
- I have many relations that I only want to save at the same time at the end of my request.
- I want to build up pricing before I save the product.

I see 2 possibilities for this.

**Solution 1** (Present in this pull-request):
```php
        $product = ProductFactory::new()->make();
        $pricing = PricingFactory::new()->make();
        $pricing->product_id = fn() => $product->id;

        $product->setRelation('pricing', $pricing);
        $product->push();
```

**Solution 2**:
```php
        $product = ProductFactory::new()->make();
        $pricing = PricingFactory::new()->make();

        $product->setRelation('pricing', $pricing, 'product_id');
        $product->push();
```

If you come up with a different solution or if it's overkill, I'd love to hear it.

