### PR TITLE
[9.x] Add `whenNotNull` method

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -147,8 +147,8 @@ trait ConditionallyLoadsAttributes
     /**
      * Retrieve a model attribute if it has been selected.
      *
-     * @param mixed $value
-     * @param mixed $default
+     * @param  mixed  $value
+     * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
     protected function whenSelected($value, $default = null)
@@ -157,7 +157,7 @@ trait ConditionallyLoadsAttributes
             $args = [$value] :
             $args = [$value, $default];
 
-        return $this->when(!is_null($value), ...$args);
+        return $this->when(! is_null($value), ...$args);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -151,7 +151,7 @@ trait ConditionallyLoadsAttributes
      * @param  mixed  $default
      * @return \Illuminate\Http\Resources\MissingValue|mixed
      */
-    protected function whenSelected($value, $default = null)
+    protected function whenNotNull($value, $default = null)
     {
         $args = func_num_args() == 1 ?
             [$value] :

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -153,9 +153,9 @@ trait ConditionallyLoadsAttributes
      */
     protected function whenSelected($value, $default = null)
     {
-        func_num_args() == 1 ?
-            $args = [$value] :
-            $args = [$value, $default];
+        $args = func_num_args() == 1 ?
+            [$value] :
+            [$value, $default];
 
         return $this->when(! is_null($value), ...$args);
     }

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -145,6 +145,22 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
+     * Retrieve a model attribute if it has been selected.
+     *
+     * @param mixed $value
+     * @param mixed $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    protected function whenSelected($value, $default = null)
+    {
+        func_num_args() == 1 ?
+            $args = [$value] :
+            $args = [$value, $default];
+
+        return $this->when(!is_null($value), ...$args);
+    }
+
+    /**
      * Retrieve an accessor when it has been appended.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -145,7 +145,7 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a model attribute if it has been selected.
+     * Retrieve a model attribute if it is not null.
      *
      * @param  mixed  $value
      * @param  mixed  $default
@@ -153,11 +153,9 @@ trait ConditionallyLoadsAttributes
      */
     protected function whenNotNull($value, $default = null)
     {
-        $args = func_num_args() == 1 ?
-            [$value] :
-            [$value, $default];
+        $arguments = func_num_args() == 1 ? [$value] : [$value, $default];
 
-        return $this->when(! is_null($value), ...$args);
+        return $this->when(! is_null($value), ...$arguments);
     }
 
     /**

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalAttributes.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalAttributes.php
@@ -9,8 +9,8 @@ class PostResourceWithOptionalAttributes extends JsonResource
     public function toArray($request)
     {
         return [
-            'id' => $this->whenSelected($this->id),
-            'title' => $this->whenSelected($this->title, 'no title'),
+            'id' => $this->whenNotNull($this->id),
+            'title' => $this->whenNotNull($this->title, 'no title'),
         ];
     }
 }

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalAttributes.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalAttributes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithOptionalAttributes extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->whenSelected($this->id),
+            'title' => $this->whenSelected($this->title, 'no title'),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -28,6 +28,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithExtraData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithJsonOptions;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithJsonOptionsAndTypeHints;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAppendedAttributes;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
@@ -159,6 +160,28 @@ class ResourceTest extends TestCase
                 'third' => 'value',
                 'fourth' => 'default',
                 'fifth' => 'default',
+            ],
+        ]);
+    }
+
+    public function testResourcesMayHaveOptionalSelectedAttributes()
+    {
+        Route::get('/', function () {
+            return new PostResourceWithOptionalAttributes(new Post([
+                'id' => 5,
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                'id' => 5,
+                'title' => 'no title',
             ],
         ]);
     }


### PR DESCRIPTION
This PR adds a new whenSelectedMethod to the ConditionallyLoadsAttributes trait. This is basically a syntactic sugar around the when method. Working with the spatie query builder, I found that I was iterating the same checks for every resource, so maybe this little wrapper could be helpful to maintain the logic inside the Resource as clean as possible.