### PR TITLE
[8.x] Add test coverage to DecryptionException thrown when tag is added manually

### DIFF
--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -160,6 +160,18 @@ class EncrypterTest extends TestCase
         $e->decrypt($payload);
     }
 
+    public function testDecryptionExceptionIsThrownWhenUnexpectedTagIsAdded()
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('Unable to use tag because the cipher algorithm does not support AEAD.');
+
+        $e = new Encrypter(str_repeat('a', 16));
+        $payload = $e->encrypt('foo');
+        $decodedPayload = json_decode(base64_decode($payload));
+        $decodedPayload->tag = 'set-manually';
+        $e->decrypt(base64_encode(json_encode($decodedPayload)));
+    }
+
     public function testExceptionThrownWithDifferentKey()
     {
         $this->expectException(DecryptException::class);


### PR DESCRIPTION
This adds test coverage for the recently merged PR https://github.com/laravel/framework/pull/41479

I have of course verified that the test fails when reverting that PR fix.