### PR TITLE
[9.x] Remove PHP 8.1 deprecated notice in `@pushOnce()` & `@includeOnce()`

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -38,7 +38,7 @@ trait CompilesStacks
     {
         $parts = explode(',', $this->stripParentheses($expression), 2);
 
-        [$stack, $id] = [$parts[0], $parts[1] ?? null];
+        [$stack, $id] = [$parts[0], $parts[1] ?? ''];
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
 
@@ -87,7 +87,7 @@ $__env->startPush('.$stack.'); ?>';
     {
         $parts = explode(',', $this->stripParentheses($expression), 2);
 
-        [$stack, $id] = [$parts[0], $parts[1] ?? null];
+        [$stack, $id] = [$parts[0], $parts[1] ?? ''];
 
         $id = trim($id) ?: "'".(string) Str::uuid()."'";
 

--- a/tests/View/Blade/BladePrependTest.php
+++ b/tests/View/Blade/BladePrependTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\View\Blade;
 
+use Illuminate\Support\Str;
+
 class BladePrependTest extends AbstractBladeTestCase
 {
     public function testPrependIsCompiled()
@@ -23,6 +25,22 @@ test
 @endPrependOnce';
 
         $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
+$__env->startPrepend(\'foo\'); ?>
+test
+<?php $__env->stopPrepend(); endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPrependOnceIsCompiledWhenIdIsMissing()
+    {
+        Str::createUuidsUsing(fn () => 'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f');
+
+        $string = '@prependOnce(\'foo\')
+test
+@endPrependOnce';
+
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\')): $__env->markAsRenderedOnce(\'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\');
 $__env->startPrepend(\'foo\'); ?>
 test
 <?php $__env->stopPrepend(); endif; ?>';

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\View\Blade;
 
+use Illuminate\Support\Str;
+
 class BladePushTest extends AbstractBladeTestCase
 {
     public function testPushIsCompiled()
@@ -22,6 +24,22 @@ test
 @endPushOnce';
 
         $expected = '<?php if (! $__env->hasRenderedOnce(\'bar\')): $__env->markAsRenderedOnce(\'bar\');
+$__env->startPush(\'foo\'); ?>
+test
+<?php $__env->stopPush(); endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testPushOnceIsCompiledWhenIdIsMissing()
+    {
+        Str::createUuidsUsing(fn () => 'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f');
+
+        $string = '@pushOnce(\'foo\')
+test
+@endPushOnce';
+
+        $expected = '<?php if (! $__env->hasRenderedOnce(\'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\')): $__env->markAsRenderedOnce(\'e60e8f77-9ac3-4f71-9f8e-a044ef481d7f\');
 $__env->startPush(\'foo\'); ?>
 test
 <?php $__env->stopPush(); endif; ?>';


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/41643

Blade directives `@includeOnce()` & `@pushOnce()` can raise a deprecated notice in PHP 8.1:

> trim(): Passing null to parameter #1 ($string) of type string is deprecated

Instead fallback to empty string `''`.