### PR TITLE
[9.x] Added whereInRaw() and whereNotInRaw()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1064,6 +1064,41 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a "where in raw" clause to the query.
+     *
+     * @param  string  $column
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereInRaw($column, $values, $boolean = 'and', $not = false)
+    {
+        $type = $not ? 'NotInRaw' : 'InRaw';
+
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        $this->wheres[] = compact('type', 'column', 'values', 'boolean');
+
+        return $this;
+    }
+
+    /**
+     * Add a "where not in raw" clause to the query.
+     *
+     * @param  string  $column
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotInRaw($column, $values, $boolean = 'and')
+    {
+        return $this->whereInRaw($column, $values, $boolean, true);
+    }
+
+    /**
      * Add a "where in raw" clause for integer values to the query.
      *
      * @param  string  $column


### PR DESCRIPTION
Currently we have a `whereIntegerInRaw()` and a `whereIntegerNotInRaw()`. These functions do not apply PDO bindings, which make the use of these raw queries really fast. The downside is that it's for integers only (it casts every value to an int).

Due to a bug in MariaDB (see https://jira.mariadb.org/browse/MDEV-27937), where `whereIn()` cannot have more than a 999 bindings or it will return 0 records (see https://github.com/laravel/framework/issues/41290), I found the Laravel function `whereIntegerInRaw()`. Unfortunately, my array has strings. So I came up with these `whereInRaw()` and `whereNotInRaw()` functions.