### PR TITLE
[9.x] Remove constructor from console command stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -21,16 +21,6 @@ class {{ class }} extends Command
     protected $description = 'Command description';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int


### PR DESCRIPTION
I don't believe there's really any reason a constructor would be used in 99% of console commands. Any dependencies can be injected directly into the `handle()` method, and if we drop the constructor, the parent constructor will be called automatically.

I know we can generate our own stubs, but I believe this applies to the large majority of users. Looking through some of my projects, not a single console command does anything in the constructor.