### PR TITLE
[9.x] Resolve authorizeable's own policy

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -609,9 +609,16 @@ class Gate implements GateContract
      */
     protected function resolveAuthCallback($user, $ability, array $arguments)
     {
-        if (isset($arguments[0]) &&
-            ! is_null($policy = $this->getPolicyFor($arguments[0])) &&
-            $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)) {
+        if (isset($arguments[0])) {
+            $policy = $this->getPolicyFor($arguments[0]);
+        } else {
+            $policy = $this->getPolicyFor($user);
+        }
+
+        if (
+            ! is_null($policy) &&
+            $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)
+        ) {
             return $callback;
         }
 


### PR DESCRIPTION
If no argument was provided to `resolveAuthCallback` it now tries to resolve Authorizeable's own policy before the ability checks.

It means, if you have defined `UserPolicy` with method `viewDashboard`, now you can write `$user->can('viewDashboard')` instead of `$user->can('viewDashboard', User::class)`.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
