### PR TITLE
[9.x] Allow specifiying custom messages for `Rule` objects

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -813,7 +813,7 @@ class Validator implements ValidatorContract
         if (! $rule->passes($attribute, $value)) {
             $this->failedRules[$attribute][get_class($rule)] = [];
 
-            $messages = $rule->message();
+            $messages = $this->getFromLocalArray($attribute, get_class($rule)) ?? $rule->message();
 
             $messages = $messages ? (array) $messages : [get_class($rule)];
 


### PR DESCRIPTION
There's not currently any simple way to specify a custom message when validating with a rule object.

Here are the current userland work-arounds and caveats:
**Ensure custom rule uses translation strings for message**
This would affect all uses of the message. Not very useful for changing the message in a single place.

**Extending the rule object with a custom `message()` method**
Not a very nice API. A lot of work for a simple thing.

**Interacting with the rule object from a `Closure` rule and using `$fail`**
Also not very nice. Requires knowledge of the Rule's dependencies, etc (think 3rd party packages).

With the changes in this PR, you can now provide a custom message to the `$messages` array.

```php
// A rule that would fail...
class Example implements Rule
{

}

$request->validate(rules: [
	'foo' => [new Example]
], messages: [
	Example::class => 'My custom message goes here!'
])
```

In this scenario, the custom messages provided to `$messages` would be used when the rule fails instead of the default message.

> **NOTE**: I'm not sure if the simple test I've provided is enough. Should I add tests to cover custom messages that have translation replacements in them too?