### PR TITLE
[9.x] Handle when $haystack is `null` in Str::contains

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -211,6 +211,10 @@ class Str
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
+        if ($haystack === null) {
+            return false;
+        }
+
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', (array) $needles);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -768,6 +768,7 @@ class SupportStrTest extends TestCase
             ['Taylor', ['xxx'], false],
             ['Taylor', '', false],
             ['', '', false],
+            [null, 'foo', false],
         ];
     }
 


### PR DESCRIPTION
Fixes this deprecation message from `str_contains`:
```
str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated
```

The deprecation warning appears when running this in a fresh install:
```
LOG_DEPRECATIONS_CHANNEL=stderr php artisan route:list --name foo
```

I opted to place it first in the method since there is no need for anything else to run.
This also has the bonus to fix the potential deprecation warning of passing `null` to `mb_strtolower` 
