### PR TITLE
[9.x] Fix `Collection::implode()` string argument

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -583,7 +583,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function implode($value, $glue = null)
     {
-        if (is_callable($value)) {
+        if ($this->useAsCallable($value)) {
             return implode($glue ?? '', $this->map($value)->all());
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2151,6 +2151,7 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([Str::of('taylor'), Str::of('dayle')]);
         $this->assertSame('taylordayle', $data->implode(''));
         $this->assertSame('taylor,dayle', $data->implode(','));
+        $this->assertSame('taylor_dayle', $data->implode('_'));
 
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertSame('taylor-foodayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email']));


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/41466 introduced by https://github.com/laravel/framework/pull/41405

`collect(['foo', 'bar'])->implode('_')` should be `'foo_bar'` but it instead attempts to call translation helper `_()`.

It needs the same fix as https://github.com/laravel/framework/pull/41424

For a callable arg, don't support global helpers. Only allow a Closure, invokable class, or [$object, 'method'] array pair.