### PR TITLE
[9.x] Make `Enumerable` and `Arrayable` covariance-aware

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -12,7 +12,7 @@ use Traversable;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  *
  * @implements \ArrayAccess<TKey, TValue>
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -12,7 +12,7 @@ use Traversable;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  *
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @extends \IteratorAggregate<TKey, TValue>

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -16,7 +16,7 @@ use Traversable;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  *
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>
  */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -18,7 +18,7 @@ use UnexpectedValueException;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  *
  * @property-read HigherOrderCollectionProxy $average
  * @property-read HigherOrderCollectionProxy $avg

--- a/src/Illuminate/Contracts/Support/Arrayable.php
+++ b/src/Illuminate/Contracts/Support/Arrayable.php
@@ -4,7 +4,7 @@ namespace Illuminate\Contracts\Support;
 
 /**
  * @template TKey of array-key
- * @template TValue
+ * @template-covariant TValue
  */
 interface Arrayable
 {


### PR DESCRIPTION
Since the templates are marked with `@template`, PHPStan won't adhere to covariance rules.

An example would be:

```php
class Parent {}
class Child extends Parent {}

/** @return Collection<int, Parent> */
function test(): Collection
{
	return collect([new Child]);
}
```

In an application of mine, a similar scenario is currently causing PHPStan to fail. This PR just updates Collection types to use the `@template-covariant` tag instead.

Running PHPStan with this branch as the framework target resolves those problems. The only thing I'm not super sure about is testing this inside of the `types` test files, wonder if @nunomaduro could provide some pointers.

This is supported by both PHPStan and Psalm, fwiw.