### PR TITLE
[9.x] Database queries containing JSON paths support array index braces, part 2

### DIFF
--- a/src/Illuminate/Database/Concerns/CompilesJsonPath.php
+++ b/src/Illuminate/Database/Concerns/CompilesJsonPath.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+use Illuminate\Support\Str;
+
+trait CompilesJsonPath
+{
+    /**
+     * Split the given JSON selector into the field and the optional path and wrap them separately.
+     *
+     * @param  string  $column
+     * @return array
+     */
+    protected function wrapJsonFieldAndPath($column)
+    {
+        $parts = explode('->', $column, 2);
+
+        $field = $this->wrap($parts[0]);
+
+        $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1], '->') : '';
+
+        return [$field, $path];
+    }
+
+    /**
+     * Wrap the given JSON path.
+     *
+     * @param  string  $value
+     * @param  string  $delimiter
+     * @return string
+     */
+    protected function wrapJsonPath($value, $delimiter = '->')
+    {
+        $value = preg_replace("/([\\\\]+)?\\'/", "''", $value);
+
+        $jsonPath = collect(explode($delimiter, $value))
+            ->map(fn ($segment) =>  $this->wrapJsonPathSegment($segment))
+            ->join('.');
+
+        return "'$".(str_starts_with($jsonPath, '[') ? '' : '.').$jsonPath."'";
+    }
+
+    /**
+     * Wrap the given JSON path segment.
+     *
+     * @param  string  $segment
+     * @return string
+     */
+    protected function wrapJsonPathSegment($segment)
+    {
+        if (preg_match('/(\[[^\]]+\])+$/', $segment, $parts)) {
+            $key = Str::beforeLast($segment, $parts[0]);
+
+            if (! empty($key)) {
+                return '"'.$key.'"'.$parts[0];
+            }
+
+            return $parts[0];
+        }
+
+        return '"'.$segment.'"';
+    }
+}

--- a/src/Illuminate/Database/Concerns/CompilesJsonPaths.php
+++ b/src/Illuminate/Database/Concerns/CompilesJsonPaths.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Concerns;
 
 use Illuminate\Support\Str;
 
-trait CompilesJsonPath
+trait CompilesJsonPaths
 {
     /**
      * Split the given JSON selector into the field and the optional path and wrap them separately.

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -2,15 +2,17 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
+use Illuminate\Database\Concerns\CompilesJsonPath;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use RuntimeException;
 
 class Grammar extends BaseGrammar
 {
+    use CompilesJsonPath;
+
     /**
      * The grammar specific operators.
      *
@@ -1257,64 +1259,6 @@ class Grammar extends BaseGrammar
     protected function wrapJsonBooleanValue($value)
     {
         return $value;
-    }
-
-    /**
-     * Split the given JSON selector into the field and the optional path and wrap them separately.
-     *
-     * @param  string  $column
-     * @return array
-     */
-    protected function wrapJsonFieldAndPath($column)
-    {
-        $parts = explode('->', $column, 2);
-
-        $field = $this->wrap($parts[0]);
-
-        $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1], '->') : '';
-
-        return [$field, $path];
-    }
-
-    /**
-     * Wrap the given JSON path.
-     *
-     * @param  string  $value
-     * @param  string  $delimiter
-     * @return string
-     */
-    protected function wrapJsonPath($value, $delimiter = '->')
-    {
-        $value = preg_replace("/([\\\\]+)?\\'/", "''", $value);
-
-        $jsonPath = collect(explode($delimiter, $value))
-            ->map(function ($segment) {
-                return $this->wrapJsonPathSegment($segment);
-            })
-            ->join('.');
-
-        return "'$".(str_starts_with($jsonPath, '[') ? '' : '.').$jsonPath."'";
-    }
-
-    /**
-     * Wrap the given JSON path segment.
-     *
-     * @param  string  $segment
-     * @return string
-     */
-    protected function wrapJsonPathSegment($segment)
-    {
-        if (preg_match('/(\[[^\]]+\])+$/', $segment, $parts)) {
-            $key = Str::beforeLast($segment, $parts[0]);
-
-            if (! empty($key)) {
-                return '"'.$key.'"'.$parts[0];
-            }
-
-            return $parts[0];
-        }
-
-        return '"'.$segment.'"';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
-use Illuminate\Database\Concerns\CompilesJsonPath;
+use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
@@ -11,7 +11,7 @@ use RuntimeException;
 
 class Grammar extends BaseGrammar
 {
-    use CompilesJsonPath;
+    use CompilesJsonPaths;
 
     /**
      * The grammar specific operators.

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager as SchemaManager;
 use Doctrine\DBAL\Schema\TableDiff;
-use Illuminate\Database\Concerns\CompilesJsonPath;
+use Illuminate\Database\Concerns\CompilesJsonPaths;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Expression;
@@ -15,7 +15,7 @@ use RuntimeException;
 
 abstract class Grammar extends BaseGrammar
 {
-    use CompilesJsonPath;
+    use CompilesJsonPaths;
 
     /**
      * If this Grammar supports schema changes wrapped in a transaction.

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager as SchemaManager;
 use Doctrine\DBAL\Schema\TableDiff;
+use Illuminate\Database\Concerns\CompilesJsonPath;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Expression;
@@ -14,6 +15,8 @@ use RuntimeException;
 
 abstract class Grammar extends BaseGrammar
 {
+    use CompilesJsonPath;
+
     /**
      * If this Grammar supports schema changes wrapped in a transaction.
      *
@@ -271,37 +274,6 @@ abstract class Grammar extends BaseGrammar
         return parent::wrapTable(
             $table instanceof Blueprint ? $table->getTable() : $table
         );
-    }
-
-    /**
-     * Split the given JSON selector into the field and the optional path and wrap them separately.
-     *
-     * @param  string  $column
-     * @return array
-     */
-    protected function wrapJsonFieldAndPath($column)
-    {
-        $parts = explode('->', $column, 2);
-
-        $field = $this->wrap($parts[0]);
-
-        $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1], '->') : '';
-
-        return [$field, $path];
-    }
-
-    /**
-     * Wrap the given JSON path.
-     *
-     * @param  string  $value
-     * @param  string  $delimiter
-     * @return string
-     */
-    protected function wrapJsonPath($value, $delimiter = '->')
-    {
-        $value = preg_replace("/([\\\\]+)?\\'/", "''", $value);
-
-        return '\'$."'.str_replace($delimiter, '"."', $value).'"\'';
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1297,6 +1297,21 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame("create table `users` (`my_json_column` varchar(255) not null, `my_other_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"some_attribute\".\"nested\"'))))", $statements[0]);
     }
 
