### PR TITLE
[9.x] Fix make:factory command to work with nested namespaces and fix guessModelName to work with new stucutre

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -59,7 +59,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__ . $stub;
+            : __DIR__.$stub;
     }
 
     /**
@@ -75,8 +75,6 @@ class FactoryMakeCommand extends GeneratorCommand
         $namespaceModel = $this->option('model')
             ? $this->qualifyModel($this->option('model'))
             : $this->guessModelName($name);
-
-
 
         $model = class_basename($namespaceModel);
         $namespace = $this->getNamespace($name);
@@ -108,7 +106,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         $name = (string)Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
 
-        return $this->laravel->databasePath() . '/factories/' . str_replace('\\', '/', $name) . '.php';
+        return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
     }
 
 
@@ -131,10 +129,10 @@ class FactoryMakeCommand extends GeneratorCommand
         }
 
         if (is_dir(app_path('Models/'))) {
-            return $this->laravel->getNamespace() . 'Models\Model';
+            return $this->laravel->getNamespace().'Models\Model';
         }
 
-        return $this->laravel->getNamespace() . 'Model';
+        return $this->laravel->getNamespace().'Model';
     }
 
     /**
@@ -150,13 +148,13 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (Str::startsWith($model, $rootNamespace . '\Models\\')) {
+        if (Str::startsWith($model, $rootNamespace.'\Models\\')) {
             return $model;
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace . 'Models\\' . $model
-            : $rootNamespace . $model;
+            ? $rootNamespace.'Models\\'.$model
+            : $rootNamespace.$model;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -52,20 +52,20 @@ class FactoryMakeCommand extends GeneratorCommand
     /**
      * Resolve the fully-qualified path to the stub.
      *
-     * @param string $stub
+     * @param  string  $stub
      * @return string
      */
     protected function resolveStubPath($stub)
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__ . $stub;
+            : __DIR__.$stub;
     }
 
     /**
      * Build the class with the given name.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function buildClass($name)
@@ -101,21 +101,20 @@ class FactoryMakeCommand extends GeneratorCommand
     /**
      * Get the destination class path.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function getPath($name)
     {
-        $name = (string)Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
+        $name = (string) Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
 
-        return $this->laravel->databasePath() . '/factories/' . str_replace('\\', '/', $name) . '.php';
+        return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
     }
-
 
     /**
      * Guess the model name from the Factory name or return a default model name.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function guessModelName($name)
@@ -131,16 +130,16 @@ class FactoryMakeCommand extends GeneratorCommand
         }
 
         if (is_dir(app_path('Models/'))) {
-            return $this->laravel->getNamespace() . 'Models\Model';
+            return $this->laravel->getNamespace().'Models\Model';
         }
 
-        return $this->laravel->getNamespace() . 'Model';
+        return $this->laravel->getNamespace().'Model';
     }
 
     /**
      * Qualify the given model class base name.
      *
-     * @param string $model
+     * @param  string  $model
      * @return string
      */
     protected function qualifyModel(string $model)
