### PR TITLE
[9.x] Add new test for session store when call remember method with key

### DIFF
--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -482,6 +482,17 @@ class SessionStoreTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
+    public function testRememberMethodReturnsPreviousValueIfItAlreadySets()
+    {
+        $session = $this->getSession();
+        $session->put('key', 'foo');
+        $result = $session->remember('key', function () {
+            return 'bar';
+        });
+        $this->assertSame('foo', $session->get('key'));
+        $this->assertSame('foo', $result);
+    }
+
     public function getSession()
     {
         $reflection = new ReflectionClass(Store::class);


### PR DESCRIPTION
This PR adds a new test for session store when calling remember method with a key which already sets.