### PR TITLE
[9.x] Update resolveFacadeInstance method docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -210,6 +210,8 @@ abstract class Facade
      *
      * @param  string  $name
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected static function resolveFacadeInstance($name)
     {


### PR DESCRIPTION
Since the $app variable is documented to be an instance of the Application class, this method is definitely a throwish one in case of a missing key on the container.

I think the public `getFacadeRoot` also needs this.