### PR TITLE
[9.x] Collection select()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -598,7 +598,7 @@ class Arr
     }
 
     /**
-     * Select and "pick" columns from a bi-dimensional array
+     * Select and "pick" columns from a bi-dimensional array.
      *
      * @param  array  $array
      * @param  array  $columns
@@ -607,11 +607,12 @@ class Arr
     public static function select(&$array, $columns)
     {
         if (is_string($columns)) {
-            $columns = array($columns);
+            $columns = [$columns];
         }
         if (is_null($columns)) {
             $columns = [];
         }
+
         return array_map(fn ($item) => array_intersect_key($item, array_flip($columns)), $array);
     }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -606,12 +606,7 @@ class Arr
      */
     public static function select(&$array, $columns)
     {
-        if (is_string($columns)) {
-            $columns = [$columns];
-        }
-        if (is_null($columns)) {
-            $columns = [];
-        }
+        $columns = (array) $columns;
 
         return array_map(fn ($item) => array_intersect_key($item, array_flip($columns)), $array);
     }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -601,14 +601,14 @@ class Arr
      * Select and "pick" columns from a bi-dimensional array.
      *
      * @param  array  $array
-     * @param  array  $columns
+     * @param  array|string  $columns
      * @return array
      */
     public static function select(&$array, $columns)
     {
-        $columns = (array) $columns;
+        $columns = static::wrap($columns);
 
-        return array_map(fn ($item) => array_intersect_key($item, array_flip($columns)), $array);
+        return array_map(fn ($item) => static::only($item, $columns), $array);
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -606,6 +606,12 @@ class Arr
      */
     public static function select(&$array, $columns)
     {
+        if (is_string($columns)) {
+            $columns = array($columns);
+        }
+        if (is_null($columns)) {
+            $columns = [];
+        }
         return array_map(fn ($item) => array_intersect_key($item, array_flip($columns)), $array);
     }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -598,6 +598,18 @@ class Arr
     }
 
     /**
+     * Select and "pick" columns from a bi-dimensional array
+     *
+     * @param  array  $array
+     * @param  array  $columns
+     * @return array
+     */
+    public static function select(&$array, $columns)
+    {
+        return array_map(fn ($item) => array_intersect_key($item, array_flip($columns)), $array);
+    }
+
+    /**
      * Set an array item to a given value using "dot" notation.
      *
      * If no key is given to the method, the entire array will be replaced.

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1047,7 +1047,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Select and "pick" columns from a bi-dimensional array
+     * Select and "pick" columns from a bi-dimensional array.
      *
      * @param  array  $columns
      * @return static

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1049,7 +1049,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Select and "pick" columns from a bi-dimensional array.
      *
-     * @param  array  $columns
+     * @param  array|string  $columns
      * @return static
      */
     public function select($columns)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1047,6 +1047,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Select and "pick" columns from a bi-dimensional array
