### PR TITLE
[9.x] Improve redis test suite

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -2,15 +2,18 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Exception;
 use Illuminate\Foundation\Application;
 use Illuminate\Redis\RedisManager;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
+use Redis;
+use Throwable;
+use UnexpectedValueException;
 
 trait InteractsWithRedis
 {
     /**
-     * Indicate connection failed if redis is not available.
+     * Indicates connection failed if redis is not available.
      *
      * @var bool
      */
@@ -21,53 +24,7 @@ trait InteractsWithRedis
      *
      * @var \Illuminate\Redis\RedisManager[]
      */
-    private $redis;
-
-    /**
-     * Setup redis connection.
-     *
-     * @return void
-     */
-    public function setUpRedis()
-    {
-        if (! extension_loaded('redis')) {
-            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
-        }
-
-        if (static::$connectionFailedOnceWithDefaultsSkip) {
-            $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
-        }
-
-        $app = $this->app ?? new Application;
-        $host = Env::get('REDIS_HOST', '127.0.0.1');
-        $port = Env::get('REDIS_PORT', 6379);
-
-        foreach ($this->redisDriverProvider() as $driver) {
-            $this->redis[$driver[0]] = new RedisManager($app, $driver[0], [
-                'cluster' => false,
-                'options' => [
-                    'prefix' => 'test_',
-                ],
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 5,
-                    'timeout' => 0.5,
-                    'name' => 'default',
-                ],
-            ]);
-        }
-
-        try {
-            $this->redis['phpredis']->connection()->flushdb();
-        } catch (Exception $e) {
-            if ($host === '127.0.0.1' && $port === 6379 && Env::get('REDIS_HOST') === null) {
-                static::$connectionFailedOnceWithDefaultsSkip = true;
-
-                $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
-            }
-        }
-    }
+    private $redisManagers = [];
 
     /**
      * Teardown redis connection.
@@ -76,42 +33,335 @@ trait InteractsWithRedis
      */
     public function tearDownRedis()
     {
-        if (isset($this->redis['phpredis'])) {
-            $this->redis['phpredis']->connection()->flushdb();
-        }
-
-        foreach ($this->redisDriverProvider() as $driver) {
-            if (isset($this->redis[$driver[0]])) {
-                $this->redis[$driver[0]]->connection()->disconnect();
-            }
+        /** @var \Illuminate\Redis\RedisManager $redisManager */
+        foreach ($this->redisManagers as $label => $redisManager) {
+            $redisManager->connection()->flushdb();
+            $redisManager->connection()->disconnect();
         }
     }
 
     /**
-     * Get redis driver provider.
+     * Builds a redis manager from a predefined list of available connection
+     * configurations.
+     *
+     * If a driver and a config are given, they are used to create a new redis
+     * connection instead of the defaulting to a predefined list of connections.
+     * This way you can also create for example cluster or a very customized
+     * redis connection.
+     *
+     * @param  string  $connection  Connection label.
+     * @param  string  $driver  Optional driver to use together with a config.
+     * @param  array  $config  Optional config to use for the connection.
+     * @return \Illuminate\Redis\RedisManager
+     */
+    public function getRedisManager($connection, $driver = 'phpredis', $config = [])
+    {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped(
+                'The redis extension is not installed. Please install the extension to enable '.__CLASS__
+            );
+        }
+
+        if (static::$connectionFailedOnceWithDefaultsSkip) {
+            $this->markTestSkipped(
+                'Trying default host/port failed, please set environment variable '.
+                'REDIS_HOST & REDIS_PORT to enable '.__CLASS__
+            );
+        }
+
+        if (! empty($config)) {
+            return $this->redisManagers[$connection] = $this->initializeRedisManager($driver, $config);
+        }
+
+        if (array_key_exists($connection, $this->redisManagers)) {
+            return $this->redisManagers[$connection];
+        }
+
+        $config = [
+            'cluster' => false,
+            'default' => [
+                'host' => env('REDIS_HOST', '127.0.0.1'),
+                'port' => (int) env('REDIS_PORT', 6379),
+                'timeout' => 0.5,
+                'database' => 5,
+                'options' => [
+                    'name' => 'base',
+                ],
+            ],
+        ];
+
+        switch ($connection) {
+            case 'predis':
+                $driver = 'predis';
+                $config['default']['options']['name'] = 'predis';
+                break;
+            case 'phpredis':
+                $config['default']['options']['name'] = 'phpredis';
+                break;
+            case 'phpredis_url':
+                $config['default']['options']['name'] = 'phpredis_url';
+                $config['default']['url'] = "redis://user@{$config['default']['host']}:{$config['default']['port']}";
+                $config['default']['host'] = 'overwrittenByUrl';
+                $config['default']['port'] = 'overwrittenByUrl';
+                break;
+            case 'phpredis_prefix':
+                $config['default']['options']['name'] = 'phpredis_prefix';
+                $config['default']['options']['prefix'] = 'laravel:';
+                break;
+            case 'phpredis_persistent':
+                $config['default']['options']['name'] = 'phpredis_persistent';
+                $config['default']['persistent'] = true;
+                $config['default']['persistent_id'] = 'laravel';
+                break;
+            case 'phpredis_scan_noretry':
+                $config['default']['options']['name'] = 'phpredis_scan_noretry';
+                $config['default']['options']['scan'] = Redis::SCAN_NORETRY;
+                break;
+            case 'phpredis_scan_retry':
+                $config['default']['options']['name'] = 'phpredis_scan_retry';
+                $config['default']['options']['scan'] = Redis::SCAN_RETRY;
+                break;
+            case 'phpredis_scan_prefix':
+                $config['default']['options']['name'] = 'phpredis_scan_prefix';
+                $config['default']['options']['scan'] = Redis::SCAN_PREFIX;
+                break;
+            case 'phpredis_scan_noprefix':
+                $config['default']['options']['name'] = 'phpredis_scan_noprefix';
+                $config['default']['options']['scan'] = Redis::SCAN_NOPREFIX;
+                break;
+            case 'phpredis_serializer_none':
+                $config['default']['options']['name'] = 'phpredis_serializer_none';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_NONE;
+                break;
+            case 'phpredis_serializer_php':
+                $config['default']['options']['name'] = 'phpredis_serializer_php';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_PHP;
+                break;
+            case 'phpredis_serializer_igbinary':
+                $config['default']['options']['name'] = 'phpredis_serializer_igbinary';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_IGBINARY;
+                break;
+            case 'phpredis_serializer_json':
+                $config['default']['options']['name'] = 'phpredis_serializer_json';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_JSON;
+                break;
+            case 'phpredis_serializer_msgpack':
+                $config['default']['options']['name'] = 'phpredis_serializer_msgpack';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_MSGPACK;
+                break;
+            case 'phpredis_compression_lzf':
+                $config['default']['options']['name'] = 'phpredis_compression_lzf';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZF;
+                break;
+            case 'phpredis_compression_zstd':
+                $config['default']['options']['name'] = 'phpredis_compression_zstd';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
+                break;
+            case 'phpredis_compression_zstd_default':
+                $config['default']['options']['name'] = 'phpredis_compression_zstd_default';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
+                $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_DEFAULT;
+                break;
+            case 'phpredis_compression_zstd_min':
+                $config['default']['options']['name'] = 'phpredis_compression_zstd_min';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
+                $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_MIN;
+                break;
+            case 'phpredis_compression_zstd_max':
+                $config['default']['options']['name'] = 'phpredis_compression_zstd_max';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
+                $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_MAX;
+                break;
+            case 'phpredis_compression_lz4':
+                $config['default']['options']['name'] = 'phpredis_compression_lz4';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                break;
+            case 'phpredis_compression_lz4_default':
+                $config['default']['options']['name'] = 'phpredis_compression_lz4_default';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                $config['default']['options']['compression_level'] = 0;
+                break;
+            case 'phpredis_compression_lz4_min':
+                $config['default']['options']['name'] = 'phpredis_compression_lz4_min';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                $config['default']['options']['compression_level'] = 1;
+                break;
+            case 'phpredis_compression_lz4_max':
+                $config['default']['options']['name'] = 'phpredis_compression_lz4_max';
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                $config['default']['options']['compression_level'] = 12;
+                break;
+            case 'phpredis_msgpack_and_lz4':
+                $config['default']['options']['name'] = 'phpredis_msgpack_and_lz4';
+                $config['default']['options']['serializer'] = Redis::SERIALIZER_MSGPACK;
+                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
+                $config['default']['options']['compression_level'] = 12;
+                break;
+            default:
+                throw new UnexpectedValueException(sprintf(
+                    'Redis manager connection configuration %s is not defined.',
+                    $connection,
+                ));
+        }
+
+        return $this->redisManagers[$connection] = $this->initializeRedisManager($driver, $config);
+    }
+
+    /**
+     * Returns a list of available redis connections.
      *
      * @return array
      */
-    public function redisDriverProvider()
+    public function getRedisConnections()
     {
         return [
-            ['predis'],
-            ['phpredis'],
+            'predis',
+            'phpredis',
         ];
     }
 
     /**
-     * Run test if redis is available.
+     * Returns an extended list of available redis connections.
      *
-     * @param  callable  $callback
-     * @return void
+     * @return array
      */
