### PR TITLE
[9.x] Refactor paginators

### DIFF
--- a/src/Illuminate/Pagination/AbstractBasePaginator.php
+++ b/src/Illuminate/Pagination/AbstractBasePaginator.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+use ArrayAccess;
+use Countable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\Traits\Tappable;
+use IteratorAggregate;
+use JsonSerializable;
+use Traversable;
+
+/**
+ * @mixin \Illuminate\Support\Collection
+ */
+abstract class AbstractBasePaginator implements ArrayAccess, Arrayable, Countable, Htmlable, IteratorAggregate, Jsonable, JsonSerializable
+{
+    use ForwardsCalls, Tappable;
+
+    /**
+     * All of the items being paginated.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $items;
+
+    /**
+     * The paginator options.
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * Render the paginator using the given view.
+     *
+     * @param  string|null  $view
+     * @param  array  $data
+     * @return \Illuminate\Contracts\Support\Htmlable
+     */
+    abstract public function render($view = null, $data = []);
+
+    /**
+     * Get the paginator's underlying collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getCollection()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Set the paginator's underlying collection.
+     *
+     * @param  \Illuminate\Support\Collection  $collection
+     * @return $this
+     */
+    public function setCollection(Collection $collection)
+    {
+        $this->items = $collection;
+
+        return $this;
+    }
+
+    /**
+     * Get the paginator options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Get an iterator for the items.
+     *
+     * @return \ArrayIterator
+     */
+    public function getIterator(): Traversable
+    {
+        return $this->items->getIterator();
+    }
+
+    /**
+     * Determine if the list of items is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return $this->items->isEmpty();
+    }
+
+    /**
+     * Determine if the list of items is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return $this->items->isNotEmpty();
+    }
+
+    /**
+     * Get the number of items for the current page.
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return $this->items->count();
+    }
+
+    /**
+     * Determine if the given item exists.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function offsetExists($key): bool
+    {
+        return $this->items->has($key);
+    }
+
+    /**
+     * Get the item at the given offset.
+     *
+     * @param  mixed  $key
+     * @return mixed
+     */
+    public function offsetGet($key): mixed
+    {
+        return $this->items->get($key);
+    }
+
+    /**
+     * Set the item at the given offset.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($key, $value): void
+    {
+        $this->items->put($key, $value);
+    }
+
+    /**
+     * Unset the item at the given key.
+     *
+     * @param  mixed  $key
+     * @return void
+     */
+    public function offsetUnset($key): void
+    {
+        $this->items->forget($key);
+    }
+
+    /**
+     * Render the contents of the paginator to HTML.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return (string) $this->render();
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Make dynamic calls into the collection.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this->getCollection(), $method, $parameters);
+    }
+
+    /**
+     * Render the contents of the paginator when casting to a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->render();
+    }
+}

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -504,7 +504,7 @@ abstract class AbstractCursorPaginator extends AbstractBasePaginator
         ]));
     }
 
-        /**
+    /**
      * Get the instance as an array.
      *
      * @return array

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -5,31 +5,17 @@ namespace Illuminate\Pagination;
 use ArrayAccess;
 use Closure;
 use Exception;
-use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Illuminate\Support\Traits\ForwardsCalls;
-use Illuminate\Support\Traits\Tappable;
-use Traversable;
 
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractCursorPaginator implements Htmlable
+abstract class AbstractCursorPaginator extends AbstractBasePaginator
 {
-    use ForwardsCalls, Tappable;
-
-    /**
-     * All of the items being paginated.
-     *
-     * @var \Illuminate\Support\Collection
-     */
-    protected $items;
-
     /**
      * The number of items to be shown per page.
      *
@@ -78,13 +64,6 @@ abstract class AbstractCursorPaginator implements Htmlable
      * @var array
      */
     protected $parameters;
-
-    /**
-     * The paginator options.
-     *
-     * @var array
-     */
-    protected $options;
 
     /**
      * The current cursor resolver callback.
@@ -509,155 +488,5 @@ abstract class AbstractCursorPaginator implements Htmlable
     public static function viewFactory()
     {
         return Paginator::viewFactory();
-    }
-
-    /**
-     * Get an iterator for the items.
-     *
-     * @return \ArrayIterator
-     */
-    public function getIterator(): Traversable
-    {
-        return $this->items->getIterator();
-    }
-
-    /**
-     * Determine if the list of items is empty.
-     *
-     * @return bool
-     */
-    public function isEmpty()
-    {
-        return $this->items->isEmpty();
-    }
-
-    /**
-     * Determine if the list of items is not empty.
-     *
-     * @return bool
-     */
-    public function isNotEmpty()
-    {
-        return $this->items->isNotEmpty();
-    }
-
-    /**
-     * Get the number of items for the current page.
-     *
-     * @return int
-     */
-    public function count(): int
-    {
-        return $this->items->count();
-    }
-
-    /**
-     * Get the paginator's underlying collection.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function getCollection()
-    {
-        return $this->items;
-    }
-
-    /**
-     * Set the paginator's underlying collection.
-     *
-     * @param  \Illuminate\Support\Collection  $collection
-     * @return $this
-     */
-    public function setCollection(Collection $collection)
-    {
-        $this->items = $collection;
-
-        return $this;
-    }
-
-    /**
-     * Get the paginator options.
-     *
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options;
-    }
-
-    /**
-     * Determine if the given item exists.
-     *
-     * @param  mixed  $key
-     * @return bool
-     */
-    public function offsetExists($key): bool
-    {
-        return $this->items->has($key);
-    }
-
-    /**
-     * Get the item at the given offset.
-     *
-     * @param  mixed  $key
-     * @return mixed
-     */
-    public function offsetGet($key): mixed
-    {
-        return $this->items->get($key);
-    }
-
-    /**
-     * Set the item at the given offset.
-     *
-     * @param  mixed  $key
-     * @param  mixed  $value
-     * @return void
-     */
-    public function offsetSet($key, $value): void
-    {
-        $this->items->put($key, $value);
-    }
-
-    /**
-     * Unset the item at the given key.
-     *
-     * @param  mixed  $key
-     * @return void
-     */
-    public function offsetUnset($key): void
-    {
-        $this->items->forget($key);
-    }
-
-    /**
-     * Render the contents of the paginator to HTML.
-     *
-     * @return string
-     */
-    public function toHtml()
-    {
-        return (string) $this->render();
-    }
-
-    /**
-     * Make dynamic calls into the collection.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        return $this->forwardCallTo($this->getCollection(), $method, $parameters);
-    }
-
-    /**
-     * Render the contents of the paginator when casting to a string.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return (string) $this->render();
     }
 }

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -489,4 +489,36 @@ abstract class AbstractCursorPaginator extends AbstractBasePaginator
     {
         return Paginator::viewFactory();
     }
+
+    /**
+     * Render the paginator using the given view.
+     *
+     * @param  string|null  $view
+     * @param  array  $data
+     * @return \Illuminate\Contracts\Support\Htmlable
+     */
+    public function render($view = null, $data = [])
+    {
+        return static::viewFactory()->make($view ?: Paginator::$defaultSimpleView, array_merge($data, [
+            'paginator' => $this,
+        ]));
+    }
+
+        /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'data' => $this->items->toArray(),
+            'path' => $this->path(),
+            'per_page' => $this->perPage(),
+            'next_cursor' => $this->nextCursor()?->encode(),
+            'next_page_url' => $this->nextPageUrl(),
+            'prev_cursor' => $this->previousCursor()?->encode(),
+            'prev_page_url' => $this->previousPageUrl(),
+        ];
+    }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -623,4 +623,37 @@ abstract class AbstractPaginator extends AbstractBasePaginator
         static::defaultView('pagination::bootstrap-5');
         static::defaultSimpleView('pagination::simple-bootstrap-5');
     }
