### PR TITLE
Update composer.json: move doctrine/dbal from require-dev to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": "^8.0.2",
         "ext-mbstring": "*",
         "ext-openssl": "*",
+        "doctrine/dbal": "^2.13.3|^3.1.4",
         "doctrine/inflector": "^2.0",
         "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^3.1",
@@ -81,7 +82,6 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.198.1",
-        "doctrine/dbal": "^2.13.3|^3.1.4",
         "fakerphp/faker": "^1.9.2",
         "guzzlehttp/guzzle": "^7.2",
         "league/flysystem-aws-s3-v3": "^3.0",


### PR DESCRIPTION
Package doctrine/dbal is used by `\Illuminate\Database\PDO\MySqlDriver`, namely it extends `\Doctrine\DBAL\Driver\AbstractMySQLDriver`.

That's why it should be moved to `require` in composer.json.

If this change won't be applied when run for production `composer install --no-dev` won't install this package and, for example, migration would fail.

In my case, it was migration with `$table->renameColumn($from, $to)`.
