### PR TITLE
[9.x] Get last item of `takeUntilTimeout` method on a `LazyCollection`

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1407,14 +1407,23 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Take items in the collection until a given point in time.
      *
      * @param  \DateTimeInterface  $timeout
+     * @param  callable(TValue, TKey)|null $callback
      * @return static
      */
-    public function takeUntilTimeout(DateTimeInterface $timeout)
+    public function takeUntilTimeout(DateTimeInterface $timeout, callable $callback = null)
     {
         $timeout = $timeout->getTimestamp();
 
-        return $this->takeWhile(function () use ($timeout) {
-            return $this->now() < $timeout;
+        return $this->takeWhile(function ($item, $key) use ($timeout, $callback) {
+            if ($this->now() < $timeout) {
+                return true;
+            };
+
+            if ($callback !== null) {
+                $callback($item, $key);
+            }
+
+            return false;
         });
     }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1407,7 +1407,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Take items in the collection until a given point in time.
      *
      * @param  \DateTimeInterface  $timeout
-     * @param  callable(TValue, TKey)|null $callback
+     * @param  callable(TValue, TKey)|null  $callback
      * @return static
      */
     public function takeUntilTimeout(DateTimeInterface $timeout, callable $callback = null)
@@ -1417,7 +1417,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         return $this->takeWhile(function ($item, $key) use ($timeout, $callback) {
             if ($this->now() < $timeout) {
                 return true;
-            };
+            }
 
             if ($callback !== null) {
                 $callback($item, $key);

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -702,6 +702,10 @@ assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUnti
 }));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntilTimeout(new DateTime()));
+assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeUntilTimeout(new DateTime(), function ($user, $int) {
+    assertType('User', $user);
+    assertType('int', $int);
+}));
 
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->takeWhile(1));
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->takeWhile(new User));


### PR DESCRIPTION
This PR allows the `takeUntilTimeout` method of a `LazyCollection` to accept a second parameter: a closure. This closure will be executed when the timeout has been reach and it will return the first item that it was not able to process anymore.
```php
$lazyCollection->takeUntilTimeout(now()->addMinute(), function ($firstNotTakenItem, $firstNotTakenItemKey) {
    // ...
});
```

## Why?

Sometimes you need to process a lot of data in a job and you can not do it in one job because the job will timeout. Let's say you have thousands of users that need to be processed.

```php
class ProcessUsersJob
{
    public $timeout = 60;

    public function handle()
    {
        User::query()
            ->where(...)
            ->cursor()
            ->each(fn ($user) => ...);
    }
}
```
This job will timeout if there a lot of users. This is were the current `takeUntilTimeout` method comes into play. We could just process users until we reach the timeout, but than we still need to know which users we have not processed yet. So we need to keep track of the last processed user in order to prevent duplicate processing. This creates a lot of overhead code which will be the same in every job that processes lots of data.
```php
class ProcessUsersJob
{
    public $timeout = 60;

    public function __construct(
       public ?int $lastProcessedUserId = null
    ) {}

    public function handle()
    {
        $lastUserId = User::query()
            ->where(...)
            ->when($this->lastProcessedUserId, fn ($query) => $query->where('id', '>', $this->lastProcessedUserId)
            ->orderBy('id')
            ->cursor()
            ->takeUntilTimeout(now()->addSeconds(55))
            ->each(function ($user) {
                // Remember the last user that has been processed
                $this->lastProcessedUserId = $user->id

                // ...
            })
            ->last()?->id;

        // If the last user id equals the last processed user id, then that means
        // we have processed all users and we do not need to dispatch a new job
        // to process the remaining unprocessed users.
        if ($lastUserId === $this->lastProcessedUserId) {
            return;
        }

        static::dispatch($this-> lastProcessedUserId);
    }
}
```
This can be simplified if the `takeUntilTimeout` returns the first item that it could not process anymore. Now we can just dispatch a new job from inside that closure and we don't need a that boilerplate code anymore.
```php
class ProcessUsersJob
{
    public $timeout = 60;

    public function __construct(
       public ?int $firstUnprocessedUserId = null
    ) {}

    public function handle()
    {
        User::query()
            ->where(...)
            ->when($this->firstUnprocessedUserId, fn ($query) => $query->where('id', '>=', $this->firstUnprocessedUserId)
            ->orderBy('id')
            ->cursor()
            ->takeUntilTimeout(now()->addSeconds(55), function ($user) {
                static::dispatch($user->id);
            })
            ->each(fn ($user) => ...);
    }
}
```