### PR TITLE
[9.x] Register extend() method in Scope interface

### DIFF
--- a/src/Illuminate/Database/Eloquent/Scope.php
+++ b/src/Illuminate/Database/Eloquent/Scope.php
@@ -12,4 +12,15 @@ interface Scope
      * @return void
      */
     public function apply(Builder $builder, Model $model);
+    
+    /**
+     * Extend the query builder with the needed functions.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @return void
+     */
+    public function extend(Builder $builder)
+    {
+        //
+    }
 }


### PR DESCRIPTION
There is no glue on the `Scope` interface that global scopes can have an `extend()` method thought to add macros to the query builder (as in the `SoftDeletingScope`). This way, if a developer wants to create macros in his scopes, he has to use the `apply()` method or investigate the framework's code to discover [this call](https://github.com/laravel/framework/blob/e4c93c4aee180dc96a3573f5df3f056093b85009/src/Illuminate/Database/Eloquent/Builder.php#L162) from the `Builder` class.