### PR TITLE
[9.x] Add new `assertJsonValidationErrorRule` testing helper

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -4,6 +4,7 @@ namespace Illuminate\Testing;
 
 use ArrayAccess;
 use Closure;
+use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
@@ -919,11 +920,11 @@ EOF;
      * Assert that the response has the given JSON validation errors.
      *
      * @param  string|array  $attribute
-     * @param  string|null  $rule
+     * @param  string|\Illuminate\Contracts\Validation\Rule|null  $rule
      * @param  string  $responseKey
      * @return $this
      */
-    public function assertJsonValidationErrorRule(string|array $attribute, ?string $rule = null, $responseKey = 'errors')
+    public function assertJsonValidationErrorRule(string|array $attribute, string|RuleContract|null $rule = null, $responseKey = 'errors')
     {
         $validationRules = $attribute;
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -915,6 +915,43 @@ EOF;
     }
 
     /**
+     * Assert that the response has the given JSON validation errors.
+     *
+     * @param  string|array  $attribute
+     * @param  string|null  $rule
+     * @param  string  $responseKey
+     * @return $this
+     */
+    public function assertJsonValidationErrorRules(string|array $attribute, ?string $rule = null, $responseKey = 'errors')
+    {
+        $validationRules = $attribute;
+
+        if (is_string($attribute)) {
+            PHPUnit::assertNotNull($rule, 'No validation rule was provided.');
+
+            $validationRules = [$attribute => $rule];
+        }
+
+        $validator = app('validator');
+
+        if (! method_exists($validator, 'getErrorMessage')) {
+            PHPUnit::fail('The current Validator instance does not have a message formatter.');
+        }
+
+        foreach ($validationRules as $attribute => $rules) {
+            $rules = Arr::wrap($rules);
+
+            foreach ($rules as $rule) {
+                $this->assertJsonValidationErrors([
+                    $attribute => $validator->getErrorMessage($attribute, $rule),
+                ], $responseKey);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has no JSON validation errors for the given keys.
      *
      * @param  string|array|null  $keys
@@ -951,43 +988,6 @@ EOF;
                 isset($errors[$key]),
                 "Found unexpected validation error for key: '{$key}'"
             );
-        }
-
-        return $this;
-    }
-
-    /**
-     * Assert that the response has the given JSON validation errors.
-     *
-     * @param  string|array  $attribute
-     * @param  string|null  $rule
-     * @param  string  $responseKey
-     * @return $this
-     */
-    public function assertJsonValidationErrorRules(string|array $attribute, ?string $rule = null, $responseKey = 'errors')
-    {
-        $validationRules = $attribute;
-
-        if (is_string($attribute)) {
-            PHPUnit::assertNotNull($rule, 'No validation rule was provided.');
-
-            $validationRules = [$attribute => $rule];
-        }
-
-        $validator = app('validator');
-
-        if (! method_exists($validator, 'getErrorMessage')) {
-            PHPUnit::fail('The current Validator instance does not have a message formatter.');
-        }
-
-        foreach ($validationRules as $attribute => $rules) {
-            $rules = Arr::wrap($rules);
-
-            foreach ($rules as $rule) {
-                $this->assertJsonValidationErrors([
-                    $attribute => $validator->getErrorMessage($attribute, $rule),
-                ], $responseKey);
-            }
         }
 
         return $this;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
+use Illuminate\Validation\Validator;
 use LogicException;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -932,20 +933,12 @@ EOF;
             $validationRules = [$attribute => $rule];
         }
 
-        $validator = app('validator');
+        $validator = new Validator(app('translator'), [], []);
 
