### PR TITLE
[9.x] Add function for testing HEAD requests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -451,6 +451,21 @@ trait MakesHttpRequests
     }
 
     /**
+     * Visit the given URI with a HEAD request.
+     *
+     * @param  string  $uri
+     * @param  array  $headers
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public function head($uri, array $headers = [])
+    {
+        $server = $this->transformHeadersToServerVars($headers);
+        $cookies = $this->prepareCookiesForRequest();
+
+        return $this->call('HEAD', $uri, [], $cookies, [], $server);
+    }
+
+    /**
      * Call the given URI with a JSON request.
      *
      * @param  string  $method

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -432,6 +432,7 @@ trait MakesHttpRequests
     public function options($uri, array $data = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
+
         $cookies = $this->prepareCookiesForRequest();
 
         return $this->call('OPTIONS', $uri, $data, $cookies, [], $server);
@@ -460,6 +461,7 @@ trait MakesHttpRequests
     public function head($uri, array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
+
         $cookies = $this->prepareCookiesForRequest();
 
         return $this->call('HEAD', $uri, [], $cookies, [], $server);


### PR DESCRIPTION
Laravel already provides testing helpers for various request types such as `GET`, `POST`, `PUT` and `DELETE`. This PR adds a helper for `HEAD` request that works similarly to existing request helpers.

Example usage:

```php
use Tests\TestCase;

class MyTest extends TestCase
{
    public function testSomeApplicationEndpoint()
    {
        $this->head('/url-being-tested')->assertOk();
    }
}
```