### PR TITLE
[9.x] Add tests for addIf() method on MessageBag

### DIFF
--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -115,6 +115,17 @@ class SupportMessageBagTest extends TestCase
         $this->assertFalse($container->has('bar'));
     }
 
+    public function testAddIf()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->addIf(true, 'foo', 'bar');
+        $this->assertTrue($container->has('foo'));
+
+        $container->addIf(false, 'bar', 'biz');
+        $this->assertFalse($container->has('bar'));
+    }
+
     public function testHasWithKeyNull()
     {
         $container = new MessageBag;


### PR DESCRIPTION
The addIf() method on MessageBag class didn't have any test to identify the functionality.