### PR TITLE
[9.x] Fix Conditional::when and Conditional::unless when called with invokable

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -13,7 +13,7 @@ trait Conditionable
      * @template TWhenParameter
      * @template TWhenReturnType
      *
-     * @param  (Closure($this): TWhenParameter)|TWhenParameter  $value
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter  $value
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return $this|TWhenReturnType
@@ -41,7 +41,7 @@ trait Conditionable
      * @template TUnlessParameter
      * @template TUnlessReturnType
      *
-     * @param  (Closure($this): TUnlessParameter)|TUnlessParameter  $value
+     * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter  $value
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $callback
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -13,7 +13,7 @@ trait Conditionable
      * @template TWhenParameter
      * @template TWhenReturnType
      *
-     * @param  (callable($this): TWhenParameter)|TWhenParameter  $value
+     * @param  (Closure($this): TWhenParameter)|TWhenParameter  $value
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return $this|TWhenReturnType
@@ -41,7 +41,7 @@ trait Conditionable
      * @template TUnlessParameter
      * @template TUnlessReturnType
      *
-     * @param  (callable($this): TUnlessParameter)|TUnlessParameter  $value
+     * @param  (Closure($this): TUnlessParameter)|TUnlessParameter  $value
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $callback
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -12,6 +12,15 @@ $iterable = [];
 /** @var Traversable<int, string> $traversable */
 $traversable = [];
 
+class Invokable
+{
+    public function __invoke(): string
+    {
+        return 'Taylor';
+    }
+}
+$invokable = new Invokable();
+
 assertType('Illuminate\Support\Collection<int, User>', $collection);
 
 assertType('Illuminate\Support\Collection<int, string>', collect(['string']));
@@ -294,6 +303,11 @@ assertType(
     )
 );
 
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->when($invokable, function ($collection, $param) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+    assertType('Invokable', $param);
+}));
+
 assertType('bool|Illuminate\Support\Collection<int, User>', $collection->whenEmpty(function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 
@@ -375,6 +389,11 @@ assertType(
         }
     )
 );
+
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->unless($invokable, function ($collection, $param) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+    assertType('Invokable', $param);
+}));
 
 assertType('bool|Illuminate\Support\Collection<int, User>', $collection->unlessEmpty(function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);


### PR DESCRIPTION
This PR fixes the PHPStan analysis when Conditional::when and Conditional::unless are called with invokable object