### PR TITLE
[9.x] add test for relative link method in FileSystem class when symfony filesystem not installed

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\LazyCollection;
 use Illuminate\Testing\Assert;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use SplFileInfo;
 
 class FilesystemTest extends TestCase
@@ -604,5 +605,21 @@ class FilesystemTest extends TestCase
         $filePerms = substr(sprintf('%o', $filePerms), -3);
 
         return (int) base_convert($filePerms, 8, 10);
+    }
+
+    public function testRelativeLinkWhenNotInstalledSymfonyFilesystem()
+    {
+        mkdir(self::$tempDir.'/tmp', 0777, true);
+        $path = self::$tempDir.'/tmp/foo.txt';
+        file_put_contents($path, '');
+        $target = self::$tempDir.'/tmp/bar.txt';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('To enable support for relative links, please install the symfony/filesystem package.');
+        $files = new Filesystem;
+        $files->relativeLink($target, $path);
+
+        $this->assertFileDoesNotExist($target);
+        $this->assertFileExists($path);
     }
 }


### PR DESCRIPTION
 add test for relative link method in FileSystem class when Symfon/Filesystem component not installed.
we expect exception when that is not installed.

```
  /**
     * Create a relative symlink to the target file or directory.
     *
     * @param  string  $target
     * @param  string  $link
     * @return void
     *
     * @throws \RuntimeException
     */
    public function relativeLink($target, $link)
    {
        if (! class_exists(SymfonyFilesystem::class)) {
            throw new RuntimeException(
                'To enable support for relative links, please install the symfony/filesystem package.'
            );
        }

        $relativeTarget = (new SymfonyFilesystem)->makePathRelative($target, dirname($link));

        $this->link($relativeTarget, $link);
    }

```
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
