### PR TITLE
[9.x] Improve factory stub type annotation

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -12,7 +12,7 @@ class {{ factory }}Factory extends Factory
     /**
      * Define the model's default state.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function definition()
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


https://github.com/laravel/laravel Ships with a `UserFactory` with an improved type annotation

https://github.com/laravel/laravel/blob/871ff9e65fea5588b1018d8770db6fc6ad37069d/database/factories/UserFactory.php#L13-L27

But when creating new factories with the `make:factory` or with `make:model` and the `-f` option, the factory definition does not include this improved type annotation.

This PR:

- Improves the type annotation on the `factory.stub` file