### PR TITLE
[9.x] Add `setNamespace` method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1401,7 +1401,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Set the application namespace.
      *
-     * @param string $namespace
+     * @param  string  $namespace
      */
     public function setNamespace($namespace)
     {

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1399,6 +1399,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Set the application namespace.
+     *
+     * @param string $namespace
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+    }
+
+    /**
      * Get the application namespace.
      *
      * @return string

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -383,6 +383,15 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame('Laravel\\Two\\', $app2->getNamespace());
     }
 
+    public function testSetNamespace()
+    {
+        $app = new Application(realpath(__DIR__.'/fixtures/laravel1'));
+        $this->assertSame('Laravel\\One\\', $app->getNamespace());
+
+        $app->setNamespace('App\\');
+        $this->assertSame('App\\', $app->getNamespace());        
+    }
+
     public function testCachePathsResolveToBootstrapCacheDirectory()
     {
         $app = new Application('/base/path');

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -389,7 +389,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame('Laravel\\One\\', $app->getNamespace());
 
         $app->setNamespace('App\\');
-        $this->assertSame('App\\', $app->getNamespace());        
+        $this->assertSame('App\\', $app->getNamespace());
     }
 
     public function testCachePathsResolveToBootstrapCacheDirectory()


### PR DESCRIPTION
This PR adds a new function to the `Foundation\Application` class:
- `setNamespace($namespace)` — Set the application namespace

**Motivation / Why:**
- If you don't want to add `composer.json` to the production bundle (my motivation)
- If your `composer.json` isn't placed in the project root (issue: #16570)

By setting namespace manually we can prevent the `Application` class from searching for `composer.json`.