### PR TITLE
[9.x] Fix support of nullable type for AsArrayObject/AsCollection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -21,7 +21,7 @@ class AsArrayObject implements Castable
             {
                 $data = json_decode($attributes[$key], true);
 
-                return is_array($data) ? new ArrayObject($data) : new ArrayObject();
+                return is_array($data) ? new ArrayObject($data) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -19,7 +19,9 @@ class AsArrayObject implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($attributes[$key]) ? new ArrayObject(json_decode($attributes[$key], true)) : null;
+                $data = json_decode($attributes[$key], true);
+
+                return is_array($data) ? new ArrayObject($data) : new ArrayObject();
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -22,7 +22,7 @@ class AsCollection implements Castable
             {
                 $data = json_decode($attributes[$key], true);
 
-                return is_array($data) ? new Collection($data) : new Collection();
+                return is_array($data) ? new Collection($data) : null;
             }
 
             public function set($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -20,7 +20,9 @@ class AsCollection implements Castable
         {
             public function get($model, $key, $value, $attributes)
             {
-                return isset($attributes[$key]) ? new Collection(json_decode($attributes[$key], true)) : null;
+                $data = json_decode($attributes[$key], true);
+
+                return is_array($data) ? new Collection($data) : new Collection();
             }
 
             public function set($model, $key, $value, $attributes)

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -17,8 +17,18 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         Schema::create('test_eloquent_model_with_custom_casts', function (Blueprint $table) {
             $table->increments('id');
             $table->text('array_object');
+            $table->json('array_object_json');
             $table->text('collection');
             $table->string('stringable');
+            $table->timestamps();
+        });
+
+        Schema::create('test_eloquent_model_with_custom_casts_nullables', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('array_object')->nullable();
+            $table->json('array_object_json')->nullable();
+            $table->text('collection')->nullable();
+            $table->string('stringable')->nullable();
             $table->timestamps();
         });
     }
@@ -28,6 +38,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $model = new TestEloquentModelWithCustomCasts;
 
         $model->array_object = ['name' => 'Taylor'];
+        $model->array_object_json = ['name' => 'Taylor'];
         $model->collection = collect(['name' => 'Taylor']);
         $model->stringable = Str::of('Taylor');
 
@@ -36,21 +47,82 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $model = $model->fresh();
 
         $this->assertEquals(['name' => 'Taylor'], $model->array_object->toArray());
+        $this->assertEquals(['name' => 'Taylor'], $model->array_object_json->toArray());
         $this->assertEquals(['name' => 'Taylor'], $model->collection->toArray());
-        $this->assertSame('Taylor', (string) $model->stringable);
+        $this->assertSame('Taylor', (string)$model->stringable);
 
         $model->array_object['age'] = 34;
         $model->array_object['meta']['title'] = 'Developer';
+
+        $model->array_object_json['age'] = 34;
+        $model->array_object_json['meta']['title'] = 'Developer';
 
         $model->save();
 
         $model = $model->fresh();
 
-        $this->assertEquals([
-            'name' => 'Taylor',
-            'age' => 34,
-            'meta' => ['title' => 'Developer'],
-        ], $model->array_object->toArray());
+        $this->assertEquals(
+            [
+                'name' => 'Taylor',
+                'age' => 34,
+                'meta' => ['title' => 'Developer'],
+            ],
+            $model->array_object->toArray()
+        );
+
+        $this->assertEquals(
+            [
+                'name' => 'Taylor',
+                'age' => 34,
+                'meta' => ['title' => 'Developer'],
+            ],
+            $model->array_object_json->toArray()
+        );
+    }
+
+    public function test_custom_casting_nullable_values()
+    {
+        $model = new TestEloquentModelWithCustomCastsNullable();
+
+        $model->array_object = null;
+        $model->array_object_json =  null;
+        $model->collection = collect();
+        $model->stringable = null;
+
+        $model->save();
+
+        $model = $model->fresh();
+
+        $this->assertEmpty($model->array_object);
+        $this->assertEmpty($model->array_object_json);
+        $this->assertEmpty($model->collection);
+        $this->assertSame('', (string)$model->stringable);
+
+        $model->array_object['name'] = 'Taylor';
+        $model->array_object['meta']['title'] = 'Developer';
+
+        $model->array_object_json['name'] = 'Taylor';
+        $model->array_object_json['meta']['title'] = 'Developer';
+
+        $model->save();
+
+        $model = $model->fresh();
+
+        $this->assertEquals(
+            [
+                'name' => 'Taylor',
+                'meta' => ['title' => 'Developer'],
+            ],
+            $model->array_object->toArray()
+        );
+
+        $this->assertEquals(
+            [
+                'name' => 'Taylor',
+                'meta' => ['title' => 'Developer'],
+            ],
+            $model->array_object_json->toArray()
+        );
     }
 }
 
