### PR TITLE
[9.x] remove useless if statement from SupportReflectorTest

### DIFF
--- a/tests/Support/SupportReflectorTest.php
+++ b/tests/Support/SupportReflectorTest.php
@@ -89,17 +89,12 @@ class B extends A
     }
 }
 
-if (PHP_MAJOR_VERSION >= 8) {
-    eval('
-namespace Illuminate\Tests\Support;
-
 class C
 {
     public function f(A|Model $x)
     {
         //
     }
-}');
 }
 
 class TestClassWithCall


### PR DESCRIPTION
because of Laravel9 min PHP requirement is 8 and above , this if statement is useless

```
if (PHP_MAJOR_VERSION >= 8) {
    eval('
namespace Illuminate\Tests\Support;
```
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
