### PR TITLE
[8.x] Added callback support on `implode` Collection method.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -559,12 +559,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Concatenate values of a given key as a string.
      *
-     * @param  string  $value
+     * @param  callable|string  $value
      * @param  string|null  $glue
      * @return string
      */
     public function implode($value, $glue = null)
     {
+        if (is_callable($value)) {
+            return implode($glue ?? '', $this->map($value)->all());
+        }
+
         $first = $this->first();
 
         if (is_array($first) || (is_object($first) && ! $first instanceof Stringable)) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2136,6 +2136,10 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([Str::of('taylor'), Str::of('dayle')]);
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
+
+        $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
+        $this->assertSame('taylor-foodayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email']));
+        $this->assertSame('taylor-foo,dayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email'], ','));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2138,8 +2138,8 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('taylor,dayle', $data->implode(','));
 
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
-        $this->assertSame('taylor-foodayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email']));
-        $this->assertSame('taylor-foo,dayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email'], ','));
+        $this->assertSame('taylor-foodayle-bar', $data->implode(function ($user) { return $user['name'].'-'.$user['email']; }));
+        $this->assertSame('taylor-foo,dayle-bar', $data->implode(function ($user) { return $user['name'].'-'.$user['email']; }, ','));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2138,8 +2138,12 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('taylor,dayle', $data->implode(','));
 
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
-        $this->assertSame('taylor-foodayle-bar', $data->implode(function ($user) { return $user['name'].'-'.$user['email']; }));
-        $this->assertSame('taylor-foo,dayle-bar', $data->implode(function ($user) { return $user['name'].'-'.$user['email']; }, ','));
+        $this->assertSame('taylor-foodayle-bar', $data->implode(function ($user) {
+            return $user['name'].'-'.$user['email'];
+        }));
+        $this->assertSame('taylor-foo,dayle-bar', $data->implode(function ($user) {
+            return $user['name'].'-'.$user['email'];
+        }, ','));
     }
 
     /**


### PR DESCRIPTION
Allow to use a callback as `$value` on `implode` Collection method to simplify -`>map()->implode()` calls:

Before:

```php
<span>{{ $user->cities->map(fn ($city) => $city->name.' ('.$city->state->name.')')->implode(', ') }}</span>
```

After:

```php
<span>{{ $user->cities->implode(fn ($city) => $city->name.' ('.$city->state->name.')', ', ') }}</span>
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
