### PR TITLE
[9.x] Resolve Markdown converter from container instead of directly instantiating it

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -471,7 +471,11 @@ class Str
      */
     public static function markdown($string, array $options = [])
     {
-        $converter = app(GithubFlavoredMarkdownConverter::class, $options);
+        if (function_exists('app')) {
+            $converter = app(GithubFlavoredMarkdownConverter::class, $options);
+        } else {
+            $converter = new GithubFlavoredMarkdownConverter($options);
+        }
 
         return (string) $converter->convert($string);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -471,7 +471,7 @@ class Str
      */
     public static function markdown($string, array $options = [])
     {
-        $converter = new GithubFlavoredMarkdownConverter($options);
+        $converter = app(GithubFlavoredMarkdownConverter::class, $options);
 
         return (string) $converter->convert($string);
     }


### PR DESCRIPTION
I'm putting the last hand at converting my blog from WordPress to Laravel (yeah!). To render blog content, I'm using the `Str::markdown()` function. 

However, I ran into the use case where I wanted to add a renderer (or extension, or whatever) to the League Commonmark environment.

Currently this is not possible, as the implementation only allowed the passing of an `$options` array to the converter. The `$options` array doesn't support adding renderers or extensions.

The solution for this is quite simple: instead of instantiating the `GithubFlavoredMarkdownConverter` directly, we can also resolve it from the container. By resolving it from the container (or was it called service location?), we opened up the opportunity to use the `->afterResolving()` function in a service provider.

This makes it very easy for developers to extend the Commonmark package or add an extension, without having to install and configure the complete Commonmark package themselves:

```php
$this->app->afterResolving(GithubFlavoredMarkdownConverter::class, function (GithubFlavoredMarkdownConverter $converter) {
    $environment = $converter->getEnvironment();

    $environment->addRenderer(Link::class, new ExternalLinkRenderer());
    // Do other things with the environment
});
```

(The use case here was to determine for every URL whether to add a `target="_blank"` attribute, based on whether the URL contains the `Request::root()`).

Thanks!