### PR TITLE
[9.x] Add support for multiple new lines

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -67,11 +67,12 @@ class Stringable implements JsonSerializable
     /**
      * Append a new line to the string.
      *
+     * @param  int  $count
      * @return $this
      */
-    public function newLine()
+    public function newLine($count = 1)
     {
-        return $this->append(PHP_EOL);
+        return $this->append(str_repeat(PHP_EOL, $count));
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -422,6 +422,7 @@ class SupportStringableTest extends TestCase
     public function testNewLine()
     {
         $this->assertSame('Laravel'.PHP_EOL, (string) $this->stringable('Laravel')->newLine());
+        $this->assertSame('foo'.PHP_EOL.PHP_EOL.'bar', (string) $this->stringable('foo')->newLine(2)->append('bar'));
     }
 
     public function testAsciiWithSpecificLocale()


### PR DESCRIPTION
Based on https://github.com/laravel/framework/pull/41622 this PR adds additional support for multiple new lines like for the console output in Artisan commands:

https://github.com/laravel/framework/blob/6f743e236a49df03dd579933e2360a3304b55c5b/src/Illuminate/Console/Concerns/InteractsWithIO.php#L371-L382

So for the use case of @foremtehan in https://github.com/laravel/framework/pull/41622#issuecomment-1076301259 the code could look like this:

```php
return str($site)
    ->newLime(2)
    ->append($this-›sub-›name)
    ->newLine()
    ->append("<b>$newTitle</b>")
    ->newLine(2)
    -> ... you get the idea
```