### PR TITLE
[9.x] Update facade.stub to revive IDE auto-completion

### DIFF
--- a/src/Illuminate/Foundation/stubs/facade.stub
+++ b/src/Illuminate/Foundation/stubs/facade.stub
@@ -5,7 +5,7 @@ namespace DummyNamespace;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \DummyTarget
+ * @mixin \DummyTarget
  */
 class DummyClass extends Facade
 {
@@ -16,6 +16,6 @@ class DummyClass extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'DummyTarget';
+        return \DummyTarget::class;
     }
 }


### PR DESCRIPTION
### Revive IDE auto-completion (The simple way)

With this simple change, real-time facades will have IDE auto-completion with no backward compatibility issues or introducing any fancy logic.


When I click on the method call, my phpstorm takes me not to the facade file but directly to the underlying implementation and that is wonderful !!!

 The hello method in this case is NOT a static method but is suggested.

([my previous PR](https://github.com/laravel/framework/pull/40434) with the same goal had a lot of logic to generate docblocks but this time it is dead simple.)


![image](https://user-images.githubusercontent.com/6961695/154571502-32265003-768a-4d19-9e6c-0b1589f8cebd.png)

## initial class:
![image](https://user-images.githubusercontent.com/6961695/154571941-a22fb5ad-27f6-4554-b6a9-f399e3a96b46.png)

## Generated cache file:

![image](https://user-images.githubusercontent.com/6961695/154573856-2ca33bd8-9d30-41c2-bdb9-d0307190172f.png)
