### PR TITLE
[9.x] Enforce stricter assertions

### DIFF
--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -56,7 +56,7 @@ class CacheManagerTest extends TestCase
 
         $driver = $cacheManager->store('my_store');
 
-        $this->assertEquals('mm(u_u)mm', $driver->flag);
+        $this->assertSame('mm(u_u)mm', $driver->flag);
     }
 
     public function testItMakesRepositoryWhenContainerHasNoDispatcher()

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -105,7 +105,7 @@ class CacheRateLimiterTest extends TestCase
 
         $rateLimiter = new RateLimiter($cache);
 
-        $this->assertEquals('foo', $rateLimiter->attempt('key', 1, function () {
+        $this->assertSame('foo', $rateLimiter->attempt('key', 1, function () {
             return 'foo';
         }, 1));
     }

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -124,7 +124,7 @@ class ConsoleEventSchedulerTest extends TestCase
     {
         $schedule = $this->schedule;
         $event = $schedule->command(ConsoleCommandStub::class);
-        $this->assertEquals('This is a description about the command', $event->description);
+        $this->assertSame('This is a description about the command', $event->description);
     }
 
     public function testItShouldBePossibleToOverwriteTheDescription()
@@ -132,7 +132,7 @@ class ConsoleEventSchedulerTest extends TestCase
         $schedule = $this->schedule;
         $event = $schedule->command(ConsoleCommandStub::class)
             ->description('This is an alternative description');
-        $this->assertEquals('This is an alternative description', $event->description);
+        $this->assertSame('This is an alternative description', $event->description);
     }
 
     public function testCallCreatesNewJobWithTimezone()

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -120,10 +120,10 @@ class CookieTest extends TestCase
         $cookieJar->expire('foobar', '/path', '/domain');
 
         $cookie = $cookieJar->queued('foobar');
-        $this->assertEquals('foobar', $cookie->getName());
+        $this->assertSame('foobar', $cookie->getName());
         $this->assertEquals(null, $cookie->getValue());
-        $this->assertEquals('/path', $cookie->getPath());
-        $this->assertEquals('/domain', $cookie->getDomain());
+        $this->assertSame('/path', $cookie->getPath());
+        $this->assertSame('/domain', $cookie->getDomain());
         $this->assertTrue($cookie->getExpiresTime() < time());
         $this->assertCount(1, $cookieJar->getQueuedCookies());
     }

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -90,7 +90,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         });
 
         $user->articles->each(function (BelongsToManySyncTestTestArticle $article) {
-            $this->assertEquals('0', $article->pivot->visible);
+            $this->assertSame('0', (string) $article->pivot->visible);
         });
     }
 
@@ -108,7 +108,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
         });
 
         $user->articles->each(function (BelongsToManySyncTestTestArticle $article) {
-            $this->assertEquals('1', $article->pivot->visible);
+            $this->assertSame('1', (string) $article->pivot->visible);
         });
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManySyncTouchesParentTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncTouchesParentTest.php
@@ -89,7 +89,7 @@ class DatabaseEloquentBelongsToManySyncTouchesParentTest extends TestCase
         Carbon::setTestNow('2021-07-20 19:13:14');
         $result = $article->users()->sync([1, 2]);
         $this->assertCount(1, collect($result['detached']));
-        $this->assertSame('3', collect($result['detached'])->first());
+        $this->assertSame('3', (string) collect($result['detached'])->first());
 
         $article->refresh();
         $this->assertSame('2021-07-20 19:13:14', $article->updated_at->format('Y-m-d H:i:s'));

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -127,7 +127,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
         $this->assertEquals(1, $models[0]->foo->getAttribute('id'));
         $this->assertEquals(2, $models[1]->foo->getAttribute('id'));
-        $this->assertEquals('3', $models[2]->foo->getAttribute('id'));
+        $this->assertSame('3', (string) $models[2]->foo->getAttribute('id'));
     }
 
     public function testAssociateMethodSetsForeignKeyOnModel()

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -183,7 +183,7 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals(1, $models[0]->foo->foreign_key);
         $this->assertEquals(2, $models[1]->foo->foreign_key);
         $this->assertNull($models[2]->foo);
-        $this->assertEquals('4', $models[3]->foo->foreign_key);
+        $this->assertSame('4', (string) $models[3]->foo->foreign_key);
     }
 
     public function testRelationCountQueryCanBeBuilt()

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -34,7 +34,7 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
         ]);
 
         $morphName = $model->getMorphClass();
-        $this->assertEquals('test', $morphName);
+        $this->assertSame('test', $morphName);
     }
 
     public function testMapsCanBeEnforcedInOneMethod()
@@ -48,7 +48,7 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
         ]);
 
         $morphName = $model->getMorphClass();
-        $this->assertEquals('test', $morphName);
+        $this->assertSame('test', $morphName);
     }
 
     protected function tearDown(): void

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -135,7 +135,7 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals('specified', $request->validated('name'));
+        $this->assertSame('specified', $request->validated('name'));
     }
 
     public function testValidatedMethodReturnsOnlyRequestedNestedValidatedData()
