### PR TITLE
[10.x] Remove default name properties

### DIFF
--- a/src/Illuminate/Auth/Console/ClearResetsCommand.php
+++ b/src/Illuminate/Auth/Console/ClearResetsCommand.php
@@ -16,17 +16,6 @@ class ClearResetsCommand extends Command
     protected $signature = 'auth:clear-resets {name? : The name of the password broker}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'auth:clear-resets';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -18,17 +18,6 @@ class CacheTableCommand extends Command
     protected $name = 'cache:table';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'cache:table';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -20,17 +20,6 @@ class ClearCommand extends Command
     protected $name = 'cache:clear';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'cache:clear';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -17,17 +17,6 @@ class ForgetCommand extends Command
     protected $signature = 'cache:forget {key : The key to remove} {store? : The store to remove the key from}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'cache:forget';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -18,17 +18,6 @@ class ScheduleFinishCommand extends Command
     protected $signature = 'schedule:finish {id} {code=0}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'schedule:finish';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -24,17 +24,6 @@ class ScheduleRunCommand extends Command
     protected $name = 'schedule:run';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'schedule:run';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -17,17 +17,6 @@ class ScheduleTestCommand extends Command
     protected $signature = 'schedule:test {--name= : The name of the scheduled command to run}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'schedule:test';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -18,17 +18,6 @@ class ScheduleWorkCommand extends Command
     protected $name = 'schedule:work';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'schedule:work';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -25,17 +25,6 @@ class DumpCommand extends Command
                 {--prune : Delete all existing migration files}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'schema:dump';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -18,17 +18,6 @@ class FactoryMakeCommand extends GeneratorCommand
     protected $name = 'make:factory';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:factory';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -23,17 +23,6 @@ class SeedCommand extends Command
     protected $name = 'db:seed';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'db:seed';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -17,17 +17,6 @@ class SeederMakeCommand extends GeneratorCommand
     protected $name = 'make:seeder';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:seeder';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -20,17 +20,6 @@ class WipeCommand extends Command
     protected $name = 'db:wipe';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'db:wipe';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -16,17 +16,6 @@ class CastMakeCommand extends GeneratorCommand
     protected $name = 'make:cast';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:cast';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
@@ -16,17 +16,6 @@ class ChannelMakeCommand extends GeneratorCommand
     protected $name = 'make:channel';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:channel';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -16,17 +16,6 @@ class ClearCompiledCommand extends Command
     protected $name = 'clear-compiled';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'clear-compiled';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -19,17 +19,6 @@ class ComponentMakeCommand extends GeneratorCommand
     protected $name = 'make:component';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:component';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -20,17 +20,6 @@ class ConfigCacheCommand extends Command
     protected $name = 'config:cache';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'config:cache';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ConfigClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigClearCommand.php
@@ -17,17 +17,6 @@ class ConfigClearCommand extends Command
     protected $name = 'config:clear';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'config:clear';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -21,17 +21,6 @@ class ConsoleMakeCommand extends GeneratorCommand
     protected $name = 'make:command';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:command';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -26,17 +26,6 @@ class DownCommand extends Command
                                  {--status=503 : The status code that should be used when returning the maintenance mode response}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'down';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EnvironmentCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentCommand.php
@@ -16,17 +16,6 @@ class EnvironmentCommand extends Command
     protected $name = 'env';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'env';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -17,17 +17,6 @@ class EventCacheCommand extends Command
     protected $signature = 'event:cache';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'event:cache';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventClearCommand.php
+++ b/src/Illuminate/Foundation/Console/EventClearCommand.php
@@ -17,17 +17,6 @@ class EventClearCommand extends Command
     protected $name = 'event:clear';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'event:clear';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -17,17 +17,6 @@ class EventGenerateCommand extends Command
     protected $name = 'event:generate';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'event:generate';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -18,17 +18,6 @@ class EventListCommand extends Command
     protected $signature = 'event:list {--event= : Filter the events by name}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'event:list';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -16,17 +16,6 @@ class EventMakeCommand extends GeneratorCommand
     protected $name = 'make:event';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:event';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -17,17 +17,6 @@ class ExceptionMakeCommand extends GeneratorCommand
     protected $name = 'make:exception';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:exception';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -20,17 +20,6 @@ class JobMakeCommand extends GeneratorCommand
     protected $name = 'make:job';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:job';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -22,17 +22,6 @@ class KeyGenerateCommand extends Command
                     {--force : Force the operation to run when in production}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'key:generate';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -21,17 +21,6 @@ class ListenerMakeCommand extends GeneratorCommand
     protected $name = 'make:listener';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:listener';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -21,17 +21,6 @@ class MailMakeCommand extends GeneratorCommand
     protected $name = 'make:mail';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:mail';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -21,17 +21,6 @@ class ModelMakeCommand extends GeneratorCommand
     protected $name = 'make:model';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:model';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -20,17 +20,6 @@ class NotificationMakeCommand extends GeneratorCommand
     protected $name = 'make:notification';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:notification';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -18,17 +18,6 @@ class ObserverMakeCommand extends GeneratorCommand
     protected $name = 'make:observer';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:observer';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -16,17 +16,6 @@ class OptimizeClearCommand extends Command
     protected $name = 'optimize:clear';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'optimize:clear';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -16,17 +16,6 @@ class OptimizeCommand extends Command
     protected $name = 'optimize';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'optimize';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -17,17 +17,6 @@ class PackageDiscoverCommand extends Command
     protected $signature = 'package:discover';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'package:discover';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -19,17 +19,6 @@ class PolicyMakeCommand extends GeneratorCommand
     protected $name = 'make:policy';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:policy';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -16,17 +16,6 @@ class ProviderMakeCommand extends GeneratorCommand
     protected $name = 'make:provider';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:provider';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -16,17 +16,6 @@ class RequestMakeCommand extends GeneratorCommand
     protected $name = 'make:request';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:request';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
