### PR TITLE
[9.x] Make throttle lock acquisition retry time configurable

### DIFF
--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -70,12 +70,12 @@ class DurationLimiter
      *
      * @param  int  $timeout
      * @param  callable|null  $callback
-     * @param int $sleepDuration The wait time in milliseconds between lock acquisition attempts
+     * @param  int  $sleep
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
      */
-    public function block($timeout, $callback = null, $sleepDuration = 750)
+    public function block($timeout, $callback = null, $sleep = 750)
     {
         $starting = time();
 
@@ -84,7 +84,7 @@ class DurationLimiter
                 throw new LimiterTimeoutException;
             }
 
-            usleep($sleepDuration * 1000);
+            usleep($sleep * 1000);
         }
 
         if (is_callable($callback)) {

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -70,11 +70,12 @@ class DurationLimiter
      *
      * @param  int  $timeout
      * @param  callable|null  $callback
+     * @param int $sleepDuration The wait time in milliseconds between lock acquisition attempts
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
      */
-    public function block($timeout, $callback = null)
+    public function block($timeout, $callback = null, $sleepDuration = 750)
     {
         $starting = time();
 
@@ -83,7 +84,7 @@ class DurationLimiter
                 throw new LimiterTimeoutException;
             }
 
-            usleep(750 * 1000);
+            usleep($sleepDuration * 1000);
         }
 
         if (is_callable($callback)) {

--- a/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
@@ -45,6 +45,13 @@ class DurationLimiterBuilder
     public $timeout = 3;
 
     /**
+     * The time in milliseconds to wait between attempts to acquire the lock
+     *
+     * @var int
+     */
+    public $retryWaitMs = 750;
+
+    /**
      * Create a new builder instance.
      *
      * @param  \Illuminate\Redis\Connections\Connection  $connection
@@ -97,6 +104,19 @@ class DurationLimiterBuilder
     }
 
     /**
+     * Set the wait time in milliseconds between lock acquisition retries
+     *
+     * @param float $retryWaitMs
+     * @return $this
+     */
+    public function retryWait(float $retryWaitMs)
+    {
+        $this->retryWaitMs = $retryWaitMs;
+
+        return $this;
+    }
+
+    /**
      * Execute the given callback if a lock is obtained, otherwise call the failure callback.
      *
      * @param  callable  $callback
@@ -110,7 +130,7 @@ class DurationLimiterBuilder
         try {
             return (new DurationLimiter(
                 $this->connection, $this->name, $this->maxLocks, $this->decay
-            ))->block($this->timeout, $callback);
+            ))->block($this->timeout, $callback, $this->retryWaitMs);
         } catch (LimiterTimeoutException $e) {
             if ($failure) {
                 return $failure($e);

--- a/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
@@ -45,11 +45,11 @@ class DurationLimiterBuilder
     public $timeout = 3;
 
     /**
-     * The time in milliseconds to wait between attempts to acquire the lock
+     * The number of milliseconds to wait between attempts to acquire the lock.
      *
      * @var int
      */
-    public $retryWaitMs = 750;
+    public $sleep = 750;
 
     /**
      * Create a new builder instance.
@@ -104,14 +104,14 @@ class DurationLimiterBuilder
     }
 
     /**
-     * Set the wait time in milliseconds between lock acquisition retries
+     * The number of milliseconds to wait between lock acquisition attempts.
      *
-     * @param float $retryWaitMs
+     * @param  int  $sleep
      * @return $this
      */
-    public function retryWait(float $retryWaitMs)
+    public function sleep($sleep)
     {
-        $this->retryWaitMs = $retryWaitMs;
+        $this->sleep = $sleep;
 
         return $this;
     }
@@ -130,7 +130,7 @@ class DurationLimiterBuilder
         try {
             return (new DurationLimiter(
                 $this->connection, $this->name, $this->maxLocks, $this->decay
-            ))->block($this->timeout, $callback, $this->retryWaitMs);
+            ))->block($this->timeout, $callback, $this->sleep);
         } catch (LimiterTimeoutException $e) {
             if ($failure) {
                 return $failure($e);


### PR DESCRIPTION
Depending on context, 750ms can be a long time to wait between retries
for a throttle.  We are making the retry time configurable so that users
can tune the throttling further.

All changes are backwards compatible.

I set the unit as milliseconds because this seemed like the natural time
unit to use.  Seconds would require floats which felt dirty.  That being
said, it's not consistent with the unit used for `->every` and `->block`
on the builder.  So I'm open to changing it for consistency.

I was additionally unsure what useful tests could be written for this
configuration.  Mocking the `usleep` function felt silly. Any suggestions 
are welcome.

```php
Redis::throttle('my-key')
    ->allow(5)
    ->every(10)
    ->retryWait(100)
    ->then(static fn () => echo "hello!");
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
