### PR TITLE
[9.x] Change how Laravel handles strict morph map with pivot classes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -730,6 +731,10 @@ trait HasRelationships
 
         if (! empty($morphMap) && in_array(static::class, $morphMap)) {
             return array_search(static::class, $morphMap, true);
+        }
+
+        if (static::class === Pivot::class) {
+            return static::class;
         }
 
         if (Relation::requiresMorphMap()) {

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\ClassMorphViolationException;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use PHPUnit\Framework\TestCase;
 
@@ -20,14 +21,14 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
     {
         $this->expectException(ClassMorphViolationException::class);
 
-        $model = TestModel::make();
+        $model = new TestModel;
 
         $model->getMorphClass();
     }
 
     public function testStrictModeDoesNotThrowExceptionWhenMorphMap()
     {
-        $model = TestModel::make();
+        $model = new TestModel;
 
         Relation::morphMap([
             'test' => TestModel::class,
@@ -39,7 +40,7 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 
     public function testMapsCanBeEnforcedInOneMethod()
     {
-        $model = TestModel::make();
+        $model = new TestModel;
 
         Relation::requireMorphMap(false);
 
@@ -49,6 +50,22 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 
         $morphName = $model->getMorphClass();
         $this->assertSame('test', $morphName);
+    }
+
+    public function testMapIgnoreGenericPivotClass()
+    {
+        $pivotModel = new Pivot();
+
+        $pivotModel->getMorphClass();
+    }
+
+    public function testMapCanBeEnforcedToCustomPivotClass()
+    {
+        $this->expectException(ClassMorphViolationException::class);
+
+        $pivotModel = new TestPivotModel();
+
+        $pivotModel->getMorphClass();
     }
 
     protected function tearDown(): void
@@ -61,5 +78,9 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 }
 
 class TestModel extends Model
+{
+}
+
+class TestPivotModel extends Pivot
 {
 }


### PR DESCRIPTION
* Generic Pivot class should always be ignored as it doesn't have any knowledge of the exact usage and is generated automatically by Laravel.
* Custom Pivot class should work the same as a normal model class since it is defined manually by the developer.

In Laravel Nova, when we attach, update attached, and detach resources we
would store the pivot model in `action_events` table and this can cause
issue when the developer attempt to use `Relation::requireMorphMap()`.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>
