### PR TITLE
[9.x] Update PackageManifest::$vendorPath initialisation for cases, when composer vendor dir is not in project directory

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -55,7 +55,7 @@ class PackageManifest
         $this->files = $files;
         $this->basePath = $basePath;
         $this->manifestPath = $manifestPath;
-        $this->vendorPath = getenv('COMPOSER_VENDOR_DIR') ?: $basePath.'/vendor';
+        $this->vendorPath = env('COMPOSER_VENDOR_DIR') ?: $basePath.'/vendor';
     }
 
     /**

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -55,7 +55,7 @@ class PackageManifest
         $this->files = $files;
         $this->basePath = $basePath;
         $this->manifestPath = $manifestPath;
-        $this->vendorPath = $basePath.'/vendor';
+        $this->vendorPath = getenv('COMPOSER_VENDOR_DIR') ?: $basePath.'/vendor';
     }
 
     /**

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Exception;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Env;
 
 class PackageManifest
 {
@@ -55,7 +56,7 @@ class PackageManifest
         $this->files = $files;
         $this->basePath = $basePath;
         $this->manifestPath = $manifestPath;
-        $this->vendorPath = env('COMPOSER_VENDOR_DIR') ?: $basePath.'/vendor';
+        $this->vendorPath = Env::get('COMPOSER_VENDOR_DIR') ?: $basePath.'/vendor';
     }
 
     /**


### PR DESCRIPTION
It's possible, that for some reason, vendor dir could be in another directory (https://getcomposer.org/doc/03-cli.md#composer-vendor-dir).

For example, when you change vendor dir in docker image for easier app bind mounting (https://github.com/BretFisher/php-docker-good-defaults/blob/master/Dockerfile).

In that case, if you run `php artisan package:discover` generated bootstrap/cache/packages.php file will contain empty array.

That's why those changes should be accepted, so even if COMPOSER_VENDOR_DIR is changed package discover working correct.

Those changes are backward compatible, because it's assumed that nobody would set or change global environment variable `COMPOSER_VENDOR_DIR` without reason.