-    public function ifRedisAvailable($callback)
+    public function getExtendedRedisConnections()
     {
-        $this->setUpRedis();
+        $connections = [
+            'predis',
+            'phpredis',
+            'phpredis_url',
+            'phpredis_prefix',
+            'phpredis_persistent',
+        ];
 
-        $callback();
+        if (defined('Redis::SCAN_NORETRY')) {
+            $connections[] = 'phpredis_scan_noretry';
+        }
 
-        $this->tearDownRedis();
+        if (defined('Redis::SCAN_RETRY')) {
+            $connections[] = 'phpredis_scan_retry';
+        }
+
+        if (defined('Redis::SCAN_PREFIX')) {
+            $connections[] = 'phpredis_scan_prefix';
+        }
+
+        if (defined('Redis::SCAN_NOPREFIX')) {
+            $connections[] = 'phpredis_scan_noprefix';
+        }
+
+        if (defined('Redis::SERIALIZER_NONE')) {
+            $connections[] = 'phpredis_serializer_none';
+        }
+
+        if (defined('Redis::SERIALIZER_PHP')) {
+            $connections[] = 'phpredis_serializer_php';
+        }
+
+        if (defined('Redis::SERIALIZER_IGBINARY')) {
+            $connections[] = 'phpredis_serializer_igbinary';
+        }
+
+        if (defined('Redis::SERIALIZER_JSON')) {
+            $connections[] = 'phpredis_serializer_json';
+        }
+
+        if (defined('Redis::SERIALIZER_MSGPACK')) {
+            $connections[] = 'phpredis_serializer_msgpack';
+        }
+
+        if (defined('Redis::COMPRESSION_LZF')) {
+            $connections[] = 'phpredis_compression_lzf';
+        }
+
+        if (defined('Redis::COMPRESSION_ZSTD')) {
+            $connections[] = 'phpredis_compression_zstd';
+            $connections[] = 'phpredis_compression_zstd_default';
+            $connections[] = 'phpredis_compression_zstd_min';
+            $connections[] = 'phpredis_compression_zstd_max';
+        }
+
+        if (defined('Redis::COMPRESSION_LZ4')) {
+            $connections[] = 'phpredis_compression_lz4';
+            $connections[] = 'phpredis_compression_lz4_default';
+            $connections[] = 'phpredis_compression_lz4_min';
+            $connections[] = 'phpredis_compression_lz4_max';
+        }
+
+        if (defined('Redis::SERIALIZER_MSGPACK') && defined('Redis::COMPRESSION_LZ4')) {
+            $connections[] = 'phpredis_msgpack_and_lz4';
+        }
+
+        return $connections;
+    }
+
+    /**
+     * Data provider for tests that lists a default set of redis connections.
+     *
+     * @return array
+     */
+    public function redisConnectionDataProvider()
+    {
+        return (new Collection($this->getRedisConnections()))->mapWithKeys(function ($label) {
+            return [
+                $label => [
+                    $label,
+                ],
+            ];
+        })->all();
+    }
+
+    /**
+     * Extended data provider for tests that also lists special configurations
+     * like serialization and compression support on phpredis.
+     *
+     * @return array
+     */
+    public function extendedRedisConnectionDataProvider()
+    {
+        return (new Collection($this->getExtendedRedisConnections()))->mapWithKeys(function ($label) {
+            return [
+                $label => [
+                    $label,
+                ],
+            ];
+        })->all();
+    }
+
+    /**
+     * Initializes a new RedisManager with the given driver and config.
+     *
+     * @param  string  $driver
+     * @param  array  $config
+     * @return \Illuminate\Redis\RedisManager
+     */
+    private function initializeRedisManager($driver, $config)
+    {
+        $app = $this->app ?? new Application();
+        $redisManager = new RedisManager($app, $driver, $config);
+
+        try {
+            $redisManager->connection()->flushdb();
+        } catch (Throwable $exception) {
+            if (
+                array_key_exists('host', $config['default']) &&
+                $config['default']['host'] === '127.0.0.1' &&
+                array_key_exists('port', $config['default']) &&
+                $config['default']['port'] === 6379 &&
+                Env::get('REDIS_HOST') === null
+            ) {
+                static::$connectionFailedOnceWithDefaultsSkip = true;
+
+                $this->markTestSkipped(
+                    'Trying default host/port failed, please set environment variable '.
+                    'REDIS_HOST & REDIS_PORT to enable '.__CLASS__
+                );
+            }
+
+            throw $exception;
+        }
+
+        return $redisManager;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -98,20 +98,9 @@ trait InteractsWithRedis
             case 'phpredis':
                 $config['default']['options']['name'] = 'phpredis';
                 break;
-            case 'phpredis_url':
-                $config['default']['options']['name'] = 'phpredis_url';
-                $config['default']['url'] = "redis://user@{$config['default']['host']}:{$config['default']['port']}";
-                $config['default']['host'] = 'overwrittenByUrl';
-                $config['default']['port'] = 'overwrittenByUrl';
-                break;
             case 'phpredis_prefix':
                 $config['default']['options']['name'] = 'phpredis_prefix';
                 $config['default']['options']['prefix'] = 'laravel:';
-                break;
-            case 'phpredis_persistent':
-                $config['default']['options']['name'] = 'phpredis_persistent';
-                $config['default']['persistent'] = true;
-                $config['default']['persistent_id'] = 'laravel';
                 break;
             case 'phpredis_scan_noretry':
                 $config['default']['options']['name'] = 'phpredis_scan_noretry';
@@ -128,10 +117,6 @@ trait InteractsWithRedis
             case 'phpredis_scan_noprefix':
                 $config['default']['options']['name'] = 'phpredis_scan_noprefix';
                 $config['default']['options']['scan'] = Redis::SCAN_NOPREFIX;
-                break;
-            case 'phpredis_serializer_none':
-                $config['default']['options']['name'] = 'phpredis_serializer_none';
-                $config['default']['options']['serializer'] = Redis::SERIALIZER_NONE;
                 break;
             case 'phpredis_serializer_php':
                 $config['default']['options']['name'] = 'phpredis_serializer_php';
@@ -156,40 +141,12 @@ trait InteractsWithRedis
             case 'phpredis_compression_zstd':
                 $config['default']['options']['name'] = 'phpredis_compression_zstd';
                 $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
-                break;
-            case 'phpredis_compression_zstd_default':
-                $config['default']['options']['name'] = 'phpredis_compression_zstd_default';
-                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
                 $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_DEFAULT;
-                break;
-            case 'phpredis_compression_zstd_min':
-                $config['default']['options']['name'] = 'phpredis_compression_zstd_min';
-                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
-                $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_MIN;
-                break;
-            case 'phpredis_compression_zstd_max':
-                $config['default']['options']['name'] = 'phpredis_compression_zstd_max';
-                $config['default']['options']['compression'] = Redis::COMPRESSION_ZSTD;
-                $config['default']['options']['compression_level'] = Redis::COMPRESSION_ZSTD_MAX;
                 break;
             case 'phpredis_compression_lz4':
                 $config['default']['options']['name'] = 'phpredis_compression_lz4';
                 $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
-                break;
-            case 'phpredis_compression_lz4_default':
-                $config['default']['options']['name'] = 'phpredis_compression_lz4_default';
-                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
                 $config['default']['options']['compression_level'] = 0;
-                break;
-            case 'phpredis_compression_lz4_min':
-                $config['default']['options']['name'] = 'phpredis_compression_lz4_min';
-                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
-                $config['default']['options']['compression_level'] = 1;
-                break;
-            case 'phpredis_compression_lz4_max':
-                $config['default']['options']['name'] = 'phpredis_compression_lz4_max';
-                $config['default']['options']['compression'] = Redis::COMPRESSION_LZ4;
-                $config['default']['options']['compression_level'] = 12;
                 break;
             case 'phpredis_msgpack_and_lz4':
                 $config['default']['options']['name'] = 'phpredis_msgpack_and_lz4';
@@ -230,9 +187,7 @@ trait InteractsWithRedis
         $connections = [
             'predis',
             'phpredis',
-            'phpredis_url',
             'phpredis_prefix',
-            'phpredis_persistent',
         ];
 
         if (defined('Redis::SCAN_NORETRY')) {
@@ -249,10 +204,6 @@ trait InteractsWithRedis
 
         if (defined('Redis::SCAN_NOPREFIX')) {
             $connections[] = 'phpredis_scan_noprefix';
-        }
-
-        if (defined('Redis::SERIALIZER_NONE')) {
-            $connections[] = 'phpredis_serializer_none';
         }
 
         if (defined('Redis::SERIALIZER_PHP')) {
@@ -277,16 +228,10 @@ trait InteractsWithRedis
 
         if (defined('Redis::COMPRESSION_ZSTD')) {
             $connections[] = 'phpredis_compression_zstd';
-            $connections[] = 'phpredis_compression_zstd_default';
-            $connections[] = 'phpredis_compression_zstd_min';
-            $connections[] = 'phpredis_compression_zstd_max';
         }
 
         if (defined('Redis::COMPRESSION_LZ4')) {
             $connections[] = 'phpredis_compression_lz4';
-            $connections[] = 'phpredis_compression_lz4_default';
-            $connections[] = 'phpredis_compression_lz4_min';
-            $connections[] = 'phpredis_compression_lz4_max';
         }
 
         if (defined('Redis::SERIALIZER_MSGPACK') && defined('Redis::COMPRESSION_LZ4')) {

--- a/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
+++ b/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
@@ -83,17 +83,6 @@ trait PacksPhpRedisValues
     }
 
     /**
-     * Determine if JSON serialization is enabled.
-     *
-     * @return bool
-     */
-    public function usesJsonSerialization(): bool
-    {
-        return defined('Redis::SERIALIZER_JSON') &&
-               $this->client->getOption(Redis::OPT_SERIALIZER) === Redis::SERIALIZER_JSON;
-    }
-
-    /**
      * Determine if compression is enabled.
      *
      * @return bool
@@ -135,6 +124,17 @@ trait PacksPhpRedisValues
     {
         return defined('Redis::COMPRESSION_LZ4') &&
                $this->client->getOption(Redis::OPT_COMPRESSION) === Redis::COMPRESSION_LZ4;
+    }
+
+    /**
+     * Determine if JSON serialization is enabled.
+     *
+     * @return bool
+     */
+    public function jsonSerialized(): bool
+    {
+        return defined('Redis::SERIALIZER_JSON') &&
+               $this->client->getOption(Redis::OPT_SERIALIZER) === Redis::SERIALIZER_JSON;
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
+++ b/src/Illuminate/Redis/Connections/PacksPhpRedisValues.php
@@ -83,6 +83,17 @@ trait PacksPhpRedisValues
     }
 
     /**
+     * Determine if JSON serialization is enabled.
+     *
+     * @return bool
+     */
+    public function usesJsonSerialization(): bool
+    {
+        return defined('Redis::SERIALIZER_JSON') &&
+               $this->client->getOption(Redis::OPT_SERIALIZER) === Redis::SERIALIZER_JSON;
+    }
+
+    /**
      * Determine if compression is enabled.
      *
      * @return bool

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -129,8 +129,8 @@ trait ValidatesAttributes
     /**
      * Overwritable dns check method. Can be mocked in tests to avoid actual calls.
      *
-     * @param string $hostname
-     * @param int $type
+     * @param  string  $hostname
+     * @param  int  $type
      * @return array|false
      */
     protected function dnsRecords($hostname, $type)

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -117,7 +117,10 @@ trait ValidatesAttributes
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
-                return count($this->dnsRecords($url.'.', DNS_A | DNS_AAAA)) > 0;
+                $records = $this->dnsRecords($url.'.', DNS_A | DNS_AAAA);
+                if (is_array($records) && count($records) > 0) {
+                    return true;
+                }
             } catch (Exception $e) {
                 return false;
             }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -117,13 +117,25 @@ trait ValidatesAttributes
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
-                return count(dns_get_record($url.'.', DNS_A | DNS_AAAA)) > 0;
+                return count($this->dnsRecords($url.'.', DNS_A | DNS_AAAA)) > 0;
             } catch (Exception $e) {
                 return false;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Overwritable dns check method. Can be mocked in tests to avoid actual calls.
+     *
+     * @param string $hostname
+     * @param int $type
+     * @return array|false
+     */
+    protected function dnsRecords($hostname, $type)
+    {
+        return dns_get_record($hostname, $type);
     }
 
     /**

--- a/tests/Integration/Cache/PhpRedisCacheLockTest.php
+++ b/tests/Integration/Cache/PhpRedisCacheLockTest.php
@@ -2,293 +2,48 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
-use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
-use Redis;
 
 class PhpRedisCacheLockTest extends TestCase
 {
     use InteractsWithRedis;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setUpRedis();
-    }
-
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
-    }
 
-    public function testRedisLockCanBeAcquiredAndReleasedWithoutSerializationAndCompression()
-    {
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    public function testRedisLockCanBeAcquiredAndReleasedWithPhpSerialization()
-    {
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    public function testRedisLockCanBeAcquiredAndReleasedWithJsonSerialization()
-    {
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_JSON);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    public function testRedisLockCanBeAcquiredAndReleasedWithIgbinarySerialization()
-    {
-        if (! defined('Redis::SERIALIZER_IGBINARY')) {
-            $this->markTestSkipped('Redis extension is not configured to support the igbinary serializer.');
-        }
-
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_IGBINARY);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    public function testRedisLockCanBeAcquiredAndReleasedWithMsgpackSerialization()
-    {
-        if (! defined('Redis::SERIALIZER_MSGPACK')) {
-            $this->markTestSkipped('Redis extension is not configured to support the msgpack serializer.');
-        }
-
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_MSGPACK);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        parent::tearDown();
     }
 
     /**
-     * @requires extension lzf
+     * @dataProvider extendedRedisConnectionDataProvider
      */
-    public function testRedisLockCanBeAcquiredAndReleasedWithLzfCompression()
+    public function testPhpRedisLockCanBeAcquiredAndReleased($connection)
     {
-        if (! defined('Redis::COMPRESSION_LZF')) {
-            $this->markTestSkipped('Redis extension is not configured to support the lzf compression.');
-        }
+        $repository = $this->getRepository($connection);
 
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZF);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
+        $repository->lock('foo')->forceRelease();
+        $this->assertNull($repository->lockConnection()->get($repository->getPrefix().'foo'));
+        $lock = $repository->lock('foo', 10);
         $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
+        $this->assertFalse($repository->lock('foo', 10)->get());
         $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        $this->assertNull($repository->lockConnection()->get($repository->getPrefix().'foo'));
     }
 
     /**
-     * @requires extension zstd
+     * Builds a cache repository out of a predefined redis connection name.
+     *
+     * @param  string  $connection
+     * @return \Illuminate\Cache\Repository
      */
-    public function testRedisLockCanBeAcquiredAndReleasedWithZstdCompression()
+    private function getRepository($connection)
     {
-        if (! defined('Redis::COMPRESSION_ZSTD')) {
-            $this->markTestSkipped('Redis extension is not configured to support the zstd compression.');
-        }
+        /** @var \Illuminate\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->get('cache');
 
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_ZSTD);
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_DEFAULT);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_MIN);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, Redis::COMPRESSION_ZSTD_MAX);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    /**
-     * @requires extension lz4
-     */
-    public function testRedisLockCanBeAcquiredAndReleasedWithLz4Compression()
-    {
-        if (! defined('Redis::COMPRESSION_LZ4')) {
-            $this->markTestSkipped('Redis extension is not configured to support the lz4 compression.');
-        }
-
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_NONE);
-        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZ4);
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 1);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 3);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-
-        $client->setOption(Redis::OPT_COMPRESSION_LEVEL, 12);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-    }
-
-    /**
-     * @requires extension Lzf
-     */
-    public function testRedisLockCanBeAcquiredAndReleasedWithSerializationAndCompression()
-    {
-        if (! defined('Redis::COMPRESSION_LZF')) {
-            $this->markTestSkipped('Redis extension is not configured to support the lzf compression.');
-        }
-
-        $this->app['config']->set('database.redis.client', 'phpredis');
-        $this->app['config']->set('cache.stores.redis.connection', 'default');
-        $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
-
-        /** @var \Illuminate\Cache\RedisStore $store */
-        $store = Cache::store('redis');
-        /** @var \Redis $client */
-        $client = $store->lockConnection()->client();
-
-        $client->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
-        $client->setOption(Redis::OPT_COMPRESSION, Redis::COMPRESSION_LZF);
-        $store->lock('foo')->forceRelease();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
-        $lock = $store->lock('foo', 10);
-        $this->assertTrue($lock->get());
-        $this->assertFalse($store->lock('foo', 10)->get());
-        $lock->release();
-        $this->assertNull($store->lockConnection()->get($store->getPrefix().'foo'));
+        return $cacheManager->repository(new RedisStore($this->getRedisManager($connection)));
     }
 }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Carbon\Carbon;
 use Exception;
