### PR TITLE
[8.x] Fix database migrations `$connection` property

### DIFF
--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -37,6 +37,11 @@ class DatabaseMigratorIntegrationTest extends TestCase
             'database' => ':memory:',
         ], 'sqlite2');
 
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ], 'sqlite3');
+
         $db->setAsGlobal();
 
         $container = new Container;
@@ -82,6 +87,55 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         $this->assertTrue(Str::contains($ran[0], 'users'));
         $this->assertTrue(Str::contains($ran[1], 'password_resets'));
+    }
+
+    public function testMigrationsDefaultConnectionCanBeChanged()
+    {
+        $ran = $this->migrator->usingConnection('sqlite2', function () {
+            return $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqllite3']);
+        });
+
+        $this->assertFalse($this->db->schema()->hasTable('users'));
+        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db->schema('sqlite2')->hasTable('users'));
+        $this->assertTrue($this->db->schema('sqlite2')->hasTable('password_resets'));
+        $this->assertFalse($this->db->schema('sqlite3')->hasTable('users'));
+        $this->assertFalse($this->db->schema('sqlite3')->hasTable('password_resets'));
+
+        $this->assertTrue(Str::contains($ran[0], 'users'));
+        $this->assertTrue(Str::contains($ran[1], 'password_resets'));
+    }
+
+    public function testMigrationsCanEachDefineConnection()
+    {
+        $ran = $this->migrator->run([__DIR__.'/migrations/connection_configured']);
+
+        $this->assertFalse($this->db->schema()->hasTable('failed_jobs'));
+        $this->assertFalse($this->db->schema()->hasTable('jobs'));
+        $this->assertFalse($this->db->schema('sqlite2')->hasTable('failed_jobs'));
+        $this->assertFalse($this->db->schema('sqlite2')->hasTable('jobs'));
+        $this->assertTrue($this->db->schema('sqlite3')->hasTable('failed_jobs'));
+        $this->assertTrue($this->db->schema('sqlite3')->hasTable('jobs'));
+
+        $this->assertTrue(Str::contains($ran[0], 'failed_jobs'));
+        $this->assertTrue(Str::contains($ran[1], 'jobs'));
+    }
+
+    public function testMigratorCannotChangeDefinedMigrationConnection()
+    {
+        $ran = $this->migrator->usingConnection('sqlite2', function () {
+            return $this->migrator->run([__DIR__.'/migrations/connection_configured']);
+        });
+
+        $this->assertFalse($this->db->schema()->hasTable('failed_jobs'));
+        $this->assertFalse($this->db->schema()->hasTable('jobs'));
+        $this->assertFalse($this->db->schema('sqlite2')->hasTable('failed_jobs'));
+        $this->assertFalse($this->db->schema('sqlite2')->hasTable('jobs'));
+        $this->assertTrue($this->db->schema('sqlite3')->hasTable('failed_jobs'));
+        $this->assertTrue($this->db->schema('sqlite3')->hasTable('jobs'));
+
+        $this->assertTrue(Str::contains($ran[0], 'failed_jobs'));
+        $this->assertTrue(Str::contains($ran[1], 'jobs'));
     }
 
     public function testMigrationsCanBeRolledBack()

--- a/tests/Database/migrations/connection_configured/2022_02_21_000000_create_failed_jobs_table.php
+++ b/tests/Database/migrations/connection_configured/2022_02_21_000000_create_failed_jobs_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The database connection that should be used by the migration.
+     *
+     * @var string
+     */
+    protected $connection = 'sqlite3';
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};

--- a/tests/Database/migrations/connection_configured/2022_02_21_120000_create_jobs_table.php
+++ b/tests/Database/migrations/connection_configured/2022_02_21_120000_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('sqlite3')->create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('sqlite3')->dropIfExists('jobs');
+    }
+};


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/41153 https://github.com/laravel/framework/issues/40097 https://github.com/laravel/framework/issues/38777 https://github.com/laravel/framework/issues/36596 https://github.com/laravel/framework/issues/31060 

The [docs](https://laravel.com/docs/8.x/migrations#setting-the-migration-connection) show the below migration will be run on the named database connection:

```php
return new class extends Migration
{
    protected $connection = 'pgsql';

    function up()
    {
        Schema::create('users', function (Blueprint $table) {
            // ...
        });
    }
}
```

However `Schema` facade-built queries will run on the app's default database connection or the `--database` command line option's named connection. The migration also requires `Schema::connection('pgsql')`:

```php
return new class extends Migration
{
    protected $connection = 'pgsql';

    function up()
    {
        Schema::connection('pgsql')->create('users', function (Blueprint $table) {
            // ...
        });
    }
}
```

This fix allows the first example to work as documented for the `up()` & `down()` methods. The selected connection priority is:

1. `Schema::connection()`
2. migration class property `$connection`
3. `php artisan migrate*` command line option `--database`
4. `config('database.default')`

I also added tests for the `Migrator@usingConnection()` method added in 7.x for the migration commands.