### PR TITLE
Adds Str::end() adds the ability to end a string with a single instance of a given value.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -271,6 +271,20 @@ class Str
     }
 
     /**
+     * End a string with a single instance of a given value.
+     *
+     * @param  string  $value
+     * @param  string  $suffix
+     * @return string
+     */
+    public static function end($value, $suffix)
+    {
+        $quoted = preg_quote($suffix, '/');
+
+        return preg_replace('/(?:'.$quoted.')+$/u', '', $value) . $suffix;
+    }
+
+    /**
      * Extracts an excerpt from text that matches the first instance of a phrase.
      *
      * @param  string  $text

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -281,7 +281,7 @@ class Str
     {
         $quoted = preg_quote($suffix, '/');
 
-        return preg_replace('/(?:'.$quoted.')+$/u', '', $value) . $suffix;
+        return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$suffix;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -197,6 +197,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * End a string with a single instance of a given value.
+     *
+     * @param  string  $suffix
+     * @return static
+     */
+    public function end($suffix)
+    {
+        return new static(Str::end($this->value, $suffix));
+    }
+
+    /**
      * Determine if the string is an exact match with the given value.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -149,6 +149,13 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith('你好', 'a'));
     }
 
+    public function testStrEnd()
+    {
+        $this->assertSame('test/string/', Str::end('test/string', '/'));
+        $this->assertSame('test/string/', Str::end('test/string/', '/'));
+        $this->assertSame('test/string/', Str::end('test/string//', '/'));
+    }
+
     public function testStrExcerpt()
     {
         $this->assertSame('...is a beautiful morn...', Str::excerpt('This is a beautiful morning', 'beautiful', ['radius' => 5]));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -175,6 +175,13 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testEnd()
+    {
+        $this->assertSame('test/string/', (string) $this->stringable('test/string')->end('/'));
+        $this->assertSame('test/string/', (string) $this->stringable('test/string/')->end('/'));
+        $this->assertSame('test/string/', (string) $this->stringable('test/string//')->end('/'));
+    }
+
     public function testWhenExactly()
     {
         $this->assertSame('Nailed it...!', (string) $this->stringable('Tony Stark')->whenExactly('Tony Stark', function ($stringable) {


### PR DESCRIPTION
This feature is the inverse of Str:start( https://laravel.com/docs/9.x/helpers#method-str-start, however it does it at the end.

ie: 

```php
Str::end('test/string', '/') 
// outputs test/string/

str('test/string')->end( '/')->value()
// outputs test/string/
```

