### PR TITLE
[9.x] DynamoDB don't set expired at value on forever

### DIFF
--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -220,7 +220,7 @@ class DynamoDbStore implements LockProvider, Store
                 ],
             ] : []),
         ]);
-        
+
         return true;
     }
 

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -220,6 +220,7 @@ class DynamoDbStore implements LockProvider, Store
                 ],
             ] : []),
         ]);
+        
         return true;
     }
 

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -196,7 +196,7 @@ class DynamoDbStore implements LockProvider, Store
     }
 
     /**
-     * Put an item in dynamo with an optional expires at value
+     * Put an item in dynamo with an optional expires at value.
      *
      * @param  string  $key
      * @param  mixed  $value
@@ -213,12 +213,12 @@ class DynamoDbStore implements LockProvider, Store
                 ],
                 $this->valueAttribute => [
                     $this->type($value) => $this->serialize($value),
-                ]
+                ],
             ], $expiresAt !== null ? [
                 $this->expirationAttribute => [
                     'N' => (string) $expiresAt,
-                ]
-            ] : [])
+                ],
+            ] : []),
         ]);
         return true;
     }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Cache;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Exception\AwsException;
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
@@ -64,6 +65,14 @@ class DynamoDbStoreTest extends TestCase
         Cache::driver('dynamodb')->lock('lock', 10)->get(function () {
             $this->assertFalse(Cache::driver('dynamodb')->lock('lock', 10)->get());
         });
+    }
+
+    public function testItCanRememberAnItemForever()
+    {
+        $cache = Cache::driver('dynamodb');
+        $cache->forever('name', 'Taylor');
+        Carbon::setTestNow(now()->addYears(1000));
+        $this->assertSame('Taylor', $cache->get('name'));
     }
 
     /**


### PR DESCRIPTION
Currently when using `Cache::driver('dynamodb')->forever('name', 'Taylor')` the item expires at time will actually be set. 
It will be set to expire in "the timestamp of 5 years in the future" seconds from now. Obviously this practically hasn't caused (and won't cause) any bugs.

However it is a bit odd to see "expiredAt" being set when looking at an item, when you don't expect it to expire. This PR has a small (backwards compatible) refactor that will omit expiredAt to be stored when using forever as expiresAt value.
