### PR TITLE
[10.x] Use Guzzle to resolve the URL against the base URL

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
@@ -695,7 +696,7 @@ class PendingRequest
      */
     public function send(string $method, string $url, array $options = [])
     {
-        $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
+        $url = (string) Psr7\UriResolver::resolve(Psr7\Utils::uriFor($this->baseUrl), Psr7\Utils::uriFor($url));
 
         $options = $this->parseHttpOptions($options);
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -597,6 +597,25 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testWithBaseUrl()
+    {
+        $this->factory->fake();
+
+        $this->factory->baseUrl('http://foo.com/')->get('get');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get';
+        });
+
+        $this->factory->fake();
+
+        $this->factory->baseUrl('http://foo.com/')->get('http://bar.com/get');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://bar.com/get';
+        });
+    }
+
     public function testCanConfirmManyHeaders()
     {
         $this->factory->fake();


### PR DESCRIPTION
## Problem
I've created an HTTP macro to easily work with an API, just like the [documentation suggests](https://laravel.com/docs/9.x/http-client#macros). The response of this API is paginated and the URL of the next page is returned in the response. This URL is absolute and making a request with a base URL and an absolute URL currently results in requests like `https://api.github.com/https://api.github.com/organizations/laravel`. Guzzle allows you to set a [base URL](https://docs.guzzlephp.org/en/stable/quickstart.html) and use absolute URL's in conjuction, so I'd expect this client to support that too.

## Solution
Guzzle has quite some [logic](https://github.com/guzzle/psr7/blob/c0dcda9f54d145bd4d062a6d15f54931a67732f9/src/UriResolver.php#L58) to resolve the URL against the base URL, so I've chosen to use the same [logic](https://github.com/guzzle/guzzle/blob/master/src/Client.php#L213). If you prefer not to use an external dependency and would like to use some other logic, please let me know!