### PR TITLE
[9.x] Make assertPath() accepts Closure

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Testing;
 
 use ArrayAccess;
+use Closure;
 use Countable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
@@ -219,7 +220,11 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertPath($path, $expect)
     {
-        PHPUnit::assertSame($expect, $this->json($path));
+        if ($expect instanceof Closure) {
+            PHPUnit::assertTrue($expect($this->json($path)));
+        } else {
+            PHPUnit::assertSame($expect, $this->json($path));
+        }
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -827,6 +827,27 @@ class TestResponseTest extends TestCase
         $response->assertJsonPath('0.id', '10');
     }
 
+    public function testAssertJsonPathWithClosure()
+    {
+        $response = TestResponse::fromBaseResponse(new Response([
+            'data' => ['foo' => 'bar'],
+        ]));
+
+        $response->assertJsonPath('data.foo', fn ($value) => $value === 'bar');
+    }
+
+    public function testAssertJsonPathWithClosureCanFail()
+    {
+        $response = TestResponse::fromBaseResponse(new Response([
+            'data' => ['foo' => 'bar'],
+        ]));
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that false is true.');
+
+        $response->assertJsonPath('data.foo', fn ($value) => $value === null);
+    }
+
     public function testAssertJsonFragment()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));


### PR DESCRIPTION
Hi,

I propose to modify `AssertableJsonString::assertPath()` in order to ease the way to write tests:
```php
$this
    ->getJson('/api/whatever')
    ->assertOK()
    ->assertJsonPath('data.created_at', fn($date) => $date !== null)
    ->assertJsonPath('data.name', fn($name) => strlen($name) > 0)
;
```

At first I thought of adding a new method, but after struggling to find a right name, I realized that accepting closures in `assertPath` would not cause any BC break.