### PR TITLE
[9.x] Assert response with any validation errors

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -847,6 +847,10 @@ EOF;
      */
     public function assertJsonValidationErrors($errors, $responseKey = 'errors')
     {
+        if (is_null($errors)) {
+            return $this->assertStatus(422);
+        }
+
         $errors = Arr::wrap($errors);
 
         PHPUnit::assertNotEmpty($errors, 'No validation errors were provided.');
@@ -1160,6 +1164,10 @@ EOF;
                                   $errorBag = 'default',
                                   $responseKey = 'errors')
     {
+        if (is_null($errors)) {
+            return $this->assertStatus(422);
+        }
+
         if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
             return $this->assertJsonValidationErrors($errors, $responseKey);
         }


### PR DESCRIPTION
Example:
```php
public function testStore()
{
     $response = $this->postJson($this->url);

     $response->assertInvalid();
}
```