### PR TITLE
[10.x] Adds a new `doesntHave` method to the session store

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -72,6 +72,14 @@ interface Session
     public function has($key);
 
     /**
+     * Checks if a key is missing or is null.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function doesntHave($key);
+
+    /**
      * Get an item from the session.
      *
      * @param  string  $key

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -231,6 +231,17 @@ class Store implements Session
     }
 
     /**
+     * Checks if a key is missing or is null.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function doesntHave($key)
+    {
+        return ! $this->has($key);
+    }
+
+    /**
      * Get an item from the session.
      *
      * @param  string  $key

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -455,6 +455,15 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->exists(['hulk.two']));
     }
 
+    public function testDoesntHaveKey()
+    {
+        $session = $this->getSession();
+        $session->put('foo', 'bar');
+        $this->assertTrue($session->doesntHave('baz'));
+        $session->put('baz', null);
+        $this->assertTrue($session->doesntHave('baz'));
+    }
+
     public function testKeyMissing()
     {
         $session = $this->getSession();


### PR DESCRIPTION
## What?
This PR adds a `doesntHave` method to the session store, which allows to check if a given key is missing from the session of if it's value is `null`.

## Why? 
Before this PR, you have to use `! session()->has('key')`. If this PR gets merged, you can use `session()->doesntHave('key')`, which IMO is much more readable.

```php
//Before
if (! session()->has('key')) {
    // Do something...
}

// After
if (session()->doesntHave('key')) {
    // Do something...
}
```

PS..: I'm sending this to master because i think adding a new method to a non internal interface is a major breaking change accordingly to semver.
