### PR TITLE
[9.x] Add tests for assertSessionHasErrors in TestResponse

### DIFF
--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1652,6 +1652,23 @@ class TestResponseTest extends TestCase
         $this->assertSame('cookie-value', $cookie->getValue());
     }
 
+    public function testAssertSessionHasErrors()
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->put('errors', $errorBag = new ViewErrorBag);
+
+        $errorBag->put('default', new MessageBag([
+            'foo' => [
+                'foo is required',
+            ],
+        ]));
+
+        $response = TestResponse::fromBaseResponse(new Response());
+
+        $response->assertSessionHasErrors(['foo']);
+    }
+
     public function testGetEncryptedCookie()
     {
         $container = Container::getInstance();


### PR DESCRIPTION
There was no tests for assertSessionHasErrors method in TestResponse class.