### PR TITLE
[9.x] Add ability to validate route parameters via callback

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -28,7 +28,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      */
     protected function handleMatchedRoute(Request $request, $route)
     {
-        if (! is_null($route)) {
+        if (! is_null($route) && $route->matches($request)) {
             return $route->bind($request);
         }
 
@@ -144,6 +144,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'fallback' => $route->isFallback,
                 'defaults' => $route->defaults,
                 'wheres' => $route->wheres,
+                'callbacks' => $route->callbacks,
                 'bindingFields' => $route->bindingFields(),
                 'lockSeconds' => $route->locksFor(),
                 'waitSeconds' => $route->waitsFor(),

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -128,7 +128,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
                 //
             }
         }
-        
+
         if ($route && $route->isFallback) {
             try {
                 $dynamicRoute = $this->routes->match($request);

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -128,7 +128,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
                 //
             }
         }
-
+        
         if ($route && $route->isFallback) {
             try {
                 $dynamicRoute = $this->routes->match($request);
@@ -301,6 +301,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setFallback($attributes['fallback'])
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])
+            ->setCallbacks($attributes['callbacks'])
             ->setBindingFields($attributes['bindingFields'])
             ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null)
             ->withTrashed($attributes['withTrashed'] ?? false);

--- a/src/Illuminate/Routing/Matching/CallbackValidator.php
+++ b/src/Illuminate/Routing/Matching/CallbackValidator.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Routing\Matching;
 
-use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 

--- a/src/Illuminate/Routing/Matching/CallbackValidator.php
+++ b/src/Illuminate/Routing/Matching/CallbackValidator.php
@@ -17,13 +17,13 @@ class CallbackValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
+        $path = rtrim($request->getPathInfo(), '/') ?: '/';
+
+        if (! preg_match($route->getCompiled()->getRegex(), rawurldecode($path), $matches)) {
+            return false;
+        }
+
         foreach ($route->callbacks as $param => $callback) {
-            $path = rtrim($request->getPathInfo(), '/') ?: '/';
-
-            if (! preg_match($route->getCompiled()->getRegex(), rawurldecode($path), $matches)) {
-                return false;
-            }
-
             if (! $callback($matches[$param] ?? null)) {
                 return false;
             }

--- a/src/Illuminate/Routing/Matching/CallbackValidator.php
+++ b/src/Illuminate/Routing/Matching/CallbackValidator.php
@@ -24,7 +24,7 @@ class CallbackValidator implements ValidatorInterface
                 return false;
             }
 
-            if (! $callback($matches[$param])) {
+            if (! $callback($matches[$param] ?? null)) {
                 return false;
             }
         }

