### PR TITLE
[9.x] Fix route:list command output

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -303,7 +303,7 @@ class RouteListCommand extends Command
             fn ($route) => array_merge($route, [
                 'action' => $this->formatActionForCli($route),
                 'method' => $route['method'] == 'GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS' ? 'ANY' : $route['method'],
-                'uri' => $route['domain'] ? ($route['domain'].'/'.$route['uri']) : $route['uri'],
+                'uri' => $route['domain'] ? ($route['domain'].'/'.ltrim($route['uri'], '/')) : $route['uri'],
             ]),
         );
 

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -35,6 +35,10 @@ class RouteListCommandTest extends TestCase
 
     public function testDisplayRoutesForCli()
     {
+        $this->router->get('/', function () {
+            //
+        });
+
         $this->router->get('closure', function () {
             return new RedirectResponse($this->urlGenerator->signedRoute('signed-route'));
         });
@@ -42,6 +46,10 @@ class RouteListCommandTest extends TestCase
         $this->router->get('controller-method/{user}', [FooController::class, 'show']);
         $this->router->post('controller-invokable', FooController::class);
         $this->router->domain('{account}.example.com')->group(function () {
+            $this->router->get('/', function () {
+                //
+            });
+
             $this->router->get('user/{id}', function ($account, $id) {
                 //
             })->name('user.show')->middleware('web');
@@ -50,6 +58,8 @@ class RouteListCommandTest extends TestCase
         $this->artisan(RouteListCommand::class)
             ->assertSuccessful()
             ->expectsOutput('')
+            ->expectsOutput('  GET|HEAD   / ..................................................... ')
+            ->expectsOutput('  GET|HEAD   {account}.example.com/ ................................ ')
             ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\Tests\Testing\Console\…')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\Tests\Testing\Cons…')


### PR DESCRIPTION
In that case, if we have a route with a `/` path in a subdomain group, the `route:list` command shows the endpoint with two slashes at the end (`{domain}.example.com//`).

This PR fixes this issue also I've added some tests to make sure it works as it should.