### PR TITLE
[9.x] Add --name option to schedule:test command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class ScheduleTestCommand extends Command
 {
@@ -11,7 +12,7 @@ class ScheduleTestCommand extends Command
      *
      * @var string
      */
-    protected $name = 'schedule:test';
+    protected $signature = 'schedule:test {--name= : The name of the scheduled command to run}';
 
     /**
      * The name of the console command.
@@ -45,7 +46,17 @@ class ScheduleTestCommand extends Command
             $commandNames[] = $command->command ?? $command->getSummaryForDisplay();
         }
 
-        $index = array_search($this->choice('Which command would you like to run?', $commandNames), $commandNames);
+        if (! empty($name = $this->option('name'))) {
+            $matches = array_filter($commandNames, fn ($commandName) => Str::endsWith($commandName, $name));
+
+            if (count($matches) !== 1) {
+                return $this->error('No scheduled command found');
+            }
+
+            $index = key($matches);
+        } else {
+            $index = array_search($this->choice('Which command would you like to run?', $commandNames), $commandNames);
+        }
 
         $event = $commands[$index];
 

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -46,11 +46,15 @@ class ScheduleTestCommand extends Command
             $commandNames[] = $command->command ?? $command->getSummaryForDisplay();
         }
 
+        if (empty($commandNames)) {
+            return $this->comment('No scheduled commands have been defined.');
+        }
+
         if (! empty($name = $this->option('name'))) {
             $matches = array_filter($commandNames, fn ($commandName) => Str::endsWith($commandName, $name));
 
             if (count($matches) !== 1) {
-                return $this->error('No scheduled command found');
+                return $this->error('No matching scheduled command found.');
             }
 
             $index = key($matches);


### PR DESCRIPTION
It would be handy to be able to schedule commands for testing using their name, rather than having to choose from a list, as often I'm looking to run a specific command, and the list numbers change as new commands are added to the schedule. This PR adds an optional `--name` option to `schedule:test` to make that possible.

It works by matching the end of the strings contained in `$commandNames`, which looks like this:
```
  0 => "'/usr/local/bin/php' 'artisan' my:cmd-1"
  1 => "'/usr/local/bin/php' 'artisan' my:cmd-2"
  2 => "named-cmd-1"
  3 => "named-cmd-2"
  4 => "App\Commands\ClassCmd"
```

So `--name=my:cmd-1` would match `0`, `--name=named-cmd-2` would match `3`, and `--name=ClassCmd` would match `4`. If there isn't an exact match then an error is returned.

I couldn't see a test class for this command, so I haven't added any additional test cases, but if someone points me in the right direction I'll happily add them. Thanks.