### PR TITLE
[9.x] Fix deprecation warnings from route:list when filtering on name or domain

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -240,10 +240,10 @@ class RouteListCommand extends Command
      */
     protected function filterRoute(array $route)
     {
-        if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
+        if (($this->option('name') && ! Str::contains((string) $route['name'], $this->option('name'))) ||
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
-            ($this->option('domain') && ! Str::contains($route['domain'], $this->option('domain'))) ||
+            ($this->option('domain') && ! Str::contains((string) $route['domain'], $this->option('domain'))) ||
             ($this->option('except-vendor') && $route['vendor'])) {
             return;
         }

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Testing\Console;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Foundation\Console\RouteListCommand;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Facade;
@@ -12,6 +13,8 @@ use Orchestra\Testbench\TestCase;
 
 class RouteListCommandTest extends TestCase
 {
+    use InteractsWithDeprecationHandling;
+
     /**
      * @var \Illuminate\Contracts\Routing\Registrar
      */
@@ -89,6 +92,24 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Testing\\Console\\FooController@show')
             ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
             ->expectsOutput('             ⇂ web')
+            ->expectsOutput('');
+    }
+
+    public function testRouteCanBeFilteredByName()
+    {
+        $this->withoutDeprecationHandling();
+
+        $this->router->get('/', function () {
+            //
+        });
+        $this->router->get('/foo', function () {
+            //
+        })->name('foo.show');
+
+        $this->artisan(RouteListCommand::class, ['--name' => 'foo'])
+            ->assertSuccessful()
+            ->expectsOutput('')
+            ->expectsOutput('  GET|HEAD       foo ...................................... foo.show')
             ->expectsOutput('');
     }
 


### PR DESCRIPTION
Cast route name and domain to string since they can be null when filtering with `--name` or `--domain`

Added a test to make sure the filtering was still working and does not throw any deprecation warnings.

More specific fix as mentioned in #41419