### PR TITLE
[9.x] Add ability to push additional pipes onto a pipeline via `chain($pipes)`

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -81,7 +81,7 @@ class Pipeline implements PipelineContract
      * @param  array|mixed  $pipes
      * @return $this
      */
-    public function chain($pipes)
+    public function pipe($pipes)
     {
         array_push($this->pipes, ...(is_array($pipes) ? $pipes : func_get_args()));
 

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -76,7 +76,7 @@ class Pipeline implements PipelineContract
     }
 
     /**
-     * Push additional pipes.
+     * Push additional pipes onto the pipeline.
      *
      * @param  array|mixed  $pipes
      * @return $this

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -76,6 +76,19 @@ class Pipeline implements PipelineContract
     }
 
     /**
+     * Push additional pipes.
+     *
+     * @param  array|mixed  $pipes
+     * @return $this
+     */
+    public function chain($pipes)
+    {
+        array_push($this->pipes, ...(is_array($pipes) ? $pipes : func_get_args()));
+
+        return $this;
+    }
+
+    /**
      * Set the method to call on the pipes.
      *
      * @param  string  $method

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -102,9 +102,9 @@ class PipelineTest extends TestCase
         $object = new stdClass();
 
         $object->value = 0;
-        
+
         $function = function ($object, $next) {
-            ++$object->value;
+            $object->value++;
 
             return $next($object);
         };

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Pipeline\Pipeline;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use stdClass;
 
 class PipelineTest extends TestCase
 {
@@ -94,6 +95,32 @@ class PipelineTest extends TestCase
         $this->assertSame('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testPipelineUsageWithChain()
+    {
+        $object = new stdClass();
+
+        $object->value = 0;
+        
+        $function = function ($object, $next) {
+            ++$object->value;
+
+            return $next($object);
+        };
+
+        $result = (new Pipeline(new Container))
+            ->send($object)
+            ->through([$function])
+            ->chain([$function])
+            ->then(
+                function ($piped) {
+                    return $piped;
+                }
+            );
+
+        $this->assertSame($object, $result);
+        $this->assertEquals(2, $object->value);
     }
 
     public function testPipelineUsageWithInvokableClass()

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -97,7 +97,7 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
-    public function testPipelineUsageWithChain()
+    public function testPipelineUsageWithPipe()
     {
         $object = new stdClass();
 
@@ -112,7 +112,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send($object)
             ->through([$function])
-            ->chain([$function])
+            ->pipe([$function])
             ->then(
                 function ($piped) {
                     return $piped;


### PR DESCRIPTION
## Description

This PR adds the ability to push additional pipes onto a pipeline via a `chain()` method.

This allows us to create a pipeline instance and pass it around the application, appending pipes onto the chain, rather than having to define all of the pipes in a single place:

```php
$pipeline = new Pipeline();

$pipeline->chain(fn ($object, $next) => $next($object));
$pipeline->chain(fn ($object, $next) => $next($object));

$pipeline->send($object)->thenReturn();
```

Let me know if you would like anything adjusted. Thanks for your time! ❤️ 