### PR TITLE
[9.x] Fix route:list --except-vendor hiding `Route::view()` & `Route::redirect()`

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -223,13 +223,31 @@ class RouteListCommand extends Command
                   str_contains($route->action['uses'], 'SerializableClosure')) {
             return false;
         } elseif (is_string($route->action['uses'])) {
-            $path = (new ReflectionClass(explode('@', $route->action['uses'])[0]))
+            if ($this->isFrameworkController($route)) {
+                return false;
+            }
+
+            $path = (new ReflectionClass($route->getControllerClass()))
                                 ->getFileName();
         } else {
             return false;
         }
 
         return str_starts_with($path, base_path('vendor'));
+    }
+
+    /**
+     * Determine if the route uses a framework controller.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return bool
+     */
+    protected function isFrameworkController(Route $route)
+    {
+        return in_array($route->getControllerClass(), [
+            '\Illuminate\Routing\RedirectController',
+            '\Illuminate\Routing\ViewController',
+        ], true);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -270,12 +270,22 @@ class Route
     public function getController()
     {
         if (! $this->controller) {
-            $class = $this->parseControllerCallback()[0];
+            $class = $this->getControllerClass();
 
             $this->controller = $this->container->make(ltrim($class, '\\'));
         }
 
         return $this->controller;
+    }
+
+    /**
+     * Get the controller class used for the route.
+     *
+     * @return string
+     */
+    public function getControllerClass()
+    {
+        return $this->parseControllerCallback()[0];
     }
 
     /**

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -113,6 +113,21 @@ class RouteListCommandTest extends TestCase
             ->expectsOutput('');
     }
 
+    public function testDisplayRoutesExceptVendor()
+    {
+        $this->router->get('foo/{user}', [FooController::class, 'show']);
+        $this->router->view('view', 'blade.path');
+        $this->router->redirect('redirect', 'destination');
+
+        $this->artisan(RouteListCommand::class, ['-v' => true, '--except-vendor' => true])
+            ->assertSuccessful()
+            ->expectsOutput('')
+            ->expectsOutput('  GET|HEAD       foo/{user} Illuminate\Tests\Testing\Console\FooController@show')
+            ->expectsOutput('  ANY            redirect .... Illuminate\Routing\RedirectController')
+            ->expectsOutput('  GET|HEAD       view .............................................. ')
+            ->expectsOutput('');
+    }
+
     protected function tearDown(): void
     {
         parent::tearDown();


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/41416

```
php artisan route:list --except-vendor
```

This doesn't show paths registered via `Route::view()` or `Route::redirect()`.

Don't consider `Illuminate\Routing\RedirectController` & `Illuminate\Routing\ViewController` as vendor-registered routes. Assume `Route::view()` or `Route::redirect()` were called in userland routes/*.php.

---

To more accurately track this, `Illuminate\Routing\Route` needs a new class property `$isVendor`. The constructor would traverse its stacktrace to find the originating call. It could be an `app()->environment('development', 'testing')`-only
code path but I don't think the `Route` class bloat is worth it considering these "magic route" methods are more a userland feature than packageland. It could also introduce a breaking change to serializing routes.