### PR TITLE
[9.x] Fix method doctypes of Arr class

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -25,7 +25,7 @@ class Arr
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
      * @param  array  $array
-     * @param  string  $key
+     * @param  string|int|float  $key
      * @param  mixed  $value
      * @return array
      */
@@ -599,7 +599,7 @@ class Arr
      * If no key is given to the method, the entire array will be replaced.
      *
      * @param  array  $array
-     * @param  string|null  $key
+     * @param  string|int|null  $key
      * @param  mixed  $value
      * @return array
      */

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -32,6 +32,8 @@ class SupportArrTest extends TestCase
 
         $this->assertEquals(['surname' => 'Mövsümov'], Arr::add([], 'surname', 'Mövsümov'));
         $this->assertEquals(['developer' => ['name' => 'Ferid']], Arr::add([], 'developer.name', 'Ferid'));
+        $this->assertEquals([1 => 'hAz'], Arr::add([], 1, 'hAz'));
+        $this->assertEquals([1 => [1 => 'hAz']], Arr::add([], 1.1, 'hAz'));
     }
 
     public function testCollapse()
@@ -760,6 +762,9 @@ class SupportArrTest extends TestCase
         $array = ['products' => 'table'];
         Arr::set($array, 'products.desk.price', 300);
         $this->assertSame(['products' => ['desk' => ['price' => 300]]], $array);
+
+        $array = [1 => 'test'];
+        $this->assertEquals([1 => 'hAz'], Arr::set($array, 1, 'hAz'));
     }
 
     public function testShuffleWithSeed()


### PR DESCRIPTION
Arr::add() support int and float too
```
$a = Arr::add([], 1, 'hAz');// result: [1 => 'hAz'] FOR INT 
$a = Arr::add([], 1.1, 'hAz');// result: [1 => [1 => 'hAz']] FOR FLOAT
```
doctype improved. 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
