### PR TITLE
[10.x] Replace password reset string constants with enum

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth\Passwords;
 use Closure;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
+use Illuminate\Contracts\Auth\PasswordResetResponse;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Support\Arr;
 use UnexpectedValueException;
@@ -43,9 +44,9 @@ class PasswordBroker implements PasswordBrokerContract
      *
      * @param  array  $credentials
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Auth\Passwords\ResetResponse
+     * @return \Illuminate\Contracts\Auth\PasswordResetResponse
      */
-    public function sendResetLink(array $credentials, Closure $callback = null): ResetResponse
+    public function sendResetLink(array $credentials, Closure $callback = null): PasswordResetResponse
     {
         // First we will check to see if we found a user at the given credentials and
         // if we did not we will redirect back to this current URI with a piece of
@@ -53,11 +54,11 @@ class PasswordBroker implements PasswordBrokerContract
         $user = $this->getUser($credentials);
 
         if (is_null($user)) {
-            return ResetResponse::InvalidUser;
+            return PasswordResetResponse::InvalidUser;
         }
 
         if ($this->tokens->recentlyCreatedToken($user)) {
-            return ResetResponse::ResetThrottled;
+            return PasswordResetResponse::ResetThrottled;
         }
 
         $token = $this->tokens->create($user);
@@ -71,7 +72,7 @@ class PasswordBroker implements PasswordBrokerContract
             $user->sendPasswordResetNotification($token);
         }
 
-        return ResetResponse::ResetLinkSent;
+        return PasswordResetResponse::ResetLinkSent;
     }
 
     /**
@@ -79,9 +80,9 @@ class PasswordBroker implements PasswordBrokerContract
      *
      * @param  array  $credentials
      * @param  \Closure  $callback
-     * @return \Illuminate\Auth\Passwords\ResetResponse
+     * @return \Illuminate\Contracts\Auth\PasswordResetResponse
      */
