### PR TITLE
[9.x] Fix directory for nested markdown files for mailables

### DIFF
--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -102,7 +102,11 @@ class MailMakeCommand extends GeneratorCommand
         $view = $this->option('markdown');
 
         if (! $view) {
-            $view = 'mail.'.Str::kebab(class_basename($this->argument('name')));
+            $name = str_replace('\\', '/', $this->argument('name'));
+
+            $view = 'mail.'.collect(explode('/', $name))
+                ->map(fn ($part) => Str::kebab($part))
+                ->implode('.');
         }
 
         return $view;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end-users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR allows for the correct location on nested markdown mailables. Useful for applications with many mailables.

Currently, if you create a mailable with a nested location, it will generate a mailable class in the nested directory. However, the markdown will be in the `mail` directory and not within the nested directory.

```bash
php artisan make:mail Registration/WelcomeEmail -m

// generates:
app\Mail\Registration\WelcomeEmail.php
resources\views\mail\welcome-email.blade.php
```

This PR will place the blade in the proper nested directory.

Proposed: 
```bash
php artisan make:mail Registration/WelcomeEmail -m

// generates:
app\Mail\Registration\WelcomeEmail.php
resources\views\mail\registration\welcome-email.blade.php
```

of course, you can manually override the location with `--markdown=(location)` but this fixes the directory when an empty markdown location is provided.

I didn't see any tests for this but I tested this thoroughly locally.  Thanks!



