### PR TITLE
Custom key support for implicit enum route binding

### DIFF
--- a/src/Illuminate/Routing/Exceptions/BackedEnumImplicitKeyMethodNotFoundException.php
+++ b/src/Illuminate/Routing/Exceptions/BackedEnumImplicitKeyMethodNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Routing\Exceptions;
+
+use RuntimeException;
+
+class BackedEnumImplicitKeyMethodNotFoundException extends RuntimeException
+{
+    /**
+     * Create a new exception instance.
+     *
+     * @param  string  $backedEnumClass
+     * @param  string  $key
+     * @return void
+     */
+    public function __construct($backedEnumClass, $key)
+    {
+        parent::__construct("Implicit key method [{$key}] not found on Backed Enum [{$backedEnumClass}].");
+    }
+}

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -125,7 +125,7 @@ class ImplicitRouteBinding
 
     protected static function getBackedEnumForBoundKey($enumClass, $field, $parameterValue)
     {
-        foreach($enumClass::cases() as $case) {
+        foreach ($enumClass::cases() as $case) {
             if ((string) $case->{$field}() === (string) $parameterValue) {
                 return $case;
             }

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -28,7 +28,7 @@ class RouteSignatureParameters
 
         return match (true) {
             ! empty($conditions['subClass']) => array_filter($parameters, fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
-            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithStringBackingType($p)),
+            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnum($p)),
             default => $parameters,
         };
     }

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -141,6 +141,25 @@ class Reflector
     }
 
     /**
+     * Determine if the parameter's type is a Backed Enum.
+     *
+     * @param  \ReflectionParameter  $parameter
+     * @return bool
+     */
+    public static function isParameterBackedEnum($parameter)
+    {
+        $backedEnumClass = (string) $parameter->getType();
+
+        if (function_exists('enum_exists') && enum_exists($backedEnumClass)) {
+            $reflectionBackedEnum = new ReflectionEnum($backedEnumClass);
+
+            return $reflectionBackedEnum->isBacked();
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if the parameter's type is a Backed Enum with a string backing type.
      *
      * @param  \ReflectionParameter  $parameter

--- a/tests/Routing/Enums.php
+++ b/tests/Routing/Enums.php
@@ -13,3 +13,17 @@ enum CategoryBackedEnum: string
     case People = 'people';
     case Fruits = 'fruits';
 }
+
+enum CategoryBackedEnumWithKey: int
+{
+    case People = 1;
+    case Fruits = 2;
+
+    public function slug(): string
+    {
+        return match($this) {
+            self::People => 'people',
+            self::Fruits => 'fruits',
+        };
+    }
+}

--- a/tests/Routing/Enums.php
+++ b/tests/Routing/Enums.php
@@ -21,7 +21,7 @@ enum CategoryBackedEnumWithKey: int
 
     public function slug(): string
     {
-        return match($this) {
+        return match ($this) {
             self::People => 'people',
             self::Fruits => 'fruits',
         };

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -39,6 +39,28 @@ class ImplicitRouteBindingTest extends TestCase
     /**
      * @requires PHP >= 8.1
      */
+    public function test_it_can_resolve_the_implicit_backed_enum_route_with_key_bindings_for_the_given_route()
+    {
+        $action = ['uses' => function (CategoryBackedEnumWithKey $category) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['category' => 'fruits'];
+        $route->setBindingFields(['category' => 'slug']);
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertSame(2, $route->parameter('category')->value);
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
     public function test_it_does_not_resolve_implicit_non_backed_enum_route_bindings_for_the_given_route()
     {
         $action = ['uses' => function (CategoryEnum $category) {


### PR DESCRIPTION
This PR introduces "custom key" support for implicitly bound enums in routes, similarly to Eloquent models.

```php
Route::get('{category:slug}', ...);
```

```php
enum Category: int {
    case People = 1;
    case Fruits = 2;

    public function slug(): string
    {
        // Up to the developer to define this...
        return match($this) {
            self::People => 'people',
            self::Fruits => 'fruits',
        };
    }
}
```

**Rationale**
An enum is often used as a model attribute to simplify DX while still efficiently persisting integers in the database. There are ample of situations where a model's enum would be included in a route as well. Currently Laravel is only able to implicitly resolve string-backed enum route bindings, but that sort of contradicts the aforementioned use case.

One could of course go with explicitly defining such an enum route binding. But since implicit model binding features a custom route key I figured a similar feature would fit the enum binding as well.

**Considerations**
The implementation of the desired "key" method is not airtight. It's up to the developer to define a value for every enum case. However, this can also be seen as an opportunity: a specific case can simply be omitted to make the binding return a 404 for that case...

**Original PR for implicit enum binding**
https://github.com/laravel/framework/pull/40281