-    public function reset(array $credentials, Closure $callback): ResetResponse
+    public function reset(array $credentials, Closure $callback): PasswordResetResponse
     {
         $user = $this->validateReset($credentials);
 
@@ -101,23 +102,23 @@ class PasswordBroker implements PasswordBrokerContract
 
         $this->tokens->delete($user);
 
-        return ResetResponse::PasswordReset;
+        return PasswordResetResponse::PasswordReset;
     }
 
     /**
      * Validate a password reset for the given credentials.
      *
      * @param  array  $credentials
-     * @return \Illuminate\Contracts\Auth\CanResetPassword|\Illuminate\Auth\Passwords\ResetResponse
+     * @return \Illuminate\Contracts\Auth\CanResetPassword|\Illuminate\Contracts\Auth\PasswordResetResponse
      */
     protected function validateReset(array $credentials)
     {
         if (is_null($user = $this->getUser($credentials))) {
-            return ResetResponse::InvalidUser;
+            return PasswordResetResponse::InvalidUser;
         }
 
         if (! $this->tokens->exists($user, $credentials['token'])) {
-            return ResetResponse::InvalidToken;
+            return PasswordResetResponse::InvalidToken;
         }
 
         return $user;

--- a/src/Illuminate/Auth/Passwords/ResetResponse.php
+++ b/src/Illuminate/Auth/Passwords/ResetResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Auth\Passwords;
+
+enum ResetResponse: string
+{
+    /**
+     * Case representing a successfully sent reminder.
+     */
+    case ResetLinkSent = 'passwords.sent';
+
+    /**
+     * Case representing a successfully reset password.
+     */
+    case PasswordReset = 'passwords.reset';
+
+    /**
+     * Case representing the user not found response.
+     */
+    case InvalidUser = 'passwords.user';
+
+    /**
+     * Case representing an invalid token.
+     */
+    case InvalidToken = 'passwords.token';
+
+    /**
+     * Case representing a throttled reset attempt.
+     */
+    case ResetThrottled = 'passwords.throttled';
+}

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Contracts\Auth;
 
 use Closure;
+use Illuminate\Auth\Passwords\ResetResponse;
 
 interface PasswordBroker
 {
@@ -10,6 +11,8 @@ interface PasswordBroker
      * Constant representing a successfully sent reminder.
      *
      * @var string
+     *
+     * @deprecated
      */
     const RESET_LINK_SENT = 'passwords.sent';
 
@@ -17,6 +20,8 @@ interface PasswordBroker
      * Constant representing a successfully reset password.
      *
      * @var string
+     *
+     * @deprecated
      */
     const PASSWORD_RESET = 'passwords.reset';
 
@@ -24,6 +29,8 @@ interface PasswordBroker
      * Constant representing the user not found response.
      *
      * @var string
+     *
+     * @deprecated
      */
     const INVALID_USER = 'passwords.user';
 
@@ -31,6 +38,8 @@ interface PasswordBroker
      * Constant representing an invalid token.
      *
      * @var string
+     *
+     * @deprecated
      */
     const INVALID_TOKEN = 'passwords.token';
 
@@ -38,6 +47,8 @@ interface PasswordBroker
      * Constant representing a throttled reset attempt.
      *
      * @var string
+     *
+     * @deprecated
      */
     const RESET_THROTTLED = 'passwords.throttled';
 
@@ -46,16 +57,16 @@ interface PasswordBroker
      *
      * @param  array  $credentials
      * @param  \Closure|null  $callback
-     * @return string
+     * @return \Illuminate\Auth\Passwords\ResetResponse
      */
-    public function sendResetLink(array $credentials, Closure $callback = null);
+    public function sendResetLink(array $credentials, Closure $callback = null): ResetResponse;
 
     /**
      * Reset the password for the given token.
      *
      * @param  array  $credentials
      * @param  \Closure  $callback
-     * @return mixed
+     * @return \Illuminate\Auth\Passwords\ResetResponse
      */
-    public function reset(array $credentials, Closure $callback);
+    public function reset(array $credentials, Closure $callback): ResetResponse;
 }

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Contracts\Auth;
 
 use Closure;
-use Illuminate\Auth\Passwords\ResetResponse;
 
 interface PasswordBroker
 {
@@ -57,16 +56,16 @@ interface PasswordBroker
      *
      * @param  array  $credentials
      * @param  \Closure|null  $callback
-     * @return \Illuminate\Auth\Passwords\ResetResponse
+     * @return \Illuminate\Contracts\Auth\PasswordResetResponse
      */
-    public function sendResetLink(array $credentials, Closure $callback = null): ResetResponse;
+    public function sendResetLink(array $credentials, Closure $callback = null): PasswordResetResponse;
 
     /**
      * Reset the password for the given token.
      *
      * @param  array  $credentials
      * @param  \Closure  $callback
-     * @return \Illuminate\Auth\Passwords\ResetResponse
+     * @return \Illuminate\Contracts\Auth\PasswordResetResponse
      */
-    public function reset(array $credentials, Closure $callback): ResetResponse;
+    public function reset(array $credentials, Closure $callback): PasswordResetResponse;
 }

--- a/src/Illuminate/Contracts/Auth/PasswordResetResponse.php
+++ b/src/Illuminate/Contracts/Auth/PasswordResetResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Contracts\Auth;
+
+enum PasswordResetResponse: string
+{
+    /**
+     * Case representing a successfully sent reminder.
+     */
+    case ResetLinkSent = 'passwords.sent';
+
+    /**
+     * Case representing a successfully reset password.
+     */
+    case PasswordReset = 'passwords.reset';
+
+    /**
+     * Case representing the user not found response.
+     */
+    case InvalidUser = 'passwords.user';
+
+    /**
+     * Case representing an invalid token.
+     */
+    case InvalidToken = 'passwords.token';
+
+    /**
+     * Case representing a throttled reset attempt.
+     */
+    case ResetThrottled = 'passwords.throttled';
+}

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Tests\Auth;
 
 use Illuminate\Auth\Passwords\PasswordBroker;
-use Illuminate\Auth\Passwords\ResetResponse;
 use Illuminate\Auth\Passwords\TokenRepositoryInterface;
 use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
+use Illuminate\Contracts\Auth\PasswordResetResponse;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Support\Arr;
 use Mockery as m;
@@ -33,7 +33,7 @@ class AuthPasswordBrokerTest extends TestCase
         $response = $broker->sendResetLink(['credentials']);
 
         $this->assertSame(PasswordBrokerContract::INVALID_USER, $response->value);
-        $this->assertSame(ResetResponse::InvalidUser, $response);
+        $this->assertSame(PasswordResetResponse::InvalidUser, $response);
     }
 
     public function testIfTokenIsRecentlyCreated()
