### PR TITLE
[9.x] Add dot to collection classes

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1516,7 +1516,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Convert an expanded array into a flatten "dot" notation array.
+     * Convert an expanded array into a flattened "dot" notation array.
      *
      * @return static
      */

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1516,6 +1516,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Convert an expanded array into a flatten "dot" notation array.
+     *
+     * @return static
+     */
+    public function dot()
+    {
+        return new static(Arr::dot($this->all()));
+    }
+
+    /**
      * Convert a flatten "dot" notation array into an expanded array.
      *
      * @return static

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1522,7 +1522,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function dot()
     {
-        return new static(Arr::dot($this->all()));
+        return new static(Arr::dot(json_decode($this->toJson(), true)));
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1462,6 +1462,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Convert an expanded array into a flatten "dot" notation array.
+     *
+     * @return static
+     */
+    public function dot()
+    {
+        return $this->passthru('dot', []);
+    }
+
+    /**
      * Convert a flatten "dot" notation array into an expanded array.
      *
      * @return static

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1462,7 +1462,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Convert an expanded array into a flatten "dot" notation array.
+     * Convert an expanded array into a flattened "dot" notation array.
      *
      * @return static
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4966,6 +4966,42 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testDot($collection)
+    {
+        $data = $collection::make([
+            'name' => 'Taylor',
+            'meta' => [
+                'foo' => 'bar',
+                'baz' => 'boom',
+                'bam' => [
+                    'boom' => 'bip',
+                ],
+            ],
+        ])->dot();
+        $this->assertSame([
+            'name' => 'Taylor',
+            'meta.foo' => 'bar',
+            'meta.baz' => 'boom',
+            'meta.bam.boom' => 'bip',
+        ], $data->all());
+
+        $data = $collection::make([
+            'foo' => [
+                'bar',
+                'baz',
+                'baz' => 'boom',
+            ],
+        ])->dot();
+        $this->assertSame([
+            'foo.0' => 'bar',
+            'foo.1' => 'baz',
+            'foo.baz' => 'boom',
+        ], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testUndot($collection)
     {
         $data = $collection::make([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4976,6 +4976,9 @@ class SupportCollectionTest extends TestCase
                 'bam' => [
                     'boom' => 'bip',
                 ],
+                'quz' => $collection::make([
+                    'bleep' => 'bloop',
+                ]),
             ],
         ])->dot();
         $this->assertSame([
@@ -4983,6 +4986,7 @@ class SupportCollectionTest extends TestCase
             'meta.foo' => 'bar',
             'meta.baz' => 'boom',
             'meta.bam.boom' => 'bip',
+            'meta.quz.bleep' => 'bloop',
         ], $data->all());
 
         $data = $collection::make([
@@ -4990,12 +4994,20 @@ class SupportCollectionTest extends TestCase
                 'bar',
                 'baz',
                 'baz' => 'boom',
+                $collection::make([
+                    'bleep' => 'bloop',
+                ]),
             ],
+            $collection::make([
+                'bleep' => 'bloop',
+            ]),
         ])->dot();
         $this->assertSame([
             'foo.0' => 'bar',
             'foo.1' => 'baz',
             'foo.baz' => 'boom',
+            'foo.2.bleep' => 'bloop',
+            '0.bleep' => 'bloop',
         ], $data->all());
     }
 


### PR DESCRIPTION
Add `dot` method to the collection classes. It's only available in the `Arr` class now.