### PR TITLE
[9.x] Make DatabaseManager macroable

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ConfigurationUrlParser;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use PDO;
 use RuntimeException;
@@ -16,6 +17,8 @@ use RuntimeException;
  */
 class DatabaseManager implements ConnectionResolverInterface
 {
+    use Macroable;
+
     /**
      * The application instance.
      *


### PR DESCRIPTION
I'd like to propose this change primarily to make my life a little easier.

I'm working with a project that has multiple database connections and was hoping that I could introduce via `Macroable` methods where I could access the various connections more easily and in a way that is a little nicer to look at.

For example, instead of this:
```php
DB::connection('foo_connection')->whatever();
```

I could do this:
```php
DB::foo()->whatever();
```

As I noted, I'm not sure if there's a different/better way to accomplish this.  I'm also not sure if there's a good reason to **not** do this.  As such, I'm open to any suggestions, links, whatever that will help.  🤓 

I'm also aware that there may be other, better reasons to make `DatabaseManager` macroable...but I can't think of any at this moment.  😜 

That's it.  🚀 