### PR TITLE
[9.x] Added betweenFirst to Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -170,6 +170,23 @@ class Str
     }
 
     /**
+     * Get the smallest possible portion of a string between two given values.
+     *
+     * @param  string  $subject
+     * @param  string  $from
+     * @param  string  $to
+     * @return string
+     */
+    public static function betweenFirst($subject, $from, $to)
+    {
+        if ($from === '' || $to === '') {
+            return $subject;
+        }
+
+        return static::before(static::after($subject, $from), $to);
+    }
+
+    /**
      * Convert a value to camel case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -131,6 +131,18 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Get the smallest possible portion of a string between two given values.
+     *
+     * @param  string  $from
+     * @param  string  $to
+     * @return static
+     */
+    public function betweenFirst($from, $to)
+    {
+        return new static(Str::betweenFirst($this->value, $from, $to));
+    }
+
+    /**
      * Convert a value to camel case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -242,6 +242,21 @@ class SupportStrTest extends TestCase
         $this->assertSame('bar', Str::between('foobarbar', 'foo', 'bar'));
     }
 
+    public function testStrBetweenFirst()
+    {
+        $this->assertSame('abc', Str::betweenFirst('abc', '', 'c'));
+        $this->assertSame('abc', Str::betweenFirst('abc', 'a', ''));
+        $this->assertSame('abc', Str::betweenFirst('abc', '', ''));
+        $this->assertSame('b', Str::betweenFirst('abc', 'a', 'c'));
+        $this->assertSame('b', Str::betweenFirst('dddabc', 'a', 'c'));
+        $this->assertSame('b', Str::betweenFirst('abcddd', 'a', 'c'));
+        $this->assertSame('b', Str::betweenFirst('dddabcddd', 'a', 'c'));
+        $this->assertSame('nn', Str::betweenFirst('hannah', 'ha', 'ah'));
+        $this->assertSame('a', Str::betweenFirst('[a]ab[b]', '[', ']'));
+        $this->assertSame('foo', Str::betweenFirst('foofoobar', 'foo', 'bar'));
+        $this->assertSame('', Str::betweenFirst('foobarbar', 'foo', 'bar'));
+    }
+
     public function testStrAfter()
     {
         $this->assertSame('nah', Str::after('hannah', 'han'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -519,6 +519,21 @@ class SupportStringableTest extends TestCase
         $this->assertSame('bar', (string) $this->stringable('foobarbar')->between('foo', 'bar'));
     }
 
+    public function testBetweenFirst()
+    {
+        $this->assertSame('abc', (string) $this->stringable('abc')->betweenFirst('', 'c'));
+        $this->assertSame('abc', (string) $this->stringable('abc')->betweenFirst('a', ''));
+        $this->assertSame('abc', (string) $this->stringable('abc')->betweenFirst('', ''));
+        $this->assertSame('b', (string) $this->stringable('abc')->betweenFirst('a', 'c'));
+        $this->assertSame('b', (string) $this->stringable('dddabc')->betweenFirst('a', 'c'));
+        $this->assertSame('b', (string) $this->stringable('abcddd')->betweenFirst('a', 'c'));
+        $this->assertSame('b', (string) $this->stringable('dddabcddd')->betweenFirst('a', 'c'));
+        $this->assertSame('nn', (string) $this->stringable('hannah')->betweenFirst('ha', 'ah'));
+        $this->assertSame('a', (string) $this->stringable('[a]ab[b]')->betweenFirst('[', ']'));
+        $this->assertSame('foo', (string) $this->stringable('foofoobar')->betweenFirst('foo', 'bar'));
+        $this->assertSame('', (string) $this->stringable('foobarbar')->betweenFirst('foo', 'bar'));
+    }
+
     public function testAfter()
     {
         $this->assertSame('nah', (string) $this->stringable('hannah')->after('han'));


### PR DESCRIPTION
I was getting unexpected results with the `between` method.

```php
Str::between('[1] bla bla [2]', '[', ']');

// Expected: '1'
// Actual: '1] bla bla [2'

```

Looking at the tests this is actually the expected result and changing it would result in a breaking change.

I added the `betweenFirst` method to get the result I expected.

```php
Str::betweenFirst('[1] bla bla [2]', '[', ']');

// '1'

```

[`between` PR](https://github.com/laravel/framework/pull/31603#issuecomment-592456723)