### PR TITLE
[9.x] Add retryUntil method to queued mailables

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -66,29 +66,6 @@ class SendQueuedMailable
     }
 
     /**
-     * Get the display name for the queued job.
-     *
-     * @return string
-     */
-    public function displayName()
-    {
-        return get_class($this->mailable);
-    }
-
-    /**
-     * Call the failed method on the mailable instance.
-     *
-     * @param  \Throwable  $e
-     * @return void
-     */
-    public function failed($e)
-    {
-        if (method_exists($this->mailable, 'failed')) {
-            $this->mailable->failed($e);
-        }
-    }
-
-    /**
      * Get the number of seconds before a released mailable will be available.
      *
      * @return mixed
@@ -114,6 +91,29 @@ class SendQueuedMailable
         }
 
         return $this->mailable->retryUntil ?? $this->mailable->retryUntil();
+    }
+
+    /**
+     * Call the failed method on the mailable instance.
+     *
+     * @param  \Throwable  $e
+     * @return void
+     */
+    public function failed($e)
+    {
+        if (method_exists($this->mailable, 'failed')) {
+            $this->mailable->failed($e);
+        }
+    }
+
+    /**
+     * Get the display name for the queued job.
+     *
+     * @return string
+     */
+    public function displayName()
+    {
+        return get_class($this->mailable);
     }
 
     /**

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -103,6 +103,20 @@ class SendQueuedMailable
     }
 
     /**
+     * Get the expiration for the notification.
+     *
+     * @return mixed
+     */
+    public function retryUntil()
+    {
+        if (! method_exists($this->mailable, 'retryUntil') && ! isset($this->mailable->retryUntil)) {
+            return;
+        }
+
+        return $this->mailable->retryUntil ?? $this->mailable->retryUntil();
+    }
+
+    /**
      * Prepare the instance for cloning.
      *
      * @return void

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -103,7 +103,7 @@ class SendQueuedMailable
     }
 
     /**
-     * Get the expiration for the notification.
+     * Get the expiration for the mailable.
      *
      * @return mixed
      */


### PR DESCRIPTION
This PR adds the ability to specify a `retryUntil()` method or `timeoutAt` property on a queued Mailable, like you can for queued notifications, which was added in the following PR https://github.com/laravel/framework/pull/30141