### PR TITLE
[9.x] Add countedSequence method to database eloquent factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -495,6 +495,17 @@ abstract class Factory
     }
 
     /**
+     * Add a new sequenced state transformation to the model definition and update count to the size of the sequence.
+     *
+     * @param  array  $sequence
+     * @return static
+     */
+    public function countedSequence(...$sequence)
+    {
+        return $this->state(new Sequence(...$sequence))->count(count($sequence));
+    }
+
+    /**
      * Add a new cross joined sequenced state transformation to the model definition.
      *
      * @param  array  $sequence

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -495,12 +495,12 @@ abstract class Factory
     }
 
     /**
-     * Add a new sequenced state transformation to the model definition and update count to the size of the sequence.
+     * Add a new sequenced state transformation to the model definition and update the pending creation count to the size of the sequence.
      *
      * @param  array  $sequence
      * @return static
      */
-    public function countedSequence(...$sequence)
+    public function forEachSequence(...$sequence)
     {
         return $this->state(new Sequence(...$sequence))->count(count($sequence));
     }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -425,6 +425,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $clazz = new \ReflectionClass($factory);
         $prop = $clazz->getProperty('count');
+        $prop->setAccessible(true);
         $value = $prop->getValue($factory);
 
         $this->assertSame(3, $value);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -417,14 +417,14 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_counted_sequence()
     {
-        $factory = FactoryTestUserFactory::new()->countedSequence(
+        $factory = FactoryTestUserFactory::new()->forEachSequence(
             ['name' => 'Taylor Otwell'],
             ['name' => 'Abigail Otwell'],
             ['name' => 'Dayle Rees']
         );
 
-        $clazz = new \ReflectionClass($factory);
-        $prop = $clazz->getProperty('count');
+        $class = new \ReflectionClass($factory);
+        $prop = $class->getProperty('count');
         $prop->setAccessible(true);
         $value = $prop->getValue($factory);
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -415,6 +415,21 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame('index: 1', $users[1]->name);
     }
 
+    public function test_counted_sequence()
+    {
+        $factory = FactoryTestUserFactory::new()->countedSequence(
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Abigail Otwell'],
+            ['name' => 'Dayle Rees']
+        );
+
+        $clazz = new \ReflectionClass($factory);
+        $prop = $clazz->getProperty('count');
+        $value = $prop->getValue($factory);
+
+        $this->assertSame(3, $value);
+    }
+
     public function test_cross_join_sequences()
     {
         $assert = function ($users) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This adds the `countedSequence` method that allows a user to provide a factory with a sequence which automatically updates the count state of the factory, this saves one the arduous tasks of counting the sequences one self and updating the state accordingly.
