### PR TITLE
[9.x] improve doctype of forget/except method of Arr class

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -142,7 +142,7 @@ class Arr
      * Get all of the given array except for a specified array of keys.
      *
      * @param  array  $array
-     * @param  array|string  $keys
+     * @param  array|string|int|float  $keys
      * @return array
      */
     public static function except($array, $keys)
@@ -256,7 +256,7 @@ class Arr
      * Remove one or many array items from a given array using "dot" notation.
      *
      * @param  array  $array
-     * @param  array|string  $keys
+     * @param  array|string|int|float  $keys
      * @return void
      */
     public static function forget(&$array, $keys)

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -149,6 +149,10 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['name' => 'taylor'], Arr::except($array, 'framework'));
         $this->assertEquals(['name' => 'taylor', 'framework' => ['name' => 'Laravel']], Arr::except($array, 'framework.language'));
         $this->assertEquals(['framework' => ['language' => 'PHP']], Arr::except($array, ['name', 'framework.name']));
+
+        $array = [1 => 'hAz', 2 => [5 => 'foo', 12 => 'baz']];
+        $this->assertEquals([1 => 'hAz'], Arr::except($array, 2));
+        $this->assertEquals([1 => 'hAz', 2 => [12 => 'baz']], Arr::except($array, 2.5));
     }
 
     public function testExists()
@@ -947,6 +951,14 @@ class SupportArrTest extends TestCase
         $array = ['emails' => ['joe@example.com' => ['name' => 'Joe'], 'jane@localhost' => ['name' => 'Jane']]];
         Arr::forget($array, ['emails.joe@example.com', 'emails.jane@localhost']);
         $this->assertEquals(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
+
+        $array = ['name' => 'hAz', '1' => 'test', 2 => 'bAz'];
+        Arr::forget($array, 1);
+        $this->assertEquals(['name' => 'hAz', 2 => 'bAz'], $array);
+
+        $array = [2 => [1 =>'products', 3 => 'users']];
+        Arr::forget($array, 2.3);
+        $this->assertEquals([2 => [1 =>'products']], $array);
     }
 
     public function testWrap()


### PR DESCRIPTION
fix doctype of Arr::forget AND Arr::except

Arr::forget
```
$array = ['name' => 'hAz', '1' => 'test', 2 => 'bAz'];
Arr::forget($array, 1);
//result:  ['name' => 'hAz', 2 => 'bAz']

$array = [2 => [1 =>'products', 3 => 'users']];
Arr::forget($array, 2.3);
//result: [2 => [1 =>'products']]
```
Arr::except
```
$array = [1 => 'hAz', 2 => [5 => 'foo', 12 => 'baz']];
Arr::except($array, 2);
 //result: [1 => 'hAz']

Arr::except($array, 2.5);
// result: [1 => 'hAz', 2 => [12 => 'baz']]
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
