### PR TITLE
[9.x] Use getter method to retrieve except array in Maintenance middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -111,7 +111,7 @@ class PreventRequestsDuringMaintenance
      */
     protected function inExceptArray($request)
     {
-        foreach ($this->except as $except) {
+        foreach ($this->getExcludedPaths() as $except) {
             if ($except !== '/') {
                 $except = trim($except, '/');
             }


### PR DESCRIPTION
Imagine somebody wants to dynamically set `$except` array in the middleware. Like the cases they are reading it from a config file. Then they should do it in `__construct()` or create their own `handle()` method.

But this way, they can easily override `getExcludedPaths()` in `app/Http/Middleware/PreventRequestsDuringMaintenance` to add their own functionality.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
