### PR TITLE
[9.x] Enable batch jobs delay for Beanstalkd queue

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -74,6 +74,25 @@ class BeanstalkdQueue extends Queue implements QueueContract
     }
 
     /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return void
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        foreach ((array) $jobs as $job) {
+            if (isset($job->delay)) {
+                $this->later($job->delay, $job, $data, $queue);
+            } else {
+                $this->push($job, $data, $queue);
+            }
+        }
+    }
+    
+    /**
      * Push a new job onto the queue.
      *
      * @param  string  $job

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -72,7 +72,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
 
         return (int) $this->pheanstalk->statsTube($queue)->current_jobs_ready;
     }
-    
+
     /**
      * Push a new job onto the queue.
      *

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -72,25 +72,6 @@ class BeanstalkdQueue extends Queue implements QueueContract
 
         return (int) $this->pheanstalk->statsTube($queue)->current_jobs_ready;
     }
-
-    /**
-     * Push an array of jobs onto the queue.
-     *
-     * @param  array  $jobs
-     * @param  mixed  $data
-     * @param  string|null  $queue
-     * @return void
-     */
-    public function bulk($jobs, $data = '', $queue = null)
-    {
-        foreach ((array) $jobs as $job) {
-            if (isset($job->delay)) {
-                $this->later($job->delay, $job, $data, $queue);
-            } else {
-                $this->push($job, $data, $queue);
-            }
-        }
-    }
     
     /**
      * Push a new job onto the queue.
@@ -153,6 +134,25 @@ class BeanstalkdQueue extends Queue implements QueueContract
                 );
             }
         );
+    }
+
+    /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string|null  $queue
+     * @return void
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        foreach ((array) $jobs as $job) {
+            if (isset($job->delay)) {
+                $this->later($job->delay, $job, $data, $queue);
+            } else {
+                $this->push($job, $data, $queue);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Enable batch jobs delay for **Beanstalkd** queue ⏰

[before]
- batch jobs was ignoring delay time when pushing into beanstalkd.

[after]
- batch jobs delay time will be considered and put into beanstalkd.

```php
use App\Jobs\ImportCsv;
use Illuminate\Bus\Batch;
use Illuminate\Support\Facades\Bus;
 
$batch = Bus::batch([
    (new ImportCsv(1, 100))->delay($delay),
    (new ImportCsv(101, 200))->delay($delay)
])->dispatch();

```
