### PR TITLE
[8.x] Close doctrineConnection on disconnect

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -825,6 +825,7 @@ class Connection implements ConnectionInterface
     public function disconnect()
     {
         $this->setPdo(null)->setReadPdo(null);
+        $this->doctrineConnection = null;
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -825,6 +825,7 @@ class Connection implements ConnectionInterface
     public function disconnect()
     {
         $this->setPdo(null)->setReadPdo(null);
+
         $this->doctrineConnection = null;
     }
 


### PR DESCRIPTION
Consider this test:

```php 
class ExampleTest extends TestCase
{
    use DatabaseMigrations; 

    protected function tearDown(): void
    {
        // parent::tearDown(); <-- Omitted on purposed (or not)

        DB::disconnect();
    }

    public function test_1()
    {
        $this->assertTrue(true);
    }

    public function test_2()
    {
        $this->assertTrue(true);
    }

    // Repeat test 102x times...

    public function test_105()
    {
        $this->assertTrue(true);
    }
}
```

With a migration that modify a column: 
```php 
public function up()
{
    Schema::create('users', function (Blueprint $table) {
        $table->increments('id');
        $table->string('user_name', 50);
    });

    Schema::table('users', function (Blueprint $table) {
        $table->string('user_name', 120)->change();
    });
}
```

On PostgreSQL, after the 100th iteration, this error will pop up:
```txt
Illuminate\Database\QueryException: SQLSTATE[08006] [7] connection to server at "127.0.0.1", port 5432 failed: FATAL:  sorry, too many clients already (SQL: create table "migrations" ("id" serial primary key not null, "migration" varchar(255) not null, "batch" integer not null))
```

While disconnect [sets the “main” PDO object as `null`](https://github.com/laravel/framework/blob/b9203fca96960ef9cd8860cb4ec99d1279353a8d/src/Illuminate/Database/Connection.php#L825-L828), the [Doctrine connection created by the “change”](https://github.com/laravel/framework/blob/b9203fca96960ef9cd8860cb4ec99d1279353a8d/src/Illuminate/Database/Connection.php#L1008) action is not. The actual connection to the database is not actually closed in this specific case as the underlying PDO object is not fully destroyed as per PHP Documentation: https://www.php.net/manual/en/pdo.connections.php. 

This bug won't affect any migration that are not modifying a column, as the Doctrine Connection is only created when needed, eg. using `->change()`. 

I understand this fix won’t have much impact on a normal Laravel install, as :
1. Laravel TestCase undefined the whole app on `tearDown()`, Connection included, closing the Doctrine connection. 
1. This test is pointless and should call `parent::tearDown();`

But in a situation where `disconnect()` is called outside of a test scenario, or anyone not using the whole Laravel TestCase _might_ [encounter](https://github.com/userfrosting/sprinkle-account/runs/5579295094?check_suite_focus=true#step:12:23) [this issue](https://bbqsoftwares.com/blog/postgre-too-many-connection). 

References : 
- https://github.com/laravel/framework/issues/18056
- https://github.com/laravel/framework/issues/18471
- https://github.com/laravel/framework/pull/20340