### PR TITLE
[9.x] Add `Str::lcfirst` to support non-ascii characters (vs php's core lcfirst fct) and add DX consistency with ucfirst wrapper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -988,6 +988,17 @@ class Str
     }
 
     /**
+     * Make a string's first character lowercase.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function lcfirst($string)
+    {
+        return static::lower(static::substr($string, 0, 1)).static::substr($string, 1);
+    }
+
+    /**
      * Make a string's first character uppercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -802,6 +802,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Make a string's first character lowercase.
+     *
+     * @return static
+     */
+    public function lcfirst()
+    {
+        return new static(Str::lcfirst($this->value));
+    }
+
+    /**
      * Make a string's first character uppercase.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -638,6 +638,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('Laravel – The PHP Framework for Web Artisans', Str::substrReplace('Laravel Framework', '– The PHP Framework for Web Artisans', 8));
     }
 
+    public function testLcfirst()
+    {
+        $this->assertSame('laravel', Str::lcfirst('Laravel'));
+        $this->assertSame('laravel framework', Str::lcfirst('Laravel framework'));
+        $this->assertSame('мама', Str::lcfirst('Мама'));
+        $this->assertSame('мама мыла раму', Str::lcfirst('Мама мыла раму'));
+    }
+
     public function testUcfirst()
     {
         $this->assertSame('Laravel', Str::ucfirst('laravel'));


### PR DESCRIPTION
I needed in several projects a function to put the first character of a sentence as lower case (not the whole sentence).

Naturally I looked for it in the `Str` class as I know the `ucfirst` function lives there, but noticed it was missing. 

I believe, by seeing the number of PRs to add this function to the framework, that many developers would enjoy this improvement to the DX. Getting consistency without having to macro the Str class in each of their projects. 

So here is a non-breaking change to welcome the lcfirst function into the Str class.

It also works properly when lowercasing non ascii characters such as À or Ö, unlike the `lcfirst` function from code PHP.