### PR TITLE
[9.x]  Unset Connection Resolver extended callback

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -397,12 +397,12 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
-     * unset an extension connection resolver.
+     * Remove an extension connection resolver.
      *
      * @param  string  $name
      * @return void
      */
-    public function forgetExtend($name)
+    public function forgetExtension($name)
     {
         unset($this->extensions[$name]); 
     }

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -404,9 +404,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function forgetExtend($name)
     {
-        if (isset($this->extensions[$name])) {
-            unset($this->extensions[$name]);
-        }
+        unset($this->extensions[$name]); 
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -397,6 +397,19 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
+     * unset an extension connection resolver.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function forgetExtend($name)
+    {
+        if (isset($this->extensions[$name])) {
+            unset($this->extensions[$name]);
+        }
+    }
+
+    /**
      * Return all of the created connections.
      *
      * @return array


### PR DESCRIPTION

Unset Connection Resolver extended callback. Specially for Octane with multitenancy application.

By default, there is a method called 'extend' in DatabaseManager class for passing connection resolver to override default connection resolver. But there is no way to unset/remove callback to rollback to default connection resolver. 

Can be used: 
`app('db').forgetExtend($name)`

