### PR TITLE
[9.x] Fix DocBlock return type

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1100,7 +1100,7 @@ class Route
     /**
      * Indicate that the route should enforce scoping of multiple implicit Eloquent bindings.
      *
-     * @return bool
+     * @return $this
      */
     public function scopeBindings()
     {


### PR DESCRIPTION
Fixes the DocBlock return type for the `scopeBindings` method form `bool` to `$this`.