### PR TITLE
[9.x] Remove unused returns and callback parameters

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -299,7 +299,7 @@ class PendingRequest
      */
     public function bodyFormat(string $format)
     {
-        return tap($this, function ($request) use ($format) {
+        return tap($this, function () use ($format) {
             $this->bodyFormat = $format;
         });
     }
@@ -344,8 +344,8 @@ class PendingRequest
      */
     public function withHeaders(array $headers)
     {
-        return tap($this, function ($request) use ($headers) {
-            return $this->options = array_merge_recursive($this->options, [
+        return tap($this, function () use ($headers) {
+            $this->options = array_merge_recursive($this->options, [
                 'headers' => $headers,
             ]);
         });
@@ -360,8 +360,8 @@ class PendingRequest
      */
     public function withBasicAuth(string $username, string $password)
     {
-        return tap($this, function ($request) use ($username, $password) {
-            return $this->options['auth'] = [$username, $password];
+        return tap($this, function () use ($username, $password) {
+            $this->options['auth'] = [$username, $password];
         });
     }
 
@@ -374,8 +374,8 @@ class PendingRequest
      */
     public function withDigestAuth($username, $password)
     {
-        return tap($this, function ($request) use ($username, $password) {
-            return $this->options['auth'] = [$username, $password, 'digest'];
+        return tap($this, function () use ($username, $password) {
+            $this->options['auth'] = [$username, $password, 'digest'];
         });
     }
 
@@ -388,8 +388,8 @@ class PendingRequest
      */
     public function withToken($token, $type = 'Bearer')
     {
-        return tap($this, function ($request) use ($token, $type) {
-            return $this->options['headers']['Authorization'] = trim($type.' '.$token);
+        return tap($this, function () use ($token, $type) {
+            $this->options['headers']['Authorization'] = trim($type.' '.$token);
         });
     }
 
@@ -401,8 +401,8 @@ class PendingRequest
      */
     public function withUserAgent($userAgent)
     {
-        return tap($this, function ($request) use ($userAgent) {
-            return $this->options['headers']['User-Agent'] = trim($userAgent);
+        return tap($this, function () use ($userAgent) {
+            $this->options['headers']['User-Agent'] = trim($userAgent);
         });
     }
 
@@ -415,8 +415,8 @@ class PendingRequest
      */
     public function withCookies(array $cookies, string $domain)
     {
-        return tap($this, function ($request) use ($cookies, $domain) {
-            return $this->options = array_merge_recursive($this->options, [
+        return tap($this, function () use ($cookies, $domain) {
+            $this->options = array_merge_recursive($this->options, [
                 'cookies' => CookieJar::fromArray($cookies, $domain),
             ]);
         });
@@ -429,8 +429,8 @@ class PendingRequest
      */
     public function withoutRedirecting()
     {
-        return tap($this, function ($request) {
-            return $this->options['allow_redirects'] = false;
+        return tap($this, function () {
+            $this->options['allow_redirects'] = false;
         });
     }
 
@@ -441,8 +441,8 @@ class PendingRequest
      */
     public function withoutVerifying()
     {
-        return tap($this, function ($request) {
-            return $this->options['verify'] = false;
+        return tap($this, function () {
+            $this->options['verify'] = false;
         });
     }
 
@@ -454,8 +454,8 @@ class PendingRequest
      */
     public function sink($to)
     {
-        return tap($this, function ($request) use ($to) {
-            return $this->options['sink'] = $to;
+        return tap($this, function () use ($to) {
+            $this->options['sink'] = $to;
         });
     }
 
@@ -512,8 +512,8 @@ class PendingRequest
      */
     public function withOptions(array $options)
     {
-        return tap($this, function ($request) use ($options) {
-            return $this->options = array_replace_recursive(
+        return tap($this, function () use ($options) {
+            $this->options = array_replace_recursive(
                 array_merge_recursive($this->options, Arr::only($options, $this->mergableOptions)),
                 $options
             );


### PR DESCRIPTION
This PR removes unused parameters and return statements from the `PendingRequest` class, this PR should not contain any changes in behaviour.
