### PR TITLE
[9.x] Loose comparison causes the value not to be saved

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1939,8 +1939,8 @@ trait HasAttributes
             return $this->fromDateTime($attribute) ===
                 $this->fromDateTime($original);
         } elseif ($this->hasCast($key, ['object', 'collection'])) {
-            return $this->castAttribute($key, $attribute) ==
-                $this->castAttribute($key, $original);
+            return $this->fromJson($attribute) ===
+                $this->fromJson($original);
         } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
             if ($original === null) {
                 return false;


### PR DESCRIPTION
The issue has been addressed in #37961.

Given an attribute with the cast `object` or `collection`, the `$model->isDirty()` method returns the wrong value due to the use of loose comparison.

Example from issue #37961:
```php
use Illuminate\Database\Eloquent\Model;

class Test extends Model
{
    protected $casts = [
        'collection' => 'collection',
    ];
    protected $fillable = [
        'collection',
    ];
}

$model = new Test(['collection' => ['key' => true]]);
$model->syncOriginal();
$model->fill(['collection' => ['key' => 'value']]);

$model->isDirty(); // false but should be true

// or
$model = new Test(['collection' => ['key' => null]]);
$model->syncOriginal();
$model->fill(['collection' => ['key' => false]]);

$model->isDirty(); // false but should be true
```

The solution proposed by @krnsptr [link](https://github.com/laravel/framework/issues/37961#issuecomment-1017184911) is in my opinion the best solution.

Furthermore, casting the attributes to object/collection prior to checking the values, makes no sense to me. We are interested in knowing if the content differs, the cast prior to this check does not provide useful additional information (only causes that you can't use strict comparison due to object being always different even with the same content). The cast also adds overhead.