### PR TITLE
[9.x] Make Illuminate\Http\JsonResponse macroable

### DIFF
--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -4,10 +4,13 @@ namespace Illuminate\Http\Resources;
 
 use Exception;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\Traits\Macroable;
 
 trait DelegatesToResource
 {
-    use ForwardsCalls;
+    use ForwardsCalls, Macroable {
+        __call as macroCall;
+    }
 
     /**
      * Get the value of the resource's route key.
@@ -145,6 +148,10 @@ trait DelegatesToResource
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         return $this->forwardCallTo($this->resource, $method, $parameters);
     }
 }


### PR DESCRIPTION
This PR makes the \Illuminate\Http\JsonResponseclass macroable. I often have to cast to a certain format. In addition, \Illuminate\Http\Request has a Macroable trait, so I expect the same with JsonResponse.

```php
// Current:

public function toArray($request): array {
    return [
        'amount' => number_format(12.0, 2, '.', ''),
    ];
}

// Proposal:

JsonResource::macro('money', function (float $amount) {
    return number_format($amount, 2, '.', '');
});

public function toArray($request): array {
    return [
        'amount' => $this->money(12.0),
    ];
}
```