### PR TITLE
[9.x] Set SES MessageId to the sent message ID

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -45,7 +45,7 @@ class SesTransport extends AbstractTransport
     protected function doSend(SentMessage $message): void
     {
         try {
-            $this->ses->sendRawEmail(
+            $result = $this->ses->sendRawEmail(
                 array_merge(
                     $this->options, [
                         'Source' => $message->getEnvelope()->getSender()->toString(),
@@ -58,6 +58,8 @@ class SesTransport extends AbstractTransport
         } catch (AwsException $e) {
             throw new Exception('Request to AWS SES API failed.', $e->getCode(), $e);
         }
+        
+        $message->setMessageId($result->get('MessageId'));
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -58,7 +58,7 @@ class SesTransport extends AbstractTransport
         } catch (AwsException $e) {
             throw new Exception('Request to AWS SES API failed.', $e->getCode(), $e);
         }
-        
+
         $message->setMessageId($result->get('MessageId'));
     }
 

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Aws\Result;
 use Aws\Ses\SesClient;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
@@ -56,10 +57,15 @@ class MailSesTransportTest extends TestCase
         $message->to('me@example.com');
         $message->bcc('you@example.com');
 
-        $client = m::mock(SesClient::class);
-        $client->shouldReceive('sendRawEmail')->once();
+        $result = m::mock(Result::class);
+        $result->shouldReceive('get')->once()->with('MessageId')->andReturn('123');
 
-        (new SesTransport($client))->send($message);
+        $client = m::mock(SesClient::class);
+        $client->shouldReceive('sendRawEmail')->once()->andReturn($result);
+
+        $sentMessage = (new SesTransport($client))->send($message);
+
+        $this->assertEquals('123', $sentMessage->getMessageId());
     }
 
     public function testSesLocalConfiguration()


### PR DESCRIPTION
This PR sets the given SES message ID as the `SentMessage`'s message ID.

As mentioned in #40696, the addition of Message ID's to the headers of the just-sent message was removed because Symfony is generating one. But the actual SES message ID may be needed, in my case, to manage the status of the sent e-mail, that may be afterwards sent by the SES service, referencing the previously given ID.