### PR TITLE
[9.x] Http Client: provide pending request to retry callback

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -715,7 +715,7 @@ class PendingRequest
                     $this->populateResponse($response);
 
                     if (! $response->successful()) {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException()) : true;
+                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException(), $this) : true;
 
                         if ($attempt < $this->tries && $shouldRetry) {
                             $response->throw();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1271,6 +1271,31 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(1);
     }
 
+    public function testRequestCanBeModifiedInRetryCallback()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->sequence()
+                ->push(['error'], 500)
+                ->push(['ok'], 200),
+        ]);
+
+        $response = $this->factory
+            ->retry(2, 1000, function ($exception, $request) {
+                $this->assertInstanceOf(PendingRequest::class, $request);
+
+                $request->withHeaders(['Foo' => 'Bar']);
+
+                return true;
+            }, false)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->successful());
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->hasHeader('Foo') && $request->header('Foo') === ['Bar'];
+        });
+    }
+
     public function testMiddlewareRunsWhenFaked()
     {
         $this->factory->fake(function (Request $request) {


### PR DESCRIPTION
In a couple of our projects, we are using the `retry` method of the Http Client to handle authentication errors. If a 401 error is thrown, we request a new token and then retry.
To achieve this, we currently have to manually create a request variable and pass the variable inside the closure in order to modify the request and set a new token on the request.
```php
($request = Http::baseUrl(...))
  ->withToken($this->getToken())
  ->retry(2, 0, function ($exception) use ($request) {
      if ($exception->response->status() !== 401) {
          return false;
      }
  
      $request->withToken($this->getNewToken());
  
      return true;
  })
  ->get('...');
```
This PR allows you to access the request as a parameter of the closure:
```php
Http::baseUrl(...)
  ->withToken($this->getToken())
  ->retry(2, 0, function ($exception, $request) { 
      if ($exception->response->status() !== 401) {
          return false;
      }
  
      $request->withToken($this->getNewToken());
  
      return true;
  })
  ->get('...');
```