### PR TITLE
[9.x] Improves `Support\Collection` reduce method type definition

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -805,7 +805,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TReduceInitial
      * @template TReduceReturnType
      *
-     * @param  callable(TReduceInitial|TReduceReturnType, TValue): TReduceReturnType  $callback
+     * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType  $callback
      * @param  TReduceInitial  $initial
      * @return TReduceReturnType
      */

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -745,7 +745,7 @@ trait EnumeratesValues
      * @template TReduceInitial
      * @template TReduceReturnType
      *
-     * @param  callable(TReduceInitial|TReduceReturnType, TValue): TReduceReturnType  $callback
+     * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType  $callback
      * @param  TReduceInitial  $initial
      * @return TReduceReturnType
      */

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -636,6 +636,14 @@ assertType('int', $collection
 
         return 1;
     }, 0));
+assertType('int', $collection
+    ->reduce(function ($int, $user, $key) {
+        assertType('User', $user);
+        assertType('int', $int);
+        assertType('int', $key);
+
+        return 1;
+    }, 0));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->replace([1]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->replace([new User]));


### PR DESCRIPTION
This PR improves `reduce()` types because it passes the key to the closure.

Whenever the reduce callback expects the third parameter static analysis fail because the type is not defined which produces the following error.
![image](https://user-images.githubusercontent.com/1761690/152578949-712d7a2c-fbbd-4911-a585-3cf570f2fa7e.png)

This was covered here #40813 but it was sent to master instead -- 9.x was not released at the time.

