### PR TITLE
[9.x] Pass listener arguments to middleware method

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -612,7 +612,7 @@ class Dispatcher implements DispatcherContract
      * Propagate listener options to the job.
      *
      * @param  mixed  $listener
-     * @param  mixed  $job
+     * @param  \Illuminate\Events\CallQueuedListener  $job
      * @return mixed
      */
     protected function propagateListenerOptions($listener, $job)
@@ -627,7 +627,7 @@ class Dispatcher implements DispatcherContract
             $job->tries = $listener->tries ?? null;
 
             $job->through(array_merge(
-                method_exists($listener, 'middleware') ? $listener->middleware() : [],
+                method_exists($listener, 'middleware') ? $listener->middleware(...$job->data) : [],
                 $listener->middleware ?? []
             ));
         });

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -116,7 +116,10 @@ class QueuedEventsTest extends TestCase
         $d->dispatch('some.event', ['foo', 'bar']);
 
         $fakeQueue->assertPushed(CallQueuedListener::class, function ($job) {
-            return count($job->middleware) === 1 && $job->middleware[0] instanceof TestMiddleware;
+            return count($job->middleware) === 1
+                && $job->middleware[0] instanceof TestMiddleware
+                && $job->middleware[0]->a === 'foo'
+                && $job->middleware[0]->b === 'bar';
         });
     }
 }
@@ -190,12 +193,12 @@ class TestDispatcherOptions implements ShouldQueue
 
 class TestDispatcherMiddleware implements ShouldQueue
 {
-    public function middleware()
+    public function middleware($a, $b)
     {
-        return [new TestMiddleware()];
+        return [new TestMiddleware($a, $b)];
     }
 
-    public function handle()
+    public function handle($a, $b)
     {
         //
     }
@@ -203,6 +206,15 @@ class TestDispatcherMiddleware implements ShouldQueue
 
 class TestMiddleware
 {
+    public $a;
+    public $b;
+
+    public function __construct($a, $b)
+    {
+        $this->a = $a;
+        $this->b = $b;
+    }
+
     public function handle($job, $next)
     {
         $next($job);


### PR DESCRIPTION
In #38128, support for job middleware was added to queued event listensers.

This pull request passes the same arguments that are passed to handle(), to the middleware() method. Doing so allows us to construct the middleware with certain context. In my use case, I am using implementing a rate limiter that is scoped to a specific user:

```php
class SyncToExternalService implements ShouldQueue
{
    public function handle(Updated $event)
    {
    }

    public function middleware(Updated $event)
    {
        return [new RateLimitMiddleware($event->user->external_service_id)];
    }
}
```

This is backwards compatible because the argument list on middleware() can still remain empty.