### PR TITLE
[9.x] handle toMailUsing and createUrlUsing for ResetPassword the same as in VerifyEmail

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,11 +59,13 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
+        $passwordResetUrl = $this->resetUrl($notifiable);
+
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+            return call_user_func(static::$toMailCallback, $notifiable, $passwordResetUrl);
         }
 
-        return $this->buildMailMessage($this->resetUrl($notifiable));
+        return $this->buildMailMessage($passwordResetUrl);
     }
 
     /**

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -98,11 +98,11 @@ class ForgotPasswordTest extends TestCase
     {
         Notification::fake();
 
-        ResetPassword::toMailUsing(function ($notifiable, $token) {
+        ResetPassword::toMailUsing(function ($notifiable, $url) {
             return (new MailMessage)
                 ->subject(__('Reset Password Notification'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
-                ->action(__('Reset Password'), route('custom.password.reset', $token))
+                ->action(__('Reset Password'), $url)
                 ->line(__('If you did not request a password reset, no further action is required.'));
         });
 
@@ -120,7 +120,7 @@ class ForgotPasswordTest extends TestCase
                 $message = $notification->toMail($user);
 
                 return ! is_null($notification->token)
-                    && $message->actionUrl === route('custom.password.reset', ['token' => $notification->token]);
+                    && $message->actionUrl === route('password.reset', ['token' => $notification->token, 'email' => $user->email]);
             }
         );
     }

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Password;
 use Illuminate\Tests\Integration\Auth\Fixtures\AuthenticationTestUser;
 use Orchestra\Testbench\Factories\UserFactory;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
 {
@@ -40,7 +41,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
     /** @test */
     public function it_cannot_send_forgot_password_email()
     {
-        $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
+        $this->expectException(RouteNotFoundException::class);
         $this->expectExceptionMessage('Route [password.reset] not defined.');
 
         Notification::fake();
@@ -95,7 +96,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
     /** @test */
     public function it_cannot_send_forgot_password_email_via_to_mail_using_without_default_route()
     {
-        $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
+        $this->expectException(RouteNotFoundException::class);
         $this->expectExceptionMessage('Route [password.reset] not defined.');
 
         Notification::fake();

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -93,15 +93,18 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
     }
 
     /** @test */
-    public function it_can_send_forgot_password_email_via_to_mail_using()
+    public function it_cannot_send_forgot_password_email_via_to_mail_using_without_default_route()
     {
+        $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
+        $this->expectExceptionMessage('Route [password.reset] not defined.');
+
         Notification::fake();
 
-        ResetPassword::toMailUsing(function ($notifiable, $token) {
+        ResetPassword::toMailUsing(function ($notifiable, $url) {
             return (new MailMessage)
                 ->subject(__('Reset Password Notification'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
-                ->action(__('Reset Password'), route('custom.password.reset', $token))
+                ->action(__('Reset Password'), $url)
                 ->line(__('If you did not request a password reset, no further action is required.'));
         });
 
@@ -119,7 +122,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
                 $message = $notification->toMail($user);
 
                 return ! is_null($notification->token)
-                    && $message->actionUrl === route('custom.password.reset', ['token' => $notification->token]);
+                    && $message->actionUrl === route('password.reset', ['token' => $notification->token, 'email' => $user->email]);
             }
         );
     }


### PR DESCRIPTION
I noticed that **createUrlUsing** callback for the **ResetPassword** notification was not called anymore, when also using the **toMailUsing** callback. 

As it did work for the **VerifyEmail** notification i expected the same behaviour.

This would be a breaking change i guess, when people expect the token as the second parameter in the toMailUsing callback.

