### PR TITLE
[10.x] Added command to generate globally unique app-id

### DIFF
--- a/src/Illuminate/Foundation/Console/AppIdGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/AppIdGenerateCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Encryption\Encrypter;
+
+class AppIdGenerateCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app-id:generate
+                    {--show : Display the app-id instead of modifying files}
+                    {--force : Force the operation to run when in production}';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'app-id:generate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set the application app-id';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $appId = $this->generateRandomAppId();
+
+        if ($this->option('show')) {
+            return $this->line('<comment>'.$appId.'</comment>');
+        }
+
+        // Next, we will replace the application app-id in the environment file so it is
+        // automatically setup for this developer. This app-id gets generated using a
+        // random string for storage.
+        if (! $this->setAppIdInEnvironmentFile($appId)) {
+            return;
+        }
+
+        $this->laravel['config']['app.app_id'] = $appId;
+
+        $this->info('Application app-id set successfully.');
+    }
+
+    /**
+     * Generate a random app-id for the application.
+     *
+     * @return string
+     */
+    protected function generateRandomAppId()
+    {
+        return uniqid();
+    }
+
+    /**
+     * Set the application app-id in the environment file.
+     *
+     * @param  string  $appId
+     * @return bool
+     */
+    protected function setAppIdInEnvironmentFile($appId)
+    {
+        $currentAppId = $this->laravel['config']['app.app_id'];
+
+        if (strlen($currentAppId) !== 0 && (! $this->confirmToProceed())) {
+            return false;
+        }
+
+        $this->writeNewEnvironmentFileWith($appId);
+
+        return true;
+    }
+
+    /**
+     * Write a new environment file with the given app-id.
+     *
+     * @param  string  $appId
+     * @return void
+     */
+    protected function writeNewEnvironmentFileWith($appId)
+    {
+        file_put_contents($this->laravel->environmentFilePath(), preg_replace(
+            $this->appIdReplacementPattern(),
+            'APP_ID='.$appId,
+            file_get_contents($this->laravel->environmentFilePath())
+        ));
+    }
+
+    /**
+     * Get a regex pattern that will match env APP_ID with any random app-id.
+     *
+     * @return string
+     */
+    protected function appIdReplacementPattern()
+    {
+        $escaped = preg_quote('='.$this->laravel['config']['app.app_id'], '/');
+
+        return "/^APP_ID{$escaped}/m";
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Foundation\Console\AppIdGenerateCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
@@ -91,6 +92,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      * @var array
      */
     protected $commands = [
+        'AppIdGenerate' => AppIdGenerateCommand::class,
         'CacheClear' => CacheClearCommand::class,
         'CacheForget' => CacheForgetCommand::class,
         'ClearCompiled' => ClearCompiledCommand::class,
@@ -204,6 +206,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         }
 
         $this->commands(array_values($commands));
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerAppIdGenerateCommand()
+    {
+        $this->app->singleton(AppIdGenerateCommand::class);
     }
 
     /**


### PR DESCRIPTION
I found that writing prefixes depends on `app_name`, which may cause data confusion, such as cache prefixes. If the user does not change `app_name`, then multiple programs may use the same prefix.

So it is recommended to use `app_id` where `unique` is required. 