### PR TITLE
[9.x] Add ExcludeIf and ProhibitedIf Validation Methods

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -5,9 +5,11 @@ namespace Illuminate\Validation;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\Dimensions;
+use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
+use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
 
@@ -90,6 +92,28 @@ class Rule
     public static function forEach($callback)
     {
         return new NestedRules($callback);
+    }
+
+    /**
+     * Get a exclude_if constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\ProhibitedIf
+     */
+    public static function excludeIf($callback)
+    {
+        return new ExcludeIf($callback);
+    }
+
+    /**
+     * Get a prohibited_if constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\ProhibitedIf
+     */
+    public static function prohibitedIf($callback)
+    {
+        return new ProhibitedIf($callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -95,6 +95,17 @@ class Rule
     }
 
     /**
+     * Get a required_if constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\RequiredIf
+     */
+    public static function requiredIf($callback)
+    {
+        return new RequiredIf($callback);
+    }
+
+    /**
      * Get a exclude_if constraint builder instance.
      *
      * @param  callable|bool  $callback
@@ -114,17 +125,6 @@ class Rule
     public static function prohibitedIf($callback)
     {
         return new ProhibitedIf($callback);
-    }
-
-    /**
-     * Get a required_if constraint builder instance.
-     *
-     * @param  callable|bool  $callback
-     * @return \Illuminate\Validation\Rules\RequiredIf
-     */
-    public static function requiredIf($callback)
-    {
-        return new RequiredIf($callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ExcludeIf.php
+++ b/src/Illuminate/Validation/Rules/ExcludeIf.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use InvalidArgumentException;
+
+class ExcludeIf
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new exclude validation rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     */
+    public function __construct($condition)
+    {
+        if (! is_string($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'exclude' : '';
+        }
+
+        return $this->condition ? 'exclude' : '';
+    }
+}

--- a/src/Illuminate/Validation/Rules/ProhibitedIf.php
+++ b/src/Illuminate/Validation/Rules/ProhibitedIf.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use InvalidArgumentException;
+
+class ProhibitedIf
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new prohibited validation rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     */
+    public function __construct($condition)
+    {
+        if (! is_string($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'prohibited' : '';
+        }
+
+        return $this->condition ? 'prohibited' : '';
+    }
+}

--- a/tests/Validation/ValidationExcludeIfTest.php
+++ b/tests/Validation/ValidationExcludeIfTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Validation\Rules\ExcludeIf;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ValidationExcludeIfTest extends TestCase
+{
+    public function testItClousureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new ExcludeIf(function () {
+            return true;
+        });
+
+        $this->assertSame('exclude', (string) $rule);
+
+        $rule = new ExcludeIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new ExcludeIf(true);
+
+        $this->assertSame('exclude', (string) $rule);
+
+        $rule = new ExcludeIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new ExcludeIf(false);
+
+        $rule = new ExcludeIf(true);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $rule = new ExcludeIf('phpinfo');
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new ExcludeIf(function () {
+            return true;
+        }));
+    }
+}

--- a/tests/Validation/ValidationProhibitedIfTest.php
+++ b/tests/Validation/ValidationProhibitedIfTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Validation\Rules\ProhibitedIf;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ValidationProhibitedIfTest extends TestCase
+{
+    public function testItClousureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new ProhibitedIf(function () {
+            return true;
+        });
+
+        $this->assertSame('prohibited', (string) $rule);
+
+        $rule = new ProhibitedIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new ProhibitedIf(true);
+
+        $this->assertSame('prohibited', (string) $rule);
+
+        $rule = new ProhibitedIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new ProhibitedIf(false);
+
+        $rule = new ProhibitedIf(true);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $rule = new ProhibitedIf('phpinfo');
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new ProhibitedIf(function () {
+            return true;
+        }));
+    }
+}


### PR DESCRIPTION
Much like the existing `Rule::requiredIf()` [method](https://laravel.com/docs/9.x/validation#rule-required-if) allows for more complex conditions, I am proposing the addition of `Rule::excludeIf()` and `Rule::prohibitedIf()`methods. These work in much the same way and will allow for more complex conditions. Examples below.

```php
use Illuminate\Support\Facades\Validator;
use Illuminate\Validation\Rule;
 
Validator::make($request->all(), [
    'role_id' => Rule::prohibitedIf($request->user()->is_expired),
]);
 
Validator::make($request->all(), [
    'role_id' => Rule::prohibitedIf(fn () => $request->user()->is_expired),
]);

Validator::make($request->all(), [
    'role_id' => Rule::excludeIf($request->user()->is_expired),
]);
 
Validator::make($request->all(), [
    'role_id' => Rule::excludeIf(fn () => $request->user()->is_expired),
]);
```