### PR TITLE
[9.x] Fire event before route matched

### DIFF
--- a/src/Illuminate/Routing/Events/RouteMatching.php
+++ b/src/Illuminate/Routing/Events/RouteMatching.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Routing\Events;
+
+class RouteMatching
+{
+    /**
+     * The request instance.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    public function __construct($request)
+    {
+        $this->request = $request;
+    }
+}

--- a/src/Illuminate/Routing/Events/Routing.php
+++ b/src/Illuminate/Routing/Events/Routing.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Routing\Events;
 
-class RouteMatching
+class Routing
 {
     /**
      * The request instance.

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -16,6 +16,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Routing\Events\RouteMatching;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -674,6 +675,8 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function findRoute($request)
     {
+        $this->events->dispatch(new RouteMatching($request));
+
         $this->current = $route = $this->routes->match($request);
 
         $route->setContainer($this->container);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -16,7 +16,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Events\RouteMatched;
-use Illuminate\Routing\Events\RouteMatching;
+use Illuminate\Routing\Events\Routing;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -675,7 +675,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function findRoute($request)
     {
-        $this->events->dispatch(new RouteMatching($request));
+        $this->events->dispatch(new Routing($request));
 
         $this->current = $route = $this->routes->match($request);
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -19,7 +19,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
-use Illuminate\Routing\Events\RouteMatching;
+use Illuminate\Routing\Events\Routing;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Routing\ResourceRegistrar;
@@ -1539,7 +1539,7 @@ class RoutingRouteTest extends TestCase
 
         $_SERVER['__router.request'] = null;
 
-        $events->listen(RouteMatching::class, function ($event) {
+        $events->listen(Routing::class, function ($event) {
             $_SERVER['__router.request'] = $event->request;
         });
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -19,6 +19,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Illuminate\Routing\Events\RouteMatching;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Routing\ResourceRegistrar;
@@ -1521,6 +1522,32 @@ class RoutingRouteTest extends TestCase
         $this->assertInstanceOf(Route::class, $_SERVER['__router.route']);
         $this->assertEquals($_SERVER['__router.route']->uri(), $route->uri());
         unset($_SERVER['__router.route']);
+    }
+
+    public function testRouterFiresRouteMatchingEvent()
+    {
+        $container = new Container;
+        $router = new Router($events = new Dispatcher, $container);
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+        $router->get('foo/bar', function () {
+            return '';
+        });
+
+        $request = Request::create('http://foo.com/foo/bar', 'GET');
+
+        $_SERVER['__router.request'] = null;
+
+        $events->listen(RouteMatching::class, function ($event) {
+            $_SERVER['__router.request'] = $event->request;
+        });
+
+        $router->dispatchToRoute($request);
+
+        $this->assertInstanceOf(Request::class, $_SERVER['__router.request']);
+        $this->assertEquals($_SERVER['__router.request'], $request);
+        unset($_SERVER['__router.request']);
     }
 
     public function testRouterPatternSetting()


### PR DESCRIPTION
Fire a new RouteMatching event before the router attempts to find a matching route. This event is a companion to the existing RouteMatched event and allows a developer access to work with the request immediately before and after routing. Since this is simply adding a new event that existing applications will not be subscribed to, I believe it is fully backward compatible. Thank you for your consideration.