### PR TITLE
[9.x] Add dumpQuery testing method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -246,4 +246,22 @@ trait InteractsWithDatabase
 
         return $this;
     }
+
+    /**
+     * Dump the database query.
+     *
+     * @return $this
+     */
+    protected function dumpQuery()
+    {
+        $database = $this->app->make('db');
+
+        $database->enableQueryLog();
+
+        $this->beforeApplicationDestroyed(function () use ($database) {
+            dump($database->getQueryLog());
+        });
+
+        return $this;
+    }
 }


### PR DESCRIPTION
## What & Why
When testing, you sometimes want to check what db queries are running especially when you fail your test.
This method enables you to do that. This is very useful for debugging.
After debugging is complete, you just erase it.

## Example
### code
```php
// web.php
Route::get('/', function () {
    $user = User::where('email', 'abc@example.net')->first();

    return view('welcome');
});

// test
/** @test */
function test_index()
{
    $this->dumpQuery();

    $this->get('/')
        ->assertOk();
}
```
### output
```php
// output
^ array:1 [
  0 => array:3 [
    "query" => "select * from "users" where "email" = ? limit 1"
    "bindings" => array:1 [
      0 => "abc@example.net"
    ]
    "time" => 0.05
  ]
]

   PASS  Tests\Feature\ExampleTest
  ✓ index

  Tests:  1 passed
  Time:   0.10s
```