### PR TITLE
[9.x] Added `whenTableHasColumn` and `whenTableDoesntHaveColumn` on Schema Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -171,6 +171,36 @@ class Builder
     }
 
     /**
+     * Execute a callback inside table builder if has a column
+     *
+     * @param  string  $table
+     * @param  string  $column
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function whenTableHasColumn(string $table, string $column, Closure $callback): void
+    {
+        if ($this->hasColumn($table, $column)) {
+            $this->table($table, fn (Blueprint $table) => $callback($table));
+        }
+    }
+
+    /**
+     * Execute a callback inside table builder if does't have a column
+     *
+     * @param  string  $table
+     * @param  string  $column
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function whenTableHasNotColumn(string $table, string $column, Closure $callback): void
+    {
+        if (! $this->hasColumn($table, $column)) {
+            $this->table($table, fn (Blueprint $table) => $callback($table));
+        }
+    }
+
+    /**
      * Get the data type for the given column name.
      *
      * @param  string  $table

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -15,6 +15,8 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
  * @method static bool dropColumns(string $table, array $columns)
+ * @method static void whenTableHasColumn(string $table, string $column, \Closure $callback)
+ * @method static void whenTableNotHasColumn(string $table, string $column, \Closure $callback)
  * @method static bool hasTable(string $table)
  * @method static void defaultStringLength(int $length)
  * @method static array getColumnListing(string $table)


### PR DESCRIPTION
On some systems, database schema is updated from multiple sources. This functions simplify the table columns update on migrations.


* Before:

```php
<?php declare(strict_types=1);

use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;
use Illuminate\Database\Migrations\Migration;

return new class extends Migration
{
    /**
     * @return void
     */
    public function up(): void
    {
        if (!Schema::hasColumn('product', 'order')) {
            Schema::table('product', function (Blueprint $table) {
                $table->unsignedInteger('order')->default(0);
            });
        }

        if (!Schema::hasColumn('product_attribute', 'order')) {
            Schema::table('product_attribute', function (Blueprint $table) {
                $table->unsignedInteger('order')->default(0);
            });
        }
    }

    /**
     * @return void
     */
    public function down(): void
    {
        if (Schema::hasColumn('product', 'order')) {
            Schema::table('product', function (Blueprint $table) {
                $table->dropColumn('order');
            });
        }

        if (Schema::hasColumn('product_attribute', 'order')) {
            Schema::table('product_attribute', function (Blueprint $table) {
                $table->dropColumn('order');
            });
        }
    }
};
```

* After


```php
<?php declare(strict_types=1);

use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;
use Illuminate\Database\Migrations\Migration;

return new class extends Migration
{
    /**
     * @return void
     */
    public function up(): void
    {
        Schema::whenTableDoesntHaveColumn('product', 'order', function (Blueprint $table) {
            $table->unsignedInteger('order')->default(0);
        });

        Schema::whenTableDoesntHaveColumn('product_attribute', 'order', function (Blueprint $table) {
            $table->unsignedInteger('order')->default(0);
        });
    }

    /**
     * @return void
     */
    public function down(): void
    {
        Schema::whenTableHasColumn('product', 'order', function (Blueprint $table) {
            $table->dropColumn('order');
        });

        Schema::whenTableHasColumn('product_attribute', 'order', function (Blueprint $table) {
            $table->dropColumn('order');
        });
    }
};
```