### PR TITLE
[9.x] Enforce Mockery m aliasing consistency

### DIFF
--- a/tests/Database/DatabaseEloquentCollectionQueueableTest.php
+++ b/tests/Database/DatabaseEloquentCollectionQueueableTest.php
@@ -5,19 +5,19 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentCollectionQueueableTest extends TestCase
 {
     protected function tearDown(): void
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testSerializesPivotsEntitiesId()
     {
-        $spy = Mockery::spy(Pivot::class);
+        $spy = m::spy(Pivot::class);
 
         $c = new Collection([$spy]);
 
@@ -30,7 +30,7 @@ class DatabaseEloquentCollectionQueueableTest extends TestCase
 
     public function testSerializesModelEntitiesById()
     {
-        $spy = Mockery::spy(Model::class);
+        $spy = m::spy(Model::class);
 
         $c = new Collection([$spy]);
 
@@ -49,7 +49,7 @@ class DatabaseEloquentCollectionQueueableTest extends TestCase
         // When the ID of a Model is binary instead of int or string, the Collection
         // serialization + JSON encoding breaks because of UTF-8 issues. Encoding
         // of a QueueableCollection must favor QueueableEntity::queueableId().
-        $mock = Mockery::mock(Model::class, [
+        $mock = m::mock(Model::class, [
             'getKey' => random_bytes(10),
             'getQueueableId' => 'mocked',
         ]);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentFactoryTest extends TestCase
@@ -24,7 +24,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $container->singleton(Generator::class, function ($app, $parameters) {
             return \Faker\Factory::create('en_US');
         });
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
 
         $db = new DB;
@@ -89,7 +89,7 @@ class DatabaseEloquentFactoryTest extends TestCase
      */
     protected function tearDown(): void
     {
-        Mockery::close();
+        m::close();
 
         $this->schema()->drop('users');
 
@@ -472,7 +472,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_resolve_nested_model_name_from_factory()
     {
-        Container::getInstance()->instance(Application::class, $app = Mockery::mock(Application::class));
+        Container::getInstance()->instance(Application::class, $app = m::mock(Application::class));
         $app->shouldReceive('getNamespace')->andReturn('Illuminate\\Tests\\Database\\Fixtures\\');
 
         Factory::useNamespace('Illuminate\\Tests\\Database\\Fixtures\\Factories\\');
@@ -484,7 +484,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_resolve_non_app_nested_model_factories()
     {
-        Container::getInstance()->instance(Application::class, $app = Mockery::mock(Application::class));
+        Container::getInstance()->instance(Application::class, $app = m::mock(Application::class));
         $app->shouldReceive('getNamespace')->andReturn('Foo\\');
 
         Factory::useNamespace('Factories\\');

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
@@ -212,7 +212,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
             public function newModelQuery()
             {
-                return Mockery::spy(parent::newModelQuery(), function (Mockery\MockInterface $mock) {
+                return m::spy(parent::newModelQuery(), function (Mockery\MockInterface $mock) {
                     $mock->shouldReceive('forceDelete')->andThrow(new Exception());
                 });
             }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -13,6 +13,7 @@ use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
@@ -212,7 +213,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
             public function newModelQuery()
             {
-                return m::spy(parent::newModelQuery(), function (Mockery\MockInterface $mock) {
+                return m::spy(parent::newModelQuery(), function (MockInterface $mock) {
                     $mock->shouldReceive('forceDelete')->andThrow(new Exception());
                 });
             }

--- a/tests/Foundation/Testing/DatabaseMigrationsTest.php
+++ b/tests/Foundation/Testing/DatabaseMigrationsTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Foundation\Testing;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabaseState;
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -22,7 +22,7 @@ class DatabaseMigrationsTest extends TestCase
             'beforeApplicationDestroyed',
         ]);
 
-        $kernelObj = Mockery::mock();
+        $kernelObj = m::mock();
         $kernelObj->shouldReceive('setArtisan')
             ->with(null);
 

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Foundation\Testing;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\RefreshDatabaseState;
-use Mockery;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -22,7 +22,7 @@ class RefreshDatabaseTest extends TestCase
             'beginDatabaseTransaction',
         ]);
 
-        $kernelObj = Mockery::mock();
+        $kernelObj = m::mock();
         $kernelObj->shouldReceive('setArtisan')
             ->with(null);
 

--- a/tests/Integration/Cookie/CookieTest.php
+++ b/tests/Integration/Cookie/CookieTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
-use Mockery;
+use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
 class CookieTest extends TestCase
@@ -45,7 +45,7 @@ class CookieTest extends TestCase
     {
         $app->instance(
             ExceptionHandler::class,
-            $handler = Mockery::mock(ExceptionHandler::class)->shouldIgnoreMissing()
+            $handler = m::mock(ExceptionHandler::class)->shouldIgnoreMissing()
         );
 
         $handler->shouldReceive('render')->andReturn(new Response);

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -38,7 +38,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\ResourceWithPreservedKeys;
 use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Subscription;
 use LogicException;
-use Mockery;
+use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
 class ResourceTest extends TestCase
@@ -1156,7 +1156,7 @@ class ResourceTest extends TestCase
     {
         $this->expectException(PostTooLargeException::class);
 
-        $request = Mockery::mock(Request::class, ['server' => ['CONTENT_LENGTH' => '2147483640']]);
+        $request = m::mock(Request::class, ['server' => ['CONTENT_LENGTH' => '2147483640']]);
         $post = new ValidatePostSize;
         $post->handle($request, function () {
         });

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Migration;
 
 use Illuminate\Support\Facades\DB;
-use Mockery;
+use Mockery as m;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -18,7 +18,7 @@ class MigratorTest extends TestCase
     {
         parent::setUp();
 
-        $this->output = Mockery::mock(OutputInterface::class);
+        $this->output = m::mock(OutputInterface::class);
         $this->subject = $this->app->make('migrator');
         $this->subject->setOutput($this->output);
         $this->subject->getRepository()->createRepository();
@@ -27,11 +27,11 @@ class MigratorTest extends TestCase
     public function testMigrate()
     {
         $this->expectOutput('<comment>Migrating:</comment> 2014_10_12_000000_create_people_table');
-        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2014_10_12_000000_create_people_table (.*)#'));
+        $this->expectOutput(m::pattern('#<info>Migrated:</info>  2014_10_12_000000_create_people_table (.*)#'));
         $this->expectOutput('<comment>Migrating:</comment> 2015_10_04_000000_modify_people_table');
-        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2015_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput(m::pattern('#<info>Migrated:</info>  2015_10_04_000000_modify_people_table (.*)#'));
         $this->expectOutput('<comment>Migrating:</comment> 2016_10_04_000000_modify_people_table');
-        $this->expectOutput(Mockery::pattern('#<info>Migrated:</info>  2016_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput(m::pattern('#<info>Migrated:</info>  2016_10_04_000000_modify_people_table (.*)#'));
 
         $this->subject->run([__DIR__.'/fixtures']);
 
@@ -48,11 +48,11 @@ class MigratorTest extends TestCase
         $this->subject->getRepository()->log('2016_10_04_000000_modify_people_table', 1);
 
         $this->expectOutput('<comment>Rolling back:</comment> 2016_10_04_000000_modify_people_table');
-        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2016_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput(m::pattern('#<info>Rolled back:</info>  2016_10_04_000000_modify_people_table (.*)#'));
         $this->expectOutput('<comment>Rolling back:</comment> 2015_10_04_000000_modify_people_table');
-        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2015_10_04_000000_modify_people_table (.*)#'));
+        $this->expectOutput(m::pattern('#<info>Rolled back:</info>  2015_10_04_000000_modify_people_table (.*)#'));
         $this->expectOutput('<comment>Rolling back:</comment> 2014_10_12_000000_create_people_table');
-        $this->expectOutput(Mockery::pattern('#<info>Rolled back:</info>  2014_10_12_000000_create_people_table (.*)#'));
+        $this->expectOutput(m::pattern('#<info>Rolled back:</info>  2014_10_12_000000_create_people_table (.*)#'));
 
         $this->subject->rollback([__DIR__.'/fixtures']);
 

--- a/tests/Integration/Session/SessionPersistenceTest.php
+++ b/tests/Integration/Session/SessionPersistenceTest.php
@@ -9,7 +9,7 @@ use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
-use Mockery;
+use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
 class SessionPersistenceTest extends TestCase
@@ -35,7 +35,7 @@ class SessionPersistenceTest extends TestCase
     {
         $app->instance(
             ExceptionHandler::class,
-            $handler = Mockery::mock(ExceptionHandler::class)->shouldIgnoreMissing()
+            $handler = m::mock(ExceptionHandler::class)->shouldIgnoreMissing()
         );
 
         $handler->shouldReceive('render')->andReturn(new Response);

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Testing;
 
 use Illuminate\Support\Facades\Artisan;
-use Mockery;
+use Mockery as m;
 use Mockery\Exception\InvalidCountException;
 use Mockery\Exception\InvalidOrderException;
 use Orchestra\Testbench\TestCase;
@@ -146,7 +146,7 @@ class ArtisanCommandTest extends TestCase
             $callback();
         } finally {
             try {
-                Mockery::close();
+                m::close();
             } catch (InvalidCountException $e) {
                 // Ignore mock exception from PendingCommand::expectsOutput().
             }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -11,13 +11,13 @@ use Illuminate\View\Compilers\ComponentTagCompiler;
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
 use InvalidArgumentException;
-use Mockery;
+use Mockery as m;
 
 class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 {
     protected function tearDown(): void
     {
-        Mockery::close();
+        m::close();
     }
 
     public function testSlotsCanBeCompiled()
@@ -180,7 +180,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testClassNamesCanBeGuessed()
     {
         $container = new Container;
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
         Container::setInstance($container);
 
@@ -194,7 +194,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testClassNamesCanBeGuessedWithNamespaces()
     {
         $container = new Container;
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
         Container::setInstance($container);
 
@@ -308,8 +308,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testClasslessComponents()
     {
         $container = new Container;
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
-        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
         $factory->shouldReceive('exists')->andReturn(true);
         Container::setInstance($container);
@@ -327,8 +327,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testClasslessComponentsWithIndexView()
     {
         $container = new Container;
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
-        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
         $factory->shouldReceive('exists')->andReturn(false, true);
         Container::setInstance($container);
@@ -346,8 +346,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testPackagesClasslessComponents()
     {
         $container = new Container;
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
-        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
         $factory->shouldReceive('exists')->andReturn(true);
         Container::setInstance($container);
@@ -384,8 +384,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testItThrowsAnExceptionForNonExistingAliases()
     {
         $container = new Container;
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
-        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
         $factory->shouldReceive('exists')->andReturn(false);
         Container::setInstance($container);
@@ -398,8 +398,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testItThrowsAnExceptionForNonExistingClass()
     {
         $container = new Container;
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
-        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
         $factory->shouldReceive('exists')->andReturn(false);
         Container::setInstance($container);
@@ -412,22 +412,22 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     public function testAttributesTreatedAsPropsAreRemovedFromFinalAttributes()
     {
         $container = new Container;
-        $container->instance(Application::class, $app = Mockery::mock(Application::class));
-        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
         $app->shouldReceive('getNamespace')->andReturn('App\\');
         $factory->shouldReceive('exists')->andReturn(false);
         Container::setInstance($container);
 
         $attributes = new ComponentAttributeBag(['userId' => 'bar', 'other' => 'ok']);
 
-        $component = Mockery::mock(\Illuminate\View\Component::class);
+        $component = m::mock(\Illuminate\View\Component::class);
         $component->shouldReceive('withName', 'test');
         $component->shouldReceive('shouldRender')->andReturn(true);
         $component->shouldReceive('resolveView')->andReturn('');
         $component->shouldReceive('data')->andReturn([]);
         $component->shouldReceive('withAttributes');
 
-        $__env = Mockery::mock(\Illuminate\View\Factory::class);
+        $__env = m::mock(\Illuminate\View\Factory::class);
         $__env->shouldReceive('getContainer->make')->with(TestProfileComponent::class, ['userId' => 'bar', 'other' => 'ok'])->andReturn($component);
         $__env->shouldReceive('startComponent');
         $__env->shouldReceive('renderComponent');
@@ -446,7 +446,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     protected function mockViewFactory($existsSucceeds = true)
     {
         $container = new Container;
-        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
         $factory->shouldReceive('exists')->andReturn($existsSucceeds);
         Container::setInstance($container);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR enforces `Mockery` `m` aliasing consistency.