+
+    /**
+     * Render the paginator using the given view.
+     *
+     * @param  string|null  $view
+     * @param  array  $data
+     * @return \Illuminate\Contracts\Support\Htmlable
+     */
+    public function render($view = null, $data = [])
+    {
+        return static::viewFactory()->make($view ?: static::$defaultSimpleView, array_merge($data, [
+            'paginator' => $this,
+        ]));
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'current_page' => $this->currentPage(),
+            'data' => $this->items->toArray(),
+            'first_page_url' => $this->url(1),
+            'from' => $this->firstItem(),
+            'path' => $this->path(),
+            'per_page' => $this->perPage(),
+            'prev_page_url' => $this->previousPageUrl(),
+            'to' => $this->lastItem(),
+        ];
+    }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -3,27 +3,13 @@
 namespace Illuminate\Pagination;
 
 use Closure;
-use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Traits\ForwardsCalls;
-use Illuminate\Support\Traits\Tappable;
-use Traversable;
 
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractPaginator implements Htmlable
+abstract class AbstractPaginator extends AbstractBasePaginator
 {
-    use ForwardsCalls, Tappable;
-
-    /**
-     * All of the items being paginated.
-     *
-     * @var \Illuminate\Support\Collection
-     */
-    protected $items;
-
     /**
      * The number of items to be shown per page.
      *
@@ -72,13 +58,6 @@ abstract class AbstractPaginator implements Htmlable
      * @var int
      */
     public $onEachSide = 3;
-
-    /**
-     * The paginator options.
-     *
-     * @var array
-     */
-    protected $options;
 
     /**
      * The current path resolver callback.
@@ -643,155 +622,5 @@ abstract class AbstractPaginator implements Htmlable
     {
         static::defaultView('pagination::bootstrap-5');
         static::defaultSimpleView('pagination::simple-bootstrap-5');
-    }
-
-    /**
-     * Get an iterator for the items.
-     *
-     * @return \ArrayIterator
-     */
-    public function getIterator(): Traversable
-    {
-        return $this->items->getIterator();
-    }
-
-    /**
-     * Determine if the list of items is empty.
-     *
-     * @return bool
-     */
-    public function isEmpty()
-    {
-        return $this->items->isEmpty();
-    }
-
-    /**
-     * Determine if the list of items is not empty.
-     *
-     * @return bool
-     */
-    public function isNotEmpty()
-    {
-        return $this->items->isNotEmpty();
-    }
-
-    /**
-     * Get the number of items for the current page.
-     *
-     * @return int
-     */
-    public function count(): int
-    {
-        return $this->items->count();
-    }
-
-    /**
-     * Get the paginator's underlying collection.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function getCollection()
-    {
-        return $this->items;
-    }
-
-    /**
-     * Set the paginator's underlying collection.
-     *
-     * @param  \Illuminate\Support\Collection  $collection
-     * @return $this
-     */
-    public function setCollection(Collection $collection)
-    {
-        $this->items = $collection;
-
-        return $this;
-    }
-
-    /**
-     * Get the paginator options.
-     *
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options;
-    }
-
-    /**
-     * Determine if the given item exists.
-     *
-     * @param  mixed  $key
-     * @return bool
-     */
-    public function offsetExists($key): bool
-    {
-        return $this->items->has($key);
-    }
-
-    /**
-     * Get the item at the given offset.
-     *
-     * @param  mixed  $key
-     * @return mixed
-     */
-    public function offsetGet($key): mixed
-    {
-        return $this->items->get($key);
-    }
-
-    /**
-     * Set the item at the given offset.
-     *
-     * @param  mixed  $key
-     * @param  mixed  $value
-     * @return void
-     */
-    public function offsetSet($key, $value): void
-    {
-        $this->items->put($key, $value);
-    }
-
-    /**
-     * Unset the item at the given key.
-     *
-     * @param  mixed  $key
-     * @return void
-     */
-    public function offsetUnset($key): void
-    {
-        $this->items->forget($key);
-    }
-
-    /**
-     * Render the contents of the paginator to HTML.
-     *
-     * @return string
-     */
-    public function toHtml()
-    {
-        return (string) $this->render();
-    }
-
-    /**
-     * Make dynamic calls into the collection.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public function __call($method, $parameters)
-    {
-        return $this->forwardCallTo($this->getCollection(), $method, $parameters);
-    }
-
-    /**
-     * Render the contents of the paginator when casting to a string.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return (string) $this->render();
     }
 }

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -70,20 +70,6 @@ class CursorPaginator extends AbstractCursorPaginator implements PaginatorContra
     }
 
     /**
-     * Render the paginator using the given view.
-     *
-     * @param  string|null  $view
-     * @param  array  $data
-     * @return \Illuminate\Contracts\Support\Htmlable
-     */
-    public function render($view = null, $data = [])
-    {
-        return static::viewFactory()->make($view ?: Paginator::$defaultSimpleView, array_merge($data, [
-            'paginator' => $this,
-        ]));
-    }
-
-    /**
      * Determine if there are more items in the data source.
      *
      * @return bool
@@ -113,23 +99,5 @@ class CursorPaginator extends AbstractCursorPaginator implements PaginatorContra
     public function onFirstPage()
     {
         return is_null($this->cursor) || ($this->cursor->pointsToPreviousItems() && ! $this->hasMore);
-    }
-
-    /**
-     * Get the instance as an array.
-     *
-     * @return array
-     */
-    public function toArray()
-    {
-        return [
-            'data' => $this->items->toArray(),
-            'path' => $this->path(),
-            'per_page' => $this->perPage(),
-            'next_cursor' => $this->nextCursor()?->encode(),
-            'next_page_url' => $this->nextPageUrl(),
-            'prev_cursor' => $this->previousCursor()?->encode(),
-            'prev_page_url' => $this->previousPageUrl(),
-        ];
     }
 }

