### PR TITLE
[9.x] Allow non length limited strings and char for postgresql

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -34,7 +34,7 @@ class Builder
     /**
      * The default string length for migrations.
      *
-     * @var int
+     * @var int|null
      */
     public static $defaultStringLength = 255;
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -509,7 +509,11 @@ class PostgresGrammar extends Grammar
      */
     protected function typeChar(Fluent $column)
     {
-        return "char({$column->length})";
+        if ($column->length) {
+            return "char({$column->length})";
+        }
+
+        return 'char';
     }
 
     /**
@@ -520,7 +524,11 @@ class PostgresGrammar extends Grammar
      */
     protected function typeString(Fluent $column)
     {
-        return "varchar({$column->length})";
+        if ($column->length) {
+            return "varchar({$column->length})";
+        }
+
+        return 'varchar';
     }
 
     /**

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Mockery as m;
@@ -432,6 +433,52 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "foo" varchar(100) null default \'bar\'', $statements[0]);
+    }
+
+    public function testAddingStringWithoutLengthLimit()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" varchar(255) not null', $statements[0]);
+
+        Builder::$defaultStringLength = null;
+
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        try {
+            $this->assertCount(1, $statements);
+            $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
+        } finally {
+            Builder::$defaultStringLength = 255;
+        }
+    }
+
+    public function testAddingCharWithoutLengthLimit()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->char('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "foo" char(255) not null', $statements[0]);
+
+        Builder::$defaultStringLength = null;
+
+        $blueprint = new Blueprint('users');
+        $blueprint->char('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        try {
+            $this->assertCount(1, $statements);
+            $this->assertSame('alter table "users" add column "foo" char not null', $statements[0]);
+        } finally {
+            Builder::$defaultStringLength = 255;
+        }
     }
 
     public function testAddingText()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Postgres allows and even encourages users to not use length limited `varchar` and `char` types, this PR allows a user to set the `Builder::$defaultStringLength` to `null` which tells the postgres grammar to generate string and char types without a length specified.


https://wiki.postgresql.org/wiki/Don%27t_Do_This#Text_storage
