### PR TITLE
[8.x] Fix require fails if is_file cached by opcache

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -24,7 +24,7 @@ class LoadConfiguration
         // First we will see if we have a cache configuration file. If we do, we'll load
         // the configuration items from that file so that it is very quick. Otherwise
         // we will need to spin through every configuration file and load them all.
-        if (is_file($cached = $app->getCachedConfigPath())) {
+        if (file_exists($cached = $app->getCachedConfigPath())) {
             $items = require $cached;
 
             $loadedFromCache = true;


### PR DESCRIPTION
Fixes #41613 

In the case where `opcache.enable_file_override` is enabled, the `is_file` call might return `true` because it's cached until the end of the script so the require will fail if it was unlinked during the execution which is the case when running the command `artisan config:cache`
This just changes `is_file` to `file_exists` which is the method to use before a require and is not affected by this issue