### PR TITLE
[9.x] Adds collection key first/last.

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -390,9 +390,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Returns the first key of the collection.
+     * Get the first key of the collection.
      *
-     * @return int|string|void|null
+     * @return mixed
      */
     public function firstKey()
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -705,9 +705,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Returns the last key of the collection.
+     * Get the last key of the collection.
      *
-     * @return int|string|null
+     * @return mixed
      */
     public function lastKey()
     {

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -390,6 +390,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Returns the first key of the collection.
+     *
+     * @return int|string|void|null
+     */
+    public function firstKey()
+    {
+        return array_key_first($this->items);
+    }
+
+    /**
      * Get a flattened array of the items in the collection.
      *
      * @param  int  $depth
@@ -692,6 +702,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function last(callable $callback = null, $default = null)
     {
         return Arr::last($this->items, $callback, $default);
+    }
+
+    /**
+     * Returns the last key of the collection.
+     *
+     * @return int|string|null
+     */
+    public function lastKey()
+    {
+        return array_key_last($this->items);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -69,6 +69,17 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('default', $result);
     }
 
+    public function testFirstKey()
+    {
+        $data = new Collection(['foo' => 'bar', 'baz' => 'quz', 'qux' => 'quux']);
+
+        $this->assertSame('foo', $data->firstKey());
+
+        $data = new Collection(['foo', 'bar', 'baz', 'quz']);
+
+        $this->assertSame(0, $data->firstKey());
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */
@@ -328,6 +339,17 @@ class SupportCollectionTest extends TestCase
         $data = new $collection;
         $result = $data->last(null, 'default');
         $this->assertSame('default', $result);
+    }
+
+    public function testLastKey()
+    {
+        $data = new Collection(['foo' => 'bar', 'baz' => 'quz', 'qux' => 'quux']);
+
+        $this->assertSame('qux', $data->lastKey());
+
+        $data = new Collection(['foo', 'bar', 'baz', 'quz']);
+
+        $this->assertSame(3, $data->lastKey());
     }
 
     public function testPopReturnsAndRemovesLastItemInCollection()


### PR DESCRIPTION
## What?

Adds methods to retrieve the first and last key of the `Collection` instance.

```php
// Before
array_key_first($collection->all());

// After
$collection->firstKey();
```

## Why?

Sometimes you want to get the last key of the collection, or get which key the last item added has. Or when unshifting (prepending) the collection.

## BC?

None, not expected the user to have a macro of the same name.