### PR TITLE
[9.x] Use arrow function in ConnectionFactory

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -177,7 +177,7 @@ class ConnectionFactory
     protected function createPdoResolverWithHosts(array $config)
     {
         return function () use ($config) {
-            foreach (Arr::shuffle($hosts = $this->parseHosts($config)) as $key => $host) {
+            foreach (Arr::shuffle($this->parseHosts($config)) as $host) {
                 $config['host'] = $host;
 
                 try {
@@ -218,9 +218,7 @@ class ConnectionFactory
      */
     protected function createPdoResolverWithoutHosts(array $config)
     {
-        return function () use ($config) {
-            return $this->createConnector($config)->connect($config);
-        };
+        return fn () => $this->createConnector($config)->connect($config);
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -44,10 +44,9 @@ class DatabaseTransactionsManager
      */
     public function rollback($connection, $level)
     {
-        $this->transactions = $this->transactions->reject(function ($transaction) use ($connection, $level) {
-            return $transaction->connection == $connection &&
-                   $transaction->level > $level;
-        })->values();
+        $this->transactions = $this->transactions->reject(
+            fn ($transaction) => $transaction->connection == $connection && $transaction->level > $level
+        )->values();
     }
 
     /**
@@ -59,9 +58,7 @@ class DatabaseTransactionsManager
     public function commit($connection)
     {
         [$forThisConnection, $forOtherConnections] = $this->transactions->partition(
-            function ($transaction) use ($connection) {
-                return $transaction->connection == $connection;
-            }
+            fn ($transaction) => $transaction->connection == $connection
         );
 
         $this->transactions = $forOtherConnections->values();


### PR DESCRIPTION
Uses php7.4 arrow function in ConnectionFactory.

It also removes two extra variables (Discovered by IDE)
![image](https://user-images.githubusercontent.com/6961695/158799225-e3f099b4-660b-41db-b0a5-3fa582bf459b.png)
