### PR TITLE
[9.x] default type of FormRequest validated method 

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -207,7 +207,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Get the validated data from the request.
      *
      * @param  string|null  $key
-     * @param  string|array|null  $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function validated($key = null, $default = null)


### PR DESCRIPTION
I think the `$default` parameter should be of type `mixed` and match the `input` method signature.

https://github.com/laravel/framework/blob/aee3fc2bffe935ce238e0a733cbde098e931b24b/src/Illuminate/Foundation/Http/FormRequest.php#L206-L216

https://github.com/laravel/framework/blob/aee3fc2bffe935ce238e0a733cbde098e931b24b/src/Illuminate/Http/Concerns/InteractsWithInput.php#L273-L285