### PR TITLE
[9.x] Added support for index and position placeholders in array validation messages

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -229,9 +229,7 @@ trait FormatsMessages
         );
 
         $message = $this->replaceInputPlaceholder($message, $attribute);
-
         $message = $this->replaceIndexPlaceholder($message, $attribute);
-
         $message = $this->replacePositionPlaceholder($message, $attribute);
 
         if (isset($this->replacers[Str::snake($rule)])) {
@@ -320,11 +318,13 @@ trait FormatsMessages
      */
     protected function replaceIndexPlaceholder($message, $attribute)
     {
-        return str_ireplace(':index', explode('.', $attribute)[1] ?? 0, $message);
+        return $this->replaceIndexOrPositionPlaceholder(
+            $message, $attribute, 'index'
+        );
     }
 
     /**
-     * Replace the :pos placeholder in the given message.
+     * Replace the :position placeholder in the given message.
      *
      * @param  string  $message
      * @param  string  $attribute
@@ -332,7 +332,65 @@ trait FormatsMessages
      */
     protected function replacePositionPlaceholder($message, $attribute)
     {
-        return str_ireplace(':pos', (int) (explode('.', $attribute)[1] ?? 0) + 1, $message);
+        return $this->replaceIndexOrPositionPlaceholder(
+            $message, $attribute, 'position', fn ($segment) => $segment + 1
+        );
+    }
+
+    /**
+     * Replace the :index or :position placeholder in the given message.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $placeholder
+     * @param  \Closure  $modifier
+     * @return string
+     */
+    protected function replaceIndexOrPositionPlaceholder($message, $attribute, $placeholder, Closure $modifier = null)
+    {
+        $segments = explode('.', $attribute);
+
+        $modifier ??= fn ($value) => $value;
+
+        $numericIndex = 1;
+
+        foreach ($segments as $segment) {
+            if (is_numeric($segment)) {
+                $message = str_ireplace(':'.$placeholder, $modifier((int) $segment), $message);
+
+                $message = str_ireplace(
+                    ':'.$this->numberToIndexOrPositionWord($numericIndex).'-'.$placeholder,
+                    $modifier((int) $segment),
+                    $message
+                );
+
+                $numericIndex++;
+            }
+        }
+
+        return $message;
+    }
+
+    /**
+     * Get the word for a index or position segment.
+     *
+     * @param  int  $value
+     * @return string
+     */
+    protected function numberToIndexOrPositionWord(int $value)
+    {
+        return [
+            1 => 'first',
+            2 => 'second',
+            3 => 'third',
+            4 => 'fourth',
+            5 => 'fifth',
+            6 => 'sixth',
+            7 => 'seventh',
+            8 => 'eighth',
+            9 => 'ninth',
+            10 => 'tenth',
+        ][(int) $value] ?? 'other';
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -321,7 +321,7 @@ trait FormatsMessages
     protected function replaceIndexPlaceholder($message, $attribute)
     {
         $index = explode('.', $attribute);
-        return str_ireplace(':index', $index[1], $message);
+        return str_ireplace(':index', $index[1] ?? 0, $message);
     }
 
     /**
@@ -334,8 +334,8 @@ trait FormatsMessages
     protected function replacePositionPlaceholder($message, $attribute)
     {
         $index = explode('.', $attribute);
-        $index[1]++;
-        return str_ireplace(':pos', $index[1], $message);
+        $i = ($index[1] ?? 0) + 1;
+        return str_ireplace(':pos', $i, $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -321,6 +321,7 @@ trait FormatsMessages
     protected function replaceIndexPlaceholder($message, $attribute)
     {
         $index = explode('.', $attribute);
+
         return str_ireplace(':index', $index[1] ?? 0, $message);
     }
 
@@ -335,6 +336,7 @@ trait FormatsMessages
     {
         $index = explode('.', $attribute);
         $i = ($index[1] ?? 0) + 1;
+
         return str_ireplace(':pos', $i, $message);
     }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -332,7 +332,7 @@ trait FormatsMessages
      */
     protected function replacePositionPlaceholder($message, $attribute)
     {
-        return str_ireplace(':pos', (int)(explode('.', $attribute)[1] ?? 0) + 1, $message);
+        return str_ireplace(':pos', (int) (explode('.', $attribute)[1] ?? 0) + 1, $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -230,6 +230,10 @@ trait FormatsMessages
 
         $message = $this->replaceInputPlaceholder($message, $attribute);
 
+        $message = $this->replaceIndexPlaceholder($message, $attribute);
+
+        $message = $this->replacePositionPlaceholder($message, $attribute);
+
         if (isset($this->replacers[Str::snake($rule)])) {
             return $this->callReplacer($message, $attribute, Str::snake($rule), $parameters, $this);
         } elseif (method_exists($this, $replacer = "replace{$rule}")) {
@@ -305,6 +309,33 @@ trait FormatsMessages
             [$value, Str::upper($value), Str::ucfirst($value)],
             $message
         );
+    }
+
+    /**
+     * Replace the :index placeholder in the given message.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @return string
+     */
+    protected function replaceIndexPlaceholder($message, $attribute)
+    {
+        $index = explode('.', $attribute);
+        return str_ireplace(':index', $index[1], $message);
+    }
+
+    /**
+     * Replace the :pos placeholder in the given message.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @return string
+     */
+    protected function replacePositionPlaceholder($message, $attribute)
+    {
+        $index = explode('.', $attribute);
+        $index[1]++;
+        return str_ireplace(':pos', $index[1], $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -320,9 +320,7 @@ trait FormatsMessages
      */
     protected function replaceIndexPlaceholder($message, $attribute)
     {
-        $index = explode('.', $attribute);
-
-        return str_ireplace(':index', $index[1] ?? 0, $message);
+        return str_ireplace(':index', explode('.', $attribute)[1] ?? 0, $message);
     }
 
     /**
@@ -334,10 +332,7 @@ trait FormatsMessages
      */
     protected function replacePositionPlaceholder($message, $attribute)
     {
-        $index = explode('.', $attribute);
-        $i = ($index[1] ?? 0) + 1;
-
-        return str_ireplace(':pos', $i, $message);
+        return str_ireplace(':pos', (int)(explode('.', $attribute)[1] ?? 0) + 1, $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -356,7 +356,9 @@ trait FormatsMessages
 
         foreach ($segments as $segment) {
             if (is_numeric($segment)) {
-                $message = str_ireplace(':'.$placeholder, $modifier((int) $segment), $message);
+                if ($numericIndex === 1) {
+                    $message = str_ireplace(':'.$placeholder, $modifier((int) $segment), $message);
+                }
 
                 $message = str_ireplace(
                     ':'.$this->numberToIndexOrPositionWord($numericIndex).'-'.$placeholder,

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -588,6 +588,10 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
+        $v = new Validator($trans, ['name' => ''], ['name' => 'required'], ['name.required' => 'Name :index is required.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 0 is required.', $v->messages()->first('name'));
+
         $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :index is required.']);
         $this->assertFalse($v->passes());
         $this->assertSame('Name 0 is required.', $v->messages()->first('input.*.name'));
@@ -615,6 +619,10 @@ class ValidationValidatorTest extends TestCase
     public function testPositionValuesAreReplaced()
     {
         $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['name' => ''], ['name' => 'required'], ['name.required' => 'Name :pos is required.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 1 is required.', $v->messages()->first('name'));
 
         $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :pos is required.']);
         $this->assertFalse($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -603,6 +603,20 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertSame('Name 0 is required.', $v->messages()->first('input.*.name'));
 
+        $v = new Validator($trans, [
+            'input' => [
+                [
+                    'name' => '',
+                    'attributes' => [
+                        'foo',
+                        1,
+                    ],
+                ]
+            ]
+        ], ['input.*.attributes.*' => 'string'], ['input.*.attributes.*.string' => 'Attribute (:first-index, :first-position) (:second-index, :second-position) must be a string.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Attribute (0, 1) (1, 2) must be a string.', $v->messages()->first('input.*.attributes.*'));
+
         $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :index is required.']);
         $this->assertFalse($v->passes());
         $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -597,7 +597,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('Name 0 is required.', $v->messages()->first('input.*.name'));
         $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':Attribute :index is required.']);
         $v->setAttributeNames([
-            'input.*.name' => 'name'
+            'input.*.name' => 'name',
         ]);
         $this->assertFalse($v->passes());
         $this->assertSame('Name 0 is required.', $v->messages()->first('input.*.name'));
@@ -607,7 +607,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));
         $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':Attribute :index is required.']);
         $v->setAttributeNames([
-            'input.*.name' => 'name'
+            'input.*.name' => 'name',
         ]);
         $this->assertFalse($v->passes());
         $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -584,6 +584,62 @@ class ValidationValidatorTest extends TestCase
         new Validator($trans, ['firstname' => 'Bob', 'lastname' => 'Smith'], ['lastname' => 'alliteration:firstname']);
     }
 
+    public function testIndexValuesAreReplaced()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :index is required.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 0 is required.', $v->messages()->first('input.*.name'));
+        $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':Attribute :index is required.']);
+        $v->setAttributeNames([
+            'input.*.name' => 'name'
+        ]);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 0 is required.', $v->messages()->first('input.*.name'));
+
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :index is required.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':Attribute :index is required.']);
+        $v->setAttributeNames([
+            'input.*.name' => 'name'
+        ]);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));
+
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :index is required.']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testPositionValuesAreReplaced()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :pos is required.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));
+        $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':Attribute :pos is required.']);
+        $v->setAttributeNames([
+            'input.*.name' => 'name'
+        ]);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));
+
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :pos is required.']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 2 is required.', $v->messages()->first('input.*.name'));
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':Attribute :pos is required.']);
+        $v->setAttributeNames([
+            'input.*.name' => 'name'
+        ]);
+        $this->assertFalse($v->passes());
+        $this->assertSame('Name 2 is required.', $v->messages()->first('input.*.name'));
+
+        $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => 'Name :pos is required.']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testCustomValidationLinesAreRespected()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -629,7 +629,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));
         $v = new Validator($trans, ['input' => [['name' => '']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':Attribute :pos is required.']);
         $v->setAttributeNames([
-            'input.*.name' => 'name'
+            'input.*.name' => 'name',
         ]);
         $this->assertFalse($v->passes());
         $this->assertSame('Name 1 is required.', $v->messages()->first('input.*.name'));
@@ -639,7 +639,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('Name 2 is required.', $v->messages()->first('input.*.name'));
         $v = new Validator($trans, ['input' => [['name' => 'Bob'], ['name' => ''], ['name' => 'Jane']]], ['input.*.name' => 'required'], ['input.*.name.required' => ':Attribute :pos is required.']);
         $v->setAttributeNames([
-            'input.*.name' => 'name'
+            'input.*.name' => 'name',
         ]);
         $this->assertFalse($v->passes());
         $this->assertSame('Name 2 is required.', $v->messages()->first('input.*.name'));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adds a backward compatible change that enables a developer to use `:index` or `:pos` in the message for array inputs. Assumes 0 or 1 respectively if it's not an array input.

Discussed in #32977