### PR TITLE
Override variadic parameter

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -933,6 +933,12 @@ class Container implements ArrayAccess, ContainerContract
             // If the dependency has an override for this particular build we will use
             // that instead as the value. Otherwise, we will continue with this run
             // of resolutions and let reflection attempt to determine the result.
+            if ($dependency->isVariadic() && $this->hasParameterOverride($dependency)) {
+                $results = array_merge($results, $this->getParameterOverride($dependency));
+
+                continue;
+            }
+
             if ($this->hasParameterOverride($dependency)) {
                 $results[] = $this->getParameterOverride($dependency);
 

--- a/tests/Container/ContainerResolveNonInstantiableTest.php
+++ b/tests/Container/ContainerResolveNonInstantiableTest.php
@@ -23,6 +23,14 @@ class ContainerResolveNonInstantiableTest extends TestCase
         $this->assertCount(0, $parent->child->objects);
         $this->assertSame(42, $parent->i);
     }
+
+    public function testResolvingOverrideVariadic()
+    {
+        $container = new Container;
+        $childClass = $container->make(ChildClass::class, ['objects' => [new TestClass(), new TestClass()]]);
+
+        $this->assertCount(2, $childClass->objects);
+    }
 }
 
 interface TestInterface
@@ -72,4 +80,8 @@ class ChildClass
     {
         $this->objects = $objects;
     }
+}
+
+class TestClass implements TestInterface
+{
 }


### PR DESCRIPTION
Issue creating object with variadic parameters
Example:
```
class ClassWithVariadicParameters
{
    public function __construct(TestInterface ...$objects)
}

$container = new Container;
$container->make(
    ClassWithVariadicParameters::class,
    [
        'objects' => [
            $container->make(TestInterface::class), 
            $container->make(TestInterface::class)
        ]
    ]
);

```
Error: 
`Argument 1 passed to ClassWithVariadicParameters::__construct() must implement interface TestInterface, array given`

@driesvints 


