### PR TITLE
[9.x] Add @template typehints for make / instance / app to improve type hints in code

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -461,9 +461,10 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Register an existing instance as shared in the container.
      *
+     * @template T
      * @param  string  $abstract
-     * @param  mixed  $instance
-     * @return mixed
+     * @param  T  $instance
+     * @return T
      */
     public function instance($abstract, $instance)
     {
@@ -683,9 +684,10 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container.
      *
-     * @param  string|callable  $abstract
+     * @template T
+     * @param  class-string<T>  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return T|mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -113,9 +113,10 @@ interface Container extends ContainerInterface
     /**
      * Register an existing instance as shared in the container.
      *
+     * @template T
      * @param  string  $abstract
-     * @param  mixed  $instance
-     * @return mixed
+     * @param  T  $instance
+     * @return T
      */
     public function instance($abstract, $instance);
 
@@ -155,9 +156,10 @@ interface Container extends ContainerInterface
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template T
+     * @param  class-string<T>  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return T|mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -829,9 +829,10 @@ class Application extends Container implements ApplicationContract, CachesConfig
     /**
      * Resolve the given type from the container.
      *
-     * @param  string  $abstract
+     * @template T
+     * @param  class-string<T>  $abstract
      * @param  array  $parameters
-     * @return mixed
+     * @return T|mixed
      */
     public function make($abstract, array $parameters = [])
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -106,9 +106,10 @@ if (! function_exists('app')) {
     /**
      * Get the available container instance.
      *
-     * @param  string|null  $abstract
+     * @template T
+     * @param  class-string<T>|mixed  $abstract
      * @param  array  $parameters
-     * @return mixed|\Illuminate\Contracts\Foundation\Application
+     * @return mixed|T|\Illuminate\Contracts\Foundation\Application
      */
     function app($abstract = null, array $parameters = [])
     {


### PR DESCRIPTION
👋

Just a small life improvements for IDE users.

- This enables resolving type of instance that container resolves without any IDE plugins.
- Helps phpstan / psalm / other tools

Screenshots from PHPstorm while testing the annotations.

<img width="630" alt="Snímek obrazovky 2022-03-15 v 16 49 52" src="https://user-images.githubusercontent.com/1878831/159009591-f91a9e13-322d-448e-bc48-d8a09823b392.png">

<img width="625" alt="DispatchJobAction" src="https://user-images.githubusercontent.com/1878831/159009587-e912e9cc-70a7-488f-ac66-428e0f201442.png">


