### PR TITLE
[9.x] Http client: retry callback exception handling (follow-up to #41762)

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Client;
 
+use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ConnectException;
@@ -715,7 +716,13 @@ class PendingRequest
                     $this->populateResponse($response);
 
                     if (! $response->successful()) {
-                        $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException()) : true;
+                        try {
+                            $shouldRetry = $this->retryWhenCallback ? call_user_func($this->retryWhenCallback, $response->toException()) : true;
+                        } catch (Exception $exception) {
+                            $shouldRetry = false;
+
+                            throw $exception;
+                        }
 
                         if ($attempt < $this->tries && $shouldRetry) {
                             $response->throw();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Http;
 
+use Exception;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as Psr7Response;
@@ -1267,6 +1268,31 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->failed());
 
         $this->assertSame(1, $whenAttempts);
+
+        $this->factory->assertSentCount(1);
+    }
+
+    public function testExceptionThrownInRetryCallbackWithoutRetrying()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 500),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory
+                ->retry(2, 1000, function ($exception) use (&$whenAttempts) {
+                    throw new Exception('Foo bar');
+                }, false)
+                ->get('http://foo.com/get');
+        } catch (Exception $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertEquals('Foo bar', $exception->getMessage());
 
         $this->factory->assertSentCount(1);
     }


### PR DESCRIPTION
Follow-up to #41762.

Because the `retryWhenCallback` is now executed inside the global `retry` helper method, an extra attempt would be made if an exception occurred in the `retryWhenCallback`. This was not the case when the `retryWhenCallback` was used as a callback by the global `retry` helper method.
By wrapping it in a try-catch, we can set `$shouldRetry` to `false` before we throw the exception again. This ensures it does not make an unnecessary attempt.