### PR TITLE
[9.x] Support modifying a char column type

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -125,6 +125,10 @@ class ChangeColumn
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }
 
+        if ($fluent['type'] === 'char') {
+            $options['fixed'] = true;
+        }
+
         if (static::doesntNeedCharacterOptions($fluent['type'])) {
             $options['customSchemaOptions'] = [
                 'collation' => '',
@@ -151,6 +155,7 @@ class ChangeColumn
             'mediumtext', 'longtext' => 'text',
             'binary' => 'blob',
             'uuid' => 'guid',
+            'char' => 'string',
             default => $type,
         });
     }

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -126,6 +126,29 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $this->assertEquals($expected2, $queries2);
     }
 
+    public function testChangingCharColumnsWork()
+    {
+        $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
+            $table->string('name');
+        });
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->char('name', 50)->change();
+        });
+
+        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
+
+        $expected = [
+            'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
+            'DROP TABLE users',
+            'CREATE TABLE users (name CHAR(50) NOT NULL COLLATE BINARY)',
+            'INSERT INTO users (name) SELECT name FROM __temp__users',
+            'DROP TABLE __temp__users',
+        ];
+
+        $this->assertEquals($expected, $queries);
+    }
+
     public function testRenameIndexWorks()
     {
         $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {


### PR DESCRIPTION
This PR provides support for modifying a `char` column type.

```php
Schema::table('users', function (Blueprint $table) {
    $table->char('name', 50)->nullable()->change();
});
```

Before this PR, modifying a `char` column led to an error:

> `Unknown column type \"char\" requested. Any Doctrine type that you use has to be registered with \\Doctrine\\DBAL\\Types\\Type::addType(). You can get a list of all the known types with \\Doctrine\\DBAL\\Types\\Type::getTypesMap(). If this error occurs during database introspection then you might have forgotten to register all database types for a Doctrine Type. Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement Type#getMappedDatabaseTypes(). If the type name is empty you might have a problem with the cache or forgot some mapping information`

But `doctrine/dbal` package actually supports modifying `char` column types as [`StringType::class`](https://github.com/doctrine/dbal/blob/e839cecc812fd04ec6c39fc865302b6a322d967d/src/Types/StringType.php) by setting `fixed` option to `true`.

So this PR, maps Laravel `char` to its Doctrine equivalent `string` type and set `fixed` option to `true` that finally [gets the SQL snippet to declare a CHAR column](https://github.com/doctrine/dbal/blob/e839cecc812fd04ec6c39fc865302b6a322d967d/src/Platforms/AbstractMySQLPlatform.php#L199).