### PR TITLE
[9.x] Make `whereBelongsTo` accept Collection

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1055,6 +1055,38 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($result, $builder);
     }
 
+    public function testWhereBelongsToOneOf()
+    {
+        $related = new EloquentBuilderTestWhereBelongsToStub([
+            'id' => 1,
+            'parent_id' => 2,
+        ]);
+
+        $parents = new Collection([new EloquentBuilderTestWhereBelongsToStub([
+            'id' => 2,
+            'parent_id' => 1,
+        ]), new EloquentBuilderTestWhereBelongsToStub([
+            'id' => 3,
+            'parent_id' => 1,
+        ])]);
+
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
+
+        $result = $builder->whereBelongsToOneOf($parents);
+        $this->assertEquals($result, $builder);
+
+        $builder = $this->getBuilder();
+        $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
+        $builder->setModel($related);
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
+
+        $result = $builder->whereBelongsToOneOf($parents, 'parent');
+        $this->assertEquals($result, $builder);
+    }
+
     public function testDeleteOverride()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1041,7 +1041,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('where')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', '=', 2, 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and');
 
         $result = $builder->whereBelongsTo($parent);
         $this->assertEquals($result, $builder);
@@ -1049,18 +1049,10 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->shouldReceive('from')->with('eloquent_builder_test_where_belongs_to_stubs');
         $builder->setModel($related);
-        $builder->getQuery()->shouldReceive('where')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', '=', 2, 'and');
+        $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2], 'and');
 
         $result = $builder->whereBelongsTo($parent, 'parent');
         $this->assertEquals($result, $builder);
-    }
-
-    public function testWhereBelongsToOneOf()
-    {
-        $related = new EloquentBuilderTestWhereBelongsToStub([
-            'id' => 1,
-            'parent_id' => 2,
-        ]);
 
         $parents = new Collection([new EloquentBuilderTestWhereBelongsToStub([
             'id' => 2,
@@ -1075,7 +1067,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($related);
         $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
 
-        $result = $builder->whereBelongsToOneOf($parents);
+        $result = $builder->whereBelongsTo($parents);
         $this->assertEquals($result, $builder);
 
         $builder = $this->getBuilder();
@@ -1083,7 +1075,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($related);
         $builder->getQuery()->shouldReceive('whereIn')->once()->with('eloquent_builder_test_where_belongs_to_stubs.parent_id', [2, 3], 'and');
 
-        $result = $builder->whereBelongsToOneOf($parents, 'parent');
+        $result = $builder->whereBelongsTo($parents, 'parent');
         $this->assertEquals($result, $builder);
     }
 


### PR DESCRIPTION
Hi there!

Extending upon #38927, I'm submitting this PR that allows you to retrieve records using a collection of related records. 

Previously, if you wanted to retrieve, for example, all Posts that belong to one of multiple Categories, you would need to perform the following query:

```php
$query->whereBelongsTo($category[0])
    ->orWhereBelongsTo($category[1])
    // etc...

// Or:
$query->whereIn('category_id', $categories->modelKeys());
```

Same as in the aforementioned PR, you would need to know the key names when building and maintain these if they change. This PR adds support for Collections passed to the `whereBelongsTo` method:

```php
$query->whereBelongsTo($categories);
```

```php
$query->whereBelongsTo($categories, 'category');
```