### PR TITLE
[9.x] compatible contract return type and method body

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -72,7 +72,7 @@ class Dispatcher implements DispatcherContract
      *
      * @param  \Closure|string|array  $events
      * @param  \Closure|string|array|null  $listener
-     * @return void
+     * @return void|\Illuminate\Support\Collection
      */
     public function listen($events, $listener = null)
     {


### PR DESCRIPTION
return type listen method was void but in the method body, we got return collection.

```
/**
     * Register an event listener with the dispatcher.
     *
     * @param  \Closure|string|array  $events
     * @param  \Closure|string|array|null  $listener
     *
     * @return **void**
     */
    public function listen($events, $listener = null)
    {
        if ($events instanceof Closure) {
            **return** collect($this->firstClosureParameterTypes($events))
                ->each(function ($event) use ($events) {
                    $this->listen($event, $events);
                });

```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