@@ -150,13 +149,13 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (Str::startsWith($model, $rootNamespace . 'Models\\')) {
+        if (Str::startsWith($model, $rootNamespace.'Models\\')) {
             return $model;
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace . 'Models\\' . $model
-            : $rootNamespace . $model;
+            ? $rootNamespace.'Models\\'.$model
+            : $rootNamespace.$model;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -76,8 +76,6 @@ class FactoryMakeCommand extends GeneratorCommand
             ? $this->qualifyModel($this->option('model'))
             : $this->guessModelName($name);
 
-
-
         $model = class_basename($namespaceModel);
         $namespace = $this->getNamespace($name);
 

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -74,7 +74,9 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $namespaceModel = $this->option('model')
             ? $this->qualifyModel($this->option('model'))
-            : $this->qualifyModel($this->guessModelName($name));
+            : $this->guessModelName($name);
+
+
 
         $model = class_basename($namespaceModel);
         $namespace = $this->getNamespace($name);
@@ -118,7 +120,7 @@ class FactoryMakeCommand extends GeneratorCommand
      */
     protected function guessModelName($name)
     {
-        if (str_ends_with($name, 'Factory')) {
+        if (Str::endsWith($name, 'Factory')) {
             $name = substr($name, 0, -7);
         }
 
@@ -129,10 +131,10 @@ class FactoryMakeCommand extends GeneratorCommand
         }
 
         if (is_dir(app_path('Models/'))) {
-            return $this->rootNamespace() . 'Models\Model';
+            return $this->laravel->getNamespace() . 'Models\Model';
         }
 
-        return $this->rootNamespace() . 'Model';
+        return $this->laravel->getNamespace() . 'Model';
     }
 
     /**
@@ -148,7 +150,7 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (Str::startsWith($model, $rootNamespace)) {
+        if (Str::startsWith($model, $rootNamespace . '\Models\\')) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -150,7 +150,7 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (Str::startsWith($model, $rootNamespace . '\Models\\')) {
+        if (Str::startsWith($model, $rootNamespace . 'Models\\')) {
             return $model;
         }
 

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -52,20 +52,20 @@ class FactoryMakeCommand extends GeneratorCommand
     /**
      * Resolve the fully-qualified path to the stub.
      *
-     * @param string $stub
+     * @param  string  $stub
      * @return string
      */
     protected function resolveStubPath($stub)
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__ . $stub;
+            : __DIR__.$stub;
     }
 
     /**
      * Build the class with the given name.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function buildClass($name)
@@ -75,8 +75,6 @@ class FactoryMakeCommand extends GeneratorCommand
         $namespaceModel = $this->option('model')
             ? $this->qualifyModel($this->option('model'))
             : $this->guessModelName($name);
-
-
 
         $model = class_basename($namespaceModel);
         $namespace = $this->getNamespace($name);
@@ -101,21 +99,21 @@ class FactoryMakeCommand extends GeneratorCommand
     /**
      * Get the destination class path.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function getPath($name)
     {
-        $name = (string)Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
+        $name = (string) Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
 
-        return $this->laravel->databasePath() . '/factories/' . str_replace('\\', '/', $name) . '.php';
+        return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
     }
 
 
     /**
      * Guess the model name from the Factory name or return a default model name.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function guessModelName($name)
@@ -131,16 +129,16 @@ class FactoryMakeCommand extends GeneratorCommand
         }
 
         if (is_dir(app_path('Models/'))) {
-            return $this->laravel->getNamespace() . 'Models\Model';
+            return $this->laravel->getNamespace().'Models\Model';
         }
 
-        return $this->laravel->getNamespace() . 'Model';
+        return $this->laravel->getNamespace().'Model';
     }
 
     /**
      * Qualify the given model class base name.
      *
-     * @param string $model
+     * @param  string  $model
      * @return string
      */
     protected function qualifyModel(string $model)
@@ -150,13 +148,13 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (Str::startsWith($model, $rootNamespace . 'Models\\')) {
+        if (Str::startsWith($model, $rootNamespace.'Models\\')) {
             return $model;
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace . 'Models\\' . $model
-            : $rootNamespace . $model;
+            ? $rootNamespace.'Models\\'.$model
+            : $rootNamespace.$model;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -52,20 +52,20 @@ class FactoryMakeCommand extends GeneratorCommand
     /**
      * Resolve the fully-qualified path to the stub.
      *
-     * @param  string  $stub
+     * @param string $stub
      * @return string
      */
     protected function resolveStubPath($stub)
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__.$stub;
+            : __DIR__ . $stub;
     }
 
     /**
      * Build the class with the given name.
      *
-     * @param  string  $name
+     * @param string $name
      * @return string
      */
     protected function buildClass($name)
@@ -75,6 +75,8 @@ class FactoryMakeCommand extends GeneratorCommand
         $namespaceModel = $this->option('model')
             ? $this->qualifyModel($this->option('model'))
             : $this->guessModelName($name);
+
+
 
         $model = class_basename($namespaceModel);
         $namespace = $this->getNamespace($name);
@@ -99,21 +101,21 @@ class FactoryMakeCommand extends GeneratorCommand
     /**
      * Get the destination class path.
      *
-     * @param  string  $name
+     * @param string $name
      * @return string
      */
     protected function getPath($name)
     {
-        $name = (string) Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
+        $name = (string)Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
 
-        return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->databasePath() . '/factories/' . str_replace('\\', '/', $name) . '.php';
     }
 
 
     /**
      * Guess the model name from the Factory name or return a default model name.
      *
-     * @param  string  $name
+     * @param string $name
      * @return string
      */
     protected function guessModelName($name)
@@ -129,16 +131,16 @@ class FactoryMakeCommand extends GeneratorCommand
         }
 
         if (is_dir(app_path('Models/'))) {
-            return $this->laravel->getNamespace().'Models\Model';
+            return $this->laravel->getNamespace() . 'Models\Model';
         }
 
-        return $this->laravel->getNamespace().'Model';
+        return $this->laravel->getNamespace() . 'Model';
     }
 
     /**
      * Qualify the given model class base name.
      *
-     * @param  string  $model
+     * @param string $model
      * @return string
      */
     protected function qualifyModel(string $model)
