### PR TITLE
[9.x] Enable batch jobs delay for redis queue ⏰

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -99,7 +99,11 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $this->getConnection()->pipeline(function () use ($jobs, $data, $queue) {
             $this->getConnection()->transaction(function () use ($jobs, $data, $queue) {
                 foreach ((array) $jobs as $job) {
-                    $this->push($job, $data, $queue);
+                    if (isset($job->delay)) {
+                        $this->later($job->delay, $job, $data, $queue);
+                    } else {
+                        $this->push($job, $data, $queue);
+                    }
                 }
             });
         });


### PR DESCRIPTION
enable batch jobs delay for **redis** queue ⏰

[before]
- batch jobs was ignoring delay time when pushing into redis.

[after]
- batch jobs delay time will be considered and stored into redis.

```php
use App\Jobs\ImportCsv;
use Illuminate\Bus\Batch;
use Illuminate\Support\Facades\Bus;
 
$batch = Bus::batch([
    (new ImportCsv(1, 100))->delay($delay),
    (new ImportCsv(101, 200))->delay($delay)
])->dispatch();

```
