### PR TITLE
[9.x] Added `@return` statement to Blade

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesRawPhp.php
@@ -20,6 +20,16 @@ trait CompilesRawPhp
     }
 
     /**
+     * Compile the return statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileReturn()
+    {
+        return '<?php return; ?>';
+    }
+
+    /**
      * Compile the unset statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -22,6 +22,13 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testReturnStatements()
+    {
+        $string = '@return';
+        $expected = '<?php return; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testPhpStatementsDontParseBladeCode()
     {
         $string = '@php echo "{{ This is a blade tag }}" @endphp';


### PR DESCRIPTION
This statement adds a `<?php return; ?>` on compiled view to allow to stop render execution on some point and avoid nested code and simplify templates.

For example, `pagination` templates can be easily updated with:

```php
@unless ($paginator->hasPages())
    @return
@endunless

<nav>
    <ul class="pagination">
```

Another addition (not in this commit) could to be add two new statements: `@returnUnless` and `@returnIf`