### PR TITLE
[9.x] Fix collection not possible group by with `Stringable`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -488,7 +488,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             }
 
             foreach ($groupKeys as $groupKey) {
-                $groupKey = is_bool($groupKey) ? (int) $groupKey : $groupKey;
+                $groupKey = is_bool($groupKey) ? (int) $groupKey : (string) $groupKey;
 
                 if (! array_key_exists($groupKey, $results)) {
                     $results[$groupKey] = new static;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

- Laravel Version: 9.x
- PHP Version: 8.1
- Database Driver & Version: N/A

### Description:
When need use the groupBy method with Stringable column on collection. then error has been displayed


### Steps To Reproduce:

Make the collection with Stringable

```php
<?php

$data = collect([
	[
		'category' => \Str::of('fruits'),
		'name' => 'Apple',
	],
	[
		'category' => \Str::of('fruits'),
		'name' => 'Banana',
	],
	[
		'category' => \Str::of('vegetable'),
		'name' => 'Cucumber',
	],
]);

```

Then call groupBy method

```php
<?php

$data->groupBy('category');
```


### Solution:

Cast key to string

