### PR TITLE
[9.x] Allow model accessors to cache any value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -19,6 +19,13 @@ class Attribute
     public $set;
 
     /**
+     * Indicates if caching is enabled for this attribute.
+     *
+     * @var bool
+     */
+    public $withCaching = false;
+
+    /**
      * Indicates if caching of objects is enabled for this attribute.
      *
      * @var bool
@@ -80,6 +87,18 @@ class Attribute
     public function withoutObjectCaching()
     {
         $this->withObjectCaching = false;
+
+        return $this;
+    }
+
+    /**
+     * Enable caching for the attribute.
+     *
+     * @return static
+     */
+    public function withCaching()
+    {
+        $this->withCaching = true;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -96,7 +96,7 @@ class Attribute
      *
      * @return static
      */
-    public function withCaching()
+    public function shouldCache()
     {
         $this->withCaching = true;
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -640,10 +640,10 @@ trait HasAttributes
             return $value;
         }, $value, $this->attributes);
 
-        if (! is_object($value) || ! $attribute->withObjectCaching) {
-            unset($this->attributeCastCache[$key]);
-        } else {
+        if ($attribute->withCaching || (is_object($value) && $attribute->withObjectCaching)) {
             $this->attributeCastCache[$key] = $value;
+        } else {
+            unset($this->attributeCastCache[$key]);
         }
 
         return $value;
@@ -1023,10 +1023,10 @@ trait HasAttributes
             )
         );
 
-        if (! is_object($value) || ! $attribute->withObjectCaching) {
-            unset($this->attributeCastCache[$key]);
-        } else {
+        if ($attribute->withCaching || (is_object($value) && $attribute->withObjectCaching)) {
             $this->attributeCastCache[$key] = $value;
+        } else {
+            unset($this->attributeCastCache[$key]);
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -630,7 +630,7 @@ trait HasAttributes
      */
     protected function mutateAttributeMarkedAttribute($key, $value)
     {
-        if (isset($this->attributeCastCache[$key])) {
+        if (array_key_exists($key, $this->attributeCastCache)) {
             return $this->attributeCastCache[$key];
         }
 

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -202,6 +202,51 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
         }
     }
 
+    public function testAttributesCanCacheStrings()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $previous = $model->virtual_string_cached;
+
+        $this->assertIsString($previous);
+
+        $this->assertSame($previous, $model->virtual_string_cached);
+    }
+
+    public function testAttributesCanCacheBooleans()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $first = $model->virtual_boolean_cached;
+
+        $this->assertIsBool($first);
+
+        foreach (range(0, 10) as $ignored) {
+            $this->assertSame($first, $model->virtual_boolean_cached);
+        }
+    }
+
+    public function testAttributesByDefaultDontCacheBooleans()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $first = $model->virtual_boolean;
+
+        $this->assertIsBool($first);
+
+        foreach (range(0, 50) as $ignored) {
+            $current = $model->virtual_boolean;
+
+            $this->assertIsBool($current);
+
+            if ($first !== $current) {
+                return;
+            }
+        }
+
+        $this->fail('"virtual_boolean" seems to be cached.');
+    }
+
     public function testCastsThatOnlyHaveGetterThatReturnsObjectAreCached()
     {
         $model = new TestEloquentModelWithAttributeCast;
@@ -360,6 +405,27 @@ class TestEloquentModelWithAttributeCast extends Model
                 return Str::random(10);
             }
         );
+    }
+
+    public function virtualStringCached(): Attribute
+    {
+        return Attribute::get(function () {
+            return Str::random(10);
+        })->withCaching();
+    }
+
+    public function virtualBooleanCached(): Attribute
+    {
+        return Attribute::get(function () {
+            return (bool) mt_rand(0, 1);
+        })->withCaching();
+    }
+
+    public function virtualBoolean(): Attribute
+    {
+        return Attribute::get(function () {
+            return (bool) mt_rand(0, 1);
+        });
     }
 
     public function virtualObject(): Attribute

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -226,6 +226,25 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
         }
     }
 
+    public function testAttributesCanCacheNull()
+    {
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $this->assertSame(0, $model->virtualNullCalls);
+
+        $first = $model->virtual_null_cached;
+
+        $this->assertNull($first);
+
+        $this->assertSame(1, $model->virtualNullCalls);
+
+        foreach (range(0, 10) as $ignored) {
+            $this->assertSame($first, $model->virtual_null_cached);
+        }
+
+        $this->assertSame(1, $model->virtualNullCalls);
+    }
+
     public function testAttributesByDefaultDontCacheBooleans()
     {
         $model = new TestEloquentModelWithAttributeCast;
@@ -426,6 +445,17 @@ class TestEloquentModelWithAttributeCast extends Model
         return Attribute::get(function () {
             return (bool) mt_rand(0, 1);
         });
+    }
+
+    public $virtualNullCalls = 0;
+
+    public function virtualNullCached(): Attribute
+    {
+        return Attribute::get(function () {
+            $this->virtualNullCalls++;
+
+            return null;
+        })->withCaching();
     }
 
     public function virtualObject(): Attribute

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -430,14 +430,14 @@ class TestEloquentModelWithAttributeCast extends Model
     {
         return Attribute::get(function () {
             return Str::random(10);
-        })->withCaching();
+        })->shouldCache();
     }
 
     public function virtualBooleanCached(): Attribute
     {
         return Attribute::get(function () {
             return (bool) mt_rand(0, 1);
-        })->withCaching();
+        })->shouldCache();
     }
 
     public function virtualBoolean(): Attribute
@@ -455,7 +455,7 @@ class TestEloquentModelWithAttributeCast extends Model
             $this->virtualNullCalls++;
 
             return null;
-        })->withCaching();
+        })->shouldCache();
     }
 
     public function virtualObject(): Attribute


### PR DESCRIPTION
Model accessors currently only cache values that are objects. This PR allows accessors to cache any value. 

I have an old project that (unfortunately) does queries in accessors. Converting these accessors to a relationship would be a better solution, but this isn't always possible. For example:

```php
public function hasChildren(): Attribute
{
    return Attribute::get(function () {
        return Company::query()
            // some complicated query
            ->exists();        
    });
}
```

Accessors only cache objects, so if `$model->has_children` is called multiple times, it will execute the query each time. 

With this PR, I can add `->shouldCache()` to ensure each model only performs the query once:

```php
public function hasChildren(): Attribute
{
    return Attribute::get(function () {
        return Company::query()
            // some complicated query
            ->exists();        
    })->shouldCache();
}
```

Of course using queries in accessors is still a bad idea because it causes N+1 problems since they can't be eager loaded. But at least this allows me to cache the results to prevent many unnecessary queries.

Another use-case for caching accessors values is an accessor that generates a hash and returns it as a string. Only generating the hash once is a performance boost.



