### PR TITLE
[9.x] Added useCurrentTimestamps function for DRY principle

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1197,6 +1197,19 @@ class Blueprint
     }
 
     /**
+     * Add creation and update timestamps with CURRENT_TIMESTAMP as default value to the table.
+     *
+     * @param  int  $precision
+     * @return void
+     */
+    public function useCurrentTimestamps($precision = 0)
+    {
+        $this->timestamp('created_at', $precision)->useCurrent();
+
+        $this->timestamp('updated_at', $precision)->useCurrent();
+    }
+
+    /**
      * Add a "deleted at" timestamp for the table.
      *
      * @param  string  $column


### PR DESCRIPTION
Hello,

after I used the QueryBuilder insert function a lot in a project with many .csv import possibilities, I found myself repeating the same two lines of code every migration to set the CURRENT_TIMESTAMP as a default value if it is not provided.

```php
$this->timestamp('created_at')->useCurrent();
$this->timestamp('updated_at')->useCurrent();
```

In my opinion and from the perspective of the DRY principle, Laravel should be able to offer this functionality. Because of this I added the useCurrentTimestamps function to the Blueprint class. It already exists test cases for the datetime functionality in combination with the useCurrent function, so I was not sure if I need to add tests. If I need to add them, I'm down for it.

Thanks for the great framework!