### PR TITLE
[9.x] Add whereNot() to Query Builder and Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -317,6 +317,29 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where not" clause to the query.
+     *
+     * @param  \Closure  $callback
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNot($callback, $boolean = 'and')
+    {
+        return $this->where($callback, null, null, $boolean . ' not');
+    }
+
+    /**
+     * Add an "or where not" clause to the query.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function orWhereNot($callback)
+    {
+        return $this->whereNot($callback, 'or');
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -325,7 +325,7 @@ class Builder implements BuilderContract
      */
     public function whereNot($callback, $boolean = 'and')
     {
-        return $this->where($callback, null, null, $boolean . ' not');
+        return $this->where($callback, null, null, $boolean.' not');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -323,7 +323,7 @@ class Builder implements BuilderContract
      * @param  string  $boolean
      * @return $this
      */
-    public function whereNot(\Closure $callback, $boolean = 'and')
+    public function whereNot(Closure $callback, $boolean = 'and')
     {
         return $this->where($callback, null, null, $boolean.' not');
     }
@@ -334,7 +334,7 @@ class Builder implements BuilderContract
      * @param  \Closure  $callback
      * @return $this
      */
-    public function orWhereNot(\Closure $callback)
+    public function orWhereNot(Closure $callback)
     {
         return $this->whereNot($callback, 'or');
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -323,7 +323,7 @@ class Builder implements BuilderContract
      * @param  string  $boolean
      * @return $this
      */
-    public function whereNot($callback, $boolean = 'and')
+    public function whereNot(\Closure $callback, $boolean = 'and')
     {
         return $this->where($callback, null, null, $boolean.' not');
     }
@@ -334,7 +334,7 @@ class Builder implements BuilderContract
      * @param  \Closure  $callback
      * @return $this
      */
-    public function orWhereNot($callback)
+    public function orWhereNot(\Closure $callback)
     {
         return $this->whereNot($callback, 'or');
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -865,7 +865,7 @@ class Builder implements BuilderContract
      * @param  string  $boolean
      * @return $this
      */
-    public function whereNot(\Closure $callback, $boolean = 'and')
+    public function whereNot(Closure $callback, $boolean = 'and')
     {
         return $this->whereNested($callback, $boolean.' not');
     }
@@ -876,7 +876,7 @@ class Builder implements BuilderContract
      * @param  \Closure  $callback
      * @return $this
      */
-    public function orWhereNot(\Closure $callback)
+    public function orWhereNot(Closure $callback)
     {
         return $this->whereNot($callback, 'or');
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -859,6 +859,29 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where not" clause to the query.
+     *
+     * @param  \Closure  $callback
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNot(\Closure $callback, $boolean = 'and')
+    {
+        return $this->whereNested($callback, $boolean . ' not');
+    }
+
+    /**
+     * Add an "or where not" clause to the query.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function orWhereNot(\Closure $callback)
+    {
+        return $this->whereNot($callback, 'or');
+    }
+
+    /**
      * Add a "where" clause comparing two columns to the query.
      *
      * @param  string|array  $first

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -867,7 +867,7 @@ class Builder implements BuilderContract
      */
     public function whereNot(\Closure $callback, $boolean = 'and')
     {
-        return $this->whereNested($callback, $boolean . ' not');
+        return $this->whereNested($callback, $boolean.' not');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -884,6 +884,44 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 
+    public function testWhereNot()
+    {
+        $nestedQuery = m::mock(Builder::class);
+        $nestedRawQuery = $this->getMockQueryBuilder();
+        $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
+        $model = $this->getMockModel()->makePartial();
+        $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('from');
+        $builder->setModel($model);
+        $builder->getQuery()->shouldReceive('addNestedWhereQuery')->once()->with($nestedRawQuery, 'and not');
+        $nestedQuery->shouldReceive('foo')->once();
+
+        $result = $builder->whereNot(function ($query) {
+            $query->foo();
+        });
+        $this->assertEquals($builder, $result);
+    }
+
+    public function testOrWhereNot()
+    {
+        $nestedQuery = m::mock(Builder::class);
+        $nestedRawQuery = $this->getMockQueryBuilder();
+        $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
+        $model = $this->getMockModel()->makePartial();
+        $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('from');
+        $builder->setModel($model);
+        $builder->getQuery()->shouldReceive('addNestedWhereQuery')->once()->with($nestedRawQuery, 'or not');
+        $nestedQuery->shouldReceive('foo')->once();
+
+        $result = $builder->orWhereNot(function ($query) {
+            $query->foo();
+        });
+        $this->assertEquals($builder, $result);
+    }
+
     public function testRealQueryHigherOrderOrWhereScopes()
     {
         $model = new EloquentBuilderTestHigherOrderWhereScopeStub;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1693,6 +1693,30 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
     }
 
+    public function testWhereNot()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot(function ($q) {
+            $q->where('email', '=', 'foo');
+        });
+        $this->assertSame('select * from "users" where not ("email" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 'foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('name', '=', 'bar')->whereNot(function ($q) {
+            $q->where('email', '=', 'foo');
+        });
+        $this->assertSame('select * from "users" where "name" = ? and not ("email" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('name', '=', 'bar')->orWhereNot(function ($q) {
+            $q->where('email', '=', 'foo');
+        });
+        $this->assertSame('select * from "users" where "name" = ? or not ("email" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
+    }
+
     public function testFullSubSelects()
     {
         $builder = $this->getBuilder();

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -63,6 +63,33 @@ class EloquentWhereTest extends DatabaseTestCase
         );
     }
 
+    public function testWhereNot()
+    {
+        /** @var \Illuminate\Tests\Integration\Database\UserWhereTest $firstUser */
+        $firstUser = UserWhereTest::create([
+            'name' => 'test-name',
+            'email' => 'test-email',
+            'address' => 'test-address',
+        ]);
+
+        /** @var \Illuminate\Tests\Integration\Database\UserWhereTest $secondUser */
+        $secondUser = UserWhereTest::create([
+            'name' => 'test-name1',
+            'email' => 'test-email1',
+            'address' => 'test-address1',
+        ]);
+
+        $this->assertTrue($secondUser->is(UserWhereTest::whereNot(function ($query) use ($firstUser) {
+            $query->where('name', '=', $firstUser->name);
+        })->first()));
+        $this->assertTrue($firstUser->is(UserWhereTest::where('name', $firstUser->name)->whereNot(function ($query) use ($secondUser) {
+            $query->where('email', $secondUser->email);
+        })->first()));
+        $this->assertTrue($secondUser->is(UserWhereTest::where('name', 'wrong-name')->orWhereNot(function ($query) use ($firstUser) {
+            $query->where('email', $firstUser->email);
+        })->first()));
+    }
+
     public function testFirstWhere()
     {
         /** @var \Illuminate\Tests\Integration\Database\UserWhereTest $firstUser */

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -132,6 +132,25 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertTrue(DB::table('posts')->where($subQuery, '!=', 'Does not match')->exists());
     }
 
+    public function testWhereNot()
+    {
+        $results = DB::table('posts')->whereNot(function ($query) {
+            $query->where('title', 'Foo Post');
+        })->get();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('Bar Post', $results[0]->title);
+    }
+
+    public function testOrWhereNot()
+    {
+        $results = DB::table('posts')->where('id', 1)->orWhereNot(function ($query) {
+            $query->where('title', 'Foo Post');
+        })->get();
+
+        $this->assertCount(2, $results);
+    }
+
     public function testWhereDate()
     {
         $this->assertSame(1, DB::table('posts')->whereDate('created_at', '2018-01-02')->count());


### PR DESCRIPTION
**Summary**
From time to time I encounter the situation I want to negate a relatively complicated query builder expression, often hidden away in a (somewhat large) scope. One could start writing the negated version of that scope, or just use `->whereNot(fn ($q) => $q->someScope())`, except that laravel does not currently provide `whereNot()` functionality. Until now each time I encountered this I have added this method by defining macros, but I think it is well worth to add this function to laravel itself.

This pull request proposes to add `whereNot()` to both the Query Builder and Eloquent Builder. Using this new method, one can now easily add a negated (nested) condition to the query builder, or e.g. define a negated scope in terms of a positive scope:
```
public function scopeIsNotFoo($query)
{
    $query->whereNot(fn ($q) => $q->isFoo());
}
```

**Added functionality**
This pull request adds 4 methods:

- `whereNot()` to the Query Builder
- `orWhereNot()` to the Query Builder
- `whereNot()` to the Eloquent Builder
- `orWhereNot()` to the Eloquent Builder

I decided to only include support for passing closures as parameters, because `whereNot('column', '=', 'foo')` to me seems inferior to just using `where('column', '!=', 'foo')`

As far as I can tell, all necessary tests are included.

**Backwards compatibility**
One minor incompatibility may be introduced by this pull request, which would be if a developer has named a database column `not` and uses `whereNot(...)` to add conditions based on this column. I think it is unlikely someone will name a column `not` as it is not descriptive, so I suppose this incompatibility can be accepted.

**Considerations**
This is my first pull request towards Laravel, I hope everything is alright. A few points of attention:
1. The two added tests in DatabaseEloquentBuilderTest.php are practically copies of `testNestedWhere()` in that same file, with minor modifications in two places. Should these be generalized using a data provider?
2. I think I have covered all tests that should be added. Can anyone check?

Thanks!