### PR TITLE
[9.x] Console: Alternative Attribute Syntax for Artisan Commands for better type support and more. 

### DIFF
--- a/src/Illuminate/Console/Attributes/Argument.php
+++ b/src/Illuminate/Console/Attributes/Argument.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Illuminate\Contracts\Console\ConsoleInput;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Argument implements ConsoleInput
+{
+    public function __construct(
+        protected string $description = '',
+        protected ?string $as = null,
+    ) {
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getAlias(): ?string
+    {
+        return $this->as;
+    }
+}

--- a/src/Illuminate/Console/Attributes/ArtisanCommand.php
+++ b/src/Illuminate/Console/Attributes/ArtisanCommand.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Console\Attributes;
 
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class CommandAttribute
+class ArtisanCommand
 {
     public function __construct(
         public string $name,
         public string $description = '',
         public string $help = '',
+        public array $aliases = [],
         public bool $hidden = false,
     ) {
     }

--- a/src/Illuminate/Console/Attributes/CommandAttribute.php
+++ b/src/Illuminate/Console/Attributes/CommandAttribute.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class CommandAttribute
+{
+    public function __construct(
+        public string $name,
+        public string $description = '',
+        public string $help = '',
+        public bool $hidden = false,
+    ) {
+    }
+}

--- a/src/Illuminate/Console/Attributes/Option.php
+++ b/src/Illuminate/Console/Attributes/Option.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Console\Attributes;
+
+use Illuminate\Contracts\Console\ConsoleInput;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class Option implements ConsoleInput
+{
+    public function __construct(
+        protected string $description = '',
+        protected ?string $as = null,
+        protected ?string $shortcut = null,
+        protected bool $negatable = false,
+    ) {
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getAlias(): ?string
+    {
+        return $this->as;
+    }
+
+    public function getShortcut(): ?string
+    {
+        return $this->shortcut;
+    }
+
+    public function isNegatable(): bool
+    {
+        return $this->negatable;
+    }
+}

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -197,7 +197,7 @@ class Command extends SymfonyCommand
             return;
         }
 
-        if ( !isset($this->signature)) {
+        if (! isset($this->signature)) {
             parent::__construct($this->name);
         }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console;
 
-use Illuminate\Console\Reflections\ArgumentReflection;
 use Illuminate\Console\Reflections\CommandReflection;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -191,11 +190,7 @@ class Command extends SymfonyCommand
     protected function intiCommandData(): void
     {
         if ($this->reflection->usesCommandAttribute()) {
-            parent::__construct($this->name = $this->reflection->getName());
-            $this->setDescription($this->reflection->getDescription());
-            $this->setHelp($this->reflection->getHelp());
-            $this->setHidden($this->reflection->isHidden());
-
+            $this->initCommandDataFromAttribute();
             return;
         }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -90,11 +90,13 @@ class Command extends SymfonyCommand
     {
         if (isset($this->signature)) {
             $this->configureUsingFluentDefinition();
+
             return;
         }
 
         if ($this->reflection->usesInputAttributes()) {
             $this->configureUsingAttributeDefinition();
+
             return;
         }
 
@@ -191,10 +193,11 @@ class Command extends SymfonyCommand
     {
         if ($this->reflection->usesCommandAttribute()) {
             $this->initCommandDataFromAttribute();
+
             return;
         }
 
-        if(!isset($this->signature)) {
+        if ( !isset($this->signature)) {
             parent::__construct($this->name);
         }
 

--- a/src/Illuminate/Console/Concerns/HasAttributeSyntax.php
+++ b/src/Illuminate/Console/Concerns/HasAttributeSyntax.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Illuminate\Console\Reflections\ArgumentReflection;
+use Illuminate\Console\Reflections\OptionReflection;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+trait HasAttributeSyntax
+{
+
+    /**
+     * Configure the console command using an Attribute definition.
+     *
+     * @return void
+     */
+    protected function configureUsingAttributeDefinition()
+    {
+        $this->configureArgumentsUsingAttributeDefinition();
+        $this->configureOptionsUsingAttributeDefinition();
+    }
+
+    protected function configureArgumentsUsingAttributeDefinition(): void
+    {
+        $this->reflection
+            ->getArguments()
+            ->each(function (ArgumentReflection $argumentReflection) {
+                $this->getDefinition()
+                    ->addArgument(
+                        $this->propertyToArgument($argumentReflection)
+                    );
+            });
+    }
+
+    protected function configureOptionsUsingAttributeDefinition(): void
+    {
+        $this->reflection
+            ->getOptions()
+            ->each(function (OptionReflection $optionReflection) {
+                $this->getDefinition()
+                    ->addOption($this->propertyToOption($optionReflection));
+            });
+    }
+
+    protected function hydrateArguments(): void
+    {
+        $this->reflection
+            ->getArguments()
+            ->each(function (ArgumentReflection $argumentReflection) {
+                $this->{$argumentReflection->getName()} = $argumentReflection->castTo($this->argument($argumentReflection->getAlias() ?? $argumentReflection->getName()));
+            });
+    }
+
+    protected function hydrateOptions(): void
+    {
+        $this->reflection
+            ->getOptions()
+            ->each(function (OptionReflection $optionReflection) {
+                $consoleName = $optionReflection->getAlias() ?? $optionReflection->getName();
+
+                if (!$optionReflection->hasRequiredValue()) {
+                    $this->{$optionReflection->getName()} = $optionReflection->castTo($this->option($consoleName));
+                    return;
+                }
+
+                if ($this->option($consoleName) === null) {
+                    return;
+                }
+
+                $this->{$optionReflection->getName()} = $optionReflection->castTo($this->option($consoleName));
+
+            });
+    }
+
+
+    protected function propertyToArgument(ArgumentReflection $argument): InputArgument
+    {
+        return match (true) {
+            $argument->isArray() && !$argument->isOptional() => $this->makeInputArgument($argument,
+                InputArgument::IS_ARRAY | InputArgument::REQUIRED),
+
+            $argument->isArray() => $this->makeInputArgument($argument, InputArgument::IS_ARRAY,
+                $argument->getDefaultValue()),
+
+            $argument->isOptional() || $argument->getDefaultValue() => $this->makeInputArgument($argument,
+                InputArgument::OPTIONAL, $argument->getDefaultValue()),
+
+            default => $this->makeInputArgument($argument, InputArgument::REQUIRED),
+        };
+    }
+
+    protected function propertyToOption(OptionReflection $option): InputOption
+    {
+        return match (true) {
+            $option->hasValue() && $option->isArray() => $this->makeInputOption(
+                $option,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                $option->getDefaultValue()
+            ),
+
+            $option->hasValue() && !$option->isOptional() => $this->makeInputOption($option,
+                InputOption::VALUE_REQUIRED),
+
+            $option->hasValue() => $this->makeInputOption($option, InputOption::VALUE_OPTIONAL,
+                $option->getDefaultValue()),
+
+            $option->isNegatable() => $this->makeInputOption(
+                $option,
+                InputOption::VALUE_NEGATABLE,
+                $option->getDefaultValue() !== null ? $option->getDefaultValue() : false
+            ),
+
+            default => $this->makeInputOption($option, InputOption::VALUE_NONE),
+        };
+    }
+
+    protected function makeInputArgument(
+        ArgumentReflection $argument,
+        int $mode,
+        string|bool|int|float|array|null $default = null
+    ): InputArgument {
+        return new InputArgument(
+            $argument->getAlias() ?? $argument->getName(),
+            $mode,
+            $argument->getDescription(),
+            $default
+        );
+    }
+
+    protected function makeInputOption(
+        OptionReflection $option,
+        int $mode,
+        string|bool|int|float|array|null $default = null
+    ): InputOption {
+        return new InputOption(
+            $option->getAlias() ?? $option->getName(),
+            $option->getShortcut(),
+            $mode,
+            $option->getDescription(),
+            $default
+        );
+    }
+}

--- a/src/Illuminate/Console/Concerns/HasAttributeSyntax.php
+++ b/src/Illuminate/Console/Concerns/HasAttributeSyntax.php
@@ -15,10 +15,19 @@ trait HasAttributeSyntax
      *
      * @return void
      */
-    protected function configureUsingAttributeDefinition()
+    protected function configureUsingAttributeDefinition(): void
     {
         $this->configureArgumentsUsingAttributeDefinition();
         $this->configureOptionsUsingAttributeDefinition();
+    }
+
+    protected function initCommandDataFromAttribute(): void
+    {
+        parent::__construct($this->name = $this->reflection->getName());
+        $this->setDescription($this->reflection->getDescription());
+        $this->setHelp($this->reflection->getHelp());
+        $this->setHidden($this->reflection->isHidden());
+        $this->setAliases($this->reflection->getAliases());
     }
 
     protected function configureArgumentsUsingAttributeDefinition(): void

--- a/src/Illuminate/Console/Concerns/HasAttributeSyntax.php
+++ b/src/Illuminate/Console/Concerns/HasAttributeSyntax.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Input\InputOption;
 
 trait HasAttributeSyntax
 {
-
     /**
      * Configure the console command using an Attribute definition.
      *
@@ -68,7 +67,7 @@ trait HasAttributeSyntax
             ->each(function (OptionReflection $optionReflection) {
                 $consoleName = $optionReflection->getAlias() ?? $optionReflection->getName();
 
-                if (!$optionReflection->hasRequiredValue()) {
+                if (! $optionReflection->hasRequiredValue()) {
                     $this->{$optionReflection->getName()} = $optionReflection->castTo($this->option($consoleName));
                     return;
                 }
@@ -78,15 +77,13 @@ trait HasAttributeSyntax
                 }
 
                 $this->{$optionReflection->getName()} = $optionReflection->castTo($this->option($consoleName));
-
             });
     }
-
 
     protected function propertyToArgument(ArgumentReflection $argument): InputArgument
     {
         return match (true) {
-            $argument->isArray() && !$argument->isOptional() => $this->makeInputArgument($argument,
+            $argument->isArray() && ! $argument->isOptional() => $this->makeInputArgument($argument,
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED),
 
             $argument->isArray() => $this->makeInputArgument($argument, InputArgument::IS_ARRAY,
@@ -108,7 +105,7 @@ trait HasAttributeSyntax
                 $option->getDefaultValue()
             ),
 
-            $option->hasValue() && !$option->isOptional() => $this->makeInputOption($option,
+            $option->hasValue() && ! $option->isOptional() => $this->makeInputOption($option,
                 InputOption::VALUE_REQUIRED),
 
             $option->hasValue() => $this->makeInputOption($option, InputOption::VALUE_OPTIONAL,

--- a/src/Illuminate/Console/Concerns/HasAttributeSyntax.php
+++ b/src/Illuminate/Console/Concerns/HasAttributeSyntax.php
@@ -69,6 +69,7 @@ trait HasAttributeSyntax
 
                 if (! $optionReflection->hasRequiredValue()) {
                     $this->{$optionReflection->getName()} = $optionReflection->castTo($this->option($consoleName));
+
                     return;
                 }
 

--- a/src/Illuminate/Console/Reflections/ArgumentReflection.php
+++ b/src/Illuminate/Console/Reflections/ArgumentReflection.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Console\Reflections;
+
+use Illuminate\Console\Attributes\Argument;
+
+class ArgumentReflection extends InputReflection
+{
+    public static function isArgument(\ReflectionProperty $property): bool
+    {
+        return ! empty($property->getAttributes(Argument::class));
+    }
+}

--- a/src/Illuminate/Console/Reflections/CommandReflection.php
+++ b/src/Illuminate/Console/Reflections/CommandReflection.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Console\Reflections;
 
 use Illuminate\Console\Attributes\Argument;
-use Illuminate\Console\Attributes\CommandAttribute;
+use Illuminate\Console\Attributes\ArtisanCommand;
 use Illuminate\Console\Attributes\Option;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
@@ -11,7 +11,7 @@ use Illuminate\Support\Collection;
 class CommandReflection
 {
     public \ReflectionClass $reflection;
-    public ?CommandAttribute $attribute;
+    public ?ArtisanCommand $attribute;
 
     public function __construct(
         public Command $command
@@ -93,9 +93,18 @@ class CommandReflection
         return $this->attribute->hidden;
     }
 
-    protected function initCommandAttribute(): ?CommandAttribute
+    public function getAliases(): array
     {
-        $attributes = $this->reflection->getAttributes(CommandAttribute::class);
+        if (!$this->usesCommandAttribute()) {
+            return [];
+        }
+
+        return $this->attribute->aliases;
+    }
+
+    protected function initCommandAttribute(): ?ArtisanCommand
+    {
+        $attributes = $this->reflection->getAttributes(ArtisanCommand::class);
 
         if (empty($attributes)) {
             return null;

--- a/src/Illuminate/Console/Reflections/CommandReflection.php
+++ b/src/Illuminate/Console/Reflections/CommandReflection.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Illuminate\Console\Reflections;
+
+use Illuminate\Console\Attributes\Argument;
+use Illuminate\Console\Attributes\CommandAttribute;
+use Illuminate\Console\Attributes\Option;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class CommandReflection
+{
+    public \ReflectionClass $reflection;
+    public ?CommandAttribute $attribute;
+
+    public function __construct(
+        public Command $command
+    ) {
+        $this->reflection = new \ReflectionClass($this->command);
+        $this->attribute = $this->initCommandAttribute();
+    }
+
+    public function usesAttributeSyntax(): bool
+    {
+        return $this->usesCommandAttribute() || $this->usesInputAttributes();
+    }
+
+    public function usesCommandAttribute(): bool
+    {
+        return $this->attribute !== null;
+    }
+
+    public function usesInputAttributes(): bool
+    {
+        return $this->getArguments()->isNotEmpty() || $this->getOptions()->isNotEmpty();
+    }
+
+    public function getArguments(): Collection
+    {
+        return collect($this->reflection->getProperties())
+            ->filter(fn(\ReflectionProperty $property) => ArgumentReflection::isArgument($property))
+            ->map(fn(\ReflectionProperty $property) => new ArgumentReflection(
+                    $property,
+                    $property->getAttributes(Argument::class)[0]->newInstance()
+                )
+            );
+    }
+
+    public function getOptions(): Collection
+    {
+        return collect($this->reflection->getProperties())
+            ->filter(fn(\ReflectionProperty $property) => OptionReflection::isOption($property))
+            ->map(fn(\ReflectionProperty $property) => new OptionReflection(
+                    $property,
+                    $property->getAttributes(Option::class)[0]->newInstance()
+                )
+            );
+    }
+
+    public function getName(): ?string
+    {
+        if (!$this->usesCommandAttribute()) {
+            return $this->command->getName();
+        }
+
+        return $this->attribute->name;
+    }
+
+    public function getDescription(): string
+    {
+        if (!$this->usesCommandAttribute()) {
+            return $this->command->getDescription();
+        }
+
+        return $this->attribute->description;
+    }
+
+    public function getHelp(): string
+    {
+        if (!$this->usesCommandAttribute()) {
+            return $this->command->getHelp();
+        }
+
+        return $this->attribute->help;
+    }
+
+    public function isHidden(): bool
+    {
+        if (!$this->usesCommandAttribute()) {
+            return $this->command->isHidden();
+        }
+
+        return $this->attribute->hidden;
+    }
+
+    protected function initCommandAttribute(): ?CommandAttribute
+    {
+        $attributes = $this->reflection->getAttributes(CommandAttribute::class);
+
+        if (empty($attributes)) {
+            return null;
+        }
+
+        return $attributes[0]->newInstance();
+    }
+}

--- a/src/Illuminate/Console/Reflections/CommandReflection.php
+++ b/src/Illuminate/Console/Reflections/CommandReflection.php
@@ -38,8 +38,8 @@ class CommandReflection
     public function getArguments(): Collection
     {
         return collect($this->reflection->getProperties())
-            ->filter(fn(\ReflectionProperty $property) => ArgumentReflection::isArgument($property))
-            ->map(fn(\ReflectionProperty $property) => new ArgumentReflection(
+            ->filter(fn (\ReflectionProperty $property) => ArgumentReflection::isArgument($property))
+            ->map(fn (\ReflectionProperty $property) => new ArgumentReflection(
                     $property,
                     $property->getAttributes(Argument::class)[0]->newInstance()
                 )
@@ -49,8 +49,8 @@ class CommandReflection
     public function getOptions(): Collection
     {
         return collect($this->reflection->getProperties())
-            ->filter(fn(\ReflectionProperty $property) => OptionReflection::isOption($property))
-            ->map(fn(\ReflectionProperty $property) => new OptionReflection(
+            ->filter(fn (\ReflectionProperty $property) => OptionReflection::isOption($property))
+            ->map(fn (\ReflectionProperty $property) => new OptionReflection(
                     $property,
                     $property->getAttributes(Option::class)[0]->newInstance()
                 )
@@ -59,7 +59,7 @@ class CommandReflection
 
     public function getName(): ?string
     {
-        if (!$this->usesCommandAttribute()) {
+        if (! $this->usesCommandAttribute()) {
             return $this->command->getName();
         }
 
@@ -68,7 +68,7 @@ class CommandReflection
 
     public function getDescription(): string
     {
-        if (!$this->usesCommandAttribute()) {
+        if (! $this->usesCommandAttribute()) {
             return $this->command->getDescription();
         }
 
@@ -77,7 +77,7 @@ class CommandReflection
 
     public function getHelp(): string
     {
-        if (!$this->usesCommandAttribute()) {
+        if (! $this->usesCommandAttribute()) {
             return $this->command->getHelp();
         }
 
@@ -86,7 +86,7 @@ class CommandReflection
 
     public function isHidden(): bool
     {
-        if (!$this->usesCommandAttribute()) {
+        if (! $this->usesCommandAttribute()) {
             return $this->command->isHidden();
         }
 
@@ -95,7 +95,7 @@ class CommandReflection
 
     public function getAliases(): array
     {
-        if (!$this->usesCommandAttribute()) {
+        if (! $this->usesCommandAttribute()) {
             return [];
         }
 

--- a/src/Illuminate/Console/Reflections/InputReflection.php
+++ b/src/Illuminate/Console/Reflections/InputReflection.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Console\Reflections;
+
+use Illuminate\Contracts\Console\ConsoleInput;
+use Illuminate\Tests\Console\StringEnum;
+use Illuminate\Validation\Rules\Enum;
+
+abstract class InputReflection
+{
+    public function __construct(
+        protected \ReflectionProperty $property,
+        protected ConsoleInput $consoleInput
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->property->getName();
+    }
+
+    public function getAlias(): ?string
+    {
+        return $this->consoleInput->getAlias();
+    }
+
+    public function getDescription(): string
+    {
+        return $this->consoleInput->getDescription();
+    }
+
+    public function getDefaultValue(): string|bool|int|float|array|null
+    {
+        return $this->property->hasDefaultValue()
+            ? $this->castFrom($this->property->getDefaultValue())
+            : null;
+    }
+
+    public function isOptional(): bool
+    {
+        return $this->property->hasDefaultValue() || $this->property->getType()?->allowsNull();
+    }
+
+    public function isArray(): bool
+    {
+        if (($type = $this->property->getType()) instanceof \ReflectionNamedType) {
+            return $type->getName() === 'array';
+        }
+
+        return false;
+    }
+
+    public function castFrom(mixed $value): int|float|array|string|bool|null
+    {
+        return match (gettype($value)) {
+            'integer', 'NULL', 'boolean', 'double', 'string', 'array' => $value,
+            'object' => enum_exists($value::class) ?  $this->castEnum($value) : $value,
+            default => $value,
+        };
+
+    }
+
+    public function castEnum(object $value): int|float|array|string|bool|null
+    {
+        return (new \ReflectionEnum($value))->isBacked()
+            ? $value->value
+            : $value->name;
+    }
+
+    public function castTo(int|array|float|string|bool|null $value): mixed
+    {
+        if (!($type = $this->property->getType())) {
+            return $value;
+        }
+
+        if (! $type instanceof \ReflectionNamedType) {
+            return $value;
+        }
+
+        if (!enum_exists($type->getName())){
+            return $value;
+        }
+
+        $enum = new \ReflectionEnum($type->getName());
+
+        return $enum->isBacked()
+            ? ($type->getName())::from((string) $value)
+            : $enum->getCase((string) $value)->getValue();
+    }
+}

--- a/src/Illuminate/Console/Reflections/InputReflection.php
+++ b/src/Illuminate/Console/Reflections/InputReflection.php
@@ -54,7 +54,7 @@ abstract class InputReflection
     {
         return match (gettype($value)) {
             'integer', 'NULL', 'boolean', 'double', 'string', 'array' => $value,
-            'object' => enum_exists($value::class) ?  $this->castEnum($value) : $value,
+            'object' => function_exists('enum_exists') && enum_exists($value::class) ?  $this->castEnum($value) : $value,
             default => $value,
         };
 
@@ -74,6 +74,10 @@ abstract class InputReflection
         }
 
         if (! $type instanceof \ReflectionNamedType) {
+            return $value;
+        }
+
+        if (!function_exists('enum_exists')){
             return $value;
         }
 

--- a/src/Illuminate/Console/Reflections/InputReflection.php
+++ b/src/Illuminate/Console/Reflections/InputReflection.php
@@ -54,10 +54,9 @@ abstract class InputReflection
     {
         return match (gettype($value)) {
             'integer', 'NULL', 'boolean', 'double', 'string', 'array' => $value,
-            'object' => function_exists('enum_exists') && enum_exists($value::class) ?  $this->castEnum($value) : $value,
+            'object' => function_exists('enum_exists') && enum_exists($value::class) ? $this->castEnum($value) : $value,
             default => $value,
         };
-
     }
 
     public function castEnum(object $value): int|float|array|string|bool|null
@@ -69,7 +68,7 @@ abstract class InputReflection
 
     public function castTo(int|array|float|string|bool|null $value): mixed
     {
-        if (!($type = $this->property->getType())) {
+        if (! ($type = $this->property->getType())) {
             return $value;
         }
 
@@ -77,11 +76,11 @@ abstract class InputReflection
             return $value;
         }
 
-        if (!function_exists('enum_exists')){
+        if (! function_exists('enum_exists')){
             return $value;
         }
 
-        if (!enum_exists($type->getName())){
+        if (! enum_exists($type->getName())){
             return $value;
         }
 

--- a/src/Illuminate/Console/Reflections/InputReflection.php
+++ b/src/Illuminate/Console/Reflections/InputReflection.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Console\Reflections;
 
 use Illuminate\Contracts\Console\ConsoleInput;
-use Illuminate\Tests\Console\StringEnum;
-use Illuminate\Validation\Rules\Enum;
 
 abstract class InputReflection
 {
@@ -76,11 +74,11 @@ abstract class InputReflection
             return $value;
         }
 
-        if (! function_exists('enum_exists')){
+        if (! function_exists('enum_exists')) {
             return $value;
         }
 
-        if (! enum_exists($type->getName())){
+        if (! enum_exists($type->getName())) {
             return $value;
         }
 

--- a/src/Illuminate/Console/Reflections/OptionReflection.php
+++ b/src/Illuminate/Console/Reflections/OptionReflection.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Console\Reflections;
+
+use Illuminate\Console\Attributes\Option;
+
+class OptionReflection extends InputReflection
+{
+    public function __construct(\ReflectionProperty $property, Option $consoleInput)
+    {
+        parent::__construct($property, $consoleInput);
+    }
+
+    public static function isOption(\ReflectionProperty $property): bool
+    {
+        return !empty($property->getAttributes(Option::class));
+    }
+
+    public function isNegatable(): bool
+    {
+        return $this->consoleInput->isNegatable();
+    }
+
+    public function hasRequiredValue(): bool
+    {
+        return $this->hasValue() && !$this->isOptional();
+    }
+
+    public function getShortcut(): ?string
+    {
+        return $this->consoleInput->getShortcut();
+    }
+
+    public function hasValue(): bool
+    {
+        if (($type = $this->property->getType()) instanceof \ReflectionNamedType) {
+            return $type->getName() !== 'bool';
+        }
+
+        return false;
+    }
+}

--- a/src/Illuminate/Console/Reflections/OptionReflection.php
+++ b/src/Illuminate/Console/Reflections/OptionReflection.php
@@ -13,7 +13,7 @@ class OptionReflection extends InputReflection
 
     public static function isOption(\ReflectionProperty $property): bool
     {
-        return !empty($property->getAttributes(Option::class));
+        return ! empty($property->getAttributes(Option::class));
     }
 
     public function isNegatable(): bool
@@ -23,7 +23,7 @@ class OptionReflection extends InputReflection
 
     public function hasRequiredValue(): bool
     {
-        return $this->hasValue() && !$this->isOptional();
+        return $this->hasValue() && ! $this->isOptional();
     }
 
     public function getShortcut(): ?string

--- a/src/Illuminate/Contracts/Console/ConsoleInput.php
+++ b/src/Illuminate/Contracts/Console/ConsoleInput.php
@@ -6,5 +6,5 @@ interface ConsoleInput
 {
     public function getDescription(): string;
 
-    public function getAlias(): ? string;
+    public function getAlias(): ?string;
 }

--- a/src/Illuminate/Contracts/Console/ConsoleInput.php
+++ b/src/Illuminate/Contracts/Console/ConsoleInput.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Contracts\Console;
+
+interface ConsoleInput
+{
+    public function getDescription(): string;
+
+    public function getAlias(): ? string;
+}

--- a/tests/Console/CommandAttributesTest.php
+++ b/tests/Console/CommandAttributesTest.php
@@ -80,7 +80,8 @@ class CommandAttributesTest extends TestCase
             }
         };
 
-        $commandOptional = new class extends Command {
+        $commandOptional = new class extends Command
+        {
             protected $name = 'test';
 
             #[Argument]
@@ -278,7 +279,9 @@ class CommandAttributesTest extends TestCase
             )]
             public string $option;
 
-            public function handle(){}
+            public function handle()
+            {
+            }
         };
 
         $definition = $command->getDefinition();
@@ -332,6 +335,7 @@ class CommandAttributesTest extends TestCase
     {
         if (PHP_VERSION_ID <= 80100) {
             $this->markTestSkipped('Enum Casting test skipped caused by PHP version.');
+
             return;
         }
 
@@ -378,6 +382,7 @@ class CommandAttributesTest extends TestCase
     {
         if (PHP_VERSION_ID <= 80100) {
             $this->markTestSkipped('Enum Casting test skipped caused by PHP version.');
+
             return;
         }
 
@@ -426,6 +431,7 @@ class CommandAttributesTest extends TestCase
         $output = new NullOutput();
 
         $command->run($input, $output);
+
         return $command;
     }
 }

--- a/tests/Console/CommandAttributesTest.php
+++ b/tests/Console/CommandAttributesTest.php
@@ -5,10 +5,8 @@ namespace Illuminate\Tests\Console;
 use Illuminate\Console\Attributes\Argument;
 use Illuminate\Console\Attributes\Option;
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Tests\Console\fixtures\AttributeCommand;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -20,8 +18,8 @@ class CommandAttributesTest extends TestCase
 {
     public function testAttributeWillBeUsed()
     {
-        $command  = new AttributeCommand();
-        $command= $this->callCommand($command);
+        $command = new AttributeCommand();
+        $command = $this->callCommand($command);
 
         $this->assertSame('test:basic', $command->getName());
         $this->assertSame('Basic Command description!', $command->getDescription());
@@ -32,7 +30,8 @@ class CommandAttributesTest extends TestCase
 
     public function testArgumentsWillBeRegisteredWithAttributeSyntax()
     {
-        $command = new class extends Command {
+        $command = new class extends Command
+        {
             protected $name = 'test';
 
             #[Argument]
@@ -46,7 +45,6 @@ class CommandAttributesTest extends TestCase
 
             public function handle()
             {
-
             }
         };
 
@@ -57,7 +55,6 @@ class CommandAttributesTest extends TestCase
             'optionalArgument' => 'Argument_Optional',
             'defaultArgument' => 'Argument_Default',
         ]);
-
 
         $this->assertTrue($definition->getArgument('requiredArgument')->isRequired());
         $this->assertSame('Argument_Required', $command->requiredArgument);
@@ -71,7 +68,8 @@ class CommandAttributesTest extends TestCase
 
     public function testArrayArgumentsWillBeRegisteredWithAttributeSyntax()
     {
-        $commandRequired = new class extends Command {
+        $commandRequired = new class extends Command
+        {
             protected $name = 'test';
 
             #[Argument]
@@ -79,7 +77,6 @@ class CommandAttributesTest extends TestCase
 
             public function handle()
             {
-
             }
         };
 
@@ -91,11 +88,11 @@ class CommandAttributesTest extends TestCase
 
             public function handle()
             {
-
             }
         };
 
-        $commandDefault = new class extends Command {
+        $commandDefault = new class extends Command
+        {
             protected $name = 'test';
 
             #[Argument]
@@ -103,10 +100,8 @@ class CommandAttributesTest extends TestCase
 
             public function handle()
             {
-
             }
         };
-
 
         $commandRequired = $this->callCommand($commandRequired, [
             'arrayArgument' => ['Array_Required'],
@@ -118,7 +113,6 @@ class CommandAttributesTest extends TestCase
         $this->assertTrue($definition->getArgument('arrayArgument')->isRequired());
         $this->assertSame(['Array_Required'], $commandRequired->arrayArgument);
 
-
         $commandOptional = $this->callCommand($commandOptional, [
             'optionalArrayArgument' => ['Array_Optional'],
         ]);
@@ -128,7 +122,6 @@ class CommandAttributesTest extends TestCase
         $this->assertTrue($definition->getArgument('optionalArrayArgument')->isArray());
         $this->assertFalse($definition->getArgument('optionalArrayArgument')->isRequired());
         $this->assertSame(['Array_Optional'], $commandOptional->optionalArrayArgument);
-
 
         $commandDefault = $this->callCommand($commandDefault, [
             'defaultArrayArgument' => ['Array_Default'],
@@ -143,13 +136,12 @@ class CommandAttributesTest extends TestCase
 
         $commandDefault = $this->callCommand($commandDefault, []);
         $this->assertSame(['Value A', 'Value B'], $commandDefault->defaultArrayArgument);
-
-
     }
 
     public function testOptionsWillBeRegisteredWithAttributeSyntax()
     {
-        $command = new class extends Command {
+        $command = new class extends Command
+        {
             protected $name = 'test';
 
             #[Option]
@@ -164,7 +156,9 @@ class CommandAttributesTest extends TestCase
             #[Option]
             public string $optionWithDefaultValue = 'default';
 
-            public function handle(){}
+            public function handle()
+            {
+            }
         };
 
         $definition = $command->getDefinition();
@@ -198,7 +192,8 @@ class CommandAttributesTest extends TestCase
 
     public function testArrayOptionsWillBeRegisteredWithAttributeSyntax()
     {
-        $command = new class extends Command {
+        $command = new class extends Command
+        {
             protected $name = 'test';
 
             #[Option]
@@ -207,7 +202,9 @@ class CommandAttributesTest extends TestCase
             #[Option]
             public array $optionDefaultArray = ['default1', 'default2'];
 
-            public function handle(){}
+            public function handle()
+            {
+            }
         };
 
         $definition = $command->getDefinition();
@@ -220,23 +217,23 @@ class CommandAttributesTest extends TestCase
         ]);
 
         $this->assertTrue($definition->getOption('optionArray')->isArray());
-        $this->assertSame(['Value A', 'Value B'],$command->optionArray);
+        $this->assertSame(['Value A', 'Value B'], $command->optionArray);
 
         $this->assertTrue($definition->getOption('optionArray')->isArray());
         $this->assertTrue($definition->getOption('optionArray')->isValueOptional());
-        $this->assertSame(['Value A', 'Value B'],$command->optionArray);
+        $this->assertSame(['Value A', 'Value B'], $command->optionArray);
 
         $command = $this->callCommand($command, [
             '--optionDefaultArray' => ['Value C', 'Value D'],
         ]);
 
         $this->assertSame(['Value C', 'Value D'], $command->optionDefaultArray);
-
     }
 
     public function testInputMetaDataWillBeRegisteredWithAttributeSyntax()
     {
-        $command = new class extends Command {
+        $command = new class extends Command
+        {
             protected $name = 'test';
 
             #[Argument(
@@ -251,7 +248,9 @@ class CommandAttributesTest extends TestCase
             )]
             public bool $option;
 
-            public function handle(){}
+            public function handle()
+            {
+            }
         };
 
         $definition = $command->getDefinition();
@@ -270,7 +269,8 @@ class CommandAttributesTest extends TestCase
 
     public function testOptionShortcutWillBeRegisteredWithAttributeSyntax()
     {
-        $command = new class extends Command {
+        $command = new class extends Command
+        {
             protected $name = 'test';
 
             #[Option(
@@ -294,7 +294,8 @@ class CommandAttributesTest extends TestCase
 
     public function testOptionNegatableWillBeRegisteredWithAttributeSyntax()
     {
-        $command = new class extends Command {
+        $command = new class extends Command
+        {
             protected $name = 'test';
 
             #[Option(
@@ -302,7 +303,9 @@ class CommandAttributesTest extends TestCase
             )]
             public bool $option;
 
-            public function handle(){}
+            public function handle()
+            {
+            }
         };
 
         $definition = $command->getDefinition();
@@ -332,7 +335,8 @@ class CommandAttributesTest extends TestCase
             return;
         }
 
-        $command = new class extends Command {
+        $command = new class extends Command
+        {
             protected $name = 'test';
 
             #[Argument]
@@ -347,7 +351,9 @@ class CommandAttributesTest extends TestCase
             #[Argument]
             public StringEnum $enumDefaultArgument = StringEnum::B;
 
-            public function handle(){}
+            public function handle()
+            {
+            }
         };
 
         $command = $this->callCommand($command, [
@@ -375,7 +381,8 @@ class CommandAttributesTest extends TestCase
             return;
         }
 
-        $command = new class extends Command {
+        $command = new class extends Command
+        {
             protected $name = 'test';
 
             #[Option]
@@ -390,7 +397,9 @@ class CommandAttributesTest extends TestCase
             #[Option]
             public StringEnum $enumDefaultOption = StringEnum::B;
 
-            public function handle(){}
+            public function handle()
+            {
+            }
         };
 
         $command = $this->callCommand($command, [

--- a/tests/Console/CommandAttributesTest.php
+++ b/tests/Console/CommandAttributesTest.php
@@ -1,0 +1,457 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\Attributes\Argument;
+use Illuminate\Console\Attributes\Option;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+if (PHP_VERSION_ID >= 80100) {
+    include 'Enums.php';
+}
+
+class CommandAttributesTest extends TestCase
+{
+    public function testAttributeWillBeUsed()
+    {
+        $this->makeCommand(meta: 'name: "test:basic", description: "Basic Command description!", help: "Some Help.", hidden: true')
+        (function (Command $command) {
+            $this->assertSame('test:basic', $command->getName());
+            $this->assertSame('Basic Command description!', $command->getDescription());
+            $this->assertSame('Some Help.', $command->getHelp());
+            $this->assertTrue($command->isHidden());
+        });
+    }
+
+    public function testArgumentsWillBeRegisteredWithAttributeSyntax()
+    {
+        $command = new class extends Command {
+            protected $name = 'test';
+
+            #[Argument]
+            public string $requiredArgument;
+
+            #[Argument]
+            public ?string $optionalArgument;
+
+            #[Argument]
+            public string $defaultArgument = 'default_value';
+
+            public function handle()
+            {
+
+            }
+        };
+
+        $definition = $command->getDefinition();
+
+        $command = $this->callCommand($command, [
+            'requiredArgument' => 'Argument_Required',
+            'optionalArgument' => 'Argument_Optional',
+            'defaultArgument' => 'Argument_Default',
+        ]);
+
+
+        $this->assertTrue($definition->getArgument('requiredArgument')->isRequired());
+        $this->assertSame('Argument_Required', $command->requiredArgument);
+
+        $this->assertFalse($definition->getArgument('optionalArgument')->isRequired());
+        $this->assertSame('Argument_Optional', $command->optionalArgument);
+
+        $this->assertSame('default_value', $definition->getArgument('defaultArgument')->getDefault());
+        $this->assertSame('Argument_Default', $command->defaultArgument);
+    }
+
+    public function testArrayArgumentsWillBeRegisteredWithAttributeSyntax()
+    {
+        $commandRequired = new class extends Command {
+            protected $name = 'test';
+
+            #[Argument]
+            public array $arrayArgument;
+
+            public function handle()
+            {
+
+            }
+        };
+
+        $commandOptional = new class extends Command {
+            protected $name = 'test';
+
+            #[Argument]
+            public ?array $optionalArrayArgument;
+
+            public function handle()
+            {
+
+            }
+        };
+
+        $commandDefault = new class extends Command {
+            protected $name = 'test';
+
+            #[Argument]
+            public array $defaultArrayArgument = ['Value A', 'Value B'];
+
+            public function handle()
+            {
+
+            }
+        };
+
+
+        $commandRequired = $this->callCommand($commandRequired, [
+            'arrayArgument' => ['Array_Required'],
+        ]);
+
+        $definition = $commandRequired->getDefinition();
+
+        $this->assertTrue($definition->getArgument('arrayArgument')->isArray());
+        $this->assertTrue($definition->getArgument('arrayArgument')->isRequired());
+        $this->assertSame(['Array_Required'], $commandRequired->arrayArgument);
+
+
+        $commandOptional = $this->callCommand($commandOptional, [
+            'optionalArrayArgument' => ['Array_Optional'],
+        ]);
+
+        $definition = $commandOptional->getDefinition();
+
+        $this->assertTrue($definition->getArgument('optionalArrayArgument')->isArray());
+        $this->assertFalse($definition->getArgument('optionalArrayArgument')->isRequired());
+        $this->assertSame(['Array_Optional'], $commandOptional->optionalArrayArgument);
+
+
+        $commandDefault = $this->callCommand($commandDefault, [
+            'defaultArrayArgument' => ['Array_Default'],
+        ]);
+
+        $definition = $commandDefault->getDefinition();
+
+        $this->assertTrue($definition->getArgument('defaultArrayArgument')->isArray());
+        $this->assertFalse($definition->getArgument('defaultArrayArgument')->isRequired());
+        $this->assertSame(['Value A', 'Value B'], $definition->getArgument('defaultArrayArgument')->getDefault());
+        $this->assertSame(['Array_Default'], $commandDefault->defaultArrayArgument);
+
+        $commandDefault = $this->callCommand($commandDefault, []);
+        $this->assertSame(['Value A', 'Value B'], $commandDefault->defaultArrayArgument);
+
+
+    }
+
+    public function testOptionsWillBeRegisteredWithAttributeSyntax()
+    {
+        $command = new class extends Command {
+            protected $name = 'test';
+
+            #[Option]
+            public bool $option;
+
+            #[Option]
+            public string $optionWithValue;
+
+            #[Option]
+            public ?string $optionWithNullableValue;
+
+            #[Option]
+            public string $optionWithDefaultValue = 'default';
+
+            public function handle(){}
+        };
+
+        $definition = $command->getDefinition();
+
+        $command = $this->callCommand($command, [
+            '--option' => true,
+            '--optionWithValue' => 'Value A',
+        ]);
+
+        $this->assertFalse($definition->getOption('option')->isValueOptional());
+        $this->assertTrue($command->option);
+
+        $this->assertTrue($definition->getOption('optionWithValue')->isValueRequired());
+        $this->assertSame('Value A', $command->optionWithValue);
+
+        $this->assertTrue($definition->getOption('optionWithNullableValue')->isValueOptional());
+        $this->assertNull($command->optionWithNullableValue);
+
+        $command = $this->callCommand($command, [
+            '--optionWithNullableValue' => 'Value B',
+        ]);
+        $this->assertSame('Value B', $command->optionWithNullableValue);
+
+        $this->assertSame('default', $definition->getOption('optionWithDefaultValue')->getDefault());
+
+        $command = $this->callCommand($command, [
+            '--optionWithDefaultValue' => 'Value C',
+        ]);
+        $this->assertSame('Value C', $command->optionWithDefaultValue);
+    }
+
+    public function testArrayOptionsWillBeRegisteredWithAttributeSyntax()
+    {
+        $command = new class extends Command {
+            protected $name = 'test';
+
+            #[Option]
+            public array $optionArray;
+
+            #[Option]
+            public array $optionDefaultArray = ['default1', 'default2'];
+
+            public function handle(){}
+        };
+
+        $definition = $command->getDefinition();
+
+        $command = $this->callCommand($command, []);
+        $this->assertSame([], $command->optionArray);
+
+        $command = $this->callCommand($command, [
+            '--optionArray' => ['Value A', 'Value B'],
+        ]);
+
+        $this->assertTrue($definition->getOption('optionArray')->isArray());
+        $this->assertSame(['Value A', 'Value B'],$command->optionArray);
+
+        $this->assertTrue($definition->getOption('optionArray')->isArray());
+        $this->assertTrue($definition->getOption('optionArray')->isValueOptional());
+        $this->assertSame(['Value A', 'Value B'],$command->optionArray);
+
+        $command = $this->callCommand($command, [
+            '--optionDefaultArray' => ['Value C', 'Value D'],
+        ]);
+
+        $this->assertSame(['Value C', 'Value D'], $command->optionDefaultArray);
+
+    }
+
+    public function testInputMetaDataWillBeRegisteredWithAttributeSyntax()
+    {
+        $command = new class extends Command {
+            protected $name = 'test';
+
+            #[Argument(
+                as: 'argumentAlias',
+                description: 'Argument Description',
+            )]
+            public string $argument = '';
+
+            #[Option(
+                as: 'optionAlias',
+                description: 'Option Description'
+            )]
+            public bool $option;
+
+            public function handle(){}
+        };
+
+        $definition = $command->getDefinition();
+
+        $this->assertSame('Argument Description', $definition->getArgument('argumentAlias')->getDescription());
+        $this->assertSame('Option Description', $definition->getOption('optionAlias')->getDescription());
+
+        $command = $this->callCommand($command, [
+            'argumentAlias' => 'Value',
+            '--optionAlias' => true,
+        ]);
+
+        $this->assertSame('Value', $command->argument);
+        $this->assertSame(true, $command->option);
+    }
+
+    public function testOptionShortcutWillBeRegisteredWithAttributeSyntax()
+    {
+        $command = new class extends Command {
+            protected $name = 'test';
+
+            #[Option(
+                shortcut: 'O'
+            )]
+            public string $option;
+
+            public function handle(){}
+        };
+
+        $definition = $command->getDefinition();
+
+        $this->assertSame('O', $definition->getOption('option')->getShortcut());
+
+        $command = $this->callCommand($command, [
+            '-O' => 'short',
+        ]);
+
+        $this->assertSame('short', $command->option);
+    }
+
+    public function testOptionNegatableWillBeRegisteredWithAttributeSyntax()
+    {
+        $command = new class extends Command {
+            protected $name = 'test';
+
+            #[Option(
+                negatable: true
+            )]
+            public bool $option;
+
+            public function handle(){}
+        };
+
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->getOption('option')->isNegatable());
+
+        $command = $this->callCommand($command, [
+            '--option' => true,
+        ]);
+
+        $this->assertTrue($command->option);
+
+        $command = $this->callCommand($command, [
+            '--no-option' => true,
+        ]);
+
+        $this->assertFalse($command->option);
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testArgumentEnumsWillBeCasted()
+    {
+        if (PHP_VERSION_ID <= 80100) {
+            $this->markTestSkipped('Enum Casting test skipped caused by PHP version.');
+            return;
+        }
+
+        $command = new class extends Command {
+            protected $name = 'test';
+
+            #[Argument]
+            public Enum $enumArgument;
+
+            #[Argument]
+            public StringEnum $enumStringArgument;
+
+            #[Argument]
+            public IntEnum $enumIntArgument;
+
+            #[Argument]
+            public StringEnum $enumDefaultArgument = StringEnum::B;
+
+            public function handle(){}
+        };
+
+        $command = $this->callCommand($command, [
+            'enumArgument' => 'B',
+            'enumStringArgument' => 'String B',
+            'enumIntArgument' => 2,
+        ]);
+
+        $this->assertSame(Enum::B, $command->enumArgument);
+
+        $this->assertSame(StringEnum::B, $command->enumStringArgument);
+
+        $this->assertSame(IntEnum::B, $command->enumIntArgument);
+
+        $this->assertSame(StringEnum::B, $command->enumDefaultArgument);
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testOptionEnumsWillBeCasted()
+    {
+        if (PHP_VERSION_ID <= 80100) {
+            $this->markTestSkipped('Enum Casting test skipped caused by PHP version.');
+            return;
+        }
+
+        $command = new class extends Command {
+            protected $name = 'test';
+
+            #[Option]
+            public Enum $enumOption;
+
+            #[Option]
+            public StringEnum $enumStringOption;
+
+            #[Option]
+            public IntEnum $enumIntOption;
+
+            #[Option]
+            public StringEnum $enumDefaultOption = StringEnum::B;
+
+            public function handle(){}
+        };
+
+        $command = $this->callCommand($command, [
+            '--enumOption' => 'B',
+            '--enumStringOption' => 'String B',
+            '--enumIntOption' => 2,
+        ]);
+
+        $this->assertSame(Enum::B, $command->enumOption);
+
+        $this->assertSame(StringEnum::B, $command->enumStringOption);
+
+        $this->assertSame(IntEnum::B, $command->enumIntOption);
+
+        $this->assertSame(StringEnum::B, $command->enumDefaultOption);
+    }
+
+    protected function makeCommand(string $properties = '', ?string $meta = null)
+    {
+        return function (callable $testScenario) use ($properties, $meta) {
+            $name = 'Test'.Str::random();
+            $meta ??= "name: '{$name}'";
+            $filePath = __DIR__."/Temp/{$name}.php";
+            $namespace = '\\Illuminate\\Tests\\Console\\Temp\\'.$name;
+
+            try {
+                $file = new Filesystem();
+                $file->put(
+                    $filePath,
+                    <<<EOT
+<?php
+namespace Illuminate\Tests\Console\Temp;
+use Illuminate\Console\Command;
+use Illuminate\Console\Attributes\CommandAttribute;
+#[CommandAttribute($meta)]
+class $name extends Command {
+$properties
+public function handle(){
+
+}
+}
+EOT
+                );
+
+                $class = new $namespace();
+
+                $testScenario($class, $name);
+
+            } finally {
+                $file->delete($filePath);
+            }
+        };
+    }
+
+    protected function callCommand(Command $command, array $input): Command
+    {
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput($input);
+        $output = new NullOutput();
+
+        $command->run($input, $output);
+        return $command;
+    }
+}

--- a/tests/Console/CommandAttributesTest.php
+++ b/tests/Console/CommandAttributesTest.php
@@ -27,6 +27,7 @@ class CommandAttributesTest extends TestCase
         $this->assertSame('Basic Command description!', $command->getDescription());
         $this->assertSame('Some Help.', $command->getHelp());
         $this->assertTrue($command->isHidden());
+        $this->assertSame(['alias:basic'], $command->getAliases());
     }
 
     public function testArgumentsWillBeRegisteredWithAttributeSyntax()

--- a/tests/Console/Enums.php
+++ b/tests/Console/Enums.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+enum Enum
+{
+    case A;
+    case B;
+    case C;
+}
+
+enum IntEnum: int
+{
+    case A = 1;
+    case B = 2;
+    case C = 3;
+}
+
+enum StringEnum: string
+{
+    case A = 'String A';
+    case B = 'String B';
+    case C = 'String C';
+}

--- a/tests/Console/fixtures/AttributeCommand.php
+++ b/tests/Console/fixtures/AttributeCommand.php
@@ -2,13 +2,14 @@
 
 namespace Illuminate\Tests\Console\fixtures;
 
-use Illuminate\Console\Attributes\CommandAttribute;
+use Illuminate\Console\Attributes\ArtisanCommand;
 use Illuminate\Console\Command;
 
-#[CommandAttribute(
+#[ArtisanCommand(
     name: "test:basic",
     description: "Basic Command description!",
     help: "Some Help.",
+    aliases: ['alias:basic'],
     hidden: true
 )]
 class AttributeCommand extends Command

--- a/tests/Console/fixtures/AttributeCommand.php
+++ b/tests/Console/fixtures/AttributeCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Console\fixtures;
+
+use Illuminate\Console\Attributes\CommandAttribute;
+use Illuminate\Console\Command;
+
+#[CommandAttribute(
+    name: "test:basic",
+    description: "Basic Command description!",
+    help: "Some Help.",
+    hidden: true
+)]
+class AttributeCommand extends Command
+{
+    public function handle(){
+
+    }
+}

--- a/tests/Console/fixtures/AttributeCommand.php
+++ b/tests/Console/fixtures/AttributeCommand.php
@@ -6,15 +6,15 @@ use Illuminate\Console\Attributes\ArtisanCommand;
 use Illuminate\Console\Command;
 
 #[ArtisanCommand(
-    name: "test:basic",
-    description: "Basic Command description!",
-    help: "Some Help.",
+    name: 'test:basic',
+    description: 'Basic Command description!',
+    help: 'Some Help.',
     aliases: ['alias:basic'],
     hidden: true
 )]
 class AttributeCommand extends Command
 {
-    public function handle(){
-
+    public function handle()
+    {
     }
 }


### PR DESCRIPTION
## 🔨 What does this PR do? 

This PR aims to add an alternative syntax to the artisan command signature by using attributes. It is fully backwards compatible and does not break the existing `$signature` syntax. 

## 👀 How does it look?
```php
#[ArtisanCommand(
    name: 'basic:command',
    description: 'Basic Command description!',
    help: 'Some Help.',
)]
class BasicCommand extends Command
{
    #[Argument]
    protected string $myArgument;

    #[Option]
    protected bool $myOption;
    
    public function handle()
    {
      // ...
    }
}
```
```bash
php artisan basic:command myArgumentValue --myOption
```

## ➕ What are the benefits?
- Static analysis is easier because every command input can, and should, be typed.
- Autocompletion by the IDE because command inputs now are simple properties instead of a function call
- Its easier to add more functionality to the command inputs because there is now a clear place where to put it. More about that in a later section "🔮 What can be done in future?".
- (Personal Opinion) It's easier to remember and write, then the `$signature` because you get more help from the IDE and you don't need to remember  the custom string syntax.
- Adds negatable options 
- Adds options with required values
- Adds command name aliases

## ➖ What are the drawbacks? 
- Of course it's a little bit more Code and complexity to maintain
- It can be more to type than the `$signature` syntax especially for small commands, but of course you could still use the  `$signature` syntax for those commands and the attributes for more complex ones.  

## 🔮 What can be done in future? 
In order to keep this PR as small as possible i only added the base functionality. But i already have a lot of ideas what can be done with this kind of syntax. 

### Casting
At the moment only Enum Types are casted by default. But it is easily possible to add a caster to an argument or option to directly cast a command input to an object, model ... or something else. This could look like this or it would check if the typed class implements the Castable interface. 
<details><summary>Show</summary>
<p>

```php
class BasicCommand extends Command
{
    #[Argument(
        cast: UserCast::class
    )]
    protected User $user;
    
    // ...
   
}
```
</p>
</details>



### Validation
Also the Validator could be added like this:  

<details><summary>Show</summary>
<p>

```php
class BasicCommand extends Command
{
    #[Argument(
        validate: 'max:30'
    )]
    protected string $shortString;
    
    // ...
   
}
```
</p>
</details>

### Auto Ask
It's a good practise to ask the user for a required argument if it was not provided instead of failing the command. This could be the default behaviour or can be turned on like this:

<details><summary>Show</summary>
<p>

```php
class BasicCommand extends Command
{
    #[Argument(
        autoAsk: true
    )]
    protected string $message;
    
    // ...
   
}
```
```bash
php artisan myCommand
Please provide a message:
$ 
```
</p>
</details>

## 🔬 How does it work?
Basically there are two differed types of attributes. The `ArtisanCommand` and the `ConsoleInput`.

### ArtisanCommand Attribute
This attribute is placed at the class level and defines the `name`, `description`, `help`, if the command is hidden and aliases for the command.  
```php
#[ArtisanCommand(
    name: 'basic:command',
    description: 'Basic Command description!',
    help: 'Some Help.',
    hidden: true,
    aliases: ['alias:command'],
)]
class BasicCommand extends Command
{
      // ...
}
```

### Console Input
Console inputs are written als properties on the command class who get decorated with ether the `Argument` or the `Option` attribute. 
```php
    #[Argument]
    protected string $myArgument;

    #[Option]
    protected bool $myOption;
```

#### Arguments

If there is a non-nullable type the argument will be required. If you want an optional argument or an argument with an default value you ether make the type nullable or add an initial value to the property

```php
    #[Argument]
    protected ?string $myArgument; // Optional argument

    #[Argument]
    protected string $myDefaultArgument = 'Your default'; // Optional argument with a default value
```

If you need an array argument simply typehint the property as array. If you want it to be optional or with a default value make it nullable or add a default. 

```php
    #[Argument]
    protected array $myArgument; // required array argument

    #[Argument]
    protected ?array $myOptionalArgument; // optional array argument

    #[Argument]
    protected array $myDefaultArgument = ['Item A', 'Item B']; // Optional array argument with a default value
```

> Beware that an optional array Argument will always be an empty array and not null.

#### Options
Options are pretty similar regarding the default and optional syntax. But with one catch. There are two different kinds of options, one without a value (simple boolean flags) and ones with values. The ones with Values are pretty much the same as the arguments. Nullable -> optional, With initial value -> default Value. 
```php
    #[Option]
    protected string $requiredValue; // if the option is used the User must specify a value  
    
    #[Option]
    protected ?string $optionalValue; // The value is optional

    #[Option]
    protected string $defaultValue = 'default'; // The option has a default value

    #[Option]
    protected array $array; // an Array Option 
```
If you want a boolean flag option simply typehint `bool`  and the value will be false if the option wasn't used and true if it was used: 
```php
    #[Option]
    protected bool $boolFlag;
```

To use shortcuts on options you can simply specify the shortcut on the `Option` attribute
```php
    #[Option(
        shortcut: 'O'
    )]
    protected bool $option;
```
If you want to use a negatable options you can simply specify it on the `Option` attribute

```php
    #[Option(
        negatable: true
    )]
    protected bool $yell;
```
```bash
php artisan basic --yell
php artisan basic --no-yell
```

#### Descriptions
Arguments and options can have a description you can simply specify it on the  attribute:

```php
    #[Argument(
        description: 'My fancy argument description'
    )]
    protected string $myArgument;

    #[Option(
        description: 'My fancy option description'
    )]
    protected bool $myOption;
```

#### Alias
Arguments and options can be aliased to avoid conflicts with other parent properties or to make the api more readable for the user: 
```php
    #[Argument(
        as: 'publicArgumentName'
    )]
    protected string $internalArgumentName;

    #[Option(
        as: 'publicOptionName'
    )]
    protected bool $internalOptionName;
```

#### Enum support
Enums will be automatically be cast back and forth. 
```php
            #[Argument]
            public MyEnum $enumArgument;

            #[Argument]
            public MyEnum $enumDefaultArgument = MyEnum::Something;
```

## ❤️ Thank you
Thank you very much for taking the time and reading this. This is my first PR to Laravel so 
i am open for feedback and discussion about the syntax or implementation and happily change the PR accordingly.  