### PR TITLE
[8.x] Stop throwing LazyLoadingViolationException for recently created model instances

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -519,7 +519,7 @@ trait HasAttributes
             return call_user_func(static::$lazyLoadingViolationCallback, $this, $key);
         }
 
-        if (!$this->exists || $this->wasRecentlyCreated) {
+        if (! $this->exists || $this->wasRecentlyCreated) {
             return;
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -519,6 +519,10 @@ trait HasAttributes
             return call_user_func(static::$lazyLoadingViolationCallback, $this, $key);
         }
 
+        if (!$this->exists || $this->wasRecentlyCreated) {
+            return;
+        }
+
         throw new LazyLoadingViolationException($this, $key);
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -384,10 +384,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Register a callback that is responsible for handling lazy loading violations.
      *
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @return void
      */
-    public static function handleLazyLoadingViolationUsing(callable $callback)
+    public static function handleLazyLoadingViolationUsing(?callable $callback)
     {
         static::$lazyLoadingViolationCallback = $callback;
     }

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -127,6 +127,8 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
         $models = EloquentStrictLoadingTestModel1::get();
 
         $models[0]->modelTwos;
+
+        Model::handleLazyLoadingViolationUsing(null);
     }
 
     public function testStrictModeWithOverriddenHandlerOnLazyLoading()

--- a/tests/Integration/Database/EloquentStrictLoadingTest.php
+++ b/tests/Integration/Database/EloquentStrictLoadingTest.php
@@ -143,6 +143,21 @@ class EloquentStrictLoadingTest extends DatabaseTestCase
 
         $models[0]->modelTwos;
     }
+
+    public function testStrictModeDoesntThrowAnExceptionOnManuallyMadeModel()
+    {
+        $model1 = EloquentStrictLoadingTestModel1WithLocalPreventsLazyLoading::make();
+        $model2 = EloquentStrictLoadingTestModel2::make();
+        $model1->modelTwos->push($model2);
+
+        $this->assertInstanceOf(Collection::class, $model1->modelTwos);
+    }
+
+    public function testStrictModeDoesntThrowAnExceptionOnRecentlyCreatedModel()
+    {
+        $model1 = EloquentStrictLoadingTestModel1WithLocalPreventsLazyLoading::create();
+        $this->assertInstanceOf(Collection::class, $model1->modelTwos);
+    }
 }
 
 class EloquentStrictLoadingTestModel1 extends Model
@@ -171,6 +186,19 @@ class EloquentStrictLoadingTestModel1WithCustomHandler extends Model
     protected function handleLazyLoadingViolation($key)
     {
         throw new \RuntimeException("Violated {$key}");
+    }
+}
+
+class EloquentStrictLoadingTestModel1WithLocalPreventsLazyLoading extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    public $preventsLazyLoading = true;
+    protected $guarded = [];
+
+    public function modelTwos()
+    {
+        return $this->hasMany(EloquentStrictLoadingTestModel2::class, 'model_1_id');
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/41420. I think the issue describes the problem and the solution pretty well.

In addition, I had to make a change in `Model::handleLazyLoadingViolationUsing` which now accepts `null`, so tests can reset the state. Class property was already nullable so I think it's a good step anyway: https://github.com/laravel/framework/blob/dd59f62a32ec99e9451bdadc62b99834f337551a/src/Illuminate/Database/Eloquent/Model.php#L170-L175

At first, I was surprised that new tests were passing without any changes in the code. Then I figured out that only a local `public $preventsLazyLoading = true;` causes the issue, while global `Model::preventLazyLoading()` does not. It seems the latter one doesn't trigger the check when using `make()` or `create()`. I'd prefer not to dive into this topic now, thus the new class in tests.