### PR TITLE
[9.x] isset and unset do no need to be called multiple time

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -264,7 +264,7 @@ class CacheManager implements FactoryContract
             'endpoint' => $config['endpoint'] ?? null,
         ];
 
-        if (isset($config['key']) && isset($config['secret'])) {
+        if (isset($config['key'], $config['secret'])) {
             $dynamoConfig['credentials'] = Arr::only(
                 $config, ['key', 'secret', 'token']
             );

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -23,8 +23,7 @@ class Reflector
             return is_callable($var, $syntaxOnly);
         }
 
-        if ((! isset($var[0]) || ! isset($var[1])) ||
-            ! is_string($var[1] ?? null)) {
+        if (! isset($var[0], $var[1]) || ! is_string($var[1] ?? null)) {
             return false;
         }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -296,7 +296,7 @@ class ComponentTagCompiler
 
         $prefix = $segments[0];
 
-        if (! isset($this->namespaces[$prefix]) || ! isset($segments[1])) {
+        if (! isset($this->namespaces[$prefix], $segments[1])) {
             return;
         }
 

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -35,8 +35,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         $table = 'baz';
 
         $creator = $this->getCreator();
-        unset($_SERVER['__migration.creator.table']);
-        unset($_SERVER['__migration.creator.path']);
+        unset($_SERVER['__migration.creator.table'], $_SERVER['__migration.creator.path']);
         $creator->afterCreate(function ($table, $path) {
             $_SERVER['__migration.creator.table'] = $table;
             $_SERVER['__migration.creator.path'] = $path;
@@ -55,8 +54,7 @@ class DatabaseMigrationCreatorTest extends TestCase
         $this->assertEquals($_SERVER['__migration.creator.table'], $table);
         $this->assertEquals($_SERVER['__migration.creator.path'], 'foo/foo_create_bar.php');
 
-        unset($_SERVER['__migration.creator.table']);
-        unset($_SERVER['__migration.creator.path']);
+        unset($_SERVER['__migration.creator.table'], $_SERVER['__migration.creator.path']);
     }
 
     public function testTableUpdateMigrationStoresMigrationFile()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR ensures that  `isset` and `unset` are only called once.
