### PR TITLE
[8.x] Throw if tag is passed but is not supported

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -164,7 +164,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
         if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
             throw new DecryptException('Could not decrypt the data.');
         }
-        
+
         if (! self::$supportedCiphers[strtolower($this->cipher)]['aead'] && is_string($tag)) {
             throw new DecryptException('The tag cannot be used because the cipher algorithm does not support AEAD');
         }

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -159,15 +159,9 @@ class Encrypter implements EncrypterContract, StringEncrypter
 
         $iv = base64_decode($payload['iv']);
 
-        $tag = empty($payload['tag']) ? null : base64_decode($payload['tag']);
-
-        if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
-            throw new DecryptException('Could not decrypt the data.');
-        }
-
-        if (! self::$supportedCiphers[strtolower($this->cipher)]['aead'] && is_string($tag)) {
-            throw new DecryptException('The tag cannot be used because the cipher algorithm does not support AEAD');
-        }
+        $this->ensureTagIsValid(
+            $tag = empty($payload['tag']) ? null : base64_decode($payload['tag'])
+        );
 
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are
@@ -257,6 +251,23 @@ class Encrypter implements EncrypterContract, StringEncrypter
         return hash_equals(
             $this->hash($payload['iv'], $payload['value']), $payload['mac']
         );
+    }
+
+    /**
+     * Ensure the given tag is a valid tag given the selected cipher.
+     *
+     * @param  string  $tag
+     * @return void
+     */
+    protected function ensureTagIsValid($tag)
+    {
+        if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
+            throw new DecryptException('Could not decrypt the data.');
+        }
+
+        if (! self::$supportedCiphers[strtolower($this->cipher)]['aead'] && is_string($tag)) {
+            throw new DecryptException('Unable to use tag because the cipher algorithm does not support AEAD.');
+        }
     }
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -164,6 +164,10 @@ class Encrypter implements EncrypterContract, StringEncrypter
         if (self::$supportedCiphers[strtolower($this->cipher)]['aead'] && strlen($tag) !== 16) {
             throw new DecryptException('Could not decrypt the data.');
         }
+        
+        if (! self::$supportedCiphers[strtolower($this->cipher)]['aead'] && is_string($tag)) {
+            throw new DecryptException('The tag cannot be used because the cipher algorithm does not support AEAD');
+        }
 
         // Here we will decrypt the value. If we are able to successfully decrypt it
         // we will then unserialize it and return it out to the caller. If we are


### PR DESCRIPTION
Original PR for 9.x: #41469 

This allows Laravel to throw a `DecryptException` (which is ignored by bug catching libraries like Sentry) instead of throwing an open_ssl exception of `openssl_decrypt(): The tag cannot be used because the cipher algorithm does not support AEAD` when a tag is passed with a value but AEAD is not supported.

This commonly seems to happen in malicious web scripts that modify the encrypted cookie values to insert exploitable tag values. The way Laravel works `tag` is never exploitable in this way. However it ends up causing a 500 error and additionally if you are using any error reporting engine you end up with thousands of issues a day with `openssl_decrypt(): The tag cannot be used because the cipher algorithm does not support AEAD` tag.

One such example of a compromised cookie:
```
{
iv: OD2GF9/yd3m6Sn6cfC2ZHw==, 
mac: e226b1d78883cde51b27317d4b3a99605c07be1fdc61f303180fad07854dd1f7, 
tag: -1 OR 2+406-406-1=0+0+0+1 -- , 
value: GA8xQCz5RCR2PvcK+HtcBbUYM9zxA62Tcz9M/5F2Eh6BzGrpqkIsNbne5Hw/ETu2mFvFE/Tk8Zmqj6wB45Ldty9CIZgSXtFRsiv/elTQlaB2Hmf9UzuKC9w1y/xwlXrw
}
```

An easy way to exploit this yourself is to go to any Laravel 9 site. Copy out the base64 session cookie, modify the `tag` key to add any value and then re-encode the cookie. As long as the site does not support AEAD it will cause a 500 error.

This simply throws a `DecryptException` if AEAD is not supported and a tag was still sent. Throwing `DecryptException` allows Laravel to function without 500ing and prevents bug catchers from reporting this.
