### PR TITLE
[9.x] Fix afterCommit and RefreshDatabase

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -47,9 +47,7 @@ trait ManagesTransactions
 
                 $this->transactions = max(0, $this->transactions - 1);
 
-                if ($this->transactions == 0 ||
-                   ($this->transactionsManager &&
-                    $this->transactionsManager->callbackApplicableTransactions()->count() === 1)) {
+                if ($this->afterCommitCallbacksShouldBeExecuted()) {
                     $this->transactionsManager?->commit($this->getName());
                 }
             } catch (Throwable $e) {
@@ -195,13 +193,23 @@ trait ManagesTransactions
 
         $this->transactions = max(0, $this->transactions - 1);
 
-        if ($this->transactions == 0 ||
-            ($this->transactionsManager &&
-             $this->transactionsManager->callbackApplicableTransactions()->count() === 1)) {
+        if ($this->afterCommitCallbacksShouldBeExecuted()) {
             $this->transactionsManager?->commit($this->getName());
         }
 
         $this->fireConnectionEvent('committed');
+    }
+
+    /**
+     * Determine if after commit callbacks should be executed.
+     *
+     * @return bool
+     */
+    protected function afterCommitCallbacksShouldBeExecuted()
+    {
+        return $this->transactions == 0 ||
+            ($this->transactionsManager &&
+             $this->transactionsManager->callbackApplicableTransactions()->count() === 1);
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -47,7 +47,9 @@ trait ManagesTransactions
 
                 $this->transactions = max(0, $this->transactions - 1);
 
-                if ($this->transactions == 0) {
+                if ($this->transactions == 0 ||
+                   ($this->transactionsManager &&
+                    $this->transactionsManager->callbackApplicableTransactions()->count() === 1)) {
                     $this->transactionsManager?->commit($this->getName());
                 }
             } catch (Throwable $e) {
@@ -193,7 +195,9 @@ trait ManagesTransactions
 
         $this->transactions = max(0, $this->transactions - 1);
 
-        if ($this->transactions == 0) {
+        if ($this->transactions == 0 ||
+            ($this->transactionsManager &&
+             $this->transactionsManager->callbackApplicableTransactions()->count() === 1)) {
             $this->transactionsManager?->commit($this->getName());
         }
 

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -12,6 +12,13 @@ class DatabaseTransactionsManager
     protected $transactions;
 
     /**
+     * The database transaction that should be ignored by callbacks.
+     *
+     * @var \Illuminate\Database\DatabaseTransactionRecord
+     */
+    protected $callbacksShouldIgnore;
+
+    /**
      * Create a new database transactions manager instance.
      *
      * @return void
@@ -47,6 +54,10 @@ class DatabaseTransactionsManager
         $this->transactions = $this->transactions->reject(
             fn ($transaction) => $transaction->connection == $connection && $transaction->level > $level
         )->values();
+
+        if ($this->transactions->isEmpty()) {
+            $this->callbacksShouldIgnore = null;
+        }
     }
 
     /**
@@ -64,6 +75,10 @@ class DatabaseTransactionsManager
         $this->transactions = $forOtherConnections->values();
 
         $forThisConnection->map->executeCallbacks();
+
+        if ($this->transactions->isEmpty()) {
+            $this->callbacksShouldIgnore = null;
+        }
     }
 
     /**
@@ -74,11 +89,26 @@ class DatabaseTransactionsManager
      */
     public function addCallback($callback)
     {
-        if ($current = $this->transactions->last()) {
+        if ($current = $this->transactions->reject(function ($transaction) {
+            return $transaction === $this->callbacksShouldIgnore;
+        })->last()) {
             return $current->addCallback($callback);
         }
 
         $callback();
+    }
+
+    /**
+     * Specify that callbacks should ignore the given transaction when determining if they should be executed.
+     *
+     * @param  \Illuminate\Database\DatabaseTransactionRecord  $transaction
+     * @return $this
+     */
+    public function callbacksShouldIgnore(DatabaseTransactionRecord $transaction)
+    {
+        $this->callbacksShouldIgnore = $transaction;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseTransactionsManager.php
+++ b/src/Illuminate/Database/DatabaseTransactionsManager.php
@@ -89,9 +89,7 @@ class DatabaseTransactionsManager
      */
     public function addCallback($callback)
     {
-        if ($current = $this->transactions->reject(function ($transaction) {
-            return $transaction === $this->callbacksShouldIgnore;
-        })->last()) {
+        if ($current = $this->callbackApplicableTransactions()->last()) {
             return $current->addCallback($callback);
         }
 
@@ -109,6 +107,18 @@ class DatabaseTransactionsManager
         $this->callbacksShouldIgnore = $transaction;
 
         return $this;
+    }
+
+    /**
+     * Get the transactions that are applicable to callbacks.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function callbackApplicableTransactions()
+    {
+        return $this->transactions->reject(function ($transaction) {
+            return $transaction === $this->callbacksShouldIgnore;
+        })->values();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -93,6 +93,12 @@ trait RefreshDatabase
             $connection->unsetEventDispatcher();
             $connection->beginTransaction();
             $connection->setEventDispatcher($dispatcher);
+
+            if ($this->app->resolved('db.transactions')) {
+                $this->app->make('db.transactions')->callbacksShouldIgnore(
+                    $this->app->make('db.transactions')->getTransactions()->first()
+                );
+            }
         }
 
         $this->beforeApplicationDestroyed(function () use ($database) {


### PR DESCRIPTION
Previously, using the `RefreshDatabase` trait was fundamentally incompatible with `afterCommit`. This is because the trait is based around the fact that it opens a transaction and rolls it back at the end of the test, never committing it. 

This slight modification updates the `DatabaseTransactionManager` to "ignore" a given transaction when determining if a callback should be executed, since we want the outer transaction to essentially be invisible.

Would appreciate some feedback on if this solves people's problems and / or creates new problems.

Fix #35857 