### PR TITLE
[9.x] Add extra type checks for model factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "mockery/mockery": "^1.4.4",
         "orchestra/testbench-core": "^7.1",
         "pda/pheanstalk": "^4.0",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^9.5.8",
         "predis/predis": "^1.1.9",
         "symfony/cache": "^6.0"

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -32,6 +32,7 @@ assertType('UserFactory', $factory = UserFactory::new());
 assertType('UserFactory', UserFactory::new(['string' => 'string']));
 assertType('UserFactory', UserFactory::new(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -45,6 +46,7 @@ assertType('array<int|string, mixed>', $factory->raw());
 assertType('array<int|string, mixed>', $factory->raw(['string' => 'string']));
 assertType('array<int|string, mixed>', $factory->raw(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -54,6 +56,7 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->createOne());
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(['string' => 'string']));
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -63,6 +66,7 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly());
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(['string' => 'string']));
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -86,6 +90,7 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
 ]));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->create(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -117,6 +122,7 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne([
 ]));
 assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -130,6 +136,7 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
 ]));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->make(function ($attributes) {
     assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -31,7 +31,7 @@ class UserFactory extends Factory
 assertType('UserFactory', $factory = UserFactory::new());
 assertType('UserFactory', UserFactory::new(['string' => 'string']));
 assertType('UserFactory', UserFactory::new(function ($attributes) {
-//    assertType('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
     return ['string' => 'string'];
 }));
 
@@ -44,7 +44,7 @@ assertType('UserFactory', $factory->configure());
 assertType('array<int|string, mixed>', $factory->raw());
 assertType('array<int|string, mixed>', $factory->raw(['string' => 'string']));
 assertType('array<int|string, mixed>', $factory->raw(function ($attributes) {
-//    assert('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
     return ['string' => 'string'];
 }));
 
@@ -53,7 +53,7 @@ assertType('array<int|string, mixed>', $factory->raw(function ($attributes) {
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOne());
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(['string' => 'string']));
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(function ($attributes) {
-//    assertType('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
     return ['string' => 'string'];
 }));
 
@@ -62,7 +62,7 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(function ($
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly());
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(['string' => 'string']));
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(function ($attributes) {
-//    assertType('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
     return ['string' => 'string'];
 }));
 
@@ -85,7 +85,7 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
     'string' => 'string',
 ]));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->create(function ($attributes) {
-//    assertType('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
     return ['string' => 'string'];
 }));
 
@@ -116,7 +116,7 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne([
     'string' => 'string',
 ]));
 assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne(function ($attributes) {
-//    assert('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
     return ['string' => 'string'];
 }));
 
@@ -129,7 +129,7 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
     'string' => 'string',
 ]));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->make(function ($attributes) {
-//    assert('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
     return ['string' => 'string'];
 }));
 


### PR DESCRIPTION
This PR is a followup to #40902, previously some type assertions were not possible due to a limitation in PHPStan, this has now been fixed (since PHPStan 1.4.7, in phpstan/phpstan-src#1019) so these assertions can be added in.