### PR TITLE
[9.x] Fix Postgres driver not dropping all tables & views

### DIFF
--- a/src/Illuminate/Database/Concerns/ParsesSearchPath.php
+++ b/src/Illuminate/Database/Concerns/ParsesSearchPath.php
@@ -18,12 +18,8 @@ trait ParsesSearchPath
             $searchPath = $matches[0];
         }
 
-        $searchPath ??= [];
-
-        array_walk($searchPath, static function (&$schema) {
-            $schema = trim($schema, '\'"');
-        });
-
-        return $searchPath;
+        return array_map(function ($schema) {
+            return trim($schema, '\'"');
+        }, $searchPath ?? []);
     }
 }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -239,14 +239,10 @@ class PostgresBuilder extends Builder
      */
     protected function parseSearchPath($searchPath)
     {
-        $searchPath = $this->baseParseSearchPath($searchPath);
-
-        array_walk($searchPath, function (&$schema) {
-            $schema = $schema === '$user'
+        return array_map(function ($schema) {
+            return $schema === '$user'
                 ? $this->connection->getConfig('username')
                 : $schema;
-        });
-
-        return $searchPath;
+        }, $this->baseParseSearchPath($searchPath));
     }
 }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -62,15 +62,15 @@ class PostgresBuilder extends Builder
     {
         $tables = [];
 
-        $excludedTables = $this->connection->getConfig('dont_drop') ?? ['spatial_ref_sys'];
+        $excludedTables = $this->grammar->escapeNames(
+            $this->connection->getConfig('dont_drop') ?? ['spatial_ref_sys']
+        );
 
         foreach ($this->getAllTables() as $row) {
             $row = (array) $row;
 
-            $table = reset($row);
-
-            if (! in_array($table, $excludedTables)) {
-                $tables[] = $table;
+            if (empty(array_intersect($this->grammar->escapeNames($row), $excludedTables))) {
+                $tables[] = $row['qualifiedname'] ?? reset($row);
             }
         }
 
@@ -95,7 +95,7 @@ class PostgresBuilder extends Builder
         foreach ($this->getAllViews() as $row) {
             $row = (array) $row;
 
-            $views[] = reset($row);
+            $views[] = $row['qualifiedname'] ?? reset($row);
         }
 
         if (empty($views)) {

--- a/tests/Database/DatabasePostgresBuilderTest.php
+++ b/tests/Database/DatabasePostgresBuilderTest.php
@@ -238,10 +238,12 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('dont_drop')->andReturn(['foo']);
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileGetAllTables')->with(['public'])->andReturn("select tablename from pg_catalog.pg_tables where schemaname in ('public')");
-        $connection->shouldReceive('select')->with("select tablename from pg_catalog.pg_tables where schemaname in ('public')")->andReturn(['users']);
-        $grammar->shouldReceive('compileDropAllTables')->with(['users'])->andReturn('drop table "'.implode('","', ['users']).'" cascade');
-        $connection->shouldReceive('statement')->with('drop table "'.implode('","', ['users']).'" cascade');
+        $grammar->shouldReceive('compileGetAllTables')->with(['public'])->andReturn("select tablename, concat('\"', schemaname, '\".\"', tablename, '\"') as qualifiedname from pg_catalog.pg_tables where schemaname in ('public')");
+        $connection->shouldReceive('select')->with("select tablename, concat('\"', schemaname, '\".\"', tablename, '\"') as qualifiedname from pg_catalog.pg_tables where schemaname in ('public')")->andReturn([['tablename' => 'users', 'qualifiedname' => '"public"."users"']]);
+        $grammar->shouldReceive('escapeNames')->with(['foo'])->andReturn(['"foo"']);
+        $grammar->shouldReceive('escapeNames')->with(['tablename' => 'users', 'qualifiedname' => '"public"."users"'])->andReturn(['tablename' => '"users"', 'qualifiedname' => '"public"."users"']);
+        $grammar->shouldReceive('compileDropAllTables')->with(['"public"."users"'])->andReturn('drop table "public"."users" cascade');
+        $connection->shouldReceive('statement')->with('drop table "public"."users" cascade');
         $builder = $this->getBuilder($connection);
 
         $builder->dropAllTables();
@@ -255,10 +257,12 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('dont_drop')->andReturn(['foo']);
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileGetAllTables')->with(['foouser', 'public', 'foo_bar-Baz.Áüõß'])->andReturn("select tablename from pg_catalog.pg_tables where schemaname in ('foouser','public','foo_bar-Baz.Áüõß')");
-        $connection->shouldReceive('select')->with("select tablename from pg_catalog.pg_tables where schemaname in ('foouser','public','foo_bar-Baz.Áüõß')")->andReturn(['users', 'users']);
-        $grammar->shouldReceive('compileDropAllTables')->with(['users', 'users'])->andReturn('drop table "'.implode('","', ['users', 'users']).'" cascade');
-        $connection->shouldReceive('statement')->with('drop table "'.implode('","', ['users', 'users']).'" cascade');
+        $grammar->shouldReceive('compileGetAllTables')->with(['foouser', 'public', 'foo_bar-Baz.Áüõß'])->andReturn("select tablename, concat('\"', schemaname, '\".\"', tablename, '\"') as qualifiedname from pg_catalog.pg_tables where schemaname in ('foouser','public','foo_bar-Baz.Áüõß')");
+        $connection->shouldReceive('select')->with("select tablename, concat('\"', schemaname, '\".\"', tablename, '\"') as qualifiedname from pg_catalog.pg_tables where schemaname in ('foouser','public','foo_bar-Baz.Áüõß')")->andReturn([['tablename' => 'users', 'qualifiedname' => '"foouser"."users"']]);
+        $grammar->shouldReceive('escapeNames')->with(['foo'])->andReturn(['"foo"']);
+        $grammar->shouldReceive('escapeNames')->with(['tablename' => 'users', 'qualifiedname' => '"foouser"."users"'])->andReturn(['tablename' => '"users"', 'qualifiedname' => '"foouser"."users"']);
+        $grammar->shouldReceive('compileDropAllTables')->with(['"foouser"."users"'])->andReturn('drop table "foouser"."users" cascade');
+        $connection->shouldReceive('statement')->with('drop table "foouser"."users" cascade');
         $builder = $this->getBuilder($connection);
 
         $builder->dropAllTables();
@@ -277,10 +281,12 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('dont_drop')->andReturn(['foo']);
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileGetAllTables')->with(['foouser', 'dev', 'test', 'spaced schema'])->andReturn("select tablename from pg_catalog.pg_tables where schemaname in ('foouser','dev','test','spaced schema')");
-        $connection->shouldReceive('select')->with("select tablename from pg_catalog.pg_tables where schemaname in ('foouser','dev','test','spaced schema')")->andReturn(['users', 'users']);
-        $grammar->shouldReceive('compileDropAllTables')->with(['users', 'users'])->andReturn('drop table "'.implode('","', ['users', 'users']).'" cascade');
-        $connection->shouldReceive('statement')->with('drop table "'.implode('","', ['users', 'users']).'" cascade');
+        $grammar->shouldReceive('compileGetAllTables')->with(['foouser', 'dev', 'test', 'spaced schema'])->andReturn("select tablename, concat('\"', schemaname, '\".\"', tablename, '\"') as qualifiedname from pg_catalog.pg_tables where schemaname in ('foouser','dev','test','spaced schema')");
+        $connection->shouldReceive('select')->with("select tablename, concat('\"', schemaname, '\".\"', tablename, '\"') as qualifiedname from pg_catalog.pg_tables where schemaname in ('foouser','dev','test','spaced schema')")->andReturn([['tablename' => 'users', 'qualifiedname' => '"foouser"."users"']]);
+        $grammar->shouldReceive('escapeNames')->with(['foo'])->andReturn(['"foo"']);
+        $grammar->shouldReceive('escapeNames')->with(['tablename' => 'users', 'qualifiedname' => '"foouser"."users"'])->andReturn(['tablename' => '"users"', 'qualifiedname' => '"foouser"."users"']);
+        $grammar->shouldReceive('compileDropAllTables')->with(['"foouser"."users"'])->andReturn('drop table "foouser"."users" cascade');
+        $connection->shouldReceive('statement')->with('drop table "foouser"."users" cascade');
         $builder = $this->getBuilder($connection);
 
         $builder->dropAllTables();

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @requires extension pdo_pgsql
+ * @requires OS Linux|Darwin
+ */
+class PostgresSchemaBuilderTest extends PostgresTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('database.connections.pgsql.search_path', 'public,private');
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        parent::defineDatabaseMigrations();
+
+        DB::statement('create schema if not exists private');
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        DB::statement('drop table if exists public.table');
+        DB::statement('drop table if exists private.table');
+
+        DB::statement('drop view if exists public.foo');
+        DB::statement('drop view if exists private.foo');
+
+        DB::statement('drop schema private');
+
+        parent::destroyDatabaseMigrations();
+    }
+
+    public function testDropAllTablesOnAllSchemas()
+    {
+        Schema::create('public.table', function (Blueprint $table) {
+            $table->increments('id');
+        });
+        Schema::create('private.table', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::dropAllTables();
+
+        $this->artisan('migrate:install');
+
+        $this->assertFalse(Schema::hasTable('public.table'));
+        $this->assertFalse(Schema::hasTable('private.table'));
+    }
+
+    public function testDropAllTablesUsesDontDropConfigOnAllSchemas()
+    {
+        $this->app['config']->set('database.connections.pgsql.dont_drop', ['spatial_ref_sys', 'table']);
+        DB::purge('pgsql');
+
+        Schema::create('public.table', function (Blueprint $table) {
+            $table->increments('id');
+        });
+        Schema::create('private.table', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::dropAllTables();
+
+        $this->artisan('migrate:install');
+
+        $this->assertTrue(Schema::hasTable('public.table'));
+        $this->assertTrue(Schema::hasTable('private.table'));
+    }
+
+    public function testDropAllTablesUsesDontDropConfigOnOneSchema()
+    {
+        $this->app['config']->set('database.connections.pgsql.dont_drop', ['spatial_ref_sys', 'private.table']);
+        DB::purge('pgsql');
+
+        Schema::create('public.table', function (Blueprint $table) {
+            $table->increments('id');
+        });
+        Schema::create('private.table', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::dropAllTables();
+
+        $this->artisan('migrate:install');
+
+        $this->assertFalse(Schema::hasTable('public.table'));
+        $this->assertTrue(Schema::hasTable('private.table'));
+    }
+
+    public function testDropAllViewsOnAllSchemas()
+    {
+        DB::statement('create view public.foo (id) as select 1');
+        DB::statement('create view private.foo (id) as select 1');
+
+        Schema::dropAllViews();
+
+        $this->assertFalse($this->hasView('public', 'foo'));
+        $this->assertFalse($this->hasView('private', 'foo'));
+    }
+
+    protected function hasView($schema, $table)
+    {
+        return DB::table('information_schema.views')
+            ->where('table_catalog', $this->app['config']->get('database.connections.pgsql.database'))
+            ->where('table_schema', $schema)
+            ->where('table_name', $table)
+            ->exists();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/41483
Replaces https://github.com/laravel/framework/pull/41541

This fixes `php artisan db:wipe` not dropping all tables & views across multiple Postgres schemas. `DROP` queries didn't schema-qualify names so only the first object found is dropped. e.g., if a "migrations" table exists in two schemas, `Schema::dropAllTables()` leaves one of those tables.

Start schema-qualifying these names to ensure each object is explicitly removed.

```sql
-- assuming config('database.connections.pgsql.search_path') === 'public,laravel'

-- before
drop table "migrations","users" cascade

-- after
drop table "public"."migrations","public"."users","laravel"."migrations","laravel"."users" cascade
```

---

This implementation is almost functionality the same as the other draft PR except it:

* simplifies quote-wrapping table/view/type names
* `Schema::getAllTables()` returns an already-quoted `$row['qualifiedname']` column. e.g,
  ```php
  [
    [
      'tablename' => 'migrations',
      'qualifiedname' => '"laravel"."migrations"',
    ],
    [
      'tablename' => 'users',
      'qualifiedname' => '"laravel"."users"',
    ],
  ]
  ```
* adds integration tests to wipe tables & views defined in two separate schemas
* replaces `array_walk()` expressions from previous PRs with simpler `array_map()`.
* clarifies up some mock `andReturn()` values from previous PRs