### PR TITLE
[9.x] Fix inconsistent results of firstOrNew() when using withCasts()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -493,7 +493,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
         // hydration of new objects via the Eloquent query builder instances.
-        $model = new static((array) $attributes);
+        $model = new static;
 
         $model->exists = $exists;
 
@@ -504,6 +504,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $model->setTable($this->getTable());
 
         $model->mergeCasts($this->casts);
+
+        $model->fill((array) $attributes);
 
         return $model;
     }

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -2,13 +2,12 @@
 
 namespace Illuminate\Tests\Database;
 
-use PHPUnit\Framework\TestCase;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentWithCastsTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -47,7 +46,6 @@ class DatabaseEloquentWithCastsTest extends TestCase
 
         $this->assertSame('07:30', $time1->time);
         $this->assertSame($time1->time, $time2->time);
-
     }
 
     public function testWithFirstOrCreate()
@@ -59,7 +57,6 @@ class DatabaseEloquentWithCastsTest extends TestCase
             ->firstOrCreate(['time' => '07:30']);
 
         $this->assertSame($time1->id, $time2->id);
-
     }
 
     /**
@@ -83,14 +80,11 @@ class DatabaseEloquentWithCastsTest extends TestCase
     }
 }
 
-
 class Time extends Eloquent
 {
     protected $guarded = [];
 
     protected $casts = [
-        "time" => "datetime"
+        'time' => 'datetime',
     ];
-
 }
-

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class DatabaseEloquentWithCastsTest extends TestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('times', function ($table) {
+            $table->increments('id');
+            $table->time('time');
+            $table->timestamps();
+        });
+    }
+
+    public function testWithFirstOrNew()
+    {
+        $time1 = Time::query()->withCasts(['time' => 'string'])
+            ->firstOrNew(['time' => '07:30']);
+
+        Time::query()->insert(['time' => '07:30']);
+
+        $time2 = Time::query()->withCasts(['time' => 'string'])
+            ->firstOrNew(['time' => '07:30']);
+
+        $this->assertSame('07:30', $time1->time);
+        $this->assertSame($time1->time, $time2->time);
+
+    }
+
+    public function testWithFirstOrCreate()
+    {
+        $time1 = Time::query()->withCasts(['time' => 'string'])
+            ->firstOrCreate(['time' => '07:30']);
+
+        $time2 = Time::query()->withCasts(['time' => 'string'])
+            ->firstOrCreate(['time' => '07:30']);
+
+        $this->assertSame($time1->id, $time2->id);
+
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+
+class Time extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        "time" => "datetime"
+    ];
+
+}
+


### PR DESCRIPTION
The issue is when using `withCasts` to override model casts, leads to inconsistent results when using `firstOrNew` method or any similar method depends on `Model::newInstance()` such as `firstOrCreate()`, `updateOrCreate`. the results are differ depends on whether the element exists on DB or not, as one result of Model `$casts` and other form `withCasts()`.

For example:
If we have a Model with `$casts = ['time' => 'datetime'];`
and by running these queries:
```php
$result1 = Model::query()->withCasts(['time' => 'string'])
    ->firstOrCreate(['time' => '07:30']);

$result2 =Model::query()->withCasts(['time' => 'string'])
    ->firstOrCreate(['time' => '07:30']);
```
both queries will leads to different entries on database as under the hood `where` method is looking for `time = 07:30` and fail to find one, then `newInstance()` method will create new instance with `datetime` cast, so the next query will fail to find `time = 07:30`  and this behavior will remain for every use of `firstOrCreate` unless there is an existent entire in DB matches the attribute.
 
So developer won't be able to depend on `firstOrCreate`, `updateOrCreate` or `firstOrNew` to have consistent and unique data in the database in such cases.

I have started with failing tests to prove the issue, and end up with solving it by modifing `newInstance` method to fill model attributes after `mergeCasts`.