### PR TITLE
[9.x] Adding additional search methods to the Arr class

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -42,8 +42,8 @@ class Arr
      * Searches an ordered array via binary searching, returns the first corresponding key index if successful.
 
      *
-     * @param mixed $array
-     * @param mixed $needle
+     * @param  mixed  $array
+     * @param  mixed  $needle
      *
      * @return false|int
      */
@@ -639,11 +639,12 @@ class Arr
     /**
      * Searches the array for a given value and returns the first corresponding key if successful.
      *
-     * @param mixed $array
-     *
+     * @param  array  $array
+     * @param  mixed  $needle
+     * @param  bool  $strict
      * @return int|string|false
      */
-    public static function search($array, mixed $needle, bool $strict = false)
+    public static function search($array, $needle, bool $strict = false)
     {
         return array_search($needle, $array, $strict);
     }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -637,8 +637,9 @@ class Arr
     /**
      * Searches the array for a given value and returns the first corresponding key if successful.
      *
-     * @param mixed $array
-     *
+     * @param  array  $array
+     * @param  mixed  $needle
+     * @param  bool  $strict
      * @return int|string|false
      */
     public static function search($array, $needle, bool $strict = false)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -57,7 +57,7 @@ class Arr
         while ($high >= $low) {
             $middle = (int) ($low + (($high - $low) / 2));
 
-            if (!isset($array[$middle])) {
+            if (! isset($array[$middle])) {
                 return false;
             }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -637,6 +637,18 @@ class Arr
     }
 
     /**
+     * Searches the array for a given value and returns the first corresponding key if successful.
+     *
+     * @param mixed $array
+     *
+     * @return int|string|false
+     */
+    public static function search($array, mixed $needle, bool $strict = false)
+    {
+        return array_search($needle, $array, $strict);
+    }
+
+    /**
      * Set an array item to a given value using "dot" notation.
      *
      * If no key is given to the method, the entire array will be replaced.

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -39,6 +39,45 @@ class Arr
     }
 
     /**
+     * Searches an ordered array via binary searching, returns the first corresponding key index if successful.
+
+     *
+     * @param mixed $array
+     * @param mixed $needle
+     *
+     * @return false|int
+     */
+    public static function binarySearch($array, $needle)
+    {
+        if (empty($array)) {
+            return false;
+        }
+
+        $low = 0;
+        $high = count($array);
+
+        while ($high >= $low) {
+            $middle = (int) ($low + (($high - $low) / 2));
+
+            if (!isset($array[$middle])) {
+                return false;
+            }
+
+            if ($array[$middle] === $needle) {
+                return $middle;
+            }
+
+            if ($array[$middle] > $needle) {
+                $high = $middle - 1;
+            } elseif ($array[$middle] < $needle) {
+                $low = $middle + 1;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Collapse an array of arrays into a single array.
      *
      * @param  iterable  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -40,11 +40,9 @@ class Arr
 
     /**
      * Searches an ordered array via binary searching, returns the first corresponding key index if successful.
-
      *
      * @param mixed $array
      * @param mixed $needle
-     *
      * @return false|int
      */
     public static function binarySearch($array, $needle)
@@ -639,7 +637,9 @@ class Arr
     /**
      * Searches the array for a given value and returns the first corresponding key if successful.
      *
+     * @param array $array
      * @param mixed $array
+     * @param bool $strict
      *
      * @return int|string|false
      */

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -53,6 +53,10 @@ class Arr
 
         $low = 0;
         $high = count($array);
+        
+        if ($high <= 2) {
+            return array_search($needle, $array);
+        }
 
         while ($high >= $low) {
             $middle = (int) ($low + (($high - $low) / 2));

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -640,7 +640,6 @@ class Arr
      * @param array $array
      * @param mixed $array
      * @param bool $strict
-     *
      * @return int|string|false
      */
     public static function search($array, mixed $needle, bool $strict = false)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -51,15 +51,16 @@ class Arr
             return false;
         }
 
-        $low = 0;
-        $high = count($array);
-        
-        if ($high <= 2) {
+        $start = 0;
+        $total = count($array);
+        $end = $total - 1;
+
+        if ($total <= 2) {
             return array_search($needle, $array);
         }
 
-        while ($high >= $low) {
-            $middle = (int) ($low + (($high - $low) / 2));
+        while ($start <= $end) {
+            $middle = (int) ($start + (($end - $start) / 2));
 
             if (! isset($array[$middle])) {
                 return false;
@@ -70,9 +71,9 @@ class Arr
             }
 
             if ($array[$middle] > $needle) {
-                $high = $middle - 1;
+                $end = $middle - 1;
             } elseif ($array[$middle] < $needle) {
-                $low = $middle + 1;
+                $start = $middle + 1;
             }
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -36,6 +36,19 @@ class SupportArrTest extends TestCase
         $this->assertEquals([1 => [1 => 'hAz']], Arr::add([], 1.1, 'hAz'));
     }
 
+    public function testBinarySearch()
+    {
+        $array = range(0, 100);
+
+        $this->assertEquals(0, Arr::binarySearch($array, 0));
+        $this->assertEquals(25, Arr::binarySearch($array, 25));
+        $this->assertEquals(50, Arr::binarySearch($array, 50));
+        $this->assertEquals(75, Arr::binarySearch($array, 75));
+        $this->assertEquals(100, Arr::binarySearch($array, 100));
+
+        $this->assertFalse(Arr::binarySearch($array, 101));
+    }
+
     public function testCollapse()
     {
         $data = [['foo', 'bar'], ['baz']];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -742,6 +742,19 @@ class SupportArrTest extends TestCase
         $this->assertSame(3, $exceptions);
     }
 
+    public function testSearch()
+    {
+        $array = range(0, 100);
+
+        $this->assertEquals(0, Arr::search($array, 0));
+        $this->assertEquals(25, Arr::search($array, 25));
+        $this->assertEquals(50, Arr::search($array, 50));
+        $this->assertEquals(75, Arr::search($array, 75));
+        $this->assertEquals(100, Arr::search($array, 100));
+
+        $this->assertFalse(Arr::search($array, 101));
+    }
+
     public function testSet()
     {
         $array = ['products' => ['desk' => ['price' => 100]]];


### PR DESCRIPTION
Hello,

This aims to add an alias to `array_search` to the Arr class and also explores introducing a binary search method.

The implementation of the binary search might not be optimal, however I'm open to discussions and adjustments.

A core implementation of binary searching on ordered arrays would be handy to have, as it can be much more performant than traditional (next, next, next) searching methods, where supported by the datasets.

Thanks.