### PR TITLE
[9.x] Add "whereIn" route parameter constraint method

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -29,18 +29,6 @@ trait CreatesRegularExpressionRouteConstraints
     }
 
     /**
-     * Specify that the given route parameters must be one of the given values.
-     *
-     * @param  array|string  $parameters
-     * @param  array  $values
-     * @return $this
-     */
-    public function whereIn($parameters, array $values)
-    {
-        return $this->assignExpressionToParameters($parameters, implode('|', $values));
-    }
-
-    /**
      * Specify that the given route parameters must be numeric.
      *
      * @param  array|string  $parameters
@@ -60,6 +48,18 @@ trait CreatesRegularExpressionRouteConstraints
     public function whereUuid($parameters)
     {
         return $this->assignExpressionToParameters($parameters, '[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}');
+    }
+
+    /**
+     * Specify that the given route parameters must be one of the given values.
+     *
+     * @param  array|string  $parameters
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereIn($parameters, array $values)
+    {
+        return $this->assignExpressionToParameters($parameters, implode('|', $values));
     }
 
     /**

--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -29,6 +29,18 @@ trait CreatesRegularExpressionRouteConstraints
     }
 
     /**
+     * Specify that the given route parameters must be one of the given values.
+     *
+     * @param  array|string  $parameters
+     * @param  array  $values
+     * @return $this
+     */
+    public function whereIn($parameters, array $values)
+    {
+        return $this->assignExpressionToParameters($parameters, implode('|', $values));
+    }
+
+    /**
      * Specify that the given route parameters must be numeric.
      *
      * @param  array|string  $parameters

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -851,6 +851,19 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereInRegistration()
+    {
+        $wheres = ['foo' => 'one|two', 'bar' => 'one|two'];
+
+        $this->router->get('/{foo}/{bar}')->whereIn(['foo', 'bar'], ['one', 'two']);
+        $this->router->get('/api/{bar}/{foo}')->whereIn(['bar', 'foo'], ['one', 'two']);
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -800,6 +800,20 @@ class RoutingRouteTest extends TestCase
         $route->where('bar', '[0-9]+');
         $this->assertFalse($route->matches($request));
 
+        $request = Request::create('foo/123', 'GET');
+        $route = new Route('GET', 'foo/{bar}', ['where' => ['bar' => '123|456'], function () {
+            //
+        }]);
+        $route->where('bar', '123|456');
+        $this->assertTrue($route->matches($request));
+
+        $request = Request::create('foo/123abc', 'GET');
+        $route = new Route('GET', 'foo/{bar}', ['where' => ['bar' => '123|456'], function () {
+            //
+        }]);
+        $route->where('bar', '123|456');
+        $this->assertFalse($route->matches($request));
+
         /*
          * Optional
          */


### PR DESCRIPTION
Alternative for https://github.com/laravel/framework/pull/41776, as suggested by @taylorotwell

An enum is often used as a model attribute to simplify DX while still efficiently persisting integers in the database. There are ample of situations where a model's enum would be included in a route as well. Currently Laravel is only able to implicitly resolve string-backed enum route bindings, but that sort of contradicts the aforementioned use case.

By adding a `whereIn` constraint method, one can easily restrict a parameter to only a few valid values. It's not even limited to enums. Any array will fit.

```php
Route::get('/foo/{bar}')->whereIn('bar', $values);
```