### PR TITLE
Assert that a response matches the specified errors

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1346,6 +1346,29 @@ EOF;
     }
 
     /**
+     * Assert that the session matches the given errors.
+     *
+     * @param  string|array  $keys
+     * @param  mixed  $format
+     * @param  string  $errorBag
+     * @return $this
+     */
+    public function assertSessionMatchesErrors($keys = [], $errorBag = 'default')
+    {
+        $this->assertSessionHasErrors($keys, null, $errorBag);
+
+        $keys = (array) $keys;
+
+        $errors = $this->session()->get('errors')->getBag($errorBag);
+
+        $diffKeys = array_diff($errors->keys(), $keys);
+
+        PHPUnit::assertEmpty($diffKeys, "Session errors doesn't match.");
+
+        return $this;
+    }
+
+    /**
      * Assert that the session has no errors.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1688,6 +1688,26 @@ class TestResponseTest extends TestCase
         $response->assertSessionDoesntHaveErrors(['foo']);
     }
 
+    public function testAssertSessionMatchesErrors()
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
+
+        $store->put('errors', $errorBag = new ViewErrorBag);
+
+        $errorBag->put('default', new MessageBag([
+            'foo' => [
+                'foo is required',
+            ],
+            'bar' => [
+                'bar is required',
+            ],
+        ]));
+
+        $response = TestResponse::fromBaseResponse(new Response());
+
+        $response->assertSessionMatchesErrors(['foo', 'bar']);
+    }
+
     public function testAssertSessionHasNoErrors()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
When you're asserting validation errors you can use `assertSessionHasErrors()` and `assertSessionDoesNotHaveErrors()`. You need to use both to ensure that just only a set of validations have failed.

But I've created a new assertion that could be interesting to be shared: `assertSessionMatchesErrors()`. 

The assertion will pass **if the provided errors and only these ones are present in the session**. 

Let's imagine a form request with 4 fields that are validated: `field1`, `field2`, `field3` and `field4`.

If you have a testcase to ensure that `field1` validation fails you need to do:

```
// To ensure that only `field1` is failing.

$this->assertSessionHasErrors(['field1']);
$this->assertSessionDoesNotHaveErrors(['field2', 'field3', 'field4']);

// Instead you can do

$this->assertSessionMatchesErrors(['field1']);
```
I've added a discussion in the [GitHub discussion board](https://github.com/laravel/framework/discussions/41741).

**WDYT?**