@@ -70,6 +142,29 @@ class TestEloquentModelWithCustomCasts extends Model
      */
     protected $casts = [
         'array_object' => AsArrayObject::class,
+        'array_object_json' => AsArrayObject::class,
+        'collection' => AsCollection::class,
+        'stringable' => AsStringable::class,
+    ];
+}
+
+class TestEloquentModelWithCustomCastsNullable extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'array_object' => AsArrayObject::class,
+        'array_object_json' => AsArrayObject::class,
         'collection' => AsCollection::class,
         'stringable' => AsStringable::class,
     ];

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -98,9 +98,11 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $this->assertEmpty($model->collection);
         $this->assertSame('', (string) $model->stringable);
 
+        $model->array_object = ['name' => 'John'];
         $model->array_object['name'] = 'Taylor';
         $model->array_object['meta']['title'] = 'Developer';
 
+        $model->array_object_json = ['name' => 'John'];
         $model->array_object_json['name'] = 'Taylor';
         $model->array_object_json['meta']['title'] = 'Developer';
 

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -49,7 +49,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $this->assertEquals(['name' => 'Taylor'], $model->array_object->toArray());
         $this->assertEquals(['name' => 'Taylor'], $model->array_object_json->toArray());
         $this->assertEquals(['name' => 'Taylor'], $model->collection->toArray());
-        $this->assertSame('Taylor', (string)$model->stringable);
+        $this->assertSame('Taylor', (string) $model->stringable);
 
         $model->array_object['age'] = 34;
         $model->array_object['meta']['title'] = 'Developer';
@@ -85,7 +85,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $model = new TestEloquentModelWithCustomCastsNullable();
 
         $model->array_object = null;
-        $model->array_object_json =  null;
+        $model->array_object_json = null;
         $model->collection = collect();
         $model->stringable = null;
 
@@ -96,7 +96,7 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
         $this->assertEmpty($model->array_object);
         $this->assertEmpty($model->array_object_json);
         $this->assertEmpty($model->collection);
-        $this->assertSame('', (string)$model->stringable);
+        $this->assertSame('', (string) $model->stringable);
 
         $model->array_object['name'] = 'Taylor';
         $model->array_object['meta']['title'] = 'Developer';


### PR DESCRIPTION

Previous fix https://github.com/laravel/framework/pull/36526 of these 2 classes not covered the behavior of php `json_encode` / `json_decode` functions when casting null.

```php
// Bugly fragment
public function get($model, $key, $value, $attributes)
{
    // if $attributes[$key] === "null" it is assumed as "set" but ArrayObject can't accept null values.
    return isset($attributes[$key]) ? new ArrayObject(json_decode($attributes[$key], true)) : null;
}
```

If you have tried to set `AsArrayObject` attribute value to null (or had it by default), `json_encode` processed it as sting `"null"` which is correct from the point of JSON, and it was stored successfully. Nothing wrong here.

But next time you tried to access the attribute, the error `ArrayObject::__construct(): Argument #1 ($array) must be of type array, null given` was raised because it was already converted to a string and `json_decode` returns `null` taking `"null"` as an argument, which is not acceptable by [ArrayObject](https://php.net/manual/en/class.arrayobject.php). `Collection` class casts null to an empty array under the hood, there was no problem on practice, but I consider better to keep the same predictable behavior of `get` methods for both cast attribute classes. 

This PR also fix potential issues with `json_encode` / `json_decode` casting boolean values. 