### PR TITLE
[9.x] Allow overriding transport type on Mailgun transporter

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -281,7 +281,7 @@ class MailManager implements FactoryContract
         }
 
         return $factory->create(new Dsn(
-            'mailgun+https',
+            'mailgun+'.($config['transport_type'] ?? 'https'),
             $config['endpoint'] ?? 'default',
             $config['secret'],
             $config['domain']

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -281,7 +281,7 @@ class MailManager implements FactoryContract
         }
 
         return $factory->create(new Dsn(
-            'mailgun+'.($config['transport_type'] ?? 'https'),
+            'mailgun+'.($config['scheme'] ?? 'https'),
             $config['endpoint'] ?? 'default',
             $config['secret'],
             $config['domain']


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In #41255 the Mailgun transport type was changed from `api` to `https`. This breaks my application, as I add some custom headers which were working fine with the API transporter, but are ignored on the messages.mime endpoint. This MR allows overriding the transport type you want to use for Mailgun, while leaving the default option unchanged.

If wanted, I can also provide a PR to add this config key to the `laravel/laravel` repo.