### PR TITLE
[9.x] Add basicAuth() to retrieve Basic Authorization

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -64,6 +64,31 @@ trait InteractsWithInput
             return str_contains($header, ',') ? strstr($header, ',', true) : $header;
         }
     }
+    
+    /**
+     * Get the basic auth from the request headers.
+     *
+     * @return object|null
+     */
+    public function basicAuth()
+    {
+        $header = $this->header('Authorization', '');
+
+        $position = strrpos($header, 'Basic ');
+
+        if ($position !== false) {
+            $basic = substr($header, $position + 6);
+            $basic = base64_decode($basic);
+            if (stripos($basic, ':')) {
+                list($username, $password) = explode(':', $basic);
+
+                return (object) [
+                    'username' => $username,
+                    'password' => $password
+                ];
+            }
+        }
+    }
 
     /**
      * Determine if the request contains a given input item key.


### PR DESCRIPTION
Add ability to retrieve basic authorization (username & password) from the Request header

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
