### PR TITLE
[10.x] Ask for confirmation when running optimze command on local environment

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -29,7 +29,7 @@ class OptimizeCommand extends Command
     public function handle()
     {
         $confirmationMessage = 'Further configuration and routes changes will not take effect unless you run the command again or clear the cache, are you sure you want to run this command?';
-        if (App::environment('local') && ! $this->confirm($confirmationMessage)) {
+        if (App::isLocal() && ! $this->confirm($confirmationMessage)) {
             return 1;
         }
 

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\App;
 
 class OptimizeCommand extends Command
 {
@@ -27,6 +28,11 @@ class OptimizeCommand extends Command
      */
     public function handle()
     {
+        $confirmationMessage = 'Further configuration and routes changes will not take effect unless you run the command again or clear the cache, are you sure you want to run this command?';
+        if (App::environment('local') && ! $this->confirm($confirmationMessage)) {
+            return 1;
+        }
+
         $this->call('config:cache');
         $this->call('route:cache');
 

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -15,6 +15,13 @@ class OptimizeCommand extends Command
     protected $name = 'optimize';
 
     /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'optimize {--force : Force the operation to run when in production}';
+
+    /**
      * The console command description.
      *
      * @var string
@@ -29,7 +36,7 @@ class OptimizeCommand extends Command
     public function handle()
     {
         $confirmationMessage = 'Further configuration and routes changes will not take effect unless you run the command again or clear the cache, are you sure you want to run this command?';
-        if (App::isLocal() && ! $this->confirm($confirmationMessage)) {
+        if (! $this->option('force') && App::isLocal() && ! $this->confirm($confirmationMessage)) {
             return 1;
         }
 

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -8,13 +8,6 @@ use Illuminate\Support\Facades\App;
 class OptimizeCommand extends Command
 {
     /**
-     * The console command name.
-     *
-     * @var string
-     */
-    protected $name = 'optimize';
-
-    /**
      * The name and signature of the console command.
      *
      * @var string


### PR DESCRIPTION
I noticed a lot of people fall into the trap of running the optimize command locally and then making changes to their configuration or routes files and not being able to see their changes take effect.

This PR will ask for confirmation when running the `optimize` artisan command on `local` environment with the message:
```
Further configuration and routes changes will not take effect unless you run the command again or clear the cache, are you sure you want to run this command?
```

Also, added a `--force` flag to the `optimize` artisan command to ignore the environment and run the command anyways.