### PR TITLE
[9.x] Store SES message ID in X-SES-Message-ID header

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -75,7 +75,7 @@ class SesTransport extends AbstractTransport
         } catch (AwsException $e) {
             throw new Exception('Request to AWS SES API failed.', $e->getCode(), $e);
         }
-        
+
         $messageId = $result->get('MessageId');
         $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $messageId);
         $message->getOriginalMessage()->getHeaders()->addHeader('X-SES-Message-ID', $messageId);

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -77,6 +77,7 @@ class SesTransport extends AbstractTransport
         }
 
         $messageId = $result->get('MessageId');
+
         $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $messageId);
         $message->getOriginalMessage()->getHeaders()->addHeader('X-SES-Message-ID', $messageId);
     }

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -57,7 +57,7 @@ class SesTransport extends AbstractTransport
         }
 
         try {
-            $this->ses->sendRawEmail(
+            $result = $this->ses->sendRawEmail(
                 array_merge(
                     $options, [
                         'Source' => $message->getEnvelope()->getSender()->toString(),
@@ -72,6 +72,10 @@ class SesTransport extends AbstractTransport
                     ]
                 )
             );
+            $messageId = $result->get('MessageId');
+
+            $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $messageId);
+            $message->getOriginalMessage()->getHeaders()->addHeader('X-SES-Message-ID', $messageId);
         } catch (AwsException $e) {
             throw new Exception('Request to AWS SES API failed.', $e->getCode(), $e);
         }

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -72,13 +72,13 @@ class SesTransport extends AbstractTransport
                     ]
                 )
             );
-            $messageId = $result->get('MessageId');
-
-            $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $messageId);
-            $message->getOriginalMessage()->getHeaders()->addHeader('X-SES-Message-ID', $messageId);
         } catch (AwsException $e) {
             throw new Exception('Request to AWS SES API failed.', $e->getCode(), $e);
         }
+        
+        $messageId = $result->get('MessageId');
+        $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $messageId);
+        $message->getOriginalMessage()->getHeaders()->addHeader('X-SES-Message-ID', $messageId);
     }
 
     /**

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -9,6 +9,7 @@ use Illuminate\Mail\MailManager;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\View\Factory;
 use Mockery as m;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Email;
 
@@ -57,7 +58,13 @@ class MailSesTransportTest extends TestCase
         $message->bcc('you@example.com');
 
         $client = m::mock(SesClient::class);
-        $client->shouldReceive('sendRawEmail')->once();
+        $sesResult = Mockery::mock();
+        $sesResult->shouldReceive('get')
+            ->with('MessageId')
+            ->once()
+            ->andReturn('ses-message-id');
+        $client->shouldReceive('sendRawEmail')->once()
+            ->andReturn($sesResult);
 
         (new SesTransport($client))->send($message);
     }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -57,6 +57,7 @@ class MailSesTransportTest extends TestCase
         $message->bcc('you@example.com');
 
         $client = m::mock(SesClient::class);
+        $client->shouldReceive('sendRawEmail')->once();
         $sesResult = m::mock();
         $sesResult->shouldReceive('get')
             ->with('MessageId')

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -57,7 +57,6 @@ class MailSesTransportTest extends TestCase
         $message->bcc('you@example.com');
 
         $client = m::mock(SesClient::class);
-        $client->shouldReceive('sendRawEmail')->once();
         $sesResult = m::mock();
         $sesResult->shouldReceive('get')
             ->with('MessageId')

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -9,7 +9,6 @@ use Illuminate\Mail\MailManager;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\View\Factory;
 use Mockery as m;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Email;
 
@@ -58,7 +57,7 @@ class MailSesTransportTest extends TestCase
         $message->bcc('you@example.com');
 
         $client = m::mock(SesClient::class);
-        $sesResult = Mockery::mock();
+        $sesResult = m::mock();
         $sesResult->shouldReceive('get')
             ->with('MessageId')
             ->once()


### PR DESCRIPTION
Restoring previous functionality with SES mail driver to store the SES message ID in X-SES-Message-ID header.  Needed to support SES message tracking in https://github.com/jdavidbakr/mail-tracker/issues/155