### PR TITLE
[9.x] Add array values test for exists validation

### DIFF
--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -94,6 +94,12 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertFalse($v->passes());
         $v->setData(['id' => 4]);
         $this->assertFalse($v->passes());
+
+        // array values
+        $v->setData(['id' => [1, 2]]);
+        $this->assertTrue($v->passes());
+        $v->setData(['id' => [3, 4]]);
+        $this->assertFalse($v->passes());
     }
 
     public function testItChoosesValidRecordsUsingWhereNotInRule()
@@ -117,6 +123,12 @@ class ValidationExistsRuleTest extends TestCase
         $v->setData(['id' => 3]);
         $this->assertTrue($v->passes());
         $v->setData(['id' => 4]);
+        $this->assertTrue($v->passes());
+
+        // array values
+        $v->setData(['id' => [1, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 4]]);
         $this->assertTrue($v->passes());
     }
 
@@ -147,6 +159,12 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertTrue($v->passes());
         $v->setData(['id' => 4]);
         $this->assertTrue($v->passes());
+
+        // array values
+        $v->setData(['id' => [1, 2]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 4]]);
+        $this->assertTrue($v->passes());
     }
 
     public function testItChoosesValidRecordsUsingWhereNotInAndWhereNotInRulesTogether()
@@ -158,6 +176,7 @@ class ValidationExistsRuleTest extends TestCase
         User::create(['id' => '2', 'type' => 'bar']);
         User::create(['id' => '3', 'type' => 'baz']);
         User::create(['id' => '4', 'type' => 'other']);
+        User::create(['id' => '5', 'type' => 'baz']);
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['id' => $rule]);
@@ -171,6 +190,14 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertTrue($v->passes());
         $v->setData(['id' => 4]);
         $this->assertFalse($v->passes());
+        $v->setData(['id' => 5]);
+        $this->assertTrue($v->passes());
+
+        // array values
+        $v->setData(['id' => [1, 2, 4]]);
+        $this->assertFalse($v->passes());
+        $v->setData(['id' => [3, 5]]);
+        $this->assertTrue($v->passes());
     }
 
     public function testItIgnoresSoftDeletes()


### PR DESCRIPTION
there wasn't any test for array values in exists rule tests.
