### PR TITLE
[9.x] Add `mapIntoSpread` method to Collections

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -694,6 +694,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function mapInto($class);
 
     /**
+     * Map the values into a new class, spreading the arguments.
+     *
+     * @template TMapIntoValue
+     *
+     * @param  class-string<TMapIntoValue>  $class
+     * @return static<TKey, TMapIntoValue>
+     */
+    public function mapIntoSpread($class);
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -393,6 +393,21 @@ trait EnumeratesValues
     }
 
     /**
+     * Map the values into a new class, spreading the arguments.
+     *
+     * @template TMapIntoValue
+     *
+     * @param  class-string<TMapIntoValue>  $class
+     * @return static<TKey, TMapIntoValue>
+     */
+    public function mapIntoSpread($class)
+    {
+        return $this->map(function ($value) use ($class) {
+            return new $class(...$value);
+        });
+    }
+
+    /**
      * Get the min value of a given key.
      *
      * @param  (callable(TValue):mixed)|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2941,6 +2941,27 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMapIntoSpread($collection)
+    {
+        $data = new $collection([
+            ['name' => 'Taylor', 'role' => 'author'],
+            ['name' => 'Mohamed', 'role' => 'maintainer'],
+        ]);
+
+        $data = $data->mapIntoSpread(TestCollectionMapIntoSpreadObject::class);
+
+        $this->assertInstanceOf(TestCollectionMapIntoSpreadObject::class, $data->get(0));
+        $this->assertSame('Taylor', $data->get(0)->name);
+        $this->assertSame('author', $data->get(0)->role);
+
+        $this->assertInstanceOf(TestCollectionMapIntoSpreadObject::class, $data->get(1));
+        $this->assertSame('Mohamed', $data->get(1)->name);
+        $this->assertSame('maintainer', $data->get(1)->role);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testNth($collection)
     {
         $data = new $collection([
@@ -5138,6 +5159,16 @@ class TestCollectionMapIntoObject
     public function __construct($value)
     {
         $this->value = $value;
+    }
+}
+
+class TestCollectionMapIntoSpreadObject
+{
+    public function __construct(
+        public string $name,
+        public string $role,
+    ) {
+        //
     }
 }
 


### PR DESCRIPTION
This pull request adds `mapIntoSpread` method to Collections.

## Why?

Since PHP 8.0, and named arguments, Data Transfer Objects (DTOs) have become more powerful.
Collections have a `mapInto` method that iterates over the collection, creating a new instance of the given class by passing the value into the constructor. This will work only if the constructor has a single argument.

For example, given we have the following class:

```php
class ArtisanDev
{
    public function __construct(
        public string $name,
        public string $role,
    ) {}
}
```

In order to map a collection's items into ArtisanDev objects, we currently have to write:

```php
collect([
    ['name' => 'Taylor', 'role' => 'author'],
    ['name' => 'Mohamed', 'role' => 'maintainer'],
])->map(function ($person) {
    return new ArtisanDev($person['name'], $person['role']);
});
```

or with arrow functions and named arguments:

```php
collect([
    ['name' => 'Taylor', 'role' => 'author'],
    ['name' => 'Mohamed', 'role' => 'maintainer'],
])->map(fn ($person) => new ArtisanDev(...$person));
```

## Solution?

The new `mapIntoSpread` collection method allows to write:

```php
collect([
    ['name' => 'Taylor', 'role' => 'author'],
    ['name' => 'Mohamed', 'role' => 'maintainer'],
])->mapIntoSpread(ArtisanDev::class);
```