### PR TITLE
[9.x] Add ability to mark a class as singleton with interface

### DIFF
--- a/src/Illuminate/Contracts/Container/IsSingleton.php
+++ b/src/Illuminate/Contracts/Container/IsSingleton.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Contracts\Container;
+
+interface IsSingleton
+{
+
+}

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Container;
 use Illuminate\Container\Container;
 use Illuminate\Container\EntryNotFoundException;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\IsSingleton;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use stdClass;
@@ -603,6 +604,16 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
 
+    public function testContainerSharedViaIsSingletonInterface()
+    {
+        $container = new Container;
+
+        $r1 = $container->make(SharedStub::class);
+        $r2 = $container->make(SharedStub::class);
+
+        $this->assertSame($r1, $r2);
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
@@ -720,4 +731,8 @@ class ContainerInjectVariableStubWithInterfaceImplementation implements IContain
     {
         $this->something = $something;
     }
+}
+
+class SharedStub implements IsSingleton {
+    //
 }


### PR DESCRIPTION
> Add ability to mark a class as singleton with interface instead of using service provider and.

## Why?

When we create a lot of services / actions and we are heavily using dependency injection it is better to mark the classes as singleton to speed things up. 

It takes some time to register all actions / services in service provider and the file is getting bigger. This would make marking singleton easy to write and even enables to find which classes are singletons via using IDE and find usages.

## Checklist

- [x] Unit test
- [x] Tested on real app - I have not found any performance issues (no notable difference in ms).
- [ ] Does it math Laravel ecosystem? **I think yes, there is already a lot of "magic" using interfaces**

```
class SharedStub implements IsSingleton {
    //
}
```

Thank you for your time




