### PR TITLE
[9.x] Add `injectOnlyActionParameters` method to Route

### DIFF
--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -38,7 +38,7 @@ class ControllerDispatcher implements ControllerDispatcherContract
     public function dispatch(Route $route, $controller, $method)
     {
         $parameters = $this->resolveClassMethodDependencies(
-            $route->parametersWithoutNulls(), $controller, $method
+            $route->parametersWithoutNulls(), $controller, $method, $route->enforcesInjectOnlyActionParameters()
         );
 
         if (method_exists($controller, 'callAction')) {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1120,6 +1120,28 @@ class Route
     }
 
     /**
+     * Indicate that the route should enforce injecting only the action's defined parameters.
+     *
+     * @return bool
+     */
+    public function injectOnlyActionParameters()
+    {
+        $this->action['inject_only_action_parameters'] = true;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the route should enforce injecting only the action's defined parameters.
+     *
+     * @return bool
+     */
+    public function enforcesInjectOnlyActionParameters()
+    {
+        return (bool) ($this->action['inject_only_action_parameters'] ?? false);
+    }
+
+    /**
      * Specify that the route should not allow concurrent requests from the same session.
      *
      * @param  int|null  $lockSeconds

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -24,8 +24,7 @@ trait RouteDependencyResolverTrait
               $instance,
               $method,
               $onlyMethodParameters = false
-    )
-    {
+    ) {
         if (! method_exists($instance, $method)) {
             return $parameters;
         }
@@ -43,7 +42,7 @@ trait RouteDependencyResolverTrait
      * @return array
      */
     public function resolveMethodDependencies(
-        array                      $parameters,
+        array $parameters,
         ReflectionFunctionAbstract $reflector,
                                    $onlyMethodParameters = false)
     {
@@ -53,7 +52,7 @@ trait RouteDependencyResolverTrait
 
         $skippableValue = new stdClass;
 
-        if ($onlyMethodParameters){
+        if ($onlyMethodParameters) {
             $this->filterToOnlyMethodParameters($parameters, $reflector);
         }
 
@@ -76,15 +75,15 @@ trait RouteDependencyResolverTrait
     /**
      * Filter parameters to only contain the method parameters.
      *
-     * @param  array $parameters
-     * @param  ReflectionFunctionAbstract $reflector
+     * @param  array  $parameters
+     * @param  ReflectionFunctionAbstract  $reflector
      * @return void
      */
     protected function filterToOnlyMethodParameters(array &$parameters, ReflectionFunctionAbstract $reflector)
     {
-        $reflectorParametersNames = array_map(fn($parameter) => $parameter->name, $reflector->getParameters());
+        $reflectorParametersNames = array_map(fn ($parameter) => $parameter->name, $reflector->getParameters());
         foreach ($parameters as $key => $parameter) {
-            if (!in_array($key, $reflectorParametersNames)) {
+            if (! in_array($key, $reflectorParametersNames)) {
                 unset($parameters[$key]);
             }
         }

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -69,7 +69,7 @@ class RouteRegistrar
         'scopeBindings',
         'where',
         'withoutMiddleware',
-        'injectOnlyActionParameters'
+        'injectOnlyActionParameters',
     ];
 
     /**
@@ -81,7 +81,7 @@ class RouteRegistrar
         'name' => 'as',
         'scopeBindings' => 'scope_bindings',
         'withoutMiddleware' => 'excluded_middleware',
-        'injectOnlyActionParameters' => 'inject_only_action_parameters'
+        'injectOnlyActionParameters' => 'inject_only_action_parameters',
     ];
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -24,6 +24,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method \Illuminate\Routing\RouteRegistrar scopeBindings()
+ * @method \Illuminate\Routing\RouteRegistrar injectOnlyActionParameters()
  * @method \Illuminate\Routing\RouteRegistrar where(array  $where)
  * @method \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string  $middleware)
  */
@@ -68,6 +69,7 @@ class RouteRegistrar
         'scopeBindings',
         'where',
         'withoutMiddleware',
+        'injectOnlyActionParameters'
     ];
 
     /**
@@ -79,6 +81,7 @@ class RouteRegistrar
         'name' => 'as',
         'scopeBindings' => 'scope_bindings',
         'withoutMiddleware' => 'excluded_middleware',
+        'injectOnlyActionParameters' => 'inject_only_action_parameters'
     ];
 
     /**

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -29,6 +29,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method static \Illuminate\Routing\RouteRegistrar prefix(string $prefix)
  * @method static \Illuminate\Routing\RouteRegistrar scopeBindings()
+ * @method static \Illuminate\Routing\RouteRegistrar injectOnlyActionParameters()
  * @method static \Illuminate\Routing\RouteRegistrar where(array $where)
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)
  * @method static \Illuminate\Routing\ResourceRegistrar resourceVerbs(array $verbs = [])

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1944,6 +1944,29 @@ class RoutingRouteTest extends TestCase
         ], $route->middleware());
     }
 
+    public function testRouteInjectOnlyActionParameters()
+    {
+        $router = $this->getRouter();
+        $router->get('{lang}/foo/{id}', [RouteTestControllerWithSpecificActionParameters::class, 'show'])
+            ->injectOnlyActionParameters();
+
+        $request = Request::create('en/foo/123', 'GET');
+
+        $response = $router->dispatch($request);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testRouteWithoutInjectOnlyActionParameters()
+    {
+        $router = $this->getRouter();
+        $router->get('{lang}/foo/{id}', [RouteTestControllerWithSpecificActionParameters::class, 'show']);
+
+        $request = Request::create('en/foo/123', 'GET');
+
+        $this->expectException('TypeError');
+        $router->dispatch($request);
+    }
+
     protected function getRouter()
     {
         $container = new Container;
@@ -2060,6 +2083,14 @@ class RouteTestClosureMiddlewareController extends Controller
     public function index()
     {
         return 'index';
+    }
+}
+
+class RouteTestControllerWithSpecificActionParameters extends Controller
+{
+    public function show(int $id)
+    {
+       return $id;
     }
 }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -2090,7 +2090,7 @@ class RouteTestControllerWithSpecificActionParameters extends Controller
 {
     public function show(int $id)
     {
-       return $id;
+        return $id;
     }
 }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1947,24 +1947,18 @@ class RoutingRouteTest extends TestCase
     public function testRouteInjectOnlyActionParameters()
     {
         $router = $this->getRouter();
-        $router->get('{lang}/foo/{id}', [RouteTestControllerWithSpecificActionParameters::class, 'show'])
-            ->injectOnlyActionParameters();
-
-        $request = Request::create('en/foo/123', 'GET');
-
-        $response = $router->dispatch($request);
-        $this->assertEquals(200, $response->getStatusCode());
-    }
-
-    public function testRouteWithoutInjectOnlyActionParameters()
-    {
-        $router = $this->getRouter();
         $router->get('{lang}/foo/{id}', [RouteTestControllerWithSpecificActionParameters::class, 'show']);
 
         $request = Request::create('en/foo/123', 'GET');
 
-        $this->expectException('TypeError');
+        $this->expectException(\TypeError::class);
         $router->dispatch($request);
+
+        $router->get('{lang}/foo/{id}', [RouteTestControllerWithSpecificActionParameters::class, 'show'])
+            ->injectOnlyActionParameters();
+
+        $response = $router->dispatch($request);
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     protected function getRouter()


### PR DESCRIPTION
This merge request adds `injectOnlyActionParameters` method to Route class.
## Why?

In some cases the developer may want to only receive the parameters he defined in the controller action even if the route changed later and got new bindings added to it.
For example:
Imagine a route like this 
```php
Route::get('hello/{id}', 'App\Http\Controllers\HelloController')
```
and the controller defined like this:
```php
class HelloController extends Controller
{
    public function __invoke(int $id)
    {
       return $id;
    }
}
```
If the route changed later on to be like so:
```php
Route::prefix('{lang}')->get('hello/{id}', 'App\Http\Controllers\HelloController')
```

The controller action defined earlier will either fail with TypeError exception  if there's a type mismatch or it'll get the `$lang`'s value as the `$id` which is an unexpected behavior.

## Solution?

I added `injectOnlyActionParameters` method that can be chained to a defined route. This function will ensure that the controller action will only receive the parameters it expects even if the route changed later.
So after applying this method to the route above, it'll look like this:
```php
Route::prefix('{lang}')->get('hello/{id}', 'App\Http\Controllers\HelloController')
    ->injectOnlyActionParameters();
 ```