### PR TITLE
[9.x] Generic doc for make method

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -155,9 +155,10 @@ interface Container extends ContainerInterface
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template T
+     * @param  class-string<T>  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return T
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -156,6 +156,7 @@ interface Container extends ContainerInterface
      * Resolve the given type from the container.
      *
      * @template T
+     *
      * @param  class-string<T>  $abstract
      * @param  array  $parameters
      * @return T


### PR DESCRIPTION
With this update, static analyzer will know the return type of `app()->make(Foo::class)`.

```php
$foo = app()->make(Foo::class);
// Now static analyzer know that $foo is an instance of Foo::class

$foo->...
// Autocomplete will suggest property and method names
```