@@ -146,7 +146,7 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals('bar', $request->validated('nested.foo'));
+        $this->assertSame('bar', $request->validated('nested.foo'));
     }
 
     /**

--- a/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithViewsTest.php
@@ -14,7 +14,7 @@ class InteractsWithViewsTest extends TestCase
     {
         $string = (string) $this->blade('@if(true)test @endif');
 
-        $this->assertEquals('test ', $string);
+        $this->assertSame('test ', $string);
     }
 
     public function testComponentCanAccessPublicProperties()
@@ -36,8 +36,8 @@ class InteractsWithViewsTest extends TestCase
 
         $component = $this->component(get_class($exampleComponent));
 
-        $this->assertEquals('bar', $component->foo);
-        $this->assertEquals('hello', $component->speak());
+        $this->assertSame('bar', $component->foo);
+        $this->assertSame('hello', $component->speak());
         $component->assertSee('content');
     }
 }

--- a/tests/Http/Middleware/TrustProxiesTest.php
+++ b/tests/Http/Middleware/TrustProxiesTest.php
@@ -26,9 +26,9 @@ class TrustProxiesTest extends TestCase
     {
         $req = $this->createProxiedRequest();
 
-        $this->assertEquals('192.168.10.10', $req->getClientIp(), 'Assert untrusted proxy x-forwarded-for header not used');
-        $this->assertEquals('http', $req->getScheme(), 'Assert untrusted proxy x-forwarded-proto header not used');
-        $this->assertEquals('localhost', $req->getHost(), 'Assert untrusted proxy x-forwarded-host header not used');
+        $this->assertSame('192.168.10.10', $req->getClientIp(), 'Assert untrusted proxy x-forwarded-for header not used');
+        $this->assertSame('http', $req->getScheme(), 'Assert untrusted proxy x-forwarded-proto header not used');
+        $this->assertSame('localhost', $req->getHost(), 'Assert untrusted proxy x-forwarded-host header not used');
         $this->assertEquals(8888, $req->getPort(), 'Assert untrusted proxy x-forwarded-port header not used');
         $this->assertSame('', $req->getBaseUrl(), 'Assert untrusted proxy x-forwarded-prefix header not used');
     }
@@ -44,11 +44,11 @@ class TrustProxiesTest extends TestCase
         $req = $this->createProxiedRequest();
         $req->setTrustedProxies(['192.168.10.10'], $this->headerAll);
 
-        $this->assertEquals('173.174.200.38', $req->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
-        $this->assertEquals('https', $req->getScheme(), 'Assert trusted proxy x-forwarded-proto header used');
-        $this->assertEquals('serversforhackers.com', $req->getHost(), 'Assert trusted proxy x-forwarded-host header used');
+        $this->assertSame('173.174.200.38', $req->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
+        $this->assertSame('https', $req->getScheme(), 'Assert trusted proxy x-forwarded-proto header used');
+        $this->assertSame('serversforhackers.com', $req->getHost(), 'Assert trusted proxy x-forwarded-host header used');
         $this->assertEquals(443, $req->getPort(), 'Assert trusted proxy x-forwarded-port header used');
-        $this->assertEquals('/prefix', $req->getBaseUrl(), 'Assert trusted proxy x-forwarded-prefix header used');
+        $this->assertSame('/prefix', $req->getBaseUrl(), 'Assert trusted proxy x-forwarded-prefix header used');
     }
 
     /**
@@ -61,7 +61,7 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
+            $this->assertSame('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
         });
     }
 
@@ -75,7 +75,7 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
+            $this->assertSame('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
         });
     }
 
@@ -89,7 +89,7 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
+            $this->assertSame('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used');
         });
     }
 
@@ -112,7 +112,7 @@ class TrustProxiesTest extends TestCase
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
                 $ips = $request->getClientIps();
-                $this->assertEquals('192.0.2.2', end($ips), 'Assert sets the '.$forwardedForHeader);
+                $this->assertSame('192.0.2.2', end($ips), 'Assert sets the '.$forwardedForHeader);
             });
         }
     }
@@ -135,7 +135,7 @@ class TrustProxiesTest extends TestCase
             $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
-                $this->assertEquals('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+                $this->assertSame('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
             });
         }
     }
@@ -158,7 +158,7 @@ class TrustProxiesTest extends TestCase
             $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
 
             $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
-                $this->assertEquals('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+                $this->assertSame('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
             });
         }
     }
@@ -179,11 +179,11 @@ class TrustProxiesTest extends TestCase
         ]);
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.40', $request->getClientIp(),
+            $this->assertSame('173.174.200.40', $request->getClientIp(),
                 'Assert trusted proxy used forwarded header for IP');
-            $this->assertEquals('https', $request->getScheme(),
+            $this->assertSame('https', $request->getScheme(),
                 'Assert trusted proxy used forwarded header for scheme');
-            $this->assertEquals('serversforhackers.com', $request->getHost(),
+            $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
             $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
         });
@@ -199,11 +199,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(),
+            $this->assertSame('173.174.200.38', $request->getClientIp(),
                 'Assert trusted proxy used forwarded header for IP');
-            $this->assertEquals('http', $request->getScheme(),
+            $this->assertSame('http', $request->getScheme(),
                 'Assert trusted proxy did not use forwarded header for scheme');
-            $this->assertEquals('localhost', $request->getHost(),
+            $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
             $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
@@ -220,11 +220,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_HOST' => 'serversforhackers.com:8888']);
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+            $this->assertSame('192.168.10.10', $request->getClientIp(),
                 'Assert trusted proxy did not use forwarded header for IP');
-            $this->assertEquals('http', $request->getScheme(),
+            $this->assertSame('http', $request->getScheme(),
                 'Assert trusted proxy did not use forwarded header for scheme');
-            $this->assertEquals('serversforhackers.com', $request->getHost(),
+            $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
             $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
@@ -241,11 +241,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+            $this->assertSame('192.168.10.10', $request->getClientIp(),
                 'Assert trusted proxy did not use forwarded header for IP');
-            $this->assertEquals('http', $request->getScheme(),
+            $this->assertSame('http', $request->getScheme(),
                 'Assert trusted proxy did not use forwarded header for scheme');
-            $this->assertEquals('localhost', $request->getHost(),
+            $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
             $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
@@ -262,14 +262,14 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+            $this->assertSame('192.168.10.10', $request->getClientIp(),
                 'Assert trusted proxy did not use forwarded header for IP');
-            $this->assertEquals('http', $request->getScheme(),
+            $this->assertSame('http', $request->getScheme(),
                 'Assert trusted proxy did not use forwarded header for scheme');
-            $this->assertEquals('localhost', $request->getHost(),
+            $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
             $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
-            $this->assertEquals('/prefix', $request->getBaseUrl(), 'Assert trusted proxy used forwarded header for prefix');
+            $this->assertSame('/prefix', $request->getBaseUrl(), 'Assert trusted proxy used forwarded header for prefix');
         });
     }
 
@@ -283,11 +283,11 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+            $this->assertSame('192.168.10.10', $request->getClientIp(),
                 'Assert trusted proxy did not use forwarded header for IP');
-            $this->assertEquals('https', $request->getScheme(),
+            $this->assertSame('https', $request->getScheme(),
                 'Assert trusted proxy used forwarded header for scheme');
-            $this->assertEquals('localhost', $request->getHost(),
+            $this->assertSame('localhost', $request->getHost(),
                 'Assert trusted proxy did not use forwarded header for host');
             $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
             $this->assertSame('', $request->getBaseUrl(), 'Assert trusted proxy did not use forwarded header for prefix');
@@ -309,14 +309,14 @@ class TrustProxiesTest extends TestCase
         $request = $this->createProxiedRequest();
 
         $trustedProxy->handle($request, function ($request) {
-            $this->assertEquals('173.174.200.38', $request->getClientIp(),
+            $this->assertSame('173.174.200.38', $request->getClientIp(),
                 'Assert trusted proxy used forwarded header for IP');
-            $this->assertEquals('https', $request->getScheme(),
+            $this->assertSame('https', $request->getScheme(),
                 'Assert trusted proxy used forwarded header for scheme');
-            $this->assertEquals('serversforhackers.com', $request->getHost(),
+            $this->assertSame('serversforhackers.com', $request->getHost(),
                 'Assert trusted proxy used forwarded header for host');
             $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
-            $this->assertEquals('/prefix', $request->getBaseUrl(), 'Assert trusted proxy used forwarded header for prefix');
+            $this->assertSame('/prefix', $request->getBaseUrl(), 'Assert trusted proxy used forwarded header for prefix');
         });
     }
 

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -37,7 +37,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
 
         $this->assertEquals(['name' => 'Taylor'], $model->array_object->toArray());
         $this->assertEquals(['name' => 'Taylor'], $model->collection->toArray());
-        $this->assertEquals('Taylor', (string) $model->stringable);
+        $this->assertSame('Taylor', (string) $model->stringable);
 
         $model->array_object['age'] = 34;
         $model->array_object['meta']['title'] = 'Developer';

--- a/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentBroadcastingTest.php
@@ -47,7 +47,7 @@ class DatabaseEloquentBroadcastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentBroadcastUser;
 
-        $this->assertEquals('Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.{testEloquentBroadcastUser}', $model->broadcastChannelRoute());
+        $this->assertSame('Illuminate.Tests.Integration.Database.TestEloquentBroadcastUser.{testEloquentBroadcastUser}', $model->broadcastChannelRoute());
     }
 
     public function testBroadcastingOnModelTrashing()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -138,7 +138,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tagsWithCustomPivot()->attach($tag->id);
 
         $this->assertInstanceOf(PostTagPivot::class, $post->tagsWithCustomPivot[0]->pivot);
-        $this->assertEquals('1507630210', $post->tagsWithCustomPivot[0]->pivot->created_at);
+        $this->assertSame('1507630210', $post->tagsWithCustomPivot[0]->pivot->created_at);
 
         $this->assertInstanceOf(PostTagPivot::class, $post->tagsWithCustomPivotClass[0]->pivot);
         $this->assertSame('posts_tags', $post->tagsWithCustomPivotClass()->getTable());
@@ -233,8 +233,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
         foreach ($post->tagsWithCustomExtraPivot as $tag) {
             $this->assertSame('exclude', $tag->pivot->flag);
-            $this->assertEquals('2017-10-10 10:10:10', $tag->pivot->getAttributes()['created_at']);
-            $this->assertEquals('2017-10-10 10:10:20', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
+            $this->assertSame('2017-10-10 10:10:10', $tag->pivot->getAttributes()['created_at']);
+            $this->assertSame('2017-10-10 10:10:20', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
         }
     }
 

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -47,9 +47,9 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals('2', $posts[0]->comments_count);
-        $this->assertEquals('0', $posts[1]->comments_count);
-        $this->assertEquals('2', $posts[0]->getOriginal('comments_count'));
+        $this->assertSame('2', (string) $posts[0]->comments_count);
+        $this->assertSame('0', (string) $posts[1]->comments_count);
+        $this->assertSame('2', (string) $posts[0]->getOriginal('comments_count'));
     }
 
     public function testLoadCountWithSameModels()
@@ -61,9 +61,9 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals('2', $posts[0]->comments_count);
-        $this->assertEquals('0', $posts[1]->comments_count);
-        $this->assertEquals('2', $posts[2]->comments_count);
+        $this->assertSame('2', (string) $posts[0]->comments_count);
+        $this->assertSame('0', (string) $posts[1]->comments_count);
+        $this->assertSame('2', (string) $posts[2]->comments_count);
     }
 
     public function testLoadCountOnDeletedModels()
@@ -75,8 +75,8 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount('comments');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals('2', $posts[0]->comments_count);
-        $this->assertEquals('0', $posts[1]->comments_count);
+        $this->assertSame('2', (string) $posts[0]->comments_count);
+        $this->assertSame('0', (string) $posts[1]->comments_count);
     }
 
     public function testLoadCountWithArrayOfRelations()
@@ -88,10 +88,10 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $posts->loadCount(['comments', 'likes']);
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertEquals('2', $posts[0]->comments_count);
-        $this->assertEquals('1', $posts[0]->likes_count);
-        $this->assertEquals('0', $posts[1]->comments_count);
-        $this->assertEquals('0', $posts[1]->likes_count);
+        $this->assertSame('2', (string) $posts[0]->comments_count);
+        $this->assertSame('1', (string) $posts[0]->likes_count);
+        $this->assertSame('0', (string) $posts[1]->comments_count);
+        $this->assertSame('0', (string) $posts[1]->likes_count);
     }
 
     public function testLoadCountDoesNotOverrideAttributesWithDefaultValue()
@@ -102,7 +102,7 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         Collection::make([$post])->loadCount('comments');
 
         $this->assertSame(200, $post->some_default_value);
-        $this->assertEquals('2', $post->comments_count);
+        $this->assertSame('2', (string) $post->comments_count);
     }
 }
 

--- a/tests/Integration/Database/QueryingWithEnumsTest.php
+++ b/tests/Integration/Database/QueryingWithEnumsTest.php
@@ -38,7 +38,7 @@ class QueryingWithEnumsTest extends DatabaseTestCase
         $this->assertNotNull($record);
         $this->assertNotNull($record2);
         $this->assertNotNull($record3);
-        $this->assertEquals('pending', $record->string_status);
+        $this->assertSame('pending', $record->string_status);
         $this->assertEquals(1, $record2->integer_status);
     }
 
@@ -52,7 +52,7 @@ class QueryingWithEnumsTest extends DatabaseTestCase
         $record = DB::table('enum_casts')->where('string_status', StringStatus::pending)->first();
 
         $this->assertNotNull($record);
-        $this->assertEquals('pending', $record->string_status);
+        $this->assertSame('pending', $record->string_status);
         $this->assertEquals(1, $record->integer_status);
     }
 }

--- a/tests/Integration/Http/Middleware/HandleCorsTest.php
+++ b/tests/Integration/Http/Middleware/HandleCorsTest.php
@@ -47,7 +47,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
@@ -58,7 +58,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
@@ -71,7 +71,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('*', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('*', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
@@ -84,7 +84,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('http://test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('http://test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
@@ -97,7 +97,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('http://api.service.test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('http://api.service.test.laravel.com', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
@@ -120,7 +120,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(204, $crawler->getStatusCode());
     }
 
@@ -131,7 +131,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
     }
 
     public function testAllowMethodAllowed()
@@ -143,7 +143,7 @@ class HandleCorsTest extends TestCase
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Methods'));
         $this->assertEquals(200, $crawler->getStatusCode());
 
-        $this->assertEquals('PONG', $crawler->getContent());
+        $this->assertSame('PONG', $crawler->getContent());
     }
 
     public function testAllowMethodNotAllowed()
@@ -163,10 +163,10 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-1, x-custom-2',
         ]);
-        $this->assertEquals('x-custom-1, x-custom-2', $crawler->headers->get('Access-Control-Allow-Headers'));
+        $this->assertSame('x-custom-1, x-custom-2', $crawler->headers->get('Access-Control-Allow-Headers'));
         $this->assertEquals(204, $crawler->getStatusCode());
 
-        $this->assertEquals('', $crawler->getContent());
+        $this->assertSame('', $crawler->getContent());
     }
 
     public function testAllowHeaderAllowedWildcardOptions()
@@ -178,10 +178,10 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
-        $this->assertEquals('x-custom-3', $crawler->headers->get('Access-Control-Allow-Headers'));
+        $this->assertSame('x-custom-3', $crawler->headers->get('Access-Control-Allow-Headers'));
         $this->assertEquals(204, $crawler->getStatusCode());
 
-        $this->assertEquals('', $crawler->getContent());
+        $this->assertSame('', $crawler->getContent());
     }
 
     public function testAllowHeaderNotAllowedOptions()
@@ -191,7 +191,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
             'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-custom-3',
         ]);
-        $this->assertEquals('x-custom-1, x-custom-2', $crawler->headers->get('Access-Control-Allow-Headers'));
+        $this->assertSame('x-custom-1, x-custom-2', $crawler->headers->get('Access-Control-Allow-Headers'));
     }
 
     public function testAllowHeaderAllowed()
@@ -203,7 +203,7 @@ class HandleCorsTest extends TestCase
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
         $this->assertEquals(200, $crawler->getStatusCode());
 
-        $this->assertEquals('PONG', $crawler->getContent());
+        $this->assertSame('PONG', $crawler->getContent());
     }
 
     public function testAllowHeaderAllowedWildcard()
@@ -217,7 +217,7 @@ class HandleCorsTest extends TestCase
         $this->assertEquals(null, $crawler->headers->get('Access-Control-Allow-Headers'));
         $this->assertEquals(200, $crawler->getStatusCode());
 
-        $this->assertEquals('PONG', $crawler->getContent());
+        $this->assertSame('PONG', $crawler->getContent());
     }
 
     public function testAllowHeaderNotAllowed()
@@ -237,7 +237,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
 
-        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(500, $crawler->getStatusCode());
     }
 
@@ -247,7 +247,7 @@ class HandleCorsTest extends TestCase
             'HTTP_ORIGIN' => 'http://localhost',
             'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
         ]);
-        $this->assertEquals('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('http://localhost', $crawler->headers->get('Access-Control-Allow-Origin'));
         $this->assertEquals(302, $crawler->getStatusCode());
     }
 

--- a/tests/Integration/Support/MultipleInstanceManagerTest.php
+++ b/tests/Integration/Support/MultipleInstanceManagerTest.php
@@ -12,10 +12,10 @@ class MultipleInstanceManagerTest extends TestCase
         $manager = new MultipleInstanceManager($this->app);
 
         $fooInstance = $manager->instance('foo');
-        $this->assertEquals('option-value', $fooInstance->config['foo-option']);
+        $this->assertSame('option-value', $fooInstance->config['foo-option']);
 
         $barInstance = $manager->instance('bar');
-        $this->assertEquals('option-value', $barInstance->config['bar-option']);
+        $this->assertSame('option-value', $barInstance->config['bar-option']);
 
         $duplicateFooInstance = $manager->instance('foo');
         $duplicateBarInstance = $manager->instance('bar');

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -75,7 +75,7 @@ class MailMessageTest extends TestCase
     public function testSubjectMethod()
     {
         $this->assertInstanceOf(Message::class, $message = $this->message->subject('foo'));
-        $this->assertEquals('foo', $message->getSymfonyMessage()->getSubject());
+        $this->assertSame('foo', $message->getSymfonyMessage()->getSubject());
     }
 
     public function testPriorityMethod()
@@ -95,6 +95,6 @@ class MailMessageTest extends TestCase
         $message = new Message(new Email());
         $message->attachData('foo', 'foo.jpg', ['mime' => 'image/jpeg']);
 
-        $this->assertEquals('foo', $message->getSymfonyMessage()->getAttachments()[0]->getBody());
+        $this->assertSame('foo', $message->getSymfonyMessage()->getAttachments()[0]->getBody());
     }
 }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -74,7 +74,7 @@ class QueueSyncQueueTest extends TestCase
         try {
             $sync->push(new SyncQueueJob());
         } catch (LogicException $e) {
-            $this->assertEquals('extraValue', $e->getMessage());
+            $this->assertSame('extraValue', $e->getMessage());
         }
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -549,7 +549,7 @@ class RoutingRouteTest extends TestCase
         $route->bind($request1);
         $this->assertTrue($route->hasParameter('id'));
         $this->assertFalse($route->hasParameter('foo'));
-        $this->assertSame('1', $route->parameter('id'));
+        $this->assertSame('1', (string) $route->parameter('id'));
         $this->assertSame('png', $route->parameter('ext'));
 
         $request2 = Request::create('images/12.png', 'GET');
@@ -857,7 +857,7 @@ class RoutingRouteTest extends TestCase
         $request1 = Request::create('images/1.png', 'GET');
         $this->assertTrue($route->matches($request1));
         $route->bind($request1);
-        $this->assertSame('1', $route->parameter('id'));
+        $this->assertSame('1', (string) $route->parameter('id'));
         $this->assertSame('png', $route->parameter('ext'));
 
         $request2 = Request::create('images/12.png', 'GET');

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -861,7 +861,7 @@ class SupportArrTest extends TestCase
             'mt-4',
         ]);
 
-        $this->assertEquals('font-bold mt-4', $classes);
+        $this->assertSame('font-bold mt-4', $classes);
 
         $classes = Arr::toCssClasses([
             'font-bold',
@@ -870,7 +870,7 @@ class SupportArrTest extends TestCase
             'mr-2' => false,
         ]);
 
-        $this->assertEquals('font-bold mt-4 ml-2', $classes);
+        $this->assertSame('font-bold mt-4 ml-2', $classes);
     }
 
     public function testWhere()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2152,31 +2152,31 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
 
-        $this->assertEquals('taylor', $data->getOrPut('name', null));
-        $this->assertEquals('foo', $data->getOrPut('email', null));
-        $this->assertEquals('male', $data->getOrPut('gender', 'male'));
+        $this->assertSame('taylor', $data->getOrPut('name', null));
+        $this->assertSame('foo', $data->getOrPut('email', null));
+        $this->assertSame('male', $data->getOrPut('gender', 'male'));
 
-        $this->assertEquals('taylor', $data->get('name'));
-        $this->assertEquals('foo', $data->get('email'));
-        $this->assertEquals('male', $data->get('gender'));
+        $this->assertSame('taylor', $data->get('name'));
+        $this->assertSame('foo', $data->get('email'));
+        $this->assertSame('male', $data->get('gender'));
 
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
 
-        $this->assertEquals('taylor', $data->getOrPut('name', function () {
+        $this->assertSame('taylor', $data->getOrPut('name', function () {
             return null;
         }));
 
-        $this->assertEquals('foo', $data->getOrPut('email', function () {
+        $this->assertSame('foo', $data->getOrPut('email', function () {
             return null;
         }));
 
-        $this->assertEquals('male', $data->getOrPut('gender', function () {
+        $this->assertSame('male', $data->getOrPut('gender', function () {
             return 'male';
         }));
 
-        $this->assertEquals('taylor', $data->get('name'));
-        $this->assertEquals('foo', $data->get('email'));
-        $this->assertEquals('male', $data->get('gender'));
+        $this->assertSame('taylor', $data->get('name'));
+        $this->assertSame('foo', $data->get('email'));
+        $this->assertSame('male', $data->get('gender'));
     }
 
     public function testPut()

--- a/tests/Support/SupportJsTest.php
+++ b/tests/Support/SupportJsTest.php
@@ -12,10 +12,10 @@ class SupportJsTest extends TestCase
 {
     public function testScalars()
     {
-        $this->assertEquals('false', (string) Js::from(false));
-        $this->assertEquals('true', (string) Js::from(true));
-        $this->assertEquals('1', (string) Js::from(1));
-        $this->assertEquals('1.1', (string) Js::from(1.1));
+        $this->assertSame('false', (string) Js::from(false));
+        $this->assertSame('true', (string) Js::from(true));
+        $this->assertSame('1', (string) Js::from(1));
+        $this->assertSame('1.1', (string) Js::from(1.1));
         $this->assertEquals(
             "'\\u003Cdiv class=\\u0022foo\\u0022\\u003E\\u0027quoted html\\u0027\\u003C\\/div\\u003E'",
             (string) Js::from('<div class="foo">\'quoted html\'</div>')

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -910,23 +910,23 @@ class SupportStringableTest extends TestCase
 
     public function testMask()
     {
-        $this->assertEquals('tay*************', $this->stringable('taylor@email.com')->mask('*', 3));
-        $this->assertEquals('******@email.com', $this->stringable('taylor@email.com')->mask('*', 0, 6));
-        $this->assertEquals('tay*************', $this->stringable('taylor@email.com')->mask('*', -13));
-        $this->assertEquals('tay***@email.com', $this->stringable('taylor@email.com')->mask('*', -13, 3));
+        $this->assertSame('tay*************', (string) $this->stringable('taylor@email.com')->mask('*', 3));
+        $this->assertSame('******@email.com', (string) $this->stringable('taylor@email.com')->mask('*', 0, 6));
+        $this->assertSame('tay*************', (string) $this->stringable('taylor@email.com')->mask('*', -13));
+        $this->assertSame('tay***@email.com', (string) $this->stringable('taylor@email.com')->mask('*', -13, 3));
 
-        $this->assertEquals('****************', $this->stringable('taylor@email.com')->mask('*', -17));
-        $this->assertEquals('*****r@email.com', $this->stringable('taylor@email.com')->mask('*', -99, 5));
+        $this->assertSame('****************', (string) $this->stringable('taylor@email.com')->mask('*', -17));
+        $this->assertSame('*****r@email.com', (string) $this->stringable('taylor@email.com')->mask('*', -99, 5));
 
-        $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->mask('*', 16));
-        $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->mask('*', 16, 99));
+        $this->assertSame('taylor@email.com', (string) $this->stringable('taylor@email.com')->mask('*', 16));
+        $this->assertSame('taylor@email.com', (string) $this->stringable('taylor@email.com')->mask('*', 16, 99));
 
-        $this->assertEquals('taylor@email.com', $this->stringable('taylor@email.com')->mask('', 3));
+        $this->assertSame('taylor@email.com', (string) $this->stringable('taylor@email.com')->mask('', 3));
 
-        $this->assertEquals('taysssssssssssss', $this->stringable('taylor@email.com')->mask('something', 3));
+        $this->assertSame('taysssssssssssss', (string) $this->stringable('taylor@email.com')->mask('something', 3));
 
-        $this->assertEquals('这是一***', $this->stringable('这是一段中文')->mask('*', 3));
-        $this->assertEquals('**一段中文', $this->stringable('这是一段中文')->mask('*', 0, 2));
+        $this->assertSame('这是一***', (string) $this->stringable('这是一段中文')->mask('*', 3));
+        $this->assertSame('**一段中文', (string) $this->stringable('这是一段中文')->mask('*', 0, 2));
     }
 
     public function testRepeat()

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -11,8 +11,8 @@ class ValidatedInputTest extends TestCase
     {
         $input = new ValidatedInput(['name' => 'Taylor', 'votes' => 100]);
 
-        $this->assertEquals('Taylor', $input->name);
-        $this->assertEquals('Taylor', $input['name']);
+        $this->assertSame('Taylor', $input->name);
+        $this->assertSame('Taylor', $input['name']);
         $this->assertEquals(['name' => 'Taylor'], $input->only(['name']));
         $this->assertEquals(['name' => 'Taylor'], $input->except(['votes']));
         $this->assertEquals(['name' => 'Taylor', 'votes' => 100], $input->all());
@@ -24,8 +24,8 @@ class ValidatedInputTest extends TestCase
 
         $input = $input->merge(['votes' => 100]);
 
-        $this->assertEquals('Taylor', $input->name);
-        $this->assertEquals('Taylor', $input['name']);
+        $this->assertSame('Taylor', $input->name);
+        $this->assertSame('Taylor', $input['name']);
         $this->assertEquals(['name' => 'Taylor'], $input->only(['name']));
         $this->assertEquals(['name' => 'Taylor'], $input->except(['votes']));
         $this->assertEquals(['name' => 'Taylor', 'votes' => 100], $input->all());

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -36,7 +36,7 @@ class ParallelTestingTest extends TestCase
                 $this->assertNull($testCase);
             }
 
-            $this->assertSame('1', $token);
+            $this->assertSame('1', (string) $token);
             $state = true;
         });
 
@@ -83,7 +83,7 @@ class ParallelTestingTest extends TestCase
             return '1';
         });
 
-        $this->assertSame('1', $parallelTesting->token());
+        $this->assertSame('1', (string) $parallelTesting->token());
     }
 
     public function callbacks()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1627,8 +1627,8 @@ class TestResponseTest extends TestCase
         $cookie = $response->getCookie('cookie-name', false);
 
         $this->assertInstanceOf(Cookie::class, $cookie);
-        $this->assertEquals('cookie-name', $cookie->getName());
-        $this->assertEquals('cookie-value', $cookie->getValue());
+        $this->assertSame('cookie-name', $cookie->getName());
+        $this->assertSame('cookie-value', $cookie->getValue());
     }
 
     public function testGetEncryptedCookie()

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -14,21 +14,21 @@ class ValidationExceptionTest extends TestCase
     {
         $exception = $this->getException([], []);
 
-        $this->assertEquals('The given data was invalid.', $exception->getMessage());
+        $this->assertSame('The given data was invalid.', $exception->getMessage());
     }
 
     public function testExceptionSummarizesOneError()
     {
         $exception = $this->getException([], ['foo' => 'required']);
 
-        $this->assertEquals('validation.required', $exception->getMessage());
+        $this->assertSame('validation.required', $exception->getMessage());
     }
 
     public function testExceptionSummarizesTwoErrors()
     {
         $exception = $this->getException([], ['foo' => 'required', 'bar' => 'required']);
 
-        $this->assertEquals('validation.required (and 1 more error)', $exception->getMessage());
+        $this->assertSame('validation.required (and 1 more error)', $exception->getMessage());
     }
 
     public function testExceptionSummarizesThreeOrMoreErrors()
@@ -39,7 +39,7 @@ class ValidationExceptionTest extends TestCase
             'baz' => 'required',
         ]);
 
-        $this->assertEquals('validation.required (and 2 more errors)', $exception->getMessage());
+        $this->assertSame('validation.required (and 2 more errors)', $exception->getMessage());
     }
 
     protected function getException($data = [], $rules = [])

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -97,7 +97,7 @@ class ValidationRuleParserTest extends TestCase
             ['items.*.type' => 'regex:/^(foo|bar)$/i']
         );
 
-        $this->assertEquals('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][0]);
+        $this->assertSame('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][0]);
     }
 
     public function testExplodeProperlyParsesRegexWithArrayOfRules()
@@ -108,8 +108,8 @@ class ValidationRuleParserTest extends TestCase
             ['items.*.type' => ['in:foo', 'regex:/^(foo|bar)$/i']]
         );
 
-        $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
-        $this->assertEquals('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][1]);
+        $this->assertSame('in:foo', $exploded->rules['items.0.type'][0]);
+        $this->assertSame('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][1]);
     }
 
     public function testExplodeProperlyParsesRegexThatDoesNotContainPipe()
@@ -120,8 +120,8 @@ class ValidationRuleParserTest extends TestCase
             ['items.*.type' => 'in:foo|regex:/^(bar)$/i']
         );
 
-        $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
-        $this->assertEquals('regex:/^(bar)$/i', $exploded->rules['items.0.type'][1]);
+        $this->assertSame('in:foo', $exploded->rules['items.0.type'][0]);
+        $this->assertSame('regex:/^(bar)$/i', $exploded->rules['items.0.type'][1]);
     }
 
     public function testExplodeFailsParsingRegexWithOtherRulesInSingleString()
@@ -132,9 +132,9 @@ class ValidationRuleParserTest extends TestCase
             ['items.*.type' => 'in:foo|regex:/^(foo|bar)$/i']
         );
 
-        $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
-        $this->assertEquals('regex:/^(foo', $exploded->rules['items.0.type'][1]);
-        $this->assertEquals('bar)$/i', $exploded->rules['items.0.type'][2]);
+        $this->assertSame('in:foo', $exploded->rules['items.0.type'][0]);
+        $this->assertSame('regex:/^(foo', $exploded->rules['items.0.type'][1]);
+        $this->assertSame('bar)$/i', $exploded->rules['items.0.type'][2]);
     }
 
     public function testExplodeProperlyFlattensRuleArraysOfArrays()
@@ -145,8 +145,8 @@ class ValidationRuleParserTest extends TestCase
             ['items.*.type' => ['in:foo', [[['regex:/^(foo|bar)$/i']]]]]
         );
 
-        $this->assertEquals('in:foo', $exploded->rules['items.0.type'][0]);
-        $this->assertEquals('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][1]);
+        $this->assertSame('in:foo', $exploded->rules['items.0.type'][0]);
+        $this->assertSame('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][1]);
     }
 
     public function testExplodeGeneratesNestedRules()
@@ -159,8 +159,8 @@ class ValidationRuleParserTest extends TestCase
 
         $results = $parser->explode([
             'users.*.name' => Rule::forEach(function ($value, $attribute, $data) {
-                $this->assertEquals('Taylor Otwell', $value);
-                $this->assertEquals('users.0.name', $attribute);
+                $this->assertSame('Taylor Otwell', $value);
+                $this->assertSame('users.0.name', $attribute);
                 $this->assertEquals($data['users.0.name'], 'Taylor Otwell');
 
                 return [Rule::requiredIf(true)];
@@ -179,8 +179,8 @@ class ValidationRuleParserTest extends TestCase
 
         $results = $parser->explode([
             'name' => Rule::forEach(function ($value, $attribute, $data = null) {
-                $this->assertEquals('Taylor Otwell', $value);
-                $this->assertEquals('name', $attribute);
+                $this->assertSame('Taylor Otwell', $value);
+                $this->assertSame('name', $attribute);
                 $this->assertEquals(['name' => 'Taylor Otwell'], $data);
 
                 return 'required';
@@ -249,18 +249,18 @@ class ValidationRuleParserTest extends TestCase
         $results = $parser->explode([
             'users.*.name' => [
                 Rule::forEach(function ($value, $attribute, $data) {
-                    $this->assertEquals('Taylor Otwell', $value);
-                    $this->assertEquals('users.0.name', $attribute);
+                    $this->assertSame('Taylor Otwell', $value);
+                    $this->assertSame('users.0.name', $attribute);
                     $this->assertEquals(['users.0.name' => 'Taylor Otwell'], $data);
 
                     return Rule::forEach(function ($value, $attribute, $data) {
                         $this->assertNull($value);
-                        $this->assertEquals('users.0.name', $attribute);
+                        $this->assertSame('users.0.name', $attribute);
                         $this->assertEquals(['users.0.name' => 'Taylor Otwell'], $data);
 
                         return Rule::forEach(function ($value, $attribute, $data) {
                             $this->assertNull($value);
-                            $this->assertEquals('users.0.name', $attribute);
+                            $this->assertSame('users.0.name', $attribute);
                             $this->assertEquals(['users.0.name' => 'Taylor Otwell'], $data);
 
                             return [Rule::requiredIf(true)];


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR enforces stricter string assertions with `assertSame`.