--- a/src/Illuminate/Routing/Matching/CallbackValidator.php
+++ b/src/Illuminate/Routing/Matching/CallbackValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Routing\Matching;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+
+class CallbackValidator implements ValidatorInterface
+{
+    /**
+     * Validate a given rule against a route and request.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function matches(Route $route, Request $request)
+    {
+        foreach ($route->callbacks as $param => $callback) {
+            $path = rtrim($request->getPathInfo(), '/') ?: '/';
+
+            if (! preg_match($route->getCompiled()->getRegex(), rawurldecode($path), $matches)) {
+                return false;
+            }
+
+            if (! $callback($matches[$param])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -632,7 +632,7 @@ class Route
      * Set a regular expression requirement on the route.
      *
      * @param  array|string  $name
-     * @param  string|null  $expression
+     * @param  string|Closure|null  $expression
      * @return $this
      */
     public function where($name, $expression = null)

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -674,6 +674,23 @@ class Route
     }
 
     /**
+     * Set a list of callback requirements on the route.
+     *
+     * @param  array  $callbacks
+     * @return $this
+     */
+    public function setCallbacks(array $callbacks)
+    {
+        foreach ($callbacks as $name => $callback) {
+            $this->callbacks[$name] = is_string($callback)
+                ? unserialize($callback)->getClosure()
+                : $callback;
+        }
+
+        return $this;
+    }
+
+    /**
      * Mark this route as a fallback route.
      *
      * @return $this
@@ -1293,7 +1310,9 @@ class Route
         }
 
         foreach ($this->callbacks as $name => $callback) {
-            $this->callbacks[$name] = new SerializableClosure($callback);
+            $this->callbacks[$name] = serialize(
+                new SerializableClosure($callback)
+            );
         }
 
         $this->compileRoute();

--- a/tests/Integration/Routing/Fixtures/callback_routes.php
+++ b/tests/Integration/Routing/Fixtures/callback_routes.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/foo/{bar}', function () {
+    return 'Regular matched route';
+})->where('bar', function ($bar) {
+    return $bar === 'baz';
+});
+
+Route::get('{slug}', function () {
+    return 'Wildcard matched route';
+})->where('slug', function ($slug) {
+    return in_array($slug, ['bar', 'baz']);
+});

--- a/tests/Integration/Routing/RouteCachingTest.php
+++ b/tests/Integration/Routing/RouteCachingTest.php
@@ -23,6 +23,18 @@ class RouteCachingTest extends TestCase
         $this->get('/foo/1')->assertRedirect('/foo/1/bar');
     }
 
+    public function testCallbackRoutes()
+    {
+        $this->routes(__DIR__.'/Fixtures/callback_routes.php');
+
+        $this->get('/foo')->assertNotFound();
+        $this->get('/bar')->assertSee('Wildcard matched route');
+        $this->get('/baz')->assertSee('Wildcard matched route');
+
+        $this->get('/foo/bar')->assertNotFound();
+        $this->get('/foo/baz')->assertSee('Regular matched route');
+    }
+
     protected function routes(string $file)
     {
         $this->defineCacheRoutes(file_get_contents($file));

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -837,7 +837,10 @@ class RoutingRouteTest extends TestCase
         });
         $route->where('bar', '[0-9]+');
         $this->assertFalse($route->matches($request));
+    }
 
+    public function testWhereCallbacksProperlyFilter()
+    {
         $request = Request::create('foo/123', 'GET');
         $route = new Route('GET', 'foo/{bar?}', function () {
             //
@@ -851,6 +854,27 @@ class RoutingRouteTest extends TestCase
             return $bar === '234';
         });
         $this->assertFalse($route->matches($request));
+
+        $request = Request::create('foo/bar', 'GET');
+        $route = new Route('GET', 'foo/{bar}/{baz?}', function () {
+            //
+        });
+        $route->where('bar', function ($bar) {
+            return $bar === 'bar';
+        });
+        $route->where('baz', function ($bar) {
+            return is_null($bar);
+        });
+        $this->assertTrue($route->matches($request));
+
+        $request = Request::create('foo/bar/baz', 'GET');
+        $route->where('bar', function ($bar) {
+            return $bar === 'bar';
+        });
+        $route->where('baz', function ($bar) {
+            return $bar === 'baz';
+        });
+        $this->assertTrue($route->matches($request));
     }
 
     public function testRoutePrefixParameterParsing()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -837,6 +837,20 @@ class RoutingRouteTest extends TestCase
         });
         $route->where('bar', '[0-9]+');
         $this->assertFalse($route->matches($request));
+
+        $request = Request::create('foo/123', 'GET');
+        $route = new Route('GET', 'foo/{bar?}', function () {
+            //
+        });
+        $route->where('bar', function ($bar) {
+            return $bar === '123';
+        });
+        $this->assertTrue($route->matches($request));
+
+        $route->where('bar', function ($bar) {
+            return $bar === '234';
+        });
+        $this->assertFalse($route->matches($request));
     }
 
     public function testRoutePrefixParameterParsing()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -875,6 +875,15 @@ class RoutingRouteTest extends TestCase
             return $bar === 'baz';
         });
         $this->assertTrue($route->matches($request));
+
+        $request = Request::create('foo/bar/baz', 'GET');
+        $route->where('bar', function ($bar) {
+            return $bar === 'bar';
+        });
+        $route->where('baz', function ($bar) {
+            return $bar === '123';
+        });
+        $this->assertFalse($route->matches($request));
     }
 
     public function testRoutePrefixParameterParsing()


### PR DESCRIPTION
## Description

This PR provides the ability to add callbacks to validate route parameters, instead of regex only.

For people (like myself) who haven't dug deep into writing regex, this helps tremendously in validating complex parameters in pure PHP, and will help newcomers to Laravel avoid writing confusing and possibly error prone regex.

## Usage

```php
Route::get('/products/{brand}', '...')->where('brand', function ($brand) {
    return in_array($brand, ['samsung', 'apple']);
});
```

```php
Route::get('/invitation/{token}', '...')->where('token', function ($token) {
    return strlen($token) === 30;
});
```

```php
Route::get('/license/{key}', '...')->where('key', function ($key) {
    $str = Str::of($key);

    return $str->length() === 32
        && $str->startsWith('1234-')
        && $str->endsWith('-4567');
});
```


## Important

This PR is not set in stone. I'm not sure if `Route::$callbacks` is the best property name to contain these "validators" (which has already been taken unfortunately).

Please let me know your thoughts, thanks for your time! 🙏 

No hard feelings on closure ❤️ 