### PR TITLE
[9.x] Allow chaining of `->newLine()`

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -372,11 +372,13 @@ trait InteractsWithIO
      * Write a blank line.
      *
      * @param  int  $count
-     * @return void
+     * @return $this
      */
     public function newLine($count = 1)
     {
         $this->output->newLine($count);
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
```php
$this->newLine();
$this->info('Success!');
```

can now be shortened to

```php
$this->newLine()->info('Success');
```

If people like this, would we want to apply this to all of our console output commands, like `warn()`, `error()`, `question()`, etc?