### PR TITLE
[9.x] Fix MySqlSchemaState does not add --ssl-ca to mysql cli + tests

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -103,9 +103,14 @@ class MySqlSchemaState extends SchemaState
     {
         $value = ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}"';
 
-        $value .= $this->connection->getConfig()['unix_socket'] ?? false
+        $config = $this->connection->getConfig();
+        $value .= $config['unix_socket'] ?? false
                         ? ' --socket="${:LARAVEL_LOAD_SOCKET}"'
-                        : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
+                        : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"';
+
+        if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_CA])) {
+            $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
+        }
 
         return $value;
     }

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\Schema\MySqlSchemaState;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMySqlSchemaStateTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     */
+    public function testConnectionString(string $expectedConnectionString, array $expectedVariables, array $dbConfig): void
+    {
+        $connection = $this->createMock(MySqlConnection::class);
+        $connection->method('getConfig')->willReturn($dbConfig);
+
+        $schemaState = new MySqlSchemaState($connection);
+
+        // test connectionString
+        $method = new \ReflectionMethod(get_class($schemaState), 'connectionString');
+        $connString = tap($method)->setAccessible(true)->invoke($schemaState);
+
+        self::assertEquals($expectedConnectionString, $connString);
+
+        // test baseVariables
+        $method = new \ReflectionMethod(get_class($schemaState), 'baseVariables');
+        $variables = tap($method)->setAccessible(true)->invoke($schemaState, $dbConfig);
+
+        self::assertEquals($expectedVariables, $variables);
+    }
+
+    public function provider(): \Generator
+    {
+        yield 'default' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '127.0.0.1',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+            ], [
+                'username' => 'root',
+                'host' => '127.0.0.1',
+                'database' => 'forge',
+            ],
+        ];
+
+        yield 'ssl_ca' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => 'ssl.ca',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                ],
+            ],
+        ];
+
+        yield 'unix socket' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [
+                'LARAVEL_LOAD_SOCKET' => '/tmp/mysql.sock',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'unix_socket' => '/tmp/mysql.sock',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
https://github.com/laravel/framework/pull/41315 + tests