### PR TITLE
[9.x] Adding the ability to use camelCase or snake_case attribute marked attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -660,8 +660,10 @@ trait HasAttributes
     {
         if ($this->isClassCastable($key)) {
             $value = $this->getClassCastableAttributeValue($key, $value);
-        } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
-                  static::$getAttributeMutatorCache[get_class($this)][$key] === true) {
+        } elseif ((isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
+                static::$getAttributeMutatorCache[get_class($this)][$key] === true) ||
+            (isset(static::$getAttributeMutatorCache[get_class($this)][str::snake($key)]) &&
+                static::$getAttributeMutatorCache[get_class($this)][str::snake($key)] === true)) {
             $value = $this->mutateAttributeMarkedAttribute($key, $value);
 
             $value = $value instanceof DateTimeInterface


### PR DESCRIPTION
See #41704 for reference.

The old style of get...Attribute() and set...Attribute supported using either snake case or camel case attribute names. The new Attribute marked attributes only support snake case. This PR adds the ability to use camel case attribute marked attributes.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
