### PR TITLE
[9.x] Allow passing query parameters to test requests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -285,12 +285,12 @@ trait MakesHttpRequests
      * @param  array  $headers
      * @return \Illuminate\Testing\TestResponse
      */
-    public function get($uri, array $headers = [])
+    public function get($uri, array $headers = [], array $parameters = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('GET', $uri, [], $cookies, [], $server);
+        return $this->call('GET', $uri, $parameters, $cookies, [], $server);
     }
 
     /**
@@ -300,9 +300,9 @@ trait MakesHttpRequests
      * @param  array  $headers
      * @return \Illuminate\Testing\TestResponse
      */
-    public function getJson($uri, array $headers = [])
+    public function getJson($uri, array $headers = [], array $parameters = [])
     {
-        return $this->json('GET', $uri, [], $headers);
+        return $this->json('GET', $uri, [], $headers, $parameters);
     }
 
     /**
@@ -459,7 +459,7 @@ trait MakesHttpRequests
      * @param  array  $headers
      * @return \Illuminate\Testing\TestResponse
      */
-    public function json($method, $uri, array $data = [], array $headers = [])
+    public function json($method, $uri, array $data = [], array $headers = [], array $parameters = [])
     {
         $files = $this->extractFilesFromDataArray($data);
 
@@ -474,7 +474,7 @@ trait MakesHttpRequests
         return $this->call(
             $method,
             $uri,
-            [],
+            $parameters,
             $this->prepareCookiesForJsonRequest(),
             $files,
             $this->transformHeadersToServerVars($headers),

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -283,6 +283,7 @@ trait MakesHttpRequests
      *
      * @param  string  $uri
      * @param  array  $headers
+     * @param  array  $parameters
      * @return \Illuminate\Testing\TestResponse
      */
     public function get($uri, array $headers = [], array $parameters = [])
@@ -298,6 +299,7 @@ trait MakesHttpRequests
      *
      * @param  string  $uri
      * @param  array  $headers
+     * @param  array  $parameters
      * @return \Illuminate\Testing\TestResponse
      */
     public function getJson($uri, array $headers = [], array $parameters = [])
@@ -457,6 +459,7 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  array  $parameters
      * @return \Illuminate\Testing\TestResponse
      */
     public function json($method, $uri, array $data = [], array $headers = [], array $parameters = [])


### PR DESCRIPTION
This allows passing parameters as array to `get`, `getJson` and `json` (because it's used by `getJson`).

```php
// Now
$this->get($uri, $headers, $params);

// Before
$this->get($uri.'?'.http_build_query($params), $headers);
// or you had to hardcode a $uri with all the query string
```

This is especially useful when reusing the `$params` where manipulations on array keys are more obvious than reassigning a whole string.

```php
$params = [
    'search' => 'keyword',
    'perPage' => 10,
    'order' => 'default',
];

$this->getJson($uri, $headers, $params)->assertDefaultOrderIsCool();

$params['order'] = 'views';
$this->getJson($uri, $headers, $params)->assertIsOrderedByViews();
```

This is not a breaking change, because it's an optional parameter at the end of the list. If one doesn't need `$headers`, they can either `get($uri, [], $params)'` or `get($uri, parameters: $params)`.

In addition to testing the new feature, I wrote a more generic test that verifies the behaviour of `json()` method (and by proxy `call()`) as those appeared to not have any direct tests.