### PR TITLE
[9.x] Making facades injectable

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -336,4 +336,18 @@ abstract class Facade
 
         return $instance->$method(...$args);
     }
+
+    /**
+     * Handle dynamic, calls to the object.
+     *
+     * @param  string  $method
+     * @param  array  $args
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public function __call($method, $args)
+    {
+        return static::__callStatic($method, $args);
+    }
 }


### PR DESCRIPTION
- This makes it possible to inject facades into controllers (just like we inject Interfaces), without sacrificing testability or mocking. (I mean the "injected facades" can also be mocked as well in exactly the same way)

- The main thing that makes people peace off, is that non-static methods on service classes must be called statically on facades. They simply find it weird.

This way it is possible to call methods on facades like they were called on the original object. making it easier to migrate to facades from injected implementations.

- The way users define their facades remains unchanged.
- This change does not impose any backward incompatibility.
---------------------
### Example:

Here we inject a service class (a low-level implementation) into the controller:
```php
use App\Hello;

public function index (Hello $hello)
{
    $hello->greet();
}
```
But we decide to migrate to something more abstract.
For example to migrate to real-time facades:
```php

use Facades\App\Hello;      //           <--- prefixed with `Facades\`

public function index (Hello $hello)
{
    $hello->greet();        //           <--- No need to change the method call (good stuff)
}
```
