### PR TITLE
[9.x] Add `mergeNotNull` helper to `Arr` and `Collection`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -452,6 +452,27 @@ class Arr
     }
 
     /**
+     * Merge arrays when the values are not null.
+     *
+     * @param  iterable  ...$arrays
+     * @return array
+     */
+    public static function mergeNotNull(array ...$arrays)
+    {
+        $result = [];
+
+        foreach ($arrays as $array) {
+            foreach ($array as $key => $value) {
+                if (! isset($result[$key]) || ! is_null($value)) {
+                    $result[$key] = $value;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Pluck an array of values from an array.
      *
      * @param  iterable  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -793,6 +793,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Merge arrays when the values are not null.
+     *
+     * @param  iterable  ...$arrays
+     * @return array
+     */
+    public function mergeNotNull(...$arrays)
+    {
+        return new static(Arr::mergeNotNull(
+            $this->items, ...array_map([$this, 'getArrayableItems'], $arrays)
+        ));
+    }
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @template TMergeRecursiveValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -780,6 +780,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Merge arrays when the values are not null.
+     *
+     * @param  iterable  ...$arrays
+     * @return array
+     */
+    public function mergeNotNull(...$arrays)
+    {
+        return $this->passthru('mergeNotNull', func_get_args());
+    }
+
+    /**
      * Recursively merge the collection with the given items.
      *
      * @template TMergeRecursiveValue

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -480,6 +480,25 @@ class SupportArrTest extends TestCase
         $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
     }
 
+    public function testMergeNotNull()
+    {
+        $first = ['a' => null, 'b' => 'b-filled'];
+        $second = ['a' => 'a-filled', 'b' => null];
+        $aOnly = ['a' => 'a-only'];
+        $bNull = ['b' => null];
+
+        $this->assertEquals(['a' => 'a-filled', 'b' => 'b-filled'], Arr::mergeNotNull($first, $second));
+        $this->assertEquals(['a' => 'a-filled', 'b' => 'b-filled'], Arr::mergeNotNull($second, $first));
+        $this->assertEquals(['a' => 'a-only', 'b' => 'b-filled'], Arr::mergeNotNull($first, $aOnly));
+        $this->assertEquals(['a' => 'a-only', 'b' => null], Arr::mergeNotNull($second, $aOnly));
+        $this->assertEquals(['a' => null, 'b' => 'b-filled'], Arr::mergeNotNull($first, $bNull));
+        $this->assertEquals(['a' => 'a-filled', 'b' => null], Arr::mergeNotNull($second, $bNull));
+        $this->assertEquals(['a' => 'a-only', 'b' => 'b-filled'], Arr::mergeNotNull($aOnly, $first));
+        $this->assertEquals(['a' => 'a-filled', 'b' => null], Arr::mergeNotNull($aOnly, $second));
+        $this->assertEquals(['a' => null, 'b' => 'b-filled'], Arr::mergeNotNull($bNull, $first));
+        $this->assertEquals(['a' => 'a-filled', 'b' => null], Arr::mergeNotNull($bNull, $second));
+    }
+
     public function testPluck()
     {
         $data = [

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1275,6 +1275,28 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMergeNotNull($collection)
+    {
+        $first = ['a' => null, 'b' => 'b-filled'];
+        $second = ['a' => 'a-filled', 'b' => null];
+        $aOnly = ['a' => 'a-only'];
+        $bNull = ['b' => null];
+
+        $this->assertEquals(['a' => 'a-filled', 'b' => 'b-filled'], (new $collection($first))->mergeNotNull($second)->all());
+        $this->assertEquals(['a' => 'a-filled', 'b' => 'b-filled'], (new $collection($second))->mergeNotNull($first)->all());
+        $this->assertEquals(['a' => 'a-only', 'b' => 'b-filled'], (new $collection($first))->mergeNotNull($aOnly)->all());
+        $this->assertEquals(['a' => 'a-only', 'b' => null], (new $collection($second))->mergeNotNull($aOnly)->all());
+        $this->assertEquals(['a' => null, 'b' => 'b-filled'], (new $collection($first))->mergeNotNull($bNull)->all());
+        $this->assertEquals(['a' => 'a-filled', 'b' => null], (new $collection($second))->mergeNotNull($bNull)->all());
+        $this->assertEquals(['a' => 'a-only', 'b' => 'b-filled'], (new $collection($aOnly))->mergeNotNull($first)->all());
+        $this->assertEquals(['a' => 'a-filled', 'b' => null], (new $collection($aOnly))->mergeNotNull($second)->all());
+        $this->assertEquals(['a' => null, 'b' => 'b-filled'], (new $collection($bNull))->mergeNotNull($first)->all());
+        $this->assertEquals(['a' => 'a-filled', 'b' => null], (new $collection($bNull))->mergeNotNull($second)->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testReplaceNull($collection)
     {
         $c = new $collection(['a', 'b', 'c']);


### PR DESCRIPTION
Add `mergeNotNull` for doing `array_merge` but overwriting only when the value is not null.