### PR TITLE
[9.x] fix: VerifyCsrfToken - http_only config

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -209,7 +209,7 @@ class VerifyCsrfToken
             $config['path'],
             $config['domain'],
             $config['secure'],
-            false,
+            $config['http_only'],
             false,
             $config['same_site'] ?? null
         );


### PR DESCRIPTION
VerifyCsrfToken - newCookie() is did not used the session config "http_only" value.