### PR TITLE
[9.x] Adds partial queue faking

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -42,11 +42,12 @@ class Queue extends Facade
     /**
      * Replace the bound instance with a fake.
      *
+     * @param  array|string  $jobsToFake
      * @return \Illuminate\Support\Testing\Fakes\QueueFake
      */
-    public static function fake()
+    public static function fake($jobsToFake = [])
     {
-        static::swap($fake = new QueueFake(static::getFacadeApplication()));
+        static::swap($fake = new QueueFake(static::getFacadeApplication(), static::getFacadeRoot(), $jobsToFake));
 
         return $fake;
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -415,7 +415,7 @@ class QueueFake extends QueueManager implements Queue
             return true;
         }
 
-        return $this->jobsToFake->contains(function ($jobToFake) use ($job){
+        return $this->jobsToFake->contains(function ($jobToFake) use ($job) {
             return get_class($job) === $jobToFake;
         });
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -19,7 +19,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @var \Illuminate\Contracts\Queue\Queue
      */
-    protected $manager;
+    protected $queue;
 
     /**
      * The job types that should be intercepted instead of pushed to the queue.
@@ -35,11 +35,11 @@ class QueueFake extends QueueManager implements Queue
      */
     protected $jobs = [];
 
-    public function __construct($app, QueueManager $manager, $jobsToFake = [])
+    public function __construct($app, QueueManager $queue, $jobsToFake = [])
     {
         parent::__construct($app);
 
-        $this->manager = $manager;
+        $this->queue = $queue;
 
         $this->jobsToFake = Collection::wrap($jobsToFake);
     }
@@ -309,7 +309,7 @@ class QueueFake extends QueueManager implements Queue
                 'queue' => $queue,
             ];
         } else {
-            $this->manager->push($job, $data, $queue);
+            $this->queue->push($job, $data, $queue);
         }
     }
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -39,7 +40,7 @@ class QueuedEventsTest extends TestCase
     {
         $d = new Dispatcher;
 
-        $fakeQueue = new QueueFake(new Container);
+        $fakeQueue = new QueueFake(new Container, m::mock(QueueManager::class));
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -55,7 +56,7 @@ class QueuedEventsTest extends TestCase
     {
         $d = new Dispatcher;
 
-        $fakeQueue = new QueueFake(new Container);
+        $fakeQueue = new QueueFake(new Container, m::mock(QueueManager::class));
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -88,7 +89,7 @@ class QueuedEventsTest extends TestCase
     {
         $d = new Dispatcher;
 
-        $fakeQueue = new QueueFake(new Container);
+        $fakeQueue = new QueueFake(new Container, m::mock(QueueManager::class));
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -106,7 +107,7 @@ class QueuedEventsTest extends TestCase
     {
         $d = new Dispatcher;
 
-        $fakeQueue = new QueueFake(new Container);
+        $fakeQueue = new QueueFake(new Container, m::mock(QueueManager::class));
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,7 @@ class MailableQueuedTest extends TestCase
 
     public function testQueuedMailableSent()
     {
-        $queueFake = new QueueFake(new Application);
+        $queueFake = new QueueFake(new Application, m::mock(QueueManager::class));
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->onlyMethods(['createMessage', 'to'])
@@ -40,7 +41,7 @@ class MailableQueuedTest extends TestCase
 
     public function testQueuedMailableWithAttachmentSent()
     {
-        $queueFake = new QueueFake(new Application);
+        $queueFake = new QueueFake(new Application, m::mock(QueueManager::class));
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->onlyMethods(['createMessage'])
@@ -69,7 +70,7 @@ class MailableQueuedTest extends TestCase
         $container->singleton('filesystem', function () use ($filesystemFactory) {
             return $filesystemFactory;
         });
-        $queueFake = new QueueFake($app);
+        $queueFake = new QueueFake($app, m::mock(QueueManager::class));
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->onlyMethods(['createMessage'])

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -65,7 +65,7 @@ class SupportTestingQueueFakeTest extends TestCase
         $job = new JobStub;
 
         $manager = m::mock(QueueManager::class);
-        $manager->shouldReceive('push')->once()->withArgs(function($passedJob) use ($job){
+        $manager->shouldReceive('push')->once()->withArgs(function($passedJob) use ($job) {
             return $passedJob === $job;
         });
 


### PR DESCRIPTION
This PR allows you to only fake certain jobs.

Useful if you want to test if one job dispatches another job.

```php
<?php

namespace App\Jobs;

use ...

class ParentJob
{
    public function handle() 
    {
        ChildJob::dispatch();
    }
{
```

```php
/** @test */
public function it_dispatches_another_job()
{
    Queue::fake(ChildJob::class);

    ParentJob::dispatch();

    Queue::assertPushed(ChildJob::class);
}
```

When using `Queue::fake()` all jobs will be faked. Therefore the `ParentJob` won't run and will never dispatch the `ChildJob`.

With this addition you can choose which job to fake. Not passing a parameter will fake all jobs like before.


**Example:** I run a web scraper which scrapes the homepage of a news site in a job. That job will then dispatch a job for every article it found.
