### PR TITLE
[9.x] Directly return the condition result.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1411,7 +1411,7 @@ trait HasAttributes
     public function hasCast($key, $types = null)
     {
         if (array_key_exists($key, $this->getCasts())) {
-            return $types ? in_array($this->getCastType($key), (array) $types, true) : true;
+            return ! $types || in_array($this->getCastType($key), (array) $types, true);
         }
 
         return false;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -985,8 +985,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // that is already in this database using the current IDs in this "where"
         // clause to only update this model. Otherwise, we'll just insert them.
         if ($this->exists) {
-            $saved = $this->isDirty() ?
-                        $this->performUpdate($query) : true;
+            $saved = ! $this->isDirty() || $this->performUpdate($query);
         }
 
         // If the model is brand new, we'll insert it into our database and set the

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2379,8 +2379,7 @@ class Builder implements BuilderContract
     {
         return Collection::make($this->orders)
                     ->reject(function ($order) use ($column) {
-                        return isset($order['column'])
-                               ? $order['column'] === $column : false;
+                        return isset($order['column']) && $order['column'] === $column;
                     })->values()->all();
     }
 

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -25,9 +25,7 @@ class SQLiteBuilder extends Builder
      */
     public function dropDatabaseIfExists($name)
     {
-        return File::exists($name)
-            ? File::delete($name)
-            : true;
+        return ! File::exists($name) || File::delete($name);
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -246,6 +246,6 @@ class WorkCommand extends Command
      */
     protected function downForMaintenance()
     {
-        return $this->option('force') ? false : $this->laravel->isDownForMaintenance();
+        return ! $this->option('force') && $this->laravel->isDownForMaintenance();
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -564,7 +564,7 @@ class Worker
      */
     protected function markJobAsFailedIfItShouldFailOnTimeout($connectionName, $job, Throwable $e)
     {
-        if (method_exists($job, 'shouldFailOnTimeout') ? $job->shouldFailOnTimeout() : false) {
+        if (method_exists($job, 'shouldFailOnTimeout') && $job->shouldFailOnTimeout()) {
             $this->failJob($job, $e);
         }
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1699,11 +1699,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'exclude_with');
 
-        if (! Arr::has($this->data, $parameters[0])) {
-            return true;
-        }
-
-        return false;
+        return ! Arr::has($this->data, $parameters[0]);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -786,7 +786,7 @@ class Validator implements ValidatorContract
      */
     protected function hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute)
     {
-        return in_array($rule, ['Unique', 'Exists']) ? ! $this->messages->has($attribute) : true;
+        return ! in_array($rule, ['Unique', 'Exists']) || ! $this->messages->has($attribute);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In many cases, conditions can be simplified: there is no need returning true or false, when we just have to return the condition result.

eg.

```php
// before
if (! Arr::has($this->data, $parameters[0])) {
    return true;
 }
 return false;

// after
return ! Arr::has($this->data, $parameters[0]);
```
