### PR TITLE
[9.x] Add "Mutex" column to 'schedule:list' command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -42,6 +42,7 @@ class ScheduleListCommand extends Command
                             ->getNextRunDate(Carbon::now()->setTimezone($event->timezone))
                             ->setTimezone(new DateTimeZone($this->option('timezone') ?? config('app.timezone')))
                             ->format('Y-m-d H:i:s P'),
+                ($event->mutex->exists($event)) ? 'Exists' : '',
             ];
         }
 
@@ -50,6 +51,7 @@ class ScheduleListCommand extends Command
             'Interval',
             'Description',
             'Next Due',
+            'Mutex',
         ], $rows ?? []);
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -42,7 +42,7 @@ class ScheduleListCommand extends Command
                             ->getNextRunDate(Carbon::now()->setTimezone($event->timezone))
                             ->setTimezone(new DateTimeZone($this->option('timezone') ?? config('app.timezone')))
                             ->format('Y-m-d H:i:s P'),
-                ($event->mutex->exists($event)) ? 'Exists' : '',
+                $event->mutex->exists($event) ? 'Yes' : '',
             ];
         }
 
@@ -51,7 +51,7 @@ class ScheduleListCommand extends Command
             'Interval',
             'Description',
             'Next Due',
-            'Mutex',
+            'Has Mutex',
         ], $rows ?? []);
     }
 }


### PR DESCRIPTION
Add "Mutex" column to 'schedule:list' command to indicate if a command is currently blocked by a mutex

Indicating the timestamp the mutex was created isn't (good) possible, because this is controlled by the store implementation and therefore differs for each possible store type

See #41311
