### PR TITLE
[9.x] Let Multiple* exceptions hold the number of records and items found

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1208,12 +1208,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $items = $this->unless($filter == null)->filter($filter);
 
-        if ($items->isEmpty()) {
+        $count = $items->count();
+
+        if ($count === 0) {
             throw new ItemNotFoundException;
         }
 
-        if ($items->count() > 1) {
-            throw new MultipleItemsFoundException;
+        if ($count > 1) {
+            throw new MultipleItemsFoundException($count);
         }
 
         return $items->first();

--- a/src/Illuminate/Collections/MultipleItemsFoundException.php
+++ b/src/Illuminate/Collections/MultipleItemsFoundException.php
@@ -6,4 +6,34 @@ use RuntimeException;
 
 class MultipleItemsFoundException extends RuntimeException
 {
+    /**
+     * The number of items found.
+     *
+     * @var int
+     */
+    protected $count;
+
+    /**
+     * MultipleItemsFoundException constructor.
+     *
+     * @param  int  $count
+     * @param  int  $code
+     * @param  \Throwable|null  $previous
+     * @return void
+     */
+    public function __construct($count, $code = 0, $previous = null)
+    {
+        $this->count = $count;
+        parent::__construct("$count items have been found.", $code, $previous);
+    }
+
+    /**
+     * Get the number of items found.
+     *
+     * @return int
+     */
+    public function getCount()
+    {
+        return $this->count;
+    }
 }

--- a/src/Illuminate/Collections/MultipleItemsFoundException.php
+++ b/src/Illuminate/Collections/MultipleItemsFoundException.php
@@ -11,10 +11,10 @@ class MultipleItemsFoundException extends RuntimeException
      *
      * @var int
      */
-    protected $count;
+    public $count;
 
     /**
-     * MultipleItemsFoundException constructor.
+     * Create a new exception instance.
      *
      * @param  int  $count
      * @param  int  $code
@@ -24,7 +24,8 @@ class MultipleItemsFoundException extends RuntimeException
     public function __construct($count, $code = 0, $previous = null)
     {
         $this->count = $count;
-        parent::__construct("$count items have been found.", $code, $previous);
+
+        parent::__construct("$count items were found.", $code, $previous);
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -309,12 +309,14 @@ trait BuildsQueries
     {
         $result = $this->take(2)->get($columns);
 
-        if ($result->isEmpty()) {
+        $count = $result->count();
+
+        if ($count === 0) {
             throw new RecordsNotFoundException;
         }
 
-        if ($result->count() > 1) {
-            throw new MultipleRecordsFoundException;
+        if ($count > 1) {
+            throw new MultipleRecordsFoundException($count);
         }
 
         return $result->first();

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -171,12 +171,14 @@ abstract class Relation implements BuilderContract
     {
         $result = $this->take(2)->get($columns);
 
-        if ($result->isEmpty()) {
+        $count = $result->count();
+
+        if ($count === 0) {
             throw (new ModelNotFoundException)->setModel(get_class($this->related));
         }
 
-        if ($result->count() > 1) {
-            throw new MultipleRecordsFoundException;
+        if ($count > 1) {
+            throw new MultipleRecordsFoundException($count);
         }
 
         return $result->first();

--- a/src/Illuminate/Database/MultipleRecordsFoundException.php
+++ b/src/Illuminate/Database/MultipleRecordsFoundException.php
@@ -6,5 +6,34 @@ use RuntimeException;
 
 class MultipleRecordsFoundException extends RuntimeException
 {
-    //
+    /**
+     * The number of records found.
+     *
+     * @var int
+     */
+    protected $count;
+
+    /**
+     * MultipleRecordsFoundException constructor.
+     *
+     * @param  int  $count
+     * @param  int  $code
+     * @param  \Throwable|null  $previous
+     * @return void
+     */
+    public function __construct($count, $code = 0, $previous = null)
+    {
+        $this->count = $count;
+        parent::__construct("$count records have been found.", $code, $previous);
+    }
+
+    /**
+     * Get the number of records found..
+     *
+     * @return int
+     */
+    public function getCount()
+    {
+        return $this->count;
+    }
 }

--- a/src/Illuminate/Database/MultipleRecordsFoundException.php
+++ b/src/Illuminate/Database/MultipleRecordsFoundException.php
@@ -11,10 +11,10 @@ class MultipleRecordsFoundException extends RuntimeException
      *
      * @var int
      */
-    protected $count;
+    public $count;
 
     /**
-     * MultipleRecordsFoundException constructor.
+     * Create a new exception instance.
      *
      * @param  int  $count
      * @param  int  $code
@@ -24,11 +24,12 @@ class MultipleRecordsFoundException extends RuntimeException
     public function __construct($count, $code = 0, $previous = null)
     {
         $this->count = $count;
-        parent::__construct("$count records have been found.", $code, $previous);
+
+        parent::__construct("$count records were found.", $code, $previous);
     }
 
     /**
-     * Get the number of records found..
+     * Get the number of records found.
      *
      * @return int
      */

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -115,7 +115,7 @@ class EloquentWhereTest extends DatabaseTestCase
             'address' => 'other-address',
         ]);
 
-        $this->expectException(MultipleRecordsFoundException::class);
+        $this->expectExceptionObject(new MultipleRecordsFoundException(2));
 
         UserWhereTest::where('name', 'test-name')->sole();
     }

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -40,7 +40,7 @@ class QueryBuilderTest extends DatabaseTestCase
             ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'created_at' => new Carbon('2017-11-12 13:14:15')],
         ]);
 
-        $this->expectException(MultipleRecordsFoundException::class);
+        $this->expectExceptionObject(new MultipleRecordsFoundException(2));
 
         DB::table('posts')->where('title', 'Foo Post')->sole();
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -104,7 +104,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testSoleThrowsExceptionIfMoreThanOneItemExists($collection)
     {
-        $this->expectException(MultipleItemsFoundException::class);
+        $this->expectExceptionObject(new MultipleItemsFoundException(2));
 
         $collection = new $collection([
             ['name' => 'foo'],
@@ -146,7 +146,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testSoleThrowsExceptionIfMoreThanOneItemExistsWithCallback($collection)
     {
-        $this->expectException(MultipleItemsFoundException::class);
+        $this->expectExceptionObject(new MultipleItemsFoundException(2));
 
         $data = new $collection(['foo', 'bar', 'bar']);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It can be pretty handy to get access to the numbers of items or records found within `MultipleItemsFoundException` and `MultipleRecordsFoundException` exceptions.

This PR ensures that those numbers are always accessible.