--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -2,16 +2,10 @@
 
 namespace Illuminate\Pagination;
 
-use ArrayAccess;
-use Countable;
 use Illuminate\Contracts\Pagination\CursorPaginator as PaginatorContract;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
-use IteratorAggregate;
-use JsonSerializable;
 
-class CursorPaginator extends AbstractCursorPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, PaginatorContract
+class CursorPaginator extends AbstractCursorPaginator implements PaginatorContract
 {
     /**
      * Indicates whether there are more items in the data source.
@@ -137,26 +131,5 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
             'prev_cursor' => $this->previousCursor()?->encode(),
             'prev_page_url' => $this->previousPageUrl(),
         ];
-    }
-
-    /**
-     * Convert the object into something JSON serializable.
-     *
-     * @return array
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
-    }
-
-    /**
-     * Convert the object to its JSON representation.
-     *
-     * @param  int  $options
-     * @return string
-     */
-    public function toJson($options = 0)
-    {
-        return json_encode($this->jsonSerialize(), $options);
     }
 }

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -185,20 +185,12 @@ class LengthAwarePaginator extends AbstractPaginator implements LengthAwarePagin
      */
     public function toArray()
     {
-        return [
-            'current_page' => $this->currentPage(),
-            'data' => $this->items->toArray(),
-            'first_page_url' => $this->url(1),
-            'from' => $this->firstItem(),
+        return array_merge(parent::toArray(), [
             'last_page' => $this->lastPage(),
             'last_page_url' => $this->url($this->lastPage()),
             'links' => $this->linkCollection()->toArray(),
             'next_page_url' => $this->nextPageUrl(),
-            'path' => $this->path(),
-            'per_page' => $this->perPage(),
-            'prev_page_url' => $this->previousPageUrl(),
-            'to' => $this->lastItem(),
             'total' => $this->total(),
-        ];
+        ]);
     }
 }

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -2,16 +2,10 @@
 
 namespace Illuminate\Pagination;
 
