### PR TITLE
[9.x] Allow passing a method name in mapInto()

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -689,9 +689,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @template TMapIntoValue
      *
      * @param  class-string<TMapIntoValue>  $class
+     * @param  string|null  $method
      * @return static<TKey, TMapIntoValue>
      */
-    public function mapInto($class);
+    public function mapInto($class, $method = null);
 
     /**
      * Merge the collection with the given items.

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -383,11 +383,16 @@ trait EnumeratesValues
      * @template TMapIntoValue
      *
      * @param  class-string<TMapIntoValue>  $class
+     * @param  string|null  $method
      * @return static<TKey, TMapIntoValue>
      */
-    public function mapInto($class)
+    public function mapInto($class, $method = null)
     {
-        return $this->map(function ($value, $key) use ($class) {
+        return $this->map(function ($value, $key) use ($class, $method) {
+            if (! is_null($method)) {
+                return (new $class)->{$method}($value, $key);
+            }
+
             return new $class($value, $key);
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2960,6 +2960,21 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMapIntoMethod($collection)
+    {
+        $data = new $collection([
+            'first', 'second',
+        ]);
+
+        $data = $data->mapInto(TestCollectionMapIntoMethodObject::class, 'transform');
+
+        $this->assertSame('first', $data->get(0)['value']);
+        $this->assertSame('second', $data->get(1)['value']);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testNth($collection)
     {
         $data = new $collection([
@@ -5157,6 +5172,16 @@ class TestCollectionMapIntoObject
     public function __construct($value)
     {
         $this->value = $value;
+    }
+}
+
+class TestCollectionMapIntoMethodObject
+{
+    public function transform($value)
+    {
+        return [
+            'value' => $value,
+        ];
     }
 }
 

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -606,6 +606,27 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testMapIntoMethodIsLazy()
+    {
+        $class = new class
+        {
+            public function transform($value)
+            {
+                return [
+                    'value' => $value,
+                ];
+            }
+        };
+
+        $this->assertDoesNotEnumerate(function ($collection) use ($class) {
+            $collection->mapInto($class, 'transform');
+        });
+
+        $this->assertEnumerates(2, function ($collection) use ($class) {
+            $collection->mapInto($class, 'transform')->take(2)->all();
+        });
+    }
+
     public function testMapSpreadIsLazy()
     {
         $data = $this->make([[1, 2], [3, 4], [5, 6], [7, 8]]);


### PR DESCRIPTION
This pr adds an extra argument to the `mapInto()` helper to pass in a method name. 
This allows you to map data into a class via the given method name.

### Use case
For example, when you are dealing with transformers that have a method instead of a constructor that accepts certain data. You receive some data from an API and want to convert that data into a valueObject.

Current way to do this is with the `map()` helper or  the `array_map` function:
```php
$data->map(fn(array $item) => MyTransformer::transform($item));

array_map(fn($item) => MyTransformer::transform($item), $data);
```
This is fine, but it would be easier to use the `mapInto()` method which is meant to map data into an object.
So with this addition, you can now set a second argument which contains the method name of the class to map the data into.

It works both with static and non-static methods

### Example
```php
$data->mapInto(MyTransfomer::class, 'transform');
```

```php
class MyTransfomer
{
    public function transform($data)
    {
        return [
            ...
        ]
    }
}
```

### Breaking changes
The added argument is optional and `null` by default, so there should be no breaking changes.
