### PR TITLE
[9.x] Improve Performance On Terminate

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1166,12 +1166,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function terminate()
     {
-        $index = 0;
-
-        while ($index < count($this->terminatingCallbacks)) {
-            $this->call($this->terminatingCallbacks[$index]);
-
-            $index++;
+        foreach ($this->terminatingCallbacks as $terminatingCallback) {
+            $this->call($terminatingCallback);
         }
     }
 


### PR DESCRIPTION
`count` is used in a loop and is a low performance construction

based on several experiments, I conclude that using `foreach` is better. Indeed, this performance increase does not really affect the framework, but why not?

* Tested on Ubuntu Server 20.04 (dual core cpu, 4 gb ram, first image)
* Tested on MacBook Air M1 2020 (second image)
* First order is better
* The test is carried out 10 times, each time the test calls 100 callbacks

## Ubuntu Server
<img width="581" alt="Screen Shot 2022-03-09 at 20 00 56" src="https://user-images.githubusercontent.com/37969970/157438501-0b3b85b2-c3a5-43f2-97aa-0bf45016f94a.png">


## MacBook Air
<img width="567" alt="Screen Shot 2022-03-09 at 19 53 41" src="https://user-images.githubusercontent.com/37969970/157436952-56ca8543-21d0-45f0-a66c-b128e8af46de.png">


```php
<?php

// create 100 dummy callback
$data = array_map(static function () {
    return static function () {
        // something
    };
}, range(1, 100));

function bench(array $data)
{
    $results = [];

// while
    $start = microtime(true);

    $i = 0;
    while ($i < count($data)) {
        $data[$i]();
        $i++;
    }

    $results['while'] = microtime(true) - $start;

// for
    $start = microtime(true);

    for ($i = 0; $i < count($data); $i++) {
        $data[$i]();
    }

    $results['for'] = microtime(true) - $start;

// foreach
    $start = microtime(true);

    foreach ($data as $value) {
        $value();
    }

    $results['foreach'] = microtime(true) - $start;

// print result

    asort($results);

    foreach ($results as $key => $value) {
        echo $key . ': ' . $value . PHP_EOL;
    }
}

// run

for ($i = 0; $i <= 10; $i++) {
    bench($data);

    echo PHP_EOL;
}

```


