### PR TITLE
[9.x] Prevent serializing default values of queued jobs

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -71,6 +71,12 @@ trait SerializesModels
                 continue;
             }
 
+            $value = $this->getPropertyValue($property);
+
+            if ($property->hasDefaultValue() && $value === $property->getDefaultValue()) {
+                continue;
+            }
+
             $name = $property->getName();
 
             if ($property->isPrivate()) {
@@ -79,9 +85,7 @@ trait SerializesModels
                 $name = "\0*\0{$name}";
             }
 
-            $values[$name] = $this->getSerializedPropertyValue(
-                $this->getPropertyValue($property)
-            );
+            $values[$name] = $this->getSerializedPropertyValue($value);
         }
 
         return $values;


### PR DESCRIPTION
When a job gets dispatched to the queue, right before deploying a new version of the code that contains an updated version of the job, it’s possible to run into deserialization errors when the queue starts again after deploying. For example, when you are upgrading your code base to use typed properties instead of doc blocks:

```php
class SyncToExternalService implements ShouldQueue
{
    use SerializesModels;
    use Queueable;

    /** @var ExternalService */
    private $externalService;

    public function handle(ExternalService $externalService)
    {
        $this->externalService = $externalService;
    }
}
```

to

```php
class SyncToExternalService implements ShouldQueue
{
    use SerializesModels;
    use Queueable;

    private ExternalService $externalService;

    public function handle(ExternalService $externalService)
    {
        $this->externalService = $externalService;
    }
}
```

Before deploying, the `$externalService` property will be included in the serialized object, with `null` as value.  After deploying the change, serializing the object won’t include `$externalService`, because then it is an uninitialized typed property. When you now try unserializing an object that was created before deploying (which happens when you start the queue again and the queue still contains jobs from before the deploy), you will get the following error:

```
TypeError: Cannot assign null to property SyncToExternalService::$externalService of type ExternalService
```

This pull request circumvents this error by not including the property on the serialized object.