### PR TITLE
[9.x] Rollback a specific batch of migrations

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -60,6 +60,7 @@ class RollbackCommand extends BaseCommand
                 $this->getMigrationPaths(), [
                     'pretend' => $this->option('pretend'),
                     'step' => (int) $this->option('step'),
+                    'batch' => (int) $this->option('batch'),
                 ]
             );
         });
@@ -86,6 +87,8 @@ class RollbackCommand extends BaseCommand
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
 
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted'],
+
+            ['batch', null, InputOption::VALUE_REQUIRED, 'The batch of migrations (identified by their batch number) to be reverted'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -88,7 +88,7 @@ class RollbackCommand extends BaseCommand
 
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted'],
 
-            ['batch', null, InputOption::VALUE_REQUIRED, 'The batch of migrations (identified by their batch number) to be reverted'],
+            ['batch', null, InputOption::VALUE_OPTIONAL, 'The batch of migrations (identified by their batch number) to be reverted'],
         ];
     }
 }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -69,6 +69,21 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Get the list of the migrations by batch number.
+     *
+     * @param  int  $batchNumber
+     * @return array
+     */
+    public function getMigrationsByBatch($batch): array
+    {
+        return $this->table()
+            ->where('batch', $batch)
+            ->orderBy('migration', 'desc')
+            ->get()
+            ->all();
+    }
+
+    /**
      * Get the last migration batch.
      *
      * @return array

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -11,13 +11,21 @@ interface MigrationRepositoryInterface
      */
     public function getRan();
 
-    /**
+     /**
      * Get the list of migrations.
      *
      * @param  int  $steps
      * @return array
      */
     public function getMigrations($steps);
+
+    /**
+     * Get the list of the migrations by batch.
+     *
+     * @param  int  $batch
+     * @return array
+     */
+    public function getMigrationsByBatch($batch): array;
 
     /**
      * Get the last migration batch.

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -11,7 +11,7 @@ interface MigrationRepositoryInterface
      */
     public function getRan();
 
-     /**
+    /**
      * Get the list of migrations.
      *
      * @param  int  $steps

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -248,6 +248,10 @@ class Migrator
             return $this->repository->getMigrations($steps);
         }
 
+        if (($batch = $options['batch'] ?? 0) > 0) {
+            return $this->repository->getMigrationsByBatch($batch);
+        }
+
         return $this->repository->getLast();
     }
 

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0, 'batch' => 0]);
 
         $this->runCommand($command);
     }
@@ -44,7 +44,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2, 'batch' => 0]);
 
         $this->runCommand($command, ['--step' => 2]);
     }
@@ -76,7 +76,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
-        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2]);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2, 'batch' => 0]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
     }


### PR DESCRIPTION
- Add a new option `batch` to the RollbackCommand.
- Add a new function `getMigrationsByBatch` to the MigrationRepositoryInterface.
- Implement `getMigrationsByBatch` in DatabaseMigrationRepository.

This new option allows the developer to rollback a specific batch of migrations. This can be helpful
in situations where a production bugfix introduced database changes after the current feature branch introduced database changes. The develop may not be able to rollback the production bugfix batch, but still wants to revert the batch from the current feature branch to make slight changes to the database migrations introduced in the current feature branch.

A PR to laravel/docs will also be submitted.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
