### PR TITLE
[9.x] Add resource binding

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -613,18 +613,14 @@ class Connection implements ConnectionInterface
     public function bindValues($statement, $bindings)
     {
         foreach ($bindings as $key => $value) {
-            if (is_int($value)) {
-                $type = PDO::PARAM_INT;
-            } elseif (is_resource($value)) {
-                $type = PDO::PARAM_LOB;
-            } else {
-                $type = PDO::PARAM_STR;
-            }
-
             $statement->bindValue(
                 is_string($key) ? $key : $key + 1,
                 $value,
-                $type
+                match (true) {
+                    is_int($value) => PDO::PARAM_INT,
+                    is_resource($value) => PDO::PARAM_LOB,
+                    default => PDO::PARAM_STR
+                },
             );
         }
     }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -613,10 +613,18 @@ class Connection implements ConnectionInterface
     public function bindValues($statement, $bindings)
     {
         foreach ($bindings as $key => $value) {
+            if (is_int($value)) {
+                $type = PDO::PARAM_INT;
+            } elseif (is_resource($value)) {
+                $type = PDO::PARAM_LOB;
+            } else {
+                $type = PDO::PARAM_STR;
+            }
+
             $statement->bindValue(
                 is_string($key) ? $key : $key + 1,
                 $value,
-                is_int($value) ? PDO::PARAM_INT : PDO::PARAM_STR
+                $type
             );
         }
     }

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -9,36 +9,9 @@ use Illuminate\Database\Schema\Grammars\PostgresGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\PostgresBuilder;
 use Illuminate\Database\Schema\PostgresSchemaState;
 use Illuminate\Filesystem\Filesystem;
-use PDO;
 
 class PostgresConnection extends Connection
 {
-    /**
-     * Bind values to their parameters in the given statement.
-     *
-     * @param  \PDOStatement  $statement
-     * @param  array  $bindings
-     * @return void
-     */
-    public function bindValues($statement, $bindings)
-    {
-        foreach ($bindings as $key => $value) {
-            if (is_int($value)) {
-                $pdoParam = PDO::PARAM_INT;
-            } elseif (is_resource($value)) {
-                $pdoParam = PDO::PARAM_LOB;
-            } else {
-                $pdoParam = PDO::PARAM_STR;
-            }
-
-            $statement->bindValue(
-                is_string($key) ? $key : $key + 1,
-                $value,
-                $pdoParam
-            );
-        }
-    }
-
     /**
      * Get the default query grammar instance.
      *


### PR DESCRIPTION
Adds support for binding resources values to PDO statement, in `Connection`. Removed the duplicate code from `PostgresConnection` as it is now handled in base class.

See #41180 for additional details.
