### PR TITLE
[9.x] Add username option for phpredis with redis ACL

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -84,10 +84,9 @@ class PhpRedisConnector implements Connector
             $this->establishConnection($client, $config);
             
             if (! empty($config['password'])) {
-                if (! empty($config['username']) && is_string($config['password'])) {
-                    $client->auth([$config['username'],$config['password']]);
-                }
-                else
+                if (isset($config['username']) && is_string($config['password'])) {
+                    $client->auth([$config['username'], $config['password']]);
+                } else {
                     $client->auth($config['password']);
                 }
             }

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -83,7 +83,10 @@ class PhpRedisConnector implements Connector
 
             $this->establishConnection($client, $config);
 
-            if (! empty($config['password'])) {
+            if (! empty($config['username']) && is_string($config['password'])) {
+                $client->auth([$config['username'],$config['password']]);
+            }
+            elseif (! empty($config['password'])) {
                 $client->auth($config['password']);
             }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -82,7 +82,7 @@ class PhpRedisConnector implements Connector
             }
 
             $this->establishConnection($client, $config);
-            
+
             if (! empty($config['password'])) {
                 if (isset($config['username']) && is_string($config['password'])) {
                     $client->auth([$config['username'], $config['password']]);

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -82,12 +82,14 @@ class PhpRedisConnector implements Connector
             }
 
             $this->establishConnection($client, $config);
-
-            if (! empty($config['username']) && is_string($config['password'])) {
-                $client->auth([$config['username'],$config['password']]);
-            }
-            elseif (! empty($config['password'])) {
-                $client->auth($config['password']);
+            
+            if (! empty($config['password'])) {
+                if (! empty($config['username']) && is_string($config['password'])) {
+                    $client->auth([$config['username'],$config['password']]);
+                }
+                else
+                    $client->auth($config['password']);
+                }
             }
 
             if (isset($config['database'])) {


### PR DESCRIPTION
Add username in config for redis ACL (username + password) usage, previously have to use an array with password option, but break some laravel app if different environements (ex: a server with password only redis, a server with ACL redis (username + password), have to edit database.php to use an array
