### PR TITLE
[9.x] Optionally cascade thrown Flysystem exceptions

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -236,7 +236,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->read($path);
         } catch (UnableToReadFile $e) {
-            //
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
         }
     }
 
@@ -330,6 +332,10 @@ class FilesystemAdapter implements CloudFilesystemContract
                 ? $this->driver->writeStream($path, $contents, $options)
                 : $this->driver->write($path, $contents, $options);
         } catch (UnableToWriteFile $e) {
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
+
             return false;
         }
 
@@ -405,6 +411,10 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->setVisibility($path, $this->parseVisibility($visibility));
         } catch (UnableToSetVisibility $e) {
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
+
             return false;
         }
 
@@ -461,6 +471,10 @@ class FilesystemAdapter implements CloudFilesystemContract
             try {
                 $this->driver->delete($path);
             } catch (UnableToDeleteFile $e) {
+                if ($this->throwsExceptions()) {
+                    throw $e;
+                }
+
                 $success = false;
             }
         }
@@ -480,6 +494,10 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->copy($from, $to);
         } catch (UnableToCopyFile $e) {
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
+
             return false;
         }
 
@@ -498,6 +516,10 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->move($from, $to);
         } catch (UnableToMoveFile $e) {
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
+
             return false;
         }
 
@@ -545,7 +567,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->readStream($path);
         } catch (UnableToReadFile $e) {
-            //
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
         }
     }
 
@@ -557,6 +581,10 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->writeStream($path, $resource, $options);
         } catch (UnableToWriteFile $e) {
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
+
             return false;
         }
 
@@ -753,6 +781,10 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->createDirectory($path);
         } catch (UnableToCreateDirectory $e) {
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
+
             return false;
         }
 
@@ -770,6 +802,10 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->deleteDirectory($directory);
         } catch (UnableToDeleteDirectory $e) {
+            if ($this->throwsExceptions()) {
+                throw $e;
+            }
+
             return false;
         }
 
@@ -836,6 +872,17 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function buildTemporaryUrlsUsing(Closure $callback)
     {
         $this->temporaryUrlCallback = $callback;
+    }
+
+
+    /**
+     * Determine if Flysystem exceptions should be thrown.
+     *
+     * @return bool
+     */
+    protected function throwsExceptions(): bool
+    {
+        return (bool) ($this->config['throws_exceptions'] ?? false);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -874,7 +874,6 @@ class FilesystemAdapter implements CloudFilesystemContract
         $this->temporaryUrlCallback = $callback;
     }
 
-
     /**
      * Determine if Flysystem exceptions should be thrown.
      *

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -236,9 +236,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->read($path);
         } catch (UnableToReadFile $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
         }
     }
 
@@ -332,9 +330,7 @@ class FilesystemAdapter implements CloudFilesystemContract
                 ? $this->driver->writeStream($path, $contents, $options)
                 : $this->driver->write($path, $contents, $options);
         } catch (UnableToWriteFile $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
 
             return false;
         }
@@ -411,9 +407,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->setVisibility($path, $this->parseVisibility($visibility));
         } catch (UnableToSetVisibility $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
 
             return false;
         }
@@ -471,9 +465,7 @@ class FilesystemAdapter implements CloudFilesystemContract
             try {
                 $this->driver->delete($path);
             } catch (UnableToDeleteFile $e) {
-                if ($this->throwsExceptions()) {
-                    throw $e;
-                }
+                throw_if($this->throwsExceptions(), $e);
 
                 $success = false;
             }
@@ -494,9 +486,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->copy($from, $to);
         } catch (UnableToCopyFile $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
 
             return false;
         }
@@ -516,9 +506,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->move($from, $to);
         } catch (UnableToMoveFile $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
 
             return false;
         }
@@ -567,9 +555,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->readStream($path);
         } catch (UnableToReadFile $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
         }
     }
 
@@ -581,9 +567,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->writeStream($path, $resource, $options);
         } catch (UnableToWriteFile $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
 
             return false;
         }
@@ -781,9 +765,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->createDirectory($path);
         } catch (UnableToCreateDirectory $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
 
             return false;
         }
@@ -802,9 +784,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->deleteDirectory($directory);
         } catch (UnableToDeleteDirectory $e) {
-            if ($this->throwsExceptions()) {
-                throw $e;
-            }
+            throw_if($this->throwsExceptions(), $e);
 
             return false;
         }
@@ -881,7 +861,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     protected function throwsExceptions(): bool
     {
-        return (bool) ($this->config['throws_exceptions'] ?? false);
+        return (bool) ($this->config['throw'] ?? false);
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -408,7 +408,7 @@ class FilesystemAdapterTest extends TestCase
             return;
         }
 
-        $this->fail('Exception was not thrown.');
+        $this->fail('UnableToReadFile exception was not thrown.');
     }
 
     public function testThrowExceptionsForReadStream()
@@ -423,24 +423,25 @@ class FilesystemAdapterTest extends TestCase
             return;
         }
 
-        $this->fail('Exception was not thrown.');
+        $this->fail('UnableToReadFile exception was not thrown.');
     }
 
-    /** @requires OS Linux|Darwin */
     public function testThrowExceptionsForPut()
     {
-        mkdir(__DIR__.'/tmp/bar', 0600);
+        $this->filesystem->write('foo.txt', 'Hello World');
 
-        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
+        chmod(__DIR__.'/tmp/foo.txt', 0400);
+
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
 
         try {
-            $adapter->put('/bar/foo.txt', 'Hello World!');
+            $adapter->put('foo.txt', 'Hello World!');
+
+            $this->fail('UnableToWriteFile exception was not thrown.');
         } catch (UnableToWriteFile $e) {
             $this->assertTrue(true);
-
-            return;
+        } finally {
+            chmod(__DIR__.'/tmp/foo.txt', 0600);
         }
-
-        $this->fail('Exception was not thrown.');
     }
 }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -408,7 +408,7 @@ class FilesystemAdapterTest extends TestCase
             return;
         }
 
