### PR TITLE
[9.x] Add startingAt and endingAt to console scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -20,6 +20,32 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to start running at a specific datetime.
+     *
+     * @param DateTime|string $end
+     * @return $this
+     */
+    public function startingAt(DateTime $start)
+    {
+        $start = Carbon::parse($start)->timezone($this->timezone);
+
+        return $this->when(fn () => Carbon::now($this->timezone) >= $start);
+    }
+
+    /**
+     * Schedule the event to stop running at a specific datetime.
+     *
+     * @param DateTime|string $end
+     * @return $this
+     */
+    public function endingAt($end)
+    {
+        $end = Carbon::parse($end)->timezone($this->timezone);
+
+        return $this->when(fn () => Carbon::now($this->timezone) < $end);
+    }
+
+    /**
      * Schedule the event to run between start and end time.
      *
      * @param  string  $startTime

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -22,12 +22,12 @@ trait ManagesFrequencies
     /**
      * Schedule the event to start running at a specific datetime.
      *
-     * @param DateTime|string $end
+     * @param \DateTime|string $end
      * @return $this
      */
-    public function startingAt(DateTime $start)
+    public function startingAt($start)
     {
-        $start = Carbon::parse($start)->timezone($this->timezone);
+        $start = Carbon::parse($start, $this->timezone);
 
         return $this->when(fn () => Carbon::now($this->timezone) >= $start);
     }
@@ -35,12 +35,12 @@ trait ManagesFrequencies
     /**
      * Schedule the event to stop running at a specific datetime.
      *
-     * @param DateTime|string $end
+     * @param \DateTime|string $end
      * @return $this
      */
     public function endingAt($end)
     {
-        $end = Carbon::parse($end)->timezone($this->timezone);
+        $end = Carbon::parse($end, $this->timezone);
 
         return $this->when(fn () => Carbon::now($this->timezone) < $end);
     }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -91,6 +91,33 @@ class ConsoleScheduledEventTest extends TestCase
         $this->assertTrue($event->isDue($app));
     }
 
+    public function testStartingEndingChecks()
+    {
+        $app = m::mock(Application::class.'[isDownForMaintenance,environment]');
+        $app->shouldReceive('isDownForMaintenance')->andReturn(false);
+        $app->shouldReceive('environment')->andReturn('production');
+
+        Carbon::setTestNow(Carbon::now());
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->startingAt(Carbon::now()->subDay())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->startingAt(Carbon::now()->subDay()->toDateString())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertFalse($event->startingAt(Carbon::now()->addDay())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->endingAt(Carbon::now()->addDay())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->endingAt(Carbon::now()->addDay()->toDateString())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertFalse($event->endingAt(Carbon::now()->subDay())->filtersPass($app));
+    }
+
     public function testTimeBetweenChecks()
     {
         $app = m::mock(Application::class.'[isDownForMaintenance,environment]');


### PR DESCRIPTION
This PR adds the `startingAt()` and `endingAt()` helper functions to the Artisan scheduler, for the situations where you want to start running a command only after or before a given date. The functions accept a DateTime or string, which is parsed to a Carbon instance.

Tests are attached to check that:

* startingAt in the past passes filters
* startingAt in the future does not pass filters
* endingAt in the future passes filters
* endingAt in the past does not pass filters

If this PR is merged I can make a pull request to the docs repo to add relevant documentation.