### PR TITLE
[9.x] Collections: Allow pluck as higher order message

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -697,12 +697,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the values of a given key.
      *
-     * @param  string|array<array-key, string>  $value
+     * @param  string|array<array-key, string>|callable  $value
      * @param  string|null  $key
      * @return static<int, mixed>
      */
     public function pluck($value, $key = null)
     {
+        if (is_callable($value)) {
+            return $this->map($value);
+        }
+        
         return new static(Arr::pluck($this->items, $value, $key));
     }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -706,7 +706,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         if (is_callable($value)) {
             return $this->map($value);
         }
-        
+
         return new static(Arr::pluck($this->items, $value, $key));
     }
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -697,7 +697,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         if (is_callable($value)) {
             return $this->map($value);
         }
-        
+
         return new static(function () use ($value, $key) {
             [$value, $key] = $this->explodePluckParameters($value, $key);
 

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -688,12 +688,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Get the values of a given key.
      *
-     * @param  string|array<array-key, string>  $value
+     * @param  string|array<array-key, string>|callable  $value
      * @param  string|null  $key
      * @return static<int, mixed>
      */
     public function pluck($value, $key = null)
     {
+        if (is_callable($value)) {
+            return $this->map($value);
+        }
+        
         return new static(function () use ($value, $key) {
             [$value, $key] = $this->explodePluckParameters($value, $key);
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -35,6 +35,7 @@ use UnexpectedValueException;
  * @property-read HigherOrderCollectionProxy $max
  * @property-read HigherOrderCollectionProxy $min
  * @property-read HigherOrderCollectionProxy $partition
+ * @property-read HigherOrderCollectionProxy $pluck
  * @property-read HigherOrderCollectionProxy $reject
  * @property-read HigherOrderCollectionProxy $skipUntil
  * @property-read HigherOrderCollectionProxy $skipWhile
@@ -81,6 +82,7 @@ trait EnumeratesValues
         'max',
         'min',
         'partition',
+        'pluck',
         'reject',
         'skipUntil',
         'skipWhile',

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -890,7 +890,7 @@ class SupportCollectionTest extends TestCase
             ['id' => 1, 'title' => 'One'],
         ]);
 
-        $this->assertSame([23, 42, 1], $data->pluck->id);
+        $this->assertSame([23, 42, 1], $data->pluck->id->toArray());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -882,6 +882,20 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testHigherOrderCollectionPluck($collection)
+    {
+        $data = new $collection([
+            ['id' => 23, 'title' => 'Foo'],
+            ['id' => 42, 'title' => 'Bar'],
+            ['id' => 1, 'title' => 'One'],
+        ]);
+
+        $this->assertSame([23, 42, 1], $data->pluck->id);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testHigherOrderUnique($collection)
     {
         $c = new $collection([


### PR DESCRIPTION
Additionally to the few other higher order message functions I just assumed that `$collection->pluck->id` was a thing but it turned out that it wasn't implemented yet. I don't see any reason why it shouldn't be implemented, so here's the pull request for it :)