### PR TITLE
[9.x] Add previousWithoutQuery and previousPath to UrlGenerator

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -21,7 +21,7 @@ interface UrlGenerator
 
     /**
      * Get the URL for the previous request without the query string.
-     * 
+     *
      * @param  mixed  $fallback
      * @return string
      */
@@ -29,7 +29,7 @@ interface UrlGenerator
 
     /**
      * Get the previous path info for the request.
-     * 
+     *
      * @param  mixed  $fallback
      * @return string
      */

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -20,6 +20,22 @@ interface UrlGenerator
     public function previous($fallback = false);
 
     /**
+     * Get the URL for the previous request without the query string.
+     * 
+     * @param  mixed  $fallback
+     * @return string
+     */
+    public function previousWithoutQuery($fallback = false);
+
+    /**
+     * Get the previous path info for the request.
+     * 
+     * @param  mixed  $fallback
+     * @return string
+     */
+    public function previousPath($fallback = false);
+
+    /**
      * Generate an absolute URL to the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -168,7 +168,7 @@ class UrlGenerator implements UrlGeneratorContract
 
     /**
      * Get the URL for the previous request without the query string.
-     * 
+     *
      * @param  mixed  $fallback
      * @return string
      */
@@ -179,7 +179,7 @@ class UrlGenerator implements UrlGeneratorContract
 
     /**
      * Get the previous path info for the request.
-     * 
+     *
      * @param  mixed  $fallback
      * @return string
      */

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -167,6 +167,28 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Get the URL for the previous request without the query string.
+     * 
+     * @param  mixed  $fallback
+     * @return string
+     */
+    public function previousWithoutQuery($fallback = false)
+    {
+        return rtrim(preg_replace('/\?.*/', '', $this->previous($fallback)), '/');
+    }
+
+    /**
+     * Get the previous path info for the request.
+     * 
+     * @param  mixed  $fallback
+     * @return string
+     */
+    public function previousPath($fallback = false)
+    {
+        return str_replace($this->to('/'), '', $this->previousWithoutQuery($fallback));
+    }
+
+    /**
      * Get the previous URL from the session if possible.
      *
      * @return string|null

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -13,6 +13,8 @@ namespace Illuminate\Support\Facades;
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static string previous($fallback = false)
+ * @method static string previousWithoutQuery($fallback = false)
+ * @method static string previousPath($fallback = false)
  * @method static string route(string $name, $parameters = [], bool $absolute = true)
  * @method static string secure(string $path, array $parameters = [])
  * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, bool $absolute = true)


### PR DESCRIPTION
This is useful when wanting to redirect back to a previous URL/path, however dropping the query string from the URL/path.

I saw that there were a few questions on how to achieve this on Stackoverflow and Laracast.

In short this would enable:

Submit form when URL is e.g. `https://website.dev/foo?bar=1` then in the controller:

```php
return redirect(url()->previousWithoutQuery());
// or 
return redirect(url()->previousPath());
```

This will redirect to URL: `https://website.dev/foo`

Idea details outlined in https://github.com/laravel/framework/discussions/41612