### PR TITLE
[9.x] Collection::only() also accept string

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -856,7 +856,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the items with the specified keys.
      *
-     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>  $keys
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string  $keys
      * @return static
      */
     public function only($keys)


### PR DESCRIPTION
The `only` method in Collection class also accept keys as string but as you can see phpstorm complains about this:

![image](https://user-images.githubusercontent.com/53290883/157852721-6a375e4f-280f-422b-9663-ed4d6fac1676.png)
