### PR TITLE
[9.x] Allows object instead of array when adding to `PendingBatch`

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -57,12 +57,12 @@ class PendingBatch
     /**
      * Add jobs to the batch.
      *
-     * @param  iterable  $jobs
+     * @param  \Illuminate\Support\Enumerable|object|array  $jobs
      * @return $this
      */
     public function add($jobs)
     {
-        foreach ($jobs as $job) {
+        foreach (Arr::wrap($jobs) as $job) {
             $this->jobs->push($job);
         }
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -117,6 +117,28 @@ class BusBatchTest extends TestCase
         $this->assertInstanceOf(CarbonImmutable::class, $batch->createdAt);
     }
 
+    public function test_jobs_can_be_added_to_pending_batch()
+    {
+        $batch = new PendingBatch(new Container, collect());
+        $this->assertCount(0, $batch->jobs);
+
+        $job = new class
+        {
+            use Batchable;
+        };
+        $batch->add([$job]);
+        $this->assertCount(1, $batch->jobs);
+
+        $secondJob = new class
+        {
+            use Batchable;
+
+            public $anotherProperty;
+        };
+        $batch->add($secondJob);
+        $this->assertCount(2, $batch->jobs);
+    }
+
     public function test_processed_jobs_can_be_calculated()
     {
         $queue = m::mock(Factory::class);


### PR DESCRIPTION
Currently you need to pass an array when you want to add to a batch.

```php
$batch = Bus::batch([]);
$batch->add([new Job]);
$batch->dispatch();
```
With this PR you can do this:
```php
$batch = Bus::batch([]);
$batch->add(new Job);
$batch->dispatch();
```

This is already possible if you want to add to an [already dispatched batch](https://github.com/laravel/framework/blob/9e7d31dcd4ba39376418d4cda425fb90809a7c2e/src/Illuminate/Bus/Batch.php#L165):
```php
$this->batch()->add(new Job);
```

The `add` function on `PendingBatch` wasn't tested yet either so I added a test.