### PR TITLE
[9.x] Added boolean to console argument function's return type docblock

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -64,7 +64,7 @@ trait InteractsWithIO
      * Get the value of a command argument.
      *
      * @param  string|null  $key
-     * @return string|array|null|bool
+     * @return array|string|bool|null
      */
     public function argument($key = null)
     {

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -64,7 +64,7 @@ trait InteractsWithIO
      * Get the value of a command argument.
      *
      * @param  string|null  $key
-     * @return string|array|null
+     * @return string|array|null|bool
      */
     public function argument($key = null)
     {


### PR DESCRIPTION
## What
`Console/Concerns/InteractsWithIO.php@argument()` should include bool (`@return string|array|null|bool`) in its return type docblock.

## Why
By calling `Artisan::call([command], [ 'fooBool' => true ])` the value returned from `$this->argument('fooBool')` in laravel commands would be a boolean.

## Reasoning
This will prevent IDEs, phpStan etc. from flagging boolean comparisons.  ie: `$this->argument('fooBool') === false`

The workaround to this is to just pass `0` or `1`, but I much prefer to use booleans to be more explicit and don't see any reason why we wouldn't include it as an option.