@@ -17,17 +17,6 @@ class ResourceMakeCommand extends GeneratorCommand
     protected $name = 'make:resource';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:resource';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -19,17 +19,6 @@ class RouteCacheCommand extends Command
     protected $name = 'route:cache';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'route:cache';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RouteClearCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteClearCommand.php
@@ -17,17 +17,6 @@ class RouteClearCommand extends Command
     protected $name = 'route:clear';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'route:clear';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -27,17 +27,6 @@ class RouteListCommand extends Command
     protected $name = 'route:list';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'route:list';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -17,17 +17,6 @@ class RuleMakeCommand extends GeneratorCommand
     protected $name = 'make:rule';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:rule';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -16,17 +16,6 @@ class ScopeMakeCommand extends GeneratorCommand
     protected $name = 'make:scope';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:scope';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -20,17 +20,6 @@ class ServeCommand extends Command
     protected $name = 'serve';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'serve';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -18,17 +18,6 @@ class StorageLinkCommand extends Command
                 {--force : Recreate existing symbolic links}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'storage:link';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -17,17 +17,6 @@ class StubPublishCommand extends Command
     protected $signature = 'stub:publish {--force : Overwrite any existing files}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'stub:publish';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -18,17 +18,6 @@ class TestMakeCommand extends GeneratorCommand
     protected $name = 'make:test';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:test';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -18,17 +18,6 @@ class UpCommand extends Command
     protected $name = 'up';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'up';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -50,17 +50,6 @@ class VendorPublishCommand extends Command
                     {--tag=* : One or many tags that have assets you want to publish}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'vendor:publish';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -19,17 +19,6 @@ class ViewCacheCommand extends Command
     protected $signature = 'view:cache';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'view:cache';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -18,17 +18,6 @@ class ViewClearCommand extends Command
     protected $name = 'view:clear';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'view:clear';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Notifications/Console/NotificationTableCommand.php
+++ b/src/Illuminate/Notifications/Console/NotificationTableCommand.php
@@ -18,17 +18,6 @@ class NotificationTableCommand extends Command
     protected $name = 'notifications:table';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'notifications:table';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -18,17 +18,6 @@ class BatchesTableCommand extends Command
     protected $name = 'queue:batches-table';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:batches-table';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/ClearCommand.php
+++ b/src/Illuminate/Queue/Console/ClearCommand.php
@@ -23,17 +23,6 @@ class ClearCommand extends Command
     protected $name = 'queue:clear';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:clear';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -18,17 +18,6 @@ class FailedTableCommand extends Command
     protected $name = 'queue:failed-table';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:failed-table';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/FlushFailedCommand.php
+++ b/src/Illuminate/Queue/Console/FlushFailedCommand.php
@@ -16,17 +16,6 @@ class FlushFailedCommand extends Command
     protected $signature = 'queue:flush {--hours= : The number of hours to retain failed job data}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:flush';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -16,17 +16,6 @@ class ForgetFailedCommand extends Command
     protected $signature = 'queue:forget {id : The ID of the failed job}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:forget';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -17,17 +17,6 @@ class ListFailedCommand extends Command
     protected $name = 'queue:failed';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:failed';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -28,17 +28,6 @@ class ListenCommand extends Command
                             {--tries=1 : Number of times to attempt a job before logging it failed}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:listen';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -22,17 +22,6 @@ class MonitorCommand extends Command
                        {--max=1000 : The maximum number of jobs that can be on the queue before an event is dispatched}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:monitor';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/PruneBatchesCommand.php
+++ b/src/Illuminate/Queue/Console/PruneBatchesCommand.php
@@ -22,17 +22,6 @@ class PruneBatchesCommand extends Command
                 {--unfinished= : The number of hours to retain unfinished batch data }';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:prune-batches';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
+++ b/src/Illuminate/Queue/Console/PruneFailedJobsCommand.php
@@ -19,17 +19,6 @@ class PruneFailedJobsCommand extends Command
                 {--hours=24 : The number of hours to retain failed jobs data}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:prune-failed';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -20,17 +20,6 @@ class RestartCommand extends Command
     protected $name = 'queue:restart';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:restart';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/RetryBatchCommand.php
+++ b/src/Illuminate/Queue/Console/RetryBatchCommand.php
@@ -17,17 +17,6 @@ class RetryBatchCommand extends Command
     protected $signature = 'queue:retry-batch {id : The ID of the batch whose failed jobs should be retried}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:retry-batch';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -24,17 +24,6 @@ class RetryCommand extends Command
                             {--range=* : Range of job IDs (numeric) to be retried}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:retry';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -18,17 +18,6 @@ class TableCommand extends Command
     protected $name = 'queue:table';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:table';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -40,17 +40,6 @@ class WorkCommand extends Command
                             {--tries=1 : Number of times to attempt a job before logging it failed}';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'queue:work';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -21,17 +21,6 @@ class ControllerMakeCommand extends GeneratorCommand
     protected $name = 'make:controller';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:controller';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
+++ b/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
@@ -19,17 +19,6 @@ class MiddlewareMakeCommand extends GeneratorCommand
     protected $name = 'make:middleware';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:middleware';
-
-    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -18,17 +18,6 @@ class SessionTableCommand extends Command
     protected $name = 'session:table';
 
     /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'session:table';
-
-    /**
      * The console command description.
      *
      * @var string


### PR DESCRIPTION
These can safely be removed from Laravel v10, regardless if https://github.com/laravel/framework/pull/41595 gets merged or not.