### PR TITLE
[9.x] Use arrow functions to bind singletons

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -15,27 +15,19 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('cache', function ($app) {
-            return new CacheManager($app);
-        });
+        $this->app->singleton('cache', fn ($app) => new CacheManager($app));
 
-        $this->app->singleton('cache.store', function ($app) {
-            return $app['cache']->driver();
-        });
+        $this->app->singleton('cache.store', fn ($app) => $app['cache']->driver());
 
-        $this->app->singleton('cache.psr6', function ($app) {
-            return new Psr16Adapter($app['cache.store']);
-        });
+        $this->app->singleton('cache.psr6', fn ($app) => new Psr16Adapter($app['cache.store']));
 
-        $this->app->singleton('memcached.connector', function () {
-            return new MemcachedConnector;
-        });
+        $this->app->singleton('memcached.connector', fn () => new MemcachedConnector);
 
-        $this->app->singleton(RateLimiter::class, function ($app) {
-            return new RateLimiter($app->make('cache')->driver(
-                $app['config']->get('cache.limiter')
-            ));
-        });
+        $this->app->singleton(RateLimiter::class,
+            fn ($app) => new RateLimiter($app->make('cache')->driver(
+                $app['config']->get('cache.limiter'))
+            )
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -424,9 +424,7 @@ class Connection implements ConnectionInterface
     {
         $statement->setFetchMode($this->fetchMode);
 
-        $this->event(new StatementPrepared(
-            $this, $statement
-        ));
+        $this->event(new StatementPrepared($this, $statement));
 
         return $statement;
     }

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -55,28 +55,18 @@ class DatabaseServiceProvider extends ServiceProvider
         // The connection factory is used to create the actual connection instances on
         // the database. We will inject the factory into the manager so that it may
         // make the connections while they are actually needed and not of before.
-        $this->app->singleton('db.factory', function ($app) {
-            return new ConnectionFactory($app);
-        });
+        $this->app->singleton('db.factory', fn ($app) => new ConnectionFactory($app));
 
         // The database manager is used to resolve various connections, since multiple
         // connections might be managed. It also implements the connection resolver
         // interface which may be used by other components requiring connections.
-        $this->app->singleton('db', function ($app) {
-            return new DatabaseManager($app, $app['db.factory']);
-        });
+        $this->app->singleton('db', fn ($app) => new DatabaseManager($app, $app['db.factory']));
 
-        $this->app->bind('db.connection', function ($app) {
-            return $app['db']->connection();
-        });
+        $this->app->bind('db.connection', fn ($app) => $app['db']->connection());
 
-        $this->app->bind('db.schema', function ($app) {
-            return $app['db']->connection()->getSchemaBuilder();
-        });
+        $this->app->bind('db.schema', fn ($app) => $app['db']->connection()->getSchemaBuilder());
 
-        $this->app->singleton('db.transactions', function ($app) {
-            return new DatabaseTransactionsManager;
-        });
+        $this->app->singleton('db.transactions', fn () => new DatabaseTransactionsManager);
     }
 
     /**
@@ -106,8 +96,6 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerQueueableEntityResolver()
     {
-        $this->app->singleton(EntityResolver::class, function () {
-            return new QueueEntityResolver;
-        });
+        $this->app->singleton(EntityResolver::class, fn () => new QueueEntityResolver);
     }
 }

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -58,11 +58,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerRepository()
     {
-        $this->app->singleton('migration.repository', function ($app) {
-            $table = $app['config']['database.migrations'];
-
-            return new DatabaseMigrationRepository($app['db'], $table);
-        });
+        $this->app->singleton('migration.repository',
+            fn ($app) => new DatabaseMigrationRepository($app['db'], $app['config']['database.migrations'])
+        );
     }
 
     /**
@@ -75,11 +73,8 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->singleton('migrator', function ($app) {
-            $repository = $app['migration.repository'];
-
-            return new Migrator($repository, $app['db'], $app['files'], $app['events']);
-        });
+        $this->app->singleton('migrator',
+            fn ($app) => new Migrator($app['migration.repository'], $app['db'], $app['files'], $app['events']));
     }
 
     /**
@@ -89,9 +84,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerCreator()
     {
-        $this->app->singleton('migration.creator', function ($app) {
-            return new MigrationCreator($app['files'], $app->basePath('stubs'));
-        });
+        $this->app->singleton('migration.creator',
+            fn ($app) => new MigrationCreator($app['files'], $app->basePath('stubs'))
+        );
     }
 
     /**
@@ -116,9 +111,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateCommand()
     {
-        $this->app->singleton(MigrateCommand::class, function ($app) {
-            return new MigrateCommand($app['migrator'], $app[Dispatcher::class]);
-        });
+        $this->app->singleton(MigrateCommand::class,
+            fn ($app) => new MigrateCommand($app['migrator'], $app[Dispatcher::class])
+        );
     }
 
     /**
@@ -138,9 +133,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateInstallCommand()
     {
-        $this->app->singleton(InstallCommand::class, function ($app) {
-            return new InstallCommand($app['migration.repository']);
-        });
+        $this->app->singleton(InstallCommand::class,
+            fn ($app) => new InstallCommand($app['migration.repository'])
+        );
     }
 
     /**
@@ -150,16 +145,12 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateMakeCommand()
     {
-        $this->app->singleton(MigrateMakeCommand::class, function ($app) {
-            // Once we have the migration creator registered, we will create the command
-            // and inject the creator. The creator is responsible for the actual file
-            // creation of the migrations, and may be extended by these developers.
-            $creator = $app['migration.creator'];
-
-            $composer = $app['composer'];
-
-            return new MigrateMakeCommand($creator, $composer);
-        });
+        // Once we have the migration creator registered, we will create the command
+        // and inject the creator. The creator is responsible for the actual file
+        // creation of the migrations, and may be extended by these developers.
+        $this->app->singleton(MigrateMakeCommand::class,
+            fn ($app) => new MigrateMakeCommand($app['migration.creator'], $app['composer'])
+        );
     }
 
     /**
@@ -179,9 +170,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateResetCommand()
     {
-        $this->app->singleton(ResetCommand::class, function ($app) {
-            return new ResetCommand($app['migrator']);
-        });
+        $this->app->singleton(
+            ResetCommand::class, fn ($app) => new ResetCommand($app['migrator'])
+        );
     }
 
     /**
@@ -191,9 +182,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRollbackCommand()
     {
-        $this->app->singleton(RollbackCommand::class, function ($app) {
-            return new RollbackCommand($app['migrator']);
-        });
+        $this->app->singleton(
+            RollbackCommand::class, fn ($app) => new RollbackCommand($app['migrator'])
+        );
     }
 
     /**
@@ -203,9 +194,9 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateStatusCommand()
     {
-        $this->app->singleton(StatusCommand::class, function ($app) {
-            return new StatusCommand($app['migrator']);
-        });
+        $this->app->singleton(
+            StatusCommand::class, fn ($app) => new StatusCommand($app['migrator'])
+        );
     }
 
     /**


### PR DESCRIPTION
Uses php 7.4 arrow function to bind singleton in the service providers.
It also remove a little bit of extra whitespace from `Connection.php`

- Conversion process is done with the help of IDE to minimize human error.