### PR TITLE
Fix sorting by precedence

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -121,10 +121,10 @@ class RouteListCommand extends Command
             return $this->getRouteInformation($route);
         })->filter()->all();
 
-        if (($sort = $this->option('sort')) !== null) {
+        $sort = $this->option('sort') == 'precedence' ? false : (Arr::exists($routes[0], $this->option('sort')) ? $this->option('sort') : 'uri');
+
+        if ($sort) {
             $routes = $this->sortRoutes($sort, $routes);
-        } else {
-            $routes = $this->sortRoutes('uri', $routes);
         }
 
         if ($this->option('reverse')) {
@@ -452,7 +452,7 @@ class RouteListCommand extends Command
             ['path', null, InputOption::VALUE_OPTIONAL, 'Only show routes matching the given path pattern'],
             ['except-path', null, InputOption::VALUE_OPTIONAL, 'Do not display the routes matching the given path pattern'],
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
-            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware) to sort by', 'uri'],
+            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (precedence, domain, method, uri, name, action, middleware) to sort by', 'uri'],
             ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
         ];
     }


### PR DESCRIPTION
This PR provides a real fix of the issue https://github.com/laravel/framework/issues/41437
The PR https://github.com/laravel/framework/pull/41448 only "validates" the disappearing of the function. 

I think the route list should have the sorting method by `precedence`.
This update keeps the default sorting by `uri` (if no sort option was given) and also prevents `Undefined array key` errors (if not a valid sort option was given)