### PR TITLE
[9.x] Redesign `php artisan schedule:list` Command.

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -98,7 +98,7 @@ class ScheduleListCommand extends Command
         });
 
         if ($events->isEmpty()) {
-            return $this->comment('No tasks have been scheduled.');
+            return $this->comment('No scheduled tasks have been defined.');
         }
 
         $this->output->writeln(

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -79,7 +79,7 @@ class ScheduleListCommand extends Command
             ));
 
             // Highlight the parameters...
-            $command = preg_replace("#(=['\"]?)([^']+)(['\"]?)#", '$1<fg=yellow;options=bold>$2</>$3', $command);
+            $command = preg_replace("#(=['\"]?)([^'\"]+)(['\"]?)#", '$1<fg=yellow;options=bold>$2</>$3', $command);
 
             return [sprintf(
                 '  <fg=yellow>%s</>  %s<fg=#6C7280>%s %s%s %s</>',

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -4,8 +4,10 @@ namespace Illuminate\Console\Scheduling;
 
 use Cron\CronExpression;
 use DateTimeZone;
+use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
+use Symfony\Component\Console\Terminal;
 
 class ScheduleListCommand extends Command
 {
@@ -24,6 +26,13 @@ class ScheduleListCommand extends Command
     protected $description = 'List the scheduled commands';
 
     /**
+     * The terminal width resolver callback.
+     *
+     * @var \Closure|null
+     */
+    protected static $terminalWidthResolver;
+
+    /**
      * Execute the console command.
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
@@ -33,25 +42,112 @@ class ScheduleListCommand extends Command
      */
     public function handle(Schedule $schedule)
     {
-        foreach ($schedule->events() as $event) {
-            $rows[] = [
-                $event->command,
-                $event->expression,
-                $event->description,
-                (new CronExpression($event->expression))
-                            ->getNextRunDate(Carbon::now()->setTimezone($event->timezone))
-                            ->setTimezone(new DateTimeZone($this->option('timezone') ?? config('app.timezone')))
-                            ->format('Y-m-d H:i:s P'),
-                $event->mutex->exists($event) ? 'Yes' : '',
-            ];
-        }
+        $events = collect($schedule->events());
+        $terminalWidth = $this->getTerminalWidth();
+        $expressionSpacing = $this->getCronExpressionSpacing($events);
 
-        $this->table([
-            'Command',
-            'Interval',
-            'Description',
-            'Next Due',
-            'Has Mutex',
-        ], $rows ?? []);
+        $events = $events->map(function ($event) use ($terminalWidth, $expressionSpacing) {
+            $expression = $this->formatCronExpression($event->expression, $expressionSpacing);
+            $command = $event->command;
+
+            if (! $this->output->isVerbose()) {
+                $command = str_replace(
+                    Application::artisanBinary(),
+                    str_replace("'", '', Application::artisanBinary()),
+                    str_replace(Application::phpBinary(), 'php', $event->command)
+                );
+            }
+
+            $command = mb_strlen($command) > 1 ? "{$command} " : '';
+            $nextDueDateLabel = 'Next Due:';
+            $nextDueDate = Carbon::create((new CronExpression($event->expression))
+                ->getNextRunDate(Carbon::now()->setTimezone($event->timezone))
+                ->setTimezone(new DateTimeZone($this->option('timezone') ?? config('app.timezone')))
+            );
+
+            $nextDueDate = $this->output->isVerbose()
+                ? $nextDueDate->format('Y-m-d H:i:s P')
+                : $nextDueDate->diffForHumans();
+
+            $hasMutex = $event->mutex->exists($event) ? 'Has Mutex › ' : '';
+
+            $dots = str_repeat('.', max(
+                $terminalWidth - mb_strlen($expression.$command.$nextDueDateLabel.$nextDueDate.$hasMutex) - 8, 0
+            ));
+
+            // Highlights the parameters.
+            $command = preg_replace("#(='?)([^']+)('?)#", '$1<fg=yellow;options=bold>$2</>$3', $command);
+
+            return [sprintf(
+                '  <fg=yellow>%s</>  %s<fg=#6C7280>%s %s%s %s</>',
+                $expression,
+                $command,
+                $dots,
+                $hasMutex,
+                $nextDueDateLabel,
+                $nextDueDate
+            ), $this->output->isVerbose() && mb_strlen($event->description) > 1 ? sprintf(
+                '  <fg=#6C7280>%s%s %s</>',
+                str_repeat(' ', mb_strlen($expression) + 2),
+                '⇁',
+                $event->description
+            ) : ''];
+        });
+
+        $this->output->writeln(
+            $events->flatten()->filter()->prepend('')->push('')->toArray()
+        );
+    }
+
+    /**
+     * Gets the spacing to be used on each event row.
+     *
+     * @param  \Illuminate\Support\Collection  $events
+     * @return array<int, int>
+     */
+    private function getCronExpressionSpacing($events)
+    {
+        $rows = $events->map(fn ($event) => array_map('mb_strlen', explode(' ', $event->expression)));
+
+        return collect($rows[0] ?? [])->keys()->map(fn ($key) => $rows->max($key));
+    }
+
+    /**
+     * Formats the cron expression based on the spacing provided.
+     *
+     * @param  string  $expression
+     * @param  array<int, int>  $spacing
+     * @return string
+     */
+    private function formatCronExpression($expression, $spacing)
+    {
+        $expression = explode(' ', $expression);
+
+        return collect($spacing)
+            ->map(fn ($length, $index) => $expression[$index] = str_pad($expression[$index], $length))
+            ->implode(' ');
+    }
+
+    /**
+     * Get the terminal width.
+     *
+     * @return int
+     */
+    public static function getTerminalWidth()
+    {
+        return is_null(static::$terminalWidthResolver)
+            ? (new Terminal)->getWidth()
+            : call_user_func(static::$terminalWidthResolver);
+    }
+
+    /**
+     * Set a callback that should be used when resolving the terminal width.
+     *
+     * @param  \Closure|null  $resolver
+     * @return void
+     */
+    public static function resolveTerminalWidthUsing($resolver)
+    {
+        static::$terminalWidthResolver = $resolver;
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -97,6 +97,10 @@ class ScheduleListCommand extends Command
             ) : ''];
         });
 
