### PR TITLE
[9.x] Improve Conditional::when and ::unless docblocks

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -10,11 +10,12 @@ trait Conditionable
     /**
      * Apply the callback if the given "value" is (or resolves to) truthy.
      *
+     * @template TWhenParameter
      * @template TWhenReturnType
      *
-     * @param  bool  $value
-     * @param  (callable($this): TWhenReturnType)|null  $callback
-     * @param  (callable($this): TWhenReturnType)|null  $default
+     * @param  (callable($this): TWhenParameter)|TWhenParameter  $value
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
+     * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return $this|TWhenReturnType
      */
     public function when($value, callable $callback = null, callable $default = null)
@@ -37,11 +38,12 @@ trait Conditionable
     /**
      * Apply the callback if the given "value" is (or resolves to) falsy.
      *
+     * @template TUnlessParameter
      * @template TUnlessReturnType
      *
-     * @param  bool  $value
-     * @param  (callable($this): TUnlessReturnType)  $callback
-     * @param  (callable($this): TUnlessReturnType)|null  $default
+     * @param  (callable($this): TUnlessParameter)|TUnlessParameter  $value
+     * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $callback
+     * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType
      */
     public function unless($value, callable $callback = null, callable $default = null)

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -247,6 +247,46 @@ assertType('Illuminate\Support\Collection<int, User>|string', $collection->when(
 
     return 'string';
 }));
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->when('Taylor', function ($collection, $name) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+    assertType('string', $name);
+}));
+assertType(
+    'Illuminate\Support\Collection<int, User>|void',
+    $collection->when(
+        'Taylor',
+        function ($collection, $name) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+            assertType('string', $name);
+        },
+        function($collection, $name) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+            assertType('string', $name);
+        }
+    )
+);
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->when(fn() =>'Taylor', function ($collection, $name) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+    assertType('string', $name);
+}));
+assertType(
+    'Illuminate\Support\Collection<int, User>|void',
+    $collection->when(
+        function($collection) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+            return 14;
+        },
+        function ($collection, $count) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+            assertType('int', $count);
+        },
+        function($collection, $count) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+            assertType('int', $count);
+        }
+    )
+);
 
 assertType('bool|Illuminate\Support\Collection<int, User>', $collection->whenEmpty(function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
@@ -289,6 +329,46 @@ assertType('Illuminate\Support\Collection<int, User>|string', $collection->unles
 
     return 'string';
 }));
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->unless('Taylor', function ($collection, $name) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+    assertType('string', $name);
+}));
+assertType(
+    'Illuminate\Support\Collection<int, User>|void',
+    $collection->unless(
+        'Taylor',
+        function ($collection, $name) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+            assertType('string', $name);
+        },
+        function($collection, $name) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+            assertType('string', $name);
+        }
+    )
+);
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->unless(fn() => 'Taylor', function ($collection, $name) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+    assertType('string', $name);
+}));
+assertType(
+    'Illuminate\Support\Collection<int, User>|void',
+    $collection->unless(
+        function($collection) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+
+            return 14;
+        },
+        function ($collection, $count) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+            assertType('int', $count);
+        },
+        function($collection, $count) {
+            assertType('Illuminate\Support\Collection<int, User>', $collection);
+            assertType('int', $count);
+        }
+    )
+);
 
 assertType('bool|Illuminate\Support\Collection<int, User>', $collection->unlessEmpty(function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -259,20 +259,20 @@ assertType(
             assertType('Illuminate\Support\Collection<int, User>', $collection);
             assertType('string', $name);
         },
-        function($collection, $name) {
+        function ($collection, $name) {
             assertType('Illuminate\Support\Collection<int, User>', $collection);
             assertType('string', $name);
         }
     )
 );
-assertType('Illuminate\Support\Collection<int, User>|void', $collection->when(fn() =>'Taylor', function ($collection, $name) {
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->when(fn () =>'Taylor', function ($collection, $name) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType('string', $name);
 }));
 assertType(
     'Illuminate\Support\Collection<int, User>|void',
     $collection->when(
-        function($collection) {
+        function ($collection) {
             assertType('Illuminate\Support\Collection<int, User>', $collection);
 
             return 14;
@@ -281,7 +281,7 @@ assertType(
             assertType('Illuminate\Support\Collection<int, User>', $collection);
             assertType('int', $count);
         },
-        function($collection, $count) {
+        function ($collection, $count) {
             assertType('Illuminate\Support\Collection<int, User>', $collection);
             assertType('int', $count);
         }
@@ -341,20 +341,20 @@ assertType(
             assertType('Illuminate\Support\Collection<int, User>', $collection);
             assertType('string', $name);
         },
-        function($collection, $name) {
+        function ($collection, $name) {
             assertType('Illuminate\Support\Collection<int, User>', $collection);
             assertType('string', $name);
         }
     )
 );
-assertType('Illuminate\Support\Collection<int, User>|void', $collection->unless(fn() => 'Taylor', function ($collection, $name) {
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->unless(fn () => 'Taylor', function ($collection, $name) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType('string', $name);
 }));
 assertType(
     'Illuminate\Support\Collection<int, User>|void',
     $collection->unless(
-        function($collection) {
+        function ($collection) {
             assertType('Illuminate\Support\Collection<int, User>', $collection);
 
             return 14;
@@ -363,7 +363,7 @@ assertType(
             assertType('Illuminate\Support\Collection<int, User>', $collection);
             assertType('int', $count);
         },
-        function($collection, $count) {
+        function ($collection, $count) {
             assertType('Illuminate\Support\Collection<int, User>', $collection);
             assertType('int', $count);
         }


### PR DESCRIPTION
This PR improves type resolution for Conditional::when and Conditional::unless

Some improvement can still be made 
```php
$collection->when('Taylor', function ($collection, $name) {});
```
should be typed as `Illuminate\Support\Collection<int, User>` and not `Illuminate\Support\Collection<int, User>|void` but I'm not sure it is possible just using docblocks