### PR TITLE
[9.x] Add selectAllExcept() method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
+use Illuminate\Support\Facades\Schema;
 
 class Builder implements BuilderContract
 {
@@ -251,6 +252,23 @@ class Builder implements BuilderContract
         }
 
         return $this;
+    }
+
+
+    /**
+     * Set the all columns to be selected except columns passed.
+     *
+     * @param  array|string  $columns
+     * @return $this
+     */
+    public function selectAllExcept($columns)
+    {
+        $columns = is_array($columns) ? $columns : [$columns];
+
+        $allColumns = Schema::getColumnListing($this->from);
+        $allColumnsExcept = collect($allColumns)->diff($columns)->toArray();
+
+        return $this->select($allColumnsExcept);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -25,7 +25,6 @@ use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
-use Illuminate\Support\Facades\Schema;
 
 class Builder implements BuilderContract
 {
@@ -84,6 +83,13 @@ class Builder implements BuilderContract
      * @var array
      */
     public $columns;
+
+    /**
+     * The columns that should be excepted.
+     *
+     * @var array
+     */
+    public $except;
 
     /**
      * Indicates if the query returns distinct results.
@@ -254,7 +260,6 @@ class Builder implements BuilderContract
         return $this;
     }
 
-
     /**
      * Set the all columns to be selected except columns passed.
      *
@@ -265,10 +270,9 @@ class Builder implements BuilderContract
     {
         $columns = is_array($columns) ? $columns : [$columns];
 
-        $allColumns = Schema::getColumnListing($this->from);
-        $allColumnsExcept = collect($allColumns)->diff($columns)->toArray();
+        $this->except = $columns;
 
-        return $this->select($allColumnsExcept);
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use RuntimeException;
 
@@ -56,6 +57,11 @@ class Grammar extends BaseGrammar
 
         if (is_null($query->columns)) {
             $query->columns = ['*'];
+        }
+
+        if (! is_null($query->except)) {
+            $allColumns = Schema::getColumnListing($query->from);
+            $query->columns = collect($allColumns)->diff($query->except)->toArray();
         }
 
         // To compile the query, we'll spin through each component of the query and

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -26,6 +26,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
+use Illuminate\Support\Facades\Schema;
 
 class DatabaseQueryBuilderTest extends TestCase
 {
@@ -292,6 +293,28 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->tap($callback)->where('email', 'foo');
         $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+    }
+
+    public function testSimpleSelectExceptColumns()
+    {
+        Schema::shouldReceive('getColumnListing')->andReturn([
+            'id', 'name'
+        ]);
+
+        $builder = $this->getBuilder();
+        $builder->selectAllExcept('name')->from('users');
+        $this->assertSame('select "id" from "users"', $builder->toSql());
+    }
+
+    public function testSelectExceptWithMultipleColumns()
+    {
+        Schema::shouldReceive('getColumnListing')->andReturn([
+            'id', 'name', 'body'
+        ]);
+
+        $builder = $this->getBuilder();
+        $builder->selectAllExcept(['name', 'body'])->from('users');
+        $this->assertSame('select "id" from "users"', $builder->toSql());
     }
 
     public function testBasicWheres()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -21,12 +21,12 @@ use Illuminate\Pagination\AbstractPaginator as Paginator;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Schema;
 use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
-use Illuminate\Support\Facades\Schema;
 
 class DatabaseQueryBuilderTest extends TestCase
 {
@@ -298,7 +298,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSimpleSelectExceptColumns()
     {
         Schema::shouldReceive('getColumnListing')->andReturn([
-            'id', 'name'
+            'id', 'name',
         ]);
 
         $builder = $this->getBuilder();
@@ -309,7 +309,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSelectExceptWithMultipleColumns()
     {
         Schema::shouldReceive('getColumnListing')->andReturn([
-            'id', 'name', 'body'
+            'id', 'name', 'body',
         ]);
 
         $builder = $this->getBuilder();


### PR DESCRIPTION
In some conditions, we need to pull all columns from the table except one which is heavy and takes lots of memory.
For example, we have a table for our articles and it has a column like `body` and we need to pull all tables except one of them (or more).

From now on we can do this:
```php
Article::query()->selectAllExcept('body')->get()
```

Or with multiple columns:

```php
Article::query()->selectAllExcept(['body', 'picture'])->get()
```

Also, I know that a query will be executed to get the tables, but in some conditions, it does make sense to execute a query instead of passing a huge array by yourself to make it happen and just filter a column.