### PR TITLE
[9.x] Integrate Laravel CORS into framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "laravel/serializable-closure": "^1.0",
         "league/commonmark": "^2.2",
         "league/flysystem": "^3.0",
+        "fruitcake/php-cors": "^1.2",
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.53.1",
         "psr/container": "^1.1.1|^2.0.1",

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -78,11 +78,7 @@ class HandleCors
      */
     protected function addHeaders(Request $request, Response $response)
     {
-        if (! $response->headers->has('Access-Control-Allow-Origin')) {
-            $response = $this->cors->addActualRequestHeaders($response, $request);
-        }
-
-        return $response;
+        return $this->cors->addActualRequestHeaders($response, $request);
     }
 
     /**

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -6,7 +6,6 @@ use Closure;
 use Fruitcake\Cors\CorsService;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class HandleCors
 {
@@ -46,7 +45,7 @@ class HandleCors
      */
     public function handle($request, Closure $next)
     {
-        if (! $this->shouldRun($request)) {
+        if (! $this->hasMatchingPath($request)) {
             return $next($request);
         }
 
@@ -66,30 +65,7 @@ class HandleCors
             $this->cors->varyHeader($response, 'Access-Control-Request-Method');
         }
 
-        return $this->addHeaders($request, $response);
-    }
-
-    /**
-     * Add the headers to the response, if they don't exist yet.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Http\Response  $response
-     * @return \Illuminate\Http\Response
-     */
-    protected function addHeaders(Request $request, Response $response)
-    {
         return $this->cors->addActualRequestHeaders($response, $request);
-    }
-
-    /**
-     * Determine if the request has a URI that should pass through the CORS flow.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
-     */
-    protected function shouldRun(Request $request): bool
-    {
-        return $this->isMatchingPath($request);
     }
 
     /**
@@ -98,7 +74,7 @@ class HandleCors
      * @param  \Illuminate\Http\Request  $request
      * @return bool
      */
