### PR TITLE
[9.x] [Collection] Add retrieve of nested keys

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -440,6 +440,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return $this->items[$key];
         }
 
+        if (str_contains((string) $key, ".")) {
+            $keys = explode('.', (string) $key);
+
+            do {
+                $nested_key = array_shift($keys);
+                $nested_value = ($nested_value ?? $this->items)[$nested_key] ?? $default;
+                $nested_value = $nested_value instanceof Collection ? $nested_value->toArray() : $nested_value;
+            } while (!empty($keys) && is_array($nested_value) && $nested_value != $default);
+
+            return empty($keys) ? $nested_value : value($default);
+        }
+
+
         return value($default);
     }
 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -440,14 +440,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             return $this->items[$key];
         }
 
-        if (str_contains((string) $key, ".")) {
+        if (str_contains((string) $key, '.')) {
             $keys = explode('.', (string) $key);
 
             do {
                 $nested_key = array_shift($keys);
                 $nested_value = ($nested_value ?? $this->items)[$nested_key] ?? $default;
                 $nested_value = $nested_value instanceof Collection ? $nested_value->toArray() : $nested_value;
-            } while (!empty($keys) && is_array($nested_value) && $nested_value != $default);
+            } while (! empty($keys) && is_array($nested_value) && $nested_value != $default);
 
             return empty($keys) ? $nested_value : value($default);
         }


### PR DESCRIPTION
**Title**: Add retrieve of nested keys

**Description**: Allow retrieve of nested keys using get method of Collection class. Important factor is that keys must be delimited by dot (.)

**Tests**: tested using existing and not existing keys

**Benefits**: I was trying to access deep keys using get method but without success. I think it is a useful feature and can avoid writing more code that what it is needed.