### PR TITLE
[9.x] Fake Temporary URLs

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -70,7 +70,9 @@ class Storage extends Facade
             'root' => $root,
         ])));
 
-        return $fake;
+        return tap($fake)->buildTemporaryUrlsUsing(function ($path, $expiration) {
+            return URL::to($path.'?expiration='.$expiration->getTimestamp());
+        });
     }
 
     /**


### PR DESCRIPTION
Currently, when you call `Storage::fake`, an actual "local" disk is created and mounted to a temporary location. However, the local disk does not support calls to `temporaryUrl`, and will receive errors if your code invokes this method during the test.

This uses the `buildTemporaryUrlsUsing` method to register a custom callback that just returns the path given as a URL with the expiration in the query string. Obviously, this does not point to a real file; however, this allows the code to execute and get a valid string back from this method that should be satisfactory for testing purposes.