### PR TITLE
[9.x] Reconnect when redis throw read error exception

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -531,10 +531,12 @@ class PhpRedisConnection extends Connection implements ConnectionContract
         try {
             return parent::command($method, $parameters);
         } catch (RedisException $e) {
-            if (str_contains($e->getMessage(), 'went away') || str_contains($e->getMessage(), 'socket')) {
-                $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
+            foreach (['went away', 'socket', 'read error on connection'] as $errorMessage) {
+                if (str_contains($e->getMessage(), $errorMessage)) {
+                    $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
+                    break;
+                }
             }
-
             throw $e;
         }
     }


### PR DESCRIPTION
ref to issue https://github.com/laravel/framework/issues/41651, and adds a match for 'read error on connection' to trigger a reconnection.