### PR TITLE
[9.x] Allow int as type for value in pluck

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -701,7 +701,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get the values of a given key.
      *
-     * @param  string|array<array-key, string>  $value
+     * @param  string|int|array<array-key, string>  $value
      * @param  string|null  $key
      * @return static<int, mixed>
      */


### PR DESCRIPTION
The Collection pluck method has always (silently) supported passing an array index key as the value, allowing you to pluck by index key. This may or may not have been intentional, but seeing as Arr::pluck() does allow for int as a value, it seems as if it should be possible. Unfortunately static analyses fails because this method does not support the int type for the value parameter. 

```
collect([
  ['a','b','c'],
  ['d','e','f'],
  ['g','h','i'],
])->pluck(1);

['b','e','h']
```

If it is in fact explicitly unsupported, then just close this PR.