### PR TITLE
[8.x] Fixes getting the trusted proxies IPs from the configuration file

### DIFF
--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -47,7 +47,7 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddresses(Request $request)
     {
-        $trustedIps = $this->proxies ?: config('trustedproxy.proxies');
+        $trustedIps = $this->proxies() ?: config('trustedproxy.proxies');
 
         if ($trustedIps === '*' || $trustedIps === '**') {
             return $this->setTrustedProxyIpAddressesToTheCallingIp($request);

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -47,7 +47,7 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddresses(Request $request)
     {
-        $trustedIps = $this->proxies();
+        $trustedIps = $this->proxies ?: config('trustedproxy.proxies');
 
         if ($trustedIps === '*' || $trustedIps === '**') {
             return $this->setTrustedProxyIpAddressesToTheCallingIp($request);


### PR DESCRIPTION
This pull request allows getting the trusted proxies IPs from the configuration file, like back in the days when we had Fideloper's package.