### PR TITLE
[9.x] Fix `takeUntilTimeout` method of `LazyCollection`

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1416,7 +1416,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         return new static(function () use ($timeout) {
             $iterator = $this->getIterator();
 
-            if ($this->now() > $timeout) {
+            if (! $iterator->valid() || $this->now() > $timeout) {
                 return;
             }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1413,8 +1413,20 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         $timeout = $timeout->getTimestamp();
 
-        return $this->takeWhile(function () use ($timeout) {
-            return $this->now() < $timeout;
+        return new static(function () use ($timeout) {
+            $iterator = $this->getIterator();
+
+            if ($this->now() > $timeout) {
+                return;
+            }
+
+            yield $iterator->key() => $iterator->current();
+
+            while ($iterator->valid() && $this->now() < $timeout) {
+                $iterator->next();
+
+                yield $iterator->key() => $iterator->current();
+            }
         });
     }
 

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -196,6 +196,32 @@ class SupportLazyCollectionTest extends TestCase
         m::close();
     }
 
+    public function testTakeUntilTimeoutWithPastTimeout()
+    {
+        $timeout = Carbon::now()->subMinute();
+
+        $mock = m::mock(LazyCollection::class.'[now]');
+
+        $results = $mock
+            ->times(10)
+            ->tap(function ($collection) use ($mock, $timeout) {
+                tap($collection)
+                    ->mockery_init($mock->mockery_getContainer())
+                    ->shouldAllowMockingProtectedMethods()
+                    ->shouldReceive('now')
+                    ->times(1)
+                    ->andReturn(
+                        (clone $timeout)->add(1, 'minute')->getTimestamp(),
+                    );
+            })
+            ->takeUntilTimeout($timeout)
+            ->all();
+
+        $this->assertSame([], $results);
+
+        m::close();
+    }
+
     public function testTapEach()
     {
         $data = LazyCollection::times(10);


### PR DESCRIPTION
_Bug was discovered in #41275 by @JosephSilber._

The current implementation of `takeUntilTimeout` method in `LazyCollection` always fetches the next item before checking if the timeout has been exceeded. This new implementation only fetches the next item when we are sure that the timeout has not been exceeded.