### PR TITLE
Laravel is not respecting time zone settings in the php.ini

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -46,7 +46,7 @@ class LoadConfiguration
             return $config->get('app.env', 'production');
         });
 
-        date_default_timezone_set($config->get('app.timezone', 'UTC'));
+        date_default_timezone_set($config->get('app.timezone', date_default_timezone_get()));
 
         mb_internal_encoding('UTF-8');
     }


### PR DESCRIPTION
Currently, the `date.timezone` setting in the php.ini is ignored.

Removing "timezone" from the `app/config.php` will always default to UTC no matter what but `date_default_timezone_get()` will default to UTC if the `date.timezone` setting is not set but use the timezone specified if it is set. 

Developers can still set a default timezone in the php.ini, have it be respected, and override it in the application if necessary.

I have a follow-up change for `laravel/laravel` to comment the timezone config by default.