### PR TITLE
[9.x] Update Mailgun transport type

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -281,7 +281,7 @@ class MailManager implements FactoryContract
         }
 
         return $factory->create(new Dsn(
-            'mailgun+api',
+            'mailgun+https',
             $config['endpoint'] ?? 'default',
             $config['secret'],
             $config['domain']


### PR DESCRIPTION
This updates the Mailgun transport typen to use `mailgun+https`. It seems this is needed for additional features like not having to specify a `to` recipient. This also is a bit closer to our own transport which also used the `/messages.mime` endpoint.

Resolves https://github.com/laravel/framework/issues/41253. The OP also confirmed this resolved their issue.