### PR TITLE
[9.x] Improve doctypes for Eloquent Factory guessing methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -708,7 +708,7 @@ abstract class Factory
     /**
      * Specify the callback that should be invoked to guess model names based on factory names.
      *
-     * @param  callable(): class-string<\Illuminate\Database\Eloquent\Model|TModel>  $callback
+     * @param  callable(self): class-string<\Illuminate\Database\Eloquent\Model|TModel>  $callback
      * @return void
      */
     public static function guessModelNamesUsing(callable $callback)
@@ -743,7 +743,7 @@ abstract class Factory
     /**
      * Specify the callback that should be invoked to guess factory names based on dynamic relationship names.
      *
-     * @param  callable(): class-string<\Illuminate\Database\Eloquent\Model|TModel>  $callback
+     * @param  callable(class-string<\Illuminate\Database\Eloquent\Model>): class-string<\Illuminate\Database\Eloquent\Factories\Factory>  $callback
      * @return void
      */
     public static function guessFactoryNamesUsing(callable $callback)

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -183,8 +183,11 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->newModel(['string' =>
 // assertType('class-string<User>', $factory->modelName());
 assertType('class-string<Illuminate\Database\Eloquent\Model>', $factory->modelName());
 
-$factory->guessModelNamesUsing(function () {
-    return User::class;
+Factory::guessModelNamesUsing(function (Factory $factory) {
+    return match (true) {
+        $factory instanceof UserFactory => User::class,
+        default => throw new LogicException('Unknown factory'),
+    };
 });
 
 $factory->useNamespace('string');
@@ -192,3 +195,10 @@ $factory->useNamespace('string');
 assertType(Factory::class, $factory::factoryForModel(User::class));
 
 assertType('class-string<Illuminate\Database\Eloquent\Factories\Factory>', $factory->resolveFactoryName(User::class));
+
+Factory::guessFactoryNamesUsing(function(string $modelName) {
+    return match ($modelName) {
+        User::class => UserFactory::class,
+        default => throw new LogicException('Unknown factory'),
+    };
+});

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -196,7 +196,7 @@ assertType(Factory::class, $factory::factoryForModel(User::class));
 
 assertType('class-string<Illuminate\Database\Eloquent\Factories\Factory>', $factory->resolveFactoryName(User::class));
 
-Factory::guessFactoryNamesUsing(function(string $modelName) {
+Factory::guessFactoryNamesUsing(function (string $modelName) {
     return match ($modelName) {
         User::class => UserFactory::class,
         default => throw new LogicException('Unknown factory'),


### PR DESCRIPTION
Improves and fixes doctypes for parameters of `Factory::guessModelNamesUsing` and `Factory::guessFactoryNamesUsing` methods.