### PR TITLE
[9.x] Fix artisan make:seeder command nested namespace and class name problem

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console\Seeds;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
 
 class SeederMakeCommand extends GeneratorCommand
 {
@@ -77,21 +78,24 @@ class SeederMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
+        $name = Str::replaceFirst($this->rootNamespace(), '', $name);
+        $name = str_replace('\\', '/', $name);
+
         if (is_dir($this->laravel->databasePath().'/seeds')) {
             return $this->laravel->databasePath().'/seeds/'.$name.'.php';
-        } else {
-            return $this->laravel->databasePath().'/seeders/'.$name.'.php';
         }
+
+        return $this->laravel->databasePath().'/seeders/'.$name.'.php';
     }
 
     /**
-     * Parse the class name and format according to the root namespace.
+     * Get the root namespace for the class.
      *
-     * @param  string  $name
      * @return string
      */
-    protected function qualifyClass($name)
+    protected function rootNamespace()
     {
-        return $name;
+        return 'Database\Seeders\\';
     }
+
 }

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -78,8 +78,7 @@ class SeederMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        $name = Str::replaceFirst($this->rootNamespace(), '', $name);
-        $name = str_replace('\\', '/', $name);
+        $name = str_replace('\\', '/', Str::replaceFirst($this->rootNamespace(), '', $name));
 
         if (is_dir($this->laravel->databasePath().'/seeds')) {
             return $this->laravel->databasePath().'/seeds/'.$name.'.php';

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -97,5 +97,4 @@ class SeederMakeCommand extends GeneratorCommand
     {
         return 'Database\Seeders\\';
     }
-
 }

--- a/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
+++ b/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace Database\Seeders;
+namespace {{ namespace }};
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;


### PR DESCRIPTION
Personally I used to structure my seeders for different parts like Auth part (for rules, permissions and users) and etc ...
but when I use 
```php
php artisan make:seeder Auth/Permissions/SomePermissionSeeder
```

The result is like this:
```php
<?php

namespace Database\Seeders;

use Illuminate\Database\Console\Seeds\WithoutModelEvents;
use Illuminate\Database\Seeder;

class Auth/Permissions/SomePermissionSeeder extends Seeder
{
    /**
     * Run the database seeds.
     *
     * @return void
     */
    public function run()
    {
        //
    }
}
```

and as you can see the namespace and class name are not correct.
after the change the result will be like this:
```php
<?php

namespace Database\Seeders\Auth\Permissions;

use Illuminate\Database\Console\Seeds\WithoutModelEvents;
use Illuminate\Database\Seeder;

class SomePermissionSeeder extends Seeder
{
    /**
     * Run the database seeds.
     *
     * @return void
     */
    public function run()
    {
        //
    }
}
```
I have changed the make:seeder command class and you can see it.
And then we can structure our seeders with artisan console command with **right** **namespace** and **class name**.