### PR TITLE
[10.x] Adds Discover class

### DIFF
--- a/src/Illuminate/Filesystem/Discover.php
+++ b/src/Illuminate/Filesystem/Discover.php
@@ -96,7 +96,7 @@ class Discover
                 continue;
             }
 
-            if (!$reflection->isInstantiable()) {
+            if (! $reflection->isInstantiable()) {
                 continue;
             }
 

--- a/src/Illuminate/Filesystem/Discover.php
+++ b/src/Illuminate/Filesystem/Discover.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
+use ReflectionClass;
+use ReflectionException;
+use Symfony\Component\Finder\SplFileInfo;
+use function lcfirst;
+use function ucfirst;
+use const DIRECTORY_SEPARATOR;
+
+class Discover
+{
+    /**
+     * Project path where all discoveries will be done.
+     *
+     * @var string
+     */
+    protected string $projectPath;
+
+    /**
+     * The base path to discover classes.
+     *
+     * @var string
+     */
+    protected string $basePath;
+
+    /**
+     * The base namespace to discover classes.
+     *
+     * @var string
+     */
+    protected string $baseNamespace;
+
+    /**
+     * If the discovery should explore deeper directories.
+     *
+     * @var bool
+     */
+    protected bool $recursive = false;
+
+    /**
+     * Create a new Discover instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  string  $path
+     */
+    public function __construct(Application $app, protected string $path)
+    {
+        $this->projectPath = $app->basePath();
+        $this->baseNamespace = $app->getNamespace();
+        $this->basePath = Str::of($app->path())->after($this->projectPath)->trim(DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * Changes the base location and root namespace to discover files.
+     *
+     * @param  string  $baseNamespace
+     * @param  string|null  $basePath
+     * @return $this
+     */
+    public function atNamespace(string $baseNamespace, string $basePath = null): static
+    {
+        $this->baseNamespace = Str::of($baseNamespace)->ucfirst()->trim('\\')->finish('\\');
+        $this->basePath = trim($basePath ?: lcfirst($baseNamespace), DIRECTORY_SEPARATOR);
+
+        return $this;
+    }
+
+    /**
+     * Search of files recursively.
+     *
+     * @return $this
+     */
+    public function recursively(): static
+    {
+        $this->recursive = true;
+
+        return $this;
+    }
+
+    /**
+     * Returns a Collection for all the classes found.
+     *
+     * @return \Illuminate\Support\Collection<string, \ReflectionClass>
+     */
+    public function all(): Collection
+    {
+        $classes = new Collection;
+
+        foreach ($this->listAllFiles() as $file) {
+            try {
+                $reflection = new ReflectionClass($this->classFromFile($file));
+            } catch (ReflectionException) {
+                continue;
+            }
+
+            if (!$reflection->isInstantiable()) {
+                continue;
+            }
+
+            $classes->put($reflection->name, $reflection);
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Builds the finder instance to locate the files.
+     *
+     * @return \Illuminate\Support\Collection<int, \Symfony\Component\Finder\SplFileInfo>
+     */
+    protected function listAllFiles(): Collection
+    {
+        return new Collection(
+            $this->recursive
+                ? File::allFiles($this->buildPath())
+                : File::files($this->buildPath())
+        );
+    }
+
+    /**
+     * Build the path to search for files.
+     *
+     * @return string
+     */
+    protected function buildPath(): string
+    {
+        return Str::of($this->path)
+            ->start(DIRECTORY_SEPARATOR)
+            ->prepend($this->basePath)
+            ->start(DIRECTORY_SEPARATOR)
+            ->prepend($this->projectPath);
+    }
+
+    /**
+     * Create a new instance of the discoverer.
+     *
+     * @param  string  $dir
+     * @return static
+     */
+    public static function in(string $dir): static
+    {
+        return new static(app(), $dir);
+    }
+
+    /**
+     * Extract the class name from the given file path.
+     *
+     * @param  \Symfony\Component\Finder\SplFileInfo  $file
+     * @return string
+     */
+    protected function classFromFile(SplFileInfo $file): string
+    {
+        return Str::of($file->getRealPath())
+            ->after($this->projectPath)
+            ->trim(DIRECTORY_SEPARATOR)
+            ->beforeLast('.php')
+            ->ucfirst()
+            ->replace(
+                [DIRECTORY_SEPARATOR, ucfirst($this->basePath.DIRECTORY_SEPARATOR)],
+                ['\\', $this->baseNamespace],
+            );
+    }
+}

--- a/src/Illuminate/Filesystem/Discover.php
+++ b/src/Illuminate/Filesystem/Discover.php
@@ -6,13 +6,9 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Illuminate\Support\Stringable;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\Finder\SplFileInfo;
-use function lcfirst;
-use function ucfirst;
-use const DIRECTORY_SEPARATOR;
 
 class Discover
 {

--- a/tests/Integration/Filesystem/DiscoverTest.php
+++ b/tests/Integration/Filesystem/DiscoverTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Filesystem;
+
+use const DIRECTORY_SEPARATOR as DS;
+use Illuminate\Filesystem\Discover;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+use ReflectionClass;
+use Symfony\Component\Finder\SplFileInfo;
+
+class DiscoverTest extends TestCase
+{
+    protected function file(string $path): Mockery\MockInterface
+    {
+        return tap(Mockery::mock(SplFileInfo::class), static function (Mockery\MockInterface $mock) use ($path): void {
+            $mock->expects('getRealPath')->andReturn(
+                Str::of(realpath(__DIR__.'/../../../src/Illuminate/'))
+                    ->append(DS.$path)
+                    ->replace(['\\', '/'], [DS, DS])
+                    ->toString()
+            );
+        });
+    }
+
+    protected function mockAllFiles(): void
+    {
+        File::expects('allFiles')->with(realpath(__DIR__.'/../../src/Illuminate/'))->andReturn([
+            $this->file('Support/Carbon.php'),
+            $this->file('Support/Manager.php'),
+            $this->file('Support/Traits/Tappable.php'),
+            $this->file('Contracts/Auth/Guard.php'),
+        ]);
+    }
+
+    public function testUsesDefaultAppPathAndNamespace(): void
+    {
+        $files = Mockery::mock($this->app->make('files'))->makePartial();
+        $files->expects('files')->with($this->app->path('Examples'))->andReturn([]);
+
+        $app = Mockery::mock($this->app)->makePartial();
+        $app->instance('files', $files);
+
+        (new Discover($app, 'Examples'))->all();
+
+        $app->shouldHaveReceived('basePath');
+        $app->shouldHaveReceived('path');
+        $app->shouldHaveReceived('getNamespace');
+    }
+
+    public function testUsesCustomNamespace()
+    {
+        $this->mock('files')->expects('files')->with($this->app->basePath('foo'.DS.'Bar'))->andReturn([]);
+
+        Discover::in('Bar')->atNamespace('Foo')->all();
+    }
+
+    public function testUsesCustomNamespaceWithBasePath()
+    {
+        $this->mock('files')->expects('files')->with($this->app->basePath('baz'.DS.'Bar'))->andReturn([]);
+
+        Discover::in('Bar')->atNamespace('Foo', 'baz')->all();
+    }
+
+    public function testUsesRecursive()
+    {
+        $this->mock('files')->expects('allFiles')->with($this->app->path('Examples'))->andReturn([]);
+
+        Discover::in('Examples')->recursively()->all();
+    }
+
+    public function testFiltersByInstantiableClasses()
+    {
+        $app = Mockery::mock($this->app)->makePartial();
+        $app->expects('basePath')->andReturn(realpath(__DIR__.'/../../../src'));
+        $app->expects('path')->andReturn(realpath(__DIR__.'/../../../src/Illuminate'));
+        $app->expects('getNamespace')->andReturn('Illuminate\\');
+
+        $this->mock('files')
+            ->expects('allFiles')
+            ->with(realpath(__DIR__.'/../../../src/Illuminate/Support'))
+            ->andReturn([
+                $this->file('Support/helpers.php'),
+                $this->file('Support/Manager.php'),
+                $this->file('Support/Stringable.php'),
+                $this->file('Support/Traits/Tappable.php'),
+            ]);
+
+        $classes = (new Discover($app, 'Support'))->recursively()->all();
+
+        $this->assertCount(1, $classes);
+        $this->assertTrue($classes->has(\Illuminate\Support\Stringable::class));
+        $this->assertInstanceOf(ReflectionClass::class, $classes->first());
+    }
+
+    public function testFiltersByNonInterfaces()
+    {
+        $app = Mockery::mock($this->app)->makePartial();
+
+        $app->expects('basePath')->andReturn(realpath(__DIR__.'/../../../src'));
+        $app->expects('path')->andReturn(realpath(__DIR__.'/../../../src/Illuminate'));
+        $app->expects('getNamespace')->andReturn('Illuminate\\');
+
+        $this->mock('files')
+            ->expects('files')
+            ->with(realpath(__DIR__.'/../../../src/Illuminate/Auth/Passwords'))
+            ->andReturn([
+                $this->file('Auth/Passwords/PasswordBroker.php'),
+                $this->file('Auth/Passwords/TokenRepositoryInterface.php'),
+            ]);
+
+        $classes = (new Discover($app, 'Auth'.DS.'Passwords'))->all();
+
+        $this->assertCount(1, $classes);
+        $this->assertTrue($classes->has(\Illuminate\Auth\Passwords\PasswordBroker::class));
+    }
+}


### PR DESCRIPTION
## What?

Introduces a class specialized in discovering files as PHP Classes. Rework of the `DiscoverEvents`, but generalized.

```php
use Illuminate\Filesystem\Discover;

$events = Discover::inside('Events')->all();
```

The main idea is to detach the _discover_ mechanism so other services or packages can also discover files from within a path, like Policies. As with the `DiscoverEvents`, it only collects instantiable classes.

```php
use Illuminate\Filesystem\Discover;
use ReflectionClass;

$policies = Discover::inside('Policies')
    ->all()
    ->filter(function (ReflectionClass $policy) {
        return str_ends_with($policy->name, 'Policy');
    });
```

- It receives an `Application` instance, so it can be mocked and tested.
- It's multi-tenancy friendly, as it supports changing the root dir and root namespace.
- Can be set to recursive.
- Returns a `Collection`, so further filters can be applied over it.

```php
use Illuminate\Filesystem\Discover;

// Find all classes in `/www/projects/laravel/myProject/Components`.
$policies = Discover::inside('Components')
    ->recursively()
    ->atNamespace('myProject', 'Project\\')
    ->all()
```

## Why?

Basically, centralize the discovery of Classes. This can be done for Policies, Events and what not. May be Components can benefit from this approach as a way to cache them.

## Why draft?

Waiting on how is received to replace the `DiscoverEvents` class for this implementation.

## BC?

Assuming this goes through, it will break all services that rely on their own "discoverer" because it will be replaced by this. It also adds the `illuminate/filesystem` dependency to these packages.