+    public function testCreateTableWithVirtualAsColumnWhenJsonColumnHasArrayKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->string('my_json_column')->virtualAsJson('my_json_column->foo[0][1]');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table `users` (`my_json_column` varchar(255) as (json_unquote(json_extract(`my_json_column`, '$.\"foo\"[0][1]'))))", $statements[0]);
+    }
+
     public function testCreateTableWithStoredAsColumn()
     {
         $conn = $this->getConnection();

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -923,6 +923,21 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('create table "users" ("my_json_column" varchar not null, "my_other_column" varchar as (json_extract("my_json_column", \'$."some_attribute"."nested"\')))', $statements[0]);
     }
 
+    public function testCreateTableWithVirtualAsColumnWhenJsonColumnHasArrayKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->string('my_json_column')->virtualAsJson('my_json_column->foo[0][1]');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame("create table \"users\" (\"my_json_column\" varchar as (json_extract(\"my_json_column\", '$.\"foo\"[0][1]')))", $statements[0]);
+    }
+
     public function testCreateTableWithStoredAsColumn()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Integration/Database/Postgres/DatabasePostgresConnectionTest.php
+++ b/tests/Integration/Database/Postgres/DatabasePostgresConnectionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Postgres;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @requires extension pdo_pgsql
+ * @requires OS Linux|Darwin
+ */
+class DatabasePostgresConnectionTest extends PostgresTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        if (! Schema::hasTable('json_table')) {
+            Schema::create('json_table', function (Blueprint $table) {
+                $table->json('json_col')->nullable();
+            });
+        }
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('json_table');
+    }
+
+    /**
+     * @dataProvider jsonWhereNullDataProvider
+     */
+    public function testJsonWhereNull($expected, $key, array $value = ['value' => 123])
+    {
+        DB::table('json_table')->insert(['json_col' => json_encode($value)]);
+
+        $this->assertSame($expected, DB::table('json_table')->whereNull("json_col->$key")->exists());
+    }
+
+    /**
+     * @dataProvider jsonWhereNullDataProvider
+     */
+    public function testJsonWhereNotNull($expected, $key, array $value = ['value' => 123])
+    {
+        DB::table('json_table')->insert(['json_col' => json_encode($value)]);
+
+        $this->assertSame(! $expected, DB::table('json_table')->whereNotNull("json_col->$key")->exists());
+    }
+
+    public function jsonWhereNullDataProvider()
+    {
+        return [
+            'key not exists' => [true, 'invalid'],
+            'key exists and null' => [true, 'value', ['value' => null]],
+            'key exists and "null"' => [false, 'value', ['value' => 'null']],
+            'key exists and not null' => [false, 'value', ['value' => false]],
+            'nested key not exists' => [true, 'nested->invalid'],
+            'nested key exists and null' => [true, 'nested->value', ['nested' => ['value' => null]]],
+            'nested key exists and "null"' => [false, 'nested->value', ['nested' => ['value' => 'null']]],
+            'nested key exists and not null' => [false, 'nested->value', ['nested' => ['value' => false]]],
+            'array index not exists' => [true, '[0]', [1 => 'invalid']],
+            'array index exists and null' => [true, '[0]', [null]],
+            'array index exists and "null"' => [false, '[0]', ['null']],
+            'array index exists and not null' => [false, '[0]', [false]],
+            'multiple array index not exists' => [true, '[0][0]', [1 => [1 => 'invalid']]],
+            'multiple array index exists and null' => [true, '[0][0]', [[null]]],
+            'multiple array index exists and "null"' => [false, '[0][0]', [['null']]],
+            'multiple array index exists and not null' => [false, '[0][0]', [[false]]],
+            'nested array index not exists' => [true, 'nested[0]', ['nested' => [1 => 'nested->invalid']]],
+            'nested array index exists and null' => [true, 'nested->value[1]', ['nested' => ['value' => [0, null]]]],
+            'nested array index exists and "null"' => [false, 'nested->value[1]', ['nested' => ['value' => [0, 'null']]]],
+            'nested array index exists and not null' => [false, 'nested->value[1]', ['nested' => ['value' => [0, false]]]],
+        ];
+    }
+
+    public function testJsonPathUpdate()
+    {
+        DB::table('json_table')->insert([
+            ['json_col' => '{"foo":["bar"]}'],
+            ['json_col' => '{"foo":["baz"]}'],
+            ['json_col' => '{"foo":[["array"]]}'],
+        ]);
+
+        $updatedCount = DB::table('json_table')->where('json_col->foo[0]', 'baz')->update([
+            'json_col->foo[0]' => 'updated',
+        ]);
+        $this->assertSame(1, $updatedCount);
+
+        $updatedCount = DB::table('json_table')->where('json_col->foo[0][0]', 'array')->update([
+            'json_col->foo[0][0]' => 'updated',
+        ]);
+        $this->assertSame(1, $updatedCount);
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/laravel/framework/pull/38391 meant to fix https://github.com/laravel/framework/issues/26415
Related to today's PR https://github.com/laravel/framework/pull/41756

1. ```php
   DB::table('json_table')
       ->where('column->json_option[0]', 'foo')
       ->update(['column->json_option[0]', => 'bar']);
   ```

   The previous PR allowed the above query to match by JSON array index. But the fixes didn't apply to the Postgres database driver that overrides `PostgresGrammer@wrapJsonSelector()`.

   Postgres does already support this:

   ```php
   DB::table('json_table')
      ->where('column->json_option->0', 'foo')
      ->update(['column->json_option->0', => 'bar']);
   ```

   This fix allows the first PHP snippet to also work, bringing it in line with the other database drivers. SQL:

   ```sql
   -- before
   update "json_table"
   set "column" = jsonb_set("column"::jsonb, '{"json_option[0]"}', '"bar"'::jsonb)
   where ("column"->'json_option[0]')::jsonb = '"foo"'::jsonb;
   
   -- after, array index is extracted and braces are stripped
   update "json_table"
   set "column" = jsonb_set("column"::jsonb, '{"json_option",0}', '"bar"'::jsonb)
   where ("column"->'json_option'->0)::jsonb = '"foo"'::jsonb;
   ```

   Now the GitHub Actions config has a Postgres container I've added some integration tests.
2. `Illuminate\Database\Schema\Grammars\Grammar@wrapJsonFieldAndPath()` was a copy and paste duplicate from `Illuminate\Database\Query\Grammars\Grammar` and didn't receive the same fixes from the previous PR. It's a far edge case for column methods `virtualAsJson()` and `storedAsJson()` to use an array index but it probably makes sense for these classes to share a trait for compiling SQL containing JSON paths.