### PR TITLE
[9.x] Refactoring Attribute.php to use php8 features 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -56,7 +56,7 @@ class Attribute
      * @param  callable  $get
      * @return static
      */
-    public static function get(callable $get)
+    public static function get(callable $get): static
     {
         return new static(get: $get);
     }
@@ -67,7 +67,7 @@ class Attribute
      * @param  callable  $set
      * @return static
      */
-    public static function set(callable $set)
+    public static function set(callable $set): static
     {
         return new static(set: $set);
     }
@@ -77,7 +77,7 @@ class Attribute
      *
      * @return static
      */
-    public function withoutObjectCaching()
+    public function withoutObjectCaching(): static
     {
         $this->withObjectCaching = false;
 

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -58,7 +58,7 @@ class Attribute
      */
     public static function get(callable $get)
     {
-        return new static($get);
+        return new static(get: $get);
     }
 
     /**
@@ -69,7 +69,7 @@ class Attribute
      */
     public static function set(callable $set)
     {
-        return new static(null, $set);
+        return new static(set: $set);
     }
 
     /**


### PR DESCRIPTION
Laravel 9  requires a minimum PHP version of 8.0 but not use PHP8 feature such as named argument and return type

To do it i refactor casts/Attribute.php  to uses named argument and return type