### PR TITLE
[9.x] Fixes eventing test

### DIFF
--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -17,6 +17,12 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake = new EventFake(m::mock(Dispatcher::class));
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        m::close();
+    }
+
     public function testAssertDispatched()
     {
         try {


### PR DESCRIPTION
Mocking assertions will only run if the mock is closed after testing.

```php
$dispatcher = m::mock(Dispatcher::class);
$dispatcher->shouldReceive('dispatch')->once();
```

This didn't throw any errors if `dispatch` wasn't called.

