### PR TITLE
[9.x] Add previousPath (standalone) to UrlGenerator

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -20,14 +20,6 @@ interface UrlGenerator
     public function previous($fallback = false);
 
     /**
-     * Get the previous path info for the request.
-     *
-     * @param  mixed  $fallback
-     * @return string
-     */
-    public function previousPath($fallback = false);
-
-    /**
      * Generate an absolute URL to the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -20,6 +20,14 @@ interface UrlGenerator
     public function previous($fallback = false);
 
     /**
+     * Get the previous path info for the request.
+     *
+     * @param  mixed  $fallback
+     * @return string
+     */
+    public function previousPath($fallback = false);
+
+    /**
      * Generate an absolute URL to the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -174,7 +174,9 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function previousPath($fallback = false)
     {
-        return str_replace($this->to('/'), '', rtrim(preg_replace('/\?.*/', '', $this->previous($fallback)), '/'));
+        $previousPath = str_replace($this->to('/'), '', rtrim(preg_replace('/\?.*/', '', $this->previous($fallback)), '/'));
+
+        return $previousPath === '' ? '/' : $previousPath;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -167,6 +167,17 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Get the previous path info for the request.
+     *
+     * @param  mixed  $fallback
+     * @return string
+     */
+    public function previousPath($fallback = false)
+    {
+        return str_replace($this->to('/'), '', rtrim(preg_replace('/\?.*/', '', $this->previous($fallback)), '/'));
+    }
+
+    /**
      * Get the previous URL from the session if possible.
      *
      * @return string|null

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -13,6 +13,7 @@ namespace Illuminate\Support\Facades;
  * @method static void macro(string $name, object|callable $macro)
  * @method static void mixin(object $mixin, bool $replace = true)
  * @method static string previous($fallback = false)
+ * @method static string previousPath($fallback = false)
  * @method static string route(string $name, $parameters = [], bool $absolute = true)
  * @method static string secure(string $path, array $parameters = [])
  * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, bool $absolute = true)

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -662,16 +662,16 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         $url->getRequest()->headers->set('referer', 'http://www.foo.com?baz=bah');
-        $this->assertSame('', $url->previousPath());
+        $this->assertSame('/', $url->previousPath());
 
         $url->getRequest()->headers->set('referer', 'http://www.foo.com/?baz=bah');
-        $this->assertSame('', $url->previousPath());
+        $this->assertSame('/', $url->previousPath());
 
         $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar?baz=bah');
         $this->assertSame('/bar', $url->previousPath());
 
         $url->getRequest()->headers->remove('referer');
-        $this->assertSame('', $url->previousPath());
+        $this->assertSame('/', $url->previousPath());
 
         $this->assertSame('/bar', $url->previousPath('/bar'));
     }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -654,6 +654,28 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertEquals($url->to('/foo'), $url->previous('/foo'));
     }
 
+    public function testPreviousPath()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com?baz=bah');
+        $this->assertSame('', $url->previousPath());
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/?baz=bah');
+        $this->assertSame('', $url->previousPath());
+
+        $url->getRequest()->headers->set('referer', 'http://www.foo.com/bar?baz=bah');
+        $this->assertSame('/bar', $url->previousPath());
+
+        $url->getRequest()->headers->remove('referer');
+        $this->assertSame('', $url->previousPath());
+
+        $this->assertSame('/bar', $url->previousPath('/bar'));
+    }
+
     public function testRouteNotDefinedException()
     {
         $this->expectException(RouteNotFoundException::class);


### PR DESCRIPTION
This is the "standalone" version of the idea outlined in https://github.com/laravel/framework/discussions/41612 ("standalone" because `previousPath` doesn't depend on `previousWithoutQuery` as in PR https://github.com/laravel/framework/pull/41662)

In short this would enable:

Submit form when URL is e.g. `https://website.dev/foo?bar=1` then in the controller:

```php
return redirect(url()->previousPath()); // /foo
```

This will redirect to URL: `https://website.dev/foo` (without the query string)

---

PR for the "dependent" version: https://github.com/laravel/framework/pull/41662