### PR TITLE
[9.x] Add support for single positional attribute in blade components

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -153,6 +153,12 @@ trait CompilesComponents
     \$\$__key = \$\$__key ?? \$__value;
 } ?>
 <?php \$attributes = \$attributes->exceptProps{$expression}; ?>
+<?php if (\$attributes->has('__positional')) {
+    \$__positionalProperty = array_key_first{$expression};
+    if (is_numeric(\$__positionalProperty)) \$__positionalProperty = {$expression}[\$__positionalProperty];
+    \$\$__positionalProperty ??= \$attributes->get('__positional');
+    unset(\$__positionalProperty, \$attributes['__positional']);
+} ?>
 <?php foreach (array_filter({$expression}, 'is_string', ARRAY_FILTER_USE_KEY) as \$__key => \$__value) {
     \$\$__key = \$\$__key ?? \$__value;
 } ?>

--- a/tests/View/Blade/BladePropsTest.php
+++ b/tests/View/Blade/BladePropsTest.php
@@ -12,6 +12,12 @@ class BladePropsTest extends AbstractBladeTestCase
     $$__key = $$__key ?? $__value;
 } ?>
 <?php $attributes = $attributes->exceptProps([\'one\' => true, \'two\' => \'string\']); ?>
+<?php if ($attributes->has(\'__positional\')) {
+    $__positionalProperty = array_key_first([\'one\' => true, \'two\' => \'string\']);
+    if (is_numeric($__positionalProperty)) $__positionalProperty = ([\'one\' => true, \'two\' => \'string\'])[$__positionalProperty];
+    $$__positionalProperty ??= $attributes->get(\'__positional\');
+    unset($__positionalProperty, $attributes[\'__positional\']);
+} ?>
 <?php foreach (array_filter(([\'one\' => true, \'two\' => \'string\']), \'is_string\', ARRAY_FILTER_USE_KEY) as $__key => $__value) {
     $$__key = $$__key ?? $__value;
 } ?>


### PR DESCRIPTION
Inspired by the new and better way to declare slot names:

```blade
<x-slot:title>
    Neat!
</x-slot>
```

This PR seeks to extend that functionality to components themselves:

The user may provide a single _positional_ attribute in the opening tag of a component. If given, it will fill the value of the first parameter on that component, unless it has already been explicitly given by name.

```blade
<!-- /resources/views/components/rating.blade.php -->

@props(['rating' => 3])
@for ($i = 0; $i < $rating; $i++)
    ⭐
@endfor
```

```blade
<ul>
    <li>Laravel: <x-rating:5 /></li>          // ⭐⭐⭐⭐⭐
    <li>Django: <x-rating:4 /></li>           // ⭐⭐⭐⭐
    <li>ASP.NET: <x-rating /></li>            // ⭐⭐⭐    [default]
    <li>Rails: <x-rating:3 rating="4" /></li> // ⭐⭐⭐⭐  [overwritten by named attribute]
</ul>
```

This works both for class-based and anonymous components. In class-based components, the first positional parameter in the constructor will be used. In anonymous components, the first property given in the `@props` tag will be used.

This is particularly neat for simpler components, where only a single straightforward attribute is needed, as was the case for the slot names. A real-project example would be a simple "repeat" utility component: `<x-repeat times="5>...</x-repeat>` could become `<x-repeat:5>...</x-repeat>`.

### Limitations

- The positional attribute value may only contain _word characters_ (`\w`), periods and hyphens, so as to conform with existing component compilation grammars.
    - **Works**: `<x-foo:bar_qux>`, `<x-foo:-3>`, `<x-foo:bar.qux>`. The attribute may also be left empty `<x-foo:>` which results in an empty string value. 
    - **Doesn't work**: `<x-foo:5,2>`, `<x-foo:['abc']>`.
- If a component alias has been defined which contains a colon, its declaration will take precedence and positional attribute will be ignored.
- Also no `$variables` or anything like that. For these cases you're better off using the existing attribute declaration.

### Breaking changes

If anyone were somehow using colons in the names of their components (`foo:bar.blade.php`), their declaration would no longer be recognized, as everything after the last colon is assumed to be the positional attribute unless explicitly defined as a component alias.

**Let me know if this looks reasonable**, and I will have some tests added ASAP.