-        $this->fail('UnableToReadFile exception was not thrown.');
+        $this->fail('Exception was not thrown.');
     }
 
     public function testThrowExceptionsForReadStream()
@@ -423,25 +423,24 @@ class FilesystemAdapterTest extends TestCase
             return;
         }
 
-        $this->fail('UnableToReadFile exception was not thrown.');
+        $this->fail('Exception was not thrown.');
     }
 
+    /** @requires OS Linux|Darwin */
     public function testThrowExceptionsForPut()
     {
-        $this->filesystem->write('foo.txt', 'Hello World');
+        mkdir(__DIR__.'/tmp/bar', 0600);
 
-        chmod(__DIR__.'/tmp/foo.txt', 0400);
-
-        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
         try {
-            $adapter->put('foo.txt', 'Hello World!');
-
-            $this->fail('UnableToWriteFile exception was not thrown.');
+            $adapter->put('/bar/foo.txt', 'Hello World!');
         } catch (UnableToWriteFile $e) {
             $this->assertTrue(true);
-        } finally {
-            chmod(__DIR__.'/tmp/foo.txt', 0600);
+
+            return;
         }
+
+        $this->fail('Exception was not thrown.');
     }
 }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -426,9 +426,10 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
+    /** @requires OS Linux|Darwin */
     public function testThrowExceptionsForPut()
     {
-        mkdir(__DIR__.DIRECTORY_SEPARATOR.'tmp'.DIRECTORY_SEPARATOR.'bar', 0600);
+        mkdir(__DIR__.'/tmp/bar', 0600);
 
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -13,6 +13,8 @@ use InvalidArgumentException;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Ftp\FtpAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\UnableToReadFile;
+use League\Flysystem\UnableToWriteFile;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -392,5 +394,52 @@ class FilesystemAdapterTest extends TestCase
             $path.$expiration->toString().implode('', $options),
             $filesystemAdapter->temporaryUrl($path, $expiration, $options)
         );
+    }
+
+    public function testThrowExceptionForGet()
+    {
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
+
+        try {
+            $adapter->get('/foo.txt');
+        } catch (UnableToReadFile $e) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
+    }
+
+    public function testThrowExceptionsForReadStream()
+    {
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
+
+        try {
+            $adapter->readStream('/foo.txt');
+        } catch (UnableToReadFile $e) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
+    }
+
+    public function testThrowExceptionsForPut()
+    {
+        mkdir(__DIR__.'/tmp/bar', 0600);
+
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
+
+        try {
+            $adapter->put('/bar/foo.txt', 'Hello World!');
+        } catch (UnableToWriteFile $e) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
     }
 }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -428,7 +428,7 @@ class FilesystemAdapterTest extends TestCase
 
     public function testThrowExceptionsForPut()
     {
-        mkdir(__DIR__.'/tmp/bar', 0600);
+        mkdir(__DIR__.DIRECTORY_SEPARATOR.'tmp'.DIRECTORY_SEPARATOR.'bar', 0600);
 
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -398,7 +398,7 @@ class FilesystemAdapterTest extends TestCase
 
     public function testThrowExceptionForGet()
     {
-        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
         try {
             $adapter->get('/foo.txt');
@@ -413,7 +413,7 @@ class FilesystemAdapterTest extends TestCase
 
     public function testThrowExceptionsForReadStream()
     {
-        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
         try {
             $adapter->readStream('/foo.txt');
@@ -431,7 +431,7 @@ class FilesystemAdapterTest extends TestCase
     {
         mkdir(__DIR__.'/tmp/bar', 0600);
 
-        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throws_exceptions' => true]);
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
         try {
             $adapter->put('/bar/foo.txt', 'Hello World!');


### PR DESCRIPTION
This PR gives the ability to optionally cascade thrown Flysystem exceptions with a `throws_exceptions` config option.

There's a concern with this: operations like the `delete` method will hard-fail now when passing multiple paths. Any paths that haven't been reached yet won't be deleted yet. Not sure if this is something we should work around?

This PR is opt-in and non-breaking.

Related: https://github.com/laravel/framework/issues/41269