### PR TITLE
[9.x] Do not prepend baseUrl to absolute urls

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -695,7 +695,7 @@ class PendingRequest
      */
     public function send(string $method, string $url, array $options = [])
     {
-        if (!Str::startsWith($url, ['http://', 'https://'])) {
+        if (! Str::startsWith($url, ['http://', 'https://'])) {
             $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
         }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -695,7 +695,9 @@ class PendingRequest
      */
     public function send(string $method, string $url, array $options = [])
     {
-        $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
+        if (!Str::startsWith($url, ['http://', 'https://'])) {
+            $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
+        }
 
         $options = $this->parseHttpOptions($options);
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -597,6 +597,25 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testWithBaseUrl()
+    {
+        $this->factory->fake();
+
+        $this->factory->baseUrl('http://foo.com/')->get('get');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get';
+        });
+
+        $this->factory->fake();
+
+        $this->factory->baseUrl('http://foo.com/')->get('http://bar.com/get');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://bar.com/get';
+        });
+    }
+
     public function testCanConfirmManyHeaders()
     {
         $this->factory->fake();


### PR DESCRIPTION
This is a non-breaking version of #41289.

## Problem
I've created an HTTP macro to easily work with an API, just like the [documentation suggests](https://laravel.com/docs/9.x/http-client#macros). The response of this API is paginated and the URL of the next page is returned in the response. This URL is absolute and making a request with a base URL and an absolute URL currently results in requests like `https://api.github.com/https://api.github.com/organizations/laravel`. Guzzle allows you to set a [base URL](https://docs.guzzlephp.org/en/stable/quickstart.html) and use absolute URL's in conjuction, so I'd expect this client to support that too.

## Solution
Guzzle follows [RFC 3986](https://tools.ietf.org/html/rfc3986#section-5.2) to resolve the URL against the base URL, but implementing the same logic will be a breaking change, as described in https://github.com/laravel/framework/pull/41289#issuecomment-1057305273. This fix is more naive and will only fix the base URL + absolute URL issue.