### PR TITLE
[9.x] Fix multiple calls to class cast mutators

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1021,6 +1021,8 @@ trait HasAttributes
      */
     protected function setAttributeMarkedMutatedAttributeValue($key, $value)
     {
+        $this->potentiallyAlteredCasts[$key] = false;
+
         $attribute = $this->{Str::camel($key)}();
 
         $callback = $attribute->set ?: function ($value) use ($key) {
@@ -1084,6 +1086,8 @@ trait HasAttributes
      */
     protected function setClassCastableAttribute($key, $value)
     {
+        $this->potentiallyAlteredCasts[$key] = false;
+
         $caster = $this->resolveCasterClass($key);
 
         $this->attributes = array_merge(

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1628,7 +1628,7 @@ trait HasAttributes
     protected function mergeAttributesFromClassCasts()
     {
         foreach ($this->classCastCache as $key => $value) {
-            if (!isset($this->potentiallyAlteredCasts[$key]) || $this->potentiallyAlteredCasts[$key] === false) {
+            if (! isset($this->potentiallyAlteredCasts[$key]) || $this->potentiallyAlteredCasts[$key] === false) {
                 continue;
             }
 
@@ -1653,7 +1653,7 @@ trait HasAttributes
     protected function mergeAttributesFromAttributeCasts()
     {
         foreach ($this->attributeCastCache as $key => $value) {
-            if (!isset($this->potentiallyAlteredCasts[$key]) || $this->potentiallyAlteredCasts[$key] === false) {
+            if (! isset($this->potentiallyAlteredCasts[$key]) || $this->potentiallyAlteredCasts[$key] === false) {
                 continue;
             }
 

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -340,7 +340,7 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
         $model->address->lineOne = '117 Spencer St.';
         $this->assertSame('117 Spencer St.', $model->getAttributes()['address_line_one']);
 
-        $this->assertEquals(2, $model->countAddressMutatorCalls);        
+        $this->assertEquals(2, $model->countAddressMutatorCalls);
     }
 }
 

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -341,6 +341,15 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
         $this->assertSame('117 Spencer St.', $model->getAttributes()['address_line_one']);
 
         $this->assertEquals(2, $model->countAddressMutatorCalls);
+
+        $model = new TestEloquentModelWithAttributeCast;
+
+        $model->address = new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House');
+        $model->address->lineOne = '117 Spencer St.';
+        $model->address = new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House');
+        $model->address->lineOne = '117 Spencer St.';
+
+        $this->assertEquals(2, $model->countAddressMutatorCalls);
     }
 }
 

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -49,8 +49,8 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
 
         $model = new TestEloquentModelWithAttributeCast;
 
-        $model->address = $address = new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House');
-        $address->lineOne = '117 Spencer St.';
+        $model->address = new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House');
+        $model->address->lineOne = '117 Spencer St.';
         $this->assertSame('117 Spencer St.', $model->getAttributes()['address_line_one']);
 
         $model = new TestEloquentModelWithAttributeCast;

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -53,8 +53,8 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $model = new TestEloquentModelWithCustomCast;
 
-        $model->address = $address = new Address('110 Kingsbrook St.', 'My Childhood House');
-        $address->lineOne = '117 Spencer St.';
+        $model->address = new Address('110 Kingsbrook St.', 'My Childhood House');
+        $model->address->lineOne = '117 Spencer St.';
         $this->assertSame('117 Spencer St.', $model->getAttributes()['address_line_one']);
 
         $model = new TestEloquentModelWithCustomCast;

--- a/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEncryptedCastingTest.php
@@ -184,11 +184,11 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
     public function testAsEncryptedCollection()
     {
         $this->encrypter->expects('encryptString')
-            ->twice()
+            ->once()
             ->with('{"key1":"value1"}')
             ->andReturn('encrypted-secret-collection-string-1');
         $this->encrypter->expects('encryptString')
-            ->times(10)
+            ->times(6)
             ->with('{"key1":"value1","key2":"value2"}')
             ->andReturn('encrypted-secret-collection-string-2');
         $this->encrypter->expects('decryptString')
@@ -242,7 +242,7 @@ class EloquentModelEncryptedCastingTest extends DatabaseTestCase
             ->with('encrypted-secret-array-string-1')
             ->andReturn('{"key1":"value1"}');
         $this->encrypter->expects('encryptString')
-            ->times(10)
+            ->times(6)
             ->with('{"key1":"value1","key2":"value2"}')
             ->andReturn('encrypted-secret-array-string-2');
         $this->encrypter->expects('decryptString')


### PR DESCRIPTION
Solves #41533. Class casts (`Attribute` included) allow the developer to use a more expressive syntax like `$model->address->lineOne = '117 Spencer St.'` avoiding assigning the object to a variable and then updating the attribute to trigger the mutator.

What the framework currently does to allow this to work is "if a mutated attribute has already been accessed once, every time I access any attribute (through `getAttributes`), call the mutator to sync the changes made to the object back to the model attributes".

My tentative solution to this issue is: every time an attribute or class mutated attribute is accessed, consider that it could potentially also lead to an object modification. So flag this attribute as "potentially altered" and call the mutator on first occasion, the remove the flag until next access.

**EDIT**

This performance check to avoid multiple calls doesn't allow anymore to modify the object by itself but you need to access the object through the model.

So given
```
$address = new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House');
$model->address = $address
```
you should do
```
$model->address->lineOne = '117 Spencer St.';
```
not
```
$address->lineOne = '117 Spencer St.';
```

I guess that this introduces a breaking change and then this PR should target the next major version.