### PR TITLE
The collection merge method supports multiple parameters

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -733,12 +733,23 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * Merge the collection with the given items.
+     * 
+     * Supports multiple parameters
      *
      * @param  mixed  $items
+     * @param  mixed  $others
      * @return static
      */
-    public function merge($items)
+    public function merge($items, ...$others)
     {
+        if (func_num_args() > 1){
+            $items = (new static(func_get_args()))
+                ->map(function ($item) {
+                    return $this->getArrayableItems($item);
+                })
+                ->flatten(1);
+        }
+
         return new static(array_merge($this->items, $this->getArrayableItems($items)));
     }
 

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -47,7 +47,7 @@ class ListenerMakeCommand extends GeneratorCommand
             'Illuminate',
             '\\',
         ])) {
-            $event = $this->laravel->getNamespace().'Events\\'.$event;
+            $event = $this->laravel->getNamespace().'Events\\'.str_replace('/', '\\', $event);
         }
 
         $stub = str_replace(

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1260,6 +1260,15 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMergeMultiple($collection)
+    {
+        $c = new $collection(['name' => 'Hello']);
+        $this->assertEquals(['name' => 'Hello', 'id' => 1, 'roles' => 'admin', 'tage' => ['a', 'b']], $c->merge(['id' => 1], ['roles' => 'admin'], ['tage' => ['a', 'b']])->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testReplaceNull($collection)
     {
         $c = new $collection(['a', 'b', 'c']);


### PR DESCRIPTION
The collection `merge()` method supports multiple parameters.

### Before:
```php
$a = ['a'];
$b = ['b'];
$c = ['c'];
$d = ['d' => ['e', 'f']];
$result = collect($a)->merge($b)->merge($c)->merge($d); //['a','b','c',['e','f']]
```
### After
```php
$a = ['a'];
$b = ['b'];
$c = ['c'];
$d = ['d' => ['e', 'f']];
$result = collect($a)->merge($b, $c, $d); //['a','b','c',['e','f']]
```