### PR TITLE
[9.x] fix adding jobs from iterable to the pending batch

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -57,12 +57,14 @@ class PendingBatch
     /**
      * Add jobs to the batch.
      *
-     * @param  \Illuminate\Support\Enumerable|object|array  $jobs
+     * @param  iterable|object|array  $jobs
      * @return $this
      */
     public function add($jobs)
     {
-        foreach (Arr::wrap($jobs) as $job) {
+        $wrappedJobs = is_iterable($jobs) ? $jobs : Arr::wrap($jobs);
+
+        foreach ($wrappedJobs as $job) {
             $this->jobs->push($job);
         }
 

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -62,9 +62,9 @@ class PendingBatch
      */
     public function add($jobs)
     {
-        $wrappedJobs = is_iterable($jobs) ? $jobs : Arr::wrap($jobs);
+        $jobs = is_iterable($jobs) ? $jobs : Arr::wrap($jobs);
 
-        foreach ($wrappedJobs as $job) {
+        foreach ($jobs as $job) {
             $this->jobs->push($job);
         }
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -147,7 +147,8 @@ class BusBatchTest extends TestCase
         $count = 3;
         $generator = function (int $jobsCount) {
             for ($i = 0; $i < $jobsCount; $i++) {
-                yield new class {
+                yield new class
+                {
                     use Batchable;
                 };
             }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -139,6 +139,24 @@ class BusBatchTest extends TestCase
         $this->assertCount(2, $batch->jobs);
     }
 
+    public function test_jobs_can_be_added_to_the_pending_batch_from_iterable()
+    {
+        $batch = new PendingBatch(new Container, collect());
+        $this->assertCount(0, $batch->jobs);
+
+        $count = 3;
+        $generator = function (int $jobsCount) {
+            for ($i = 0; $i < $jobsCount; $i++) {
+                yield new class {
+                    use Batchable;
+                };
+            }
+        };
+
+        $batch->add($generator($count));
+        $this->assertCount($count, $batch->jobs);
+    }
+
     public function test_processed_jobs_can_be_calculated()
     {
         $queue = m::mock(Factory::class);


### PR DESCRIPTION
In one of the previous PRs (#41475) has been added feature that allows to add one job to the pending batch. That feature breaks ability to add jobs to the pending batch from iterable (f.e. generators). This PR brings back this ability.