### PR TITLE
[9.x] Add Arr::pad

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -504,6 +504,19 @@ class Arr
     }
 
     /**
+     * Pad an array to the specified length with a value.
+     *
+     * @param  array  $array
+     * @param  int  $length
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function pad($array, $length, $value)
+    {
+        return array_pad($array, $length, $value);
+    }
+
+    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -492,7 +492,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([0, 0, 0], Arr::pad([], 3, 0));
         $this->assertEquals([0, 0, 0], Arr::pad([], 3, 0));
         $this->assertEquals([1, 0, 0], Arr::pad([1], 3, 0));
-        $this->assertEquals([0, 0, 1,], Arr::pad([1], -3, 0));
+        $this->assertEquals([0, 0, 1], Arr::pad([1], -3, 0));
     }
 
     public function testPluck()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -484,6 +484,17 @@ class SupportArrTest extends TestCase
         $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
     }
 
+    public function testPad()
+    {
+        $this->assertEquals([], Arr::pad([], 0, 0));
+        $this->assertEquals([1], Arr::pad([1], 0, 0));
+        $this->assertEquals([0, 0, 0], Arr::pad([], 3, 0));
+        $this->assertEquals([0, 0, 0], Arr::pad([], 3, 0));
+        $this->assertEquals([0, 0, 0], Arr::pad([], 3, 0));
+        $this->assertEquals([1, 0, 0], Arr::pad([1], 3, 0));
+        $this->assertEquals([0, 0, 1,], Arr::pad([1], -3, 0));
+    }
+
     public function testPluck()
     {
         $data = [


### PR DESCRIPTION
Added missing pad method to Arr class.

```php
Arr::pad([1], 3, 0);     // [1, 0, 0]
Arr::pad([1], -3, 0);    // [0, 0, 1]
Arr::pad([], 3, 0);      // [0, 0, 0]
Arr::pad([1], 0, 0);     // [1]
```

Use case example:
```php
$string = 'A-1';
[$char, $int] = Arr::pad(explode('-', $array), 2, null); // fix a possible exception if string is "A" or "B-"
```