### PR TITLE
[10.x] Adds partial queue faking

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,24 +6,4 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.ref_name }}
-
-      - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
-        with:
-          latest-version: ${{ github.event.release.tag_name }}
-          release-notes: ${{ github.event.release.body }}
-          compare-url-target-revision: ${{ github.event.release.target_commitish }}
-
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          branch: ${{ github.event.release.target_commitish }}
-          commit_message: Update CHANGELOG.md
-          file_pattern: CHANGELOG.md
+    uses: laravel/.github/.github/workflows/update-changelog.yml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Release Notes for 9.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.2.0...9.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.3.0...9.x)
+
+
+## [v9.3.0 (2022-03-02)](https://github.com/laravel/framework/compare/v9.2.0...v9.3.0)
+
+### Added
+- Add NotificationFake::assertNothingSentTo() by @axlon ([#41232](https://github.com/laravel/framework/pull/41232))
+- Support --ssl-ca on schema load and dump by @DeepDiver1975 ([#40931](https://github.com/laravel/framework/pull/40931))
+- Add whereNot() to Query Builder and Eloquent Builder by @marcovo ([#41096](https://github.com/laravel/framework/pull/41096))
+- Added support for index and position placeholders in array validation messages by @Bird87ZA ([#41123](https://github.com/laravel/framework/pull/41123))
+- Add resource binding by @aedart ([#41233](https://github.com/laravel/framework/pull/41233))
+- Add ability to push additional pipes onto a pipeline via chain($pipes) by @stevebauman ([#41256](https://github.com/laravel/framework/pull/41256))
+- Add option to filter out routes defined in vendor packages in route:list command by @amiranagram ([#41254](https://github.com/laravel/framework/pull/41254))
+
+### Fixed
+- Query PostgresBuilder fixes for renamed config 'search_path' by @derekmd ([#41215](https://github.com/laravel/framework/pull/41215))
+- Improve doctypes for Eloquent Factory guessing methods by @bastien-phi ([#41245](https://github.com/laravel/framework/pull/41245))
+- Fix Conditional::when and Conditional::unless when called with invokable by @bastien-phi ([#41270](https://github.com/laravel/framework/pull/41270))
+- Improves Support\Collection reduce method type definition by @fdalcin ([#41272](https://github.com/laravel/framework/pull/41272))
+- Fix inconsistent results of firstOrNew() when using withCasts() by @Attia-Ahmed ([#41257](https://github.com/laravel/framework/pull/41257))
+- Fix implicitBinding and withTrashed route with child with no SoftDeletes trait by @stein-j ([#41282](https://github.com/laravel/framework/pull/41282))
+
+### Changed
+- Unset Connection Resolver extended callback by @emrancu ([#41216](https://github.com/laravel/framework/pull/41216))
+- Update Mailgun transport type by @driesvints ([#41255](https://github.com/laravel/framework/pull/41255))
 
 
 ## [v9.2.0 (2022-02-22)](https://github.com/laravel/framework/compare/v9.1.0...v9.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,31 @@
 # Release Notes for 9.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.3.0...9.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.3.1...9.x)
 
+## [v9.3.1](https://github.com/laravel/framework/compare/v9.3.0...v9.3.1) - 2022-03-03
+
+### Added
+
+- Optionally cascade thrown Flysystem exceptions by @driesvints in https://github.com/laravel/framework/pull/41308
+
+### Changed
+
+- Allow overriding transport type on Mailgun transporter by @jnoordsij in https://github.com/laravel/framework/pull/41309
+- Change how Laravel handles strict morph map with pivot classes by @crynobone in https://github.com/laravel/framework/pull/41304
+
+### Fixed
+
+- $job can be an object in some methods by @villfa in https://github.com/laravel/framework/pull/41244
+- Fix docblock on Batch class by @yoeriboven in https://github.com/laravel/framework/pull/41295
+- Correct `giveConfig` param doc by @Neol3108 in https://github.com/laravel/framework/pull/41314
+- Fix MySqlSchemaState does not add --ssl-ca to mysql cli  by @DeepDiver1975 in https://github.com/laravel/framework/pull/41315
+- Do not prepend baseUrl to absolute urls by @JaZo in https://github.com/laravel/framework/pull/41307
+- Fixes getting the trusted proxies IPs from the configuration file by @nunomaduro in https://github.com/laravel/framework/pull/41322
 
 ## [v9.3.0 (2022-03-02)](https://github.com/laravel/framework/compare/v9.2.0...v9.3.0)
 
 ### Added
+
 - Add NotificationFake::assertNothingSentTo() by @axlon ([#41232](https://github.com/laravel/framework/pull/41232))
 - Support --ssl-ca on schema load and dump by @DeepDiver1975 ([#40931](https://github.com/laravel/framework/pull/40931))
 - Add whereNot() to Query Builder and Eloquent Builder by @marcovo ([#41096](https://github.com/laravel/framework/pull/41096))
@@ -15,6 +35,7 @@
 - Add option to filter out routes defined in vendor packages in route:list command by @amiranagram ([#41254](https://github.com/laravel/framework/pull/41254))
 
 ### Fixed
+
 - Query PostgresBuilder fixes for renamed config 'search_path' by @derekmd ([#41215](https://github.com/laravel/framework/pull/41215))
 - Improve doctypes for Eloquent Factory guessing methods by @bastien-phi ([#41245](https://github.com/laravel/framework/pull/41245))
 - Fix Conditional::when and Conditional::unless when called with invokable by @bastien-phi ([#41270](https://github.com/laravel/framework/pull/41270))
@@ -23,13 +44,14 @@
 - Fix implicitBinding and withTrashed route with child with no SoftDeletes trait by @stein-j ([#41282](https://github.com/laravel/framework/pull/41282))
 
 ### Changed
+
 - Unset Connection Resolver extended callback by @emrancu ([#41216](https://github.com/laravel/framework/pull/41216))
 - Update Mailgun transport type by @driesvints ([#41255](https://github.com/laravel/framework/pull/41255))
-
 
 ## [v9.2.0 (2022-02-22)](https://github.com/laravel/framework/compare/v9.1.0...v9.2.0)
 
 ### Added
+
 - Added `Illuminate/Database/Eloquent/Casts/Attribute::make()` ([#41014](https://github.com/laravel/framework/pull/41014))
 - Added `Illuminate/Collections/Arr::keyBy()` ([#41029](https://github.com/laravel/framework/pull/41029))
 - Added expectsOutputToContain to the PendingCommand. ([#40984](https://github.com/laravel/framework/pull/40984))
@@ -43,6 +65,7 @@
 - Allow specifiying custom messages for Rule objects ([#41145](https://github.com/laravel/framework/pull/41145))
 
 ### Fixed
+
 - Fixed Queue Failed_jobs insert issue with Exception contain UNICODE ([#41020](https://github.com/laravel/framework/pull/41020))
 - Fixes attempt to log deprecations on mocks ([#41057](https://github.com/laravel/framework/pull/41057))
 - Fixed loadAggregate not correctly applying casts ([#41050](https://github.com/laravel/framework/pull/41050))
@@ -55,6 +78,7 @@
 - Fix database migrations $connection property ([#41161](https://github.com/laravel/framework/pull/41161))
 
 ### Changed
+
 - Cursor pagination: convert original column to expression ([#41003](https://github.com/laravel/framework/pull/41003))
 - Cast $perPage to integer on Paginator ([#41073](https://github.com/laravel/framework/pull/41073))
 - Restore S3 client extra options ([#41097](https://github.com/laravel/framework/pull/41097))
@@ -67,71 +91,75 @@
 - Pass AWS temporary URL options to createPresignedRequest method ([#41156](https://github.com/laravel/framework/pull/41156))
 - Let Multiple* exceptions hold the number of records and items found ([#41164](https://github.com/laravel/framework/pull/41164))
 
-
 ## [v9.1.0 (2022-02-15)](https://github.com/laravel/framework/compare/v9.0.2...v9.1.0)
 
 ### Added
-* Added the ability to use the uniqueFor method for Jobs by @andrey-helldar in https://github.com/laravel/framework/pull/40974
-* Add filtering of route:list by domain by @Synchro in https://github.com/laravel/framework/pull/40970
-* Added dropForeignIdFor method to match foreignIdFor method by @bretto36 in https://github.com/laravel/framework/pull/40950
-* Adds `Str::excerpt` by @nunomaduro in https://github.com/laravel/framework/pull/41000
-* Make:model --morph flag to generate MorphPivot model by @michael-rubel in https://github.com/laravel/framework/pull/41011
-* Add doesntContain to higher order proxies by @edemots in https://github.com/laravel/framework/pull/41034
+
+- Added the ability to use the uniqueFor method for Jobs by @andrey-helldar in https://github.com/laravel/framework/pull/40974
+- Add filtering of route:list by domain by @Synchro in https://github.com/laravel/framework/pull/40970
+- Added dropForeignIdFor method to match foreignIdFor method by @bretto36 in https://github.com/laravel/framework/pull/40950
+- Adds `Str::excerpt` by @nunomaduro in https://github.com/laravel/framework/pull/41000
+- Make:model --morph flag to generate MorphPivot model by @michael-rubel in https://github.com/laravel/framework/pull/41011
+- Add doesntContain to higher order proxies by @edemots in https://github.com/laravel/framework/pull/41034
 
 ### Changed
-* Improve types on model factory methods by @axlon in https://github.com/laravel/framework/pull/40902
-* Add support for passing array as the second parameter for the group method. by @hossein-zare in https://github.com/laravel/framework/pull/40945
-* Makes `ExceptionHandler::renderForConsole` internal on contract by @nunomaduro in https://github.com/laravel/framework/pull/40956
-* Put the error message at the bottom of the exceptions by @nshiro in https://github.com/laravel/framework/pull/40886
-* Expose next and previous cursor of cursor paginator by @gdebrauwer in https://github.com/laravel/framework/pull/41001
+
+- Improve types on model factory methods by @axlon in https://github.com/laravel/framework/pull/40902
+- Add support for passing array as the second parameter for the group method. by @hossein-zare in https://github.com/laravel/framework/pull/40945
+- Makes `ExceptionHandler::renderForConsole` internal on contract by @nunomaduro in https://github.com/laravel/framework/pull/40956
+- Put the error message at the bottom of the exceptions by @nshiro in https://github.com/laravel/framework/pull/40886
+- Expose next and previous cursor of cursor paginator by @gdebrauwer in https://github.com/laravel/framework/pull/41001
 
 ### Fixed
-* Fix FTP root config by @driesvints in https://github.com/laravel/framework/pull/40939
-* Allows tls encryption to be used with port different than 465 with starttls by @nicolalazzaro in https://github.com/laravel/framework/pull/40943
-* Catch suppressed deprecation logs by @nunomaduro in https://github.com/laravel/framework/pull/40942
-* Fix typo in method documentation by @shadman-ahmed in https://github.com/laravel/framework/pull/40951
-* Patch regex rule parsing due to `Rule::forEach()` by @stevebauman in https://github.com/laravel/framework/pull/40941
-* Fix replacing request options by @driesvints in https://github.com/laravel/framework/pull/40954
-* Fix `MessageSent` event by @driesvints in https://github.com/laravel/framework/pull/40963
-* Add firstOr() function to BelongsToMany relation by @r-kujawa in https://github.com/laravel/framework/pull/40828
-* Fix `isRelation()` failing to check an `Attribute` by @rodrigopedra in https://github.com/laravel/framework/pull/40967
-* Fix default pivot attributes by @iamgergo in https://github.com/laravel/framework/pull/40947
-* Fix enum casts arrayable behaviour by @diegotibi in https://github.com/laravel/framework/pull/40885
-* Solve exception error: Undefined array key "", in artisan route:list command by @manuglopez in https://github.com/laravel/framework/pull/41031
-* Fix Duplicate Route Namespace by @moisish in https://github.com/laravel/framework/pull/41021
-* Fix the error message when no routes are detected by @LukeTowers in https://github.com/laravel/framework/pull/41017
-* Fix mails with tags and metadata are not queuable by @joostdebruijn in https://github.com/laravel/framework/pull/41028
 
+- Fix FTP root config by @driesvints in https://github.com/laravel/framework/pull/40939
+- Allows tls encryption to be used with port different than 465 with starttls by @nicolalazzaro in https://github.com/laravel/framework/pull/40943
+- Catch suppressed deprecation logs by @nunomaduro in https://github.com/laravel/framework/pull/40942
+- Fix typo in method documentation by @shadman-ahmed in https://github.com/laravel/framework/pull/40951
+- Patch regex rule parsing due to `Rule::forEach()` by @stevebauman in https://github.com/laravel/framework/pull/40941
+- Fix replacing request options by @driesvints in https://github.com/laravel/framework/pull/40954
+- Fix `MessageSent` event by @driesvints in https://github.com/laravel/framework/pull/40963
+- Add firstOr() function to BelongsToMany relation by @r-kujawa in https://github.com/laravel/framework/pull/40828
+- Fix `isRelation()` failing to check an `Attribute` by @rodrigopedra in https://github.com/laravel/framework/pull/40967
+- Fix default pivot attributes by @iamgergo in https://github.com/laravel/framework/pull/40947
+- Fix enum casts arrayable behaviour by @diegotibi in https://github.com/laravel/framework/pull/40885
+- Solve exception error: Undefined array key "", in artisan route:list command by @manuglopez in https://github.com/laravel/framework/pull/41031
+- Fix Duplicate Route Namespace by @moisish in https://github.com/laravel/framework/pull/41021
+- Fix the error message when no routes are detected by @LukeTowers in https://github.com/laravel/framework/pull/41017
+- Fix mails with tags and metadata are not queuable by @joostdebruijn in https://github.com/laravel/framework/pull/41028
 
 ## [v9.0.2 (2022-02-10)](https://github.com/laravel/framework/compare/v9.0.1...v9.0.2)
 
 ### Added
-* Add disabled directive by @belzaaron in https://github.com/laravel/framework/pull/40900
+
+- Add disabled directive by @belzaaron in https://github.com/laravel/framework/pull/40900
 
 ### Changed
-* Widen the type of `Collection::unique` `$key` parameter by @NiclasvanEyk in https://github.com/laravel/framework/pull/40903
-* Makes `ExceptionHandler::renderForConsole` internal by @nunomaduro in https://github.com/laravel/framework/pull/40936
-* Removal of Google Font integration from default exception templates by @bashgeek in https://github.com/laravel/framework/pull/40926
-* Allow base JsonResource class to be collected by @jwohlfert23 in https://github.com/laravel/framework/pull/40896
+
+- Widen the type of `Collection::unique` `$key` parameter by @NiclasvanEyk in https://github.com/laravel/framework/pull/40903
+- Makes `ExceptionHandler::renderForConsole` internal by @nunomaduro in https://github.com/laravel/framework/pull/40936
+- Removal of Google Font integration from default exception templates by @bashgeek in https://github.com/laravel/framework/pull/40926
+- Allow base JsonResource class to be collected by @jwohlfert23 in https://github.com/laravel/framework/pull/40896
 
 ### Fixed
-* Fix Support\Collection reject method type definition by @joecampo in https://github.com/laravel/framework/pull/40899
-* Fix SpoofCheckValidation namespace change by @eduardor2k in https://github.com/laravel/framework/pull/40923
-* Fix notification email recipient by @driesvints in https://github.com/laravel/framework/pull/40921
-* Fix publishing visibility by @driesvints in https://github.com/laravel/framework/pull/40918
-* Fix Mailable->priority() by @giggsey in https://github.com/laravel/framework/pull/40917
 
+- Fix Support\Collection reject method type definition by @joecampo in https://github.com/laravel/framework/pull/40899
+- Fix SpoofCheckValidation namespace change by @eduardor2k in https://github.com/laravel/framework/pull/40923
+- Fix notification email recipient by @driesvints in https://github.com/laravel/framework/pull/40921
+- Fix publishing visibility by @driesvints in https://github.com/laravel/framework/pull/40918
+- Fix Mailable->priority() by @giggsey in https://github.com/laravel/framework/pull/40917
 
 ## [v9.0.1 (2022-02-09)](https://github.com/laravel/framework/compare/v9.0.0...v9.0.1)
 
 ### Changed
-* Improves `Support\Collection` each method type definition by @zingimmick in https://github.com/laravel/framework/pull/40879
+
+- Improves `Support\Collection` each method type definition by @zingimmick in https://github.com/laravel/framework/pull/40879
 
 ### Fixed
-* Update Mailable.php by @rentalhost in https://github.com/laravel/framework/pull/40868
-* Switch to null coalescing operator in Conditionable by @inxilpro in https://github.com/laravel/framework/pull/40888
-* Bring back old return behaviour by @ankurk91 in https://github.com/laravel/framework/pull/40880
 
+- Update Mailable.php by @rentalhost in https://github.com/laravel/framework/pull/40868
+- Switch to null coalescing operator in Conditionable by @inxilpro in https://github.com/laravel/framework/pull/40888
+- Bring back old return behaviour by @ankurk91 in https://github.com/laravel/framework/pull/40880
 
 ## [v9.0.0 (2022-02-08)](https://github.com/laravel/framework/compare/8.x...v9.0.0)
 

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "mockery/mockery": "^1.4.4",
         "orchestra/testbench-core": "^7.1",
         "pda/pheanstalk": "^4.0",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^9.5.8",
         "predis/predis": "^1.1.9",
         "symfony/cache": "^6.0"

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -466,4 +466,15 @@ class Batch implements Arrayable, JsonSerializable
     {
         return $this->toArray();
     }
+
+    /**
+     * Dynamically access the batch's "options" via properties.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->options[$key] ?? null;
+    }
 }

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -155,7 +155,7 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Add additional jobs to the batch.
      *
-     * @param  \Illuminate\Support\Enumerable|array  $jobs
+     * @param  \Illuminate\Support\Enumerable|object|array  $jobs
      * @return self
      */
     public function add($jobs)

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -805,7 +805,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TReduceInitial
      * @template TReduceReturnType
      *
-     * @param  callable(TReduceInitial|TReduceReturnType, TValue): TReduceReturnType  $callback
+     * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType  $callback
      * @param  TReduceInitial  $initial
      * @return TReduceReturnType
      */

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1024,7 +1024,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                 $chunk[$iterator->key()] = $iterator->current();
 
                 if (count($chunk) == $size) {
-                    yield tap(new static($chunk), function () use (&$chunk, $step) {
+                    yield (new static($chunk))->tap(function () use (&$chunk, $step) {
                         $chunk = array_slice($chunk, $step, null, true);
                     });
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -745,7 +745,7 @@ trait EnumeratesValues
      * @template TReduceInitial
      * @template TReduceReturnType
      *
-     * @param  callable(TReduceInitial|TReduceReturnType, TValue): TReduceReturnType  $callback
+     * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType  $callback
      * @param  TReduceInitial  $initial
      * @return TReduceReturnType
      */

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -13,7 +13,7 @@ trait Conditionable
      * @template TWhenParameter
      * @template TWhenReturnType
      *
-     * @param  (Closure($this): TWhenParameter)|TWhenParameter  $value
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter  $value
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return $this|TWhenReturnType
@@ -41,7 +41,7 @@ trait Conditionable
      * @template TUnlessParameter
      * @template TUnlessReturnType
      *
-     * @param  (Closure($this): TUnlessParameter)|TUnlessParameter  $value
+     * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter  $value
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $callback
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -13,7 +13,7 @@ trait Conditionable
      * @template TWhenParameter
      * @template TWhenReturnType
      *
-     * @param  (callable($this): TWhenParameter)|TWhenParameter  $value
+     * @param  (Closure($this): TWhenParameter)|TWhenParameter  $value
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return $this|TWhenReturnType
@@ -41,7 +41,7 @@ trait Conditionable
      * @template TUnlessParameter
      * @template TUnlessReturnType
      *
-     * @param  (callable($this): TUnlessParameter)|TUnlessParameter  $value
+     * @param  (Closure($this): TUnlessParameter)|TUnlessParameter  $value
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $callback
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -372,11 +372,13 @@ trait InteractsWithIO
      * Write a blank line.
      *
      * @param  int  $count
-     * @return void
+     * @return $this
      */
     public function newLine($count = 1)
     {
         $this->output->newLine($count);
+        
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -377,7 +377,7 @@ trait InteractsWithIO
     public function newLine($count = 1)
     {
         $this->output->newLine($count);
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -86,7 +86,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      * Specify the configuration item to bind as a primitive.
      *
      * @param  string  $key
-     * @param  ?string  $default
+     * @param  mixed  $default
      * @return void
      */
     public function giveConfig($key, $default = null)

--- a/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php
@@ -32,7 +32,7 @@ interface ContextualBindingBuilder
      * Specify the configuration item to bind as a primitive.
      *
      * @param  string  $key
-     * @param  ?string  $default
+     * @param  mixed  $default
      * @return void
      */
     public function giveConfig($key, $default = null);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -730,6 +731,10 @@ trait HasRelationships
 
         if (! empty($morphMap) && in_array(static::class, $morphMap)) {
             return array_search(static::class, $morphMap, true);
+        }
+
+        if (static::class === Pivot::class) {
+            return static::class;
         }
 
         if (Relation::requiresMorphMap()) {

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -708,7 +708,7 @@ abstract class Factory
     /**
      * Specify the callback that should be invoked to guess model names based on factory names.
      *
-     * @param  callable(): class-string<\Illuminate\Database\Eloquent\Model|TModel>  $callback
+     * @param  callable(self): class-string<\Illuminate\Database\Eloquent\Model|TModel>  $callback
      * @return void
      */
     public static function guessModelNamesUsing(callable $callback)
@@ -743,7 +743,7 @@ abstract class Factory
     /**
      * Specify the callback that should be invoked to guess factory names based on dynamic relationship names.
      *
-     * @param  callable(): class-string<\Illuminate\Database\Eloquent\Model|TModel>  $callback
+     * @param  callable(class-string<\Illuminate\Database\Eloquent\Model>): class-string<\Illuminate\Database\Eloquent\Factories\Factory>  $callback
      * @return void
      */
     public static function guessFactoryNamesUsing(callable $callback)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -493,7 +493,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
         // hydration of new objects via the Eloquent query builder instances.
-        $model = new static((array) $attributes);
+        $model = new static;
 
         $model->exists = $exists;
 
@@ -504,6 +504,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $model->setTable($this->getTable());
 
         $model->mergeCasts($this->casts);
+
+        $model->fill((array) $attributes);
 
         return $model;
     }

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Database\Eloquent;
 
 /**
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed(bool $withTrashed = true)
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
- * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed(bool $withTrashed = true)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
  */
 trait SoftDeletes
 {

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -125,6 +125,10 @@ class ChangeColumn
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }
 
+        if ($fluent['type'] === 'char') {
+            $options['fixed'] = true;
+        }
+
         if (static::doesntNeedCharacterOptions($fluent['type'])) {
             $options['customSchemaOptions'] = [
                 'collation' => '',
@@ -151,6 +155,7 @@ class ChangeColumn
             'mediumtext', 'longtext' => 'text',
             'binary' => 'blob',
             'uuid' => 'guid',
+            'char' => 'string',
             default => $type,
         });
     }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -103,9 +103,15 @@ class MySqlSchemaState extends SchemaState
     {
         $value = ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}"';
 
-        $value .= $this->connection->getConfig()['unix_socket'] ?? false
+        $config = $this->connection->getConfig();
+
+        $value .= $config['unix_socket'] ?? false
                         ? ' --socket="${:LARAVEL_LOAD_SOCKET}"'
-                        : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
+                        : ' --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"';
+
+        if (isset($config['options'][\PDO::MYSQL_ATTR_SSL_CA])) {
+            $value .= ' --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"';
+        }
 
         return $value;
     }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -236,7 +236,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->read($path);
         } catch (UnableToReadFile $e) {
-            //
+            throw_if($this->throwsExceptions(), $e);
         }
     }
 
@@ -330,6 +330,8 @@ class FilesystemAdapter implements CloudFilesystemContract
                 ? $this->driver->writeStream($path, $contents, $options)
                 : $this->driver->write($path, $contents, $options);
         } catch (UnableToWriteFile $e) {
+            throw_if($this->throwsExceptions(), $e);
+
             return false;
         }
 
@@ -405,6 +407,8 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->setVisibility($path, $this->parseVisibility($visibility));
         } catch (UnableToSetVisibility $e) {
+            throw_if($this->throwsExceptions(), $e);
+
             return false;
         }
 
@@ -461,6 +465,8 @@ class FilesystemAdapter implements CloudFilesystemContract
             try {
                 $this->driver->delete($path);
             } catch (UnableToDeleteFile $e) {
+                throw_if($this->throwsExceptions(), $e);
+
                 $success = false;
             }
         }
@@ -480,6 +486,8 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->copy($from, $to);
         } catch (UnableToCopyFile $e) {
+            throw_if($this->throwsExceptions(), $e);
+
             return false;
         }
 
@@ -498,6 +506,8 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->move($from, $to);
         } catch (UnableToMoveFile $e) {
+            throw_if($this->throwsExceptions(), $e);
+
             return false;
         }
 
@@ -545,7 +555,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->readStream($path);
         } catch (UnableToReadFile $e) {
-            //
+            throw_if($this->throwsExceptions(), $e);
         }
     }
 
@@ -557,6 +567,8 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->writeStream($path, $resource, $options);
         } catch (UnableToWriteFile $e) {
+            throw_if($this->throwsExceptions(), $e);
+
             return false;
         }
 
@@ -753,6 +765,8 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->createDirectory($path);
         } catch (UnableToCreateDirectory $e) {
+            throw_if($this->throwsExceptions(), $e);
+
             return false;
         }
 
@@ -770,6 +784,8 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             $this->driver->deleteDirectory($directory);
         } catch (UnableToDeleteDirectory $e) {
+            throw_if($this->throwsExceptions(), $e);
+
             return false;
         }
 
@@ -836,6 +852,16 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function buildTemporaryUrlsUsing(Closure $callback)
     {
         $this->temporaryUrlCallback = $callback;
+    }
+
+    /**
+     * Determine if Flysystem exceptions should be thrown.
+     *
+     * @return bool
+     */
+    protected function throwsExceptions(): bool
+    {
+        return (bool) ($this->config['throw'] ?? false);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -35,7 +35,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '9.2.0';
+    const VERSION = '9.3.0';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.83.2';
+    const VERSION = '8.83.3';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\ViewController;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionFunction;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Terminal;
 
@@ -148,6 +149,7 @@ class RouteListCommand extends Command
             'name' => $route->getName(),
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
+            'vendor' => $this->isVendorRoute($route),
         ]);
     }
 
@@ -207,6 +209,27 @@ class RouteListCommand extends Command
     }
 
     /**
+     * Determine if the route has been defined outside of the application.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return bool
+     */
+    protected function isVendorRoute(Route $route)
+    {
+        if ($route->action['uses'] instanceof Closure) {
+            $path = (new ReflectionFunction($route->action['uses']))
+                                ->getFileName();
+        } elseif (is_string($route->action['uses'])) {
+            $path = (new ReflectionClass(explode('@', $route->action['uses'])[0]))
+                                ->getFileName();
+        } else {
+            return false;
+        }
+
+        return str_starts_with($path, base_path('vendor'));
+    }
+
+    /**
      * Filter the route by URI and / or name.
      *
      * @param  array  $route
@@ -217,7 +240,8 @@ class RouteListCommand extends Command
         if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
-            ($this->option('domain') && ! Str::contains($route['domain'], $this->option('domain')))) {
+            ($this->option('domain') && ! Str::contains($route['domain'], $this->option('domain'))) ||
+            ($this->option('except-vendor') && $route['vendor'])) {
             return;
         }
 
@@ -426,6 +450,7 @@ class RouteListCommand extends Command
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (precedence, domain, method, uri, name, action, middleware) to sort by', 'uri'],
+            ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -219,6 +219,9 @@ class RouteListCommand extends Command
         if ($route->action['uses'] instanceof Closure) {
             $path = (new ReflectionFunction($route->action['uses']))
                                 ->getFileName();
+        } elseif (is_string($route->action['uses']) &&
+                  str_contains($route->action['uses'], 'SerializableClosure')) {
+            return false;
         } elseif (is_string($route->action['uses'])) {
             $path = (new ReflectionClass(explode('@', $route->action['uses'])[0]))
                                 ->getFileName();

--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -21,16 +21,6 @@ class {{ class }} extends Command
     protected $description = 'Command description';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return int

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -207,7 +207,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Get the validated data from the request.
      *
      * @param  string|null  $key
-     * @param  string|array|null  $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function validated($key = null, $default = null)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -695,7 +695,9 @@ class PendingRequest
      */
     public function send(string $method, string $url, array $options = [])
     {
-        $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
+        if (! Str::startsWith($url, ['http://', 'https://'])) {
+            $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
+        }
 
         $options = $this->parseHttpOptions($options);
 

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -47,7 +47,7 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddresses(Request $request)
     {
-        $trustedIps = $this->proxies();
+        $trustedIps = $this->proxies() ?: config('trustedproxy.proxies');
 
         if ($trustedIps === '*' || $trustedIps === '**') {
             return $this->setTrustedProxyIpAddressesToTheCallingIp($request);

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -281,7 +281,7 @@ class MailManager implements FactoryContract
         }
 
         return $factory->create(new Dsn(
-            'mailgun+api',
+            'mailgun+https',
             $config['endpoint'] ?? 'default',
             $config['secret'],
             $config['domain']

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -281,7 +281,7 @@ class MailManager implements FactoryContract
         }
 
         return $factory->create(new Dsn(
-            'mailgun+https',
+            'mailgun+'.($config['scheme'] ?? 'https'),
             $config['endpoint'] ?? 'default',
             $config['secret'],
             $config['domain']

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -76,6 +76,19 @@ class Pipeline implements PipelineContract
     }
 
     /**
+     * Push additional pipes onto the pipeline.
+     *
+     * @param  array|mixed  $pipes
+     * @return $this
+     */
+    public function pipe($pipes)
+    {
+        array_push($this->pipes, ...(is_array($pipes) ? $pipes : func_get_args()));
+
+        return $this;
+    }
+
+    /**
      * Set the method to call on the pipes.
      *
      * @param  string  $method

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -47,7 +47,7 @@ class ImplicitRouteBinding
                         : 'resolveRouteBinding';
 
             if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
-                $childRouteBindingMethod = $route->allowsTrashedBindings()
+                $childRouteBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';
 

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -42,11 +42,12 @@ class Queue extends Facade
     /**
      * Replace the bound instance with a fake.
      *
+     * @param  array|string  $jobsToFake
      * @return \Illuminate\Support\Testing\Fakes\QueueFake
      */
-    public static function fake()
+    public static function fake($jobsToFake = [])
     {
-        static::swap($fake = new QueueFake(static::getFacadeApplication()));
+        static::swap($fake = new QueueFake(static::getFacadeApplication(), static::getFacadeRoot(), $jobsToFake));
 
         return $fake;
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -272,7 +272,7 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Push a new job onto the queue.
      *
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed  $data
      * @param  string|null  $queue
      * @return mixed
@@ -302,7 +302,7 @@ class QueueFake extends QueueManager implements Queue
      * Push a new job onto the queue after a delay.
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed  $data
      * @param  string|null  $queue
      * @return mixed
@@ -316,7 +316,7 @@ class QueueFake extends QueueManager implements Queue
      * Push a new job onto the queue.
      *
      * @param  string  $queue
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed  $data
      * @return mixed
      */
@@ -330,7 +330,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @param  string  $queue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  string  $job
+     * @param  string|object  $job
      * @param  mixed  $data
      * @return mixed
      */

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -415,7 +415,7 @@ class QueueFake extends QueueManager implements Queue
             return true;
         }
 
-        return $this->jobsToFake->contains(function ($jobToFake) use ($job){
+        return $this->jobsToFake->contains(function ($jobToFake) use ($job) {
             return get_class($job) === $jobToFake;
         });
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -19,7 +19,7 @@ class QueueFake extends QueueManager implements Queue
      *
      * @var \Illuminate\Contracts\Queue\Queue
      */
-    protected $manager;
+    protected $queue;
 
     /**
      * The job types that should be intercepted instead of pushed to the queue.
@@ -35,11 +35,11 @@ class QueueFake extends QueueManager implements Queue
      */
     protected $jobs = [];
 
-    public function __construct($app, QueueManager $manager, $jobsToFake = [])
+    public function __construct($app, QueueManager $queue, $jobsToFake = [])
     {
         parent::__construct($app);
 
-        $this->manager = $manager;
+        $this->queue = $queue;
 
         $this->jobsToFake = Collection::wrap($jobsToFake);
     }
@@ -309,7 +309,7 @@ class QueueFake extends QueueManager implements Queue
                 'queue' => $queue,
             ];
         } else {
-            $this->manager->push($job, $data, $queue);
+            $this->queue->push($job, $data, $queue);
         }
     }
 

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\ClassMorphViolationException;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use PHPUnit\Framework\TestCase;
 
@@ -20,14 +21,14 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
     {
         $this->expectException(ClassMorphViolationException::class);
 
-        $model = TestModel::make();
+        $model = new TestModel;
 
         $model->getMorphClass();
     }
 
     public function testStrictModeDoesNotThrowExceptionWhenMorphMap()
     {
-        $model = TestModel::make();
+        $model = new TestModel;
 
         Relation::morphMap([
             'test' => TestModel::class,
@@ -39,7 +40,7 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 
     public function testMapsCanBeEnforcedInOneMethod()
     {
-        $model = TestModel::make();
+        $model = new TestModel;
 
         Relation::requireMorphMap(false);
 
@@ -49,6 +50,22 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 
         $morphName = $model->getMorphClass();
         $this->assertSame('test', $morphName);
+    }
+
+    public function testMapIgnoreGenericPivotClass()
+    {
+        $pivotModel = new Pivot();
+
+        $pivotModel->getMorphClass();
+    }
+
+    public function testMapCanBeEnforcedToCustomPivotClass()
+    {
+        $this->expectException(ClassMorphViolationException::class);
+
+        $pivotModel = new TestPivotModel();
+
+        $pivotModel->getMorphClass();
     }
 
     protected function tearDown(): void
@@ -61,5 +78,9 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 }
 
 class TestModel extends Model
+{
+}
+
+class TestPivotModel extends Pivot
 {
 }

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentWithCastsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    protected function createSchema()
+    {
+        $this->schema()->create('times', function ($table) {
+            $table->increments('id');
+            $table->time('time');
+            $table->timestamps();
+        });
+    }
+
+    public function testWithFirstOrNew()
+    {
+        $time1 = Time::query()->withCasts(['time' => 'string'])
+            ->firstOrNew(['time' => '07:30']);
+
+        Time::query()->insert(['time' => '07:30']);
+
+        $time2 = Time::query()->withCasts(['time' => 'string'])
+            ->firstOrNew(['time' => '07:30']);
+
+        $this->assertSame('07:30', $time1->time);
+        $this->assertSame($time1->time, $time2->time);
+    }
+
+    public function testWithFirstOrCreate()
+    {
+        $time1 = Time::query()->withCasts(['time' => 'string'])
+            ->firstOrCreate(['time' => '07:30']);
+
+        $time2 = Time::query()->withCasts(['time' => 'string'])
+            ->firstOrCreate(['time' => '07:30']);
+
+        $this->assertSame($time1->id, $time2->id);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class Time extends Eloquent
+{
+    protected $guarded = [];
+
+    protected $casts = [
+        'time' => 'datetime',
+    ];
+}

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\Schema\MySqlSchemaState;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMySqlSchemaStateTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     */
+    public function testConnectionString(string $expectedConnectionString, array $expectedVariables, array $dbConfig): void
+    {
+        $connection = $this->createMock(MySqlConnection::class);
+        $connection->method('getConfig')->willReturn($dbConfig);
+
+        $schemaState = new MySqlSchemaState($connection);
+
+        // test connectionString
+        $method = new \ReflectionMethod(get_class($schemaState), 'connectionString');
+        $connString = tap($method)->setAccessible(true)->invoke($schemaState);
+
+        self::assertEquals($expectedConnectionString, $connString);
+
+        // test baseVariables
+        $method = new \ReflectionMethod(get_class($schemaState), 'baseVariables');
+        $variables = tap($method)->setAccessible(true)->invoke($schemaState, $dbConfig);
+
+        self::assertEquals($expectedVariables, $variables);
+    }
+
+    public function provider(): \Generator
+    {
+        yield 'default' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '127.0.0.1',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+            ], [
+                'username' => 'root',
+                'host' => '127.0.0.1',
+                'database' => 'forge',
+            ],
+        ];
+
+        yield 'ssl_ca' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --ssl-ca="${:LARAVEL_LOAD_SSL_CA}"', [
+                'LARAVEL_LOAD_SOCKET' => '',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => 'ssl.ca',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'options' => [
+                    \PDO::MYSQL_ATTR_SSL_CA => 'ssl.ca',
+                ],
+            ],
+        ];
+
+        yield 'unix socket' => [
+            ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --socket="${:LARAVEL_LOAD_SOCKET}"', [
+                'LARAVEL_LOAD_SOCKET' => '/tmp/mysql.sock',
+                'LARAVEL_LOAD_HOST' => '',
+                'LARAVEL_LOAD_PORT' => '',
+                'LARAVEL_LOAD_USER' => 'root',
+                'LARAVEL_LOAD_PASSWORD' => '',
+                'LARAVEL_LOAD_DATABASE' => 'forge',
+                'LARAVEL_LOAD_SSL_CA' => '',
+            ], [
+                'username' => 'root',
+                'database' => 'forge',
+                'unix_socket' => '/tmp/mysql.sock',
+            ],
+        ];
+    }
+}

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -126,6 +126,29 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $this->assertEquals($expected2, $queries2);
     }
 
+    public function testChangingCharColumnsWork()
+    {
+        $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
+            $table->string('name');
+        });
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->char('name', 50)->change();
+        });
+
+        $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
+
+        $expected = [
+            'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
+            'DROP TABLE users',
+            'CREATE TABLE users (name CHAR(50) NOT NULL COLLATE BINARY)',
+            'INSERT INTO users (name) SELECT name FROM __temp__users',
+            'DROP TABLE __temp__users',
+        ];
+
+        $this->assertEquals($expected, $queries);
+    }
+
     public function testRenameIndexWorks()
     {
         $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -39,7 +40,7 @@ class QueuedEventsTest extends TestCase
     {
         $d = new Dispatcher;
 
-        $fakeQueue = new QueueFake(new Container);
+        $fakeQueue = new QueueFake(new Container, m::mock(QueueManager::class));
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -55,7 +56,7 @@ class QueuedEventsTest extends TestCase
     {
         $d = new Dispatcher;
 
-        $fakeQueue = new QueueFake(new Container);
+        $fakeQueue = new QueueFake(new Container, m::mock(QueueManager::class));
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -88,7 +89,7 @@ class QueuedEventsTest extends TestCase
     {
         $d = new Dispatcher;
 
-        $fakeQueue = new QueueFake(new Container);
+        $fakeQueue = new QueueFake(new Container, m::mock(QueueManager::class));
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;
@@ -106,7 +107,7 @@ class QueuedEventsTest extends TestCase
     {
         $d = new Dispatcher;
 
-        $fakeQueue = new QueueFake(new Container);
+        $fakeQueue = new QueueFake(new Container, m::mock(QueueManager::class));
 
         $d->setQueueResolver(function () use ($fakeQueue) {
             return $fakeQueue;

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -396,7 +396,7 @@ class FilesystemAdapterTest extends TestCase
         );
     }
 
-    public function testThrowExceptionForGet()
+    public function testThrowExceptionsForGet()
     {
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
@@ -426,19 +426,22 @@ class FilesystemAdapterTest extends TestCase
         $this->fail('Exception was not thrown.');
     }
 
-    /** @requires OS Linux|Darwin */
     public function testThrowExceptionsForPut()
     {
-        mkdir(__DIR__.'/tmp/bar', 0600);
+        $this->filesystem->write('foo.txt', 'Hello World');
+
+        chmod(__DIR__.'/tmp/foo.txt', 0400);
 
         $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
 
         try {
-            $adapter->put('/bar/foo.txt', 'Hello World!');
+            $adapter->put('/foo.txt', 'Hello World!');
         } catch (UnableToWriteFile $e) {
             $this->assertTrue(true);
 
             return;
+        } finally {
+            chmod(__DIR__.'/tmp/foo.txt', 0600);
         }
 
         $this->fail('Exception was not thrown.');

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -13,6 +13,8 @@ use InvalidArgumentException;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Ftp\FtpAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\UnableToReadFile;
+use League\Flysystem\UnableToWriteFile;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -392,5 +394,53 @@ class FilesystemAdapterTest extends TestCase
             $path.$expiration->toString().implode('', $options),
             $filesystemAdapter->temporaryUrl($path, $expiration, $options)
         );
+    }
+
+    public function testThrowExceptionForGet()
+    {
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
+
+        try {
+            $adapter->get('/foo.txt');
+        } catch (UnableToReadFile $e) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
+    }
+
+    public function testThrowExceptionsForReadStream()
+    {
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
+
+        try {
+            $adapter->readStream('/foo.txt');
+        } catch (UnableToReadFile $e) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
+    }
+
+    /** @requires OS Linux|Darwin */
+    public function testThrowExceptionsForPut()
+    {
+        mkdir(__DIR__.'/tmp/bar', 0600);
+
+        $adapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['throw' => true]);
+
+        try {
+            $adapter->put('/bar/foo.txt', 'Hello World!');
+        } catch (UnableToWriteFile $e) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -597,6 +597,25 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testWithBaseUrl()
+    {
+        $this->factory->fake();
+
+        $this->factory->baseUrl('http://foo.com/')->get('get');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get';
+        });
+
+        $this->factory->fake();
+
+        $this->factory->baseUrl('http://foo.com/')->get('http://bar.com/get');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://bar.com/get';
+        });
+    }
+
     public function testCanConfirmManyHeaders()
     {
         $this->factory->fake();

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\SendQueuedMailable;
+use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,7 @@ class MailableQueuedTest extends TestCase
 
     public function testQueuedMailableSent()
     {
-        $queueFake = new QueueFake(new Application);
+        $queueFake = new QueueFake(new Application, m::mock(QueueManager::class));
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->onlyMethods(['createMessage', 'to'])
@@ -40,7 +41,7 @@ class MailableQueuedTest extends TestCase
 
     public function testQueuedMailableWithAttachmentSent()
     {
-        $queueFake = new QueueFake(new Application);
+        $queueFake = new QueueFake(new Application, m::mock(QueueManager::class));
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->onlyMethods(['createMessage'])
@@ -69,7 +70,7 @@ class MailableQueuedTest extends TestCase
         $container->singleton('filesystem', function () use ($filesystemFactory) {
             return $filesystemFactory;
         });
-        $queueFake = new QueueFake($app);
+        $queueFake = new QueueFake($app, m::mock(QueueManager::class));
         $mailer = $this->getMockBuilder(Mailer::class)
             ->setConstructorArgs($this->getMocks())
             ->onlyMethods(['createMessage'])

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -65,7 +65,7 @@ class SupportTestingQueueFakeTest extends TestCase
         $job = new JobStub;
 
         $manager = m::mock(QueueManager::class);
-        $manager->shouldReceive('push')->once()->withArgs(function($passedJob) use ($job){
+        $manager->shouldReceive('push')->once()->withArgs(function($passedJob) use ($job) {
             return $passedJob === $job;
         });
 

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -31,7 +31,8 @@ class UserFactory extends Factory
 assertType('UserFactory', $factory = UserFactory::new());
 assertType('UserFactory', UserFactory::new(['string' => 'string']));
 assertType('UserFactory', UserFactory::new(function ($attributes) {
-//    assertType('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -44,7 +45,8 @@ assertType('UserFactory', $factory->configure());
 assertType('array<int|string, mixed>', $factory->raw());
 assertType('array<int|string, mixed>', $factory->raw(['string' => 'string']));
 assertType('array<int|string, mixed>', $factory->raw(function ($attributes) {
-//    assert('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -53,7 +55,8 @@ assertType('array<int|string, mixed>', $factory->raw(function ($attributes) {
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOne());
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(['string' => 'string']));
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(function ($attributes) {
-//    assertType('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -62,7 +65,8 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->createOne(function ($
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly());
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(['string' => 'string']));
 assertType('Illuminate\Database\Eloquent\Model', $factory->createOneQuietly(function ($attributes) {
-//    assertType('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -85,7 +89,8 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
     'string' => 'string',
 ]));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->create(function ($attributes) {
-//    assertType('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -116,7 +121,8 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne([
     'string' => 'string',
 ]));
 assertType('Illuminate\Database\Eloquent\Model', $factory->makeOne(function ($attributes) {
-//    assert('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 
@@ -129,7 +135,8 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
     'string' => 'string',
 ]));
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->make(function ($attributes) {
-//    assert('array<string, mixed>', $attributes);
+    assertType('array<string, mixed>', $attributes);
+
     return ['string' => 'string'];
 }));
 

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -183,8 +183,11 @@ assertType('Illuminate\Database\Eloquent\Model', $factory->newModel(['string' =>
 // assertType('class-string<User>', $factory->modelName());
 assertType('class-string<Illuminate\Database\Eloquent\Model>', $factory->modelName());
 
-$factory->guessModelNamesUsing(function () {
-    return User::class;
+Factory::guessModelNamesUsing(function (Factory $factory) {
+    return match (true) {
+        $factory instanceof UserFactory => User::class,
+        default => throw new LogicException('Unknown factory'),
+    };
 });
 
 $factory->useNamespace('string');
@@ -192,3 +195,10 @@ $factory->useNamespace('string');
 assertType(Factory::class, $factory::factoryForModel(User::class));
 
 assertType('class-string<Illuminate\Database\Eloquent\Factories\Factory>', $factory->resolveFactoryName(User::class));
+
+Factory::guessFactoryNamesUsing(function (string $modelName) {
+    return match ($modelName) {
+        User::class => UserFactory::class,
+        default => throw new LogicException('Unknown factory'),
+    };
+});

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -12,6 +12,15 @@ $iterable = [];
 /** @var Traversable<int, string> $traversable */
 $traversable = [];
 
+class Invokable
+{
+    public function __invoke(): string
+    {
+        return 'Taylor';
+    }
+}
+$invokable = new Invokable();
+
 assertType('Illuminate\Support\Collection<int, User>', $collection);
 
 assertType('Illuminate\Support\Collection<int, string>', collect(['string']));
@@ -294,6 +303,11 @@ assertType(
     )
 );
 
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->when($invokable, function ($collection, $param) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+    assertType('Invokable', $param);
+}));
+
 assertType('bool|Illuminate\Support\Collection<int, User>', $collection->whenEmpty(function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
 
@@ -375,6 +389,11 @@ assertType(
         }
     )
 );
+
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->unless($invokable, function ($collection, $param) {
+    assertType('Illuminate\Support\Collection<int, User>', $collection);
+    assertType('Invokable', $param);
+}));
 
 assertType('bool|Illuminate\Support\Collection<int, User>', $collection->unlessEmpty(function ($collection) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -636,6 +636,14 @@ assertType('int', $collection
 
         return 1;
     }, 0));
+assertType('int', $collection
+    ->reduce(function ($int, $user, $key) {
+        assertType('User', $user);
+        assertType('int', $int);
+        assertType('int', $key);
+
+        return 1;
+    }, 0));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection::make([1])->replace([1]));
 assertType('Illuminate\Support\Collection<int, User>', $collection->replace([new User]));


### PR DESCRIPTION
This PR allows you to only fake certain jobs.

Useful if you want to test if one job dispatches another job.

```php
<?php

namespace App\Jobs;

use ...

class ParentJob
{
    public function handle() 
    {
        ChildJob::dispatch();
    }
{
```

```php
/** @test */
public function it_dispatches_another_job()
{
    Queue::fake(ChildJob::class);

    ParentJob::dispatch();

    Queue::assertPushed(ChildJob::class);
}
```

When using `Queue::fake()` all jobs will be faked. Therefore the `ParentJob` won't run and will never dispatch the `ChildJob`.

With this addition you can choose which job to fake. Not passing a parameter will fake all jobs like before.


**Example:** I run a web scraper which scrapes the homepage of a news site in a job. That job will then dispatch a job for every article it found.
