### PR TITLE
[9.x] Improve types on factory state() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -469,7 +469,7 @@ abstract class Factory
     /**
      * Add a new state transformation to the model definition.
      *
-     * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $state
+     * @param  (callable(array<string, mixed>, \Illuminate\Database\Eloquent\Model|null=): array<string, mixed>)|array<string, mixed>  $state
      * @return static
      */
     public function state($state)

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -141,7 +141,15 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
 }));
 
 assertType('UserFactory', $factory->state(['string' => 'string']));
-assertType('UserFactory', $factory->state(function () {
+assertType('UserFactory', $factory->state(function ($attributes) {
+    assertType('array<string, mixed>', $attributes);
+
+    return ['string' => 'string'];
+}));
+assertType('UserFactory', $factory->state(function ($attributes, $model) {
+    assertType('array<string, mixed>', $attributes);
+    assertType('Illuminate\Database\Eloquent\Model|null', $model);
+
     return ['string' => 'string'];
 }));
 


### PR DESCRIPTION
As per the Laravel docs (https://laravel.com/docs/9.x/database-testing#has-many-relationships), the `state()` method can accept a callable with 2 parameters, e.g. 

```php
$user = User::factory()
        ->has(
            Post::factory()
                    ->count(3)
                    ->state(function (array $attributes, User $user) {
                        return ['user_type' => $user->type];
                    })
        )
        ->create();
```

Currently, the type-hinting on the `state()` method doesn't support this (and throws an error when using static analysis). This PR adds the optional second parameter to the type hint.