### PR TITLE
[9.x] Fix implicitBinding and withTrashed route with child with no SoftDeletes trait

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -47,7 +47,7 @@ class ImplicitRouteBinding
                         : 'resolveRouteBinding';
 
             if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
-                $childRouteBindingMethod = $route->allowsTrashedBindings()
+                $childRouteBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';
 


### PR DESCRIPTION
This fixes an issue caused when using _implicitBinding_ and _withTrashed_ on a route and where the parent model **has** the SoftDelete trait and the child **doesn't have** the SoftDelete trait.

Ex:

```php
class User extends Model
{
    use SoftDeletes;

    public function posts()
    {
        return $this->hasMany(Post::class);
    }

}

class Posts extends Model
{
    //
}

Route::scopeBindings()->get('users/{user}/posts/{post}', /*...*/)->withTrashed();
```

The following route call `/users/1/posts/2` will throw this error `Call to undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::withTrashed()`.

____

This PR adds an extra check to verify if the child model instance has the SoftDeletes trait.