-    protected function isMatchingPath(Request $request): bool
+    protected function hasMatchingPath(Request $request): bool
     {
         $paths = $this->getPathsByHost($request->getHost());
 

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -69,7 +69,7 @@ class HandleCors
     }
 
     /**
-     * Get the path from the config, to see if the CORS Service should run.
+     * Get the path from the configuration to determine if the CORS service should run.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return bool
@@ -92,7 +92,7 @@ class HandleCors
     }
 
     /**
-     * Paths by given host or string values in config by default.
+     * Get the CORS paths for the given host.
      *
      * @param  string  $host
      * @return array

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -69,7 +69,7 @@ class HandleCors
     }
 
     /**
-     * The the path from the config, to see if the CORS Service should run.
+     * Get the path from the config, to see if the CORS Service should run.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return bool

--- a/src/Illuminate/Http/Middleware/HandleCors.php
+++ b/src/Illuminate/Http/Middleware/HandleCors.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Illuminate\Http\Middleware;
+
+use Closure;
+use Fruitcake\Cors\CorsService;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class HandleCors
+{
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
+     * The CORS service instance.
+     *
+     * @var \Fruitcake\Cors\CorsService
+     */
+    protected $cors;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Fruitcake\Cors\CorsService  $cors
+     * @return void
+     */
+    public function __construct(Container $container, CorsService $cors)
+    {
+        $this->container = $container;
+        $this->cors = $cors;
+    }
+
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Illuminate\Http\Response
+     */
+    public function handle($request, Closure $next)
+    {
+        if (! $this->shouldRun($request)) {
+            return $next($request);
+        }
+
+        $this->cors->setOptions($this->container['config']->get('cors', []));
+
+        if ($this->cors->isPreflightRequest($request)) {
+            $response = $this->cors->handlePreflightRequest($request);
+
+            $this->cors->varyHeader($response, 'Access-Control-Request-Method');
+
+            return $response;
+        }
+
+        $response = $next($request);
+
+        if ($request->getMethod() === 'OPTIONS') {
+            $this->cors->varyHeader($response, 'Access-Control-Request-Method');
+        }
+
+        return $this->addHeaders($request, $response);
+    }
+
+    /**
+     * Add the headers to the response, if they don't exist yet.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Response  $response
+     * @return \Illuminate\Http\Response
+     */
+    protected function addHeaders(Request $request, Response $response)
+    {
+        if (! $response->headers->has('Access-Control-Allow-Origin')) {
+            $response = $this->cors->addActualRequestHeaders($response, $request);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Determine if the request has a URI that should pass through the CORS flow.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function shouldRun(Request $request): bool
+    {
+        return $this->isMatchingPath($request);
+    }
+
+    /**
+     * The the path from the config, to see if the CORS Service should run.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function isMatchingPath(Request $request): bool
+    {
+        $paths = $this->getPathsByHost($request->getHost());
+
+        foreach ($paths as $path) {
+            if ($path !== '/') {
+                $path = trim($path, '/');
+            }
+
+            if ($request->fullUrlIs($path) || $request->is($path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Paths by given host or string values in config by default.
+     *
+     * @param  string  $host
+     * @return array
+     */
+    protected function getPathsByHost(string $host)
+    {
+        $paths = $this->container['config']->get('cors.paths', []);
+
+        if (isset($paths[$host])) {
+            return $paths[$host];
+        }
+
+        return array_filter($paths, function ($path) {
+            return is_string($path);
+        });
+    }
+}

--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Http\Middleware;
 
-use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
 
@@ -40,7 +39,7 @@ abstract class TrustHosts
      * @param  \Closure  $next
      * @return \Illuminate\Http\Response
      */
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, $next)
     {
         if ($this->shouldSpecifyTrustedHosts()) {
             Request::setTrustedHosts(array_filter($this->hosts()));

--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Middleware;
 
+use Closure;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request;
 
@@ -36,10 +37,10 @@ abstract class TrustHosts
      * Handle the incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  callable  $next
+     * @param  \Closure  $next
      * @return \Illuminate\Http\Response
      */
-    public function handle(Request $request, $next)
+    public function handle(Request $request, Closure $next)
     {
         if ($this->shouldSpecifyTrustedHosts()) {
             Request::setTrustedHosts(array_filter($this->hosts()));

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-json": "*",
+        "fruitcake/php-cors": "^1.2",
         "illuminate/collections": "^9.0",
         "illuminate/macroable": "^9.0",
         "illuminate/session": "^9.0",

--- a/tests/Integration/Http/Middleware/HandleCorsTest.php
+++ b/tests/Integration/Http/Middleware/HandleCorsTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Middleware;
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use Orchestra\Testbench\TestCase;
+
+class HandleCorsTest extends TestCase
+{
+    use ValidatesRequests;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $kernel = $app->make(Kernel::class);
+        $kernel->prependMiddleware(HandleCors::class);
+
+        $router = $app['router'];
+
+        $this->addWebRoutes($router);
+        $this->addApiRoutes($router);
+
+        parent::getEnvironmentSetUp($app);
+    }
+
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']['cors'] = [
+            'paths' => ['api/*'],
+            'supports_credentials' => false,
+            'allowed_origins' => ['http://localhost'],
+            'allowed_headers' => ['X-Custom-1', 'X-Custom-2'],
+            'allowed_methods' => ['GET', 'POST'],
+            'exposed_headers' => [],
+            'max_age' => 0,
+        ];
+    }
+
+    public function testShouldReturnHeaderAssessControlAllowOriginWhenDontHaveHttpOriginOnRequest()
+    {
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
+    public function testOptionsAllowOriginAllowed()
+    {
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
+    public function testAllowAllOrigins()
+    {
+        $this->app['config']->set('cors.allowed_origins', ['*']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://laravel.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('*', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
+    public function testAllowAllOriginsWildcard()
+    {
+        $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://test.laravel.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('http://test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
+    public function testOriginsWildcardIncludesNestedSubdomains()
+    {
+        $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://api.service.test.laravel.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('http://api.service.test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
+    public function testAllowAllOriginsWildcardNoMatch()
+    {
+        $this->app['config']->set('cors.allowed_origins', ['*.laravel.com']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://test.symfony.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Origin'));
+    }
+
+    public function testOptionsAllowOriginAllowedNonExistingRoute()
+    {
+        $crawler = $this->call('OPTIONS', 'api/pang', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+    }
+
+    public function testOptionsAllowOriginNotAllowed()
+    {
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://otherhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+    }
+
+    public function testAllowMethodAllowed()
+    {
+        $crawler = $this->call('POST', 'web/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+        $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Methods'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+
+        $this->assertEquals('PONG', $crawler->getContent());
+    }
+
+    public function testAllowMethodNotAllowed()
+    {
+        $crawler = $this->call('POST', 'web/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'PUT',
+        ]);
+        $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Methods'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+    }
+
+    public function testAllowHeaderAllowedOptions()
+    {
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+            'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-1, x-custom-2',
+        ]);
+        $this->assertEquals('x-custom-1, x-custom-2', $crawler->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+
+        $this->assertEquals('', $crawler->getContent());
+    }
+
+    public function testAllowHeaderAllowedWildcardOptions()
+    {
+        $this->app['config']->set('cors.allowed_headers', ['*']);
+
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+            'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
+        ]);
+        $this->assertEquals('x-custom-3', $crawler->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals(204, $crawler->getStatusCode());
+
+        $this->assertEquals('', $crawler->getContent());
+    }
+
+    public function testAllowHeaderNotAllowedOptions()
+    {
+        $crawler = $this->call('OPTIONS', 'api/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+            'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
+        ]);
+        $this->assertEquals('x-custom-1, x-custom-2', $crawler->headers->get('Access-Control-Allow-Headers'));
+    }
+
+    public function testAllowHeaderAllowed()
+    {
+        $crawler = $this->call('POST', 'web/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-1, x-custom-2',
+        ]);
+        $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+
+        $this->assertEquals('PONG', $crawler->getContent());
+    }
+
+    public function testAllowHeaderAllowedWildcard()
+    {
+        $this->app['config']->set('cors.allowed_headers', ['*']);
+
+        $crawler = $this->call('POST', 'web/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
+        ]);
+        $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+
+        $this->assertEquals('PONG', $crawler->getContent());
+    }
+
+    public function testAllowHeaderNotAllowed()
+    {
+        $crawler = $this->call('POST', 'web/ping', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
+        ]);
+        $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+    }
+
+    public function testError()
+    {
+        $crawler = $this->call('POST', 'api/error', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(500, $crawler->getStatusCode());
+    }
+
+    public function testValidationException()
+    {
+        $crawler = $this->call('POST', 'api/validation', [], [], [], [
+            'HTTP_ORIGIN' => 'http://localhost',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
+        ]);
+        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals(302, $crawler->getStatusCode());
+    }
+
+    protected function addWebRoutes(Router $router)
+    {
+        $router->post('web/ping', [
+            'uses' => function () {
+                return 'PONG';
+            }
+        ]);
+    }
+
+    protected function addApiRoutes(Router $router)
+    {
+        $router->post('api/ping', [
+            'uses' => function () {
+                return 'PONG';
+            }
+        ]);
+
+        $router->put('api/ping', [
+            'uses' => function () {
+                return 'PONG';
+            }
+        ]);
+
+        $router->post('api/error', [
+            'uses' => function () {
+                abort(500);
+            }
+        ]);
+
+        $router->post('api/validation', [
+            'uses' => function (Request $request) {
+                $this->validate($request, [
+                    'name' => 'required',
+                ]);
+
+                return 'ok';
+            }
+        ]);
+    }
+}

--- a/tests/Integration/Http/Middleware/HandleCorsTest.php
+++ b/tests/Integration/Http/Middleware/HandleCorsTest.php
@@ -256,7 +256,7 @@ class HandleCorsTest extends TestCase
         $router->post('web/ping', [
             'uses' => function () {
                 return 'PONG';
-            }
+            },
         ]);
     }
 
@@ -265,19 +265,19 @@ class HandleCorsTest extends TestCase
         $router->post('api/ping', [
             'uses' => function () {
                 return 'PONG';
-            }
+            },
         ]);
 
         $router->put('api/ping', [
             'uses' => function () {
                 return 'PONG';
-            }
+            },
         ]);
 
         $router->post('api/error', [
             'uses' => function () {
                 abort(500);
-            }
+            },
         ]);
 
         $router->post('api/validation', [
@@ -287,7 +287,7 @@ class HandleCorsTest extends TestCase
                 ]);
 
                 return 'ok';
-            }
+            },
         ]);
     }
 }


### PR DESCRIPTION
This PR ports the middleware from https://github.com/fruitcake/laravel-cors over to the core Laravel framework. The main reason is that we want to remove a circular dependency we rely on additionally to the fact that we eliminate another dependency of the skeleton. 

All credits for the code go to @barryvdh of @fruitcake. Thanks for maintaining that package for so long!

After this PR has been merged and tagged I'll undraft the PR that contains the changes needed for the Laravel skeleton: https://github.com/laravel/laravel/pull/5825