### PR TITLE
[9.x] Factory generation fixes

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -79,13 +79,9 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $model = class_basename($namespaceModel);
 
-        if ($this->option('model') && Str::startsWith($namespaceModel, $this->rootNamespace().'Models')) {
-            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, $this->rootNamespace().'Models\\'), '\\');
-        } else {
-            $namespace = $this->getNamespace(
-                Str::replaceFirst('App', 'Database\\Factories', $this->qualifyClass($this->getNameInput()))
-            );
-        }
+        $namespace = $this->getNamespace(
+            Str::replaceFirst($this->rootNamespace(), 'Database\\Factories\\', $this->qualifyClass($this->getNameInput()))
+        );
 
         $replace = [
             '{{ factoryNamespace }}' => $namespace,

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -79,10 +79,12 @@ class FactoryMakeCommand extends GeneratorCommand
 
         $model = class_basename($namespaceModel);
 
-        if (Str::startsWith($namespaceModel, $this->rootNamespace().'Models')) {
+        if ($this->option('model') && Str::startsWith($namespaceModel, $this->rootNamespace().'Models')) {
             $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, $this->rootNamespace().'Models\\'), '\\');
         } else {
-            $namespace = 'Database\\Factories';
+            $namespace = $this->getNamespace(
+                Str::replaceFirst('App', 'Database\\Factories', $this->qualifyClass($this->getNameInput()))
+            );
         }
 
         $replace = [


### PR DESCRIPTION
This PR attempts to fix namespacing problems when using `make:factory` to create nested factories.