### PR TITLE
[9x] Remove redundant check in FormRequest::validated()

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -212,13 +212,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validated($key = null, $default = null)
     {
-        if (! is_null($key)) {
-            return data_get(
-                $this->validator->validated(), $key, $default
-            );
-        }
-
-        return $this->validator->validated();
+        return data_get($this->validator->validated(), $key, $default);
     }
 
     /**


### PR DESCRIPTION
Hi! 

this PR aims to remove a redundant check in `Illuminate\Foundation\Http\FormRequest`:

```php
// Illuminate\Foundation\Http\FormRequest lines 213-222

public function validated($key = null, $default = null)
{
    if (! is_null($key)) {
        return data_get(
            $this->validator->validated(), $key, $default
        );
    }

    return $this->validator->validated();
}
```

the `!is_null` is used to return the entire validated set if a `$key` is not provided

but the same check is done inside the `data_get()` helper:

```php
// Illuminate\Collections\helpers.php lines 46-49

function data_get($target, $key, $default = null)
{
    if (is_null($key)) {
        return $target;
    }
    //...
}
```

so it can be safely removed and the code can be made simpler

**note** the same optimization can be done in `master`, will open a new PR for it if this gets approved