### PR TITLE
[9.x] Add `htmlContains` and `textContains` to `Mailable` class

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -877,7 +877,7 @@ class Mailable implements MailableContract, Renderable
         $view = $this->buildView();
 
         return str_contains(
-            is_array($view) ? $view['text'] ?? $view[1] ?? '' : $view,
+            is_array($view) ? $view['text'] ?? $view[1] ?? '' : '',
             $string
         );
     }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -839,14 +839,16 @@ class Mailable implements MailableContract, Renderable
      */
     public function htmlContains(string $string)
     {
-        Container::getInstance()->call([$this, 'build']);
+        return $this->withLocale($this->locale, function () use ($string) {
+            Container::getInstance()->call([$this, 'build']);
 
-        $view = $this->buildView();
+            $view = $this->buildView();
 
-        return str_contains(
-            is_array($view) ? $view['html'] ?? $view[0] ?? '' : $view,
-            $string
-        );
+            return str_contains(
+                is_array($view) ? $view['html'] ?? $view[0] ?? '' : $view,
+                $string
+            );
+        });
     }
 
     /**
@@ -872,14 +874,16 @@ class Mailable implements MailableContract, Renderable
      */
     public function textContains(string $string)
     {
-        Container::getInstance()->call([$this, 'build']);
+        return $this->withLocale($this->locale, function () use ($string) {
+            Container::getInstance()->call([$this, 'build']);
 
-        $view = $this->buildView();
+            $view = $this->buildView();
 
-        return str_contains(
-            is_array($view) ? $view['text'] ?? $view[1] ?? '' : '',
-            $string
-        );
+            return str_contains(
+                is_array($view) ? $view['text'] ?? $view[1] ?? '' : '',
+                $string
+            );
+        });
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -832,6 +832,24 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Determine if the given string is present in the HTML email body.
+     *
+     * @param  string  $string
+     * @return bool
+     */
+    public function htmlContains(string $string)
+    {
+        Container::getInstance()->call([$this, 'build']);
+
+        $view = $this->buildView();
+
+        return str_contains(
+            is_array($view) ? $view['html'] ?? $view[0] ?? '' : $view,
+            $string
+        );
+    }
+
+    /**
      * Set the plain text view for the message.
      *
      * @param  string  $textView
@@ -844,6 +862,24 @@ class Mailable implements MailableContract, Renderable
         $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
+    }
+
+    /**
+     * Determine if the given string is present in the plain-text email body.
+     *
+     * @param  string  $string
+     * @return bool
+     */
+    public function textContains(string $string)
+    {
+        Container::getInstance()->call([$this, 'build']);
+
+        $view = $this->buildView();
+
+        return str_contains(
+            is_array($view) ? $view['text'] ?? $view[1] ?? '' : $view,
+            $string
+        );
     }
 
     /**

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -165,6 +165,15 @@ class SendingMailWithLocaleTest extends TestCase
             app('mailer')->getSymfonyTransport()->messages()[1]->toString()
         );
     }
+
+    public function testLocaleWithHtmlContains()
+    {
+        $mailable = new TestMail;
+        $mailable->locale('es');
+        $mailable->markdown('view');
+
+        $this->assertTrue($mailable->htmlContains('nombre'));
+    }
 }
 
 class TestMail extends Mailable

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -362,6 +362,17 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->textContains('Taylor Otwell'));
     }
 
+    public function testTextContainsWithViewAndNoText()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $view = m::mock(Factory::class);
+        $view->shouldNotReceive('__toString');
+
+        $mailable->view($view);
+        $this->assertFalse($mailable->textContains('Taylor Otwell'));
+    }
+
     public function testItIgnoresDuplicatedRawAttachments()
     {
         $mailable = new WelcomeMailableStub;

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -311,6 +311,57 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasSubject('foo'));
     }
 
+    public function testHtmlContains()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->html('My name is Taylor Otwell');
+
+        $this->assertTrue($mailable->htmlContains('Taylor Otwell'));
+        $this->assertFalse($mailable->htmlContains('Otwell Taylor'));
+    }
+
+    public function testHtmlContainsWithView()
+    {
+        $mailable = new WelcomeMailableStub;
+        $view = m::mock(Factory::class);
+        $view->shouldReceive('__toString')->once()->andReturn('My name is Taylor Otwell');
+
+        $mailable->view($view);
+
+        $this->assertTrue($mailable->htmlContains('Taylor Otwell'));
+    }
+
+    public function testHtmlContainsWithViewAndText()
+    {
+        $mailable = new WelcomeMailableStub;
+        $view = m::mock(Factory::class);
+        $view->shouldReceive('__toString')->once()->andReturn('My name is Taylor Otwell');
+
+        $mailable->view($view);
+        $mailable->text('text');
+
+        $this->assertTrue($mailable->htmlContains('Taylor Otwell'));
+    }
+
+    public function testTextContains()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->text('My name is Taylor Otwell');
+
+        $this->assertTrue($mailable->textContains('Taylor Otwell'));
+        $this->assertFalse($mailable->textContains('Otwell Taylor'));
+    }
+
+    public function testTextContainsWithView()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->view(m::mock(Factory::class));
+        $mailable->text('My name is Taylor Otwell');
+
+        $this->assertTrue($mailable->textContains('Taylor Otwell'));
+    }
+
     public function testItIgnoresDuplicatedRawAttachments()
     {
         $mailable = new WelcomeMailableStub;


### PR DESCRIPTION
This PR adds `htmlContains` and `textContains` to the `Mailable` class.

This way the user can check with the `Mail::assertSent` method:

## Example:

```php
Mail::fake();

Mail::assertSent(NewUserMail::class, fn ($mail) =>
    $mail->hasTo('john@doe.com') &&
    $mail->hasSubject('Login Information') &&
    $mail->htmlContains($password) &&
    $mail->textContains($password)
);
```

I also notice that are methods like the `assertSeeInHtml` but that does not work well with the `Mail::fake()`.

We can also rename it to be called like `->seeInHtml` and `->seeInText` if you think that is better.

Hope this is a cool addition,
Thanks,
Francisco