### PR TITLE
[9.x] Add NotificationFake::assertNothingSentTo()

### DIFF
--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
  * @method static mixed channel(string|null $name = null)
  * @method static void assertNotSentTo(mixed $notifiable, string|\Closure $notification, callable $callback = null)
  * @method static void assertNothingSent()
+ * @method static void assertNothingSentTo(mixed $notifiable)
  * @method static void assertSentOnDemand(string|\Closure $notification, callable $callback = null)
  * @method static void assertSentTo(mixed $notifiable, string|\Closure $notification, callable $callback = null)
  * @method static void assertSentOnDemandTimes(string $notification, int $times = 1)

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -159,7 +159,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
     }
 
     /**
-     * Assert that no notifications were sent to the notifiable.
+     * Assert that no notifications were sent to the given notifiable.
      *
      * @param  mixed  $notifiable
      * @return void

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -159,6 +159,34 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
     }
 
     /**
+     * Assert that no notifications were sent to the notifiable.
+     *
+     * @param  mixed  $notifiable
+     * @return void
+     *
+     * @throws \Exception
+     */
+    public function assertNothingSentTo($notifiable)
+    {
+        if (is_array($notifiable) || $notifiable instanceof Collection) {
+            if (count($notifiable) === 0) {
+                throw new Exception('No notifiable given.');
+            }
+
+            foreach ($notifiable as $singleNotifiable) {
+                $this->assertNothingSentTo($singleNotifiable);
+            }
+
+            return;
+        }
+
+        PHPUnit::assertEmpty(
+            $this->notifications[get_class($notifiable)][$notifiable->getKey()] ?? [],
+            'Notifications were sent unexpectedly.',
+        );
+    }
+
+    /**
      * Assert the total amount of times a notification was sent.
      *
      * @param  string  $notification

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -106,6 +106,32 @@ class SupportTestingNotificationFakeTest extends TestCase
         }
     }
 
+    public function testAssertNothingSent()
+    {
+        $this->fake->assertNothingSent();
+        $this->fake->send($this->user, new NotificationStub);
+
+        try {
+            $this->fake->assertNothingSent();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Notifications were sent unexpectedly.'));
+        }
+    }
+
+    public function testAssertNothingSentTo()
+    {
+        $this->fake->assertNothingSentTo($this->user);
+        $this->fake->send($this->user, new NotificationStub);
+
+        try {
+            $this->fake->assertNothingSentTo($this->user);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Notifications were sent unexpectedly.'));
+        }
+    }
+
     public function testAssertSentToFailsForEmptyArray()
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
Right now there is no easy way to assert that no notifications have been sent to a specific notifiable. Laravel does allow you to assert that no notifications have been sent at all, but this isn't always applicable.

This is primarily an issue when a piece of code dispatches various notification types to different notifiables, for example:

```php
$uploader = User::factory()->createOne();
$podcast = Podcast::factory()->for($uploader)->createOne();
$episode = PodcastEpisode::factory()->for($podcast)->createOne();

$subscriber = User::factory()->hasAttached($podcast)->createOne();
$randomUser = User::factory()->createOne();

Bus::dispatchSync(new ProcessPodcast($episode));

Notification::assertSentTo($uploader, EpisodeProcessed::class);
Notification::assertSentTo($subscriber, NewEpisodeAvailable::class);

Notification::assertNotSentTo($randomUser, EpisodeProcessed::class);
Notification::assertNotSentTo($randomUser, NewEpisodeAvailable::class);
```

The example above is quite simple and only sends 2 notifications, but the number of calls to `assertNotSentTo` would increase by one for every additional notification type that is dispatched.

This PR aims to simplify testing in these kinds of scenario's by adding `Notification::assertNothingSentTo($notifiable)`

PS. This PR includes a test for `NotificationFake::assertNothingSent()`, which appeared to be missing