### PR TITLE
[9.x] No need to declare a variable which is returned right after

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -748,11 +748,9 @@ class Str
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
-        $subject = $caseSensitive
+        return $caseSensitive
                     ? str_replace($search, '', $subject)
                     : str_ireplace($search, '', $subject);
-
-        return $subject;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -88,9 +88,8 @@ class ComponentTagCompiler
     {
         $value = $this->compileSelfClosingTags($value);
         $value = $this->compileOpeningTags($value);
-        $value = $this->compileClosingTags($value);
 
-        return $value;
+        return $this->compileClosingTags($value);
     }
 
     /**
@@ -563,9 +562,8 @@ class ComponentTagCompiler
         $value = $this->escapeSingleQuotesOutsideOfPhpBlocks($value);
 
         $value = str_replace('<?php echo ', '\'.', $value);
-        $value = str_replace('; ?>', '.\'', $value);
 
-        return $value;
+        return str_replace('; ?>', '.\'', $value);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR ensures that no variables are declared, to be returned just after.
