### PR TITLE
[9.x] Ignore empty redis username string in `PhpRedisConnector`

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -83,8 +83,8 @@ class PhpRedisConnector implements Connector
 
             $this->establishConnection($client, $config);
 
-            if (! empty($config['password'])) {
-                if (isset($config['username']) && is_string($config['password'])) {
+            if (!empty($config['password'])) {
+                if (isset($config['username']) && $config['username'] !== '' && is_string($config['password'])) {
                     $client->auth([$config['username'], $config['password']]);
                 } else {
                     $client->auth($config['password']);

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -83,7 +83,7 @@ class PhpRedisConnector implements Connector
 
             $this->establishConnection($client, $config);
 
-            if (!empty($config['password'])) {
+            if (! empty($config['password'])) {
                 if (isset($config['username']) && $config['username'] !== '' && is_string($config['password'])) {
                     $client->auth([$config['username'], $config['password']]);
                 } else {


### PR DESCRIPTION
A username option was added to the `PhpRedisConnector` in https://github.com/laravel/framework/pull/41683.

However, some services, such as Heroku, produce a `REDIS_URL` connection string that has an empty username part.

This is causing the following exception:

```
RedisException: WRONGPASS invalid username-password pair or user is disabled.
```

So given the following `REDIS_URL` format:

```
redis://username:password@host:port
```

The following url string, with a blank username, will thrown an error.

```
redis://:abc123@redishost.example:12345
```

## Solution

I have added an extra check to ensure that the provided username isn't an empty string before attempting to use it.

## Considerations

I have used a `$config['username'] !== ''` check rather than `! empty($config['username'])` in the small off chance that the username value is falsey (eg `0`).

You might just say why not update the `REDIS_URL` and replace the empty username part with `null`. 

That's possible, but the issue is services such as Heroku will generate these `REDIS_*` variables at any time, such as when upgrading the redis instance, so it would need to be manually changed each time the credentials were generated.

## Tests

Sorry, I couldn't see any existing tests for this class so wasn't quite sure where to begin.

Feel free to point me in the right direction if a test is required for this.

