### PR TITLE
[10.x] Added `assertClosurePushed` and `assertClosureNotPushed`

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -17,8 +17,10 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static mixed pushRaw(string $payload, string $queue = null, array $options = [])
  * @method static string getConnectionName()
  * @method static void assertNotPushed(string|\Closure $job, callable $callback = null)
+ * @method static void assertClosureNotPushed(callable $callback = null)
  * @method static void assertNothingPushed()
  * @method static void assertPushed(string|\Closure $job, callable|int $callback = null)
+ * @method static void assertClosurePushed(callable|int $callback = null)
  * @method static void assertPushedOn(string $queue, string|\Closure $job, callable $callback = null)
  * @method static void assertPushedWithChain(string $job, array $expectedChain = [], callable $callback = null)
  *

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Testing\Fakes;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ReflectsClosures;
@@ -202,6 +203,28 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
+     * Assert if a closure was pushed based on a truth-test callback.
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public function assertClosurePushed($callback = null)
+    {
+        $this->assertPushed(CallQueuedClosure::class, $callback);
+    }
+
+    /**
+     * Determine if a closure was pushed based on a truth-test callback.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertClosureNotPushed($callback = null)
+    {
+        $this->assertNotPushed(CallQueuedClosure::class, $callback);
+    }
+
+    /**
      * Determine if the given chain is entirely composed of objects.
      *
      * @param  array  $chain
@@ -311,6 +334,10 @@ class QueueFake extends QueueManager implements Queue
     public function push($job, $data = '', $queue = null)
     {
         if ($this->shouldFakeJob($job)) {
+            if ($job instanceof Closure) {
+                $job = CallQueuedClosure::create($job);
+            }
+
             $this->jobs[is_object($job) ? get_class($job) : $job][] = [
                 'job' => $job,
                 'queue' => $queue,

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -214,7 +214,7 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
-     * Determine if a closure was pushed based on a truth-test callback.
+     * Assert that a closure was not pushed based on a truth-test callback.
      *
      * @param  callable|null  $callback
      * @return void

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -314,6 +314,36 @@ class SupportTestingQueueFakeTest extends TestCase
             )));
         }
     }
+
+    public function testAssertClosurePushed()
+    {
+        $this->fake->push(function () {
+            // Do nothing
+        });
+
+        $this->fake->assertClosurePushed();
+    }
+
+    public function testAssertClosurePushedWithTimes()
+    {
+        $this->fake->push(function () {
+            // Do nothing
+        });
+
+        $this->fake->push(function () {
+            // Do nothing
+        });
+
+        $this->fake->assertClosurePushed(2);
+    }
+
+    public function testAssertClosureNotPushed()
+    {
+        $this->fake->push($this->job);
+
+        $this->fake->assertClosureNotPushed();
+    }
+
 }
 
 class JobStub

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -343,7 +343,6 @@ class SupportTestingQueueFakeTest extends TestCase
 
         $this->fake->assertClosureNotPushed();
     }
-
 }
 
 class JobStub


### PR DESCRIPTION
Hey! This PR proposes 2 new methods that can be used in tests: `assertClosurePushed` and `assertClosureNotPushed`.

Say we have either of these snippets of code in our apps:

```php
dispatch(function () {
    // Do something here...
});

// Or...
Queue::push(function () {
    // Do something here...
});
```

If we wanted to assert in our test that a closure was queued (or not queued), and we used the `dispatch` helper we'd need to write something like this:

```php
use Illuminate\Queue\CallQueuedClosure;

Queue::fake();

Queue::assertPushed(CallQueuedClosure::class);

Queue::assertNotPushed(CallQueuedClosure::class);
```

If we wanted to assert in our test that a closure was queued(or not queued), and we used the `Queue::push` helper we'd need to write something like this:

```php
Queue::fake();

Queue::assertPushed(\Closure::class);

Queue::assertNotPushed(\Closure::class);
```

So, I've added a small change to the `QueueFake` class that creates a `CallQueuedClosure` class for consistency, so that both `Queue::push` and `dispatch` act the same way. I guess that this would be a breaking change because if anyone is using `Queue::assertPushed(\Closure::class)` with the `Queue::push()` method, the assertions would now fail.

I've also added two new methods I think will make the code a little bit easier to read like so:

```php
use Illuminate\Queue\CallQueuedClosure;

Queue::fake();

Queue::assertClosurePushed();

Queue::assertClosureNotPushed();
```

The `assertClosurePushed` method will also support callbacks and checking the times that a closure was pushed too.

These methods aren't really huge additions and might not be needed, but I just thought it was worth putting the idea out there. My main reason is that I don't think it's immediately obvious how we can test that a closure is pushed onto the queue and can be a bit confusing for newer devs because they'll need to use different assertions based on if they'd used `dispatch` or `Queue::fake()` (maybe an addition to the docs could be more suitable instead?). So, hopefully, this change would make it a bit easier for devs to use in tests.

Apologies if there's already an easier way of doing this that I hadn't noticed.

If it's something you think might be useful, please let me know if there's anything that I might need to change 😄