-use ArrayAccess;
-use Countable;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator as LengthAwarePaginatorContract;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
-use IteratorAggregate;
-use JsonSerializable;
 
-class LengthAwarePaginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, LengthAwarePaginatorContract
+class LengthAwarePaginator extends AbstractPaginator implements LengthAwarePaginatorContract
 {
     /**
      * The total number of items before slicing.
@@ -206,26 +200,5 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             'to' => $this->lastItem(),
             'total' => $this->total(),
         ];
-    }
-
-    /**
-     * Convert the object into something JSON serializable.
-     *
-     * @return array
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
-    }
-
-    /**
-     * Convert the object to its JSON representation.
-     *
-     * @param  int  $options
-     * @return string
-     */
-    public function toJson($options = 0)
-    {
-        return json_encode($this->jsonSerialize(), $options);
     }
 }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -2,16 +2,10 @@
 
 namespace Illuminate\Pagination;
 
-use ArrayAccess;
-use Countable;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
-use IteratorAggregate;
-use JsonSerializable;
 
-class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, PaginatorContract
+class Paginator extends AbstractPaginator implements PaginatorContract
 {
     /**
      * Determine if there are more items in the data source.
@@ -151,26 +145,5 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
             'prev_page_url' => $this->previousPageUrl(),
             'to' => $this->lastItem(),
         ];
-    }
-
-    /**
-     * Convert the object into something JSON serializable.
-     *
-     * @return array
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
-    }
-
-    /**
-     * Convert the object to its JSON representation.
-     *
-     * @param  int  $options
-     * @return string
-     */
-    public function toJson($options = 0)
-    {
-        return json_encode($this->jsonSerialize(), $options);
     }
 }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -91,20 +91,6 @@ class Paginator extends AbstractPaginator implements PaginatorContract
     }
 
     /**
-     * Render the paginator using the given view.
-     *
-     * @param  string|null  $view
-     * @param  array  $data
-     * @return \Illuminate\Contracts\Support\Htmlable
-     */
-    public function render($view = null, $data = [])
-    {
-        return static::viewFactory()->make($view ?: static::$defaultSimpleView, array_merge($data, [
-            'paginator' => $this,
-        ]));
-    }
-
-    /**
      * Manually indicate that the paginator does have more pages.
      *
      * @param  bool  $hasMore
@@ -134,16 +120,8 @@ class Paginator extends AbstractPaginator implements PaginatorContract
      */
     public function toArray()
     {
-        return [
-            'current_page' => $this->currentPage(),
-            'data' => $this->items->toArray(),
-            'first_page_url' => $this->url(1),
-            'from' => $this->firstItem(),
+        return array_merge(parent::toArray(), [
             'next_page_url' => $this->nextPageUrl(),
-            'path' => $this->path(),
-            'per_page' => $this->perPage(),
-            'prev_page_url' => $this->previousPageUrl(),
-            'to' => $this->lastItem(),
-        ];
+        ]);
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -553,7 +553,7 @@ class ResourceTest extends TestCase
         );
 
         $this->assertEquals(
-            '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/?page=1","last":"\/?page=1","prev":null,"next":null},"meta":{"current_page":1,"from":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","active":false},{"url":"\/?page=1","label":"1","active":true},{"url":null,"label":"Next &raquo;","active":false}],"path":"\/","per_page":15,"to":1,"total":10}}',
+            '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/?page=1","last":"\/?page=1","prev":null,"next":null},"meta":{"current_page":1,"from":1,"path":"\/","per_page":15,"to":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","active":false},{"url":"\/?page=1","label":"1","active":true},{"url":null,"label":"Next &raquo;","active":false}],"total":10}}',
             $response->baseResponse->content()
         );
     }


### PR DESCRIPTION
This PR refactors the paginator classes (`Paginator`, `LengthAwarePaginator`, `CusrorPaginator`).

-------

I realized there were a lots of code that are exactly the same in the 3 paginator classes or in their parent abstract classes. 

Also, it was interesting to see that in some cases the child class was implementing an interface, but it was its parent who held the method for that interface. I know it's not a bug (and it's possible there is a reason behind it), but it looked a bit wierd for me.

The point is, I created an abstract base paginator that holds all the common methods for the paginators also the common interfaces they implement.

--------

Note: I made the `render` method as an abstract, since it is called in the `AbstractBasePaginator` class but its implementation (not the method signature) is different in all three classes.

--------

Why? Besides code duplication, I face with a situation where I use cursor and length aware pagination. I'm planning to sumbit a PR where we can easily add custom data for the array representation of the pagination classes (like custom meta stuff, in some case it can be handy).

There is no point to add the same code to all the 3 classes, so as a first step I thought it's a good idea to refactor a bit to prevent future duplication.

--------

This should not be a BC, because yes, the base paginator has the interfaces now, but also it holds all the relevant methods as well. For the child classes nothing has changed because they inherit the same code that they has before.