### PR TITLE
[9.x] Add tests for old input assertion

### DIFF
--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1683,6 +1683,27 @@ class TestResponseTest extends TestCase
         $response->assertSessionHas(['foo', 'bar']);
     }
 
+    public function testAssertSessionHasInput()
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->put('_old_input', [
+            'foo' => 'value',
+            'bar' => 'value',
+        ]);
+
+        $response = TestResponse::fromBaseResponse(new Response());
+
+        $response->assertSessionHasInput('foo');
+        $response->assertSessionHasInput('foo', 'value');
+        $response->assertSessionHasInput('bar');
+        $response->assertSessionHasInput('bar', 'value');
+        $response->assertSessionHasInput(['foo', 'bar']);
+        $response->assertSessionHasInput('foo', function ($value) {
+            return $value === 'value';
+        });
+    }
+
     public function testGetEncryptedCookie()
     {
         $container = Container::getInstance();


### PR DESCRIPTION
There were no test for `assertSessionHasInput` method on TestResponse class.