### PR TITLE
[9.x] Extend eloquent higher order proxy properties

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -22,6 +22,8 @@ use ReflectionMethod;
 
 /**
  * @property-read HigherOrderBuilderProxy $orWhere
+ * @property-read HigherOrderBuilderProxy $whereNot
+ * @property-read HigherOrderBuilderProxy $orWhereNot
  *
  * @mixin \Illuminate\Database\Query\Builder
  */
@@ -89,6 +91,8 @@ class Builder implements BuilderContract
      */
     protected $higherOrderPassthru = [
         'orWhere',
+        'whereNot',
+        'orWhereNot',
     ];
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -85,17 +85,6 @@ class Builder implements BuilderContract
     ];
 
     /**
-     * The properties that should be proxied to query builder.
-     *
-     * @var string[]
-     */
-    protected $higherOrderPassthru = [
-        'orWhere',
-        'whereNot',
-        'orWhereNot',
-    ];
-
-    /**
      * The methods that should be returned from query builder.
      *
      * @var string[]
@@ -1668,7 +1657,7 @@ class Builder implements BuilderContract
      */
     public function __get($key)
     {
-        if (in_array($key, $this->higherOrderPassthru)) {
+        if (in_array($key, ['orWhere', 'whereNot', 'orWhereNot'])) {
             return new HigherOrderBuilderProxy($this, $key);
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -83,6 +83,15 @@ class Builder implements BuilderContract
     ];
 
     /**
+     * The properties that should be proxied to query builder.
+     *
+     * @var string[]
+     */
+    protected $higherOrderPassthru = [
+        'orWhere',
+    ];
+
+    /**
      * The methods that should be returned from query builder.
      *
      * @var string[]
@@ -1655,7 +1664,7 @@ class Builder implements BuilderContract
      */
     public function __get($key)
     {
-        if ($key === 'orWhere') {
+        if (in_array($key, $this->higherOrderPassthru)) {
             return new HigherOrderBuilderProxy($this, $key);
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -956,6 +956,38 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "table" where "one" = ? or ("two" = ?) or ("three" = ?)', $query->toSql());
     }
 
+    public function testRealQueryHigherOrderWhereNotScopes()
+    {
+        $model = new EloquentBuilderTestHigherOrderWhereScopeStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->one()->whereNot->two();
+        $this->assertSame('select * from "table" where "one" = ? and not ("two" = ?)', $query->toSql());
+    }
+
+    public function testRealQueryChainedHigherOrderWhereNotScopes()
+    {
+        $model = new EloquentBuilderTestHigherOrderWhereScopeStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->one()->whereNot->two()->whereNot->three();
+        $this->assertSame('select * from "table" where "one" = ? and not ("two" = ?) and not ("three" = ?)', $query->toSql());
+    }
+
+    public function testRealQueryHigherOrderOrWhereNotScopes()
+    {
+        $model = new EloquentBuilderTestHigherOrderWhereScopeStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->one()->orWhereNot->two();
+        $this->assertSame('select * from "table" where "one" = ? or not ("two" = ?)', $query->toSql());
+    }
+
+    public function testRealQueryChainedHigherOrderOrWhereNotScopes()
+    {
+        $model = new EloquentBuilderTestHigherOrderWhereScopeStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->one()->orWhereNot->two()->orWhereNot->three();
+        $this->assertSame('select * from "table" where "one" = ? or not ("two" = ?) or not ("three" = ?)', $query->toSql());
+    }
+
     public function testSimpleWhere()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Hello,

Pull requests https://github.com/laravel/framework/pull/41096 and https://github.com/laravel/framework/pull/41296 added the ability to negate query conditions, primarily negating closures of conditions or in other words: scopes.

I remembered there was a nice way of changing the `boolean` of model scopes from `and` to `or` using the [HigherOrderBuilderProxy](https://github.com/laravel/framework/tree/9.x/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php#L8).
I decided to add an easy way to add proxied properties and for starters in addition to the `orWhere` method I also added the methods `whereNot` and `orWhereNot` to be proxied.

I have also added tests.

This is what is changed in terms of coding and syntactic sugar.

Before you would write:
```php
Model::query()->whereNot(function (Builder $query) {
    $query->someScope();
});

Model::query()->orWhereNot(function (Builder $query) {
    $query->someOtherScope();
});
```

Now you can use:
```php
Model::query()->whereNot->someScope();

Model::query()->orWhereNot->someOtherScope();
```

I think this is quite nice looking code.