### PR TITLE
[9.x] Allow eloquent whereNot() and orWhereNot() to work on column and value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -317,26 +317,30 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "where not" clause to the query.
+     * Add a basic "where not" clause to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
      */
-    public function whereNot(Closure $callback, $boolean = 'and')
+    public function whereNot($column, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->where($callback, null, null, $boolean.' not');
+        return $this->where($column, $operator, $value, $boolean.' not');
     }
 
     /**
      * Add an "or where not" clause to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return $this
      */
-    public function orWhereNot(Closure $callback)
+    public function orWhereNot($column, $operator = null, $value = null)
     {
-        return $this->whereNot($callback, 'or');
+        return $this->whereNot($column, $operator, $value, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -884,26 +884,30 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a "where not" clause to the query.
+     * Add a basic "where not" clause to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|string|array  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
      */
-    public function whereNot(Closure $callback, $boolean = 'and')
+    public function whereNot($column, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->whereNested($callback, $boolean.' not');
+        return $this->where($column, $operator, $value, $boolean.' not');
     }
 
     /**
      * Add an "or where not" clause to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|string|array  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
      * @return $this
      */
-    public function orWhereNot(Closure $callback)
+    public function orWhereNot($column, $operator = null, $value = null)
     {
-        return $this->whereNot($callback, 'or');
+        return $this->whereNot($column, $operator, $value, 'or');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -884,6 +884,15 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 
+    public function testSimpleWhereNot()
+    {
+        $model = new EloquentBuilderTestStub();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->whereNot('name', 'foo')->whereNot('name', '<>', 'bar');
+        $this->assertEquals('select * from "table" where not "name" = ? and not "name" <> ?', $query->toSql());
+        $this->assertEquals(['foo', 'bar'], $query->getBindings());
+    }
+
     public function testWhereNot()
     {
         $nestedQuery = m::mock(Builder::class);
@@ -901,6 +910,15 @@ class DatabaseEloquentBuilderTest extends TestCase
             $query->foo();
         });
         $this->assertEquals($builder, $result);
+    }
+
+    public function testSimpleOrWhereNot()
+    {
+        $model = new EloquentBuilderTestStub();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->orWhereNot('name', 'foo')->orWhereNot('name', '<>', 'bar');
+        $this->assertEquals('select * from "table" where not "name" = ? or not "name" <> ?', $query->toSql());
+        $this->assertEquals(['foo', 'bar'], $query->getBindings());
     }
 
     public function testOrWhereNot()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -302,6 +302,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testBasicWhereNot()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot('name', 'foo')->whereNot('name', '<>', 'bar');
+        $this->assertSame('select * from "users" where not "name" = ? and not "name" <> ?', $builder->toSql());
+        $this->assertEquals(['foo', 'bar'], $builder->getBindings());
+    }
+
     public function testWheresWithArrayValue()
     {
         $builder = $this->getBuilder();
@@ -714,6 +722,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhere('email', '=', 'foo');
         $this->assertSame('select * from "users" where "id" = ? or "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
+    }
+
+    public function testBasicOrWhereNot()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orWhereNot('name', 'foo')->orWhereNot('name', '<>', 'bar');
+        $this->assertSame('select * from "users" where not "name" = ? or not "name" <> ?', $builder->toSql());
+        $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
     public function testRawWheres()


### PR DESCRIPTION
Hi,

This PR https://github.com/laravel/framework/pull/41096 added `whereNot()` and `orWhereNot()` to the eloquent query builder and query builder.

The PR allows to apply a where not on a group of wheres but does not allow to do something like this

```php
$query->whereNot('role', 'admin'); // WHERE NOT role = 'admin'
``` 

This PR adds that (for both whereNot() and orWhereNot() ) while it also keeps the ability to use a where not on grouped wheres as well.

It will keep the same method signature developers are used to when using `where()` and `orWhere()` by allowing to specify and `$operator` and `$column` variables

If this PR is merged now, it will be a good thing since the Original PR was not yet tagged in any new release.