### PR TITLE
[9.x] Fix getController bug on Route

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -270,9 +270,13 @@ class Route
     public function getController()
     {
         if (! $this->controller) {
-            $class = $this->getControllerClass();
+            if (is_string($this->action['uses'])) {
+                $class = $this->parseControllerCallback()[0];
 
-            $this->controller = $this->container->make(ltrim($class, '\\'));
+                $this->controller = $this->container->make(ltrim($class, '\\'));
+            } elseif (is_a($this->action['uses'], Closure::class)) {
+                $this->controller = $this->action['uses'];
+            }
         }
 
         return $this->controller;


### PR DESCRIPTION
The `getController` method obviously assumes that the `$this->action['uses']` is always a string and it starts to parse it, But it is sometimes a `Closure`.

Laravel internally uses this method only after it makes sure that the controller is an action in the `run` method, but since this is a public method it should have a way to cover the below usage.

To prove the bug, you can run this on a newly installed laravel instance at the end of the `web.php` file or from a typical controller method.
```php
foreach (app('router')->getRoutes()->getRoutes() as $route) {
     dump($route->getController());
}
```


Using latest version of laravel 9.x:
![image](https://user-images.githubusercontent.com/6961695/159157401-258553c5-29b4-4750-ad63-79a93a571acb.png)

(I just stumbled upon this bug when I was working on my laravel-microscope package.)