### PR TITLE
[9.x] Remove `static` return types

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Database\Eloquent;
 
 /**
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed(bool $withTrashed = true)
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
  */
 trait SoftDeletes
 {


### PR DESCRIPTION
I would definitely like a second set of eyes on this, but I'm pretty sure these methods will only return instances of the Eloquent or Query Builder.  It was a little difficult to find how these methods are called, but it's in the `\Illuminate\Database\Eloquent\SoftDeletingScope`.

The reason I came across this was that I was trying to select trashed Eloquent models on a specific database connection.

```php
$user = User::withTrashed()->on($connection);
```

This doesn't actually work, but the IDE thinks it's okay, because it sees `withTrashed()` returning `static`, which is `\App\User` which extends the `\Illuminate\Database\Eloquent\Model`, which *does* have the `on()` method.

In reality, it returns the `\Illuminate\Database\Eloquent\Builder` which **does not** have the `on()` method.