### PR TITLE
[8.x] Ensure int type of getSeconds() output

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -529,7 +529,7 @@ class Repository implements ArrayAccess, CacheContract
             $duration = Carbon::now()->diffInRealSeconds($duration, false);
         }
 
-        return (int) $duration > 0 ? $duration : 0;
+        return (int) ($duration > 0 ? $duration : 0);
     }
 
     /**


### PR DESCRIPTION
Hello 👋 In Carbon 3, diff* will return a float (current behavior of floatDiff*) so value is never truncated and result will be less surprising when having 0.999 day or the like.

`getSeconds()` PHPDoc says `int` and it sounds like the intent behind the `(int)` cast was to ensure it, but due to operator precedence, it's actually doing `((int) $duration) > 0 ? $duration : 0` so the type of the return is actually not in control of the method. Make the cast as the last step ensure it.

Side note: it's present from 6.x to master, I can change the branch if 6.x/7.x should still be supported.

Thanks 🙏 