### PR TITLE
[9.x] Restore S3 client extra options

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -233,6 +233,7 @@ class FilesystemManager implements FactoryContract
         $s3Config = $this->formatS3Config($config);
 
         $root = (string) ($s3Config['root'] ?? '');
+        $options = $config['options'] ?? [];
 
         $visibility = new AwsS3PortableVisibilityConverter(
             $config['visibility'] ?? Visibility::PUBLIC
@@ -242,7 +243,7 @@ class FilesystemManager implements FactoryContract
 
         $client = new S3Client($s3Config);
 
-        $adapter = new S3Adapter($client, $s3Config['bucket'], $root, $visibility, null, [], $streamReads);
+        $adapter = new S3Adapter($client, $s3Config['bucket'], $root, $visibility, null, $options, $streamReads);
 
         return new AwsS3V3Adapter(
             $this->createFlysystem($adapter, $config), $adapter, $s3Config, $client

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -234,8 +234,6 @@ class FilesystemManager implements FactoryContract
 
         $root = (string) ($s3Config['root'] ?? '');
 
-        $options = $config['options'] ?? [];
-
         $visibility = new AwsS3PortableVisibilityConverter(
             $config['visibility'] ?? Visibility::PUBLIC
         );
@@ -244,7 +242,7 @@ class FilesystemManager implements FactoryContract
 
         $client = new S3Client($s3Config);
 
-        $adapter = new S3Adapter($client, $s3Config['bucket'], $root, $visibility, null, $options, $streamReads);
+        $adapter = new S3Adapter($client, $s3Config['bucket'], $root, $visibility, null, $config['options'] ?? [], $streamReads);
 
         return new AwsS3V3Adapter(
             $this->createFlysystem($adapter, $config), $adapter, $s3Config, $client

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -233,6 +233,7 @@ class FilesystemManager implements FactoryContract
         $s3Config = $this->formatS3Config($config);
 
         $root = (string) ($s3Config['root'] ?? '');
+
         $options = $config['options'] ?? [];
 
         $visibility = new AwsS3PortableVisibilityConverter(


### PR DESCRIPTION
Hi,

PR https://github.com/laravel/framework/pull/33612 introduce a breaking change in S3 file-system

Previously we could set extra options to S3 client like this

```php
's3' => [
            'driver' => 's3',
            'key' => env('AWS_ACCESS_KEY_ID'),
            'secret' => env('AWS_SECRET_ACCESS_KEY'),
            'region' => env('AWS_DEFAULT_REGION'),
            'bucket' => env('AWS_BUCKET'),
            'url' => env('AWS_URL'),
            'endpoint' => env('AWS_ENDPOINT'),
            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
            // set extra options
            'options' => [
                'CacheControl' => 'max-age=2592000', // seconds
            ],
        ],
```

This PR restore this feature.