@@ -148,13 +150,13 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (Str::startsWith($model, $rootNamespace.'Models\\')) {
+        if (Str::startsWith($model, $rootNamespace . 'Models\\')) {
             return $model;
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace.'Models\\'.$model
-            : $rootNamespace.$model;
+            ? $rootNamespace . 'Models\\' . $model
+            : $rootNamespace . $model;
     }
 
     /**

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -76,12 +76,7 @@ class FactoryMakeCommand extends GeneratorCommand
                         : $this->qualifyModel($this->guessModelName($name));
 
         $model = class_basename($namespaceModel);
-
-        if (Str::startsWith($namespaceModel, $this->rootNamespace().'Models')) {
-            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, $this->rootNamespace().'Models\\'), '\\');
-        } else {
-            $namespace = 'Database\\Factories';
-        }
+        $namespace = $this->getNamespace($name);
 
         $replace = [
             '{{ factoryNamespace }}' => $namespace,
@@ -136,6 +131,16 @@ class FactoryMakeCommand extends GeneratorCommand
         }
 
         return $this->rootNamespace().'Model';
+    }
+
+    /**
+     * Get the root namespace for the class.
+     *
+     * @return string
+     */
+    protected function rootNamespace()
+    {
+        return 'Database\Factories\\';
     }
 
     /**

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -59,7 +59,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__.$stub;
+            : __DIR__ . $stub;
     }
 
     /**
@@ -75,6 +75,8 @@ class FactoryMakeCommand extends GeneratorCommand
         $namespaceModel = $this->option('model')
             ? $this->qualifyModel($this->option('model'))
             : $this->guessModelName($name);
+
+
 
         $model = class_basename($namespaceModel);
         $namespace = $this->getNamespace($name);
@@ -106,7 +108,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         $name = (string)Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
 
-        return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->databasePath() . '/factories/' . str_replace('\\', '/', $name) . '.php';
     }
 
 
@@ -129,10 +131,10 @@ class FactoryMakeCommand extends GeneratorCommand
         }
 
         if (is_dir(app_path('Models/'))) {
-            return $this->laravel->getNamespace().'Models\Model';
+            return $this->laravel->getNamespace() . 'Models\Model';
         }
 
-        return $this->laravel->getNamespace().'Model';
+        return $this->laravel->getNamespace() . 'Model';
     }
 
     /**
@@ -148,13 +150,13 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (Str::startsWith($model, $rootNamespace.'\Models\\')) {
+        if (Str::startsWith($model, $rootNamespace . '\Models\\')) {
             return $model;
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace.'Models\\'.$model
-            : $rootNamespace.$model;
+            ? $rootNamespace . 'Models\\' . $model
+            : $rootNamespace . $model;
     }
 
     /**


### PR DESCRIPTION
If you run this
```php
php artisan make:factory Test/Sub1/Sub2/User
```
then yout would have this result:
```php
<?php

namespace Database\Factories;

use Illuminate\Database\Eloquent\Factories\Factory;

/**
 * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Model>
 */
class UserFactory extends Factory
{
    /**
     * Define the model's default state.
     *
     * @return array<string, mixed>
     */
    public function definition()
    {
        return [
            //
        ];
    }
}
```
as you can see the namespace is not correct also notice <\App\Models\Model> that should be <\App\Models\User> because I have User Model, and actually I think guessing model names had some problems
but with new changes all the problems was fixed and the result would be like this:
```php
<?php

namespace Database\Factories\Test\Sub1\Sub2;

use Illuminate\Database\Eloquent\Factories\Factory;

/**
 * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
 */
class UserFactory extends Factory
{
    /**
     * Define the model's default state.
     *
     * @return array<string, mixed>
     */
    public function definition()
    {
        return [
            //
        ];
    }
}
```
as you can see the namespace and model name are correct now.
also guessing model name is correct now. 
I also removed old syntax and used laravel Str and Arr facades.