### PR TITLE
Add d() alias for the dump() function.

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -919,3 +919,17 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('d')) {
+    /**
+     * It is an alias for the dump() function.
+     *
+     * @param  mixed  $var
+     * @param  mixed  ...$moreVars
+     * @return  array|mixed
+     */
+    function d($var, ...$moreVars)
+    {
+        return dump($var, ...$moreVars);
+    }
+}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -926,7 +926,7 @@ if (! function_exists('d')) {
      *
      * @param  mixed  $var
      * @param  mixed  ...$moreVars
-     * @return  array|mixed
+     * @return array|mixed
      */
     function d($var, ...$moreVars)
     {


### PR DESCRIPTION
I think this alias would be helpful during development or debuging. If we have dd() why don’t we have d()?