### PR TITLE
[9.x] Don't report renderable exception when $dontReport is true

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -270,6 +270,10 @@ class Handler implements ExceptionHandlerContract
      */
     protected function shouldntReport(Throwable $e)
     {
+        if (property_exists($e, 'dontReport') && $e->dontReport === true) {
+            return true;
+        }
+
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
         return ! is_null(Arr::first($dontReport, function ($type) use ($e) {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -95,6 +95,15 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->report(new UnReportableException('Exception message'));
     }
 
+    public function testHandlerDoesNotReportExceptionWhenDeclaredNotTo()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldNotReceive('error');
+
+        $this->handler->report(new NonReportingException('Exception message'));
+    }
+
     public function testHandlerCallsReportMethodWithDependencies()
     {
         $reporter = m::mock(ReportingService::class);
@@ -376,6 +385,11 @@ class UnReportableException extends Exception
     {
         return false;
     }
+}
+
+class NonReportingException extends Exception
+{
+    public $dontReport = true;
 }
 
 class ContextProvidingException extends Exception


### PR DESCRIPTION
Currently, if we don't want to report a [renderable exception](https://laravel.com/docs/9.x/errors#renderable-exceptions), we need to define an empty `report()` method like below.

```php
class CustomException extends Exception
{
    /**
     * Report the exception.
     *
     * @return bool|null
     */
    public function report()
    {
        //
    }
 
    /**
     * Render the exception into an HTTP response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return \Illuminate\Http\Response
     */
    public function render($request)
    {
        return response(...);
    }
}
```

Alternatively, we can add the exception to the `$dontReport` array in the exception handler. However, as the application grows, this array can become very long.

This PR will allow us to mark a renderable exception "unreportable" by setting the exception's `$dontReport` property to `true` without having to define an empty `report()` method.

```php
class CustomException extends Exception
{
    // This exception won't be reported.
    public $dontReport = true;
 
    /**
     * Render the exception into an HTTP response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return \Illuminate\Http\Response
     */
    public function render($request)
    {
        return response(...);
    }
}
```