### PR TITLE
[9.x] Added 'override' method for Blade components

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -243,6 +243,42 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         return new static(array_merge($attributeDefaults, $attributes));
     }
 
+    public function override(array $overrideAttributes = [])
+    {
+        // Find any attributes which should be overridden.
+        $overrideKeys = array_intersect_assoc(
+            array_keys($overrideAttributes),
+            array_keys($this->attributes)
+        );
+
+        if (! count($overrideKeys)) {
+            return $this;
+        }
+
+        // Loop through any attribute keys (e.g. - "class")
+        foreach ($overrideKeys as $overrideKey) {
+            // Loop through each override set for the attribute.
+            foreach ($overrideAttributes[$overrideKey] as $existingValue => $newValue) {
+                $replace = [];
+
+                // Loop through each word in the attribute and to find any of the
+                // values that match a given pattern and should be replaced.
+                foreach (explode(' ', $this->attributes[$overrideKey]) as $string) {
+                    if (Str::is($newValue, $string)) {
+                        $replace = array_merge(
+                            $replace,
+                            [$string => null, $existingValue => $string]
+                        );
+                    }
+                }
+
+                $this->attributes[$overrideKey] = Str::swap($replace, $this->attributes[$overrideKey]);
+            }
+        }
+
+        return $this;
+    }
+
     /**
      * Determine if the specific attribute value should be escaped.
      *

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -94,4 +94,43 @@ class ViewComponentAttributeBagTest extends TestCase
             'test-extract-2' => 'defaultValue',
         ]));
     }
+
+    public function testAttributesCanBeOverridden()
+    {
+        $bag = new ComponentAttributeBag(['class' => 'text-white bg-blue', 'name' => 'test']);
+
+        // Using a wildcard to match "text-*".
+        $this->assertSame(
+            'font-bold text-white  bg-blue',
+            $bag->merge(['class' => 'font-bold text-red'])->override(['class' => ['text-red' => 'text-*']])->get('class')
+        );
+
+        // Using the exact same class name.
+        $this->assertSame(
+            'font-bold text-white  bg-blue',
+            $bag->merge(['class' => 'font-bold text-red'])->override(['class' => ['text-red' => 'text-white']])->get('class')
+        );
+
+        // Overriding multiple classes at once
+        $this->assertSame(
+            'font-bold text-white bg-blue  ',
+            $bag->merge(['class' => 'font-bold text-red bg-green'])
+                ->override(['class' => ['text-red' => 'text-white', 'bg-green' => 'bg-blue']])
+                ->get('class')
+        );
+
+        // Using a different pattern that shouldn't match a class.
+        // This should be ignored and not override any classes.
+        $this->assertSame(
+            'font-bold text-red text-white bg-blue',
+            $bag->merge(['class' => 'font-bold text-red'])->override(['class' => ['text-red' => 'text-blue']])->get('class')
+        );
+
+        // Using a different attribute name that shouldn't match a class.
+        // This should be ignored and not override any classes.
+        $this->assertSame(
+            'font-bold text-red text-white bg-blue',
+            $bag->merge(['class' => 'font-bold text-red'])->override(['name' => ['text-red' => 'text-white']])->get('class')
+        );
+    }
 }


### PR DESCRIPTION
Hey! This PR adds a new "override" method that you can call on Blade components. The easiest way to explain what it does is to show an example of the problem it solves:

Say you have a component like this:

```blade
{{-- resources/views/components/button.blade.php --}}

<button {{ $attributes->merge(['class' => 'text-red']) }}>
    {{ $slot }}
</button>
```

Then let's say that you call that component in your Blade view like this:

```blade
<x-button class="text-white">
    Submit
</x-button>
```

The HTML output of the component will look something like this:

```html
<button class="text-red text-white">
    Submit
</button>
```

As you can imagine, depending on how the style sheets for a project have been set up, there may be conflicting styles between "text-red" and "text-white". In this example, there probably wouldn't be, but it's only a basic one to try and explain the general idea.

With my new proposed `override()` method, you'd be able to set some rules on your components to define some rules when certain default attributes on a component should be overridden.

For example, we could update the above component to something like this:

```blade
{{-- resources/views/components/button.blade.php --}}

<button {{ $attributes->merge(['class' => 'text-red'])->override(['class' => ['text-red' => 'text-white']]) }} >
    {{ $slot }}
</button>
```

In that example, we've specified that if `text-white` is passed to the `class` attribute of the component, we'll remove `text-red`. So, that means that we'll get the following HTML output:


```html
<button class="text-white">
    Submit
</button>
```

Hardcoding the specific override styles is a bit restrictive, so I also the ability to use wildcards patterns. For example, instead of using `['text-red' => 'text-white']`, we could use `['text-red' => 'text-*']` like this:

```blade
{{-- resources/views/components/button.blade.php --}}

<button {{ $attributes->merge(['class' => 'text-red'])->override(['class' => ['text-red' => 'text-*']]) }} >
    {{ $slot }}
</button>
```

This would mean that we could override the `text-red` class if any class is passed in that begins with `text-` (e.g. text-white, text-blue, text-green).

We could also set this up for multiple CSS classes rather than just one class, like this:

```blade
{{-- resources/views/components/button.blade.php --}}

<button {{ $attributes->merge(['class' => 'text-red bg-blue'])->override(['class' => ['text-red' => 'text-*', 'bg-blue' => 'bg-*']]) }} >
    {{ $slot }}
</button>
```

I'm sure that the solution I have come up with so far could be improved and is likely not covering some use cases, but hopefully, the general idea is okay? If it's the kind of thing you might think is useful and worth merging, please let me know if you need any changes making 😄

(P.S. - Apologies for such a long PR description!)