### PR TITLE
[9.x] Add option to filter out routes defined in vendor packages in `route:list` command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -450,7 +450,7 @@ class RouteListCommand extends Command
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (precedence, domain, method, uri, name, action, middleware) to sort by', 'uri'],
-            ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined in vendor'],
+            ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -209,25 +209,24 @@ class RouteListCommand extends Command
     }
 
     /**
-     * Detect if the route has been defined inside one of the composer packages.
+     * Determine if the route has been defined outside of the application.
      *
      * @param  \Illuminate\Routing\Route  $route
      * @return bool
-     *
-     * @throws \ReflectionException
      */
     protected function isVendorRoute(Route $route)
     {
         if ($route->action['uses'] instanceof Closure) {
-            $fileName = (new ReflectionFunction($route->action['uses']))
-                ->getFileName();
+            $path = (new ReflectionFunction($route->action['uses']))
+                                ->getFileName();
+        } elseif (is_string($route->action['uses'])) {
+            $path = (new ReflectionClass(explode('@', $route->action['uses'])[0]))
+                                ->getFileName();
         } else {
-            [$actionClass] = explode('@', $route->action['uses']);
-            $fileName = (new ReflectionClass($actionClass))
-                ->getFileName();
+            return false;
         }
 
-        return str_starts_with($fileName, base_path('vendor'));
+        return str_starts_with($path, base_path('vendor'));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\ViewController;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionFunction;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Terminal;
 
@@ -148,6 +149,7 @@ class RouteListCommand extends Command
             'name' => $route->getName(),
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
+            'vendor' => $this->isVendorRoute($route),
         ]);
     }
 
@@ -207,6 +209,27 @@ class RouteListCommand extends Command
     }
 
     /**
+     * Detect if the route has been defined inside one of the composer packages.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return bool
+     * @throws \ReflectionException
+     */
+    protected function isVendorRoute(Route $route)
+    {
+        if ($route->action['uses'] instanceof Closure) {
+            $fileName = (new ReflectionFunction($route->action['uses']))
+                ->getFileName();
+        } else {
+            [$actionClass] = explode('@', $route->action['uses']);
+            $fileName = (new ReflectionClass($actionClass))
+                ->getFileName();
+        }
+
+        return str_starts_with($fileName, base_path('vendor'));
+    }
+
+    /**
      * Filter the route by URI and / or name.
      *
      * @param  array  $route
@@ -217,7 +240,8 @@ class RouteListCommand extends Command
         if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
-            ($this->option('domain') && ! Str::contains($route['domain'], $this->option('domain')))) {
+            ($this->option('domain') && ! Str::contains($route['domain'], $this->option('domain'))) ||
+            ($this->option('except-vendor') && $route['vendor'])) {
             return;
         }
 
@@ -426,6 +450,7 @@ class RouteListCommand extends Command
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (precedence, domain, method, uri, name, action, middleware) to sort by', 'uri'],
+            ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined in vendor']
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -213,6 +213,7 @@ class RouteListCommand extends Command
      *
      * @param  \Illuminate\Routing\Route  $route
      * @return bool
+     *
      * @throws \ReflectionException
      */
     protected function isVendorRoute(Route $route)
@@ -450,7 +451,7 @@ class RouteListCommand extends Command
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (precedence, domain, method, uri, name, action, middleware) to sort by', 'uri'],
-            ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined in vendor']
+            ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined in vendor'],
         ];
     }
 }


### PR DESCRIPTION
This PR adds the ability for `route:list` command to filter out routes defined in vendor (third-party) packages.

```sh
php artisan route:list --except-vendor
```

IMHO, very useful option in projects that have tons of registered routes via third-party packages (Horizon, Nova, Debugbar, etc.).

Tests are missing because I can't figure out a way to mock routes so they show another path other than where I defined them (in the test class). So maybe someone can help me out.

Also let me know if `--except-vendor` is not a good option name for the command.

Cheers.