### PR TITLE
[9.x] Show Closure Location on the `schedule:list`

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -142,7 +142,7 @@ class ScheduleListCommand extends Command
     }
 
     /**
-     * Get the location and line number for the event closure.
+     * Get the file and line number for the event closure.
      *
      * @param  \Illuminate\Console\Scheduling\CallbackEvent  $event
      * @return string

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -142,22 +142,22 @@ class ScheduleListCommand extends Command
     }
 
     /**
-     * Gets the location and line number to the event closure.
+     * Get the location and line number for the event closure.
      *
-     * @param  CallbackEvent  $event
+     * @param  \Illuminate\Console\Scheduling\CallbackEvent  $event
      * @return string
      */
     private function getClosureLocation(CallbackEvent $event)
     {
-        $property = (new ReflectionClass($event))->getProperty('callback');
-        $property->setAccessible(true);
+        $function = new ReflectionFunction(tap((new ReflectionClass($event))->getProperty('callback'))
+                        ->setAccessible(true)
+                        ->getValue($event));
 
-        $callback = $property->getValue($event);
-        $reflection = new ReflectionFunction($callback);
-
-        $path = str_replace(base_path().DIRECTORY_SEPARATOR, '', $reflection->getFileName() ?: '');
-
-        return $path.':'.$reflection->getStartLine();
+        return sprintf(
+            '%s:%s',
+            str_replace(base_path().DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
+            $function->getStartLine()
+        );
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -6,7 +6,6 @@ use Cron\CronExpression;
 use DateTimeZone;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
-use Illuminate\Console\Scheduling\CallbackEvent;
 use Illuminate\Support\Carbon;
 use ReflectionClass;
 use ReflectionFunction;

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -155,7 +155,7 @@ class ScheduleListCommand extends Command
 
         return sprintf(
             '%s:%s',
-            str_replace(base_path().DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
+            str_replace($this->laravel->basePath().DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
             $function->getStartLine()
         );
     }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -23,17 +23,20 @@ class ScheduleListCommandTest extends TestCase
 
     public function testDisplaySchedule()
     {
-        $this->schedule->call(fn () => '')->everyMinute();
         $this->schedule->command(FooCommand::class)->quarterly();
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
 
+        $this->schedule->call(fn () => '')->everyMinute();
+        $closureLineNumber = __LINE__ - 1;
+        $closureFilePath = __FILE__;
+
         $this->artisan(ScheduleListCommand::class)
             ->assertSuccessful()
-            ->expectsOutput('  * *     * *      *  ............................ Next Due: 1 minute from now')
             ->expectsOutput('  0 0     1 1-12/3 *  php artisan foo:command .... Next Due: 3 months from now')
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
-            ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now');
+            ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }
 
     public function testDisplayScheduleInVerboseMode()


### PR DESCRIPTION
A little improvement to the redesign of the `schedule:list` to show the closure location.

## Example:

```php
$schedule->call(fn () => 'Some Closure')->everyMinute();
```

## Before

<img width="1275" alt="Screen Shot 2022-03-15 at 16 19 33" src="https://user-images.githubusercontent.com/823088/158423788-e6bdaff2-3861-4443-97c7-be03c82bd088.png">

## After

<img width="1265" alt="Screen Shot 2022-03-15 at 16 16 44" src="https://user-images.githubusercontent.com/823088/158423449-94834af7-ef23-4234-818a-e6a5e9f7ca57.png">