### PR TITLE
Became possible pass enum obj to default value

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -330,9 +330,19 @@ abstract class Grammar extends BaseGrammar
             return $value;
         }
 
-        return is_bool($value)
-                    ? "'".(int) $value."'"
-                    : "'".(string) $value."'";
+        if(is_object($value))
+		{
+			if(isset($value->value))
+			{
+				return "'".(string) $value->value."'";
+			}else{
+				throw new RuntimeException("Obejct most to be an enum");
+			}
+		}
+        
+		return is_bool($value)
+            ? "'".(int) $value."'"
+            : "'".(string) $value."'";
     }
 
     /**


### PR DESCRIPTION
we have to pass 'string' default value in migration but this changes help to us be easiest use enum obj. for example : 

$table->string('status')->default(StatusEnum::Draft->value); **===>** $table->string('status')->default(StatusEnum::Draft);