+        if ($events->isEmpty()) {
+            return $this->comment('No tasks have been scheduled.');
+        }
+
         $this->output->writeln(
             $events->flatten()->filter()->prepend('')->push('')->toArray()
         );

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -54,7 +54,7 @@ class ScheduleListCommand extends Command
             if (! $this->output->isVerbose()) {
                 $command = str_replace(
                     Application::artisanBinary(),
-                    str_replace("'", '', Application::artisanBinary()),
+                    preg_replace("#['\"]#", '', Application::artisanBinary()),
                     str_replace(Application::phpBinary(), 'php', $event->command)
                 );
             }
@@ -79,7 +79,7 @@ class ScheduleListCommand extends Command
             ));
 
             // Highlight the parameters...
-            $command = preg_replace("#(='?)([^']+)('?)#", '$1<fg=yellow;options=bold>$2</>$3', $command);
+            $command = preg_replace("#(=['\"]?)([^']+)(['\"]?)#", '$1<fg=yellow;options=bold>$2</>$3', $command);
 
             return [sprintf(
                 '  <fg=yellow>%s</>  %s<fg=#6C7280>%s %s%s %s</>',

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -48,6 +48,7 @@ class ScheduleListCommand extends Command
 
         $events = $events->map(function ($event) use ($terminalWidth, $expressionSpacing) {
             $expression = $this->formatCronExpression($event->expression, $expressionSpacing);
+
             $command = $event->command;
 
             if (! $this->output->isVerbose()) {
@@ -59,7 +60,9 @@ class ScheduleListCommand extends Command
             }
 
             $command = mb_strlen($command) > 1 ? "{$command} " : '';
+
             $nextDueDateLabel = 'Next Due:';
+
             $nextDueDate = Carbon::create((new CronExpression($event->expression))
                 ->getNextRunDate(Carbon::now()->setTimezone($event->timezone))
                 ->setTimezone(new DateTimeZone($this->option('timezone') ?? config('app.timezone')))
@@ -75,7 +78,7 @@ class ScheduleListCommand extends Command
                 $terminalWidth - mb_strlen($expression.$command.$nextDueDateLabel.$nextDueDate.$hasMutex) - 8, 0
             ));
 
-            // Highlights the parameters.
+            // Highlight the parameters...
             $command = preg_replace("#(='?)([^']+)('?)#", '$1<fg=yellow;options=bold>$2</>$3', $command);
 
             return [sprintf(

--- a/tests/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleListCommandTest.php
@@ -47,6 +47,8 @@ class ScheduleListCommandTest extends TestCase
     {
         parent::tearDown();
 
+        putenv('SHELL_VERBOSITY');
+
         ScheduleListCommand::resolveTerminalWidthUsing(null);
     }
 }

--- a/tests/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleListCommandTest.php
@@ -5,7 +5,9 @@ namespace Illuminate\Tests\Console\Scheduling;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
+use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Facade;
 use Orchestra\Testbench\TestCase;
 
 class ScheduleListCommandTest extends TestCase
@@ -48,6 +50,7 @@ class ScheduleListCommandTest extends TestCase
         parent::tearDown();
 
         putenv('SHELL_VERBOSITY');
+        AliasLoader::getInstance()->setAliases([]);
 
         ScheduleListCommand::resolveTerminalWidthUsing(null);
     }

--- a/tests/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleListCommandTest.php
@@ -39,7 +39,7 @@ class ScheduleListCommandTest extends TestCase
 
         $this->artisan(ScheduleListCommand::class, ['-v' => true])
             ->assertSuccessful()
-            ->expectsOutputToContain('Next Due: ' . now()->setMinutes(1)->format('Y-m-d H:i:s P'))
+            ->expectsOutputToContain('Next Due: '.now()->setMinutes(1)->format('Y-m-d H:i:s P'))
             ->expectsOutput('             ⇁ This is the description of the command.');
     }
 

--- a/tests/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleListCommandTest.php
@@ -57,4 +57,3 @@ class FooCommand extends Command
 
     protected $description = 'This is the description of the command.';
 }
-

--- a/tests/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Console/Scheduling/ScheduleListCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\ScheduleListCommand;
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+
+class ScheduleListCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(now()->startOfYear());
+        ScheduleListCommand::resolveTerminalWidthUsing(fn () => 80);
+
+        $this->schedule = $this->app->make(Schedule::class);
+    }
+
+    public function testDisplaySchedule()
+    {
+        $this->schedule->call(fn () => '')->everyMinute();
+        $this->schedule->command(FooCommand::class)->quarterly();
+        $this->schedule->command('inspire')->twiceDaily(14, 18);
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('  * *     * *      *  ............................ Next Due: 1 minute from now')
+            ->expectsOutput('  0 0     1 1-12/3 *  php artisan foo:command .... Next Due: 3 months from now')
+            ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now');
+    }
+
+    public function testDisplayScheduleInVerboseMode()
+    {
+        $this->schedule->command(FooCommand::class)->everyMinute();
+
+        $this->artisan(ScheduleListCommand::class, ['-v' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Next Due: ' . now()->setMinutes(1)->format('Y-m-d H:i:s P'))
+            ->expectsOutput('             ⇁ This is the description of the command.');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        ScheduleListCommand::resolveTerminalWidthUsing(null);
+    }
+}
+
+class FooCommand extends Command
+{
+    protected $signature = 'foo:command';
+
+    protected $description = 'This is the description of the command.';
+}
+

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -5,9 +5,7 @@ namespace Illuminate\Tests\Integration\Console\Scheduling;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
-use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Facade;
 use Orchestra\Testbench\TestCase;
 
 class ScheduleListCommandTest extends TestCase

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\ProcessUtils;
 use Orchestra\Testbench\TestCase;
 
 class ScheduleListCommandTest extends TestCase
@@ -25,12 +26,14 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->call(fn () => '')->everyMinute();
         $this->schedule->command(FooCommand::class)->quarterly();
         $this->schedule->command('inspire')->twiceDaily(14, 18);
+        $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
 
         $this->artisan(ScheduleListCommand::class)
             ->assertSuccessful()
             ->expectsOutput('  * *     * *      *  ............................ Next Due: 1 minute from now')
             ->expectsOutput('  0 0     1 1-12/3 *  php artisan foo:command .... Next Due: 3 months from now')
-            ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now');
+            ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
+            ->expectsOutput("  * *     * *      *  php artisan foobar a=". ProcessUtils::escapeArgument('b') ." ... Next Due: 1 minute from now");
     }
 
     public function testDisplayScheduleInVerboseMode()

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -50,7 +50,7 @@ class ScheduleListCommandTest extends TestCase
         parent::tearDown();
 
         putenv('SHELL_VERBOSITY');
