### PR TITLE
[9.x] Fix docblock on Batch class

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -155,7 +155,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Add additional jobs to the batch.
      *
-     * @param  \Illuminate\Support\Enumerable|array  $jobs
+     * @param  \Illuminate\Support\Enumerable|array|object  $jobs
      * @return self
      */
     public function add($jobs)


### PR DESCRIPTION
You can add jobs to a batch inside a job in two ways.

```php
// Send an array of jobs
$this->batch()->add([new SomeJob('argument1')]);

// Send one job
$this->batch()->add(new SomeJob('argument1'));
```

The DocBlock however fails to reflect this. Sending just the instance returns a warning in PHPStorm.

This PR updates the DocBlock and fixes the issue.