### PR TITLE
[9.x] Add String::squish() helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -882,7 +882,7 @@ class Str
     }
 
     /**
-     * Squish all blank space in a string.
+     * Squish all blank space from the given string.
      *
      * @param  string  $value
      * @return string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -882,7 +882,7 @@ class Str
     }
 
     /**
-     * Squish all blank space from the given string.
+     * Remove all "extra" blank space from the given string.
      *
      * @param  string  $value
      * @return string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -882,6 +882,17 @@ class Str
     }
 
     /**
+     * Squish all blank space in a string.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function squish($value)
+    {
+        return preg_replace('/\s+/', ' ', trim($value));
+    }
+
+    /**
      * Determine if a given string starts with a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -634,7 +634,6 @@ class Stringable implements JsonSerializable
         return new static(Str::squish($this->value));
     }
 
-
     /**
      * Begin a string with a single instance of a given value.
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -625,6 +625,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Squish all blank space from the given string.
+     *
+     * @return static
+     */
+    public function squish()
+    {
+        return new static(Str::squish($this->value));
+    }
+
+
+    /**
      * Begin a string with a single instance of a given value.
      *
      * @param  string  $prefix

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -625,7 +625,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Squish all blank space from the given string.
+     * Remove all "extra" blank space from the given string.
      *
      * @return static
      */

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -538,6 +538,16 @@ class SupportStrTest extends TestCase
         $this->assertSame('żółtałódka', Str::snake('ŻółtaŁódka'));
     }
 
+    public function testSquish()
+    {
+        $this->assertSame('laravel php framework', Str::squish(' laravel   php  framework '));
+        $this->assertSame('laravel php framework', Str::squish('
+            laravel
+            php
+            framework
+        '));
+    }
+
     public function testStudly()
     {
         $this->assertSame('LaravelPHPFramework', Str::studly('laravel_p_h_p_framework'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -541,6 +541,7 @@ class SupportStrTest extends TestCase
     public function testSquish()
     {
         $this->assertSame('laravel php framework', Str::squish(' laravel   php  framework '));
+        $this->assertSame('laravel php framework', Str::squish("laravel\t\tphp\n\nframework"));
         $this->assertSame('laravel php framework', Str::squish('
             laravel
             php

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -613,7 +613,7 @@ class SupportStringableTest extends TestCase
 
     public function testSquish()
     {
-        $this->assertSame('words with spaces', (string) $this->stringable(' words  with  spaces   ')->squish());
+        $this->assertSame('words with spaces', (string) $this->stringable(' words  with   spaces ')->squish());
         $this->assertSame('words with spaces', (string) $this->stringable("words\t\twith\n\nspaces")->squish());
         $this->assertSame('words with spaces', (string) $this->stringable('
             words

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -611,6 +611,17 @@ class SupportStringableTest extends TestCase
         $this->assertSame('', (string) $this->stringable('')->slug());
     }
 
+    public function testSquish()
+    {
+        $this->assertSame('words with spaces', (string) $this->stringable(' words  with  spaces   ')->squish());
+        $this->assertSame('words with spaces', (string) $this->stringable("words\t\twith\n\nspaces")->squish());
+        $this->assertSame('words with spaces', (string) $this->stringable('
+            words
+            with
+            spaces
+        ')->squish());
+    }
+
     public function testStart()
     {
         $this->assertSame('/test/string', (string) $this->stringable('test/string')->start('/'));


### PR DESCRIPTION
This proposes a new string helper method called `squish`, which is named similarly to the one in Rails. I know there's a lot of fair scrutiny given to adding new helpers but felt it was worth putting it out there in case you saw the usefulness that I do.

My use-cases are both when outputting user input that had additional unnecessary whitespace, and also when creating interpolated strings that have optional values (i.e. `"A {$description} listing has been created."`). In both of these instances using `squish` would make the content appear more professional.

If you do like this addition I can follow-up and add it to `Stringable` as well.