### PR TITLE
[8.x] Added `withCountAsStated()` and `loadCountAsStated()` methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -69,9 +69,10 @@ class Collection extends BaseCollection implements QueueableCollection
      * @param  array|string  $relations
      * @param  string  $column
      * @param  string  $function
+     * @param  bool  $preserveRelationState
      * @return $this
      */
-    public function loadAggregate($relations, $column, $function = null)
+    public function loadAggregate($relations, $column, $function = null, $preserveRelationState = false)
     {
         if ($this->isEmpty()) {
             return $this;
@@ -80,7 +81,7 @@ class Collection extends BaseCollection implements QueueableCollection
         $models = $this->first()->newModelQuery()
             ->whereKey($this->modelKeys())
             ->select($this->first()->getKeyName())
-            ->withAggregate($relations, $column, $function)
+            ->withAggregate($relations, $column, $function, $preserveRelationState)
             ->get()
             ->keyBy($this->first()->getKeyName());
 
@@ -109,6 +110,17 @@ class Collection extends BaseCollection implements QueueableCollection
     public function loadCount($relations)
     {
         return $this->loadAggregate($relations, '*', 'count');
+    }
+
+    /**
+     * Load a set of relationship counts onto the collection as exactly stated in the relation definition.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadCountAsStated($relations)
+    {
+        return $this->loadAggregate($relations, '*', 'count', true);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -574,7 +574,7 @@ trait QueriesRelationships
             $query->callScope($constraints);
 
             if ($preserveRelationState) {
-                $query = DB::query()->from($query, $name . '_aggregate')->select(new Expression('count(*)'));
+                $query = $query->getConnection()->query()->from($query, $name . '_aggregate')->select(new Expression('count(*)'));
             } else {
                 $query = $query->mergeConstraintsFrom($relation->getQuery())->toBase();
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -574,7 +574,7 @@ trait QueriesRelationships
             $query->callScope($constraints);
 
             if ($preserveRelationState) {
-                $query = $query->getConnection()->query()->from($query, $name . '_aggregate')->select(new Expression('count(*)'));
+                $query = $query->getConnection()->query()->from($query, $name.'_aggregate')->select(new Expression('count(*)'));
             } else {
                 $query = $query->mergeConstraintsFrom($relation->getQuery())->toBase();
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -11,7 +11,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 trait QueriesRelationships

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -640,11 +640,12 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array|string  $relations
      * @param  string  $column
      * @param  string  $function
+     * @param  bool  $preserveRelationState
      * @return $this
      */
-    public function loadAggregate($relations, $column, $function = null)
+    public function loadAggregate($relations, $column, $function = null, $preserveRelationState = false)
     {
-        $this->newCollection([$this])->loadAggregate($relations, $column, $function);
+        $this->newCollection([$this])->loadAggregate($relations, $column, $function, $preserveRelationState);
 
         return $this;
     }
@@ -660,6 +661,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $relations = is_string($relations) ? func_get_args() : $relations;
 
         return $this->loadAggregate($relations, '*', 'count');
+    }
+
+    /**
+     * Eager load relation counts on the model as exactly stated in the relation definition.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadCountAsStated($relations)
+    {
+        $relations = is_string($relations) ? func_get_args() : $relations;
+
+        return $this->loadAggregate($relations, '*', 'count', true);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1061,7 +1061,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->withCountAsStated('posts');
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id") as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountAsStatedAndSelect()
@@ -1070,7 +1070,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->select('id')->withCountAsStated('posts');
 
-        $this->assertSame('select "id", (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "id", (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id") as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountAsStatedAndMergedWheres()
@@ -1081,8 +1081,8 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->where('bam', '>', 'qux');
         }]);
 
-        $this->assertSame('select "id", (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ?) as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
-        $this->assertEquals(['qux', true], $builder->getBindings());
+        $this->assertSame('select "id", (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id" and "bam" > ?) as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertEquals(['qux'], $builder->getBindings());
     }
 
     public function testWithCountAsStatedAndGlobalScope()
@@ -1092,14 +1092,14 @@ class DatabaseEloquentBuilderTest extends TestCase
             return $query->addSelect('id');
         });
 
-        $builder = $model->select('id')->withCount(['posts']);
+        $builder = $model->select('id')->withCountAsStated(['posts']);
 
         // Remove the global scope so it doesn't interfere with any other tests
         EloquentBuilderTestModelCloseRelatedStub::addGlobalScope('withCountAsStated', function ($query) {
             //
         });
 
-        $this->assertSame('select "id", (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "id", (select count(*) from (select "id" from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id") as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountAsStatedAndConstraintsAndHaving()
@@ -1107,11 +1107,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestModelParentStub;
 
         $builder = $model->where('bar', 'baz');
-        $builder->withCount(['posts' => function ($q) {
+        $builder->withCountAsStated(['posts' => function ($q) {
             $q->where('bam', '>', 'qux');
         }])->having('posts_count', '>=', 1);
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ?) as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs" where "bar" = ? having "posts_count" >= ?', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id" and "bam" > ?) as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs" where "bar" = ? having "posts_count" >= ?', $builder->toSql());
         $this->assertEquals(['qux', 'baz', 1], $builder->getBindings());
     }
 
@@ -1119,27 +1119,27 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->withCount('posts as posts_bar');
+        $builder = $model->withCountAsStated('posts as posts_bar');
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "posts_aggregate") as "posts_bar" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id") as "posts_aggregate") as "posts_bar" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountAsStatedMultipleAndPartialRename()
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->withCount(['posts as posts_bar', 'posts']);
+        $builder = $model->withCountAsStated(['posts as posts_bar', 'posts']);
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "posts_aggregate") as "posts_bar", (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id") as "posts_aggregate") as "posts_bar", (select count(*) from (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id") as "posts_aggregate") as "posts_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountAsStatedWithJoinAndSelect()
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->withCount(['postsWithJoin']);
+        $builder = $model->withCountAsStated(['postsWithJoin']);
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select distinct(bar.id) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."post_id" = "eloquent_builder_test_model_close_related_stubs"."id" inner join "bar" on "bar"."post_id" = "posts"."id") as "posts_aggregate") as "posts_with_join_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from (select "distinct(bar"."id)" from "eloquent_builder_test_model_close_related_stubs" inner join "bar" on "bar"."post_id" = "posts"."id" where "eloquent_builder_test_model_parent_stubs"."id" = "eloquent_builder_test_model_close_related_stubs"."eloquent_builder_test_model_parent_stub_id") as "postsWithJoin_aggregate") as "posts_with_join_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithExists()

--- a/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
@@ -42,7 +42,10 @@ class EloquentCollectionLoadCountAsStatedTest extends DatabaseTestCase
             $comment->likes()->save(new NewCommentLike);
             $comment->likes()->save(new NewCommentLike);
         });
-        tap($post->comments[1], fn ($comment) => $comment->likes()->save(new NewCommentLike));
+
+        tap($post->comments[1], function ($comment) {
+            $comment->likes()->save(new NewCommentLike);
+        });
 
         $post->likes()->save(new NewLike);
 
@@ -136,7 +139,7 @@ class NewPost extends Model
 
     public function commentWithLikes()
     {
-        return $this->comments()->join('new_comment_likes', 'new_comment_likes.new_comment_id', 'new_comments.id');
+        return $this->comments()->join('new_comment_likes', 'new_comment_likes.new_comment_id', 'new_comments.id')->select('new_comment_likes.*');
     }
 
     public function likes()

--- a/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
@@ -65,7 +65,7 @@ class EloquentCollectionLoadCountAsStatedTest extends DatabaseTestCase
 
     public function testLoadCountAsStatedWithSameModels()
     {
-        $posts = NewPost::all()->push(Post::first());
+        $posts = NewPost::all()->push(NewPost::first());
 
         DB::enableQueryLog();
 
@@ -136,7 +136,7 @@ class NewPost extends Model
 
     public function commentWithLikes()
     {
-        return $this->comments()->join('new_comment_likes', 'new_comment_likes.comment_id', 'new_comments.id');
+        return $this->comments()->join('new_comment_likes', 'new_comment_likes.new_comment_id', 'new_comments.id');
     }
 
     public function likes()

--- a/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
@@ -61,9 +61,9 @@ class EloquentCollectionLoadCountAsStatedTest extends DatabaseTestCase
         $posts->loadCountAsStated('commentWithLikes');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertSame('3', $posts[0]->comment_with_likes_count);
-        $this->assertSame('0', $posts[1]->comment_with_likes_count);
-        $this->assertSame('3', $posts[0]->getOriginal('comment_with_likes_count'));
+        $this->assertEquals('3', $posts[0]->comment_with_likes_count);
+        $this->assertEquals('0', $posts[1]->comment_with_likes_count);
+        $this->assertEquals('3', $posts[0]->getOriginal('comment_with_likes_count'));
     }
 
     public function testLoadCountAsStatedWithSameModels()
@@ -89,8 +89,8 @@ class EloquentCollectionLoadCountAsStatedTest extends DatabaseTestCase
         $posts->loadCountAsStated('commentWithLikes');
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertSame('3', $posts[0]->comment_with_likes_count);
-        $this->assertSame('0', $posts[1]->comment_with_likes_count);
+        $this->assertEquals('3', $posts[0]->comment_with_likes_count);
+        $this->assertEquals('0', $posts[1]->comment_with_likes_count);
     }
 
     public function testLoadCountAsStatedWithArrayOfRelations()
@@ -102,12 +102,12 @@ class EloquentCollectionLoadCountAsStatedTest extends DatabaseTestCase
         $posts->loadCountAsStated(['comments', 'commentWithLikes', 'likes']);
 
         $this->assertCount(1, DB::getQueryLog());
-        $this->assertSame('2', $posts[0]->comments_count);
-        $this->assertSame('3', $posts[0]->comment_with_likes_count);
-        $this->assertSame('1', $posts[0]->likes_count);
-        $this->assertSame('0', $posts[1]->comments_count);
-        $this->assertSame('0', $posts[1]->comment_with_likes_count);
-        $this->assertSame('0', $posts[1]->likes_count);
+        $this->assertEquals('2', $posts[0]->comments_count);
+        $this->assertEquals('3', $posts[0]->comment_with_likes_count);
+        $this->assertEquals('1', $posts[0]->likes_count);
+        $this->assertEquals('0', $posts[1]->comments_count);
+        $this->assertEquals('0', $posts[1]->comment_with_likes_count);
+        $this->assertEquals('0', $posts[1]->likes_count);
     }
 
     public function testLoadCountAsStatedDoesNotOverrideAttributesWithDefaultValue()
@@ -117,8 +117,8 @@ class EloquentCollectionLoadCountAsStatedTest extends DatabaseTestCase
 
         Collection::make([$post])->loadCountAsStated('commentWithLikes');
 
-        $this->assertSame(200, $post->some_default_value);
-        $this->assertSame('3', $post->comment_with_likes_count);
+        $this->assertEquals(200, $post->some_default_value);
+        $this->assertEquals('3', $post->comment_with_likes_count);
     }
 }
 

--- a/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Integration\Database;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentCollectionLoadCountAsStatedTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('some_default_value');
+            $table->softDeletes();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('likes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('comment_likes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('comment_id');
+        });
+
+        $post = Post::create();
+        $post->comments()->saveMany([new Comment, new Comment]);
+
+        tap($post->comments[0], function ($comment) {
+            $comment->likes()->save(new CommentLike);
+            $comment->likes()->save(new CommentLike);
+        });
+        tap($post->comments[1], fn($comment) => $comment->likes()->save(new CommentLike));
+
+        $post->likes()->save(new Like);
+
+        Post::create();
+    }
+
+    public function testLoadCountAsStated()
+    {
+        $posts = Post::all();
+
+        DB::enableQueryLog();
+
+        $posts->loadCountAsStated('commentWithLikes');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame('3', $posts[0]->comment_with_likes_count);
+        $this->assertSame('0', $posts[1]->comment_with_likes_count);
+        $this->assertSame('3', $posts[0]->getOriginal('comment_with_likes_count'));
+    }
+
+    public function testLoadCountAsStatedWithSameModels()
+    {
+        $posts = Post::all()->push(Post::first());
+
+        DB::enableQueryLog();
+
+        $posts->loadCountAsStated('commentWithLikes');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertEquals('3', $posts[0]->comment_with_likes_count);
+        $this->assertEquals('0', $posts[1]->comment_with_likes_count);
+        $this->assertEquals('3', $posts[2]->comment_with_likes_count);
+    }
+
+    public function testLoadCountAsStatedOnDeletedModels()
+    {
+        $posts = Post::all()->each->delete();
+
+        DB::enableQueryLog();
+
+        $posts->loadCountAsStated('commentWithLikes');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame('3', $posts[0]->comment_with_likes_count);
+        $this->assertSame('0', $posts[1]->comment_with_likes_count);
+    }
+
+    public function testLoadCountAsStatedWithArrayOfRelations()
+    {
+        $posts = Post::all();
+
+        DB::enableQueryLog();
+
+        $posts->loadCountAsStated(['comments', 'commentWithLikes', 'likes']);
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('3', $posts[0]->comment_with_likes_count);
+        $this->assertSame('1', $posts[0]->likes_count);
+        $this->assertSame('0', $posts[1]->comments_count);
+        $this->assertSame('0', $posts[1]->comment_with_likes_count);
+        $this->assertSame('0', $posts[1]->likes_count);
+    }
+
+    public function testLoadCountAsStatedDoesNotOverrideAttributesWithDefaultValue()
+    {
+        $post = Post::first();
+        $post->some_default_value = 200;
+
+        Collection::make([$post])->loadCountAsStated('commentWithLikes');
+
+        $this->assertSame(200, $post->some_default_value);
+        $this->assertSame('3', $post->comment_with_likes_count);
+    }
+}
+
+class Post extends Model
+{
+    use SoftDeletes;
+
+    protected $attributes = [
+        'some_default_value' => 100,
+    ];
+
+    public $timestamps = false;
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function commentWithLikes()
+    {
+        return $this->comments()->join('comment_likes', 'comment_likes.comment_id', 'comments.id');
+    }
+
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function likes()
+    {
+        return $this->hasMany(CommentLike::class);
+    }
+}
+
+class Like extends Model
+{
+    public $timestamps = false;
+}
+
+class CommentLike extends Model
+{
+    public $timestamps = false;
+}

--- a/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountAsStatedTest.php
@@ -42,7 +42,7 @@ class EloquentCollectionLoadCountAsStatedTest extends DatabaseTestCase
             $comment->likes()->save(new NewCommentLike);
             $comment->likes()->save(new NewCommentLike);
         });
-        tap($post->comments[1], fn($comment) => $comment->likes()->save(new NewCommentLike));
+        tap($post->comments[1], fn ($comment) => $comment->likes()->save(new NewCommentLike));
 
         $post->likes()->save(new NewLike);
 


### PR DESCRIPTION
These two new methods `withCountAsStated()` and `loadCountAsStated()` allows us to customize the relationship queries while loading the counts as sub-select.

Example:

```
Class User extends Model {
    public function commentedUsers() {
        return $this->hasMany(Post::class)->join('comments', 'posts.id', 'comments.post_id')->selectRaw('distinct(user_id)');
    }
}


// Before

User::withCount('commentedUsers')->first();

// Query: select users.*, (select count(*) from posts where posts.user_id = users.id) as commented_users_count from users limit 1;

// After

User::withCountAsStated('commentedUsers')->first();

// Query: select users.*, (select count(*) from (select distinct(user_id) from posts join comments on posts.id = comments.post_id where posts.user_id = users.id) as commented_users_aggregate) as commented_users_count from users limit 1;
```

And the `withCount()` and `loadCount()` method still behave the same.

This behaviour allows one to customize the count query for the sub-select and avoiding the need for writing raw sub-select because of the default behaviour.
