### PR TITLE
[9.x] Fix setUp and tearDown method visibility and casing.

### DIFF
--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -171,7 +171,7 @@ EOF, str_replace("\r", '', $output->fetch()));
         return $output;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -10,7 +10,7 @@ class CanConfigureMigrationCommandsTest extends TestCase
 {
     protected $traitObject;
 
-    protected function setup(): void
+    protected function setUp(): void
     {
         $this->traitObject = $this->getObjectForTrait(CanConfigureMigrationCommands::class);
     }

--- a/tests/Integration/Database/EloquentMassPrunableTest.php
+++ b/tests/Integration/Database/EloquentMassPrunableTest.php
@@ -94,7 +94,7 @@ class EloquentMassPrunableTest extends DatabaseTestCase
         $this->assertEquals(2000, MassPrunableSoftDeleteTestModel::withTrashed()->count());
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Testing/AssertRedirectToSignedRouteTest.php
+++ b/tests/Testing/AssertRedirectToSignedRouteTest.php
@@ -90,7 +90,7 @@ class AssertRedirectToSignedRouteTest extends TestCase
             ->assertRedirectToSignedRoute('signed-route');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
+++ b/tests/Testing/Concerns/InteractsWithDeprecationHandlingTest.php
@@ -14,7 +14,7 @@ class InteractsWithDeprecationHandlingTest extends TestCase
 
     protected $deprecationsFound = false;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -42,7 +42,7 @@ class InteractsWithDeprecationHandlingTest extends TestCase
         trigger_error('Something is deprecated', E_USER_DEPRECATED);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         set_error_handler($this->original);
 

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -97,7 +97,7 @@ class TestDatabasesTest extends TestCase
         ];
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -82,7 +82,7 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -97,7 +97,7 @@ class ParallelTestingTest extends TestCase
         ];
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fix `setUp` and `tearDown` method visibility and casing.
