### PR TITLE
[9.x] Adds `toFixedArray` to Enumerate Values trait

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
 use JsonSerializable;
+use SplFixedArray;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 use UnexpectedValueException;
@@ -858,6 +859,16 @@ trait EnumeratesValues
     public function collect()
     {
         return new Collection($this->all());
+    }
+
+    /**
+     * Get the collection of items as a fixed array object, using integer keys.
+     *
+     * @return \SplFixedArray<int, mixed>
+     */
+    public function toFixedArray()
+    {
+        return SplFixedArray::fromArray($this->values()->toArray());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -20,6 +20,7 @@ use JsonSerializable;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use SplFixedArray;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use UnexpectedValueException;
@@ -633,6 +634,17 @@ class SupportCollectionTest extends TestCase
 
         $this->assertInstanceOf(LazyCollection::class, $lazy);
         $this->assertSame([1, 2, 3, 4, 5], $lazy->all());
+    }
+
+    public function testFixedArrayReturnsSplFixedArray()
+    {
+        $data = new Collection(['foo' => 'bar', 'baz' => 'quz', 'qux' => ['cougar']]);
+
+        $this->assertInstanceOf(SplFixedArray::class, $data->toFixedArray());
+        $this->assertCount(3, $data->toFixedArray());
+        $this->assertSame('bar', $data->toFixedArray()[0]);
+        $this->assertSame('quz', $data->toFixedArray()[1]);
+        $this->assertSame(['cougar'], $data->toFixedArray()[2]);
     }
 
     /**


### PR DESCRIPTION
## What?

Allows a Collection to become a `SplFixedArray` with one method. Fixed arrays consume less memory, so this allows to operate on large datasets of primitives without exhausting PHP memory, or where a `LazyCollection` is not available.

```php
foreach($veryLargeCollection->toFixedArray() as $line) {
    // ...
}
```

## Why?

Because sometimes arrays become very large and PHP likes to reserve more memory to it even when it won't grow any larger.

## Why not a `FixedCollection`

Because it breaks the `Enumerable` contract. Since an `SplFixedArray` uses integer keys, any key manipulation is invalid. 

## BC?

I highly doubt somebody as macro'ed `toFixedArray()`.

## Benchs?

Execute this in your tests:

```php
public function test_bench(): void
{
    $collection = Collection::times(10000, fn() => Str::random());
    
    echo memory_get_usage();

    $collection = $collection->toFixedArray();

    // Should report less memory than the previous call.
    echo memory_get_usage();
}
```