### PR TITLE
[9.x] Enable cache tags for DynamoDB driver

### DIFF
--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -5,13 +5,12 @@ namespace Illuminate\Cache;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Exception\DynamoDbException;
 use Illuminate\Contracts\Cache\LockProvider;
-use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use RuntimeException;
 
-class DynamoDbStore implements LockProvider, Store
+class DynamoDbStore extends TaggableStore implements LockProvider
 {
     use InteractsWithTime;
 

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -66,6 +66,49 @@ class DynamoDbStoreTest extends TestCase
         });
     }
 
+    public function testCanStoreItemsWithTags()
+    {
+        $store = Cache::driver('dynamodb');
+        $store->tags(['people', 'artists'])->put('John', 'foo', 2);
+        $store->tags(['people', 'authors'])->put('Anne', 'bar', 2);
+
+        $this->assertSame('foo', $store->tags(['people', 'artists'])->get('John'));
+        $this->assertSame('bar', $store->tags(['people', 'authors'])->get('Anne'));
+
+        $store->tags(['people', 'artists'])->put('John', 'baz');
+        $store->tags(['people', 'authors'])->put('Anne', 'qux');
+
+        $this->assertSame('baz', $store->tags(['people', 'artists'])->get('John'));
+        $this->assertSame('qux', $store->tags(['people', 'authors'])->get('Anne'));
+
+        $store->tags('authors')->flush();
+        $this->assertNull($store->tags(['people', 'authors'])->get('Anne'));
+        $this->assertSame('baz', $store->tags(['people', 'artists'])->get('John'));
+
+        $store->tags(['people', 'authors'])->flush();
+        $this->assertNull($store->tags(['people', 'artists'])->get('John'));
+    }
+
+    public function testCanStoreManyTaggedCacheItems()
+    {
+        $store = Cache::driver('dynamodb');
+
+        $store->tags(['people', 'artists'])->putMany(['John' => 'foo', 'Jane' => 'bar'], 2);
+
+        $this->assertSame('foo', $store->tags(['people', 'artists'])->get('John'));
+        $this->assertSame('bar', $store->tags(['people', 'artists'])->get('Jane'));
+
+        $store->tags(['people', 'artists'])->putMany(['John' => 'baz', 'Jane' => 'qux']);
+
+        $this->assertSame('baz', $store->tags(['people', 'artists'])->get('John'));
+        $this->assertSame('qux', $store->tags(['people', 'artists'])->get('Jane'));
+
+        $store->tags(['people', 'artists'])->putMany(['John' => 'baz', 'Jane' => 'qux'], -1);
+
+        $this->assertNull($store->tags(['people', 'artists'])->get('John'));
+        $this->assertNull($store->tags(['people', 'artists'])->get('Jane'));
+    }
+
     /**
      * Define environment setup.
      *


### PR DESCRIPTION
This PR enables cache tags for the dynamoDB cache driver.

One known caveat is that when a user flushes tags (`Cache::tags('authors')->flush();`), the cache tag keys are refreshed but the original cache item still remains in the DynamoDB table, now ignored as should, but still taking up some space. I believe this is the same for all other cache methods though, except for the Redis implementation.