### PR TITLE
[9.x] Remove trailing full stop from error message

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -91,7 +91,7 @@ class HasInDatabase extends Constraint
             $results = $query->limit($this->show)->get();
 
             if ($results->isEmpty()) {
-                return 'The table is empty.';
+                return 'The table is empty';
             }
 
             $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);


### PR DESCRIPTION
This removes a full stop from the error message as it appears that the full stop is added to the message already, resulting in two full stops:

```
  • Tests\Unit\Jobs\Rooms\RealtimeAlertsTest > it records sent alerts
  Failed asserting that a row in the table [alerts] matches the attributes {
      "user_id": 18,
      "alertable_type": "App\\Models\\Room",
      "alertable_id": 4,
      "broadcast_at": "2022-01-01 00:00:00"
  }.
  
  The table is empty..
```

Similar error messages appear in the other database testing concerns - `NotSoftDeletedInDatabase` and `SoftDeletedInDatabase` and they also omit this trailing full stop.