### PR TITLE
[9.x] Add support for table check constraints

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
 class Blueprint
@@ -446,6 +447,19 @@ class Blueprint
     }
 
     /**
+     * Indicate that the given check constraints should be dropped.
+     *
+     * @param  string|array  $constraints
+     * @return \Illuminate\Support\Fluent
+     */
+    public function dropCheck($constraints)
+    {
+        $constraints = is_array($constraints) ? $constraints : func_get_args();
+
+        return $this->addCommand('dropCheck', compact('constraints'));
+    }
+
+    /**
      * Indicate that the given indexes should be renamed.
      *
      * @param  string  $from
@@ -626,6 +640,35 @@ class Blueprint
         $this->commands[count($this->commands) - 1] = $command;
 
         return $command;
+    }
+
+    /**
+     * Specify a check constraint for the table.
+     *
+     * @param  string  $expression
+     * @param  string|null  $constraint
+     * @return \Illuminate\Support\Fluent
+     */
+    public function check($expression, $constraint = null)
+    {
+        $constraint = $constraint ?: $this->createCheckName($expression);
+
+        return $this->addCommand('check', compact('expression', 'constraint'));
+    }
+
+    /**
+     * Create a default check constraint name for the table.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function createCheckName($expression)
+    {
+        return Str::of("{$this->prefix}{$this->table}_{$expression}_check")
+            ->replaceMatches('#[\W_]+#', '_')
+            ->trim('_')
+            ->lower()
+            ->value();
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -152,6 +152,36 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a check constraint command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileCheck(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter table %s add constraint %s check (%s)',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->constraint),
+            $command->expression,
+        );
+    }
+
+    /**
+     * Compile a drop check constraint command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileDropCheck(Blueprint $blueprint, Fluent $command)
+    {
+        $constraints = $this->prefixArray('drop constraint', $this->wrapArray($command->constraints));
+
+        return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $constraints);
+    }
+
+    /**
      * Compile the blueprint's column definitions.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -138,7 +138,7 @@ class SQLiteGrammar extends Grammar
         $commands = $this->getCommandsByName($blueprint, 'check');
 
         return collect($commands)
-            ->map(fn($commands) => sprintf(', constraint %s check (%s)',
+            ->map(fn ($commands) => sprintf(', constraint %s check (%s)',
                 $this->wrap($commands->constraint),
                 $commands->expression,
             ))
@@ -232,7 +232,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileCheck(Blueprint $blueprint, Fluent $command)
     {
-        if(! $blueprint->creating()) {
+        if (! $blueprint->creating()) {
             throw new RuntimeException('This database driver does not support adding check constraints to existing tables.');
         }
 
@@ -245,7 +245,7 @@ class SQLiteGrammar extends Grammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
-
+     *
      * @throws \RuntimeException
      */
     public function compileDropCheck(Blueprint $blueprint, Fluent $command)

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -450,7 +450,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = clone $base;
         $this->assertEquals([
             'create table `users` (`age` int unsigned not null) default character set utf8 collate \'utf8_unicode_ci\'',
-            'alter table `users` add constraint `min_age_check` check (age>21)'
+            'alter table `users` add constraint `min_age_check` check (age>21)',
         ], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;


### PR DESCRIPTION
This pull requests adds support for table check constraints (Documentation: [MySQL](https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html) | [PostrgeSQL](https://www.postgresql.org/docs/14/ddl-constraints.html) | [SQLite](https://www.sqlite.org/lang_createtable.html#check_constraints) | [SQL Server](https://docs.microsoft.com/en-us/sql/relational-databases/tables/unique-constraints-and-check-constraints?view=sql-server-ver15#Check)).

````php
Schema::create('users', function (Blueprint $table) {
    $table->id();
    $table->unsignedInteger('age');

    $table->check('age>=21');
});

Schema::create('events', function (Blueprint $table) {
    $table->id();
    $table->string('name');
    $table->datetime('starts_at');
    $table->datetime('ends_at')->nullable();
    $table->unsignedInteger('price');
    $table->unsignedInteger('discounted_price');

    $table->check('ends_at IS NULL OR ends_at>starts_at');
    $table->check('discounted_price <= price', 'check_valid_discounts');
});

````

In our use case, a `Booking` has many `BookingItems`, which morph to a `contractor`, who can either be a `Hotel` or a `Flight`. In case of a `Hotel` we need to known the `room_id`, for any other `contractor_type`the `room_id` must be `null`.

While we will continue to validate this in the application, this PR allows us to add another layer of integrity for the database:

```php
Schema::create('booking_items', function (Blueprint $table) {
    $table->id();
    $table->morphs('contractor');
    $table->foreignId('room_id')->constraint()->nullable();

    $table->check('contractor_type!="hotel" OR room_id IS NOT NULL');
});
```

All the default database drivers have support for check constraints (edit: For MySQL 5.7 The CHECK clause is parsed but ignored by all storage engines.). SQLite comes with a number of limitions:
- SQLite cannot add check constraints to existing tables.
- SQLite cannot drop check constraints.

Some similar limitations are currently covered in `Blueprint::ensureCommandsAreValid()` ([link](https://github.com/laravel/framework/blob/7d37bd140f23b171d54af81637c8e7905c443d61/src/Illuminate/Database/Schema/Blueprint.php#L152)), while more recent PRs throw exceptions inside of the corresponding methods of `SQLiteGrammar` (e.g. `compileSpatialIndex` ([link](https://github.com/laravel/framework/blob/7d37bd140f23b171d54af81637c8e7905c443d61/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php#L188)). I followed the later approach for now.

Note that the `expression` is considered "raw", meaning that it is not wrapped or parsed in any way. As long as it is valid SQL, the underlying database should handle it well.

I was torn between `$table->check(...)` and `$table->checkConstraint(...)` and I'm of course open for suggestions.
Please let me know if there's anything to be changed, improved or clarified.

If this gets merged, I'd be happy to look into inline column checks next as in `$table->integer('age)->check('age>=21')`.