### PR TITLE
Eloquent\Builder $query->value() clear return type on not finding a model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -611,6 +611,8 @@ class Builder implements BuilderContract
     {
         if ($result = $this->first([$column])) {
             return $result->{Str::afterLast($column, '.')};
+        } else {
+            return null;
         }
     }
 


### PR DESCRIPTION
Theoretically should not change anything (I am uncertain of how PHP handles evaluating a no-return, but maybe it auto returns null), but should clearly indicate to readers that in case of not being able to find a model through the query, value() returns null. This matches the behaviour in Query\Builder.