### PR TITLE
[10.x] Update ResetPassword.php

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,11 +59,13 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
+        $resetUrl = $this->resetUrl($notifiable);
+
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+            return call_user_func(static::$toMailCallback, $notifiable, $this->token, $resetUrl);
         }
 
-        return $this->buildMailMessage($this->resetUrl($notifiable));
+        return $this->buildMailMessage($resetUrl);
     }
 
     /**

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -90,12 +90,17 @@ class ForgotPasswordTest extends TestCase
     {
         Notification::fake();
 
-        ResetPassword::toMailUsing(function ($notifiable, $token) {
+        ResetPassword::createUrlUsing(function ($user, string $token) {
+            return route('custom.password.reset', $token);
+        });
+
+        ResetPassword::toMailUsing(function ($notifiable, $token, $url) {
             return (new MailMessage)
                 ->subject(__('Reset Password Notification'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
-                ->action(__('Reset Password'), route('custom.password.reset', $token))
-                ->line(__('If you did not request a password reset, no further action is required.'));
+                ->action(__('Reset Password'), $url)
+                ->line(__('If you did not request a password reset, no further action is required.'))
+                ->line(__('Your reset token is: ' . $token));
         });
 
         UserFactory::new()->create();

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -100,7 +100,7 @@ class ForgotPasswordTest extends TestCase
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
                 ->action(__('Reset Password'), $url)
                 ->line(__('If you did not request a password reset, no further action is required.'))
-                ->line(__('Your reset token is: ' . $token));
+                ->line(__('Your reset token is: '.$token));
         });
 
         UserFactory::new()->create();


### PR DESCRIPTION
Setting 
`ResetPassword::createUrlUsing` 
was useless if also
 `ResetPassword::toMailUsing`
was set. 

The resetUrl wasn't calculated by the given ResetPassword::createUrlUsing callback and wasn't passed to the  ResetPassword::toMailUsing callback.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
