### PR TITLE
[9.x] Mark lazy method as internal

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -68,6 +68,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get a lazy collection for the items in this collection.
      *
      * @return \Illuminate\Support\LazyCollection<TKey, TValue>
+     *
+     * @internal This method is only meant to be used internally and not in userland.
      */
     public function lazy()
     {


### PR DESCRIPTION
People keep trying to use this method while it's only meant to be used internally.