### PR TITLE
[9.x] Only add a trailing colon to prefix if one isn't already present

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -5,6 +5,7 @@ namespace Illuminate\Cache;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Redis\Connections\PhpRedisConnection;
+use Illuminate\Support\Str;
 
 class RedisStore extends TaggableStore implements LockProvider
 {
@@ -320,7 +321,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function setPrefix($prefix)
     {
-        $this->prefix = ! empty($prefix) ? $prefix.':' : '';
+        $this->prefix = ! empty($prefix) ? Str::finish($prefix, ':') : '';
     }
 
     /**


### PR DESCRIPTION
I noticed when working with redis cache that my keys would often show up with double colons.  It took me a while, but I tracked it down to the redis store class that automatically appends a colon to any existing prefix.  Of course, if the prefix already contains a colon, then one gets a double colon.

My OCD got the better of me and I thought it would be nice to make sure one has a colon and only adds it if needed.

I should note that one of the issues with this seems to be how the prefixes are treated a bit inconsistently.  I configure my prefixes consistently, ending them all with a colon.  In most cases, no additional colon is added by the framework.  However, in this case, one is.  I'm not 100% certain, but I think when it's used/accessed as a database, then it just gets the database prefix and no additional colon is added.  But, when used/accessed as a cache, then it gets the database prefix, then the cache prefix...**with** the additional colon.

So...like I said, I might be missing something, but I think this is a nice way to make things a little more consistent.  Yes...I'm a little more certain after running:

- The redis database prefix does **not** get a colon appended.  (Configuration path: `database.redis.options.prefix`)
- The redis cache prefix **does** get a colon appended.  (Configuration path: `cache.prefix`)

So, again, if I'm not mistaken, then perhaps it would make sense to try to either append a colon across the board...or not.  😜 

It's not a major issue but I like how `Str::finish()` does the job nicely.  I hope it's OK.  🤓 