### PR TITLE
[9.x] Allow `VerifyCsrfToken`'s CSRF cookie to be extended

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -189,13 +189,25 @@ class VerifyCsrfToken
         }
 
         $response->headers->setCookie(
-            new Cookie(
-                'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
-                $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
-            )
+            $this->newCookie($request, $config)
         );
 
         return $response;
+    }
+
+    /**
+     * Create the CSRF token that will be sent with the response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Config\Repository
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    protected function newCookie($request, $config)
+    {
+        return new Cookie(
+            'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
+            $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -188,15 +188,13 @@ class VerifyCsrfToken
             $response = $response->toResponse($request);
         }
 
-        $response->headers->setCookie(
-            $this->newCookie($request, $config)
-        );
+        $response->headers->setCookie($this->newCookie($request, $config));
 
         return $response;
     }
 
     /**
-     * Create the CSRF token that will be sent with the response.
+     * Create a new "XSRF-TOKEN" cookie that contains the CSRF token.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  array  $config
@@ -205,8 +203,15 @@ class VerifyCsrfToken
     protected function newCookie($request, $config)
     {
         return new Cookie(
-            'XSRF-TOKEN', $request->session()->token(), $this->availableAt(60 * $config['lifetime']),
-            $config['path'], $config['domain'], $config['secure'], false, false, $config['same_site'] ?? null
+            'XSRF-TOKEN',
+            $request->session()->token(),
+            $this->availableAt(60 * $config['lifetime']),
+            $config['path'],
+            $config['domain'],
+            $config['secure'],
+            false,
+            false,
+            $config['same_site'] ?? null
         );
     }
 

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -199,7 +199,7 @@ class VerifyCsrfToken
      * Create the CSRF token that will be sent with the response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  array $config
+     * @param  array  $config
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     protected function newCookie($request, $config)

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -199,7 +199,7 @@ class VerifyCsrfToken
      * Create the CSRF token that will be sent with the response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Config\Repository
+     * @param  array $config
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     protected function newCookie($request, $config)


### PR DESCRIPTION
This PR moves how the CSRF token is created to its own method.

# Why?
There are some cases in multi-tenant systems that the user might want to change the CSRF token name to prevent 419 errors. Multiple Auth providers make this happen as well mainly in XHR requests. This also allows multi-tenant systems to update the token's domain (ie, pull the current tenant's custom domain) from the middleware layer.

I think this is going to help a lot with people using Inertia to allow customization in how `XSRF-TOKEN` is named by adding the tenant ID, or even the user type.

By allowing the cookie to be extended in user-land, the user can create 2 different `VerifyCsrfToken` classes and allow it to be modified without having to extend the whole `addCookieToResponse` method.

```php
class VerifyCsrfToken extends Middleware {
    protected function newCookie($request, $config)
    {
        return new Cookie(
            "XSRF-TOKEN-{$request->user()->type}",
            $request->session()->token(),
            $this->availableAt(60 * $config['lifetime']),
            $config['path'],
            $config['domain'],
            $config['secure'],
            false,
            false,
            $config['same_site'] ?? null,
        );
    }
}
```

