### PR TITLE
[9.x] Add contract for notification channels

### DIFF
--- a/src/Illuminate/Contracts/Notifications/Channel.php
+++ b/src/Illuminate/Contracts/Notifications/Channel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Contracts\Notifications;
+
+use Illuminate\Notifications\Notification;
+
+interface Channel
+{
+    /**
+     * Send the given notification.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function send($notifiable, Notification $notification);
+}

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -58,7 +58,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * Get a channel instance.
      *
      * @param  string|null  $name
-     * @return mixed
+     * @return \Illuminate\Contracts\Notifications\Channel
      */
     public function channel($name = null)
     {
@@ -68,7 +68,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     /**
      * Create an instance of the database driver.
      *
-     * @return \Illuminate\Notifications\Channels\DatabaseChannel
+     * @return \Illuminate\Contracts\Notifications\Channel
      */
     protected function createDatabaseDriver()
     {
@@ -78,7 +78,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     /**
      * Create an instance of the broadcast driver.
      *
-     * @return \Illuminate\Notifications\Channels\BroadcastChannel
+     * @return \Illuminate\Contracts\Notifications\Channel
      */
     protected function createBroadcastDriver()
     {
@@ -88,7 +88,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     /**
      * Create an instance of the mail driver.
      *
-     * @return \Illuminate\Notifications\Channels\MailChannel
+     * @return \Illuminate\Contracts\Notifications\Channel
      */
     protected function createMailDriver()
     {

--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Notifications\Channels;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Notifications\Channel;
 use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Notification;
 use RuntimeException;
 
-class BroadcastChannel
+class BroadcastChannel implements Channel
 {
     /**
      * The event dispatcher.

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -2,10 +2,11 @@
 
 namespace Illuminate\Notifications\Channels;
 
+use Illuminate\Contracts\Notifications\Channel;
 use Illuminate\Notifications\Notification;
 use RuntimeException;
 
-class DatabaseChannel
+class DatabaseChannel implements Channel
 {
     /**
      * Send the given notification.

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -4,6 +4,7 @@ namespace Illuminate\Notifications\Channels;
 
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable;
+use Illuminate\Contracts\Notifications\Channel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Markdown;
 use Illuminate\Notifications\Notification;
@@ -12,7 +13,7 @@ use Illuminate\Support\Str;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 
-class MailChannel
+class MailChannel implements Channel
 {
     /**
      * The mailer implementation.


### PR DESCRIPTION
As we call send method on notification channel [(NotificationSender.php)](https://github.com/laravel/framework/blob/19b0abf57abc74d09aa059057a5b6576f127c7dc/src/Illuminate/Notifications/NotificationSender.php#L148), maybe we could use contracts to implement it every notification channel.