### PR TITLE
[9.x] Fix setPriority Call for MailChannel

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -143,7 +143,7 @@ class MailChannel
         $this->addAttachments($mailMessage, $message);
 
         if (! is_null($message->priority)) {
-            $mailMessage->setPriority($message->priority);
+            $mailMessage->priority($message->priority);
         }
 
         if ($message->tags) {

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -98,7 +98,7 @@ class SendingMailNotificationsTest extends TestCase
 
                 $message->shouldReceive('subject')->once()->with('Test Mail Notification');
 
-                $message->shouldReceive('setPriority')->once()->with(1);
+                $message->shouldReceive('priority')->once()->with(1);
 
                 $closure($message);
 
@@ -144,7 +144,7 @@ class SendingMailNotificationsTest extends TestCase
 
                 $message->shouldReceive('subject')->once()->with('Test Mail Notification');
 
-                $message->shouldReceive('setPriority')->once()->with(1);
+                $message->shouldReceive('priority')->once()->with(1);
 
                 $closure($message);
 


### PR DESCRIPTION
Fixes #41119 

There seems to be some leftover from Swiftmailer which still uses setPriority.