-        AliasLoader::getInstance()->setAliases([]);
+        // AliasLoader::getInstance()->setAliases([]);
 
         ScheduleListCommand::resolveTerminalWidthUsing(null);
     }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -50,7 +50,6 @@ class ScheduleListCommandTest extends TestCase
         parent::tearDown();
 
         putenv('SHELL_VERBOSITY');
-        // AliasLoader::getInstance()->setAliases([]);
 
         ScheduleListCommand::resolveTerminalWidthUsing(null);
     }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -33,7 +33,7 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * *     * *      *  ............................ Next Due: 1 minute from now')
             ->expectsOutput('  0 0     1 1-12/3 *  php artisan foo:command .... Next Due: 3 months from now')
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
-            ->expectsOutput("  * *     * *      *  php artisan foobar a=". ProcessUtils::escapeArgument('b') ." ... Next Due: 1 minute from now");
+            ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now');
     }
 
     public function testDisplayScheduleInVerboseMode()

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Console\Scheduling;
+namespace Illuminate\Tests\Integration\Console\Scheduling;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;


### PR DESCRIPTION
This PR Improves the look for the `php artisan schedule:list` command.

The design was heavily inspired by the new version of the `route:list`.

##  Before:

<img width="2242" alt="image" src="https://user-images.githubusercontent.com/823088/157936646-72974ee1-deeb-4af5-ab19-d6bb74cffa7b.png">

## After

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/823088/157937451-43a97e88-e81d-4c12-af00-d51e6d58ed23.png">

Also there is available a verbose mode that will show the **full cli path**, **raw dates* and **description**.

### Verbose Mode

<img width="1805" alt="image" src="https://user-images.githubusercontent.com/823088/157937594-0ac6f73a-d81a-404f-b240-654b6b81cc4f.png">


Cheers,
Francisco