+use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
@@ -11,74 +13,88 @@ class RedisCacheLockTest extends TestCase
 {
     use InteractsWithRedis;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setUpRedis();
-    }
-
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
+        Carbon::setTestNow(false);
+
+        parent::tearDown();
     }
 
-    public function testRedisLocksCanBeAcquiredAndReleased()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testRedisLocksCanBeAcquiredAndReleased($connection)
     {
-        Cache::store('redis')->lock('foo')->forceRelease();
+        $repository = $this->getRepository($connection);
+        $repository->lock('foo')->forceRelease();
 
-        $lock = Cache::store('redis')->lock('foo', 10);
+        $lock = $repository->lock('foo', 10);
         $this->assertTrue($lock->get());
-        $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
+        $this->assertFalse($repository->lock('foo', 10)->get());
         $lock->release();
 
-        $lock = Cache::store('redis')->lock('foo', 10);
+        $lock = $repository->lock('foo', 10);
         $this->assertTrue($lock->get());
-        $this->assertFalse(Cache::store('redis')->lock('foo', 10)->get());
-        Cache::store('redis')->lock('foo')->release();
+        $this->assertFalse($repository->lock('foo', 10)->get());
+        $repository->lock('foo')->release();
     }
 
     public function testRedisLockCanHaveASeparateConnection()
     {
         $this->app['config']->set('cache.stores.redis.lock_connection', 'default');
 
+        $this->app['redis'] = $this->getRedisManager('phpredis');
+
         $this->assertSame('default', Cache::store('redis')->lock('foo')->getConnectionName());
     }
 
