### PR TITLE
[9.x] remove unnecessary null coalescing operator for retryDelay

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -723,7 +723,7 @@ class PendingRequest
 
                 throw new ConnectionException($e->getMessage(), 0, $e);
             }
-        }, $this->retryDelay ?? 100, $this->retryWhenCallback);
+        }, $this->retryDelay, $this->retryWhenCallback);
     }
 
     /**


### PR DESCRIPTION
Just because assigning default value to `retryDelay` in [line 103 ](https://github.com/laravel/framework/blob/19b0abf57abc74d09aa059057a5b6576f127c7dc/src/Illuminate/Http/Client/PendingRequest.php#L103) this operator may redundant.