### PR TITLE
[9.x] Add tests for schedule:test command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
 
 class ScheduleTestCommand extends Command
 {
@@ -70,7 +71,7 @@ class ScheduleTestCommand extends Command
 
         $event = $commands[$index];
 
-        $this->line('<info>['.date('c').'] Running scheduled command:</info> '.$event->getSummaryForDisplay());
+        $this->line('<info>['.Carbon::now()->format('c').'] Running scheduled command:</info> '.$event->getSummaryForDisplay());
 
         $event->run($this->laravel);
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -75,4 +75,11 @@ class ScheduleTestCommand extends Command
 
         $event->run($this->laravel);
     }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleTestCommand.php
@@ -75,11 +75,4 @@ class ScheduleTestCommand extends Command
 
         $event->run($this->laravel);
     }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        Carbon::setTestNow(null);
-    }
 }

--- a/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
@@ -72,6 +72,13 @@ class ScheduleTestCommandTest extends TestCase
             )
             ->expectsOutput(sprintf('[%s] Running scheduled command: callback', $this->timestamp));
     }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
 }
 
 class BarCommandStub extends Command

--- a/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
@@ -21,7 +21,7 @@ class ScheduleTestCommandTest extends TestCase
         $this->schedule = $this->app->make(Schedule::class);
     }
 
-    public function testNoDefinedCommands()
+    public function testRunNoDefinedCommands()
     {
         $this->artisan(ScheduleTestCommand::class)
             ->assertSuccessful()

--- a/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleTestCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console\Scheduling;
+
+use Illuminate\Console\Application;
+use Illuminate\Console\Command;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Console\Scheduling\ScheduleTestCommand;
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+
+class ScheduleTestCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(now()->startOfYear());
+
+        $this->timestamp = now()->startOfYear()->format('c');
+        $this->schedule = $this->app->make(Schedule::class);
+    }
+
+    public function testNoDefinedCommands()
+    {
+        $this->artisan(ScheduleTestCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('No scheduled commands have been defined.');
+    }
+
+    public function testRunNoMatchingCommand()
+    {
+        $this->schedule->command(BarCommandStub::class);
+
+        $this->artisan(ScheduleTestCommand::class, ['--name' => 'missing:command'])
+            ->assertSuccessful()
+            ->expectsOutput('No matching scheduled command found.');
+    }
+
+    public function testRunUsingNameOption()
+    {
+        $this->schedule->command(BarCommandStub::class)->name('bar-command');
+        $this->schedule->job(BarJobStub::class);
+        $this->schedule->call(fn () => true)->name('callback');
+
+        $this->artisan(ScheduleTestCommand::class, ['--name' => 'bar:command'])
+            ->assertSuccessful()
+            ->expectsOutput(sprintf('[%s] Running scheduled command: bar-command', $this->timestamp));
+
+        $this->artisan(ScheduleTestCommand::class, ['--name' => BarJobStub::class])
+            ->assertSuccessful()
+            ->expectsOutput(sprintf('[%s] Running scheduled command: %s', $this->timestamp, BarJobStub::class));
+
+        $this->artisan(ScheduleTestCommand::class, ['--name' => 'callback'])
+            ->assertSuccessful()
+            ->expectsOutput(sprintf('[%s] Running scheduled command: callback', $this->timestamp));
+    }
+
+    public function testRunUsingChoices()
+    {
+        $this->schedule->command(BarCommandStub::class)->name('bar-command');
+        $this->schedule->job(BarJobStub::class);
+        $this->schedule->call(fn () => true)->name('callback');
+
+        $this->artisan(ScheduleTestCommand::class)
+            ->assertSuccessful()
+            ->expectsChoice(
+                'Which command would you like to run?',
+                'callback',
+                [Application::formatCommandString('bar:command'), BarJobStub::class, 'callback'],
+                true
+            )
+            ->expectsOutput(sprintf('[%s] Running scheduled command: callback', $this->timestamp));
+    }
+}
+
+class BarCommandStub extends Command
+{
+    protected $signature = 'bar:command';
+
+    protected $description = 'This is the description of the command.';
+}
+
+class BarJobStub
+{
+    public function __invoke()
+    {
+        // ..
+    }
+}


### PR DESCRIPTION
This PR adds some basic test coverage for the `schedule:test` command. I switched the `date()` call in the command to a `Carbon` instance so I could fix the timestamp in the tests.