### PR TITLE
[9.x] Fix #41302

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -531,7 +531,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         try {
             return parent::command($method, $parameters);
         } catch (RedisException $e) {
-            if (str_contains($e->getMessage(), 'went away') || str_contains($s->getMessage(), 'socket')) {
+            if (str_contains($e->getMessage(), 'went away') || str_contains($e->getMessage(), 'socket')) {
                 $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
             }
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -531,7 +531,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         try {
             return parent::command($method, $parameters);
         } catch (RedisException $e) {
-            if (str_contains($e->getMessage(), 'went away')) {
+            if (str_contains($e->getMessage(), 'went away') || str_contains($s->getMessage(), 'socket')) {
                 $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
             }
 


### PR DESCRIPTION
This is an alternative option to PR #41502, and adds a match
for 'socket' ("socket error when (reading|writing)") to trigger
a reconnection.

I am not sure if this check is valid in other languages.

My personal preference would be to remove the entire if and
ALWAYS reconnect on any Exception

Signed-Off-By: Rob Thomas xrobau@gmail.com