### PR TITLE
[9.x] Fix LazyCollection#takeUntilTimeout

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1414,18 +1414,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         $timeout = $timeout->getTimestamp();
 
         return new static(function () use ($timeout) {
-            $iterator = $this->getIterator();
-
-            if (! $iterator->valid() || $this->now() > $timeout) {
+            if ($this->now() >= $timeout) {
                 return;
             }
 
-            yield $iterator->key() => $iterator->current();
+            foreach ($this as $key => $value) {
+                yield $key => $value;
 
-            while ($iterator->valid() && $this->now() < $timeout) {
-                $iterator->next();
-
-                yield $iterator->key() => $iterator->current();
+                if ($this->now() >= $timeout) {
+                    break;
+                }
             }
         });
     }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Tests\Support;
 
 use Exception;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\ItemNotFoundException;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\MultipleItemsFoundException;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -1212,6 +1214,72 @@ class SupportLazyCollectionIsLazyTest extends TestCase
                 return $item === 10;
             })->all();
         });
+    }
+
+    public function testTakeUntilTimeoutIsLazy()
+    {
+        tap(m::mock(LazyCollection::class.'[now]')->times(100), function ($mock) {
+            $this->assertDoesNotEnumerateCollection($mock, function ($mock) {
+                $timeout = Carbon::now();
+
+                $results = $mock
+                    ->tap(function ($collection) use ($mock, $timeout) {
+                        tap($collection)
+                            ->mockery_init($mock->mockery_getContainer())
+                            ->shouldAllowMockingProtectedMethods()
+                            ->shouldReceive('now')
+                            ->times(1)
+                            ->andReturn(
+                                $timeout->getTimestamp()
+                            );
+                    })
+                    ->takeUntilTimeout($timeout)
+                    ->all();
+            });
+        });
+
+        tap(m::mock(LazyCollection::class.'[now]')->times(100), function ($mock) {
+            $this->assertEnumeratesCollection($mock, 1, function ($mock) {
+                $timeout = Carbon::now();
+
+                $results = $mock
+                    ->tap(function ($collection) use ($mock, $timeout) {
+                        tap($collection)
+                            ->mockery_init($mock->mockery_getContainer())
+                            ->shouldAllowMockingProtectedMethods()
+                            ->shouldReceive('now')
+                            ->times(2)
+                            ->andReturn(
+                                (clone $timeout)->sub(1, 'minute')->getTimestamp(),
+                                $timeout->getTimestamp()
+                            );
+                    })
+                    ->takeUntilTimeout($timeout)
+                    ->all();
+            });
+        });
+
+        tap(m::mock(LazyCollection::class.'[now]')->times(100), function ($mock) {
+            $this->assertEnumeratesCollectionOnce($mock, function ($mock) {
+                $timeout = Carbon::now();
+
+                $results = $mock
+                    ->tap(function ($collection) use ($mock, $timeout) {
+                        tap($collection)
+                            ->mockery_init($mock->mockery_getContainer())
+                            ->shouldAllowMockingProtectedMethods()
+                            ->shouldReceive('now')
+                            ->times(100)
+                            ->andReturn(
+                                (clone $timeout)->sub(1, 'minute')->getTimestamp()
+                            );
+                    })
+                    ->takeUntilTimeout($timeout)
+                    ->all();
+            });
+        });
+
+        m::close();
     }
 
     public function testTakeWhileIsLazy()

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -196,32 +196,6 @@ class SupportLazyCollectionTest extends TestCase
         m::close();
     }
 
-    public function testTakeUntilTimeoutWithPastTimeout()
-    {
-        $timeout = Carbon::now()->subMinute();
-
-        $mock = m::mock(LazyCollection::class.'[now]');
-
-        $results = $mock
-            ->times(10)
-            ->tap(function ($collection) use ($mock, $timeout) {
-                tap($collection)
-                    ->mockery_init($mock->mockery_getContainer())
-                    ->shouldAllowMockingProtectedMethods()
-                    ->shouldReceive('now')
-                    ->times(1)
-                    ->andReturn(
-                        (clone $timeout)->add(1, 'minute')->getTimestamp(),
-                    );
-            })
-            ->takeUntilTimeout($timeout)
-            ->all();
-
-        $this->assertSame([], $results);
-
-        m::close();
-    }
-
     public function testTapEach()
     {
         $data = LazyCollection::times(10);


### PR DESCRIPTION
Fixes #41354

1. Actually make it fully lazy, never pulling an extra item.
2. Simplify the code quite a bit.
3. Add a lazy test.
4. Remove superfluous test.