### PR TITLE
[9.x] Add `isWithParameters` method and an alias named `isWith`

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1198,7 +1198,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         return $this->current() && $this->current()->named(...$patterns);
     }
-    
+
     /**
      * Alias for the "isWithParameters" method.
      *
@@ -1229,6 +1229,7 @@ class Router implements BindingRegistrar, RegistrarContract
                 }
             }
         }
+
         return false;
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1198,6 +1198,39 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         return $this->current() && $this->current()->named(...$patterns);
     }
+    
+    /**
+     * Alias for the "isWithParameters" method.
+     *
+     * @param  mixed  ...$patterns
+     * @return bool
+     */
+    public function isWith(...$patterns)
+    {
+        return $this->isWithParameters(...$patterns);
+    }
+
+    /**
+     * Determine if the current route matches a pattern (named routes, with or without parameters).
+     *
+     * @param  mixed  ...$patterns
+     * @return bool
+     */
+    public function isWithParameters(...$patterns)
+    {
+        foreach ($patterns as $pattern) {
+            if (is_string($pattern)) {
+                if ($this->currentRouteNamed([$pattern])) {
+                    return true;
+                }
+            } else {
+                if (url()->current() == route($pattern[0], $pattern[1] ?? [])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
     /**
      * Get the current route action.

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1224,7 +1224,7 @@ class Router implements BindingRegistrar, RegistrarContract
                     return true;
                 }
             } else {
-                if (url()->current() == route($pattern[0], $pattern[1] ?? [])) {
+                if ($this->getCurrentRequest()->url() == route($pattern[0], $pattern[1] ?? [])) {
                     return true;
                 }
             }


### PR DESCRIPTION
With using Route::isWith() we can extend Route::is() functionality to check named routes with parameters.

Usage :
```
Route::isWith(
    'without.parameter', 
    ['parameters.removed'], 
    ['with.parameter', 'john'],
    ['with.parameter', ['name' => 'john']]
) {
    //
}
```