### PR TITLE
[9.x] Add `mergeUnshift` helper to `Collection`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -806,6 +806,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Merge the given items with the collection.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static
+     */
+    public function mergeUnshift($items)
+    {
+        return new static(array_merge($this->getArrayableItems($items), $this->items));
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @template TCombineValue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -793,6 +793,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Merge the given items with the collection.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>  $items
+     * @return static
+     */
+    public function mergeUnshift($items)
+    {
+        return $this->passthru('mergeUnshift', func_get_args());
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @template TCombineValue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1275,6 +1275,21 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMergeUnshift($collection)
+    {
+        $c = new $collection(['name' => 'Hello']);
+        $this->assertEquals(['name' => 'Hello'], $c->mergeUnshift(null)->all());
+
+        $c = new $collection(['name' => 'Hello']);
+        $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->mergeUnshift(['id' => 1])->all());
+
+        $c = new $collection(['name' => 'Hello']);
+        $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->mergeUnshift(new $collection(['name' => 'World', 'id' => 1]))->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testReplaceNull($collection)
     {
         $c = new $collection(['a', 'b', 'c']);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -600,6 +600,9 @@ assertType('Illuminate\Support\Collection<int, string>', $collection->make(['str
 assertType('Illuminate\Support\Collection<int, int|string>', $collection->make([1])->mergeRecursive([2 => 'string']));
 assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->mergeRecursive(['string']));
 
+assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->mergeUnshift([2]));
+assertType('Illuminate\Support\Collection<int, string>', $collection->make(['string'])->mergeUnshift(['string']));
+
 assertType('Illuminate\Support\Collection<string, int>', $collection->make(['string' => 'string'])->combine([2]));
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->combine([1]));
 

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -496,6 +496,9 @@ assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make([
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->mergeRecursive([2]));
 assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make(['string'])->mergeRecursive(['string']));
 
+assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->mergeUnshift([2]));
+assertType('Illuminate\Support\LazyCollection<int, string>', $collection->make(['string'])->mergeUnshift(['string']));
+
 assertType('Illuminate\Support\LazyCollection<string, int>', $collection->make(['string' => 'string'])->combine([2]));
 assertType('Illuminate\Support\LazyCollection<int, int>', $collection->make([1])->combine([1]));
 


### PR DESCRIPTION
Add `mergeUnshift` to merge existing collection to passed parameter, as opposite to `merge`. Currently there's `prepend` that prepend only a single value.