### PR TITLE
[9.x] Enable dispatchAfterResponse for batch 🔥

### DIFF
--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -271,7 +271,7 @@ class PendingBatch
     }
 
     /**
-     * Dispatch the batch after the current process.
+     * Dispatch the batch after the response is sent to the browser.
      *
      * @return \Illuminate\Bus\Batch
      */
@@ -283,7 +283,7 @@ class PendingBatch
 
         if ($batch) {
             $this->container->terminating(function () use ($batch) {
-                $this->dispatchAlreadyCreated($batch);
+                $this->dispatchExistingBatch($batch);
             });
         }
 
@@ -291,14 +291,14 @@ class PendingBatch
     }
 
     /**
-     * Dispatch already created batch.
+     * Dispatch an existing batch.
      *
      * @param \Illuminate\Bus\Batch $batch
      * @return void
      *
      * @throws \Throwable
      */
-    private function dispatchAlreadyCreated($batch)
+    protected function dispatchExistingBatch($batch)
     {
         try {
             $batch = $batch->add($this->jobs);


### PR DESCRIPTION
## Before
Batch can't be dispatched after the response is sent to the user.

## After
Batch can be dispatched and all jobs will be saved to storage after response.

## Use Case
- You need to dispatch a large number of jobs that takes a lot of time to insert into the database without blocking the current request. 
- You don't need your worker to process jobs until the response is finished.

## Changes
- added dispatchAfterResponse method to:
1. store batch itself into database
2. register a terminating callback to dispatch batch jobs
3. return created batch

- added private dispatchAlreadyCreated method to:
1. dispatch batch jobs and fire BatchDispatched event like before but without creating
batch because we already created it in dispatchAfterResponse

## Example

```php

use App\Jobs\ImportCsv;
use Illuminate\Bus\Batch;
use Illuminate\Support\Facades\Bus;
use Throwable;
 
$batch = Bus::batch([
    new ImportCsv(1, 100),
    new ImportCsv(101, 200),
    new ImportCsv(201, 300),
    new ImportCsv(301, 400),
    new ImportCsv(401, 500),
])->then(function (Batch $batch) {
    // All jobs completed successfully...
})->catch(function (Batch $batch, Throwable $e) {
    // First batch job failure detected...
})->finally(function (Batch $batch) {
    // The batch has finished executing...
})->dispatchAfterResponse();  //Jobs will be dispatched after response sent to user
 
return $batch->id; //also it returns batch object so you can access batch id 

```
