### PR TITLE
[9.x] Add validation to check if all items exists in database

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\AllExists;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
@@ -113,5 +114,17 @@ class Rule
     public static function unique($table, $column = 'NULL')
     {
         return new Unique($table, $column);
+    }
+
+    /**
+     * Get a all_exists constraint builder instance.
+     *
+     * @param  string  $table
+     * @param  string  $column
+     * @return \Illuminate\Validation\Rules\AllExists
+     */
+    public static function allExists($table, $column = 'NULL')
+    {
+        return new AllExists($table, $column);
     }
 }

--- a/src/Illuminate/Validation/Rules/AllExists.php
+++ b/src/Illuminate/Validation/Rules/AllExists.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class AllExists implements Rule
+{
+    use DatabaseRule;
+
+    /**
+     * Ignore soft deleted models during the existence check.
+     *
+     * @param string $deletedAtColumn
+     * @return $this
+     */
+    public function withoutTrashed($deletedAtColumn = 'deleted_at')
+    {
+        $this->whereNull($deletedAtColumn);
+
+        return $this;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        // if value is empty validation shall pass.
+        if (empty($value)) {
+            return true;
+        }
+
+        $this->validateRuleValue($value);
+
+        $countResult = $this->buildQuery($value)->count($this->column);
+
+        return $countResult == count($value);
+    }
+
+    /**
+     * build base query for checking existence.
+     *
+     * @param array $value
+     * @return \Illuminate\Database\Query\Builder;
+     */
+    private function buildQuery($value)
+    {
+        $query = DB::table($this->table)->whereIn($this->column, $value);
+
+        // add wheres to query.
+        $query->where($this->wheres);
+
+        // add closures to query.
+        foreach ($this->queryCallbacks() as $closure) {
+            $query->where($closure);
+        }
+
+        return $query;
+    }
+
+    /**
+     * validate given values.
+     *
+     * @param $value
+     * @throws \RuntimeException
+     */
+    private function validateRuleValue($value): void
+    {
+        if (!is_array($value)) {
+            throw new RuntimeException('[AllExistsRule] : validation value must be array.');
+        }
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        $message = trans('validation.allExists');
+
+        return $message === 'validation.allExists'
+            ? [':attribute are invalid.']
+            : $message;
+    }
+}

