### PR TITLE
[9.x] Build PaginatedResourceResponse with Container so it can be overridden.

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Resources\Json;
 
 use Countable;
+use Illuminate\Container\Container;
 use Illuminate\Http\Resources\CollectsResources;
 use Illuminate\Pagination\AbstractCursorPaginator;
 use Illuminate\Pagination\AbstractPaginator;
@@ -130,6 +131,6 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
             $this->resource->appends($this->queryParameters);
         }
 
-        return (new PaginatedResourceResponse($this))->toResponse($request);
+        return Container::getInstance()->makeWith(PaginatedResourceResponse::class, ['resource' => $this])->toResponse($request);
     }
 }


### PR DESCRIPTION
Build PaginatedResourceResponse with Container so it can be overridden.

Use the paginationInformation method to override a single PaginatedResourceResponse json return. If you need to override all of them, you need to rewrite them.