### PR TITLE
[9.x] Add "order by" with field concatenation clause to the query

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2243,6 +2243,30 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add "order by" with field concatenation clause to the query.
+     *
+     * @param array $columns
+     * @param string $direction
+     * @return $this
+     */
+    public function orderByConcat(array $columns, $direction = 'asc')
+    {
+        if (empty($columns)) {
+            return $this;
+        }
+
+        if (is_null($this->columns)) {
+            $this->select([$this->from.'.*']);
+        }
+
+        $alias ??= Str::snake(implode(' ', $columns));
+
+        $this->addSelect(new Expression('CONCAT('.implode(',', $columns).') as '.$alias));
+
+        return $this->orderBy($alias, $direction);
+    }
+
+    /**
      * Alias to set the "offset" value of the query.
      *
      * @param  int  $value

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2247,9 +2247,10 @@ class Builder implements BuilderContract
      *
      * @param array $columns
      * @param string $direction
+     * @param string|null $as
      * @return $this
      */
-    public function orderByConcat(array $columns, $direction = 'asc')
+    public function orderByConcat(array $columns, $direction = 'asc', $as = null)
     {
         if (empty($columns)) {
             return $this;
@@ -2259,7 +2260,7 @@ class Builder implements BuilderContract
             $this->select([$this->from.'.*']);
         }
 
-        $alias ??= Str::snake(implode(' ', $columns));
+        $alias = $as ?: Str::snake(implode(' ', $columns));
 
         $this->addSelect(new Expression('CONCAT('.implode(',', $columns).') as '.$alias));
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1277,6 +1277,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" order by "name" desc', $builder->toSql());
 
         $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByConcat(['name', 'email'], 'desc');
+        $this->assertSame('select *, CONCAT(name,email) as name_email from "users" order by "name_email" desc', $builder->toSql());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('public', 1)
             ->unionAll($this->getBuilder()->select('*')->from('videos')->where('public', 1))
             ->orderByRaw('field(category, ?, ?) asc', ['news', 'opinion']);


### PR DESCRIPTION
This PR adds convenient sorting with field concatenation

```php
User::query()->orderByConcat(['first_name', 'last_name'], 'desc')->get()
```

```sql
select *, CONCAT(first_name, last_name) as first_name_last_name from "users" order by "first_name_last_name" desc
```

especially useful in the presence of Accessors, reducing the logic

```php
protected function name(): Attribute
    {
        return Attribute::make(
            get: fn ($value) => $this->first_name . ' ' . $this->last_name,
        );
    }
```