### PR TITLE
[9.x] RateLimiting: Fix tooManyAttempts method

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -92,11 +92,11 @@ class RateLimiter
         $key = $this->cleanRateLimiterKey($key);
 
         if ($this->attempts($key) >= $maxAttempts) {
-            if ($this->cache->has($key.':timer')) {
+            if ($this->cache->has($key.':timer') && $this->availableIn($key) !== 0) {
                 return true;
             }
 
-            $this->resetAttempts($key);
+            $this->clear($key);
         }
 
         return false;


### PR DESCRIPTION
The current usage of tooManyAttempts has some issues. In this pull request I tried fixing it
Currently, tooManyAttempts never resets when the timer finishes