### PR TITLE
[9.x] Fix parsing `config('database.connections.pgsql.search_path')`

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -127,7 +127,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
     protected function parseSearchPath($searchPath)
     {
         if (is_string($searchPath)) {
-            preg_match_all('/[a-zA-z0-9$]{1,}/i', $searchPath, $matches);
+            preg_match_all('/[^\s,"\']+/', $searchPath, $matches);
 
             $searchPath = $matches[0];
         }
@@ -144,7 +144,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
     /**
      * Format the search path for the DSN.
      *
-     * @param  array|string  $searchPath
+     * @param  array  $searchPath
      * @return string
      */
     protected function quoteSearchPath($searchPath)

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -89,27 +89,103 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function testPostgresSearchPathIsSet()
+    /**
+     * @dataProvider provideSearchPaths
+     *
+     * @param  string  $searchPath
+     * @param  string  $expectedSql
+     */
+    public function testPostgresSearchPathIsSet($searchPath, $expectedSql)
     {
         $dsn = 'pgsql:host=foo;dbname=\'bar\'';
-        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => 'public', 'charset' => 'utf8'];
+        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => $searchPath, 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($statement);
-        $connection->shouldReceive('prepare')->once()->with('set search_path to "public"')->andReturn($statement);
+        $connection->shouldReceive('prepare')->once()->with($expectedSql)->andReturn($statement);
         $statement->shouldReceive('execute')->twice();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
     }
 
-    public function testPostgresSearchPathArraySupported()
+    public function provideSearchPaths()
+    {
+        return [
+            'all-lowercase' => [
+                'public',
+                'set search_path to "public"',
+            ],
+            'case-sensitive' => [
+                'Public',
+                'set search_path to "Public"',
+            ],
+            'special characters' => [
+                '¡foo_bar-Baz!.Áüõß',
+                'set search_path to "¡foo_bar-Baz!.Áüõß"',
+            ],
+            'single-quoted' => [
+                "'public'",
+                'set search_path to "public"',
+            ],
+            'double-quoted' => [
+                '"public"',
+                'set search_path to "public"',
+            ],
+            'variable' => [
+                '$user',
+                'set search_path to "$user"',
+            ],
+            'delimit space' => [
+                'public user',
+                'set search_path to "public", "user"',
+            ],
+            'delimit newline' => [
+                "public\nuser\r\n\ttest",
+                'set search_path to "public", "user", "test"',
+            ],
+            'delimit comma' => [
+                'public,user',
+                'set search_path to "public", "user"',
+            ],
+            'delimit comma and space' => [
+                'public, user',
+                'set search_path to "public", "user"',
+            ],
+            'single-quoted many' => [
+                "'public', 'user'",
+                'set search_path to "public", "user"',
+            ],
+            'double-quoted many' => [
+                '"public", "user"',
+                'set search_path to "public", "user"',
+            ],
+            'quoted space is unsupported in string' => [
+                '"public user"',
+                'set search_path to "public", "user"',
+            ],
+            'array' => [
+                ['public', 'user'],
+                'set search_path to "public", "user"',
+            ],
+            'array with variable' => [
+                ['public', '$user'],
+                'set search_path to "public", "$user"',
+            ],
+            'array with delimiter characters' => [
+                ['public', '"user"', "'test'", 'spaced schema'],
+                'set search_path to "public", "user", "test", "spaced schema"',
+            ],
+        ];
+    }
+
+    public function testPostgresSearchPathFallbackToConfigKeySchema()
     {
         $dsn = 'pgsql:host=foo;dbname=\'bar\'';
-        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => ['public', '"user"'], 'charset' => 'utf8'];
+        $config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', '"user"'], 'charset' => 'utf8'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
@@ -118,38 +194,6 @@ class DatabaseConnectorTest extends TestCase
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($statement);
         $connection->shouldReceive('prepare')->once()->with('set search_path to "public", "user"')->andReturn($statement);
         $statement->shouldReceive('execute')->twice();
-        $result = $connector->connect($config);
-
-        $this->assertSame($result, $connection);
-    }
-
-    public function testPostgresSearchPathCommaSeparatedValueSupported()
-    {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\'';
-        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => 'public, "user"', 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
-        $connection->shouldReceive('prepare')->once()->with('set search_path to "public", "user"')->andReturn($connection);
-        $connection->shouldReceive('execute')->twice();
-        $result = $connector->connect($config);
-
-        $this->assertSame($result, $connection);
-    }
-
-    public function testPostgresSearchPathVariablesSupported()
-    {
-        $dsn = 'pgsql:host=foo;dbname=\'bar\'';
-        $config = ['host' => 'foo', 'database' => 'bar', 'search_path' => '"$user", public, user', 'charset' => 'utf8'];
-        $connector = $this->getMockBuilder('Illuminate\Database\Connectors\PostgresConnector')->setMethods(['createConnection', 'getOptions'])->getMock();
-        $connection = m::mock('stdClass');
-        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
-        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
-        $connection->shouldReceive('prepare')->once()->with('set search_path to "$user", "public", "user"')->andReturn($connection);
-        $connection->shouldReceive('execute')->twice();
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/41062

e.g., Config value `'test-db'` was being parsed as `set search_path to "test", "db"` instead of `set search_path to "test-db"`

9.x renamed `config('database.connections.pgsql.schema')` to `config('database.connections.pgsql.search_path')` and introduced special handling if the config value is a string containing many segments. The [originating PR](https://github.com/laravel/framework/pull/35463#issuecomment-767263747) has some examples. However the given `PostgresConnector` regex doesn't consider the full range of characters allowed in a schema or variable name - specifically `'-'` and accented characters.

Replace the `'search_path'` regex alphanumeric-only allowlist of characters with a blocklist of  delimiters when  `config('database.connections.pgsql.search_path')` is a string value. Technically Postgres _does_ allow our config delimiter characters (spaces, comma, quotes) in symbols so an array configuration can instead be used for such schema names. (However non-wrapping single/double quote characters in such array configs still aren't supported.)

```php
return [
    'default' => env('DB_CONNECTION', 'mysql'),
    'connections' => [
        'pgsql' => [
            'search_path' => [
                "'public'",
                '"$user"',
                'containing commas, and spaces'
                // 'can\'t name schema with "inner quotes"'
            ],
```

```sql
set search_path to "public", "$user", "containing commas, and spaces"
```

---

* Roll methods `testPostgresSearchPathCommaSeparatedValueSupported()` & `testPostgresSearchPathVariablesSupported()` into `testPostgresSearchPathIsSet()` with the fuller coverage `provideSearchPaths()` data set.
* `testPostgresSearchPathArraySupported()` is repurposed to show `config('database.connections.pgsql.schema')` from versions < 9.x is used when the `'search_path'` config key is absent.
* Fix `PostgresConnector::quoteSearchPath()` parameter docblock since passing in a string value would throw an exception for being un-`Countable`. Its only  use is being passed `parseSearchPath()`'s return value which is an array.