### PR TITLE
[9.x] Exactly match scheduled command --name in schedule:test

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 
@@ -51,7 +52,11 @@ class ScheduleTestCommand extends Command
         }
 
         if (! empty($name = $this->option('name'))) {
-            $matches = array_filter($commandNames, fn ($commandName) => Str::endsWith($commandName, $name));
+            $commandBinary = Application::phpBinary().' '.Application::artisanBinary();
+
+            $matches = array_filter($commandNames, function ($commandName) use ($commandBinary, $name) {
+                 return trim(Str::replace($commandBinary, '', $commandName)) === $name;
+            });
 
             if (count($matches) !== 1) {
                 return $this->error('No matching scheduled command found.');

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
-use Illuminate\Support\Str;
 
 class ScheduleTestCommand extends Command
 {
@@ -55,7 +54,7 @@ class ScheduleTestCommand extends Command
             $commandBinary = Application::phpBinary().' '.Application::artisanBinary();
 
             $matches = array_filter($commandNames, function ($commandName) use ($commandBinary, $name) {
-                return trim(Str::replace($commandBinary, '', $commandName)) === $name;
+                return trim(str_replace($commandBinary, '', $commandName)) === $name;
             });
 
             if (count($matches) !== 1) {

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -55,7 +55,7 @@ class ScheduleTestCommand extends Command
             $commandBinary = Application::phpBinary().' '.Application::artisanBinary();
 
             $matches = array_filter($commandNames, function ($commandName) use ($commandBinary, $name) {
-                 return trim(Str::replace($commandBinary, '', $commandName)) === $name;
+                return trim(Str::replace($commandBinary, '', $commandName)) === $name;
             });
 
             if (count($matches) !== 1) {


### PR DESCRIPTION
I've stripped the PHP and Artisan binary paths off of the command names here. This means instead of looking at the end of the string, which could accidentally match the wrong command, an exact match can be done.