### PR TITLE
[9.x] Make reconnectIfMissingConnection public

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -814,7 +814,7 @@ class Connection implements ConnectionInterface
      *
      * @return void
      */
-    protected function reconnectIfMissingConnection()
+    public function reconnectIfMissiegConnection()
     {
         if (is_null($this->pdo)) {
             $this->reconnect();


### PR DESCRIPTION
## Summary
I've use-cases where I need to get the PDO from a connection but also
need to respect, in case a disconnect happened, to perform a reconnect.

Currently, I've to:
- get pdo
- check if null
- call reconnect

everywhere I need it. Or I could just call this one on the connection
object, if it were public, and then get the PDO.
