### PR TITLE
[9.x] Define a new method to create a through model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -115,7 +115,7 @@ trait HasRelationships
      */
     public function hasOneThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $secondLocalKey = null)
     {
-        $through = new $through;
+        $through = $this->newThroughInstance($through);
 
         $firstKey = $firstKey ?: $this->getForeignKey();
 
@@ -387,7 +387,7 @@ trait HasRelationships
      */
     public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $secondLocalKey = null)
     {
-        $through = new $through;
+        $through = $this->newThroughInstance($through);
 
         $firstKey = $firstKey ?: $this->getForeignKey();
 
@@ -757,6 +757,17 @@ trait HasRelationships
                 $instance->setConnection($this->connection);
             }
         });
+    }
+
+    /**
+     * Create a new model instance for a through model.
+     *
+     * @param  string  $class
+     * @return mixed
+     */
+    protected function newThroughInstance($class)
+    {
+        return new $class;
     }
 
     /**


### PR DESCRIPTION
It is helpful to have a customizable method for creating a new model instance for a through model without overriding the whole [`hasOneThrough`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php#L116-L118) or [`hasManyThrough`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php#L388-L390) methods. It is just as useful as [`newRelatedInstance`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php#L753-L760) method.