### PR TITLE
[9.x] Add soleValue method to query builders

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -615,6 +615,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a single column's value from the first result of a query if it's the sole matching record.
+     *
+     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @return mixed
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
+     * @throws \Illuminate\Database\MultipleRecordsFoundException
+     */
+    public function soleValue($column)
+    {
+        return $this->sole([$column])->{Str::afterLast($column, '.')};
+    }
+
+    /**
      * Get a single column's value from the first result of the query or throw an exception.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2517,6 +2517,22 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a single column's value from the first result of a query if it's the sole matching record.
+     *
+     * @param  string  $column
+     * @return mixed
+     *
+     * @throws \Illuminate\Database\RecordsNotFoundException
+     * @throws \Illuminate\Database\MultipleRecordsFoundException
+     */
+    public function soleValue($column)
+    {
+        $result = (array) $this->sole([$column]);
+
+        return reset($result);
+    }
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently we have the following methods
```php
$query->sole(['id']); // bails if there is not exactly one result, but returns an object
$query->value('id');  // returns just the value, but no safety around there being exactly one result
```

However if we want the id of the sole result we must do `$query->sole(['id'])->id`.

This PR adds a new method to both builders `soleValue` which is the same logic as `value` (removing the null checks since sole will bail) and uses `sole` instead of `first` internally allowing us to do 
```php
$query->sole(['id']);    // bails if there is not exactly one result, but returns an object
$query->value('id');     // returns just the value, but no safety around there being exactly one result
$query->soleValue('id'); // bails if there is not exactly one result and returns just the value
```