### PR TITLE
Update ResetPassword.php

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,11 +59,13 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
+        $resetUrl = $this->resetUrl($notifiable);
+        
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+            return call_user_func(static::$toMailCallback, $notifiable, $this->token, $resetUrl);
         }
 
-        return $this->buildMailMessage($this->resetUrl($notifiable));
+        return $this->buildMailMessage($resetUrl);
     }
 
     /**


### PR DESCRIPTION
Setting 
`ResetPassword::createUrlUsing` 
was useless if also
 `ResetPassword::toMailUsing`
was set. 

The resetUrl wasn't calculated by the given ResetPassword::createUrlUsing callback and wasn't passed to the  ResetPassword::toMailUsing callback.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
