### PR TITLE
[9.x] Use Original Foreign Key Attribute Instead of Accessor In Belongs To Relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -74,7 +74,7 @@ class BelongsTo extends Relation
      */
     public function getResults()
     {
-        if (is_null($this->child->{$this->foreignKey})) {
+        if (is_null($this->child->getRawOriginal($this->foreignKey))) {
             return $this->getDefaultFor($this->parent);
         }
 
@@ -94,7 +94,7 @@ class BelongsTo extends Relation
             // of the related models matching on the foreign key that's on a parent.
             $table = $this->related->getTable();
 
-            $this->query->where($table.'.'.$this->ownerKey, '=', $this->child->{$this->foreignKey});
+            $this->query->where($table.'.'.$this->ownerKey, '=', $this->child->getRawOriginal($this->foreignKey));
         }
     }
 
@@ -337,7 +337,7 @@ class BelongsTo extends Relation
      */
     public function getParentKey()
     {
-        return $this->child->{$this->foreignKey};
+        return $this->child->getRawOriginal($this->foreignKey);
     }
 
     /**


### PR DESCRIPTION
This PR will fix following situation (if that matters)

Suppose I have a **Payment** model with **status** column and following accessor and belongsTo relation. 

```
    public function getStatusAttribute()
    {
        return match ($this->attributes['status']) {
            1 => 'Pending',
            2 => 'Paid',
            3 => 'Deleted',
        };    
    }

    public function payStatus()
    {
        return $this->belongsTo(Status::class, 'status');
    }
```

The belongsTo relation won't work as intended. Because foreign key argument **status** is a column which have a accessor defined (with same name). So when relation get resolved it will get mutated value of status instead of original as foreign key value which I think should't be for relation.  