-        if (! method_exists($validator, 'getErrorMessage')) {
-            PHPUnit::fail('The current Validator instance does not have a message formatter.');
-        }
-
-        foreach ($validationRules as $attribute => $rules) {
-            $rules = Arr::wrap($rules);
-
-            foreach ($rules as $rule) {
-                $this->assertJsonValidationErrors([
-                    $attribute => $validator->getErrorMessage($attribute, $rule),
-                ], $responseKey);
-            }
+        foreach ($validationRules as $attribute => $rule) {
+            $this->assertJsonValidationErrors([
+                $attribute => $validator->getErrorMessage($attribute, $rule),
+            ], $responseKey);
         }
 
         return $this;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -957,6 +957,43 @@ EOF;
     }
 
     /**
+     * Assert that the response has the given JSON validation errors.
+     *
+     * @param  string|array  $attribute
+     * @param  string|null  $rule
+     * @param  string  $responseKey
+     * @return $this
+     */
+    public function assertJsonValidationErrorRules(string|array $attribute, ?string $rule = null, $responseKey = 'errors')
+    {
+        $validationRules = $attribute;
+
+        if (is_string($attribute)) {
+            PHPUnit::assertNotNull($rule, 'No validation rule was provided.');
+
+            $validationRules = [$attribute => $rule];
+        }
+
+        $validator = app('validator');
+
+        if (! method_exists($validator, 'getErrorMessage')) {
+            PHPUnit::fail('The current Validator instance does not have a message formatter.');
+        }
+
+        foreach ($validationRules as $attribute => $rules) {
+            $rules = Arr::wrap($rules);
+
+            foreach ($rules as $rule) {
+                $this->assertJsonValidationErrors([
+                    $attribute => $validator->getErrorMessage($attribute, $rule),
+                ], $responseKey);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Validate and return the decoded response JSON.
      *
      * @return \Illuminate\Testing\AssertableJsonString

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -923,7 +923,7 @@ EOF;
      * @param  string  $responseKey
      * @return $this
      */
-    public function assertJsonValidationErrorRules(string|array $attribute, ?string $rule = null, $responseKey = 'errors')
+    public function assertJsonValidationErrorRule(string|array $attribute, ?string $rule = null, $responseKey = 'errors')
     {
         $validationRules = $attribute;
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1444,7 +1444,7 @@ class Validator implements ValidatorContract
         return [
             $this->makeReplacements(
                 $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
-            )
+            ),
         ];
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1395,6 +1395,60 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Get the error messages for an attribute and a validation rule.
+     *
+     * @param  string  $attribute
+     * @param  string|\Illuminate\Contracts\Validation\Rule  $rule
+     * @return array
+     */
+    public function getErrorMessage(string $attribute, string|RuleContract $rule): array
+    {
+        [$rule, $parameters] = ValidationRuleParser::parse($rule);
+        $result = [];
+
+        if ($rule === '') {
+            return $result;
+        }
+
+        // First we will get the correct keys for the given attribute in case the field is nested in
+        // an array. Then we determine if the given rule accepts other field names as parameters.
+        // If so, we will replace any asterisks found in the parameters with the correct keys.
+        if ($this->dependsOnOtherFields($rule)) {
+            $parameters = $this->replaceDotInParameters($parameters);
+
+            if ($keys = $this->getExplicitKeys($attribute)) {
+                $parameters = $this->replaceAsterisksInParameters($parameters, $keys);
+            }
+        }
+
+        if ($rule instanceof RuleContract) {
+            $messages = $rule->message();
+
+            $messages = $messages ? (array) $messages : [get_class($rule)];
+
+            foreach ($messages as $message) {
+                $result[] = $this->makeReplacements(
+                    $message, $attribute, get_class($rule), []
+                );
+            }
+
+            return $result;
+        }
+
+        $attribute = str_replace(
+            [$this->dotPlaceholder, '__asterisk__'],
+            ['.', '*'],
+            $attribute
+        );
+
+        return [
+            $this->makeReplacements(
+                $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
+            )
+        ];
+    }
+
+    /**
      * Get the Presence Verifier implementation.
      *
      * @param  string|null  $connection

--- a/tests/Integration/Testing/TestResponseTest.php
+++ b/tests/Integration/Testing/TestResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Testing;
 
+use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -35,6 +36,33 @@ class TestResponseTest extends TestCase
         );
 
         $testResponse->assertJsonValidationErrorRule(['key' => 'required']);
+    }
+
+    public function testassertJsonValidationErrorRuleWithCustomRule()
+    {
+        $rule = new class implements RuleContract
+        {
+            public function passes($attribute, $value)
+            {
+                return true;
+            }
+
+            public function message()
+            {
+                return ':attribute must be baz';
+            }
+        };
+
+        $data = [
+            'status' => 'ok',
+            'errors' => ['key' => 'key must be baz'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrorRule('key', $rule);
     }
 
     public function testassertJsonValidationErrorRuleWithNoRule()

--- a/tests/Integration/Testing/TestResponseTest.php
+++ b/tests/Integration/Testing/TestResponseTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase;
 
 class TestResponseTest extends TestCase
 {
-    public function testAssertJsonValidationErrorRulesWithString()
+    public function testassertJsonValidationErrorRuleWithString()
     {
         $data = [
             'status' => 'ok',
@@ -20,10 +20,10 @@ class TestResponseTest extends TestCase
             (new Response)->setContent(json_encode($data))
         );
 
-        $testResponse->assertJsonValidationErrorRules('key', 'required');
+        $testResponse->assertJsonValidationErrorRule('key', 'required');
     }
 
-    public function testAssertJsonValidationErrorRulesWithArray()
+    public function testassertJsonValidationErrorRuleWithArray()
     {
         $data = [
             'status' => 'ok',
@@ -34,15 +34,15 @@ class TestResponseTest extends TestCase
             (new Response)->setContent(json_encode($data))
         );
 
-        $testResponse->assertJsonValidationErrorRules(['key' => 'required']);
+        $testResponse->assertJsonValidationErrorRule(['key' => 'required']);
     }
 
-    public function testAssertJsonValidationErrorRulesWithNoRule()
+    public function testassertJsonValidationErrorRuleWithNoRule()
     {
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('No validation rule was provided.');
 
         $response = TestResponse::fromBaseResponse(new Response());
-        $response->assertJsonValidationErrorRules('foo');
+        $response->assertJsonValidationErrorRule('foo');
     }
 }

--- a/tests/Integration/Testing/TestResponseTest.php
+++ b/tests/Integration/Testing/TestResponseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Testing;
+
+use Illuminate\Http\Response;
+use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\ExpectationFailedException;
+use Orchestra\Testbench\TestCase;
+
+class TestResponseTest extends TestCase
+{
+    public function testAssertJsonValidationErrorRulesWithString()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['key' => 'The key field is required.'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrorRules('key', 'required');
+    }
+
+    public function testAssertJsonValidationErrorRulesWithArray()
+    {
+        $data = [
+            'status' => 'ok',
+            'errors' => ['key' => 'The key field is required.'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrorRules(['key' => 'required']);
+    }
+
+    public function testAssertJsonValidationErrorRulesWithNoRule()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('No validation rule was provided.');
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertJsonValidationErrorRules('foo');
+    }
+}

--- a/tests/Integration/Testing/TestResponseTest.php
+++ b/tests/Integration/Testing/TestResponseTest.php
@@ -5,8 +5,8 @@ namespace Illuminate\Tests\Integration\Testing;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
-use PHPUnit\Framework\ExpectationFailedException;
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\ExpectationFailedException;
 
 class TestResponseTest extends TestCase
 {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Testing;
 
 use Exception;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
@@ -21,7 +22,7 @@ use JsonSerializable;
 use Mockery as m;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
 
@@ -1654,6 +1655,28 @@ class TestResponseTest extends TestCase
         $this->assertInstanceOf(Cookie::class, $cookie);
         $this->assertEquals($cookieName, $cookie->getName());
         $this->assertEquals($cookieValue, $cookie->getValue());
+    }
+
+    public function testAssertJsonValidationErrorRulesWithNoRule()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('No validation rule was provided.');
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertJsonValidationErrorRules('foo');
+    }
+
+    public function testAssertJsonValidationErrorRulesWithoutFormatter()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The current Validator instance does not have a message formatter.');
+
+        $fakeValidator = new class {};
+
+        $this->app->instance(ValidatorContract::class, $fakeValidator);
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->assertJsonValidationErrorRules('foo', 'bar');
     }
 
     private function makeMockResponse($content)

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Testing;
 
 use Exception;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Model;
@@ -22,7 +21,7 @@ use JsonSerializable;
 use Mockery as m;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
-use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
 
@@ -1655,28 +1654,6 @@ class TestResponseTest extends TestCase
         $this->assertInstanceOf(Cookie::class, $cookie);
         $this->assertEquals($cookieName, $cookie->getName());
         $this->assertEquals($cookieValue, $cookie->getValue());
-    }
-
-    public function testAssertJsonValidationErrorRulesWithNoRule()
-    {
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('No validation rule was provided.');
-
-        $response = TestResponse::fromBaseResponse(new Response());
-        $response->assertJsonValidationErrorRules('foo');
-    }
-
-    public function testAssertJsonValidationErrorRulesWithoutFormatter()
-    {
-        $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('The current Validator instance does not have a message formatter.');
-
-        $fakeValidator = new class {};
-
-        $this->app->instance(ValidatorContract::class, $fakeValidator);
-
-        $response = TestResponse::fromBaseResponse(new Response());
-        $response->assertJsonValidationErrorRules('foo', 'bar');
     }
 
     private function makeMockResponse($content)

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7096,6 +7096,54 @@ class ValidationValidatorTest extends TestCase
         );
     }
 
+    public function testGetErrorMessageWithBuiltinRule()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines([
+            'validation.required_array_keys' => 'The :attribute field must contain entries for :values',
+            'validation.required' => 'The :attribute field is required.',
+        ], 'en');
+
+        $validator = new Validator($trans, [], []);
+
+        $this->assertSame(
+            ['The foo field is required.'],
+            $validator->getErrorMessage('foo', 'required')
+        );
+
+        $this->assertSame(
+            ['The foo field must contain entries for bar, baz'],
+            $validator->getErrorMessage('foo', 'required_array_keys:bar,baz')
+        );
+    }
+
+    public function testGetErrorMessageWithCustomRule()
+    {
+        $rule = new class implements Rule
+        {
+            public function passes($attribute, $value)
+            {
+                return true;
+            }
+
+            public function message()
+            {
+                return ':attribute must be baz';
+            }
+        };
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            [],
+            []
+        );
+
+        $this->assertSame(
+            ['foo must be baz'],
+            $validator->getErrorMessage('foo', $rule)
+        );
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);


### PR DESCRIPTION
This PR proposes and adds a new `assertJsonValidationErrorRule` testing helper for HTTP testing.  
If approved and merged I'll submit a PR for the docs too in the new 2 days 🤞 

### Why

Currently if you want to test that your endpoint returns a validation error you can use `assertJsonValidationErrorFor` or `assertJsonValidationErrors`. The issue with both of them is that you're  probably just checking that a validation error is returned, but not **what error** is returned; this is not the best idea because your test could fail for another reason.

If you want to check for a specific error you have to compile the message error yourself (replacing the placeholders) or just harcoding it.

```php
$this->postJson('/')
    ->assertJsonValidationErrorFor('foo'); // This passes, but what's the error message? It can be everything

$this->postJson('/')
    ->assertJsonValidationErrors([
        'foo' => 'The foo field is required.', // Hardcoded
    ]);

$this->postJson('/')
    ->assertJsonValidationErrors([
        'foo' => str_replace(':attribute', 'foo', trans('validation.required')), // Manual replacing, how do you handle custom rules? And what about rule arguments?
    ]);
```

### Solution

The new `assertJsonValidationErrorRule`, in conjuction with a new `Validator` public method to compile messages, can take care of everything for you: it retrieves the translated message, does the replaces and works with custom rules too.

```php
$this->postJson('/')
    ->assertJsonValidationErrorRule('foo', 'required'); // Compiles to "The foo field is required."
```

You can search for multiple errors too:

```php
$this->postJson('/')
    ->assertJsonValidationErrorRule([
        'foo' => 'required', // Compiles to "The foo field is required."
        'bar' => 'required_array_keys:foo,baz', // Compiles to "The bar field must contain entries for foo, baz"
    ]);
```

And, of course, you can pass your custom validation rule:

```php
class MyCustomRule implements Rule
{
    public function passes($attribute, $value)
    {
        return $value === 'baz';
    }

    public function message()
    {
        return ':attribute must be baz';
    }
}

$this->postJson('/')
    ->assertJsonValidationErrorRule('foo', new MyCustomRule()); // Compiles to "foo must be baz"
```