### PR TITLE
[9.x] remove extra useless parameter for method serialize in EncryptCookie

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -135,7 +135,7 @@ class EncryptCookies
     {
         return is_array($cookie)
                         ? $this->decryptArray($cookie)
-                        : $this->encrypter->decrypt($cookie, static::serialized($name));
+                        : $this->encrypter->decrypt($cookie, static::serialized());
     }
 
     /**
@@ -150,7 +150,7 @@ class EncryptCookies
 
         foreach ($cookie as $key => $value) {
             if (is_string($value)) {
-                $decrypted[$key] = $this->encrypter->decrypt($value, static::serialized($key));
+                $decrypted[$key] = $this->encrypter->decrypt($value, static::serialized());
             }
 
             if (is_array($value)) {
@@ -178,7 +178,7 @@ class EncryptCookies
                 $cookie,
                 $this->encrypter->encrypt(
                     CookieValuePrefix::create($cookie->getName(), $this->encrypter->getKey()).$cookie->getValue(),
-                    static::serialized($cookie->getName())
+                    static::serialized()
                 )
             ));
         }
@@ -216,10 +216,9 @@ class EncryptCookies
     /**
      * Determine if the cookie contents should be serialized.
      *
-     * @param  string  $name
      * @return bool
      */
-    public static function serialized($name)
+    public static function serialized()
     {
         return static::$serialize;
     }


### PR DESCRIPTION
in serialize method we got $name parameter but we doesn't use it anywhere in method body

```
public static function serialized($name)
    {
        return static::$serialize;
    }
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
