### PR TITLE
[9.x] Show `Job` class instead of closure on `schedule:list`

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -52,6 +52,7 @@ class ScheduleListCommand extends Command
             $expression = $this->formatCronExpression($event->expression, $expressionSpacing);
 
             $command = $event->command;
+            $description = $event->description;
 
             if (! $this->output->isVerbose()) {
                 $command = str_replace(
@@ -62,7 +63,12 @@ class ScheduleListCommand extends Command
             }
 
             if ($event instanceof CallbackEvent) {
-                $command = 'Closure at: '.$this->getClosureLocation($event);
+                if (class_exists($event->description)) {
+                    $command = $event->description;
+                    $description = '';
+                } else {
+                    $command = 'Closure at: '.$this->getClosureLocation($event);
+                }
             }
 
             $command = mb_strlen($command) > 1 ? "{$command} " : '';
@@ -95,11 +101,11 @@ class ScheduleListCommand extends Command
                 $hasMutex,
                 $nextDueDateLabel,
                 $nextDueDate
-            ), $this->output->isVerbose() && mb_strlen($event->description) > 1 ? sprintf(
+            ), $this->output->isVerbose() && mb_strlen($description) > 1 ? sprintf(
                 '  <fg=#6C7280>%s%s %s</>',
                 str_repeat(' ', mb_strlen($expression) + 2),
                 '⇁',
-                $event->description
+                $description
             ) : ''];
         });
 

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -26,6 +26,7 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command(FooCommand::class)->quarterly();
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
+        $this->schedule->job(FooJob::class)->everyMinute();
 
         $this->schedule->call(fn () => '')->everyMinute();
         $closureLineNumber = __LINE__ - 1;
@@ -36,6 +37,7 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  0 0     1 1-12/3 *  php artisan foo:command .... Next Due: 3 months from now')
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }
 
@@ -64,4 +66,8 @@ class FooCommand extends Command
     protected $signature = 'foo:command';
 
     protected $description = 'This is the description of the command.';
+}
+
+class FooJob
+{
 }


### PR DESCRIPTION
This PR adds missing feature reported by @flightsupport on https://github.com/laravel/framework/pull/41445#issuecomment-1068444354.

# Before:

<img width="1618" alt="Screen Shot 2022-03-17 at 16 16 50" src="https://user-images.githubusercontent.com/823088/158845409-570033ad-af39-459b-93b6-783175c42772.png">

# After:

<img width="1121" alt="Screen Shot 2022-03-17 at 16 16 24" src="https://user-images.githubusercontent.com/823088/158845481-c273bf25-282f-4b4c-a1c8-16ab27a392b9.png">
