### PR TITLE
[9.x] Fixes HTTP::pool response when a URL returns a null status code

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -790,7 +790,7 @@ class PendingRequest
                 });
             })
             ->otherwise(function (TransferException $e) {
-                return $e instanceof RequestException ? $this->populateResponse(new Response($e->getResponse())) : $e;
+                return $e instanceof RequestException && $e->getResponse() ? $this->populateResponse(new Response($e->getResponse())) : $e;
             });
     }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -790,7 +790,7 @@ class PendingRequest
                 });
             })
             ->otherwise(function (TransferException $e) {
-                return $e instanceof RequestException && $e->getResponse() ? $this->populateResponse(new Response($e->getResponse())) : $e;
+                return $e instanceof RequestException && $e->hasResponse() ? $this->populateResponse(new Response($e->getResponse())) : $e;
             });
     }
 


### PR DESCRIPTION
 This PR fixes the bug reported by [sfilzek](https://github.com/sfilzek).

When we try to use HTTP::pool with a URL having an expired certificate, Guzzle returns a RequestException with a null response. I've added an extra check to make sure if the guzzle response is not null then populateResponse otherwise returns the exception.