### PR TITLE
[9.x] Allow passing named arguments to dynamic scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1244,7 +1244,7 @@ class Builder implements BuilderContract
         $originalWhereCount = is_null($query->wheres)
                     ? 0 : count($query->wheres);
 
-        $result = $scope(...array_values($parameters)) ?? $this;
+        $result = $scope(...$parameters) ?? $this;
 
         if (count((array) $query->wheres) > $originalWhereCount) {
             $this->addNewWheresWithinGroup($query, $originalWhereCount);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -832,6 +832,28 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
     }
 
+    public function testQueryDynamicScopes()
+    {
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('from');
+        $builder->getQuery()->shouldReceive('where')->once()->with('bar', 'foo');
+        $builder->setModel($model = new EloquentBuilderTestDynamicScopeStub);
+        $result = $builder->dynamic('bar', 'foo');
+
+        $this->assertEquals($builder, $result);
+    }
+
+    public function testQueryDynamicScopesNamed()
+    {
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('from');
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo', 'foo');
+        $builder->setModel($model = new EloquentBuilderTestDynamicScopeStub);
+        $result = $builder->dynamic(bar: 'foo');
+
+        $this->assertEquals($builder, $result);
+    }
+
     public function testNestedWhere()
     {
         $nestedQuery = m::mock(Builder::class);
@@ -1904,6 +1926,14 @@ class EloquentBuilderTestScopeStub extends Model
     public function scopeApproved($query)
     {
         $query->where('foo', 'bar');
+    }
+}
+
+class EloquentBuilderTestDynamicScopeStub extends Model
+{
+    public function scopeDynamic($query, $foo = 'foo', $bar = 'bar')
+    {
+        $query->where($foo, $bar);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, it is only possible to pass a full set of arguments to a scope. Since PHP 8.0 added support for named arguments, it is nice to have this option on scopes as well.