### PR TITLE
[9.x] Include missing PHPDoc signature for includeUnvalidatedArrayKeys()

### DIFF
--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Contracts\Validation\Validator make(array $data, array $rules, array $messages = [], array $customAttributes = [])
+ * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
  * @method static void extend(string $rule, \Closure|string $extension, string $message = null)
  * @method static void extendImplicit(string $rule, \Closure|string $extension, string $message = null)


### PR DESCRIPTION
Laravel 9 includes the option to `includeUnvalidatedArrayKeys` to opt-in to previous Laravel 8 behaviour with regards to [unvalidated array keys](https://laravel.com/docs/9.x/upgrade#unvalidated-array-keys) validation.

When adding this on within the boot method of one of the service providers I noticed it was undocumented in the Laravel Validator Facade.

I'm requesting to add the declaration to the signature for transparency.