### PR TITLE
Simpify `Request::is()` and `Request::fullUrlIs()`

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -209,9 +209,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function is(...$patterns)
     {
-        $path = $this->decodedPath();
-
-        return collect($patterns)->contains(fn ($pattern) => Str::is($pattern, $path));
+        return Str::is($patterns, $this->decodedPath());
     }
 
     /**
@@ -233,9 +231,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function fullUrlIs(...$patterns)
     {
-        $url = $this->fullUrl();
-
-        return collect($patterns)->contains(fn ($pattern) => Str::is($pattern, $url));
+        return Str::is($patterns, $this->fullUrl());
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/framework/pull/39857 replaced a foreach loop with a `Collection::contains()`, but the `Str::is()` method can already handle an array of patterns to find a single match.

So it makes sense to pass the the variadic arguments directly to this method instead of a foreach loop or a collection method.