### PR TITLE
[9.x] BCC broken on 9.x with AWS SES Mail Transport

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -51,12 +51,9 @@ class SesTransport extends AbstractTransport
     protected function doSend(SentMessage $message): void
     {
         try {
-            /**
-             * Batch up API calls to adhere to the recipient limit of the service.
-             * See Also: https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.Ses.SesClient.html#_sendRawEmail.
-             */
-            $recipientList = collect($message->getEnvelope()->getRecipients());
-            foreach ($recipientList->chunk(self::RECIPIENT_LIMIT) as $recipients) {
+            // Batch up API calls to adhere to the recipient limit of the service.
+            // See also: https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.Ses.SesClient.html#_sendRawEmail.
+            foreach (collect($message->getEnvelope()->getRecipients())->chunk(self::RECIPIENT_LIMIT) as $recipients) {
                 $this->ses->sendRawEmail(
                     array_merge(
                         $this->options, [


### PR DESCRIPTION
After upgrading to Laravel 9.x, bcc in our application stopped working
with the SES email transport. After reviewing the migration/upgrade
documentation and the code differences from 8.x -> 9.x, it's clear the
change in mailers likely exposed this; however, I also noticed a couple
fundamental, mechanical issues with the implementation:

1) Lack of Destinations specified in the array
2) No adherence to the 50 recipient limit of SES

I've corrected both of those and now can receive To/Cc/Bcc emails.

See Also: https://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html
See Also: https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.Ses.SesClient.html#_sendRawEmail
See Also: https://docs.aws.amazon.com/ses/latest/dg/quotas.html
