### PR TITLE
[9.x] Remove duplicate queries to find batch

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -179,12 +179,13 @@ class CallQueuedHandler
         $uses = class_uses_recursive($command);
 
         if (! in_array(Batchable::class, $uses) ||
-            ! in_array(InteractsWithQueue::class, $uses) ||
-            is_null($command->batch())) {
+            ! in_array(InteractsWithQueue::class, $uses)) {
             return;
         }
 
-        $command->batch()->recordSuccessfulJob($command->job->uuid());
+        if ($batch = $command->batch()) {
+            $batch->recordSuccessfulJob($command->job->uuid());
+        }
     }
 
     /**
@@ -273,12 +274,13 @@ class CallQueuedHandler
      */
     protected function ensureFailedBatchJobIsRecorded(string $uuid, $command, $e)
     {
-        if (! in_array(Batchable::class, class_uses_recursive($command)) ||
-            is_null($command->batch())) {
+        if (! in_array(Batchable::class, class_uses_recursive($command))) {
             return;
         }
 
-        $command->batch()->recordFailedJob($uuid, $e);
+        if ($batch = $command->batch()) {
+            $batch->recordFailedJob($uuid, $e);
+        }
     }
 
     /**


### PR DESCRIPTION
Everytime the `Batchable::batch()` method is called, a database query is performed using the `DatabaseBatchRepository`.

So when we are recording successful/failed jobs, first we fetch the batch to check if it's null, and then we fetch it again to record the job. 

Since it's rendundant to fetch the batch two times from the database, this PR fetches the batch once, and if it exists, it will record the job.