@@ -47,7 +47,7 @@ class AuthPasswordBrokerTest extends TestCase
         $response = $broker->sendResetLink(['foo']);
 
         $this->assertSame(PasswordBrokerContract::RESET_THROTTLED, $response->value);
-        $this->assertSame(ResetResponse::ResetThrottled, $response);
+        $this->assertSame(PasswordResetResponse::ResetThrottled, $response);
     }
 
     public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
@@ -81,7 +81,7 @@ class AuthPasswordBrokerTest extends TestCase
         $response = $broker->sendResetLink(['foo']);
 
         $this->assertSame(PasswordBrokerContract::RESET_LINK_SENT, $response->value);
-        $this->assertSame(ResetResponse::ResetLinkSent, $response);
+        $this->assertSame(PasswordResetResponse::ResetLinkSent, $response);
     }
 
     public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid()
@@ -89,7 +89,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['creds'])->andReturn(null);
 
-        $this->assertSame(ResetResponse::InvalidUser, $broker->reset(['creds'], function () {
+        $this->assertSame(PasswordResetResponse::InvalidUser, $broker->reset(['creds'], function () {
             //
         }));
     }
@@ -106,7 +106,7 @@ class AuthPasswordBrokerTest extends TestCase
         });
 
         $this->assertSame(PasswordBrokerContract::INVALID_TOKEN, $response->value);
-        $this->assertSame(ResetResponse::InvalidToken, $response);
+        $this->assertSame(PasswordResetResponse::InvalidToken, $response);
     }
 
     public function testResetRemovesRecordOnReminderTableAndCallsCallback()
@@ -128,7 +128,7 @@ class AuthPasswordBrokerTest extends TestCase
         $response = $broker->reset(['password' => 'password', 'token' => 'token'], $callback);
 
         $this->assertSame(PasswordBrokerContract::PASSWORD_RESET, $response->value);
-        $this->assertSame(ResetResponse::PasswordReset, $response);
+        $this->assertSame(PasswordResetResponse::PasswordReset, $response);
         $this->assertEquals(['user' => $user, 'password' => 'password'], $_SERVER['__password.reset.test']);
     }
 
@@ -150,7 +150,7 @@ class AuthPasswordBrokerTest extends TestCase
         $response = $broker->sendResetLink(['foo'], $closure);
 
         $this->assertEquals(PasswordBrokerContract::RESET_LINK_SENT, $response->value);
-        $this->assertEquals(ResetResponse::ResetLinkSent, $response);
+        $this->assertEquals(PasswordResetResponse::ResetLinkSent, $response);
 
         $this->assertTrue($executed);
     }


### PR DESCRIPTION
With dropping php8.0 support it makes sense to use an enum to represent a limited set of responses.

This PR replaces the password reset string constants with an enum. I have used a string backed enum so it can be used with minimal migration to support both Laravel9 and 10:

```php
$responseString = is_object($response) ? $response->value : $response;
```

If this deemed unnecessary I will remove the constants from the interface and the test.