### PR TITLE
Bugfix #41302 - Add an explicit reconnect for failed Redis connections

### DIFF
--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -36,8 +36,8 @@ abstract class Connection
      */
     protected $events;
 
-     /**
-     * Indicates if the connection is invalid and needs to reconnect
+    /**
+     * Indicates if the connection is invalid and needs to reconnect.
      *
      * @var bool
      */
@@ -115,6 +115,7 @@ abstract class Connection
      * @param  string  $method
      * @param  array  $parameters
      * @return mixed
+     *
      * @throws \Exception Throws an exception if this connection should not be used
      */
     public function command($method, array $parameters = [])
@@ -126,7 +127,7 @@ abstract class Connection
 
             // Basically - if you see this, this is a bug in whatever is NOT using RedisManager
             // to get Redis objects.
-            throw new \Exception("The Redis connection " . $this->name . " has been marked as failed and needs to be recreated.");
+            throw new \Exception('The Redis connection '.$this->name.' has been marked as failed and needs to be recreated.');
         }
         $start = microtime(true);
 
@@ -136,6 +137,7 @@ abstract class Connection
             // If there is a RedisException, this connection is no longer usable.
             // Mark the connection as shouldReconnect, and return an empty array.
             $this->shouldReconnect = true;
+
             return [];
         }
 

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -135,10 +135,10 @@ abstract class Connection
             $result = $this->client->{$method}(...$parameters);
         } catch (\RedisException $e) {
             // If there is a RedisException, this connection is no longer usable.
-            // Mark the connection as shouldReconnect, and return an empty array.
+            // Mark the connection as shouldReconnect, and re-throw the Exception
             $this->shouldReconnect = true;
 
-            return [];
+            throw $e;
         }
 
         $time = round((microtime(true) - $start) * 1000, 2);

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -177,8 +177,8 @@ class RedisManager implements Factory
         }
 
         return match ($this->driver) {
-            'predis' => new PredisConnector(),
-            'phpredis' => new PhpRedisConnector(),
+            'predis' => new PredisConnector,
+            'phpredis' => new PhpRedisConnector,
             default => null,
         };
     }
@@ -191,7 +191,7 @@ class RedisManager implements Factory
      */
     protected function parseConnectionConfiguration($config)
     {
-        $parsed = (new ConfigurationUrlParser())->parseConfiguration($config);
+        $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
 
         $driver = strtolower($parsed['driver'] ?? '');
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -87,7 +87,7 @@ class RedisManager implements Factory
             // If the connection has had a fatal socket error, the \Redis object
             // in this connection is no longer valid, and needs to be destroyed
             // and recreated.
-            if (!$this->connections[$name]->shouldReconnect) {
+            if (! $this->connections[$name]->shouldReconnect) {
                 return $this->connections[$name];
             }
             // Unset and destroy the Connection object to ensure it's cleaned up.
@@ -117,7 +117,7 @@ class RedisManager implements Factory
         if (isset($this->config[$name])) {
             return $this->connector()->connect(
                 $this->parseConnectionConfiguration($this->config[$name]),
-                array_merge(Arr::except($options, 'parameters'), ['parameters' => Arr::get($options, 'parameters.' . $name, Arr::get($options, 'parameters', []))])
+                array_merge(Arr::except($options, 'parameters'), ['parameters' => Arr::get($options, 'parameters.'.$name, Arr::get($options, 'parameters', []))])
             );
         }
 


### PR DESCRIPTION
When a \Redis connection has a socket/connection error, there's no
reliable way to re-establish the connection. This adds a simple
public 'shouldRestart' bool (based on the existing Queue\Worker
'stopWorkerIfLostConnection' code) to the Redis Connection, which
is checked in RedisManager and recreated if needed there.

Signed-Off-By: Rob Thomas <xrobau@gmail.com>