### PR TITLE
[9.x] Requires upcoming Testbench 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "league/flysystem-ftp": "^3.0",
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.4.4",
-        "orchestra/testbench-core": "^7.0",
+        "orchestra/testbench-core": "^7.1",
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.0",
         "predis/predis": "^1.1.9",


### PR DESCRIPTION
I plan to remove logic added in 7.0 that was added to handle Laravel 9 beta releases.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>