### PR TITLE
[9.x] returned template in container make()

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -157,7 +157,7 @@ interface Container extends ContainerInterface
      *
      * @template T
      *
-     * @param  class-string<T> $abstract
+     * @param  class-string<T>  $abstract
      * @param  array  $parameters
      * @return T
      *

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -155,9 +155,11 @@ interface Container extends ContainerInterface
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template T
+     *
+     * @param  class-string<T> $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return T
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */


### PR DESCRIPTION
This is a little change, but I think it could be very helpful for many developers.

After adding a template to phpdocs of Container contract we'd be able to get all hints about resolved class:

![obraz](https://user-images.githubusercontent.com/10898728/158775561-f6375a67-f325-44b4-894a-f95716bf676d.png)
