### PR TITLE
[9.x] Adds class discoverer `Discover`

### DIFF
--- a/src/Illuminate/Filesystem/Discover.php
+++ b/src/Illuminate/Filesystem/Discover.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionException;
-use const DIRECTORY_SEPARATOR;
 
 class Discover
 {
@@ -117,7 +116,7 @@ class Discover
                 continue;
             }
 
-            if (!$reflection->isInstantiable()) {
+            if (! $reflection->isInstantiable()) {
                 continue;
             }
 

--- a/src/Illuminate/Filesystem/Discover.php
+++ b/src/Illuminate/Filesystem/Discover.php
@@ -169,11 +169,10 @@ class Discover
     /**
      * Create a new instance of the discoverer.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application|null  $app
      * @return static
      */
-    public static function make($app = null)
+    public static function inside(string $dir)
     {
-        return new static($app ?? app());
+        return (new static(app()))->in($dir);
     }
 }

--- a/src/Illuminate/Filesystem/Discover.php
+++ b/src/Illuminate/Filesystem/Discover.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionException;
+use const DIRECTORY_SEPARATOR;
 
 class Discover
 {
@@ -157,13 +158,15 @@ class Discover
      */
     protected function classFromFile($file)
     {
-        $class = trim(Str::replaceFirst($this->root, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
-
-        return str_replace(
-            [DIRECTORY_SEPARATOR, ucfirst($this->baseDir.'\\')],
-            ['\\', $this->baseNamespace],
-            ucfirst(Str::replaceLast('.php', '', $class))
-        );
+        return Str::of($file->getRealPath())
+            ->after($this->root)
+            ->trim(DIRECTORY_SEPARATOR)
+            ->beforeLast('.php')
+            ->ucfirst()
+            ->replace(
+                [DIRECTORY_SEPARATOR, ucfirst($this->baseDir.'\\')],
+                ['\\', $this->baseNamespace]
+            )->toString();
     }
 
     /**

--- a/src/Illuminate/Filesystem/Discover.php
+++ b/src/Illuminate/Filesystem/Discover.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use ReflectionException;
+
+class Discover
+{
+    /**
+     * Project path to look for.
+     *
+     * @var string
+     */
+    protected string $root;
+
+    /**
+     * The path from the base directory to look for classes.
+     *
+     * @var string|null
+     */
+    protected $dir = '';
+
+    /**
+     * The base directory to look for files.
+     *
+     * @var string|null
+     */
+    protected $baseDir = '';
+
+    /**
+     * The base namespace of the discovered files.
+     *
+     * @var string
+     */
+    protected string $baseNamespace = '';
+
+    /**
+     * How much to traverse the path being discovered.
+     *
+     * @var bool
+     */
+    protected $recursively = false;
+
+    /**
+     * Create a new Discover instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     */
+    public function __construct(protected Application $app)
+    {
+        $this->root = $app->basePath();
+    }
+
+    /**
+     * Sets the path to discover classes.
+     *
+     * @param  string  $dir
+     * @return $this
+     */
+    public function in($dir)
+    {
+        $this->dir = $dir;
+
+        return $this;
+    }
+
+    /**
+     * Changes the base location and root namespace to discover files.
+     *
+     * @param  string  $baseDir
+     * @param  string  $namespace
+     * @return $this
+     */
+    public function atNamespace(string $baseDir, string $namespace)
+    {
+        $this->baseDir = $baseDir;
+        $this->baseNamespace = $namespace;
+
+        return $this;
+    }
+
+    /**
+     * Discover all files from the directory path, recursively.
+     *
+     * @return $this
+     */
+    public function recursively()
+    {
+        $this->recursively = true;
+
+        return $this;
+    }
+
+    /**
+     * Returns all discovered classes.
+     *
+     * @return \Illuminate\Support\Collection<string, \ReflectionClass>
+     */
+    public function all()
+    {
+        $path = $this->normalizedPath();
+
+        $classes = collect();
+
+        $files = $this->recursively
+            ? $this->app->make('files')->allFiles($path)
+            : $this->app->make('files')->files($path);
+
+        foreach ($files as $file) {
+            try {
+                $reflection = new ReflectionClass($this->classFromFile($file));
+            } catch (ReflectionException) {
+                continue;
+            }
+
+            if (!$reflection->isInstantiable()) {
+                continue;
+            }
+
+            $classes->put($reflection->name, $reflection);
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Ensure there is a base directory and namespace to look for.
+     *
+     * @return string
+     */
+    protected function normalizedPath()
+    {
+        $this->baseDir = $this->baseDir ?: Str::of($this->app->path())
+            ->after($this->root)
+            ->ltrim(DIRECTORY_SEPARATOR)
+            ->toString();
+
+        $this->baseNamespace = Str::finish($this->baseNamespace ?: $this->app->getNamespace(), '\\');
+
+        $path = $this->root.DIRECTORY_SEPARATOR.$this->baseDir;
+
+        if ($this->dir) {
+            $path .= DIRECTORY_SEPARATOR.$this->dir;
+        }
+
+        return $path;
+    }
+
+    /**
+     * Extract the class name from the given file path.
+     *
+     * @param  \Symfony\Component\Finder\SplFileInfo  $file
+     * @return string
+     */
+    protected function classFromFile($file)
+    {
+        $class = trim(Str::replaceFirst($this->root, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+
+        return str_replace(
+            [DIRECTORY_SEPARATOR, ucfirst($this->baseDir.'\\')],
+            ['\\', $this->baseNamespace],
+            ucfirst(Str::replaceLast('.php', '', $class))
+        );
+    }
+
+    /**
+     * Create a new instance of the discoverer.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application|null  $app
+     * @return static
+     */
+    public static function make($app = null)
+    {
+        return new static($app ?? app());
+    }
+}

--- a/tests/Filesystem/DiscoverTest.php
+++ b/tests/Filesystem/DiscoverTest.php
@@ -2,14 +2,13 @@
 
 namespace Illuminate\Tests\Filesystem;
 
+use const DIRECTORY_SEPARATOR as DS;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Discover;
 use Illuminate\Filesystem\Filesystem;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\SplFileInfo;
-use function realpath;
-use const DIRECTORY_SEPARATOR as DS;
 
 class DiscoverTest extends TestCase
 {

--- a/tests/Filesystem/DiscoverTest.php
+++ b/tests/Filesystem/DiscoverTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Filesystem\Discover;
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\SplFileInfo;
+use function realpath;
+use const DIRECTORY_SEPARATOR as DS;
+
+class DiscoverTest extends TestCase
+{
+    protected $files;
+    protected $app;
+    protected $discover;
+
+    protected function setUp(): void
+    {
+        $this->app = Mockery::mock(Application::class);
+        $this->files = Mockery::mock(Filesystem::class);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Mockery::close();
+    }
+
+    protected function returnRealSupportFiles()
+    {
+        $this->app->expects('basePath')->withNoArgs()->andReturn(realpath(__DIR__.'/../../src'));
+        $this->app->expects('path')->withNoArgs()->andReturn('Illuminate');
+        $this->app->expects('getNamespace')->withNoArgs()->andReturn('Illuminate\\');
+        $this->app->expects('make')->with('files')->andReturn($this->files);
+    }
+
+    public function testUsesAppDefaultPathsAndNamespaces()
+    {
+        $this->app->expects('basePath')->withNoArgs()->andReturn('/projects/laravel');
+        $this->app->expects('path')->withNoArgs()->andReturn('app');
+        $this->app->expects('getNamespace')->withNoArgs()->andReturn('App\\');
+        $this->app->expects('make')->with('files')->andReturn($this->files);
+
+        $this->files->expects('files')->with('/projects/laravel'.DS.'app')->andReturn([]);
+
+        $this->assertEmpty((new Discover($this->app))->all());
+    }
+
+    public function testUsesDifferentPathAndNamespace()
+    {
+        $this->app->expects('basePath')->withNoArgs()->andReturn('/projects/laravel');
+        $this->app->expects('path')->never();
+        $this->app->expects('getNamespace')->never();
+        $this->app->expects('make')->with('files')->andReturn($this->files);
+
+        $this->files->expects('files')->with('/projects/laravel'.DS.'foo')->andReturn([]);
+
+        $this->assertEmpty((new Discover($this->app))->atNamespace('foo', 'Bar')->all());
+    }
+
+    public function testRetrievesClassesInFirstLevelByDefault()
+    {
+        $this->app->expects('basePath')->withNoArgs()->andReturn('/projects/laravel');
+        $this->app->expects('path')->withNoArgs()->andReturn('app');
+        $this->app->expects('getNamespace')->withNoArgs()->andReturn('App\\');
+        $this->app->expects('make')->with('files')->andReturn($this->files);
+
+        $this->files->expects('files')->with('/projects/laravel'.DS.'app')->andReturn([]);
+
+        $this->assertEmpty((new Discover($this->app))->all());
+    }
+
+    public function testRetrievesClassesRecursively()
+    {
+        $this->app->expects('basePath')->withNoArgs()->andReturn('/projects/laravel');
+        $this->app->expects('path')->withNoArgs()->andReturn('app');
+        $this->app->expects('getNamespace')->withNoArgs()->andReturn('App\\');
+        $this->app->expects('make')->with('files')->andReturn($this->files);
+
+        $this->files->expects('allFiles')->with('/projects/laravel'.DS.'app')->andReturn([]);
+
+        $this->assertEmpty((new Discover($this->app))->recursively()->all());
+    }
+
+    public function testFiltersFilesByPath()
+    {
+        $this->app->expects('basePath')->withNoArgs()->andReturn('/projects/laravel');
+        $this->app->expects('path')->withNoArgs()->andReturn('app');
+        $this->app->expects('getNamespace')->withNoArgs()->andReturn('App\\');
+        $this->app->expects('make')->with('files')->andReturn($this->files);
+
+        $this->files->expects('files')
+            ->with('/projects/laravel'.DS.'app'.DS.'FilterPath')
+            ->andReturn([]);
+
+        $this->assertEmpty((new Discover($this->app))->in('FilterPath')->all());
+    }
+
+    public function testFiltersFilesByPhpClasses()
+    {
+        $this->returnRealSupportFiles();
+
+        $this->files->expects('files')
+            ->with(realpath(__DIR__.'/../../src/Illuminate'.DS.'Support'))
+            ->andReturn([
+                new SplFileInfo(realpath(__DIR__.'/../../src/Illuminate'.DS.'Support'.DS.'helpers.php'), '', ''),
+                new SplFileInfo(realpath(__DIR__.'/../../src/Illuminate'.DS.'Support'.DS.'Fluent.php'), '', ''),
+                new SplFileInfo(realpath(__DIR__.'/../../src/Illuminate'.DS.'Support'.DS.'Stringable.php'), '', ''),
+            ]);
+
+        $files = (new Discover($this->app))->in('Support')->all();
+
+        $this->assertCount(2, $files);
+        $this->assertTrue($files->has(\Illuminate\Support\Fluent::class));
+        $this->assertTrue($files->has(\Illuminate\Support\Stringable::class));
+    }
+
+    public function testRetrievesOnlyInstantiableClasses()
+    {
+        $this->returnRealSupportFiles();
+
+        $this->files->expects('files')
+            ->with(realpath(__DIR__.'/../../src/Illuminate'.DS.'Support'))
+            ->andReturn([
+                new SplFileInfo(realpath(__DIR__.'/../../src/Illuminate'.DS.'Support'.DS.'Manager.php'), '', ''),
+                new SplFileInfo(realpath(__DIR__.'/../../src/Illuminate'.DS.'Support'.DS.'InteractsWithTime.php'), '', ''),
+                new SplFileInfo(realpath(__DIR__.'/../../src/Illuminate'.DS.'Support'.DS.'Stringable.php'), '', ''),
+            ]);
+
+        $files = (new Discover($this->app))->in('Support')->all();
+
+        $this->assertCount(1, $files);
+        $this->assertTrue($files->has(\Illuminate\Support\Stringable::class));
+    }
+}


### PR DESCRIPTION
## What?

Introduces a class specialized in discovering files as PHP Classes. Rework of the `DiscoverEvents`, but generalized.

```php
use Illuminate\Filesystem\Discover;

$events = Discover::inside('Events')->all();
```

The main idea is to detach the _discover_ mechanism so other services or packages can also discover files from within a path, like Policies. As with the `DiscoverEvents`, it only collects instantiable classes.

```php
use Illuminate\Filesystem\Discover;
use ReflectionClass;

$policies = Discover::inside('Policies')
    ->all()
    ->filter(function (ReflectionClass $policy) {
        return str_ends_with($policy->name, 'Policy');
    });
```

- It receives an `Application` instance, so it can be mocked and tested.
- It's multi-tenancy friendly, as it supports changing the root dir and root namespace.
- Can be set to recursive.
- Returns a `Collection`, so further filters can be applied over it.

```php
use Illuminate\Filesystem\Discover;

// Find all classes in `/www/projects/laravel/myProject/Components`.
$policies = Discover::inside('Components')
    ->recursively()
    ->atNamespace('myProject', 'Project\\')
    ->all()
```

## Why?

Basically, centralize the discovery of Classes. This can be done for Policies, Events and what not. May be Components can benefit from this approach as a way to cache them.

## BC?

None, is only additive. May be in next version we could get rid of `DiscoverEvents` and whatever the Gate does to find Policies (it doesn't work recursively last time I checked).

> PS: Should I PR this to `master` instead?