### PR TITLE
[9.x] Dump and die after X times

### DIFF
--- a/src/Illuminate/Support/VarDumper.php
+++ b/src/Illuminate/Support/VarDumper.php
@@ -54,8 +54,8 @@ class VarDumper
     /**
      * Dumps and dies after the given time.
      *
-     * @var int
-     * @var array
+     * @param int
+     * @param array
      *
      * @return void|Symfony\Component\VarDumper\VarDumper
      */
@@ -147,7 +147,7 @@ class VarDumper
     /**
      * Exists from dumping.
      *
-     * @var string|int
+     * @param string|int
      *
      * @return void
      */

--- a/src/Illuminate/Support/VarDumper.php
+++ b/src/Illuminate/Support/VarDumper.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Support;
 
-use Symfony\Component\VarDumper\VarDumper;
+use Symfony\Component\VarDumper\VarDumper as SymfonyVarDumper;
 
 class VarDumper
 {
@@ -18,6 +18,10 @@ class VarDumper
      */
     public static function ddt(int $times, ...$vars)
     {
+        if (! $times) {
+            exit(1);
+        }
+        
         if (!in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && !headers_sent()) {
             header('HTTP/1.1 500 Internal Server Error');
         }
@@ -27,7 +31,7 @@ class VarDumper
         }
 
         foreach ($vars as $v) {
-            VarDumper::dump($v);
+            SymfonyVarDumper::dump($v);
         }
 
         self::$times --;
@@ -42,7 +46,7 @@ class VarDumper
     /**
      * Determines is there more time to dump.
      */
-    private function moreTimes(): bool
+    private static function moreTimes(): bool
     {
         return self::$times !== 0;
     }

--- a/src/Illuminate/Support/VarDumper.php
+++ b/src/Illuminate/Support/VarDumper.php
@@ -14,16 +14,62 @@ class VarDumper
     private static int $times = 0;
 
     /**
+     * Determines it's on testing or not.
+     *
+     * @var bool
+     */
+    private static bool $testing = false;
+
+    /**
+     * Number of something has dumped.
+     *
+     * @var int
+     */
+    private static int $dumpedCount = 0;
+
+    /**
+     * Gets those that has dumped.
+     *
+     * @var array
+     */
+    private static array $dumpedItems = [];
+
+    /**
+     * Determines that died.
+     *
+     * @var bool
+     */
+    private static bool $died = false;
+
+    /**
+     * Sets testing environment.
+     *
+     * @return void
+     */
+    public static function fake()
+    {
+        self::$testing = true;
+    }
+
+    /**
      * Dumps and dies after the given time.
+     *
+     * @var int $times
+     * @var array $vars
+     * @return void|Symfony\Component\VarDumper\VarDumper
      */
     public static function ddt(int $times, ...$vars)
     {
-        if (! $times) {
-            exit(1);
-        }
-        
         if (!in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && !headers_sent()) {
             header('HTTP/1.1 500 Internal Server Error');
+        }
+
+        if (self::$died) {
+            return;
+        }
+
+        if (! $times) {
+            return self::exit(1);
         }
 
         if (self::$times === 0) {
@@ -31,22 +77,98 @@ class VarDumper
         }
 
         foreach ($vars as $v) {
-            SymfonyVarDumper::dump($v);
+            self::$dumpedItems[] = $v;
+
+            if (! self::$testing) {
+                SymfonyVarDumper::dump($v);
+                continue;
+            }
+
+            self::$dumpedCount ++;
         }
 
         self::$times --;
 
-        if (!self::moreTimes()) {
+        if (! self::moreTimes()) {
             self::$times = 0;
 
-            exit(1);
+            return self::exit(1);
         }
     }
 
     /**
-     * Determines is there more time to dump.
+     * Gets number of something has dumped.
+     *
+     * @return int
      */
-    private static function moreTimes(): bool
+    public static function getDumpedCount()
+    {
+        return self::$dumpedCount;
+    }
+
+    /**
+     * Gets dumped things.
+     *
+     * @return array
+     */
+    public static function getDumpedItems()
+    {
+        return self::$dumpedItems;
+    }
+
+    /**
+     * Gets that is died.
+     *
+     * @return bool
+     */
+    public static function died()
+    {
+        return self::$died;
+    }
+
+    /**
+     * Resets properties.
+     *
+     * @return void
+     */
+    public static function reset()
+    {
+        $defaultPropertiesValue = [
+            'times' => 0,
+            'testing' => false,
+            'dumpedCount' => 0,
+            'dumpedItems' => [],
+            'died' => false,
+        ];
+
+        foreach ($defaultPropertiesValue as $property => $default) {
+            self::${$property} = $default;
+        }
+    }
+
+    /**
+     * Exists from dumping.
+     *
+     * @var string|int
+     * @return void
+     */
+    private static function exit($status)
+    {
+        if (! self::$testing) {
+            exit($status);
+        }
+
+        self::$died = true;
+
+        return;
+    }
+
+    /**
+     * Determines is there more time to dump.
+     *
+     * @return bool
+     */
+    private static function moreTimes()
     {
         return self::$times !== 0;
     }

--- a/src/Illuminate/Support/VarDumper.php
+++ b/src/Illuminate/Support/VarDumper.php
@@ -56,7 +56,6 @@ class VarDumper
      *
      * @param int
      * @param array
-     *
      * @return void|Symfony\Component\VarDumper\VarDumper
      */
     public static function ddt(int $times, ...$vars)
@@ -148,7 +147,6 @@ class VarDumper
      * Exists from dumping.
      *
      * @param string|int
-     *
      * @return void
      */
     private static function exit($status)

--- a/src/Illuminate/Support/VarDumper.php
+++ b/src/Illuminate/Support/VarDumper.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Symfony\Component\VarDumper\VarDumper;
+
+class VarDumper
+{
+    /**
+     * Times to dump.
+     *
+     * @var int
+     */
+    private static int $times = 0;
+
+    /**
+     * Dumps and dies after the given time.
+     */
+    public static function ddt(int $times, ...$vars)
+    {
+        if (!in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && !headers_sent()) {
+            header('HTTP/1.1 500 Internal Server Error');
+        }
+
+        if (self::$times === 0) {
+            self::$times = $times;
+        }
+
+        foreach ($vars as $v) {
+            VarDumper::dump($v);
+        }
+
+        self::$times --;
+
+        if (!self::moreTimes()) {
+            self::$times = 0;
+
+            exit(1);
+        }
+    }
+
+    /**
+     * Determines is there more time to dump.
+     */
+    private function moreTimes(): bool
+    {
+        return self::$times !== 0;
+    }
+}

--- a/src/Illuminate/Support/VarDumper.php
+++ b/src/Illuminate/Support/VarDumper.php
@@ -83,15 +83,12 @@ class VarDumper
                 SymfonyVarDumper::dump($v);
                 continue;
             }
-
-            self::$dumpedCount ++;
         }
 
