### PR TITLE
[9.x] Add `exists()` method to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1620,6 +1620,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if any item exists in the collection.
+     *
+     * @return bool
+     */
+    public function exists(): bool
+    {
+        return $this->count() > 0;
+    }
+
+    /**
      * Count the number of items in the collection by a field or using a callback.
      *
      * @param  (callable(TValue, TKey): mixed)|string|null  $countBy

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1582,6 +1582,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if any item exists in the collection.
+     *
+     * @return bool
+     */
+    public function exists(): bool
+    {
+        return $this->count() > 0;
+    }
+
+    /**
      * Make an iterator from the given source.
      *
      * @template TIteratorKey of array-key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -767,6 +767,28 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testCount($collection)
+    {
+        $c = new $collection(['foo', 'bar']);
+        $this->assertSame(2, $c->count());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testExists($collection)
+    {
+        $c = new $collection([['id' => 1, 'name' => 'foo'], ['id' => 2, 'name' => 'bar']]);
+
+        $this->assertTrue($c->where('name', 'foo')->exists());
+        $this->assertTrue($c->where('id', 2)->exists());
+        $this->assertFalse($c->where('name', 'baz')->exists());
+        $this->assertFalse($c->where('id', 3)->exists());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testCountable($collection)
     {
         $c = new $collection(['foo', 'bar']);


### PR DESCRIPTION
This new method:

```
if ($collection->where(...)->exists())
```

it's just a shortcut for:

```
if ($collection->where(...)->count() > 0)
```

To me, it's handy. What do you guys think about it?