### PR TITLE
[9.x] Add temporary file helpers

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -18,6 +18,25 @@ class Filesystem
     use Macroable;
 
     /**
+     * The currently open temporary files.
+     *
+     * @var array
+     */
+    protected static $openTemporaryFiles = [];
+
+    /**
+     * Close all teh currently open temporary files.
+     *
+     * @return void
+     */
+    public static function closeOpenTemporaryFiles()
+    {
+        while ($pointer = array_pop(self::$openTemporaryFiles)) {
+            fclose($pointer);
+        }
+    }
+
+    /**
      * Determine if a file or directory exists.
      *
      * @param  string  $path
@@ -746,7 +765,11 @@ class Filesystem
      */
     public function temporaryFilename()
     {
-        return stream_get_meta_data(tmpfile())['uri'];
+        $handle = tmpfile();
+
+        self::$openTemporaryFiles[] = $handle;
+
+        return stream_get_meta_data($handle)['uri'];
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -738,4 +738,32 @@ class Filesystem
     {
         return $this->deleteDirectory($directory, true);
     }
+
+    /**
+     * Get the path to a temporary file (will be removed when script ends).
+     *
+     * @return string
+     */
+    public function temporaryFilename()
+    {
+        return stream_get_meta_data(tmpfile())['uri'];
+    }
+
+    /**
+     * Write to a temporary file.
+     *
+     * @param  string  $contents
+     * @param  bool  $lock
+     * @return false|string
+     */
+    public function putTemporary($contents, $lock = false)
+    {
+        $path = $this->temporaryFilename();
+
+        if ($this->put($path, $contents, $lock) === false) {
+            return false;
+        }
+
+        return $path;
+    }
 }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Queue\Queue;
 use Illuminate\Support\Carbon;
@@ -203,6 +204,7 @@ abstract class TestCase extends BaseTestCase
         Artisan::forgetBootstrappers();
         Queue::createPayloadUsing(null);
         HandleExceptions::forgetApp();
+        Filesystem::closeOpenTemporaryFiles();
 
         if ($this->callbackException) {
             throw $this->callbackException;

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -582,7 +582,7 @@ class FilesystemTest extends TestCase
     public function testTemporaryFilename()
     {
         $fs = new Filesystem;
-        $this->assertStringContainsString(realpath(sys_get_temp_dir()), realpath($fs->temporaryFilename()));
+        $this->assertFileExists($fs->temporaryFilename());
     }
 
     public function testPutTemporary()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -582,14 +582,13 @@ class FilesystemTest extends TestCase
     public function testTemporaryFilename()
     {
         $fs = new Filesystem;
-        $this->assertStringContainsString(sys_get_temp_dir(), $fs->temporaryFilename());
+        $this->assertStringContainsString(realpath(sys_get_temp_dir()), realpath($fs->temporaryFilename()));
     }
 
     public function testPutTemporary()
     {
         $files = new Filesystem;
         $path = $files->putTemporary('Hello World');
-        $this->assertStringContainsString(sys_get_temp_dir(), $path);
         $this->assertStringEqualsFile($path, 'Hello World');
     }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -593,6 +593,22 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($path, 'Hello World');
     }
 
+    public function testCloseOpenTemporaryFiles()
+    {
+        $files = new Filesystem;
+
+        $path1 = $files->temporaryFilename();
+        $path2 = $files->putTemporary('');
+
+        $this->assertFileExists($path1);
+        $this->assertFileExists($path2);
+
+        Filesystem::closeOpenTemporaryFiles();
+
+        $this->assertFileDoesNotExist($path1);
+        $this->assertFileDoesNotExist($path2);
+    }
+
     /**
      * @param  string  $file
      * @return int

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -579,6 +579,20 @@ class FilesystemTest extends TestCase
         $this->assertSame('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash(self::$tempDir.'/foo.txt'));
     }
 
+    public function testTemporaryFilename()
+    {
+        $fs = new Filesystem;
+        $this->assertStringContainsString(sys_get_temp_dir(), $fs->temporaryFilename());
+    }
+
+    public function testPutTemporary()
+    {
+        $files = new Filesystem;
+        $path = $files->putTemporary('Hello World');
+        $this->assertStringContainsString(sys_get_temp_dir(), $path);
+        $this->assertStringEqualsFile($path, 'Hello World');
+    }
+
     /**
      * @param  string  $file
      * @return int


### PR DESCRIPTION
This adds three new functions to the `Filesystem` class:

- `temporaryFilename()` — returns the path to a temporary file that will be removed when the script ends
- `putTemporary()` — write contents to a temporary file that will be removed when the script ends
- `closeOpenTemporaryFiles()` — a static method to close all open temporary file handles (useful for testing and probably should be added to Octane if this PR is merged)