### PR TITLE
[9.x] imrove doctype methods(join/implode) of Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -578,7 +578,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Concatenate values of a given key as a string.
      *
      * @param  callable|string  $value
-     * @param  string|null  $glue
+     * @param  string|null|int|float  $glue
      * @return string
      */
     public function implode($value, $glue = null)
@@ -643,8 +643,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
-     * @param  string  $glue
-     * @param  string  $finalGlue
+     * @param  string|int|float  $glue
+     * @param  string|int|float  $finalGlue
      * @return string
      */
     public function join($glue, $finalGlue = '')

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1715,6 +1715,10 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('a', (new $collection(['a']))->join(', ', ' and '));
 
         $this->assertSame('', (new $collection([]))->join(', ', ' and '));
+
+        $this->assertSame('a1b1c2d', (new $collection(['a', 'b', 'c', 'd']))->join(1, 2));
+
+        $this->assertSame('a3.4b3.4c2.9d', (new $collection(['a', 'b', 'c', 'd']))->join(3.4, 2.9));
     }
 
     /**
@@ -2156,6 +2160,10 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertSame('taylor-foodayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email']));
         $this->assertSame('taylor-foo,dayle-bar', $data->implode(fn ($user) => $user['name'].'-'.$user['email'], ','));
+
+        $data = new $collection(['taylor', 'dayle']);
+        $this->assertSame('taylor8dayle', $data->implode(8));
+        $this->assertSame('taylor2.3dayle', $data->implode(2.3));
     }
 
     /**


### PR DESCRIPTION
Fix doctype of join | implode method of collection 


implode:
```
$data = new $collection(['taylor', 'dayle']);
$data->implode(8);// Result 'taylor8dayle'
$data->implode(2.3); // Result: 'taylor2.3dayle'
```


join:

```
(new $collection(['a', 'b', 'c', 'd']))->join(1, 2));//Result: 'a1b1c2d'
(new $collection(['a', 'b', 'c', 'd']))->join(3.4, 2.9));//Result: 'a3.4b3.4c2.9d'
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
