### PR TITLE
[9.x] Adds `isEqual` to compare file hashes in filesystem

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -503,14 +503,14 @@ class Filesystem
      * Check if both files are the same by comparing their hash.
      *
      * @param  string  $file
-     * @param  string  $comparable
+     * @param  string  $compared
      * @return bool
      */
-    public function isEqual($file, $comparable)
+    public function isEqual($file, $compared)
     {
         $hash = @md5_file($file);
 
-        return $hash && $hash === @md5_file($comparable);
+        return $hash && $hash === @md5_file($compared);
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -500,17 +500,17 @@ class Filesystem
     }
 
     /**
-     * Check if both files are the same by comparing their hash.
+     * Determine if two files are the same by comparing their hashes.
      *
-     * @param  string  $file
-     * @param  string  $compared
+     * @param  string  $firstFile
+     * @param  string  $secondFile
      * @return bool
      */
-    public function isEqual($file, $compared)
+    public function hasSameHash($firstFile, $secondFile)
     {
-        $hash = @md5_file($file);
+        $hash = @md5_file($firstFile);
 
-        return $hash && $hash === @md5_file($compared);
+        return $hash && $hash === @md5_file($secondFile);
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -500,6 +500,20 @@ class Filesystem
     }
 
     /**
+     * Check if both files are the same by comparing their hash.
+     *
+     * @param  string  $file
+     * @param  string  $comparable
+     * @return bool
+     */
+    public function isEqual($file, $comparable)
+    {
+        $hash = @md5_file($file);
+
+        return $hash && $hash === @md5_file($comparable);
+    }
+
+    /**
      * Determine if the given path is a file.
      *
      * @param  string  $file

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -15,6 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool deleteDirectory(string $directory, bool $preserve = false)
  * @method static bool exists(string $path)
  * @method static bool isDirectory(string $directory)
+ * @method static bool isEqual(string $file, string $compared)
  * @method static bool isFile(string $file)
  * @method static bool isReadable(string $path)
  * @method static bool isWritable(string $path)

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -544,7 +544,7 @@ class FilesystemTest extends TestCase
         $this->assertEquals($data, file_get_contents(self::$tempDir.'/text/foo2.txt'));
     }
 
-    public function testIsEqualChecksFileHashes()
+    public function testHasSameHashChecksFileHashes()
     {
         $filesystem = new Filesystem;
 
@@ -553,10 +553,10 @@ class FilesystemTest extends TestCase
         file_put_contents(self::$tempDir.'/text/foo2.txt', 'contents');
         file_put_contents(self::$tempDir.'/text/foo3.txt', 'invalid');
 
-        $this->assertTrue($filesystem->isEqual(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo2.txt'));
-        $this->assertFalse($filesystem->isEqual(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo3.txt'));
-        $this->assertFalse($filesystem->isEqual(self::$tempDir.'/text/foo4.txt', self::$tempDir.'/text/foo.txt'));
-        $this->assertFalse($filesystem->isEqual(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo4.txt'));
+        $this->assertTrue($filesystem->hasSameHash(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo2.txt'));
+        $this->assertFalse($filesystem->hasSameHash(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo3.txt'));
+        $this->assertFalse($filesystem->hasSameHash(self::$tempDir.'/text/foo4.txt', self::$tempDir.'/text/foo.txt'));
+        $this->assertFalse($filesystem->hasSameHash(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo4.txt'));
     }
 
     public function testIsFileChecksFilesProperly()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -544,6 +544,21 @@ class FilesystemTest extends TestCase
         $this->assertEquals($data, file_get_contents(self::$tempDir.'/text/foo2.txt'));
     }
 
+    public function testIsEqualChecksFileHashes()
+    {
+        $filesystem = new Filesystem;
+
+        mkdir(self::$tempDir.'/text');
+        file_put_contents(self::$tempDir.'/text/foo.txt', 'contents');
+        file_put_contents(self::$tempDir.'/text/foo2.txt', 'contents');
+        file_put_contents(self::$tempDir.'/text/foo3.txt', 'invalid');
+
+        $this->assertTrue($filesystem->isEqual(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo2.txt'));
+        $this->assertFalse($filesystem->isEqual(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo3.txt'));
+        $this->assertFalse($filesystem->isEqual(self::$tempDir.'/text/foo4.txt', self::$tempDir.'/text/foo.txt'));
+        $this->assertFalse($filesystem->isEqual(self::$tempDir.'/text/foo.txt', self::$tempDir.'/text/foo4.txt'));
+    }
+
     public function testIsFileChecksFilesProperly()
     {
         $filesystem = new Filesystem;


### PR DESCRIPTION
## What?

Allows to compare two files if these exists and their hashes are the same.

```php
use Illuminate\Support\Facades\File;

if (File::isEqual('foo.txt', 'bar.txt')) {
   return 'Both files are equal.'
}
```

It will always return `false` if one of the compared files doesn't exist.

## Why?

Useful to check if a file copied was later edited without using `exists()` and `hash()` damn every time.

## BC?

Is not expected the developer to have a macro of the same name for different functionality.