### PR TITLE
[10.x] Add ability to purge after resolved callbacks

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1165,6 +1165,21 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Purge all after resolving callbacks.
+     *
+     * @param  \Closure|string  $abstract
+     * @return void
+     */
+    public function purgeAfterResolvingCallbacks($abstract)
+    {
+        if (is_string($abstract)) {
+            $abstract = $this->getAlias($abstract);
+        }
+
+        unset($this->afterResolvingCallbacks[$abstract]);
+    }
+
+    /**
      * Fire all of the before resolving callbacks.
      *
      * @param  string  $abstract

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -207,4 +207,12 @@ interface Container extends ContainerInterface
      * @return void
      */
     public function afterResolving($abstract, Closure $callback = null);
+
+    /**
+     * Purge all after resolving callbacks.
+     *
+     * @param  \Closure|string  $abstract
+     * @return void
+     */
+    public function purgeAfterResolvingCallbacks($abstract);
 }


### PR DESCRIPTION
sometimes we need to purge all callbacks that are chained on resolving an abstract.

like we need to resolve a FormRequest to do/check something but we see afterResolve method chained on ValidatesWhenResolved Trait in FormRequestServiceProvider.

I know we can replace our Custom Application class with Laravel Application Class and our functions but it seemed to me maybe it is useful.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
