### PR TITLE
[10.x] Change `ResetPassword::resetUrl()` visibility to `public static`

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -63,7 +63,7 @@ class ResetPassword extends Notification
             return call_user_func(static::$toMailCallback, $notifiable, $this->token);
         }
 
-        return $this->buildMailMessage($this->resetUrl($notifiable));
+        return $this->buildMailMessage(static::resetUrl($notifiable, $this->token));
     }
 
     /**
@@ -86,16 +86,17 @@ class ResetPassword extends Notification
      * Get the reset URL for the given notifiable.
      *
      * @param  mixed  $notifiable
+     * @param  string  $token
      * @return string
      */
-    protected function resetUrl($notifiable)
+    public static function resetUrl($notifiable, $token)
     {
         if (static::$createUrlCallback) {
-            return call_user_func(static::$createUrlCallback, $notifiable, $this->token);
+            return call_user_func(static::$createUrlCallback, $notifiable, $token);
         }
 
         return url(route('password.reset', [
-            'token' => $this->token,
+            'token' => $token,
             'email' => $notifiable->getEmailForPasswordReset(),
         ], false));
     }


### PR DESCRIPTION
This provide solution for project using `ResetPassword::toMailUsing()` and `ResetPassword::createMailUsing()`.

For example:

```php
ResetPassword::createUrlUsing(function ($user, string $token) {
    return route('custom.password.reset', $token);
});

ResetPassword::toMailUsing(function ($notifiable, $token) {
    return (new MailMessage)
        ->subject(__('Reset Password Notification'))
        ->line(__('You are receiving this email because we received a password reset request for your account.'))
        ->action(__('Reset Password'), ResetPassword::resetUrl($notifiable, $token))
        ->line(__('If you did not request a password reset, no further action is required.'));
}); 
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>