### PR TITLE
[9.x] Add empty directory assertion to `Storage::fake()`

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -149,6 +149,21 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Determine if a directory is empty.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function assertDirectoryEmpty($path)
+    {
+        PHPUnit::assertEmpty(
+            $this->allFiles($path), "Directory [{$path}] is not empty."
+        );
+
+        return $this;
+    }
+
+    /**
      * Determine if a file or directory exists.
      *
      * @param  string  $path


### PR DESCRIPTION
I was trying to assert that a given directory was empty in some tests and was surprised to see that there was no bulit-in assertion to handle this.

This PR proposes adding an `assertDirectoryEmpty($path)` method to the Storage fake.

Obviously this is just a cleaner version of doing...
```php
$this->assertEmpty(Storage::disk('temp')->allFiles('/foo'));
```
vs

```php
Storage::disk('temp')->assertDirectoryEmpty('/foo');
```