-    public function testRedisLocksCanBlockForSeconds()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testRedisLocksCanBlockForSeconds($connection)
     {
-        Cache::store('redis')->lock('foo')->forceRelease();
-        $this->assertSame('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
+        $repository = $this->getRepository($connection);
+        Carbon::setTestNow();
+
+        $repository->lock('foo')->forceRelease();
+        $this->assertSame('taylor', $repository->lock('foo', 10)->block(1, function () {
             return 'taylor';
         }));
 
-        Cache::store('redis')->lock('foo')->forceRelease();
-        $this->assertTrue(Cache::store('redis')->lock('foo', 10)->block(1));
+        $repository->lock('foo')->forceRelease();
+        $this->assertTrue($repository->lock('foo', 10)->block(1));
     }
 
-    public function testConcurrentRedisLocksAreReleasedSafely()
+    /**
+     * @dataProvider redisConnectionDataProvider
+     */
+    public function testConcurrentRedisLocksAreReleasedSafely($connection)
     {
-        Cache::store('redis')->lock('foo')->forceRelease();
+        $repository = $this->getRepository($connection);
+        $repository->lock('foo')->forceRelease();
 
-        $firstLock = Cache::store('redis')->lock('foo', 1);
+        $firstLock = $repository->lock('foo', 1);
         $this->assertTrue($firstLock->get());
-        sleep(2);
+        usleep(1100000);
 
-        $secondLock = Cache::store('redis')->lock('foo', 10);
+        $secondLock = $repository->lock('foo', 10);
         $this->assertTrue($secondLock->get());
 
         $firstLock->release();
 
-        $this->assertFalse(Cache::store('redis')->lock('foo')->get());
+        $this->assertFalse($repository->lock('foo')->get());
     }
 
-    public function testRedisLocksWithFailedBlockCallbackAreReleased()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testRedisLocksWithFailedBlockCallbackAreReleased($connection)
     {
-        Cache::store('redis')->lock('foo')->forceRelease();
+        $repository = $this->getRepository($connection);
+        $repository->lock('foo')->forceRelease();
 
-        $firstLock = Cache::store('redis')->lock('foo', 10);
+        $firstLock = $repository->lock('foo', 10);
 
         try {
             $firstLock->block(1, function () {
@@ -90,22 +106,40 @@ class RedisCacheLockTest extends TestCase
             // thrown by the callback was handled.
         }
 
-        $secondLock = Cache::store('redis')->lock('foo', 1);
+        $secondLock = $repository->lock('foo', 1);
 
         $this->assertTrue($secondLock->get());
     }
 
-    public function testRedisLocksCanBeReleasedUsingOwnerToken()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testRedisLocksCanBeReleasedUsingOwnerToken($connection)
     {
-        Cache::store('redis')->lock('foo')->forceRelease();
+        $repository = $this->getRepository($connection);
+        $repository->lock('foo')->forceRelease();
 
-        $firstLock = Cache::store('redis')->lock('foo', 10);
+        $firstLock = $repository->lock('foo', 10);
         $this->assertTrue($firstLock->get());
         $owner = $firstLock->owner();
 
-        $secondLock = Cache::store('redis')->restoreLock('foo', $owner);
+        $secondLock = $repository->restoreLock('foo', $owner);
         $secondLock->release();
 
-        $this->assertTrue(Cache::store('redis')->lock('foo')->get());
+        $this->assertTrue($repository->lock('foo')->get());
+    }
+
+    /**
+     * Builds a cache repository out of a predefined redis connection name.
+     *
+     * @param  string  $connection
+     * @return \Illuminate\Cache\Repository
+     */
+    private function getRepository($connection)
+    {
+        /** @var \Illuminate\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->get('cache');
+
+        return $cacheManager->repository(new RedisStore($this->getRedisManager($connection)));
     }
 }

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -2,47 +2,204 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Illuminate\Cache\RedisStore;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Orchestra\Testbench\TestCase;
 
 class RedisStoreTest extends TestCase
 {
     use InteractsWithRedis;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->setUpRedis();
-    }
-
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
+
+        parent::tearDown();
     }
 
-    public function testItCanStoreInfinite()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanStoreInfinite($connection)
     {
-        Cache::store('redis')->clear();
+        $repository = $this->getRepository($connection);
+        /** @var \Illuminate\Cache\RedisStore $redisStore */
+        $redisStore = $repository->getStore();
+        $redisConnection = $redisStore->connection();
 
-        $result = Cache::store('redis')->put('foo', INF);
-        $this->assertTrue($result);
-        $this->assertSame(INF, Cache::store('redis')->get('foo'));
+        if ($redisConnection instanceof PhpRedisConnection && $redisConnection->usesJsonSerialization()) {
+            $this->markTestSkipped(
+                'JSON does not support INF or -INF. It will be serialized to null '.
+                'and as a result phpredis will store it as 0.'
+            );
+        }
 
-        $result = Cache::store('redis')->put('bar', -INF);
+        $result = $repository->put('foo', INF);
         $this->assertTrue($result);
-        $this->assertSame(-INF, Cache::store('redis')->get('bar'));
+        $this->assertSame(INF, $repository->get('foo'));
+
+        $result = $repository->put('foo', -INF);
+        $this->assertTrue($result);
+        $this->assertSame(-INF, $repository->get('foo'));
     }
 
-    public function testItCanStoreNan()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanStoreNan($connection)
     {
-        Cache::store('redis')->clear();
+        $repository = $this->getRepository($connection);
+        /** @var \Illuminate\Cache\RedisStore $redisStore */
+        $redisStore = $repository->getStore();
+        $redisConnection = $redisStore->connection();
 
-        $result = Cache::store('redis')->put('foo', NAN);
+        if ($redisConnection instanceof PhpRedisConnection && $redisConnection->usesJsonSerialization()) {
+            $this->markTestSkipped(
+                'JSON does not support NAN. It will be serialized to null '.
+                'and as a result phpredis will store it as 0.'
+            );
+        }
+
+        $result = $repository->put('foo', NAN);
         $this->assertTrue($result);
-        $this->assertNan(Cache::store('redis')->get('foo'));
+        $this->assertNan($repository->get('foo'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanAdd($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->add('foo', 'test test test');
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo'));
+        $result = $repository->forget('foo');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanAddWithTtl($connection)
+    {
+        $this->markTestIncomplete('Needs support in the RedisStore first.');
+
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->add('foo', 'test test test', 10);
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo'));
+        $result = $repository->forget('foo');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanPut($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put('foo', 'test test test');
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo'));
+        $result = $repository->forget('foo');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanPutWithTtl($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put('foo', 'test test test', 10);
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo'));
+        $result = $repository->forget('foo');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanPutMany($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put([
+            'foo1' => 'test test test',
+            'foo2' => 'best best best',
+        ], null);
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo1'));
+        $result = $repository->forget('foo1');
+        $this->assertSame('best best best', $repository->get('foo2'));
+        $result = $repository->forget('foo2');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanPutManyWithTtl($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put([
+            'foo1' => 'test test test',
+            'foo2' => 'best best best',
+        ], 10);
+        $this->assertTrue($result);
+        $this->assertSame('test test test', $repository->get('foo1'));
+        $result = $repository->forget('foo1');
+        $this->assertSame('best best best', $repository->get('foo2'));
+        $result = $repository->forget('foo2');
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCanGetMany($connection)
+    {
+        $repository = $this->getRepository($connection);
+
+        $result = $repository->put([
+            'foo1' => 'test test test',
+            'foo2' => 'best best best',
+            'foo3' => 'this is the best test',
+        ], null);
+        $this->assertTrue($result);
+        $result = $repository->getMultiple(['foo1', 'foo2', 'foo3', 'foo4'], 'sure?');
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('foo1', $result);
+        $this->assertArrayHasKey('foo2', $result);
+        $this->assertArrayHasKey('foo3', $result);
+        $this->assertArrayHasKey('foo4', $result);
+        $this->assertSame('test test test', $result['foo1']);
+        $this->assertSame('best best best', $result['foo2']);
+        $this->assertSame('this is the best test', $result['foo3']);
+        $this->assertSame('sure?', $result['foo4']);
+        $result = $repository->deleteMultiple(['foo1', 'foo2', 'foo3']);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Builds a cache repository out of a predefined redis connection name.
+     *
+     * @param  string  $connection
+     * @return \Illuminate\Cache\Repository
+     */
+    private function getRepository($connection)
+    {
+        /** @var \Illuminate\Cache\CacheManager $cacheManager */
+        $cacheManager = $this->app->get('cache');
+
+        return $cacheManager->repository(new RedisStore($this->getRedisManager($connection)));
     }
 }

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -83,22 +83,6 @@ class RedisStoreTest extends TestCase
     /**
      * @dataProvider extendedRedisConnectionDataProvider
      */
-    public function testItCanAddWithTtl($connection)
-    {
-        $this->markTestIncomplete('Needs support in the RedisStore first.');
-
-        $repository = $this->getRepository($connection);
-
-        $result = $repository->add('foo', 'test test test', 10);
-        $this->assertTrue($result);
-        $this->assertSame('test test test', $repository->get('foo'));
-        $result = $repository->forget('foo');
-        $this->assertTrue($result);
-    }
-
-    /**
-     * @dataProvider extendedRedisConnectionDataProvider
-     */
     public function testItCanPut($connection)
     {
         $repository = $this->getRepository($connection);

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -28,7 +28,7 @@ class RedisStoreTest extends TestCase
         $redisStore = $repository->getStore();
         $redisConnection = $redisStore->connection();
 
-        if ($redisConnection instanceof PhpRedisConnection && $redisConnection->usesJsonSerialization()) {
+        if ($redisConnection instanceof PhpRedisConnection && $redisConnection->jsonSerialized()) {
             $this->markTestSkipped(
                 'JSON does not support INF or -INF. It will be serialized to null '.
                 'and as a result phpredis will store it as 0.'
@@ -54,7 +54,7 @@ class RedisStoreTest extends TestCase
         $redisStore = $repository->getStore();
         $redisConnection = $redisStore->connection();
 
-        if ($redisConnection instanceof PhpRedisConnection && $redisConnection->usesJsonSerialization()) {
+        if ($redisConnection instanceof PhpRedisConnection && $redisConnection->jsonSerialized()) {
             $this->markTestSkipped(
                 'JSON does not support NAN. It will be serialized to null '.
                 'and as a result phpredis will store it as 0.'

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -15,8 +15,10 @@ class ThrottleRequestsWithRedisTest extends TestCase
 
     protected function tearDown(): void
     {
+        Carbon::setTestNow(false);
+        $this->tearDownRedis();
+
         parent::tearDown();
-        Carbon::setTestNow(null);
     }
 
     public function getEnvironmentSetUp($app)
@@ -24,38 +26,41 @@ class ThrottleRequestsWithRedisTest extends TestCase
         $app['config']->set('hashing', ['driver' => 'bcrypt']);
     }
 
-    public function testLockOpensImmediatelyAfterDecay()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testLockOpensImmediatelyAfterDecay($connection)
     {
-        $this->ifRedisAvailable(function () {
-            $now = Carbon::now();
+        $this->app['redis'] = $this->getRedisManager($connection);
 
-            Carbon::setTestNow($now);
+        $now = Carbon::now();
 
-            Route::get('/', function () {
-                return 'yes';
-            })->middleware(ThrottleRequestsWithRedis::class.':2,1');
+        Carbon::setTestNow($now);
 
-            $response = $this->withoutExceptionHandling()->get('/');
-            $this->assertSame('yes', $response->getContent());
-            $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-            $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
+        Route::get('/', function () {
+            return 'yes';
+        })->middleware(ThrottleRequestsWithRedis::class.':2,1');
 
-            $response = $this->withoutExceptionHandling()->get('/');
-            $this->assertSame('yes', $response->getContent());
-            $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
-            $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertSame('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
 
-            Carbon::setTestNow($finish = $now->addSeconds(58));
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertSame('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
 
-            try {
-                $this->withoutExceptionHandling()->get('/');
-            } catch (Throwable $e) {
-                $this->assertEquals(429, $e->getStatusCode());
-                $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
-                $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
-                // $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
-                // $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [$finish->getTimestamp() + 2, $finish->getTimestamp() + 3]));
-            }
-        });
+        Carbon::setTestNow($finish = $now->addSeconds(58));
+
+        try {
+            $this->withoutExceptionHandling()->get('/');
+        } catch (Throwable $e) {
+            $this->assertEquals(429, $e->getStatusCode());
+            $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            // $this->assertTrue(in_array($e->getHeaders()['Retry-After'], [2, 3]));
+            // $this->assertTrue(in_array($e->getHeaders()['X-RateLimit-Reset'], [$finish->getTimestamp() + 2, $finish->getTimestamp() + 3]));
+        }
     }
 }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -11,7 +11,7 @@ use Illuminate\Queue\RedisQueue;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
-use Mockery as m;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class RedisQueueIntegrationTest extends TestCase
@@ -32,26 +32,27 @@ class RedisQueueIntegrationTest extends TestCase
     {
         parent::setUp();
 
-        $this->setUpRedis();
+        Carbon::setTestNow(Carbon::now());
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
-        Carbon::setTestNow(null);
         $this->tearDownRedis();
-        m::close();
+        Carbon::setTestNow(false);
+        Mockery::close();
+        Str::createUuidsNormally();
+
+        parent::tearDown();
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testExpiredJobsArePopped($driver)
+    public function testExpiredJobsArePopped($connection)
     {
-        $this->setQueue($driver);
+        $this->setQueue($connection);
 
         $jobs = [
             new RedisQueueIntegrationTestJob(0),
@@ -72,30 +73,28 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($jobs[3], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
         $this->assertNull($this->queue->pop());
 
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
-        $this->assertEquals(3, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
+        $this->assertEquals(1, $this->getRedisManager($connection)->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(3, $this->getRedisManager($connection)->connection()->zcard('queues:default:reserved'));
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      * @requires extension pcntl
      *
-     * @param  mixed  $driver
+     * @param  mixed  $connection
      *
      * @throws \Exception
      */
-    public function testBlockingPop($driver)
+    public function testBlockingPop($connection)
     {
         $this->tearDownRedis();
 
         if ($pid = pcntl_fork() > 0) {
-            $this->setUpRedis();
-            $this->setQueue($driver, 'default', null, 60, 10);
+            $this->setQueue($connection, 'default', null, 60, 10);
             $this->assertEquals(12, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
         } elseif ($pid == 0) {
-            $this->setUpRedis();
             $this->setQueue('phpredis');
-            sleep(1);
+            usleep(1100000);
             $this->queue->push(new RedisQueueIntegrationTestJob(12));
             exit;
         } else {
@@ -103,31 +102,33 @@ class RedisQueueIntegrationTest extends TestCase
         }
     }
 
-    // /**
-    //  * @dataProvider redisDriverProvider
-    //  *
-    //  * @param  string  $driver
-    //  */
-    // public function testMigrateMoreThan100Jobs($driver)
-    // {
-    //     $this->setQueue($driver);
-    //     for ($i = -1; $i >= -201; $i--) {
-    //         $this->queue->later($i, new RedisQueueIntegrationTestJob($i));
-    //     }
-    //     for ($i = -201; $i <= -1; $i++) {
-    //         $this->assertEquals($i, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
-    //         $this->assertEquals(-$i - 1, $this->redis[$driver]->llen('queues:default:notify'));
-    //     }
-    // }
+    /**
+     * @dataProvider redisConnectionDataProvider
+     *
+     * @param  string  $connection
+     */
+    public function testMigrateMoreThan100Jobs($connection)
+    {
+        $this->markTestSkipped('Skip test for now');
+
+        $this->setQueue($connection);
+        for ($i = -1; $i >= -201; $i--) {
+            $this->queue->later($i, new RedisQueueIntegrationTestJob($i));
+        }
+        for ($i = -201; $i <= -1; $i++) {
+            $this->assertEquals($i, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
+            $this->assertEquals(-$i - 1, $this->getRedisManager($connection)->llen('queues:default:notify'));
+        }
+    }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testPopProperlyPopsJobOffOfRedis($driver)
+    public function testPopProperlyPopsJobOffOfRedis($connection)
     {
-        $this->setQueue($driver);
+        $this->setQueue($connection);
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
@@ -146,8 +147,8 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($redisJob->getJobId(), json_decode($redisJob->getReservedJob())->id);
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(1, $this->getRedisManager($connection)->connection()->zcard('queues:default:reserved'));
+        $result = $this->getRedisManager($connection)->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 60);
@@ -156,13 +157,13 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testPopProperlyPopsDelayedJobOffOfRedis($driver)
+    public function testPopProperlyPopsDelayedJobOffOfRedis($connection)
     {
-        $this->setQueue($driver);
+        $this->setQueue($connection);
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
         $this->queue->later(-10, $job);
@@ -173,8 +174,8 @@ class RedisQueueIntegrationTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(1, $this->getRedisManager($connection)->connection()->zcard('queues:default:reserved'));
+        $result = $this->getRedisManager($connection)->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 60);
@@ -183,13 +184,13 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testPopPopsDelayedJobOffOfRedisWhenExpireNull($driver)
+    public function testPopPopsDelayedJobOffOfRedisWhenExpireNull($connection)
     {
-        $this->setQueue($driver, 'default', null, null);
+        $this->setQueue($connection, 'default', null, null);
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
@@ -203,8 +204,8 @@ class RedisQueueIntegrationTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(1, $this->getRedisManager($connection)->connection()->zcard('queues:default:reserved'));
+        $result = $this->getRedisManager($connection)->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before);
@@ -213,13 +214,13 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testBlockingPopProperlyPopsJobOffOfRedis($driver)
+    public function testBlockingPopProperlyPopsJobOffOfRedis($connection)
     {
-        $this->setQueue($driver, 'default', null, 60, 5);
+        $this->setQueue($connection, 'default', null, 60, 5);
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
@@ -234,17 +235,17 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testBlockingPopProperlyPopsExpiredJobs($driver)
+    public function testBlockingPopProperlyPopsExpiredJobs($connection)
     {
         Str::createUuidsUsing(function () {
             return 'uuid';
         });
 
-        $this->setQueue($driver, 'default', null, 60, 5);
+        $this->setQueue($connection, 'default', null, 60, 5);
 
         $jobs = [
             new RedisQueueIntegrationTestJob(0),
@@ -257,21 +258,19 @@ class RedisQueueIntegrationTest extends TestCase
         $this->assertEquals($jobs[0], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
         $this->assertEquals($jobs[1], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
 
-        $this->assertEquals(0, $this->redis[$driver]->connection()->llen('queues:default:notify'));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
-        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-
-        Str::createUuidsNormally();
+        $this->assertEquals(0, $this->getRedisManager($connection)->connection()->llen('queues:default:notify'));
+        $this->assertEquals(0, $this->getRedisManager($connection)->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(2, $this->getRedisManager($connection)->connection()->zcard('queues:default:reserved'));
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testNotExpireJobsWhenExpireNull($driver)
+    public function testNotExpireJobsWhenExpireNull($connection)
     {
-        $this->setQueue($driver, 'default', null, null);
+        $this->setQueue($connection, 'default', null, null);
 
         // Make an expired reserved job
         $failed = new RedisQueueIntegrationTestJob(-20);
@@ -293,8 +292,8 @@ class RedisQueueIntegrationTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $this->assertEquals(2, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(2, $this->getRedisManager($connection)->connection()->zcard('queues:default:reserved'));
+        $result = $this->getRedisManager($connection)->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
 
         foreach ($result as $payload => $score) {
             $command = unserialize(json_decode($payload)->data->command);
@@ -312,13 +311,13 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testExpireJobsWhenExpireSet($driver)
+    public function testExpireJobsWhenExpireSet($connection)
     {
-        $this->setQueue($driver, 'default', null, 30);
+        $this->setQueue($connection, 'default', null, 30);
 
         // Push an item into queue
         $job = new RedisQueueIntegrationTestJob(10);
@@ -331,8 +330,8 @@ class RedisQueueIntegrationTest extends TestCase
         $after = $this->currentTime();
 
         // Check reserved queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $result = $this->redis[$driver]->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
+        $this->assertEquals(1, $this->getRedisManager($connection)->connection()->zcard('queues:default:reserved'));
+        $result = $this->getRedisManager($connection)->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['withscores' => true]);
         $reservedJob = array_keys($result)[0];
         $score = $result[$reservedJob];
         $this->assertLessThanOrEqual($score, $before + 30);
@@ -341,13 +340,13 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testRelease($driver)
+    public function testRelease($connection)
     {
-        $this->setQueue($driver);
+        $this->setQueue($connection);
 
         // push a job into queue
         $job = new RedisQueueIntegrationTestJob(30);
@@ -361,9 +360,9 @@ class RedisQueueIntegrationTest extends TestCase
         $after = $this->currentTime();
 
         // check the content of delayed queue
-        $this->assertEquals(1, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(1, $this->getRedisManager($connection)->connection()->zcard('queues:default:delayed'));
 
-        $results = $this->redis[$driver]->connection()->zrangebyscore('queues:default:delayed', -INF, INF, ['withscores' => true]);
+        $results = $this->getRedisManager($connection)->connection()->zrangebyscore('queues:default:delayed', -INF, INF, ['withscores' => true]);
 
         $payload = array_keys($results)[0];
 
@@ -382,13 +381,13 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testReleaseInThePast($driver)
+    public function testReleaseInThePast($connection)
     {
-        $this->setQueue($driver);
+        $this->setQueue($connection);
         $job = new RedisQueueIntegrationTestJob(30);
         $this->queue->push($job);
 
@@ -400,13 +399,13 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testDelete($driver)
+    public function testDelete($connection)
     {
-        $this->setQueue($driver);
+        $this->setQueue($connection);
 
         $job = new RedisQueueIntegrationTestJob(30);
         $this->queue->push($job);
@@ -416,21 +415,21 @@ class RedisQueueIntegrationTest extends TestCase
 
         $redisJob->delete();
 
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard('queues:default:delayed'));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->zcard('queues:default:reserved'));
-        $this->assertEquals(0, $this->redis[$driver]->connection()->llen('queues:default'));
+        $this->assertEquals(0, $this->getRedisManager($connection)->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(0, $this->getRedisManager($connection)->connection()->zcard('queues:default:reserved'));
+        $this->assertEquals(0, $this->getRedisManager($connection)->connection()->llen('queues:default'));
 
         $this->assertNull($this->queue->pop());
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testClear($driver)
+    public function testClear($connection)
     {
-        $this->setQueue($driver);
+        $this->setQueue($connection);
 
         $job1 = new RedisQueueIntegrationTestJob(30);
         $job2 = new RedisQueueIntegrationTestJob(40);
@@ -440,17 +439,17 @@ class RedisQueueIntegrationTest extends TestCase
 
         $this->assertEquals(2, $this->queue->clear(null));
         $this->assertEquals(0, $this->queue->size());
-        $this->assertEquals(0, $this->redis[$driver]->connection()->llen('queues:default:notify'));
+        $this->assertEquals(0, $this->getRedisManager($connection)->connection()->llen('queues:default:notify'));
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testSize($driver)
+    public function testSize($connection)
     {
-        $this->setQueue($driver);
+        $this->setQueue($connection);
         $this->assertEquals(0, $this->queue->size());
         $this->queue->push(new RedisQueueIntegrationTestJob(1));
         $this->assertEquals(1, $this->queue->size());
@@ -465,13 +464,13 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testPushJobQueuedEvent($driver)
+    public function testPushJobQueuedEvent($connection)
     {
-        $events = m::mock(Dispatcher::class);
+        $events = Mockery::mock(Dispatcher::class);
         $events->shouldReceive('dispatch')->withArgs(function (JobQueued $jobQueued) {
             $this->assertInstanceOf(RedisQueueIntegrationTestJob::class, $jobQueued->job);
             $this->assertIsString(RedisQueueIntegrationTestJob::class, $jobQueued->id);
@@ -479,31 +478,31 @@ class RedisQueueIntegrationTest extends TestCase
             return true;
         })->andReturnNull()->once();
 
-        $container = m::mock(Container::class);
+        $container = Mockery::mock(Container::class);
         $container->shouldReceive('bound')->with('events')->andReturn(true)->once();
         $container->shouldReceive('offsetGet')->with('events')->andReturn($events)->once();
 
-        $queue = new RedisQueue($this->redis[$driver]);
+        $queue = new RedisQueue($this->getRedisManager($connection));
         $queue->setContainer($container);
 
         $queue->push(new RedisQueueIntegrationTestJob(5));
     }
 
     /**
-     * @dataProvider redisDriverProvider
+     * @dataProvider redisConnectionDataProvider
      *
-     * @param  string  $driver
+     * @param  string  $connection
      */
-    public function testBulkJobQueuedEvent($driver)
+    public function testBulkJobQueuedEvent($connection)
     {
-        $events = m::mock(Dispatcher::class);
-        $events->shouldReceive('dispatch')->with(m::type(JobQueued::class))->andReturnNull()->times(3);
+        $events = Mockery::mock(Dispatcher::class);
+        $events->shouldReceive('dispatch')->with(Mockery::type(JobQueued::class))->andReturnNull()->times(3);
 
-        $container = m::mock(Container::class);
+        $container = Mockery::mock(Container::class);
         $container->shouldReceive('bound')->with('events')->andReturn(true)->times(3);
         $container->shouldReceive('offsetGet')->with('events')->andReturn($events)->times(3);
 
-        $queue = new RedisQueue($this->redis[$driver]);
+        $queue = new RedisQueue($this->getRedisManager($connection));
         $queue->setContainer($container);
 
         $queue->bulk([
@@ -520,10 +519,10 @@ class RedisQueueIntegrationTest extends TestCase
      * @param  int  $retryAfter
      * @param  int|null  $blockFor
      */
-    private function setQueue($driver, $default = 'default', $connection = null, $retryAfter = 60, $blockFor = null)
+    private function setQueue($redisConnection, $default = 'default', $connection = null, $retryAfter = 60, $blockFor = null)
     {
-        $this->queue = new RedisQueue($this->redis[$driver], $default, $connection, $retryAfter, $blockFor);
-        $this->container = m::spy(Container::class);
+        $this->queue = new RedisQueue($this->getRedisManager($redisConnection), $default, $connection, $retryAfter, $blockFor);
+        $this->container = Mockery::spy(Container::class);
         $this->queue->setContainer($this->container);
     }
 }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -3,575 +3,599 @@
 namespace Illuminate\Tests\Redis;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Redis\Connections\PhpRedisConnection;
-use Illuminate\Redis\RedisManager;
-use Mockery as m;
+use Mockery;
 use PHPUnit\Framework\TestCase;
-use Predis\Client;
 use Redis;
 
 class RedisConnectionTest extends TestCase
 {
     use InteractsWithRedis;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->setUpRedis();
-    }
-
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         $this->tearDownRedis();
+        Mockery::close();
 
-        m::close();
+        parent::tearDown();
     }
 
-    public function testItSetsValuesWithExpiry()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSetsValuesWithExpiry($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed', 'EX', 5, 'NX');
-            $this->assertSame('mohamed', $redis->get('one'));
-            $this->assertNotEquals(-1, $redis->ttl('one'));
+        $redis = $this->getRedisManager($connection);
 
-            // It doesn't override when NX mode
-            $redis->set('one', 'taylor', 'EX', 5, 'NX');
-            $this->assertSame('mohamed', $redis->get('one'));
+        $redis->set('one', 'mohamed', 'EX', 5, 'NX');
+        $this->assertSame('mohamed', $redis->get('one'));
+        $this->assertNotEquals(-1, $redis->ttl('one'));
 
-            // It overrides when XX mode
-            $redis->set('one', 'taylor', 'EX', 5, 'XX');
-            $this->assertSame('taylor', $redis->get('one'));
+        // It doesn't override when NX mode
+        $redis->set('one', 'taylor', 'EX', 5, 'NX');
+        $this->assertSame('mohamed', $redis->get('one'));
 
-            // It fails if XX mode is on and key doesn't exist
-            $redis->set('two', 'taylor', 'PX', 5, 'XX');
-            $this->assertNull($redis->get('two'));
+        // It overrides when XX mode
+        $redis->set('one', 'taylor', 'EX', 5, 'XX');
+        $this->assertSame('taylor', $redis->get('one'));
 
-            $redis->set('three', 'mohamed', 'PX', 5000);
-            $this->assertSame('mohamed', $redis->get('three'));
-            $this->assertNotEquals(-1, $redis->ttl('three'));
-            $this->assertNotEquals(-1, $redis->pttl('three'));
+        // It fails if XX mode is on and key doesn't exist
+        $redis->set('two', 'taylor', 'PX', 5, 'XX');
+        $this->assertNull($redis->get('two'));
 
-            $redis->flushall();
+        $redis->set('three', 'mohamed', 'PX', 5000);
+        $this->assertSame('mohamed', $redis->get('three'));
+        $this->assertNotEquals(-1, $redis->ttl('three'));
+        $this->assertNotEquals(-1, $redis->pttl('three'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItDeletesKeys($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('one', 'mohamed');
+        $redis->set('two', 'mohamed');
+        $redis->set('three', 'mohamed');
+
+        $redis->del('one');
+        $this->assertNull($redis->get('one'));
+        $this->assertNotNull($redis->get('two'));
+        $this->assertNotNull($redis->get('three'));
+
+        $redis->del('two', 'three');
+        $this->assertNull($redis->get('two'));
+        $this->assertNull($redis->get('three'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItChecksForExistence($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('one', 'mohamed');
+        $redis->set('two', 'mohamed');
+
+        $this->assertEquals(1, $redis->exists('one'));
+        $this->assertEquals(0, $redis->exists('nothing'));
+        $this->assertEquals(2, $redis->exists('one', 'two'));
+        $this->assertEquals(2, $redis->exists('one', 'two', 'nothing'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItExpiresKeys($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('one', 'mohamed');
+        $this->assertEquals(-1, $redis->ttl('one'));
+        $this->assertEquals(1, $redis->expire('one', 10));
+        $this->assertNotEquals(-1, $redis->ttl('one'));
+
+        $this->assertEquals(0, $redis->expire('nothing', 10));
+
+        $redis->set('two', 'mohamed');
+        $this->assertEquals(-1, $redis->ttl('two'));
+        $this->assertEquals(1, $redis->pexpire('two', 10));
+        $this->assertNotEquals(-1, $redis->pttl('two'));
+
+        $this->assertEquals(0, $redis->pexpire('nothing', 10));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRenamesKeys($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('one', 'mohamed');
+        $redis->rename('one', 'two');
+        $this->assertNull($redis->get('one'));
+        $this->assertSame('mohamed', $redis->get('two'));
+
+        $redis->set('three', 'adam');
+        $redis->renamenx('two', 'three');
+        $this->assertSame('mohamed', $redis->get('two'));
+        $this->assertSame('adam', $redis->get('three'));
+
+        $redis->renamenx('two', 'four');
+        $this->assertNull($redis->get('two'));
+        $this->assertSame('mohamed', $redis->get('four'));
+        $this->assertSame('adam', $redis->get('three'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItAddsMembersToSortedSet($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set', 1, 'mohamed');
+        $this->assertEquals(1, $redis->zcard('set'));
+
+        $redis->zadd('set', 2, 'taylor', 3, 'adam');
+        $this->assertEquals(3, $redis->zcard('set'));
+
+        $redis->zadd('set', ['jeffrey' => 4, 'matt' => 5]);
+        $this->assertEquals(5, $redis->zcard('set'));
+
+        $redis->zadd('set', 'NX', 1, 'beric');
+        $this->assertEquals(6, $redis->zcard('set'));
+
+        $redis->zadd('set', 'NX', ['joffrey' => 1]);
+        $this->assertEquals(7, $redis->zcard('set'));
+
+        $redis->zadd('set', 'XX', ['ned' => 1]);
+        $this->assertEquals(7, $redis->zcard('set'));
+
+        $this->assertEquals(1, $redis->zadd('set', ['sansa' => 10]));
+        $this->assertEquals(0, $redis->zadd('set', 'XX', 'CH', ['arya' => 11]));
+
+        $redis->zadd('set', ['mohamed' => 100]);
+        $this->assertEquals(100, $redis->zscore('set', 'mohamed'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCountsMembersInSortedSet($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
+
+        $this->assertEquals(1, $redis->zcount('set', 1, 5));
+        $this->assertEquals(2, $redis->zcount('set', '-inf', '+inf'));
+        $this->assertEquals(2, $redis->zcard('set'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItIncrementsScoreOfSortedSet($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
+        $redis->zincrby('set', 2, 'jeffrey');
+        $this->assertEquals(3, $redis->zscore('set', 'jeffrey'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSetsKeyIfNotExists($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->set('name', 'mohamed');
+
+        $this->assertSame(0, $redis->setnx('name', 'taylor'));
+        $this->assertSame('mohamed', $redis->get('name'));
+
+        $this->assertSame(1, $redis->setnx('boss', 'taylor'));
+        $this->assertSame('taylor', $redis->get('boss'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSetsHashFieldIfNotExists($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->hset('person', 'name', 'mohamed');
+
+        $this->assertSame(0, $redis->hsetnx('person', 'name', 'taylor'));
+        $this->assertSame('mohamed', $redis->hget('person', 'name'));
+
+        $this->assertSame(1, $redis->hsetnx('person', 'boss', 'taylor'));
+        $this->assertSame('taylor', $redis->hget('person', 'boss'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCalculatesIntersectionOfSortedSetsAndStores($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
+        $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+
+        $redis->zinterstore('output', ['set1', 'set2']);
+        $this->assertEquals(2, $redis->zcard('output'));
+        $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
+        $this->assertEquals(5, $redis->zscore('output', 'matt'));
+
+        $redis->zinterstore('output2', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'sum',
+        ]);
+        $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
+        $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+
+        $redis->zinterstore('output3', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'min',
+        ]);
+        $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
+        $this->assertEquals(6, $redis->zscore('output3', 'matt'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItCalculatesUnionOfSortedSetsAndStores($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
+        $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+
+        $redis->zunionstore('output', ['set1', 'set2']);
+        $this->assertEquals(3, $redis->zcard('output'));
+        $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
+        $this->assertEquals(5, $redis->zscore('output', 'matt'));
+        $this->assertEquals(3, $redis->zscore('output', 'taylor'));
+
+        $redis->zunionstore('output2', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'sum',
+        ]);
+        $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
+        $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+        $this->assertEquals(9, $redis->zscore('output2', 'taylor'));
+
+        $redis->zunionstore('output3', ['set1', 'set2'], [
+            'weights' => [3, 2],
+            'aggregate' => 'min',
+        ]);
+        $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
+        $this->assertEquals(6, $redis->zscore('output3', 'matt'));
+        $this->assertEquals(9, $redis->zscore('output3', 'taylor'));
+    }
+
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRangeInSortedSet($connection)
+    {
+        $redis = $this->getRedisManager($connection);
+
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['jeffrey', 'matt'], $redis->zrange('set', 0, 1));
+        $this->assertEquals(['jeffrey', 'matt', 'taylor'], $redis->zrange('set', 0, -1));
+
+        if ($connection === 'predis') {
+            $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, 'withscores'));
+        } else {
+            $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, true));
         }
     }
 
-    public function testItDeletesKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRevRangeInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->set('two', 'mohamed');
-            $redis->set('three', 'mohamed');
+        $redis = $this->getRedisManager($connection);
 
-            $redis->del('one');
-            $this->assertNull($redis->get('one'));
-            $this->assertNotNull($redis->get('two'));
-            $this->assertNotNull($redis->get('three'));
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['taylor', 'matt'], $redis->ZREVRANGE('set', 0, 1));
+        $this->assertEquals(['taylor', 'matt', 'jeffrey'], $redis->ZREVRANGE('set', 0, -1));
 
-            $redis->del('two', 'three');
-            $this->assertNull($redis->get('two'));
-            $this->assertNull($redis->get('three'));
-
-            $redis->flushall();
+        if ($connection === 'predis') {
+            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, 'withscores'));
+        } else {
+            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, true));
         }
     }
 
-    public function testItChecksForExistence()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRangeByScoreInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->set('two', 'mohamed');
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertEquals(1, $redis->exists('one'));
-            $this->assertEquals(0, $redis->exists('nothing'));
-            $this->assertEquals(2, $redis->exists('one', 'two'));
-            $this->assertEquals(2, $redis->exists('one', 'two', 'nothing'));
-
-            $redis->flushall();
-        }
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['jeffrey'], $redis->zrangebyscore('set', 0, 3));
+        $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
+            'withscores' => true,
+            'limit' => [
+                'offset' => 1,
+                'count' => 2,
+            ],
+        ]));
+        $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
+            'withscores' => true,
+            'limit' => [1, 2],
+        ]));
     }
 
-    public function testItExpiresKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRevRangeByScoreInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $this->assertEquals(-1, $redis->ttl('one'));
-            $this->assertEquals(1, $redis->expire('one', 10));
-            $this->assertNotEquals(-1, $redis->ttl('one'));
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertEquals(0, $redis->expire('nothing', 10));
-
-            $redis->set('two', 'mohamed');
-            $this->assertEquals(-1, $redis->ttl('two'));
-            $this->assertEquals(1, $redis->pexpire('two', 10));
-            $this->assertNotEquals(-1, $redis->pttl('two'));
-
-            $this->assertEquals(0, $redis->pexpire('nothing', 10));
-
-            $redis->flushall();
-        }
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
+        $this->assertEquals(['taylor'], $redis->ZREVRANGEBYSCORE('set', 10, 6));
+        $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
+            'withscores' => true,
+            'limit' => [
+                'offset' => 1,
+                'count' => 2,
+            ],
+        ]));
+        $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
+            'withscores' => true,
+            'limit' => [1, 2],
+        ]));
     }
 
-    public function testItRenamesKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsRankInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('one', 'mohamed');
-            $redis->rename('one', 'two');
-            $this->assertNull($redis->get('one'));
-            $this->assertSame('mohamed', $redis->get('two'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->set('three', 'adam');
-            $redis->renamenx('two', 'three');
-            $this->assertSame('mohamed', $redis->get('two'));
-            $this->assertSame('adam', $redis->get('three'));
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
 
-            $redis->renamenx('two', 'four');
-            $this->assertNull($redis->get('two'));
-            $this->assertSame('mohamed', $redis->get('four'));
-            $this->assertSame('adam', $redis->get('three'));
-
-            $redis->flushall();
-        }
+        $this->assertEquals(0, $redis->zrank('set', 'jeffrey'));
+        $this->assertEquals(2, $redis->zrank('set', 'taylor'));
     }
 
-    public function testItAddsMembersToSortedSet()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItReturnsScoreInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', 1, 'mohamed');
-            $this->assertEquals(1, $redis->zcard('set'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->zadd('set', 2, 'taylor', 3, 'adam');
-            $this->assertEquals(3, $redis->zcard('set'));
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
 
-            $redis->zadd('set', ['jeffrey' => 4, 'matt' => 5]);
-            $this->assertEquals(5, $redis->zcard('set'));
-
-            $redis->zadd('set', 'NX', 1, 'beric');
-            $this->assertEquals(6, $redis->zcard('set'));
-
-            $redis->zadd('set', 'NX', ['joffrey' => 1]);
-            $this->assertEquals(7, $redis->zcard('set'));
-
-            $redis->zadd('set', 'XX', ['ned' => 1]);
-            $this->assertEquals(7, $redis->zcard('set'));
-
-            $this->assertEquals(1, $redis->zadd('set', ['sansa' => 10]));
-            $this->assertEquals(0, $redis->zadd('set', 'XX', 'CH', ['arya' => 11]));
-
-            $redis->zadd('set', ['mohamed' => 100]);
-            $this->assertEquals(100, $redis->zscore('set', 'mohamed'));
-
-            $redis->flushall();
-        }
+        $this->assertEquals(1, $redis->zscore('set', 'jeffrey'));
+        $this->assertEquals(10, $redis->zscore('set', 'taylor'));
     }
 
-    public function testItCountsMembersInSortedSet()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRemovesMembersInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertEquals(1, $redis->zcount('set', 1, 5));
-            $this->assertEquals(2, $redis->zcount('set', '-inf', '+inf'));
-            $this->assertEquals(2, $redis->zcard('set'));
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
 
-            $redis->flushall();
-        }
+        $redis->zrem('set', 'jeffrey');
+        $this->assertEquals(3, $redis->zcard('set'));
+
+        $redis->zrem('set', 'matt', 'adam');
+        $this->assertEquals(1, $redis->zcard('set'));
     }
 
-    public function testItIncrementsScoreOfSortedSet()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRemovesMembersByScoreInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 10]);
-            $redis->zincrby('set', 2, 'jeffrey');
-            $this->assertEquals(3, $redis->zscore('set', 'jeffrey'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->flushall();
-        }
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
+        $redis->ZREMRANGEBYSCORE('set', 5, '+inf');
+        $this->assertEquals(1, $redis->zcard('set'));
     }
 
-    public function testItSetsKeyIfNotExists()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRemovesMembersByRankInSortedSet($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('name', 'mohamed');
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertSame(0, $redis->setnx('name', 'taylor'));
-            $this->assertSame('mohamed', $redis->get('name'));
-
-            $this->assertSame(1, $redis->setnx('boss', 'taylor'));
-            $this->assertSame('taylor', $redis->get('boss'));
-
-            $redis->flushall();
-        }
+        $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
+        $redis->ZREMRANGEBYRANK('set', 1, -1);
+        $this->assertEquals(1, $redis->zcard('set'));
     }
 
-    public function testItSetsHashFieldIfNotExists()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSetsMultipleHashFields($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->hset('person', 'name', 'mohamed');
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertSame(0, $redis->hsetnx('person', 'name', 'taylor'));
-            $this->assertSame('mohamed', $redis->hget('person', 'name'));
+        $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
+        $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash'));
 
-            $this->assertSame(1, $redis->hsetnx('person', 'boss', 'taylor'));
-            $this->assertSame('taylor', $redis->hget('person', 'boss'));
-
-            $redis->flushall();
-        }
+        $redis->hmset('hash2', 'name', 'mohamed', 'hobby', 'diving');
+        $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash2'));
     }
 
-    public function testItCalculatesIntersectionOfSortedSetsAndStores()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItGetsMultipleHashFields($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
-            $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+        $redis = $this->getRedisManager($connection);
 
-            $redis->zinterstore('output', ['set1', 'set2']);
-            $this->assertEquals(2, $redis->zcard('output'));
-            $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
-            $this->assertEquals(5, $redis->zscore('output', 'matt'));
+        $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
 
-            $redis->zinterstore('output2', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'sum',
-            ]);
-            $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
-            $this->assertEquals(12, $redis->zscore('output2', 'matt'));
+        $this->assertEquals(['mohamed', 'diving'],
+            $redis->hmget('hash', 'name', 'hobby')
+        );
 
-            $redis->zinterstore('output3', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'min',
-            ]);
-            $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
-            $this->assertEquals(6, $redis->zscore('output3', 'matt'));
-
-            $redis->flushall();
-        }
+        $this->assertEquals(['mohamed', 'diving'],
+            $redis->hmget('hash', ['name', 'hobby'])
+        );
     }
 
-    public function testItCalculatesUnionOfSortedSetsAndStores()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItGetsMultipleKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set1', ['jeffrey' => 1, 'matt' => 2, 'taylor' => 3]);
-            $redis->zadd('set2', ['jeffrey' => 2, 'matt' => 3]);
+        $redis = $this->getRedisManager($connection);
 
-            $redis->zunionstore('output', ['set1', 'set2']);
-            $this->assertEquals(3, $redis->zcard('output'));
-            $this->assertEquals(3, $redis->zscore('output', 'jeffrey'));
-            $this->assertEquals(5, $redis->zscore('output', 'matt'));
-            $this->assertEquals(3, $redis->zscore('output', 'taylor'));
-
-            $redis->zunionstore('output2', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'sum',
-            ]);
-            $this->assertEquals(7, $redis->zscore('output2', 'jeffrey'));
-            $this->assertEquals(12, $redis->zscore('output2', 'matt'));
-            $this->assertEquals(9, $redis->zscore('output2', 'taylor'));
-
-            $redis->zunionstore('output3', ['set1', 'set2'], [
-                'weights' => [3, 2],
-                'aggregate' => 'min',
-            ]);
-            $this->assertEquals(3, $redis->zscore('output3', 'jeffrey'));
-            $this->assertEquals(6, $redis->zscore('output3', 'matt'));
-            $this->assertEquals(9, $redis->zscore('output3', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRangeInSortedSet()
-    {
-        foreach ($this->connections() as $connector => $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['jeffrey', 'matt'], $redis->zrange('set', 0, 1));
-            $this->assertEquals(['jeffrey', 'matt', 'taylor'], $redis->zrange('set', 0, -1));
-
-            if ($connector === 'predis') {
-                $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, 'withscores'));
-            } else {
-                $this->assertEquals(['jeffrey' => 1, 'matt' => 5], $redis->zrange('set', 0, 1, true));
-            }
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRevRangeInSortedSet()
-    {
-        foreach ($this->connections() as $connector => $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['taylor', 'matt'], $redis->ZREVRANGE('set', 0, 1));
-            $this->assertEquals(['taylor', 'matt', 'jeffrey'], $redis->ZREVRANGE('set', 0, -1));
-
-            if ($connector === 'predis') {
-                $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, 'withscores'));
-            } else {
-                $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->ZREVRANGE('set', 0, 1, true));
-            }
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRangeByScoreInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['jeffrey'], $redis->zrangebyscore('set', 0, 3));
-            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
-                'withscores' => true,
-                'limit' => [
-                    'offset' => 1,
-                    'count' => 2,
-                ],
-            ]));
-            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
-                'withscores' => true,
-                'limit' => [1, 2],
-            ]));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRevRangeByScoreInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-            $this->assertEquals(['taylor'], $redis->ZREVRANGEBYSCORE('set', 10, 6));
-            $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
-                'withscores' => true,
-                'limit' => [
-                    'offset' => 1,
-                    'count' => 2,
-                ],
-            ]));
-            $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
-                'withscores' => true,
-                'limit' => [1, 2],
-            ]));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsRankInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-
-            $this->assertEquals(0, $redis->zrank('set', 'jeffrey'));
-            $this->assertEquals(2, $redis->zrank('set', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItReturnsScoreInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10]);
-
-            $this->assertEquals(1, $redis->zscore('set', 'jeffrey'));
-            $this->assertEquals(10, $redis->zscore('set', 'taylor'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItRemovesMembersInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-
-            $redis->zrem('set', 'jeffrey');
-            $this->assertEquals(3, $redis->zcard('set'));
-
-            $redis->zrem('set', 'matt', 'adam');
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItRemovesMembersByScoreInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-            $redis->ZREMRANGEBYSCORE('set', 5, '+inf');
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItRemovesMembersByRankInSortedSet()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->zadd('set', ['jeffrey' => 1, 'matt' => 5, 'taylor' => 10, 'adam' => 11]);
-            $redis->ZREMRANGEBYRANK('set', 1, -1);
-            $this->assertEquals(1, $redis->zcard('set'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItSetsMultipleHashFields()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
-            $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash'));
-
-            $redis->hmset('hash2', 'name', 'mohamed', 'hobby', 'diving');
-            $this->assertEquals(['name' => 'mohamed', 'hobby' => 'diving'], $redis->hgetall('hash2'));
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItGetsMultipleHashFields()
-    {
-        foreach ($this->connections() as $redis) {
-            $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
-
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', 'name', 'hobby')
-            );
-
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', ['name', 'hobby'])
-            );
-
-            $redis->flushall();
-        }
-    }
-
-    public function testItGetsMultipleKeys()
-    {
         $valueSet = ['name' => 'mohamed', 'hobby' => 'diving'];
 
-        foreach ($this->connections() as $redis) {
-            $redis->mset($valueSet);
+        $redis->mset($valueSet);
 
-            $this->assertEquals(
-                array_values($valueSet),
-                $redis->mget(array_keys($valueSet))
-            );
-
-            $redis->flushall();
-        }
+        $this->assertEquals(
+            array_values($valueSet),
+            $redis->mget(array_keys($valueSet))
+        );
     }
 
-    public function testItFlushes()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItFlushes($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('name', 'Till');
-            $this->assertSame(1, $redis->exists('name'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->flushdb();
-            $this->assertSame(0, $redis->exists('name'));
-        }
+        $redis->set('name', 'Till');
+        $this->assertSame(1, $redis->exists('name'));
+
+        $redis->flushdb();
+        $this->assertSame(0, $redis->exists('name'));
     }
 
-    public function testItFlushesAsynchronous()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItFlushesAsynchronous($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->set('name', 'Till');
-            $this->assertSame(1, $redis->exists('name'));
+        $redis = $this->getRedisManager($connection);
 
-            $redis->flushdb('ASYNC');
-            $this->assertSame(0, $redis->exists('name'));
-        }
+        $redis->set('name', 'Till');
+        $this->assertSame(1, $redis->exists('name'));
+
+        $redis->flushdb('ASYNC');
+        $this->assertSame(0, $redis->exists('name'));
     }
 
-    public function testItRunsEval()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRunsEval($connection)
     {
-        foreach ($this->connections() as $redis) {
-            if ($redis instanceof PhpRedisConnection) {
-                // User must decide what needs to be serialized and compressed.
-                $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', ...$redis->pack(['mohamed']));
-            } else {
-                $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
-            }
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertSame('mohamed', $redis->get('name'));
-
-            $redis->flushall();
+        if ($redis->connection() instanceof PhpRedisConnection) {
+            // User must decide what needs to be serialized and compressed.
+            $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', ...$redis->pack(['mohamed']));
+        } else {
+            $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
         }
+
+        $this->assertSame('mohamed', $redis->get('name'));
     }
 
-    public function testItRunsPipes()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRunsPipes($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $result = $redis->pipeline(function ($pipe) {
-                $pipe->set('test:pipeline:1', 1);
-                $pipe->get('test:pipeline:1');
-                $pipe->set('test:pipeline:2', 2);
-                $pipe->get('test:pipeline:2');
-            });
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertCount(4, $result);
-            $this->assertEquals(1, $result[1]);
-            $this->assertEquals(2, $result[3]);
+        $result = $redis->pipeline(function ($pipe) {
+            $pipe->set('test:pipeline:1', 1);
+            $pipe->get('test:pipeline:1');
+            $pipe->set('test:pipeline:2', 2);
+            $pipe->get('test:pipeline:2');
+        });
 
-            $redis->flushall();
-        }
+        $this->assertCount(4, $result);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[3]);
     }
 
-    public function testItRunsTransactions()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRunsTransactions($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $result = $redis->transaction(function ($pipe) {
-                $pipe->set('test:transaction:1', 1);
-                $pipe->get('test:transaction:1');
-                $pipe->set('test:transaction:2', 2);
-                $pipe->get('test:transaction:2');
-            });
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertCount(4, $result);
-            $this->assertEquals(1, $result[1]);
-            $this->assertEquals(2, $result[3]);
+        $result = $redis->transaction(function ($pipe) {
+            $pipe->set('test:transaction:1', 1);
+            $pipe->get('test:transaction:1');
+            $pipe->set('test:transaction:2', 2);
+            $pipe->get('test:transaction:2');
+        });
 
-            $redis->flushall();
-        }
+        $this->assertCount(4, $result);
+        $this->assertEquals(1, $result[1]);
+        $this->assertEquals(2, $result[3]);
     }
 
-    public function testItRunsRawCommand()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItRunsRawCommand($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $redis->executeRaw(['SET', 'test:raw:1', '1']);
+        $redis = $this->getRedisManager($connection);
 
-            $this->assertEquals(
-                1, $redis->executeRaw(['GET', 'test:raw:1'])
-            );
+        $redis->executeRaw(['SET', 'test:raw:1', '1']);
 
-            $redis->flushall();
-        }
+        $this->assertEquals(
+            1, $redis->executeRaw(['GET', 'test:raw:1'])
+        );
     }
 
     public function testItDispatchesQueryEvent()
     {
-        foreach ($this->connections() as $redis) {
-            $redis->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $redis = $this->getRedisManager('phpredis');
 
-            $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) {
-                $this->assertSame('get', $event->command);
-                $this->assertEquals(['foobar'], $event->parameters);
-                $this->assertSame('default', $event->connectionName);
-                $this->assertInstanceOf(Connection::class, $event->connection);
+        $redis->setEventDispatcher($events = Mockery::mock(Dispatcher::class));
 
-                return true;
-            }));
+        $events->shouldReceive('dispatch')->once()->with(Mockery::on(function ($event) {
+            $this->assertSame('get', $event->command);
+            $this->assertEquals(['foobar'], $event->parameters);
+            $this->assertSame('default', $event->connectionName);
+            $this->assertInstanceOf(Connection::class, $event->connection);
 
-            $redis->get('foobar');
+            return true;
+        }));
 
-            $redis->unsetEventDispatcher();
-        }
+        $redis->get('foobar');
+
+        $redis->unsetEventDispatcher();
     }
 
     public function testItPersistsConnection()
@@ -582,195 +606,196 @@ class RedisConnectionTest extends TestCase
 
         $this->assertSame(
             'laravel',
-            $this->connections()['persistent']->getPersistentID()
+            $this->getRedisManager('phpredis_persistent')->getPersistentID()
         );
     }
 
-    public function testItScansForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItScansForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $initialKeys = ['test:scan:1', 'test:scan:2'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($initialKeys as $k => $key) {
-                $redis->set($key, 'test');
-                $initialKeys[$k] = $this->getPrefix($redis->client()).$key;
+        $initialKeys = ['test:scan:1', 'test:scan:2'];
+
+        foreach ($initialKeys as $k => $key) {
+            $redis->set($key, 'test');
+            $initialKeys[$k] = $this->getPrefix($redis->client()).$key;
+        }
+
+        $iterator = null;
+
+        do {
+            [$cursor, $returnedKeys] = $redis->scan($iterator);
+
+            if (! is_array($returnedKeys)) {
+                $returnedKeys = [$returnedKeys];
             }
 
-            $iterator = null;
-
-            do {
-                [$cursor, $returnedKeys] = $redis->scan($iterator);
-
-                if (! is_array($returnedKeys)) {
-                    $returnedKeys = [$returnedKeys];
-                }
-
-                foreach ($returnedKeys as $returnedKey) {
-                    $this->assertContains($returnedKey, $initialKeys);
-                }
-            } while ($iterator > 0);
-
-            $redis->flushAll();
-        }
+            foreach ($returnedKeys as $returnedKey) {
+                $this->assertContains($returnedKey, $initialKeys);
+            }
+        } while ($iterator > 0);
     }
 
-    public function testItZscansForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItZscansForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $members = [100 => 'test:zscan:1', 200 => 'test:zscan:2'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($members as $score => $member) {
-                $redis->zadd('set', $score, $member);
+        $members = [100 => 'test:zscan:1', 200 => 'test:zscan:2'];
+
+        foreach ($members as $score => $member) {
+            $redis->zadd('set', $score, $member);
+        }
+
+        $iterator = null;
+        $result = [];
+
+        do {
+            [$iterator, $returnedMembers] = $redis->zscan('set', $iterator);
+
+            if (! is_array($returnedMembers)) {
+                $returnedMembers = [$returnedMembers];
             }
 
-            $iterator = null;
-            $result = [];
+            foreach ($returnedMembers as $member => $score) {
+                $this->assertArrayHasKey((int) $score, $members);
+                $this->assertContains($member, $members);
+            }
 
-            do {
-                [$iterator, $returnedMembers] = $redis->zscan('set', $iterator);
+            $result += $returnedMembers;
+        } while ($iterator > 0);
 
-                if (! is_array($returnedMembers)) {
-                    $returnedMembers = [$returnedMembers];
-                }
+        $this->assertCount(2, $result);
 
-                foreach ($returnedMembers as $member => $score) {
-                    $this->assertArrayHasKey((int) $score, $members);
-                    $this->assertContains($member, $members);
-                }
+        $iterator = null;
+        [$iterator, $returned] = $redis->zscan('set', $iterator, ['match' => 'test:unmatch:*']);
+        $this->assertEmpty($returned);
 
-                $result += $returnedMembers;
-            } while ($iterator > 0);
-
-            $this->assertCount(2, $result);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->zscan('set', $iterator, ['match' => 'test:unmatch:*']);
-            $this->assertEmpty($returned);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->zscan('set', $iterator, ['count' => 5]);
-            $this->assertCount(2, $returned);
-
-            $redis->flushAll();
-        }
+        $iterator = null;
+        [$iterator, $returned] = $redis->zscan('set', $iterator, ['count' => 5]);
+        $this->assertCount(2, $returned);
     }
 
-    public function testItHscansForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItHscansForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $fields = ['name' => 'mohamed', 'hobby' => 'diving'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($fields as $field => $value) {
-                $redis->hset('hash', $field, $value);
+        $fields = ['name' => 'mohamed', 'hobby' => 'diving'];
+
+        foreach ($fields as $field => $value) {
+            $redis->hset('hash', $field, $value);
+        }
+
+        $iterator = null;
+        $result = [];
+
+        do {
+            [$iterator, $returnedFields] = $redis->hscan('hash', $iterator);
+
+            foreach ($returnedFields as $field => $value) {
+                $this->assertArrayHasKey($field, $fields);
+                $this->assertContains($value, $fields);
             }
 
-            $iterator = null;
-            $result = [];
+            $result += $returnedFields;
+        } while ($iterator > 0);
 
-            do {
-                [$iterator, $returnedFields] = $redis->hscan('hash', $iterator);
+        $this->assertCount(2, $result);
 
-                foreach ($returnedFields as $field => $value) {
-                    $this->assertArrayHasKey($field, $fields);
-                    $this->assertContains($value, $fields);
-                }
+        $iterator = null;
+        [$iterator, $returned] = $redis->hscan('hash', $iterator, ['match' => 'test:unmatch:*']);
+        $this->assertEmpty($returned);
 
-                $result += $returnedFields;
-            } while ($iterator > 0);
-
-            $this->assertCount(2, $result);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->hscan('hash', $iterator, ['match' => 'test:unmatch:*']);
-            $this->assertEmpty($returned);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->hscan('hash', $iterator, ['count' => 5]);
-            $this->assertCount(2, $returned);
-
-            $redis->flushAll();
-        }
+        $iterator = null;
+        [$iterator, $returned] = $redis->hscan('hash', $iterator, ['count' => 5]);
+        $this->assertCount(2, $returned);
     }
 
-    public function testItSscansForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSscansForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $members = ['test:sscan:1', 'test:sscan:2'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($members as $member) {
-                $redis->sadd('set', $member);
-            }
+        $members = ['test:sscan:1', 'test:sscan:2'];
 
-            $iterator = null;
-            $result = [];
-
-            do {
-                [$iterator, $returnedMembers] = $redis->sscan('set', $iterator);
-
-                foreach ($returnedMembers as $member) {
-                    $this->assertContains($member, $members);
-                    array_push($result, $member);
-                }
-            } while ($iterator > 0);
-
-            $this->assertCount(2, $result);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->sscan('set', $iterator, ['match' => 'test:unmatch:*']);
-            $this->assertEmpty($returned);
-
-            $iterator = null;
-            [$iterator, $returned] = $redis->sscan('set', $iterator, ['count' => 5]);
-            $this->assertCount(2, $returned);
-
-            $redis->flushAll();
+        foreach ($members as $member) {
+            $redis->sadd('set', $member);
         }
+
+        $iterator = null;
+        $result = [];
+
+        do {
+            [$iterator, $returnedMembers] = $redis->sscan('set', $iterator);
+
+            foreach ($returnedMembers as $member) {
+                $this->assertContains($member, $members);
+                array_push($result, $member);
+            }
+        } while ($iterator > 0);
+
+        $this->assertCount(2, $result);
+
+        $iterator = null;
+        [$iterator, $returned] = $redis->sscan('set', $iterator, ['match' => 'test:unmatch:*']);
+        $this->assertEmpty($returned);
+
+        $iterator = null;
+        [$iterator, $returned] = $redis->sscan('set', $iterator, ['count' => 5]);
+        $this->assertCount(2, $returned);
     }
 
-    public function testItSPopsForKeys()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testItSPopsForKeys($connection)
     {
-        foreach ($this->connections() as $redis) {
-            $members = ['test:spop:1', 'test:spop:2', 'test:spop:3', 'test:spop:4'];
+        $redis = $this->getRedisManager($connection);
 
-            foreach ($members as $member) {
-                $redis->sadd('set', $member);
-            }
+        $members = ['test:spop:1', 'test:spop:2', 'test:spop:3', 'test:spop:4'];
 
-            $result = $redis->spop('set');
-            $this->assertIsNotArray($result);
-            $this->assertContains($result, $members);
-
-            $result = $redis->spop('set', 1);
-
-            $this->assertIsArray($result);
-            $this->assertCount(1, $result);
-
-            $result = $redis->spop('set', 2);
-
-            $this->assertIsArray($result);
-            $this->assertCount(2, $result);
-
-            $redis->flushAll();
+        foreach ($members as $member) {
+            $redis->sadd('set', $member);
         }
+
+        $result = $redis->spop('set');
+        $this->assertIsNotArray($result);
+        $this->assertContains($result, $members);
+
+        $result = $redis->spop('set', 1);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+
+        $result = $redis->spop('set', 2);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
     }
 
-    public function testPhpRedisScanOption()
+    /**
+     * @dataProvider extendedRedisConnectionDataProvider
+     */
+    public function testMacroable($connection)
     {
-        foreach ($this->connections() as $redis) {
-            if ($redis->client() instanceof Client) {
-                continue;
-            }
+        Connection::macro('foo', function () {
+            return 'foo';
+        });
 
-            $iterator = null;
-
-            do {
-                $returned = $redis->scan($iterator);
-
-                if ($redis->client()->getOption(Redis::OPT_SCAN) === Redis::SCAN_RETRY) {
-                    $this->assertEmpty($returned);
-                }
-            } while ($iterator > 0);
-        }
+        $this->assertSame(
+            'foo',
+            $this->getRedisManager($connection)->foo()
+        );
     }
 
     private function getPrefix($client)
@@ -780,217 +805,5 @@ class RedisConnectionTest extends TestCase
         }
 
         return $client->getOptions()->prefix;
-    }
-
-    public function testMacroable()
-    {
-        Connection::macro('foo', function () {
-            return 'foo';
-        });
-
-        foreach ($this->connections() as $redis) {
-            $this->assertSame(
-                'foo',
-                $redis->foo()
-            );
-        }
-    }
-
-    public function connections()
-    {
-        $connections = [
-            'predis' => $this->redis['predis']->connection(),
-            'phpredis' => $this->redis['phpredis']->connection(),
-        ];
-
-        $host = env('REDIS_HOST', '127.0.0.1');
-        $port = env('REDIS_PORT', 6379);
-
-        $connections[] = (new RedisManager(new Application, 'phpredis', [
-            'cluster' => false,
-            'default' => [
-                'url' => "redis://user@$host:$port",
-                'host' => 'overwrittenByUrl',
-                'port' => 'overwrittenByUrl',
-                'database' => 5,
-                'options' => ['prefix' => 'laravel:'],
-                'timeout' => 0.5,
-            ],
-        ]))->connection();
-
-        $connections['persistent'] = (new RedisManager(new Application, 'phpredis', [
-            'cluster' => false,
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'database' => 6,
-                'options' => ['prefix' => 'laravel:'],
-                'timeout' => 0.5,
-                'persistent' => true,
-                'persistent_id' => 'laravel',
-            ],
-        ]))->connection();
-
-        $connections[] = (new RedisManager(new Application, 'phpredis', [
-            'cluster' => false,
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'database' => 7,
-                'options' => ['serializer' => Redis::SERIALIZER_JSON],
-                'timeout' => 0.5,
-            ],
-        ]))->connection();
-
-        $connections[] = (new RedisManager(new Application, 'phpredis', [
-            'cluster' => false,
-            'default' => [
-                'host' => $host,
-                'port' => $port,
-                'database' => 8,
-                'options' => ['scan' => Redis::SCAN_RETRY],
-                'timeout' => 0.5,
-            ],
-        ]))->connection();
-
-        if (defined('Redis::COMPRESSION_LZF')) {
-            $connections['compression_lzf'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 9,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZF,
-                        'name' => 'compression_lzf',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-        }
-
-        if (defined('Redis::COMPRESSION_ZSTD')) {
-            $connections['compression_zstd'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 10,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'name' => 'compression_zstd',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_zstd_default'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 11,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'compression_level' => Redis::COMPRESSION_ZSTD_DEFAULT,
-                        'name' => 'compression_zstd_default',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_zstd_min'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 12,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'compression_level' => Redis::COMPRESSION_ZSTD_MIN,
-                        'name' => 'compression_zstd_min',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_zstd_max'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 13,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_ZSTD,
-                        'compression_level' => Redis::COMPRESSION_ZSTD_MAX,
-                        'name' => 'compression_zstd_max',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-        }
-
-        if (defined('Redis::COMPRESSION_LZ4')) {
-            $connections['compression_lz4'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 14,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZ4,
-                        'name' => 'compression_lz4',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_lz4_default'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 15,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZ4,
-                        'compression_level' => 0,
-                        'name' => 'compression_lz4_default',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_lz4_min'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 16,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZ4,
-                        'compression_level' => 1,
-                        'name' => 'compression_lz4_min',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-
-            $connections['compression_lz4_max'] = (new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 17,
-                    'options' => [
-                        'compression' => Redis::COMPRESSION_LZ4,
-                        'compression_level' => 12,
-                        'name' => 'compression_lz4_max',
-                    ],
-                    'timeout' => 0.5,
-                ],
-            ]))->connection();
-        }
-
-        return $connections;
     }
 }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -606,7 +606,26 @@ class RedisConnectionTest extends TestCase
 
         $this->assertSame(
             'laravel',
-            $this->getRedisManager('phpredis_persistent')->getPersistentID()
+            $this
+                ->getRedisManager(
+                    'phpredis_persistent',
+                    'phpredis',
+                    [
+                        'cluster' => false,
+                        'default' => [
+                            'host' => env('REDIS_HOST', '127.0.0.1'),
+                            'port' => (int) env('REDIS_PORT', 6379),
+                            'timeout' => 0.5,
+                            'database' => 5,
+                            'persistent' => true,
+                            'persistent_id' => 'laravel',
+                            'options' => [
+                                'name' => 'phpredis_persistent',
+                            ],
+                        ],
+                    ]
+                )
+                ->getPersistentID()
         );
     }
 

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Redis;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Redis\RedisManager;
 use PHPUnit\Framework\TestCase;
 use Redis;
 
@@ -39,7 +41,7 @@ class RedisConnectorTest extends TestCase
         $host = env('REDIS_HOST', '127.0.0.1');
         $port = env('REDIS_PORT', 6379);
 
-        $predis = $this->getRedisManager('predis', 'predis', [
+        $predis = new RedisManager(new Application, 'predis', [
             'cluster' => false,
             'options' => [
                 'prefix' => 'test_',
@@ -77,21 +79,20 @@ class RedisConnectorTest extends TestCase
         $host = env('REDIS_HOST', '127.0.0.1');
         $port = env('REDIS_PORT', 6379);
 
-        $predis = $this->getRedisManager('predis', 'predis', [
+        $predis = new RedisManager(new Application, 'predis', [
             'cluster' => false,
             'options' => [
                 'prefix' => 'test_',
             ],
             'default' => [
-                'url' => "tls1.2://{$host}:{$port}",
+                'url' => "tls://{$host}:{$port}",
                 'database' => 5,
                 'timeout' => 0.5,
             ],
         ]);
         $predisClient = $predis->connection()->client();
         $parameters = $predisClient->getConnection()->getParameters();
-        // Predis can not recognize properly different tls versions and reports tcp in that case.
-        $this->assertSame('tcp', $parameters->scheme);
+        $this->assertSame('tls', $parameters->scheme);
         $this->assertEquals($host, $parameters->host);
         $this->assertEquals($port, $parameters->port);
 
@@ -116,7 +117,7 @@ class RedisConnectorTest extends TestCase
         $host = env('REDIS_HOST', '127.0.0.1');
         $port = env('REDIS_PORT', 6379);
 
-        $predis = $this->getRedisManager('predis', 'predis', [
+        $predis = new RedisManager(new Application, 'predis', [
             'cluster' => false,
             'options' => [
                 'prefix' => 'test_',
@@ -160,7 +161,7 @@ class RedisConnectorTest extends TestCase
         $username = 'testuser';
         $password = 'testpw';
 
-        $predis = $this->getRedisManager('predis', 'predis', [
+        $predis = new RedisManager(new Application, 'predis', [
             'default' => [
                 'host' => $host,
                 'port' => $port,
@@ -181,7 +182,7 @@ class RedisConnectorTest extends TestCase
         $host = env('REDIS_HOST', '127.0.0.1');
         $port = env('REDIS_PORT', 6379);
 
-        $predis = $this->getRedisManager('predis', 'predis', [
+        $predis = new RedisManager(new Application, 'predis', [
             'cluster' => false,
             'options' => [
                 'replication' => 'sentinel',
@@ -246,7 +247,7 @@ class RedisConnectorTest extends TestCase
         $predisClient2 = $predis2->client();
         $this->assertEquals('test_default_config_', $predisClient2->getOptions()->prefix->getPrefix());
 
-        $phpRedis1 = new RedisManager(new Application, 'phpredis', [
+        $phpRedis1 = $this->getRedisManager('phpredis', 'phpredis', [
             'cluster' => false,
             'options' => [
                 'prefix' => 'test_',
@@ -265,7 +266,7 @@ class RedisConnectorTest extends TestCase
         $phpRedisClient1 = $phpRedis1->connection()->client();
         $this->assertEquals('test_default_options_', $phpRedisClient1->getOption(Redis::OPT_PREFIX));
 
-        $phpRedis2 = new RedisManager(new Application, 'phpredis', [
+        $phpRedis2 = $this->getRedisManager('phpredis', 'phpredis', [
             'cluster' => false,
             'options' => [
                 'prefix' => 'test_',

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3557,7 +3557,7 @@ class ValidationValidatorTest extends TestCase
                 ['x' => 'http://www.google.com'],
                 true,
             ],
-            'Google About With Subdomain' => [
+            'Google With Subdomain About Page' => [
                 ['x' => 'http://www.google.com/about'],
                 true,
             ],

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -27,6 +27,7 @@ use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use InvalidArgumentException;
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
@@ -3522,23 +3523,45 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
-    public function testValidateActiveUrl()
+    /**
+     * @dataProvider activeUrlDataProvider
+     */
+    public function testValidateActiveUrl($data, $outcome)
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'active_url']);
-        $this->assertFalse($v->passes());
+        $v = m::mock(
+            new Validator($trans, $data, ['x' => 'active_url']),
+            function (MockInterface $mock) {
+                $mock->shouldAllowMockingProtectedMethods()->shouldReceive('dnsRecords')->withAnyArgs()->zeroOrMoreTimes()->andReturn(['hit']);
+            }
+        );
+        $this->assertEquals($outcome, $v->passes());
+    }
 
-        $v = new Validator($trans, ['x' => ['fdsfs', 'fdsfds']], ['x' => 'active_url']);
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'active_url']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['x' => 'http://www.google.com'], ['x' => 'active_url']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['x' => 'http://www.google.com/about'], ['x' => 'active_url']);
-        $this->assertTrue($v->passes());
+    public function activeUrlDataProvider()
+    {
+        return [
+            'Invalid Url' => [
+                ['x' => 'aslsdlks'],
+                false,
+            ],
+            'Invalid Urls' => [
+                ['x' => 'fdsfs', 'fdsfds'],
+                false,
+            ],
+            'Google Without Subdomain' => [
+                ['x' => 'http://google.com'],
+                true,
+            ],
+            'Google With Subdomain' => [
+                ['x' => 'http://www.google.com'],
+                true,
+            ],
+            'Google About With Subdomain' => [
+                ['x' => 'http://www.google.com/about'],
+                true,
+            ],
+        ];
     }
 
     public function testValidateImage()


### PR DESCRIPTION
This is a follow up of https://github.com/laravel/framework/pull/40569, splitting the original pull request up. This pull request is about refining the existing redis test suite making it easy to test future changes related to redis.

### What changed

- Added data providers with named data sets to allow easy testing of different redis connection configurations.
- All tests in all components that use redis are now using the new data providers to test all supported redis connection settings separately making it easy to pinpoint which redis setting causes an issue with an existing or new component.

If any test related to redis fails, it will now output the exact data set that caused the failure:

![image](https://user-images.githubusercontent.com/7612582/152594220-f4736693-af7a-4989-9710-02d0da7492c2.png)

### How to use

Now when you need to test something where redis is used, you can simply add the helper trait in the beginning like so:

```php
use InteractsWithRedis;
```

Then to let a test run through all possible redis variations, add one of the following doc blocks:

```php
/**
 * Runs this test with only two basic redis connections where one is using the predis driver and
 * the other the phpredis driver.
 *
 * @dataProvider redisConnectionDataProvider
 */
public function testSomethingRelatedToRedis($connection)
{
    $this->app['redis'] = $this->getRedisManager($connection);
    ...
}
```

```php
/**
 * Runs this test with the basic connection set and in addition advanced connection configurations like
 * persistent connections, prefix, scan options, serialization, compression etc.
 *
 * @dataProvider extendedRedisConnectionDataProvider
 */
public function testSomethingRelatedToRedis($connection)
{
    $this->app['redis'] = $this->getRedisManager($connection);
    ...
}
```

To get a custom redis connection during a test you can also pass two additional parameters to the `getRedisManager` helper method where the second parameter is the driver and third parameter an connection config array:

```php
$redisManager = $this->getRedisManager('predis_custom', 'predis', [
    'cluster' => false,
    'options' => [
        'prefix' => 'test_',
    ],
    'default' => [
        'url' => "redis://{$host}:{$port}",
        'database' => 5,
        'timeout' => 0.5,
    ],
]);
```

To properly clean up after every test provide the following method call in your tearDown method:

```php
protected function tearDown(): void
{
    $this->tearDownRedis();

    parent::tearDown();
}
```