### PR TITLE
Fix limit perPage in Eloquent simplePaginate function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -867,7 +867,7 @@ class Builder implements BuilderContract
         // Next we will set the limit and offset for this query so that when we get the
         // results we get the proper section of results. Then, we'll create the full
         // paginator instances for these results with the given page and per page.
-        $this->skip(($page - 1) * $perPage)->take($perPage + 1);
+        $this->skip(($page - 1) * $perPage)->take($perPage);
 
         return $this->simplePaginator($this->get($columns), $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),


### PR DESCRIPTION
Limit value should be the same as `perPage`, this small issue is not critical since the offset is right and limit is only 1 more than it should be, but it's right to fix if that's the case

This a scenario of the issue: 
For example, 
It retrieve first 11 records (1 --> 11) in `page = 1` and `perpage = 10` but it should retrieve only the first 10 (1 --> 10).
It retrieve 11 records (10 --> 21) in `page = 2` and `perpage = 10` but it should retrieve only the first 10 (10 --> 20).
Notice that row #11 is retrieved twice.

Notes:
1. The output is fine somehow, but I have discovered this issue when I used `DB::enableQueryLog()` and `DB::getQueryLog()`.
2. This fix **DOES** another bug, causing the value of `next_page_url` to be null, I've tried to investigate it more but it seems that I lost in it.