### PR TITLE
[9.x] Add null typing to connection property in \Illuminate\Database\Eloquent\Factories\Factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -41,35 +41,35 @@ abstract class Factory
     /**
      * The state transformations that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection|null
+     * @var \Illuminate\Support\Collection
      */
     protected $states;
 
     /**
      * The parent relationships that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection|null
+     * @var \Illuminate\Support\Collection
      */
     protected $has;
 
     /**
      * The child relationships that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection|null
+     * @var \Illuminate\Support\Collection
      */
     protected $for;
 
     /**
      * The "after making" callbacks that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection|null
+     * @var \Illuminate\Support\Collection
      */
     protected $afterMaking;
 
     /**
      * The "after creating" callbacks that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection|null
+     * @var \Illuminate\Support\Collection
      */
     protected $afterCreating;
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -129,11 +129,11 @@ abstract class Factory
                                 $connection = null)
     {
         $this->count = $count;
-        $this->states = $states ?: new Collection;
-        $this->has = $has ?: new Collection;
-        $this->for = $for ?: new Collection;
-        $this->afterMaking = $afterMaking ?: new Collection;
-        $this->afterCreating = $afterCreating ?: new Collection;
+        $this->states = $states ?? new Collection;
+        $this->has = $has ?? new Collection;
+        $this->for = $for ?? new Collection;
+        $this->afterMaking = $afterMaking ?? new Collection;
+        $this->afterCreating = $afterCreating ?? new Collection;
         $this->connection = $connection;
         $this->faker = $this->withFaker();
     }
@@ -516,7 +516,7 @@ abstract class Factory
     {
         return $this->newInstance([
             'has' => $this->has->concat([new Relationship(
-                $factory, $relationship ?: $this->guessRelationship($factory->modelName())
+                $factory, $relationship ?? $this->guessRelationship($factory->modelName())
             )]),
         ]);
     }
@@ -548,7 +548,7 @@ abstract class Factory
             'has' => $this->has->concat([new BelongsToManyRelationship(
                 $factory,
                 $pivot,
-                $relationship ?: Str::camel(Str::plural(class_basename(
+                $relationship ?? Str::camel(Str::plural(class_basename(
                     $factory instanceof Factory
                         ? $factory->modelName()
                         : Collection::wrap($factory)->first()
@@ -568,7 +568,7 @@ abstract class Factory
     {
         return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
             $factory,
-            $relationship ?: Str::camel(class_basename(
+            $relationship ?? Str::camel(class_basename(
                 $factory instanceof Factory ? $factory->modelName() : $factory
             ))
         )])]);
@@ -688,7 +688,7 @@ abstract class Factory
      */
     public function modelName()
     {
-        $resolver = static::$modelNameResolver ?: function (self $factory) {
+        $resolver = static::$modelNameResolver ?? function (self $factory) {
             $namespacedFactoryBasename = Str::replaceLast(
                 'Factory', '', Str::replaceFirst(static::$namespace, '', get_class($factory))
             );
@@ -702,7 +702,7 @@ abstract class Factory
                         : $appNamespace.$factoryBasename;
         };
 
-        return $this->model ?: $resolver($this);
+        return $this->model ?? $resolver($this);
     }
 
     /**
@@ -769,7 +769,7 @@ abstract class Factory
      */
     public static function resolveFactoryName(string $modelName)
     {
-        $resolver = static::$factoryNameResolver ?: function (string $modelName) {
+        $resolver = static::$factoryNameResolver ?? function (string $modelName) {
             $appNamespace = static::appNamespace();
 
             $modelName = Str::startsWith($modelName, $appNamespace.'Models\\')
@@ -820,7 +820,7 @@ abstract class Factory
         $relatedModel = get_class($this->newModel()->{$relationship}()->getRelated());
 
         if (method_exists($relatedModel, 'newFactory')) {
-            $factory = $relatedModel::newFactory() ?: static::factoryForModel($relatedModel);
+            $factory = $relatedModel::newFactory() ?? static::factoryForModel($relatedModel);
         } else {
             $factory = static::factoryForModel($relatedModel);
         }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -41,42 +41,42 @@ abstract class Factory
     /**
      * The state transformations that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection|null
      */
     protected $states;
 
     /**
      * The parent relationships that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection|null
      */
     protected $has;
 
     /**
      * The child relationships that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection|null
      */
     protected $for;
 
     /**
      * The "after making" callbacks that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection|null
      */
     protected $afterMaking;
 
     /**
      * The "after creating" callbacks that will be applied to the model.
      *
-     * @var \Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection|null
      */
     protected $afterCreating;
 
     /**
      * The name of the database connection that will be used to create the models.
      *
-     * @var string
+     * @var string|null
      */
     protected $connection;
 


### PR DESCRIPTION
When extending the Factory in my application, using a null coalescing operator on `$this->connection` and running static analysis using Larastan, I got an error `Property Illuminate\Database\Eloquent\Factories\Factory<Illuminate\Database\Eloquent\Model>::$connection (string) in isset() is not nullable.` 

However, the constructor by defaults sets `$this->connection = null;`. Similarly, there are some other nullable properties. This PR fixes the docstring typehints on these properties.