### PR TITLE
[9.x] Adds "freezeTime" helper for tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Carbon;
 trait InteractsWithTime
 {
     /**
-     * Freezes the current time.
+     * Freeze time.
      *
      * @param  callable|null  $callback
      * @return mixed
@@ -19,7 +19,7 @@ trait InteractsWithTime
     }
 
     /**
-     * Freezes the current second.
+     * Freeze time at the beginning of the current second.
      *
      * @param  callable|null  $callback
      * @return mixed
@@ -52,7 +52,7 @@ trait InteractsWithTime
         Carbon::setTestNow($date);
 
         if ($callback) {
-            return tap($callback(), function () {
+            return tap($callback(Carbon::now()), function () {
                 Carbon::setTestNow();
             });
         }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -8,6 +8,17 @@ use Illuminate\Support\Carbon;
 trait InteractsWithTime
 {
     /**
+     * Freezes the current time.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function freezeTime($callback = null)
+    {
+        $this->travelTo(Carbon::now()->startOfSecond(), $callback);
+    }
+
+    /**
      * Begin travelling to another time.
      *
      * @param  int  $value

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -11,11 +11,11 @@ trait InteractsWithTime
      * Freezes the current time.
      *
      * @param  callable|null  $callback
-     * @return void
+     * @return mixed
      */
     public function freezeTime($callback = null)
     {
-        $this->travelTo(Carbon::now()->startOfSecond(), $callback);
+        return $this->travelTo(Carbon::now(), $callback);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -19,6 +19,17 @@ trait InteractsWithTime
     }
 
     /**
+     * Freezes the current second.
+     *
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    public function freezeSecond($callback = null)
+    {
+        return $this->travelTo(Carbon::now()->startOfSecond(), $callback);
+    }
+
+    /**
      * Begin travelling to another time.
      *
      * @param  int  $value


### PR DESCRIPTION
## What?

The `freezeTime()` method in tests will freeze the current time.

```php
public function test_something()
{
    $this->freezeTime();
}
```

This is equivalent to `$this->travelTo(Carbon::now())`.

This PR also adds `freezeSecond()` which does the same, but sets the time at the start of the current second. This _fixes_ any problem when comparing dates that have no sub-second precision, like the default database timestamps.

```php
public function test_something()
{
    $this->freezeSecond();

    User::factory()->createOne();

    static::assertEquals(now(), User::find(1)->created_at);
}
```

## Why?

Just better syntax.