### PR TITLE
[9.x] Add `X` headers when using `Mail::alwaysTo`

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -390,6 +390,7 @@ class Mailer implements MailerContract, MailQueueContract
     protected function setGlobalToAndRemoveCcAndBcc($message)
     {
         $message->forgetTo();
+
         $message->to($this->to['address'], $this->to['name'], true);
 
         $message->forgetCc();

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -389,6 +389,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function setGlobalToAndRemoveCcAndBcc($message)
     {
+        $message->forgetTo();
         $message->to($this->to['address'], $this->to['name'], true);
 
         $message->forgetCc();

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -106,6 +106,21 @@ class Message
     }
 
     /**
+     * Remove all to addresses from the message.
+     *
+     * @return $this
+     */
+    public function forgetTo()
+    {
+        if ($header = $this->message->getHeaders()->get('To')) {
+            $this->addAddressesDebugHeader('X-To', $this->message->getTo());
+            $header->setAddresses([]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a carbon copy to the message.
      *
      * @param  string|array  $address
@@ -134,6 +149,7 @@ class Message
     public function forgetCc()
     {
         if ($header = $this->message->getHeaders()->get('Cc')) {
+            $this->addAddressesDebugHeader('X-Cc', $this->message->getCC());
             $header->setAddresses([]);
         }
 
@@ -169,6 +185,7 @@ class Message
     public function forgetBcc()
     {
         if ($header = $this->message->getHeaders()->get('Bcc')) {
+            $this->addAddressesDebugHeader('X-Bcc', $this->message->getBcc());
             $header->setAddresses([]);
         }
 
@@ -216,6 +233,23 @@ class Message
         } else {
             $this->message->{"add{$type}"}(new Address($address, (string) $name));
         }
+
+        return $this;
+    }
+
+    /**
+     * Adds a debug header for a list of recipients.
+     *
+     * @param  string  $header
+     * @param  Address[]  $addresses
+     * @return $this
+     */
+    protected function addAddressesDebugHeader(string $header, array $addresses)
+    {
+        $this->message->getHeaders()->addTextHeader(
+            $header,
+            implode(', ', array_map(fn ($a) => $a->toString(), $addresses)),
+        );
 
         return $this;
     }

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -241,7 +241,7 @@ class Message
      * Adds a debug header for a list of recipients.
      *
      * @param  string  $header
-     * @param  Address[]  $addresses
+     * @param  \Symfony\Component\Mime\Address[]  $addresses
      * @return $this
      */
     protected function addAddressesDebugHeader(string $header, array $addresses)

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -106,14 +106,15 @@ class Message
     }
 
     /**
-     * Remove all to addresses from the message.
+     * Remove all "to" addresses from the message.
      *
      * @return $this
      */
     public function forgetTo()
     {
         if ($header = $this->message->getHeaders()->get('To')) {
-            $this->addAddressesDebugHeader('X-To', $this->message->getTo());
+            $this->addAddressDebugHeader('X-To', $this->message->getTo());
+
             $header->setAddresses([]);
         }
 
@@ -149,7 +150,8 @@ class Message
     public function forgetCc()
     {
         if ($header = $this->message->getHeaders()->get('Cc')) {
-            $this->addAddressesDebugHeader('X-Cc', $this->message->getCC());
+            $this->addAddressDebugHeader('X-Cc', $this->message->getCC());
+
             $header->setAddresses([]);
         }
 
@@ -185,7 +187,8 @@ class Message
     public function forgetBcc()
     {
         if ($header = $this->message->getHeaders()->get('Bcc')) {
-            $this->addAddressesDebugHeader('X-Bcc', $this->message->getBcc());
+            $this->addAddressDebugHeader('X-Bcc', $this->message->getBcc());
+
             $header->setAddresses([]);
         }
 
@@ -238,13 +241,13 @@ class Message
     }
 
     /**
-     * Adds a debug header for a list of recipients.
+     * Add an address debug header for a list of recipients.
      *
      * @param  string  $header
      * @param  \Symfony\Component\Mime\Address[]  $addresses
      * @return $this
      */
-    protected function addAddressesDebugHeader(string $header, array $addresses)
+    protected function addAddressDebugHeader(string $header, array $addresses)
     {
         $this->message->getHeaders()->addTextHeader(
             $header,

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -210,9 +210,11 @@ class MailMailerTest extends TestCase
         });
 
         $this->assertSame('taylor@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
-        $this->assertStringContainsString('X-To: nuno@laravel.com', $sentMessage->toString());
-        $this->assertStringContainsString('X-Cc: dries@laravel.com', $sentMessage->toString());
-        $this->assertStringContainsString('X-Bcc: james@laravel.com', $sentMessage->toString());
+        $this->assertDoesNotMatchRegularExpression('/^To: nuno@laravel.com/m', $sentMessage->toString());
+        $this->assertDoesNotMatchRegularExpression('/^Cc: dries@laravel.com/m', $sentMessage->toString());
+        $this->assertMatchesRegularExpression('/^X-To: nuno@laravel.com/m', $sentMessage->toString());
+        $this->assertMatchesRegularExpression('/^X-Cc: dries@laravel.com/m', $sentMessage->toString());
+        $this->assertMatchesRegularExpression('/^X-Bcc: james@laravel.com/m', $sentMessage->toString());
         $this->assertFalse($recipients->contains('nuno@laravel.com'));
         $this->assertFalse($recipients->contains('dries@laravel.com'));
         $this->assertFalse($recipients->contains('james@laravel.com'));

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -200,6 +200,7 @@ class MailMailerTest extends TestCase
 
         $sentMessage = $mailer->send('foo', ['data'], function (Message $message) {
             $message->from('hello@laravel.com');
+            $message->to('nuno@laravel.com');
             $message->cc('dries@laravel.com');
             $message->bcc('james@laravel.com');
         });
@@ -209,8 +210,11 @@ class MailMailerTest extends TestCase
         });
 
         $this->assertSame('taylor@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
-        $this->assertStringNotContainsString('dries@laravel.com', $sentMessage->toString());
-        $this->assertStringNotContainsString('james@laravel.com', $sentMessage->toString());
+        $this->assertStringContainsString('X-To: nuno@laravel.com', $sentMessage->toString());
+        $this->assertStringContainsString('X-Cc: dries@laravel.com', $sentMessage->toString());
+        $this->assertStringContainsString('X-Bcc: james@laravel.com', $sentMessage->toString());
+        $this->assertFalse($recipients->contains('nuno@laravel.com'));
+        $this->assertFalse($recipients->contains('dries@laravel.com'));
         $this->assertFalse($recipients->contains('james@laravel.com'));
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When using `Mail::alwaysTo` in development environments, the original To, Cc and Bcc are lost. This makes it difficult to determine where the email was going to during testing. 

This PR adds the original to, cc and bcc into X-Headers in the email so this information can be retrieved, while still preventing the email being sent to these recipients. 

The below screenshot of Helo shows `alwaysTo` being set, an attempt to send an email with To, Cc, Bcc and the resultant email with the added headers. 

![image](https://user-images.githubusercontent.com/67807/154697393-7c046713-1027-4c43-afd1-a9decb4d8da6.png)



