### PR TITLE
[9.x] Allow to run a number of migrations at a time

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -24,7 +24,8 @@ class MigrateCommand extends BaseCommand
                 {--schema-path= : The path to a schema dump file}
                 {--pretend : Dump the SQL queries that would be run}
                 {--seed : Indicates if the seed task should be re-run}
-                {--step : Force the migrations to be run so they can be rolled back individually}';
+                {--step=false : Force the migrations to be run so they can be rolled back individually, ' .
+                    'by providing a number of migrations to run, or "true" to run all available.}';
 
     /**
      * The console command description.


### PR DESCRIPTION
This would make the `php artisan migrate` command be complementary to `php artisan migrate:rollback` by allowing to control the maximum number of migrations ran at a time. 
This change is (almost) backwards compatible - not supplying the --step option runs it as usual, supplying --step true runs as --step does currently.
What it allows is doing --step N, where N is an integer; then, this number of migrations runs at most.
This is useful for releases where multiple migrations may be present but testing shows there may be issues to fix before reaching production. Particularly so given that by default, some migrator grammars do not run migrations as transactions.
The current changes modify the command and the migrator behaviour, but NOT the tests. I'm not certain what tests to write to verify the possible options, and to verify that it in fact can run only some migrations vs all.
