### PR TITLE
[9.x] Custom Cast serialize castable attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1956,6 +1956,8 @@ trait HasAttributes
                 $this->castAttribute($key, $original);
         } elseif ($this->isClassCastable($key) && in_array($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
+        } elseif ($this->isClassSerializable($key)) {
+            return $this->serializeClassCastableAttribute($key, $attribute) === $this->serializeClassCastableAttribute($key, $original);
         }
 
         return is_numeric($attribute) && is_numeric($original)

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest;
 
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Collection;
@@ -20,6 +22,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
             $table->json('array_as_json_field')->nullable();
             $table->json('object_as_json_field')->nullable();
             $table->json('collection_as_json_field')->nullable();
+            $table->json('customcast_as_json_field')->nullable();
         });
     }
 
@@ -63,11 +66,56 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
     {
         /** @var \Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest\JsonCast $user */
         $user = JsonCast::create([
-            'collection_as_json_field' => new Collection(['key1' => 'value1']),
+            'collection_as_json_field' => new Collection(['key1' => 'value1', 'key2' => 'value2']),
         ]);
 
         $this->assertInstanceOf(Collection::class, $user->collection_as_json_field);
         $this->assertSame('value1', $user->collection_as_json_field->get('key1'));
+
+        $user->collection_as_json_field = new Collection(['key2' => 'value2', 'key1' => 'value1']);
+        $this->assertFalse($user->isDirty());
+    }
+
+    public function testCustomCastsAreCastable()
+    {
+        /** @var \Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest\JsonCast $model */
+        $model = JsonCast::create([
+            'customcast_as_json_field' => new Driver('Taylor', '123-456-7890'),
+        ]);
+
+        $this->assertInstanceOf(Driver::class, $model->customcast_as_json_field);
+        $this->assertSame('Taylor', $model->customcast_as_json_field->name);
+        $this->assertSame('123-456-7890', $model->customcast_as_json_field->phone);
+    }
+
+    public function testCustomCastsSerializesCastableAttributesAndOriginalIsEquivalent()
+    {
+        $invertedArr = [
+            'phone' => '123-456-7890',
+            'name' => 'Taylor',
+        ];
+
+        $originalArr = [
+            'name' => 'Taylor',
+            'phone' => '123-456-7890',
+        ];
+
+        \DB::table('json_casts')->insert([
+            'customcast_as_json_field' => json_encode($invertedArr)
+        ]);
+
+        /** @var \Illuminate\Tests\Integration\Database\EloquentModelJsonCastingTest\JsonCast $model */
+        $model = JsonCast::first();
+
+        $this->assertInstanceOf(Driver::class, $model->customcast_as_json_field);
+        $this->assertSame('Taylor', $model->customcast_as_json_field->name);
+        $this->assertSame('123-456-7890', $model->customcast_as_json_field->phone);
+        $this->assertSame($originalArr, $model->customcast_as_json_field->toArray());
+
+        $model->customcast_as_json_field = json_encode($originalArr);
+
+        $this->assertTrue($model->isClean('customcast_as_json_field'));
+        $this->assertTrue($model->originalIsEquivalent('customcast_as_json_field'));
     }
 }
 
@@ -77,6 +125,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
  * @property $array_as_json_field
  * @property $object_as_json_field
  * @property $collection_as_json_field
+ * @property Driver|null $customcast_as_json_field
  */
 class JsonCast extends Model
 {
@@ -90,5 +139,114 @@ class JsonCast extends Model
         'array_as_json_field' => 'array',
         'object_as_json_field' => 'object',
         'collection_as_json_field' => 'collection',
+        'customcast_as_json_field' => DriverCast::class,
     ];
+}
+
+/**
+ * Eloquent Casts...
+ */
+class DriverCast implements CastsAttributes, SerializesCastableAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return Driver
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        $value = json_decode($value, true);
+
+        return Driver::fromArray(is_array($value) ? $value : []);
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  Driver|string|null  $value
+     * @param  array  $attributes
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        if ($value instanceof Driver) {
+            $valueAsArray = $value->toArray();
+        } else {
+            $value = is_null($value) ? [] : json_decode($value, true);
+            $valueAsArray = Driver::fromArray(is_array($value) ? $value : []);
+        }
+
+        return json_encode($valueAsArray);
+    }
+
+    /**
+     * Get the serialized representation of the value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function serialize($model, string $key, $value, array $attributes)
+    {
+        if ($value instanceof Driver) {
+            return $value->toArray();
+        }
+        if (is_array($value)) {
+            return $value;
+        }
+
+        return null;
+    }
+}
+
+class Driver
+{
+    /**
+     * @var string|null
+     */
+    public $name;
+
+    /**
+     * @var string|null
+     */
+    public $phone;
+
+    public function __construct($name, $phone)
+    {
+        $this->name = $name;
+        $this->phone = $phone;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'name' => $this->name,
+            'phone' => $this->phone,
+        ];
+    }
+
+    /**
+     * @param  array|null  $driver
+     * @return Driver
+     */
+    public static function fromArray(array $driver = null)
+    {
+        $driver = is_array($driver) ? $driver : [];
+
+        return new self(
+            $driver['name'] ?? null,
+            $driver['phone'] ?? null
+        );
+    }
 }


### PR DESCRIPTION

[Two JSON objects are equal if they have the same set of keys, and each key has the same value in both objects](https://dev.mysql.com/doc/refman/8.0/en/json.html#json-comparison).
```php
{"a": 1, "b": 2} = {"b": 2, "a": 1}
```

Now if you want to casts your JSON attribute to a [Custom Cast](https://laravel.com/docs/9.x/eloquent-mutators#attribute-casting) and the json keys do not match the **serialized** representation of the value, Laravel determines the given attribute(s) have been modified ("is dirty"). 

We don't have this issue with the "AsCollection" and "AsArrayObject" casts because Laravel will decode first to compare the values.

Thanks.