### PR TITLE
[9.x] Improve command name handling

### DIFF
--- a/src/Illuminate/Auth/Console/ClearResetsCommand.php
+++ b/src/Illuminate/Auth/Console/ClearResetsCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Auth\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'auth:clear-resets')]
 class ClearResetsCommand extends Command
 {
     /**

--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Cache\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'cache:table')]
 class CacheTableCommand extends Command
 {
     /**

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -5,11 +5,9 @@ namespace Illuminate\Cache\Console;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'cache:clear')]
 class ClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Cache\Console;
 
 use Illuminate\Cache\CacheManager;
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'cache:forget')]
 class ForgetCommand extends Command
 {
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Support\Traits\Macroable;
+use ReflectionClass;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -84,6 +85,40 @@ class Command extends SymfonyCommand
         if (! isset($this->signature)) {
             $this->specifyParameters();
         }
+    }
+
+    /**
+     * Return the command name.
+     *
+     * @return string|null
+     */
+    public static function getDefaultName(): ?string
+    {
+        $class = static::class;
+
+        $signature = (new ReflectionClass($class))->getDefaultProperties()['signature'] ?? null;
+
+        if (isset($signature)) {
+            return Parser::parse($signature)[0];
+        }
+
+        $name = (new ReflectionClass($class))->getDefaultProperties()['name'] ?? null;
+
+        return $name ?: parent::getDefaultName();
+    }
+
+    /**
+     * Return the command description.
+     *
+     * @return string|null
+     */
+    public static function getDefaultDescription(): ?string
+    {
+        $class = static::class;
+
+        $description = (new ReflectionClass($class))->getDefaultProperties()['description'] ?? null;
+
+        return $description ?: parent::getDefaultDescription();
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Console\Scheduling;
 use Illuminate\Console\Command;
 use Illuminate\Console\Events\ScheduledBackgroundTaskFinished;
 use Illuminate\Contracts\Events\Dispatcher;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'schedule:finish')]
 class ScheduleFinishCommand extends Command
 {
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -10,10 +10,8 @@ use Illuminate\Console\Events\ScheduledTaskStarting;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Date;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
-#[AsCommand(name: 'schedule:run')]
 class ScheduleRunCommand extends Command
 {
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'schedule:test')]
 class ScheduleTestCommand extends Command
 {
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -4,10 +4,8 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Process;
 
-#[AsCommand(name: 'schedule:work')]
 class ScheduleWorkCommand extends Command
 {
     /**

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -9,9 +9,7 @@ use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Events\SchemaDumped;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'schema:dump')]
 class DumpCommand extends Command
 {
     /**

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -4,10 +4,8 @@ namespace Illuminate\Database\Console\Factories;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:factory')]
 class FactoryMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -6,11 +6,9 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Model;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'db:seed')]
 class SeedCommand extends Command
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Database\Console\Seeds;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:seeder')]
 class SeederMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -4,10 +4,8 @@ namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'db:wipe')]
 class WipeCommand extends Command
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:cast')]
 class CastMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:channel')]
 class ChannelMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'clear-compiled')]
 class ClearCompiledCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -5,10 +5,8 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:component')]
 class ComponentMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -6,10 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use LogicException;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
-#[AsCommand(name: 'config:cache')]
 class ConfigCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ConfigClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigClearCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'config:clear')]
 class ConfigClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -4,11 +4,9 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:command')]
 class ConsoleMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -7,10 +7,8 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeEnabled;
 use Illuminate\Foundation\Exceptions\RegisterErrorViewPaths;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Throwable;
 
-#[AsCommand(name: 'down')]
 class DownCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/EnvironmentCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'env')]
 class EnvironmentCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'event:cache')]
 class EventCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/EventClearCommand.php
+++ b/src/Illuminate/Foundation/Console/EventClearCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'event:clear')]
 class EventClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'event:generate')]
 class EventGenerateCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Closure;
 use Illuminate\Console\Command;
 use ReflectionFunction;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'event:list')]
 class EventListCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:event')]
 class EventMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -3,10 +3,8 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:exception')]
 class ExceptionMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -4,10 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:job')]
 class JobMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Encryption\Encrypter;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'key:generate')]
 class KeyGenerateCommand extends Command
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -5,10 +5,8 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:listener')]
 class ListenerMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -5,10 +5,8 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:mail')]
 class MailMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -5,10 +5,8 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:model')]
 class ModelMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -4,10 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:notification')]
 class NotificationMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -4,10 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use InvalidArgumentException;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:observer')]
 class ObserverMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'optimize:clear')]
 class OptimizeClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'optimize')]
 class OptimizeCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Foundation\PackageManifest;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'package:discover')]
 class PackageDiscoverCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -5,10 +5,8 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use LogicException;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:policy')]
 class PolicyMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:provider')]
 class ProviderMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:request')]
 class RequestMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
@@ -3,10 +3,8 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:resource')]
 class ResourceMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -6,9 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'route:cache')]
 class RouteCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/RouteClearCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteClearCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'route:clear')]
 class RouteClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -12,11 +12,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionFunction;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Terminal;
 
-#[AsCommand(name: 'route:list')]
 class RouteListCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -3,10 +3,8 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:rule')]
 class RuleMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:scope')]
 class ScopeMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -4,12 +4,10 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Env;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
-#[AsCommand(name: 'serve')]
 class ServeCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'storage:link')]
 class StorageLinkCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'stub:publish')]
 class StubPublishCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -4,10 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:test')]
 class TestMakeCommand extends GeneratorCommand
 {
     /**

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\MaintenanceModeDisabled;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'up')]
 class UpCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -13,9 +13,7 @@ use League\Flysystem\Local\LocalFilesystemAdapter as LocalAdapter;
 use League\Flysystem\MountManager;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\Visibility;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'vendor:publish')]
 class VendorPublishCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -4,11 +4,9 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-#[AsCommand(name: 'view:cache')]
 class ViewCacheCommand extends Command
 {
     /**

--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use RuntimeException;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'view:clear')]
 class ViewClearCommand extends Command
 {
     /**

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Notifications\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'notifications:table')]
 class NotificationTableCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:batches-table')]
 class BatchesTableCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -6,11 +6,9 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use ReflectionClass;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'queue:clear')]
 class ClearCommand extends Command
 {
     use ConfirmableTrait;

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:failed-table')]
 class FailedTableCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/FlushFailedCommand.php
+++ b/src/Illuminate/Queue/Console/FlushFailedCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:flush')]
 class FlushFailedCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:forget')]
 class ForgetFailedCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:failed')]
 class ListFailedCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Queue\Listener;
 use Illuminate\Queue\ListenerOptions;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:listen')]
 class ListenCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -7,9 +7,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Queue\Events\QueueBusy;
 use Illuminate\Support\Collection;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:monitor')]
 class MonitorCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -7,9 +7,7 @@ use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\PrunableBatchRepository;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:prune-batches')]
 class PruneBatchesCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Queue\Failed\PrunableFailedJobProvider;
 use Illuminate\Support\Carbon;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:prune-failed')]
 class PruneFailedJobsCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Support\InteractsWithTime;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:restart')]
 class RestartCommand extends Command
 {
     use InteractsWithTime;

--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Queue\Console;
 
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:retry-batch')]
 class RetryBatchCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -8,9 +8,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Queue\Events\JobRetryRequested;
 use Illuminate\Support\Arr;
 use RuntimeException;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:retry')]
 class RetryCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:table')]
 class TableCommand extends Command
 {
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -11,9 +11,7 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'queue:work')]
 class WorkCommand extends Command
 {
     /**

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -5,10 +5,8 @@ namespace Illuminate\Routing\Console;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use InvalidArgumentException;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:controller')]
 class ControllerMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
+++ b/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
@@ -4,9 +4,7 @@ namespace Illuminate\Routing\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'make:middleware')]
 class MiddlewareMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -5,9 +5,7 @@ namespace Illuminate\Session\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
-use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'session:table')]
 class SessionTableCommand extends Command
 {
     /**


### PR DESCRIPTION
This PR improves how the default name and description of a command are returned by giving precedence to the command signature and name property, just like in a command's constructor. This allows Symfony's lazy loading of a command to continue to function, without having to resolve the command from the container. Additionally, this PR allows you to make the new command attribute optional with Symfony 6.1

The most important changes in this PR are the overwriting of the `getDefaultName` and `getDefaultDescription` methods.

In Laravel v10, we may safely remove the deprecated static `$defaultName` property.