### PR TITLE
[9.x] Add hasSubject method to Mailables

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -778,14 +778,14 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
-     * Determine if the given subject is set on the mailable.
+     * Determine if the mailable has the given subject.
      *
      * @param  string  $subject
      * @return bool
      */
     public function hasSubject($subject)
     {
-        return $this->subject == $subject;
+        return $this->subject === $subject;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -778,6 +778,17 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Determine if the given subject is set on the mailable.
+     *
+     * @param  string  $subject
+     * @return bool
+     */
+    public function hasSubject($subject)
+    {
+        return $this->subject == $subject;
+    }
+
+    /**
      * Set the Markdown template for the message.
      *
      * @param  string  $view

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -304,6 +304,13 @@ class MailMailableTest extends TestCase
         }
     }
 
+    public function testMailableSetsSubjectCorrectly()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->subject('foo');
+        $this->assertTrue($mailable->hasSubject('foo'));
+    }
+
     public function testItIgnoresDuplicatedRawAttachments()
     {
         $mailable = new WelcomeMailableStub;


### PR DESCRIPTION
This PR adds the ability to call `hasSubject()` on a Mailable.

This compliments the existing methods `hasTo()`, `hasCC()`, `hasBCC()` and `hasFrom()` allowing for easier code readability, especially in tests.