### PR TITLE
[9.x] Correct `giveConfig` param doc

### DIFF
--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -86,7 +86,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      * Specify the configuration item to bind as a primitive.
      *
      * @param  string  $key
-     * @param  ?string  $default
+     * @param  mixed  $default
      * @return void
      */
     public function giveConfig($key, $default = null)

--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -32,7 +32,7 @@ interface ContextualBindingBuilder
      * Specify the configuration item to bind as a primitive.
      *
      * @param  string  $key
-     * @param  ?string  $default
+     * @param  mixed  $default
      * @return void
      */
     public function giveConfig($key, $default = null);


### PR DESCRIPTION
This PR corrects the phpdoc for the `giveConfig` method on `\Illuminate\Contracts\Container\ContextualBindingBuilder` and `\Illuminate\Container\ContextualBindingBuilder`. I believe it wasn't intentional to restrict the default param to string or null in the original PR(s): #36241 and #39819

As you can see the `get` method on the config repository accepts mixed: https://github.com/laravel/framework/blob/e7d67f4ae06b15e8665de7c443c5933cbf5087d2/src/Illuminate/Config/Repository.php#L44

So I believe this should also be reflected on the `giveConfig` method.