### PR TITLE
[9.x] Fix getController on Route class

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -265,11 +265,11 @@ class Route
     /**
      * Get the controller instance for the route.
      *
-     * @return mixed
+     * @return object|null
      */
     public function getController()
     {
-        if (! $this->controller) {
+        if (! $this->controller && $this->isControllerAction()) {
             $class = $this->getControllerClass();
 
             $this->controller = $this->container->make(ltrim($class, '\\'));


### PR DESCRIPTION
The `getController` method obviously assumes that the `$this->action['uses']` is always a string and it starts to parse it, But it is sometimes a `Closure`.

Laravel internally uses this method only after it makes sure that the controller is an action in the `run` method, but since this is a public method it should have a way to cover the below usage.
- Since the `isControllerAction` is protected we can not expect the caller to check it before calling the  `getController`.

To prove the bug, you can run this on a newly installed laravel instance from a typical controller method or a command.
```php
foreach (app('router')->getRoutes()->getRoutes() as $route) {
     dump($route->getController());
}
```
- This can be considered as a breaking change since it was throwing a `TypeError` before, now instead it is returning null.


Using latest version of laravel 9.x:
![image](https://user-images.githubusercontent.com/6961695/159157401-258553c5-29b4-4750-ad63-79a93a571acb.png)

(I just stumbled upon this bug when I was working on my laravel-microscope package.)