### PR TITLE
[9.x] Added callable support to operatorForWhere on Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -311,7 +311,7 @@ trait EnumeratesValues
     /**
      * Get the first item by the given key value pair.
      *
-     * @param  string  $key
+     * @param  callable|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return TValue|null
@@ -548,7 +548,7 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair.
      *
-     * @param  string  $key
+     * @param  callable|string  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return static
@@ -995,13 +995,17 @@ trait EnumeratesValues
     /**
      * Get an operator checker callback.
      *
-     * @param  string  $key
+     * @param  callable|string  $key
      * @param  string|null  $operator
      * @param  mixed  $value
      * @return \Closure
      */
     protected function operatorForWhere($key, $operator = null, $value = null)
     {
+        if (is_callable($key)) {
+            return $key;
+        }
+
         if (func_num_args() === 1) {
             $value = true;
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -276,6 +276,11 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('gasket', $data->firstWhere('material', 'rubber')['type']);
         $this->assertNull($data->firstWhere('material', 'nonexistent'));
         $this->assertNull($data->firstWhere('nonexistent', 'key'));
+
+        $this->assertSame('book', $data->firstWhere(fn ($value) => $value['material'] === 'papger')['type']);
+        $this->assertSame('gasket', $data->firstWhere(fn ($value) => $value['material'] === 'rubber')['type']);
+        $this->assertNull($data->firstWhere(fn ($value) => $value['material'] === 'nonexistent'));
+        $this->assertNull($data->firstWhere(fn ($value) => ($value['nonexistent'] ?? null) === 'key'));
     }
 
     /**
@@ -998,6 +1003,16 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(
             [],
             $c->where('v', '>', $object)->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 3], ['v' => '3']],
+            $c->where(fn ($value) => $value['v'] == 3)->values()->all()
+        );
+
+        $this->assertEquals(
+            [['v' => 3]],
+            $c->where(fn ($value) => $value['v'] === 3)->values()->all()
         );
 
         $c = new $collection([['v' => 1], ['v' => $object]]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -277,7 +277,7 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($data->firstWhere('material', 'nonexistent'));
         $this->assertNull($data->firstWhere('nonexistent', 'key'));
 
-        $this->assertSame('book', $data->firstWhere(fn ($value) => $value['material'] === 'papger')['type']);
+        $this->assertSame('book', $data->firstWhere(fn ($value) => $value['material'] === 'paper')['type']);
         $this->assertSame('gasket', $data->firstWhere(fn ($value) => $value['material'] === 'rubber')['type']);
         $this->assertNull($data->firstWhere(fn ($value) => $value['material'] === 'nonexistent'));
         $this->assertNull($data->firstWhere(fn ($value) => ($value['nonexistent'] ?? null) === 'key'));


### PR DESCRIPTION
Added `callable` support to `operatorForWhere`.

Currently only Collection methods `where` and `whereFirst` are used without `callable` support.

Adding callable to `operatorForWhere` allow complex usages as:

```php
$city = $cities->firstWhere(fn ($city) => $city->state->available && ($city->state->id === $stateId));
```
or
```php
$state = $states->firstWhere(fn ($state) => (bool)$state->cities->firstWhere('id', $cityId));
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
