### PR TITLE
[9.x] Add column helper to allow easier use of database functions

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -94,9 +94,7 @@ abstract class Grammar
         }
 
         if (!$alias = $column->getAlias()) {
-            return $this->isExpression($value)
-                ? $value->getValue()
-                : $this->wrapSegments(explode('.', $value));
+            return $this->wrap($value, $prefixAlias);
         }
 
         if ($this->isExpression($value)) {

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -81,7 +81,7 @@ abstract class Grammar
     /**
      * Wrap a column object.
      *
-     * @param  \Illuminate\Database\Query\Column $column
+     * @param  \Illuminate\Database\Query\Column  $column
      * @param  bool  $prefixAlias
      * @return string
      */
@@ -93,7 +93,7 @@ abstract class Grammar
             $value = $this->wrapColumnFunction($column, $prefixAlias);
         }
 
-        if (!$alias = $column->getAlias()) {
+        if (! $alias = $column->getAlias()) {
             return $this->wrap($value, $prefixAlias);
         }
 
@@ -107,7 +107,7 @@ abstract class Grammar
     /**
      * Wrap database function call from a column.
      *
-     * @param  \Illuminate\Database\Query\Column $column
+     * @param  \Illuminate\Database\Query\Column  $column
      * @param  bool  $prefixAlias
      * @return \Illuminate\Database\Query\Expression
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1917,7 +1917,7 @@ class Builder implements BuilderContract
     /**
      * Add a "group by" clause to the query.
      *
-     * @param  array|string  ...$groups
+     * @param  array|string|\Illuminate\Database\Query\Column  ...$groups
      * @return $this
      */
     public function groupBy(...$groups)
@@ -2150,7 +2150,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|\Illuminate\Database\Query\Column|string  $column
      * @param  string  $direction
      * @return $this
      *
@@ -2183,7 +2183,7 @@ class Builder implements BuilderContract
     /**
      * Add a descending "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|\Illuminate\Database\Query\Column|string  $column
      * @return $this
      */
     public function orderByDesc($column)
@@ -2194,7 +2194,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|\Illuminate\Database\Query\Column|string  $column
      * @return $this
      */
     public function latest($column = 'created_at')
@@ -2205,7 +2205,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause for a timestamp to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|\Illuminate\Database\Query\Column|string  $column
      * @return $this
      */
     public function oldest($column = 'created_at')

--- a/src/Illuminate/Database/Query/Column.php
+++ b/src/Illuminate/Database/Query/Column.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+/**
+ * @method static \Illuminate\Database\Query\Column max(string|Column $name)
+ * @method static \Illuminate\Database\Query\Column min(string|Column $name)
+ * @method static \Illuminate\Database\Query\Column sum(string|Column $name)
+ * @method static \Illuminate\Database\Query\Column avg(string|Column $name)
+ * @method static \Illuminate\Database\Query\Column date(string|Column $name)
+ */
+class Column
+{
+    /**
+     * @var \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string
+     */
+    protected $name;
+
+    /**
+     * @var string|null
+     */
+    protected $alias = null;
+
+    /**
+     * @var string|null
+     */
+    protected $function = null;
+
+    /**
+     * @var array
+     */
+    protected $parameters = [];
+
+    /**
+     * @var string[]
+     */
+    protected static $basicFunctions = [
+        'min',
+        'max',
+        'sum',
+        'avg',
+        'date'
+    ];
+
+    /**
+     * @param  \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  $name
+     * @param  string|null  $function
+     * @param  array  $parameters
+     * @return void
+     */
+    public function __construct($name, $function = null, $parameters = [])
+    {
+        $this->name = $name;
+        $this->function = $function ? strtolower($function) : null;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @param  string  $name
+     * @param  array  $arguments
+     * @return \Illuminate\Database\Query\Column
+     * @throws \Exception
+     */
+    public static function __callStatic($name, $arguments)
+    {
+        if (!in_array($name, static::$basicFunctions)) {
+            // TODO: change exception type
+            throw new \Exception('Cannot find a basic function with the name ' . $name);
+        }
+
+        return new self($arguments[0], $name);
+    }
+
+    /**
+     * @param  \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  $name
+     * @return static
+     */
+    public static function name($name): self
+    {
+        return new self($name);
+    }
+
+    /**
+     * @param \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  ...$columns
+     *
+     * @return static
+     */
+    public static function coalesce(...$columns): self
+    {
+        return new self(array_shift($columns), 'coalesce', $columns);
+    }
+
+    /**
+     * @param \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  ...$columns
+     *
+     * @return static
+     */
+    public static function concat(...$columns): self
+    {
+        return new self(array_shift($columns), 'concat', $columns);
+    }
+
+    /**
+     * @param  string|null  $alias
+     * @return $this
+     */
+    public function as($alias = null)
+    {
+        $this->alias = $alias;
+
+        return $this;
+    }
+
+    /**
+     * @return \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFunction()
+    {
+        return $this->function;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Illuminate/Database/Query/Column.php
+++ b/src/Illuminate/Database/Query/Column.php
@@ -74,7 +74,7 @@ class Column
     }
 
     /**
-     * @param  \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  $name
+     * @param  \Illuminate\Database\Query\Expression|string  $name
      * @return static
      */
     public static function name($name): self
@@ -83,8 +83,16 @@ class Column
     }
 
     /**
-     * @param \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  ...$columns
-     *
+     * @param  \Illuminate\Database\Query\Expression|string  $name
+     * @return static
+     */
+    public static function count($name = '*'): self
+    {
+        return new self($name, 'count');
+    }
+
+    /**
+     * @param  \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  ...$columns
      * @return static
      */
     public static function coalesce(...$columns): self
@@ -93,8 +101,7 @@ class Column
     }
 
     /**
-     * @param \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  ...$columns
-     *
+     * @param  \Illuminate\Database\Query\Column|\Illuminate\Database\Query\Expression|string  ...$columns
      * @return static
      */
     public static function concat(...$columns): self

--- a/src/Illuminate/Database/Query/Column.php
+++ b/src/Illuminate/Database/Query/Column.php
@@ -61,7 +61,7 @@ class Column
      * @param  string  $name
      * @param  array  $arguments
      * @return \Illuminate\Database\Query\Column
-     * 
+     *
      * @throws \RuntimeException
      */
     public static function __callStatic($name, $arguments)

--- a/src/Illuminate/Database/Query/Column.php
+++ b/src/Illuminate/Database/Query/Column.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Query;
 
+use RuntimeException;
+
 /**
  * @method static \Illuminate\Database\Query\Column max(string|Column $name)
  * @method static \Illuminate\Database\Query\Column min(string|Column $name)
@@ -59,13 +61,13 @@ class Column
      * @param  string  $name
      * @param  array  $arguments
      * @return \Illuminate\Database\Query\Column
-     * @throws \Exception
+     * 
+     * @throws \RuntimeException
      */
     public static function __callStatic($name, $arguments)
     {
         if (!in_array($name, static::$basicFunctions)) {
-            // TODO: change exception type
-            throw new \Exception('Cannot find a basic function with the name ' . $name);
+            throw new RuntimeException('Cannot find a basic database function with the name ' . $name);
         }
 
         return new self($arguments[0], $name);

--- a/src/Illuminate/Database/Query/Column.php
+++ b/src/Illuminate/Database/Query/Column.php
@@ -41,7 +41,7 @@ class Column
         'max',
         'sum',
         'avg',
-        'date'
+        'date',
     ];
 
     /**
@@ -66,8 +66,8 @@ class Column
      */
     public static function __callStatic($name, $arguments)
     {
-        if (!in_array($name, static::$basicFunctions)) {
-            throw new RuntimeException('Cannot find a basic database function with the name ' . $name);
+        if (! in_array($name, static::$basicFunctions)) {
+            throw new RuntimeException('Cannot find a basic database function with the name '.$name);
         }
 
         return new self($arguments[0], $name);

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Query\Grammars;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class SQLiteGrammar extends Grammar
 {
@@ -325,6 +326,24 @@ class SQLiteGrammar extends Grammar
             'delete from sqlite_sequence where name = ?' => [$query->from],
             'delete from '.$this->wrapTable($query->from) => [],
         ];
+    }
+
+    /**
+     * Wrap database function call from a column.
+     *
+     * @param  \Illuminate\Database\Query\Column $column
+     * @param  bool  $prefixAlias
+     * @return \Illuminate\Database\Query\Expression
+     *
+     * @throws \RuntimeException
+     */
+    protected function wrapColumnFunction($column, $prefixAlias = false)
+    {
+        if ($column->getFunction() === 'concat') {
+            throw new RuntimeException('This database driver does not support the concat function.');
+        }
+
+        return parent::wrapColumnFunction($column, $prefixAlias);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -331,7 +331,7 @@ class SQLiteGrammar extends Grammar
     /**
      * Wrap database function call from a column.
      *
-     * @param  \Illuminate\Database\Query\Column $column
+     * @param  \Illuminate\Database\Query\Column  $column
      * @param  bool  $prefixAlias
      * @return \Illuminate\Database\Query\Expression
      *

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4626,6 +4626,14 @@ SQL;
     public function testColumnSelectFunctions()
     {
         $builder = $this->getBuilder();
+        $builder->select(Column::count())->from('users')->where('email', 'foo')->orderBy('email');
+        $this->assertSame('select COUNT(*) from "users" where "email" = ? order by "email" asc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select(Column::count('id'))->from('users')->where('email', 'foo')->orderBy('email');
+        $this->assertSame('select COUNT("id") from "users" where "email" = ? order by "email" asc', $builder->toSql());
+
+        $builder = $this->getBuilder();
         $builder->select(Column::max('id'))->from('users')->where('email', 'foo')->orderBy('email');
         $this->assertSame('select MAX("id") from "users" where "email" = ? order by "email" asc', $builder->toSql());
 
@@ -4660,6 +4668,14 @@ SQL;
 
     public function testColumnSelectFunctionsWithAlias()
     {
+        $builder = $this->getBuilder();
+        $builder->select(Column::count()->as('user_count'))->from('users')->where('email', 'foo')->orderBy('email');
+        $this->assertSame('select COUNT(*) as "user_count" from "users" where "email" = ? order by "email" asc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select(Column::count('id')->as('user_count'))->from('users')->where('email', 'foo')->orderBy('email');
+        $this->assertSame('select COUNT("id") as "user_count" from "users" where "email" = ? order by "email" asc', $builder->toSql());
+
         $builder = $this->getBuilder();
         $builder->select(Column::max('id')->as('max_id'))->from('users')->where('email', 'foo')->orderBy('email');
         $this->assertSame('select MAX("id") as "max_id" from "users" where "email" = ? order by "email" asc', $builder->toSql());


### PR DESCRIPTION
## Description

This pull request implements a new column helper to allow the use of certain database functions in the query builder. This means you can now easily use aggregate functions like `COUNT` or `MIN` when selecting, ordering or grouping any data.

Currently, if you want to use any of the existing database functions you are forced to use `DB::raw()` helper and write the query yourself.

This shouldn't have an impact on existing applications as this is an entirely new class, and it's split up into seperate functions in the Grammar class.

## Example

Say you want to fetch the daily views of all categories on your shop. Today you would have to do as follows:

```php
DB::table('category_views')
    ->select(
        DB::raw('DATE(created_at) as date'),
        DB::raw('SUM(views) as total_views'),
    )
    ->groupBy('date')
    ->get();
```

This can now be done using a helper class called `Column`

```php
DB::table('category_views')
    ->select(
        Column::date('created_at')->as('date'),
        Column::sum('views')->as('total_views'),
    )
    ->groupBy('date')
    ->get();
```

Translates to: `select DATE("created_at") as "date", SUM("views") as "total_views" from "category_views" group by "date"`

This can also easily be used with DB::raw() if you want to.

```php
DB::table('scores')
    ->select(
        Column::date('created_at')->as('date'),
        Column::avg(DB::raw('score - 1'))->as('avg_score'),
    )
    ->groupBy('date')
    ->get();
```

Translates to: `select DATE("created_at") as "date", AVG(score - 1) as "avg_score" from "scores" group by "date"`

There are currently two functions accepting multiple parameters: `CONCAT` and `COALESCE`.

```php
User::select(
    Column::concat(Column::name('first_name'), ' ', Column::name('last_name')),
)->get()
```

```php
User::select(
    Column::coalesce(Column::name('primary_contact'), Column::name('default_contact'), 'no contact'),
)->get()
```

## Advantages
- **No more writing raw queries:** instead of having to manually write every function using `DB::raw` you can now use the new column class for this.
- **Extendability:** This opens up for extending the column class to handle advanced nested queries by using a fluent builder instead of manually creating the query.
  - `SUM(total_price - discount) as discount` could potentially be allowed in the future using some sort of fluent syntax for the new `Column`. I have some ideas for this if the pull request is accepted.

## Caveats

I had to implement the `Column::name()` method to allow the grammar builder to determine if the parameter is a string, or an actual column in the database.
This causes the functions allow multiple parameters to look cluttered.  

If you have any idea of how else to handle this I'm all ears, as I don't think this is quite as clean as I'd like.

## Note

There are a lot more database functions than present in this pull request, but I wanted to integrate the most used ones and keep it simple to see if there is any interest in this. New ones should be easy to implement in the future.

Let me know if there is anything that stands out and needs a bit of explaining.

![image](https://user-images.githubusercontent.com/5139119/160207966-e52ca183-c574-4e1d-9b54-3fa60a94f756.png)

