### PR TITLE
[9.x] Remove unnecessary empty keys in encrypted data

### DIFF
--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -69,13 +69,13 @@ class EncrypterTest extends TestCase
         $this->assertSame('bar', $mixed->decrypt($encrypted));
     }
 
-    public function testThatAnAeadCipherIncludesTag()
+    public function testThatAnAeadCipherIncludesTagButNoMac()
     {
         $e = new Encrypter(str_repeat('b', 32), 'AES-256-GCM');
         $encrypted = $e->encrypt('foo');
         $data = json_decode(base64_decode($encrypted));
 
-        $this->assertEmpty($data->mac);
+        $this->assertFalse(isset($data->mac));
         $this->assertNotEmpty($data->tag);
     }
 
@@ -107,13 +107,13 @@ class EncrypterTest extends TestCase
         $e->decrypt($encrypted);
     }
 
-    public function testThatANonAeadCipherIncludesMac()
+    public function testThatANonAeadCipherIncludesMacButNoTag()
     {
         $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
         $encrypted = $e->encrypt('foo');
         $data = json_decode(base64_decode($encrypted));
 
-        $this->assertEmpty($data->tag);
+        $this->assertFalse(isset($data->tag));
         $this->assertNotEmpty($data->mac);
     }
 


### PR DESCRIPTION
The encryption payload contains either a `mac` or a `tag` for integrity check, and the name is different depending on the encryption mode being used (`CBC` or `GCM` mode). Currently, one of `mac/tag` is always empty (when the other is used), but still present in the encrypted data.

Example of data encrypted with `GCM` mode
`{"iv":"4bSa...,"value":"lPaA...","tag":"yRrQa...","mac":""}` (note the empty `mac`)

Example of data encrypted with `CBC` mode
`{"iv":"JIIW...","value":"W/VFc...,"mac":"b53c...","tag":""}` (note the empty `tag`)

This PR removes this extra key with the empty value.

This is BC since the chosen encryption mode determines if `mac` or `tag` is read. However data encrypted with this PR will not be decryptable on older versions since the presence of the `mac` key was necessary in `validPayload`. I don't know how you usually handle such "non-rollbackable" changes, which might cause problems with aspects like queue workers reading new data on an older version (if not being restarted correctly).  I'm absolutely fine with accepting the empty keys if that is an unnecessary risk, or re-targeting this at 10.x if that is better.

An alternative approach could of course be to use the same key for both, however that would require more changes and could lead to confusion. The fact that the encryption payload reveals the method (which it already does) is not a security problem since there is a fixed set of methods to choose from (currently 2), i.e. it only reduces brute-force complexity by a low constant factor.