--- a/tests/Validation/ValidationAllExistsRuleTest.php
+++ b/tests/Validation/ValidationAllExistsRuleTest.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\AllExists;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ValidationAllExistsRuleTest extends TestCase
+{
+    protected function setUpTranslator(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator',
+            fn() => new Translator(
+                new ArrayLoader, 'en'
+            )
+        );
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function setUpDB(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    public function setUp(): void
+    {
+        $this->setUpTranslator();
+        $this->setUpDB();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('tags', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->softDeletes();
+        });
+    }
+
+    public function testValidationPassWhenAllValuesExist()
+    {
+        $this->seedData();
+
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'tags_id' => [2, 3],
+            ],
+            [
+                'tags_id' => (new AllExists(AllExistsTestTag::class, 'id'))->withoutTrashed()
+            ]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidationPassWhenAllValuesExistWithWhereCondition()
+    {
+        $this->seedData();
+
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'tags_id' => [2, 3],
+            ],
+            [
+                'tags_id' => (new AllExists(AllExistsTestTag::class, 'id'))
+                    ->where('name','ab')
+            ]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidationPassWhenAllValuesExistWithClosure()
+    {
+        $this->seedData();
+
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'tags_id' => [2, 3],
+            ],
+            [
+                'tags_id' => (new AllExists(AllExistsTestTag::class, 'id'))
+                    ->using(fn($q) => $q->where('name', 'ab'))
+            ]
+        );
+
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidationFailsWhenAllValuesNotExist()
+    {
+        $this->seedData();
+
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'tags_id' => [1, 2, 3],
+            ],
+            [
+                'tags_id' => (new AllExists(AllExistsTestTag::class, 'id'))->withoutTrashed()
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['tags id are invalid.'], $v->messages()->get('tags_id'));
+    }
+
+    public function testValidationFailsWhenAllValuesExistWithWhereCondition()
+    {
+        $this->seedData();
+
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'tags_id' => [2, 3, 4],
+            ],
+            [
+                'tags_id' => (new AllExists(AllExistsTestTag::class, 'id'))
+                    ->where('name','ab')
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['tags id are invalid.'], $v->messages()->get('tags_id'));
+    }
+
+    public function testValidationFailsWhenAllValuesNotExistWithClosure()
+    {
+        $this->seedData();
+
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'tags_id' => [2, 3, 4],
+            ],
+            [
+                'tags_id' => (new AllExists(AllExistsTestTag::class, 'id'))
+                    ->using(fn ($q) => $q->where('name', 'ab'))
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['tags id are invalid.'], $v->messages()->get('tags_id'));
+    }
+
+    public function testThrowsExceptionWhenValueIsNotArray()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('[AllExistsRule] : validation value must be array.');
+
+         $v = new Validator(
+            resolve('translator'),
+            [
+                'tags_id' => 'something',
+            ],
+            [
+                'tags_id' => new AllExists(AllExistsTestTag::class, 'id')
+            ]
+        );
+         $v->passes();
+
+    }
+
+
+    /**
+     * Helpers...
+     */
+    protected function seedData()
+    {
+        AllExistsTestTag::query()->insert([
+            ['id' => 1, 'name' => 'za', 'deleted_at' => date('Y-m-d')],
+            ['id' => 2, 'name' => 'ab', 'deleted_at' => null],
+            ['id' => 3, 'name' => 'ab', 'deleted_at' => null],
+            ['id' => 4, 'name' => 'vb', 'deleted_at' => null],
+        ]);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    protected function tearDownTranslator(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+
+    protected function tearDownDB()
+    {
+        $this->schema()->drop('tags');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownTranslator();
+        $this->tearDownDB();
+    }
+}
+
+class AllExistsTestTag extends Eloquent
+{
+    use SoftDeletes;
+
+    protected $table = 'tags';
+    protected $guarded = [];
+}


### PR DESCRIPTION
let's assume there are two post and tag resources and they have many to many relation.

when a request for creating or updating post is sent we have to validate each tag separately and check if all exists. 

```
...

'tags_id' => ['nullable', 'array'],
'tags_id.*' => [Rule::exists('tags', 'id')]

...
```
this can lead to a lot of queries depending on  ```tags_id``` values.

this PR validate all items at same time.

```
     /**
     * Determine if the validation rule passes.
     *
     * @param string $attribute
     * @param mixed $value
     * @return bool
     */
    public function passes($attribute, $value)
    {
        // if value is empty validation shall pass.
        if (empty($value)) {
            return true;
        }

        $this->validateRuleValue($value);

        $countResult = $this->buildQuery($value)->count($this->column);

        return $countResult == count($value);
    }

```
how it works : rule creates count query on given column (since rule is using DatabaseRule trait conditions like ```where```, ```whereNull```, ```whereNot```, ```whereNotNull```, ```whereIn```, ```whereNotIn```, ```using```  and also ```withoutTrashed``` can be use.) and checks result against input values count.


1. basic

```
...
// tags_id = [1, 2, 3]
'tags_id' => [
		'nullable', 
		'array', 
		Rule::AllExists('tags', 'id')
	      ],
...

```

2. with conditions

```
...
// tags_id = [1, 2, 3]
'tags_id' => [
		'nullable', 
		'array', 
		Rule::AllExists('tags', 'id')->where('column', 'value')
	      ],,
...

```


3. withoutTrashed condition

```
...
// tags_id = [1, 2, 3]
'tags_id' => [
		'nullable', 
		'array', 
		Rule::AllExists('tags', 'id')->withoutTrashed()
	     ],
...

```