### PR TITLE
[8.x] Run `afterResolving` callbacks if the type is resolved

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1160,7 +1160,14 @@ class Container implements ArrayAccess, ContainerContract
         if ($abstract instanceof Closure && is_null($callback)) {
             $this->globalAfterResolvingCallbacks[] = $abstract;
         } else {
-            $this->afterResolvingCallbacks[$abstract][] = $callback;
+            // if the type is resolved, we can already run the callback on the object.
+            if($this->resolved($abstract)) {
+                $object = $this->get($abstract);
+                $this->fireCallbackArray($object, [$callback]);    
+            }else {
+                // if not resolved save the callbacks for later execution.
+                $this->afterResolvingCallbacks[$abstract][] = $callback;
+            }
         }
     }
 


### PR DESCRIPTION
Hello guys. 

I am sorry if my explanation on issue https://github.com/laravel/framework/issues/41394 was not enough. I hope with this PR the things I tried to explain become more clear for what I meant.

**Adding callbacks to `afterResolvingCallbacks` array have no effect at all if the type is already resolved in the container.** 

This proposal aims to check if the type is already resolved when someone tries `$this->app->afterResolving('something', function() {}))` and `something` is already resolved. That callback would never be run, will just sit in the `afterResolvingCallbacks` array forever.

I haven't mess much with Laravel core, so I hope I am not attempting to do something eregious, if I am, please disregard, but it does not make sense to me that I define an `afterResolving` callback on something and it does not run because it is already resolved, if it is resolved, fine, just run what I want since the resolving part is done. I guess this is the mindset to look at this `afterResolving` callback? 

I look at it as a issue from Laravel side since it accepts my `afterResolving` callbacks in the ServiceProvider so I expect that whenever that type is resolved, It would run those callbacks, even if previously resolved.

Once again, sorry for insisting in this issue, I think there is something more we can do here, and I am here to help on what I can. 👍 

Even if this is not the proper or most adequate way to solve this, with some guidance I can try to work something out. 

I know Laravel eco-system is huge, but this `afterResolving` callbacks have taken hours of sleep from many developers across many packages like:

https://github.com/spatie/laravel-permission/pull/2048
https://github.com/Laravel-Backpack/CRUD/issues/4251
https://github.com/spatie/laravel-markdown/pull/35

And atleast 3 or 4 more that I am aware of. 

Debugging this have been an hell, help us here please 😅 

Thanks for everything, 🙏 
