### PR TITLE
[9.x] Do not transform `JsonSerializable` instances to array in HTTP client methods

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
@@ -747,7 +748,13 @@ class PendingRequest
             $options[$this->bodyFormat] = $this->pendingBody;
         }
 
-        return collect($options)->toArray();
+        return collect($options)->map(function ($value, $key) {
+            if ($key === 'json' && $value instanceof JsonSerializable) {
+                return $value;
+            }
+
+            return $value instanceof Arrayable ? $value->toArray() : $value;
+        })->all();
     }
 
     /**


### PR DESCRIPTION
This is a follow-up of #41055.

## Problem
When a class implements both `Arrayable` and `JsonSerializable`, the former currently takes precedence. However, a class can have different forms for `Arrayable` and `JsonSerializable`. For example, an empty hashmap should be an empty array in array form, but an empty object in JSON form i.e. `{"attributes":{}}`. This is especially important if the endpoint always expects an object, even if it is empty. So I'd expect that if I post an object as JSON, and setup the correct `jsonSerialize` method, it'll be serialized as such, not transformed to an array.

## Solution
This PR will skip transforming the request data, only in JSON body format, if it implements `JsonSerializable` and thus passes it 1:1 to Guzzle for JSON serialization.

## Change
Given the following class:
```php
class Foo implements JsonSerializable, Arrayable
{
    public function jsonSerialize(): mixed
    {
        return [
            'attributes' => (object) [],
        ];
    }

    public function toArray(): array
    {
        return [
            'attributes' => [],
        ];
    }
}
```

### Before
```php
Http::post('http://example.com', new Foo); // posts {"attributes": []}
```

### After
```php
Http::post('http://example.com', new Foo); // posts {"attributes": {}}
```