+     *
+     * @param  array  $columns
+     * @return static
+     */
+    public function select($columns)
+    {
+        return new static(Arr::select($this->items, $columns));
+    }
+
+    /**
      * Get and remove the first N items from the collection.
      *
      * @param  int  $count

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5031,6 +5031,62 @@ class SupportCollectionTest extends TestCase
             [LazyCollection::class],
         ];
     }
+
+    public function testSelect()
+    {
+        $c = Collection::make([
+            ['product' => 'Desk', 'price' => 200, 'active' => true],
+            ['product' => 'Chair', 'price' => 100, 'active' => true],
+            ['product' => 'Door', 'price' => 300, 'active' => false],
+            ['product' => 'Bookcase', 'price' => 150, 'active' => true],
+            ['product' => 'Door', 'price' => 100, 'active' => true],
+        ])->select(['price'])->all();
+        $this->assertCount(5, $c);
+        $this->assertCount(1, $c[0]);
+
+        $c = Collection::make([
+            ['product' => 'Desk', 'price' => 200, 'active' => true],
+            ['product' => 'Chair', 'price' => 100, 'active' => true],
+            ['product' => 'Door', 'price' => 300, 'active' => false],
+            ['product' => 'Bookcase', 'price' => 150, 'active' => true],
+            ['product' => 'Door', 'price' => 100, 'active' => true],
+        ])->select(['price', 'product'])->all();
+        $this->assertCount(5, $c);
+        $this->assertCount(2, $c[0]);
+        $this->assertEquals('Bookcase', $c[3]['product']);
+
+        $c = Collection::make([
+            ['product' => 'Desk', 'price' => 200, 'active' => true],
+            ['product' => 'Chair',  'active' => true],
+            ['product' => 'Door', 'price' => 300, 'active' => false],
+            ['product' => 'Bookcase', 'price' => 150, 'active' => true],
+            ['product' => 'Door', 'price' => 100, 'active' => true],
+        ])->select(['price', 'product'])->all();
+        $this->assertCount(5, $c);
+        $this->assertCount(2, $c[0]);
+        $this->assertCount(1, $c[1]);
+        $this->assertEquals('Bookcase', $c[3]['product']);
+
+        $c = Collection::make([
+            ['product' => 'Desk', 'price' => 200, 'active' => true],
+            ['product' => 'Chair',  'active' => true],
+            ['product' => 'Door', 'price' => 300, 'active' => false],
+            ['product' => 'Bookcase', 'price' => 150, 'active' => true],
+            ['product' => 'Door', 'price' => 100, 'active' => true],
+        ])->select(['fieldnotexist'])->all();
+        $this->assertCount(5, $c);
+        $this->assertCount(0, $c[0]);
+        $this->assertCount(0, $c[1]);
+
+        $c = Collection::make([
+        ])->select(['field'])->all();
+        $this->assertCount(0, $c);
+        
+
+    }
+
+
+
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5091,7 +5091,7 @@ class SupportCollectionTest extends TestCase
         ])->select('product')->all();
         $this->assertCount(5, $c);
         $this->assertCount(1, $c[1]);
-   
+
         $c = Collection::make([
             ['product' => 'Desk', 'price' => 200, 'active' => true],
             ['product' => 'Chair', 'price' => 100, 'active' => true],
@@ -5101,11 +5101,7 @@ class SupportCollectionTest extends TestCase
         ])->select(null)->all();
         $this->assertCount(5, $c);
         $this->assertCount(0, $c[1]);
-
     }
-
-
-
 }
 
 class TestSupportCollectionHigherOrderItem

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5081,7 +5081,26 @@ class SupportCollectionTest extends TestCase
         $c = Collection::make([
         ])->select(['field'])->all();
         $this->assertCount(0, $c);
-        
+
+        $c = Collection::make([
+            ['product' => 'Desk', 'price' => 200, 'active' => true],
+            ['product' => 'Chair', 'price' => 100, 'active' => true],
+            ['product' => 'Door', 'price' => 300, 'active' => false],
+            ['product' => 'Bookcase', 'price' => 150, 'active' => true],
+            ['product' => 'Door', 'price' => 100, 'active' => true],
+        ])->select('product')->all();
+        $this->assertCount(5, $c);
+        $this->assertCount(1, $c[1]);
+   
+        $c = Collection::make([
+            ['product' => 'Desk', 'price' => 200, 'active' => true],
+            ['product' => 'Chair', 'price' => 100, 'active' => true],
+            ['product' => 'Door', 'price' => 300, 'active' => false],
+            ['product' => 'Bookcase', 'price' => 150, 'active' => true],
+            ['product' => 'Door', 'price' => 100, 'active' => true],
+        ])->select(null)->all();
+        $this->assertCount(5, $c);
+        $this->assertCount(0, $c[1]);
 
     }
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -687,6 +687,8 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->reverse());
 //    return true;
 // }));
 
+assertType('Illuminate\Support\Collection<int, array>', $collection::make([["code"=>1, "number"=>101], ["code"=>2, "number"=>102]])->select(["code"]));
+
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->shuffle());
 assertType('Illuminate\Support\Collection<int, User>', $collection->shuffle());
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -687,7 +687,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->reverse());
 //    return true;
 // }));
 
-assertType('Illuminate\Support\Collection<int, array>', $collection::make([["code"=>1, "number"=>101], ["code"=>2, "number"=>102]])->select(["code"]));
+assertType('Illuminate\Support\Collection<int, array>', $collection::make([['code'=>1, 'number'=>101], ['code'=>2, 'number'=>102]])->select(['code']));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->shuffle());
 assertType('Illuminate\Support\Collection<int, User>', $collection->shuffle());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -687,7 +687,7 @@ assertType('Illuminate\Support\Collection<int, User>', $collection->reverse());
 //    return true;
 // }));
 
-assertType('Illuminate\Support\Collection<int, array>', $collection::make([['code'=>1, 'number'=>101], ['code'=>2, 'number'=>102]])->select(['code']));
+assertType('Illuminate\Support\Collection<int, array{code: int, number: int}>', $collection::make([['code'=>1, 'number'=>101], ['code'=>2, 'number'=>102]])->select(['code']));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->shuffle());
 assertType('Illuminate\Support\Collection<int, User>', $collection->shuffle());


### PR DESCRIPTION
As explained here: https://github.com/laravel/framework/discussions/41521 , I open a PR for introducing _select()_ method for Collection.
_select()_ get data from bi-dimensional array by keys.

I created also tests in tests/Support/SupportCollectionTest.php adding _testSelect()_ method with some test case (not existent columns, null columns, string column.