+        self::$dumpedCount ++;
         self::$times --;
 
         if (! self::moreTimes()) {
-            self::$times = 0;
-
             return self::exit(1);
         }
     }
@@ -158,6 +155,7 @@ class VarDumper
             exit($status);
         }
 
+        self::$times = 0;
         self::$died = true;
 
         return;

--- a/src/Illuminate/Support/VarDumper.php
+++ b/src/Illuminate/Support/VarDumper.php
@@ -54,13 +54,14 @@ class VarDumper
     /**
      * Dumps and dies after the given time.
      *
-     * @var int $times
-     * @var array $vars
+     * @var int
+     * @var array
+     *
      * @return void|Symfony\Component\VarDumper\VarDumper
      */
     public static function ddt(int $times, ...$vars)
     {
-        if (!in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && !headers_sent()) {
+        if (! in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && ! headers_sent()) {
             header('HTTP/1.1 500 Internal Server Error');
         }
 
@@ -85,8 +86,8 @@ class VarDumper
             }
         }
 
-        self::$dumpedCount ++;
-        self::$times --;
+        self::$dumpedCount++;
+        self::$times--;
 
         if (! self::moreTimes()) {
             return self::exit(1);
@@ -147,6 +148,7 @@ class VarDumper
      * Exists from dumping.
      *
      * @var string|int
+     *
      * @return void
      */
     private static function exit($status)
@@ -157,8 +159,6 @@ class VarDumper
 
         self::$times = 0;
         self::$died = true;
-
-        return;
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -425,7 +425,7 @@ if (! function_exists('ddt')) {
      * Dumps and dies after given time.
      *
      * @param  int  $times
-     * @param  array $vars
+     * @param  array  $vars
      */
     function ddt(int $times, ...$vars)
     {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -420,7 +420,7 @@ if (! function_exists('with')) {
     }
 }
 
-if (!function_exists('ddt')) {
+if (! function_exists('ddt')) {
     /**
      * Dumps and dies after given time.
      *

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -428,6 +428,6 @@ if (!function_exists('ddt')) {
      */
     function ddt(int $times, ...$vars)
     {
-        return DumpService::ddt($times, ...$vars);
+        return VarDumper::ddt($times, ...$vars);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -418,3 +418,16 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (!function_exists('ddt')) {
+    /**
+     * Dumps and dies after the given time.
+     *
+     * @param  int  $times
+     * @param  mixed[] $vars
+     */
+    function ddt(int $times, ...$vars)
+    {
+        return VarDumper::ddt($times, ...$vars);
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Str;
+use Illuminate\Support\VarDumper;
 
 if (! function_exists('append_config')) {
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -421,13 +421,13 @@ if (! function_exists('with')) {
 
 if (!function_exists('ddt')) {
     /**
-     * Dumps and dies after the given time.
+     * Dumps and dies after given time.
      *
      * @param  int  $times
-     * @param  mixed[] $vars
+     * @param  array $vars
      */
     function ddt(int $times, ...$vars)
     {
-        return VarDumper::ddt($times, ...$vars);
+        return DumpService::ddt($times, ...$vars);
     }
 }

--- a/tests/Support/SupportVarDumperTest.php
+++ b/tests/Support/SupportVarDumperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\VarDumper;
+use PHPUnit\Framework\TestCase;
+
+class SupportVarDumperTest extends TestCase
+{
+    public function test_ddt_works()
+    {
+        VarDumper::fake();
+
+        $array = ['a', 'b', 'c', 'd', 'e'];
+
+        foreach ($array as $item) {
+            ddt(3, $item);
+        }
+
+        $this->assertEquals(VarDumper::getDumpedCount(), 3);
+        $this->assertTrue(VarDumper::died());
+        $this->assertEquals(['a', 'b', 'c'],  VarDumper::getDumpedItems());
+
+        VarDumper::reset();
+    }
+
+    public function test_works_with_count_of_array()
+    {
+        VarDumper::fake();
+        $array = ['a', 'b', 'c', 'd', 'e'];
+        
+        foreach ($array as $item) {
+            ddt(count($array), $item);
+        }
+
+        $this->assertEquals(VarDumper::getDumpedCount(), count($array));
+        $this->assertTrue(VarDumper::died());
+        $this->assertEquals($array,  VarDumper::getDumpedItems());
+
+        VarDumper::reset();
+    }
+
+    public function test_zero_times_wont_dump_anything_and_just_dies()
+    {
+        VarDumper::fake();
+
+        $array = ['a', 'b', 'c', 'd', 'e'];
+
+        foreach ($array as $item) {
+            ddt(0, $item);
+        }
+
+        $this->assertEquals(VarDumper::getDumpedCount(), 0);
+        $this->assertTrue(VarDumper::died());
+        $this->assertEquals([],  VarDumper::getDumpedItems());
+    }
+}

--- a/tests/Support/SupportVarDumperTest.php
+++ b/tests/Support/SupportVarDumperTest.php
@@ -53,5 +53,7 @@ class SupportVarDumperTest extends TestCase
         $this->assertEquals(VarDumper::getDumpedCount(), 0);
         $this->assertTrue(VarDumper::died());
         $this->assertEquals([],  VarDumper::getDumpedItems());
+        
+        VarDumper::reset();
     }
 }

--- a/tests/Support/SupportVarDumperTest.php
+++ b/tests/Support/SupportVarDumperTest.php
@@ -22,13 +22,27 @@ class SupportVarDumperTest extends TestCase
         $this->assertEquals(['a', 'b', 'c'],  VarDumper::getDumpedItems());
 
         VarDumper::reset();
+
+        VarDumper::fake();
+
+        $array = ['a', 'b', 'c', 'd', 'e'];
+
+        foreach ($array as $item) {
+            ddt(4, $item, 'test');
+        }
+
+        $this->assertEquals(VarDumper::getDumpedCount(), 4);
+        $this->assertTrue(VarDumper::died());
+        $this->assertEquals(['a', 'test', 'b', 'test', 'c', 'test', 'd', 'test'],  VarDumper::getDumpedItems());
+
+        VarDumper::reset();
     }
 
     public function test_works_with_count_of_array()
     {
         VarDumper::fake();
         $array = ['a', 'b', 'c', 'd', 'e'];
-        
+
         foreach ($array as $item) {
             ddt(count($array), $item);
         }
@@ -53,7 +67,7 @@ class SupportVarDumperTest extends TestCase
         $this->assertEquals(VarDumper::getDumpedCount(), 0);
         $this->assertTrue(VarDumper::died());
         $this->assertEquals([],  VarDumper::getDumpedItems());
-        
+
         VarDumper::reset();
     }
 }

--- a/tests/Support/SupportVarDumperTest.php
+++ b/tests/Support/SupportVarDumperTest.php
@@ -19,7 +19,7 @@ class SupportVarDumperTest extends TestCase
 
         $this->assertEquals(VarDumper::getDumpedCount(), 3);
         $this->assertTrue(VarDumper::died());
-        $this->assertEquals(['a', 'b', 'c'],  VarDumper::getDumpedItems());
+        $this->assertEquals(['a', 'b', 'c'], VarDumper::getDumpedItems());
 
         VarDumper::reset();
 
@@ -33,7 +33,7 @@ class SupportVarDumperTest extends TestCase
 
         $this->assertEquals(VarDumper::getDumpedCount(), 4);
         $this->assertTrue(VarDumper::died());
-        $this->assertEquals(['a', 'test', 'b', 'test', 'c', 'test', 'd', 'test'],  VarDumper::getDumpedItems());
+        $this->assertEquals(['a', 'test', 'b', 'test', 'c', 'test', 'd', 'test'], VarDumper::getDumpedItems());
 
         VarDumper::reset();
     }
@@ -49,7 +49,7 @@ class SupportVarDumperTest extends TestCase
 
         $this->assertEquals(VarDumper::getDumpedCount(), count($array));
         $this->assertTrue(VarDumper::died());
-        $this->assertEquals($array,  VarDumper::getDumpedItems());
+        $this->assertEquals($array, VarDumper::getDumpedItems());
 
         VarDumper::reset();
     }
@@ -66,7 +66,7 @@ class SupportVarDumperTest extends TestCase
 
         $this->assertEquals(VarDumper::getDumpedCount(), 0);
         $this->assertTrue(VarDumper::died());
-        $this->assertEquals([],  VarDumper::getDumpedItems());
+        $this->assertEquals([], VarDumper::getDumpedItems());
 
         VarDumper::reset();
     }


### PR DESCRIPTION
Dumps and dies after the given time.

```php
foreach (['a','b','c','d'] as $item) {
  ddt(3, $item, 'test');

  // will dump variables and dies after( when ) 3 times.
}
```

![1](https://user-images.githubusercontent.com/68776630/155118207-ce86ad8d-8c16-418f-9c1d-f74d7c2d890f.png)

```php
foreach (['a','b','c','d'] as $item) {
  ddt(1, $item, 'test');

  // will dump variables and dies after( when ) 1 time. (like dd())
}
```

![2](https://user-images.githubusercontent.com/68776630/155118448-4e65dadb-edb4-4ca0-9893-7d6d7a2f0552.png)


```php
foreach (['a','b','c','d'] as $item) {
  ddt(0, $item, 'test');
}

  // just dies.
```
![3](https://user-images.githubusercontent.com/68776630/155118614-35b874bb-2a13-4e0b-9f7e-2e232f080e3a.png)



it also can be useful when don't have size of array, or just want to dump more items and die.

