### PR TITLE
[9.x] Added getWithoutCasting on Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -48,6 +48,13 @@ class Builder implements BuilderContract
     protected $model;
 
     /**
+     * Indicates that the model does not make any casting.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected static $disableModelAttributeCasting = false;
+
+    /**
      * The relationships that should be eager loaded.
      *
      * @var array
@@ -653,6 +660,8 @@ class Builder implements BuilderContract
     {
         $builder = $this->applyScopes();
 
+        $builder->model->disableAttributeCasting = self::$disableModelAttributeCasting;
+
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded, which will solve the
         // n+1 query issue for the developers to avoid running a lot of queries.
@@ -661,6 +670,24 @@ class Builder implements BuilderContract
         }
 
         return $builder->getModel()->newCollection($models);
+    }
+
+    /**
+     * Execute the query as a "select" statement.
+     * And disables attribute casting for the models.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
+    public function getWithoutCasting($columns = ['*'])
+    {
+        self::$disableModelAttributeCasting = true;
+
+        $get = $this->get($columns);
+
+        self::$disableModelAttributeCasting = false;
+
+        return $get;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -263,6 +263,10 @@ trait HasAttributes
      */
     protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
     {
+        if ($this->disableAttributeCasting) {
+            return $attributes;
+        }
+
         foreach ($this->getCasts() as $key => $value) {
             if (! array_key_exists($key, $attributes) ||
                 in_array($key, $mutatedAttributes)) {
@@ -692,6 +696,10 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
+        if ($this->disableAttributeCasting) {
+            return $value;
+        }
+
         $castType = $this->getCastType($key);
 
         if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -119,6 +119,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected $escapeWhenCastingToString = false;
 
     /**
+     * Indicates that the object does not make any casting.
+     *
+     * @var bool
+     */
+    public $disableAttributeCasting = false;
+
+    /**
      * The connection resolver instance.
      *
      * @var \Illuminate\Database\ConnectionResolverInterface
@@ -505,6 +512,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $model->mergeCasts($this->casts);
 
+        $model->disableAttributeCasting = $this->disableAttributeCasting;
+
         $model->fill((array) $attributes);
 
         return $model;
@@ -567,6 +576,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function all($columns = ['*'])
     {
         return static::query()->get(
+            is_array($columns) ? $columns : func_get_args()
+        );
+    }
+
+    /**
+     * Get all of the models from the database. No checking is done.
+     *
+     * @param  array|mixed  $columns
+     * @return \Illuminate\Database\Eloquent\Collection<int, static>
+     */
+    public static function allWithoutCasting($columns = ['*'])
+    {
+        return static::query()->getWithoutCasting(
             is_array($columns) ? $columns : func_get_args()
         );
     }


### PR DESCRIPTION
I recently helped on a project, where they send a lot of json data (about 8 MB) to the frontend, so that they don't need to make ajax calls in between. Whether you find this approach good or bad, that was just the case and I had to work with it, and the frontend was built on top of that. But the performance was very bad and the request took far to long. So I tried to optimize their api endpoints.

I don't know exactly why, but they decided to add casts for all attributes to quite all of their models. Something like this:

```
class Foo extends Model

    ...

    protected $casts = [
        'id'                          => 'integer',
        'uuid'                        => EfficientUuid::class,
        'tenant_id'                   => 'integer',
        'type'                        => 'string',
        'program_id'        => 'integer',
        'sprint_id'         => 'integer',
        'structure_id'      => 'integer',
        'element_status_id' => 'integer',
        'status_id'         => 'integer',
        'position'                    => 'integer',
        'parent_id'                   => 'integer',
        '_lft'                        => 'integer',
        '_rgt'                        => 'integer',
        'name'                        => 'string',
        'name_short'                  => 'string',
        'description'                 => 'string',
        'description_short'           => 'string',
        'summary'                     => 'string',
        'weight'                      => 'float',
        'shortcut'                    => 'string',
        'link'                        => 'string',
        ...
        ...
        The list goes on...
    ];
```

And this on all of their models, and they also had a lot of relations on some of the models!

I seeded 1.000 foo and 10.000 posts and 1.000 orders.

Now if I wanted to eager load `Foo` with its relations like so (and notice that the relations also had lots of attribute cast fields defined):

```
Route::get('/foo', function () {
    $foo = Foo::with('posts', 'orders')->get();
    return $foo;
});
```

If I ran postman and query the route, it returns 3,4 MB data and takes 6-7 sec!
I analysed the code with [xhprof ](https://www.php.net/manual/de/book.xhprof.php) and saw that `getCast` and `getCastType` took around 3sec.

Since often most of the data is already in the right format without casting it explicitly, I implemented this approach of `getWithoutCasting` and `allWithoutCasting` to make the model avoid casting.

So requesting the same endpoint like so, returns 3,2 MB data and only took 2-3 sec!:
```
Route::get('/foo', function () {
    $foo = Foo::with('posts', 'orders')->getWithoutCasting();
    return $foo;
});
```