### PR TITLE
[9.x] improve some test of CacheManager

### DIFF
--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -22,13 +22,13 @@ class CacheManagerTest extends TestCase
 
     public function testCustomDriverClosureBoundObjectIsCacheManager()
     {
-        $cacheManager = new CacheManager([
-            'config' => [
-                'cache.stores.'.__CLASS__ => [
-                    'driver' => __CLASS__,
-                ],
+        $userConfig = [
+            'cache.stores.'.__CLASS__ => [
+                'driver' => __CLASS__,
             ],
-        ]);
+        ];
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
         $driver = function () {
             return $this;
         };
@@ -118,13 +118,13 @@ class CacheManagerTest extends TestCase
 
     public function testForgetDriverForgets()
     {
-        $cacheManager = new CacheManager([
-            'config' => [
-                'cache.stores.forget' => [
-                    'driver' => 'forget',
-                ],
+        $userConfig = [
+            'cache.stores.forget' => [
+                'driver' => 'forget',
             ],
-        ]);
+        ];
+        $app = $this->getApp($userConfig);
+        $cacheManager = new CacheManager($app);
         $cacheManager->extend('forget', function () {
             return new ArrayStore;
         });


### PR DESCRIPTION
the test should be like real Laravel in up working.
CacheManager expect Application Contract Not Array

```
    /**
    * Create a new Cache manager instance.
     *
     * @param  \Illuminate\Contracts\Foundation\Application  $app
     * @return void
     */
    public function __construct($app)
    {
        $this->app = $app;
    }
```
 
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
