### PR TITLE
[8.x] Allow for callables with beforeSending

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -989,11 +989,11 @@ class PendingRequest
     public function runBeforeSendingCallbacks($request, array $options)
     {
         return tap($request, function ($request) use ($options) {
-            $this->beforeSendingCallbacks->each->__invoke(
-                (new Request($request))->withData($options['laravel_data']),
-                $options,
-                $this
-            );
+            $this->beforeSendingCallbacks->each(function ($callback) use ($request, $options) {
+                call_user_func(
+                    $callback, (new Request($request))->withData($options['laravel_data']), $options, $this
+                );
+            });
         });
     }
 


### PR DESCRIPTION
This PR allows `beforeSending` to accept any callable, not just invokables. This makes it adhere to its DocBlock type.

See https://github.com/laravel/framework/issues/41486