### PR TITLE
[9.x] Enable batch jobs delay for SQS queue

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -80,6 +80,25 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return void
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        foreach ((array) $jobs as $job) {
+            if (isset($job->delay)) {
+                $this->later($job->delay, $job, $data, $queue);
+            } else {
+                $this->push($job, $data, $queue);
+            }
+        }
+    }
+
+    /**
      * Push a new job onto the queue.
      *
      * @param  string  $job

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -80,25 +80,6 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
     }
 
     /**
-     * Push an array of jobs onto the queue.
-     *
-     * @param  array  $jobs
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     * @return void
-     */
-    public function bulk($jobs, $data = '', $queue = null)
-    {
-        foreach ((array) $jobs as $job) {
-            if (isset($job->delay)) {
-                $this->later($job->delay, $job, $data, $queue);
-            } else {
-                $this->push($job, $data, $queue);
-            }
-        }
-    }
-
-    /**
      * Push a new job onto the queue.
      *
      * @param  string  $job
@@ -158,6 +139,25 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
                 ])->get('MessageId');
             }
         );
+    }
+
+    /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return void
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        foreach ((array) $jobs as $job) {
+            if (isset($job->delay)) {
+                $this->later($job->delay, $job, $data, $queue);
+            } else {
+                $this->push($job, $data, $queue);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Enable batch jobs delay for **SQS** queue ⏰

[before]
- batch jobs was ignoring delay time when sending message to sqs.

[after]
- batch jobs delay time will be considered and sent to sqs.

```php
use App\Jobs\ImportCsv;
use Illuminate\Bus\Batch;
use Illuminate\Support\Facades\Bus;
 
$batch = Bus::batch([
    (new ImportCsv(1, 100))->delay($delay),
    (new ImportCsv(101, 200))->delay($delay)
])->dispatch();

```

