### PR TITLE
[9.x] Add tests for Pluralizer::inflector() method to verify object

### DIFF
--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -4,6 +4,8 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
+use Doctrine\Inflector\Inflector;
+use Illuminate\Support\Pluralizer;
 
 class SupportPluralizerTest extends TestCase
 {
@@ -111,6 +113,16 @@ class SupportPluralizerTest extends TestCase
         $this->assertPluralStudly('SomeUsers', 'SomeUser', collect());
         $this->assertPluralStudly('SomeUser', 'SomeUser', collect(['one']));
         $this->assertPluralStudly('SomeUsers', 'SomeUser', collect(['one', 'two']));
+    }
+
+    public function testInflectorObjectIsCreatedProperly()
+    {
+        $firstObject = Pluralizer::inflector();
+        $this->assertInstanceOf(Inflector::class, $firstObject);
+
+        $secondObject = Pluralizer::inflector();
+
+        $this->assertTrue($firstObject === $secondObject);
     }
 
     private function assertPluralStudly($expected, $value, $count = 2)


### PR DESCRIPTION
There was no test to identify the `Inflector` object.
This object should be created one time (kind of singleton) and it should be an instance of the `\Doctrine\Inflector\Inflector::class` class.

The first and second event n created object should be equal to the first object and it should not create an object per each method call.