### PR TITLE
[9.x] Discover anonymous Blade components in other folders

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -17,6 +17,7 @@ namespace Illuminate\Support\Facades;
  * @method static void compile(string|null $path = null)
  * @method static void component(string $class, string|null $alias = null, string $prefix = '')
  * @method static void components(array $components, string $prefix = '')
+ * @method static void anonymousComponentNamespace(string $directory, string $prefix)
  * @method static void componentNamespace(string $namespace, string $prefix)
  * @method static void directive(string $name, callable $handler)
  * @method static void extend(callable $compiler)

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -18,7 +18,7 @@ namespace Illuminate\Support\Facades;
  * @method static void component(string $class, string|null $alias = null, string $prefix = '')
  * @method static void components(array $components, string $prefix = '')
  * @method static void anonymousComponentNamespace(string $directory, string $prefix)
- * @method static void componentNamespace(string $namespace, string $prefix)
+ * @method static void componentNamespace(string $prefix, string $directory = null)
  * @method static void directive(string $name, callable $handler)
  * @method static void extend(callable $compiler)
  * @method static void if(string $name, callable $callback)

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -48,6 +48,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $customDirectives = [];
 
     /**
+     * The array of anonymous component namespaces to autoload from.
+     *
+     * @var array
+     */
+    protected $anonymousComponentNamespaces = [];
+
+    /**
      * All custom "condition" handlers.
      *
      * @var array
@@ -673,6 +680,19 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Register an anonymous component namespace.
+     *
+     * @param  string  $directory
+     * @param  string  $prefix
+     * @return void
+     */
+    public function anonymousComponentNamespace($directory, $prefix)
+    {
+        // Store the directory as dot notation.
+        $this->anonymousComponentNamespaces[$prefix] = Str::replace('/', '.', $directory);
+    }
+
+    /**
      * Register a class-based component namespace.
      *
      * @param  string  $namespace
@@ -682,6 +702,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function componentNamespace($namespace, $prefix)
     {
         $this->classComponentNamespaces[$prefix] = $namespace;
+    }
+
+    /**
+     * Get the registered anonymous component namespaces.
+     *
+     * @return array
+     */
+    public function getAnonymousComponentNamespaces()
+    {
+        return $this->anonymousComponentNamespaces;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -682,14 +682,18 @@ class BladeCompiler extends Compiler implements CompilerInterface
     /**
      * Register an anonymous component namespace.
      *
-     * @param  string  $directory
      * @param  string  $prefix
+     * @param  string  $directory
      * @return void
      */
-    public function anonymousComponentNamespace($directory, $prefix)
+    public function anonymousComponentNamespace(string $prefix, string $directory = null)
     {
-        // Store the directory as dot notation.
-        $this->anonymousComponentNamespaces[$prefix] = Str::replace('/', '.', $directory);
+        if ($directory === null) {
+            $directory = $prefix;
+        }
+
+        // Store the directory in dot notation.
+        $this->anonymousComponentNamespaces[$prefix] = (string) Str::of($directory)->replace('/', '.')->trim('. ');
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -48,13 +48,6 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $customDirectives = [];
 
     /**
-     * The array of anonymous component namespaces to autoload from.
-     *
-     * @var array
-     */
-    protected $anonymousComponentNamespaces = [];
-
-    /**
      * All custom "condition" handlers.
      *
      * @var array
@@ -128,6 +121,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @var array
      */
     protected $rawBlocks = [];
+
+    /**
+     * The array of anonymous component namespaces to autoload from.
+     *
+     * @var array
+     */
+    protected $anonymousComponentNamespaces = [];
 
     /**
      * The array of class component aliases and their class names.
@@ -682,18 +682,18 @@ class BladeCompiler extends Compiler implements CompilerInterface
     /**
      * Register an anonymous component namespace.
      *
-     * @param  string  $prefix
      * @param  string  $directory
+     * @param  string|null  $prefix
      * @return void
      */
-    public function anonymousComponentNamespace(string $prefix, string $directory = null)
+    public function anonymousComponentNamespace(string $directory, string $prefix = null)
     {
-        if ($directory === null) {
-            $directory = $prefix;
-        }
+        $prefix ??= $directory;
 
-        // Store the directory in dot notation.
-        $this->anonymousComponentNamespaces[$prefix] = (string) Str::of($directory)->replace('/', '.')->trim('. ');
+        $this->anonymousComponentNamespaces[$prefix] = Str::of($directory)
+                ->replace('/', '.')
+                ->trim('. ')
+                ->toString();
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -276,12 +276,13 @@ class ComponentTagCompiler
         // by the developer. We can use these folders to guess the correct view name.
         $guess = collect($this->blade->getAnonymousComponentNamespaces())
             // Next, we'll filter out the component paths that cannot be used here, based on their prefix.
-            // For example, for the anonymous component "<x-admin:dashboard>", we should look for the 'dashboard'
+            // For example, for the anonymous component "<x-admin::dashboard>", we should look for the 'dashboard'
             // view in the folder associated with the 'admin' prefix.
             ->filter(function ($directory, $prefix) use ($component): bool {
                 return Str::startsWith($component, $prefix.'::');
             })
             // Next, we'll prepend the default components directory and our full component name. This is convention.
+            // Prepending it ensures that the /components always has precedence over the cutom directories.
             ->prepend('components', $component)
             // Finally, we'll go over the components and prefixes and check whether we can find a matching view name.
             ->reduce(function($carry, $directory, $prefix) use ($component, $viewFactory) {

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -296,7 +296,7 @@ class ComponentTagCompiler
                     return $view;
                 }
 
-                if ($viewFactory->exists($view = $this->guessViewName($componentName).'.index')) {
+                if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory).'.index')) {
                     return $view;
                 }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -285,7 +285,7 @@ class ComponentTagCompiler
             // Prepending it ensures that the /components always has precedence over the cutom directories.
             ->prepend('components', $component)
             // Finally, we'll go over the components and prefixes and check whether we can find a matching view name.
-            ->reduce(function($carry, $directory, $prefix) use ($component, $viewFactory) {
+            ->reduce(function ($carry, $directory, $prefix) use ($component, $viewFactory) {
                 $componentName = Str::after($component, $prefix.'::');
 
                 if ($carry !== null) {

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -271,26 +271,17 @@ class ComponentTagCompiler
             return $class;
         }
 
-        // The following code serves to guess the view name for this component.
-        // First, we'll create a collection with the custom component paths provided
-        // by the developer. We can use these folders to guess the correct view name.
         $guess = collect($this->blade->getAnonymousComponentNamespaces())
-            // Next, we'll filter out the component paths that cannot be used here, based on their prefix.
-            // For example, for the anonymous component "<x-admin::dashboard>", we should look for the 'dashboard'
-            // view in the folder associated with the 'admin' prefix.
-            ->filter(function ($directory, $prefix) use ($component): bool {
+            ->filter(function ($directory, $prefix) use ($component) {
                 return Str::startsWith($component, $prefix.'::');
             })
-            // Next, we'll prepend the default components directory and our full component name. This is convention.
-            // Prepending it ensures that the /components always has precedence over the cutom directories.
             ->prepend('components', $component)
-            // Finally, we'll go over the components and prefixes and check whether we can find a matching view name.
             ->reduce(function ($carry, $directory, $prefix) use ($component, $viewFactory) {
-                $componentName = Str::after($component, $prefix.'::');
-
-                if ($carry !== null) {
+                if (! is_null($carry)) {
                     return $carry;
                 }
+
+                $componentName = Str::after($component, $prefix.'::');
 
                 if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory))) {
                     return $view;
@@ -299,11 +290,9 @@ class ComponentTagCompiler
                 if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory).'.index')) {
                     return $view;
                 }
-
-                return null;
             });
 
-        if ($guess !== null) {
+        if (! is_null($guess)) {
             return $guess;
         }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -6,7 +6,6 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 use Illuminate\View\Component;
@@ -371,7 +370,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $container->instance(Factory::class, $factory = m::mock(Factory::class));
 
         $app->shouldReceive('getNamespace')->andReturn('App\\');
-        $factory->shouldReceive('exists')->andReturnUsing(function($arg) {
+        $factory->shouldReceive('exists')->andReturnUsing(function ($arg) {
             // In our test, we'll do as if the 'public.frontend.anonymous-component'
             // view exists and not the others.
             return $arg === 'public.frontend.anonymous-component';
@@ -405,7 +404,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $container->instance(Factory::class, $factory = m::mock(Factory::class));
 
         $app->shouldReceive('getNamespace')->andReturn('App\\');
-        $factory->shouldReceive('exists')->andReturnUsing(function(string $viewNameBeingCheckedForExistence) {
+        $factory->shouldReceive('exists')->andReturnUsing(function (string $viewNameBeingCheckedForExistence) {
             // In our test, we'll do as if the 'public.frontend.anonymous-component'
             // view exists and not the others.
             return $viewNameBeingCheckedForExistence === 'admin.auth.components.anonymous-component.index';

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 use Illuminate\View\Component;
@@ -362,6 +363,74 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
+    public function testClasslessComponentsWithAnonymousComponentNamespace()
+    {
+        $container = new Container;
+
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
+
+        $app->shouldReceive('getNamespace')->andReturn('App\\');
+        $factory->shouldReceive('exists')->andReturnUsing(function($arg) {
+            // In our test, we'll do as if the 'public.frontend.anonymous-component'
+            // view exists and not the others.
+            return $arg === 'public.frontend.anonymous-component';
+        });
+
+        Container::setInstance($container);
+
+        $blade = m::mock(BladeCompiler::class)->makePartial();
+
+        $blade->shouldReceive('getAnonymousComponentNamespaces')->andReturn([
+            'frontend' => 'public.frontend',
+        ]);
+
+        $compiler = $this->compiler([], [], $blade);
+
+        $result = $compiler->compileTags('<x-frontend::anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'frontend::anonymous-component', ['view' => 'public.frontend.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\View\AnonymousComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
+            '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
+    public function testClasslessComponentsWithAnonymousComponentNamespaceWithIndexView()
+    {
+        $container = new Container;
+
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
+
+        $app->shouldReceive('getNamespace')->andReturn('App\\');
+        $factory->shouldReceive('exists')->andReturnUsing(function(string $viewNameBeingCheckedForExistence) {
+            // In our test, we'll do as if the 'public.frontend.anonymous-component'
+            // view exists and not the others.
+            return $viewNameBeingCheckedForExistence === 'admin.auth.components.anonymous-component.index';
+        });
+
+        Container::setInstance($container);
+
+        $blade = m::mock(BladeCompiler::class)->makePartial();
+
+        $blade->shouldReceive('getAnonymousComponentNamespaces')->andReturn([
+            'admin.auth' => 'admin.auth.components',
+        ]);
+
+        $compiler = $this->compiler([], [], $blade);
+
+        $result = $compiler->compileTags('<x-admin.auth::anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'admin.auth::anonymous-component', ['view' => 'admin.auth.components.anonymous-component.index','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\View\AnonymousComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
+            '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
     public function testAttributeSanitization()
     {
         $class = new class
@@ -451,10 +520,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         Container::setInstance($container);
     }
 
-    protected function compiler($aliases = [])
+    protected function compiler(array $aliases = [], array $namespaces = [], ?BladeCompiler $blade = null)
     {
         return new ComponentTagCompiler(
-            $aliases
+            $aliases, $namespaces, $blade
         );
     }
 }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -235,7 +235,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler->anonymousComponentNamespace('admin', '/admin/components');
         $this->assertEquals(['admin' => 'admin.components'], $compiler->getAnonymousComponentNamespaces());
 
-        // Test directory is automatically inferred from the namespace
+        // Test directory is automatically inferred from the prefix if not given.
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
 
         $compiler->anonymousComponentNamespace('frontend');

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -222,17 +222,17 @@ class ViewBladeCompilerTest extends TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
 
-        $compiler->anonymousComponentNamespace('frontend', ' public/frontend ');
+        $compiler->anonymousComponentNamespace(' public/frontend ', 'frontend');
         $this->assertEquals(['frontend' => 'public.frontend'], $compiler->getAnonymousComponentNamespaces());
 
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
 
-        $compiler->anonymousComponentNamespace('frontend', 'public/frontend/');
+        $compiler->anonymousComponentNamespace('public/frontend/', 'frontend');
         $this->assertEquals(['frontend' => 'public.frontend'], $compiler->getAnonymousComponentNamespaces());
 
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
 
-        $compiler->anonymousComponentNamespace('admin', '/admin/components');
+        $compiler->anonymousComponentNamespace('/admin/components', 'admin');
         $this->assertEquals(['admin' => 'admin.components'], $compiler->getAnonymousComponentNamespaces());
 
         // Test directory is automatically inferred from the prefix if not given.
@@ -244,7 +244,7 @@ class ViewBladeCompilerTest extends TestCase
         // Test that the prefix can also contain dots.
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
 
-        $compiler->anonymousComponentNamespace('frontend.auth', 'frontend/auth');
+        $compiler->anonymousComponentNamespace('frontend/auth', 'frontend.auth');
         $this->assertEquals(['frontend.auth' => 'frontend.auth'], $compiler->getAnonymousComponentNamespaces());
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -218,6 +218,36 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertEquals(['prefix-forms:input' => 'App\View\Components\Forms\Input'], $compiler->getClassComponentAliases());
     }
 
+    public function testAnonymousComponentNamespacesCanBeStored()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+
+        $compiler->anonymousComponentNamespace('frontend', ' public/frontend ');
+        $this->assertEquals(['frontend' => 'public.frontend'], $compiler->getAnonymousComponentNamespaces());
+
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+
+        $compiler->anonymousComponentNamespace('frontend', 'public/frontend/');
+        $this->assertEquals(['frontend' => 'public.frontend'], $compiler->getAnonymousComponentNamespaces());
+
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+
+        $compiler->anonymousComponentNamespace('admin', '/admin/components');
+        $this->assertEquals(['admin' => 'admin.components'], $compiler->getAnonymousComponentNamespaces());
+
+        // Test directory is automatically inferred from the namespace
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+
+        $compiler->anonymousComponentNamespace('frontend');
+        $this->assertEquals(['frontend' => 'frontend'], $compiler->getAnonymousComponentNamespaces());
+
+        // Test that the prefix can also contain dots.
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+
+        $compiler->anonymousComponentNamespace('frontend.auth', 'frontend/auth');
+        $this->assertEquals(['frontend.auth' => 'frontend.auth'], $compiler->getAnonymousComponentNamespaces());
+    }
+
     protected function getFiles()
     {
         return m::mock(Filesystem::class);


### PR DESCRIPTION
Do you like anonymous components? (I like them a lot) And did you ever want to also 'enable' anonymous components for directories other than `resources/views/components`? 

For example, `resources/views/admin` and `resources/view/frontend`? And autodiscover the components like `<x-admin::component.name`?

This PR introduces exactly that. It allows the developer to register a directory and a prefix, which would allow to use the files in those directories as anonymous components. This would get rid of things like `@include` and provide developers with the ability to use the attribute bag everywhere.

## Example

In your service provider, you can register the directories you want to enable discovery for:

```php
// Prefix <x-admin::your.component> and folder: resources/views/admin 
Blade::anonymousComponentNamespace('admin', 'admin'); 

// Second parameter is nullable and defaults to first parameter, so this means the same:
Blade::anonymousComponentNamespace('admin'); 

// Prefix <x-frontend.auth::your.component> and folder: resources/views/public/auth
Blade::anonymousComponentNamespace('public/auth', 'frontend.auth');
```

Now you can use this in your Blade files like this:

```blade
<!-- Looks for resources/views/admin/dashboard/widget.blade.php OR resources/views/admin/dashboard/widget/index.blade.php -->
<x-admin::dashboard.widget>

<!-- Looks for resources/views/public/auth/login/form.blade.php OR resources/views/public/auth/login/form/index.blade.php -->
<x-frontend::login.form>
```

I added some additional inline comments to the compiler-file just for clarity, but feel free to trim this down however you want. 

I took inspiration from the original PR that introduced anonymous components (#31363). I'm a slightly unsure how this should be tested, perhaps @driesvints could give me a hint?

This is a feature I wanted for a long time and I hope this will be useful to many developers! The syntax is in line with package components.




