### PR TITLE
[9.x] Add method to AwsS3V3Adapter

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -83,7 +83,7 @@ class AwsS3V3Adapter extends FilesystemAdapter
     }
 
     /**
-     * Get the S3 client.
+     * Get the underlying S3 client.
      *
      * @return \Aws\S3\S3Client
      */

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -81,4 +81,14 @@ class AwsS3V3Adapter extends FilesystemAdapter
 
         return (string) $uri;
     }
+
+    /**
+     * Get the S3 client.
+     *
+     * @return \Aws\S3\S3Client
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
 }


### PR DESCRIPTION
Make it convenient to retrieve the client of `\Illuminate\Filesystem\AwsS3V3Adapter`, like `getDriver()` or `getAdapter()` of `\Illuminate\Filesystem\FilesystemAdapter`