### PR TITLE
[9.x] Add `insensitive_in` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1186,6 +1186,31 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate an attribute is contained within a list of values without
+     * regardless of the attribute's case.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    public function validateInsensitiveIn($attribute, $value, $parameters)
+    {
+        if (is_array($value) && $this->hasRule($attribute, 'Array')) {
+            foreach ($value as $element) {
+                if (is_array($element)) {
+                    return false;
+                }
+            }
+
+            return count(array_udiff($value, $parameters, 'strcasecmp')) === 0;
+        }
+
+        return ! is_array($value) &&
+            in_array(strtolower($value), array_map('strtolower', $parameters));
+    }
+
+    /**
      * Validate that the values of an attribute are in another attribute.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
+use Illuminate\Validation\Rules\InsensitiveIn;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
@@ -64,6 +65,15 @@ class Rule
         }
 
         return new In(is_array($values) ? $values : func_get_args());
+    }
+
+    public static function insensitiveIn($values)
+    {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        return new InsensitiveIn(is_array($values) ? $values : func_get_args());
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/InsensitiveIn.php
+++ b/src/Illuminate/Validation/Rules/InsensitiveIn.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class InsensitiveIn
+{
+    /**
+     * The name of the rule.
+     */
+    protected $rule = 'insensitive_in';
+
+    /**
+     * The accepted values.
+     *
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * Create a new in rule instance.
+     *
+     * @param  array  $values
+     * @return void
+     */
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     *
+     * @see \Illuminate\Validation\ValidationRuleParser::parseParameters
+     */
+    public function __toString()
+    {
+        $values = array_map(function ($value) {
+            return '"'.str_replace('"', '""', $value).'"';
+        }, $this->values);
+
+        return $this->rule.':'.implode(',', $values);
+    }
+}

--- a/tests/Validation/ValidationInsensitiveInRuleTest.php
+++ b/tests/Validation/ValidationInsensitiveInRuleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Tests\Validation\fixtures\Values;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\InsensitiveIn;
+use PHPUnit\Framework\TestCase;
+
+class ValidationInsensitiveInRuleTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = new InsensitiveIn(['Laravel', 'Framework', 'PHP']);
+
+        $this->assertSame('insensitive_in:"Laravel","Framework","PHP"', (string) $rule);
+
+        $rule = new InsensitiveIn(['Life, the Universe and Everything', 'this is a "quote"']);
+
+        $this->assertSame('insensitive_in:"Life, the Universe and Everything","this is a ""quote"""', (string) $rule);
+
+        $rule = new InsensitiveIn(["a,b\nc,d"]);
+
+        $this->assertSame("insensitive_in:\"a,b\nc,d\"", (string) $rule);
+
+        $rule = Rule::insensitiveIn([1, 2, 3, 4]);
+
+        $this->assertSame('insensitive_in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::insensitiveIn(collect([1, 2, 3, 4]));
+
+        $this->assertSame('insensitive_in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::InsensitiveIn(new Values);
+
+        $this->assertSame('insensitive_in:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::InsensitiveIn('1', '2', '3', '4');
+
+        $this->assertSame('insensitive_in:"1","2","3","4"', (string) $rule);
+    }
+}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2799,6 +2799,50 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateInsensitiveIn()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+//        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'Insensitive_in:bar,baz']);
+//        $this->assertFalse($v->passes());
+//
+//        $trans = $this->getIlluminateArrayTranslator();
+//        $v = new Validator($trans, ['name' => 0], ['name' => 'insensitive_in:bar,baz']);
+//        $this->assertFalse($v->passes());
+//
+//        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'insensitive_in:foo,baz']);
+//        $this->assertTrue($v->passes());
+//
+//        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'insensitive_in:FOO,baz']);
+//        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 'Foo'], ['name' => 'insensitive_in:fOo,baz']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'Array|insensitive_in:foo,baz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'qux']], ['name' => 'Array|insensitive_in:foo,baz,qux']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo,bar', 'qux']], ['name' => 'Array|insensitive_in:"foo,bar",baz,qux']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo,bAr', 'QUX']], ['name' => 'Array|insensitive_in:"foo,bar",baz,qux']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 'f"o"o'], ['name' => 'insensitive_in:"f""O""o",baz,qux']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => "a,b\nc,d"], ['name' => "insensitive_in:\"a,b\nc,d\""]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'Alpha|insensitive_in:foo,Bar']);
+        $this->assertFalse($v->passes());
+
+//        $v = new Validator($trans, ['name' => ['foo', []]], ['name' => 'Array|insensitive_in:foo,bar']);
+//        $this->assertFalse($v->passes());
+    }
+
     public function testValidateNotIn()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2802,18 +2802,17 @@ class ValidationValidatorTest extends TestCase
     public function testValidateInsensitiveIn()
     {
         $trans = $this->getIlluminateArrayTranslator();
-//        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'Insensitive_in:bar,baz']);
-//        $this->assertFalse($v->passes());
-//
-//        $trans = $this->getIlluminateArrayTranslator();
-//        $v = new Validator($trans, ['name' => 0], ['name' => 'insensitive_in:bar,baz']);
-//        $this->assertFalse($v->passes());
-//
-//        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'insensitive_in:foo,baz']);
-//        $this->assertTrue($v->passes());
-//
-//        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'insensitive_in:FOO,baz']);
-//        $this->assertTrue($v->passes());
+        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'Insensitive_in:bar,baz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => 0], ['name' => 'insensitive_in:bar,baz']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'insensitive_in:foo,baz']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 'foo'], ['name' => 'insensitive_in:FOO,baz']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['name' => 'Foo'], ['name' => 'insensitive_in:fOo,baz']);
         $this->assertTrue($v->passes());
@@ -2839,8 +2838,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'Alpha|insensitive_in:foo,Bar']);
         $this->assertFalse($v->passes());
 
-//        $v = new Validator($trans, ['name' => ['foo', []]], ['name' => 'Array|insensitive_in:foo,bar']);
-//        $this->assertFalse($v->passes());
+        $v = new Validator($trans, ['name' => ['foo', []]], ['name' => 'Array|insensitive_in:foo,bar']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateNotIn()


### PR DESCRIPTION
Hi! This PR adds a new `insensitive_in` rule that's similar to `in` but is case-insensitive.

I've had a need for this in a couple of projects in the past, so I thought I'd propose it just in case anyone else has run into the same situation. Sometimes, I want to be able to validate that a value exists in a given list but don't need to necessarily care about the string's case. In my own projects, I'd convert the item and the allowable values to lower case before passing them into the `in` rule. This new rule could remove the need to change any data for validating it.

Examples where the rule would fail using `in` but pass with `insensitive_in`:

```php
Validator::make(['foo' => 'Bar'], ['foo' => 'required|string|insensitive_in:bar']);
Validator::make(['foo' => 'Bar'], ['foo' => 'required|string|insensitive_in:BAR']);
Validator::make(['foo' => 'Bar'], ['foo' => ['required', 'string', Rule::insensitiveIn('bar')]);
```

There's a bit of duplication between the `in` and `insensitive_in` rules, so I think there's probably room for me to clean it up a bit more if you'd like?

If it's something that you think might be worthwhile but needs some changes, please let me know and I'll get it sorted ASAP 😄