### PR TITLE
[8.x] $job can be an object in some methods

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -272,7 +272,7 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed  $data
      * @param  string|null  $queue
      * @return mixed
@@ -302,7 +302,7 @@ class QueueFake extends QueueManager implements Queue
      * Push a new job onto the queue after a delay.
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed  $data
      * @param  string|null  $queue
      * @return mixed
@@ -316,7 +316,7 @@ class QueueFake extends QueueManager implements Queue
      * Push a new job onto the queue.
      *
      * @param  string  $queue
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed  $data
      * @return mixed
      */
@@ -330,7 +330,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @param  string  $queue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed  $data
      * @return mixed
      */


### PR DESCRIPTION
This PR fixes the PHPDoc for `push()`, `pushOn()`, `later()` and `laterOn()`.