### PR TITLE
[9.x] Add query builder method `whereJsonContainsKey()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1777,6 +1777,57 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a clause that determines if a JSON path exists to the query.
+     *
+     * @param  string  $column
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereJsonContainsKey($column, $boolean = 'and', $not = false)
+    {
+        $type = 'JsonContainsKey';
+
+        $this->wheres[] = compact('type', 'column', 'boolean', 'not');
+
+        return $this;
+    }
+
+    /**
+     * Add an "or" clause that determines if a JSON path exists to the query.
+     *
+     * @param  string  $column
+     * @return $this
+     */
+    public function orWhereJsonContainsKey($column)
+    {
+        return $this->whereJsonContainsKey($column, 'or');
+    }
+
+    /**
+     * Add a clause that determines if a JSON path does not exist to the query.
+     *
+     * @param  string  $column
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereJsonDoesntContainKey($column, $boolean = 'and')
+    {
+        return $this->whereJsonContainsKey($column, $boolean, true);
+    }
+
+    /**
+     * Add an "or" clause that determines if a JSON path does not exist to the query.
+     *
+     * @param  string  $column
+     * @return $this
+     */
+    public function orWhereJsonDoesntContainKey($column)
+    {
+        return $this->whereJsonDoesntContainKey($column, 'or');
+    }
+
+    /**
      * Add a "where JSON length" clause to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -623,6 +623,35 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "where JSON contains key" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereJsonContainsKey(Builder $query, $where)
+    {
+        $not = $where['not'] ? 'not ' : '';
+
+        return $not.$this->compileJsonContainsKey(
+            $where['column']
+        );
+    }
+
+    /**
+     * Compile a "JSON contains key" statement into SQL.
+     *
+     * @param  string  $column
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function compileJsonContainsKey($column)
+    {
+        throw new RuntimeException('This database engine does not support JSON contains key operations.');
+    }
+
+    /**
      * Compile a "where JSON length" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -101,6 +101,19 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains key" statement into SQL.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    protected function compileJsonContainsKey($column)
+    {
+        [$field, $path] = $this->wrapJsonFieldAndPath($column);
+
+        return 'ifnull(json_contains_path('.$field.', \'one\''.$path.'), 0)';
+    }
+
+    /**
      * Compile a "JSON length" statement into SQL.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -225,12 +225,14 @@ class PostgresGrammar extends Grammar
     protected function compileJsonContainsKey($column)
     {
         $segments = explode('->', $column);
+
         $lastSegment = array_pop($segments);
 
         if (filter_var($lastSegment, FILTER_VALIDATE_INT) !== false) {
             $i = $lastSegment;
         } elseif (preg_match('/\[(-?[0-9]+)\]$/', $lastSegment, $matches)) {
             $segments[] = Str::beforeLast($lastSegment, $matches[0]);
+
             $i = $matches[1];
         }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -217,6 +217,38 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains key" statement into SQL.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    protected function compileJsonContainsKey($column)
+    {
+        $segments = explode('->', $column);
+        $lastSegment = array_pop($segments);
+
+        if (filter_var($lastSegment, FILTER_VALIDATE_INT) !== false) {
+            $i = $lastSegment;
+        } elseif (preg_match('/\[(-?[0-9]+)\]$/', $lastSegment, $matches)) {
+            $segments[] = Str::beforeLast($lastSegment, $matches[0]);
+            $i = $matches[1];
+        }
+
+        $column = str_replace('->>', '->', $this->wrap(implode('->', $segments)));
+
+        if (isset($i)) {
+            return vsprintf('case when %s then %s else false end', [
+                'jsonb_typeof(('.$column.")::jsonb) = 'array'",
+                'jsonb_array_length(('.$column.')::jsonb) >= '.($i < 0 ? abs($i) : $i + 1),
+            ]);
+        }
+
+        $key = "'".str_replace("'", "''", $lastSegment)."'";
+
+        return 'coalesce(('.$column.')::jsonb ?? '.$key.', false)';
+    }
+
+    /**
      * Compile a "JSON length" statement into SQL.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -133,6 +133,19 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains key" statement into SQL.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    protected function compileJsonContainsKey($column)
+    {
+        [$field, $path] = $this->wrapJsonFieldAndPath($column);
+
+        return 'json_type('.$field.$path.') is not null';
+    }
+
+    /**
      * Compile an update statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -174,10 +174,12 @@ class SqlServerGrammar extends Grammar
     protected function compileJsonContainsKey($column)
     {
         $segments = explode('->', $column);
+
         $lastSegment = array_pop($segments);
 
         if (preg_match('/\[([0-9]+)\]$/', $lastSegment, $matches)) {
             $segments[] = Str::beforeLast($lastSegment, $matches[0]);
+
             $key = $matches[1];
         } else {
             $key = "'".str_replace("'", "''", $lastSegment)."'";

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -166,6 +166,29 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a "JSON contains key" statement into SQL.
+     *
+     * @param  string  $column
+     * @return string
+     */
+    protected function compileJsonContainsKey($column)
+    {
+        $segments = explode('->', $column);
+        $lastSegment = array_pop($segments);
+
+        if (preg_match('/\[([0-9]+)\]$/', $lastSegment, $matches)) {
+            $segments[] = Str::beforeLast($lastSegment, $matches[0]);
+            $key = $matches[1];
+        } else {
+            $key = "'".str_replace("'", "''", $lastSegment)."'";
+        }
+
+        [$field, $path] = $this->wrapJsonFieldAndPath(implode('->', $segments));
+
+        return $key.' in (select [key] from openjson('.$field.$path.'))';
+    }
+
+    /**
      * Compile a "JSON length" statement into SQL.
      *
      * @param  string  $column

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -121,4 +121,34 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         ]);
         $this->assertSame(1, $updatedCount);
     }
+
+    /**
+     * @dataProvider jsonContainsKeyDataProvider
+     */
+    public function testWhereJsonContainsKey($count, $column)
+    {
+        DB::table(self::TABLE)->insert([
+            ['json_col' => '{"foo":{"bar":["baz"]}}'],
+            ['json_col' => '{"foo":{"bar":false}}'],
+            ['json_col' => '{"foo":{}}'],
+            ['json_col' => '{"foo":[{"bar":"bar"},{"baz":"baz"}]}'],
+            ['json_col' => '{"bar":null}'],
+        ]);
+
+        $this->assertSame($count, DB::table(self::TABLE)->whereJsonContainsKey($column)->count());
+    }
+
+    public function jsonContainsKeyDataProvider()
+    {
+        return [
+            'string key' => [4, 'json_col->foo'],
+            'nested key exists' => [2, 'json_col->foo->bar'],
+            'string key missing' => [0, 'json_col->none'],
+            'integer key with arrow ' => [0, 'json_col->foo->bar->0'],
+            'integer key with braces' => [2, 'json_col->foo->bar[0]'],
+            'integer key missing' => [0, 'json_col->foo->bar[1]'],
+            'mixed keys' => [1, 'json_col->foo[1]->baz'],
+            'null value' => [1, 'json_col->bar'],
+        ];
+    }
 }

--- a/tests/Integration/Database/Postgres/DatabasePostgresConnectionTest.php
+++ b/tests/Integration/Database/Postgres/DatabasePostgresConnectionTest.php
@@ -90,4 +90,34 @@ class DatabasePostgresConnectionTest extends PostgresTestCase
         ]);
         $this->assertSame(1, $updatedCount);
     }
+
+    /**
+     * @dataProvider jsonContainsKeyDataProvider
+     */
+    public function testWhereJsonContainsKey($count, $column)
+    {
+        DB::table('json_table')->insert([
+            ['json_col' => '{"foo":{"bar":["baz"]}}'],
+            ['json_col' => '{"foo":{"bar":false}}'],
+            ['json_col' => '{"foo":{}}'],
+            ['json_col' => '{"foo":[{"bar":"bar"},{"baz":"baz"}]}'],
+            ['json_col' => '{"bar":null}'],
+        ]);
+
+        $this->assertSame($count, DB::table('json_table')->whereJsonContainsKey($column)->count());
+    }
+
+    public function jsonContainsKeyDataProvider()
+    {
+        return [
+            'string key' => [4, 'json_col->foo'],
+            'nested key exists' => [2, 'json_col->foo->bar'],
+            'string key missing' => [0, 'json_col->none'],
+            'integer key with arrow ' => [1, 'json_col->foo->bar->0'],
+            'integer key with braces' => [1, 'json_col->foo->bar[0]'],
+            'integer key missing' => [0, 'json_col->foo->bar[1]'],
+            'mixed keys' => [1, 'json_col->foo[1]->baz'],
+            'null value' => [1, 'json_col->bar'],
+        ];
+    }
 }

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerConnectionTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerConnectionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SqlServer;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @requires extension pdo_sqlsrv
+ * @requires OS Linux|Darwin
+ */
+class DatabaseSqlServerConnectionTest extends SqlServerTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        if (! Schema::hasTable('json_table')) {
+            Schema::create('json_table', function (Blueprint $table) {
+                $table->json('json_col')->nullable();
+            });
+        }
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('json_table');
+    }
+
+    /**
+     * @dataProvider jsonContainsKeyDataProvider
+     */
+    public function testWhereJsonContainsKey($count, $column)
+    {
+        DB::table('json_table')->insert([
+            ['json_col' => '{"foo":{"bar":["baz"]}}'],
+            ['json_col' => '{"foo":{"bar":false}}'],
+            ['json_col' => '{"foo":{}}'],
+            ['json_col' => '{"foo":[{"bar":"bar"},{"baz":"baz"}]}'],
+            ['json_col' => '{"bar":null}'],
+        ]);
+
+        $this->assertSame($count, DB::table('json_table')->whereJsonContainsKey($column)->count());
+    }
+
+    public function jsonContainsKeyDataProvider()
+    {
+        return [
+            'string key' => [4, 'json_col->foo'],
+            'nested key exists' => [2, 'json_col->foo->bar'],
+            'string key missing' => [0, 'json_col->none'],
+            'integer key with arrow ' => [1, 'json_col->foo->bar->0'],
+            'integer key with braces' => [1, 'json_col->foo->bar[0]'],
+            'integer key missing' => [0, 'json_col->foo->bar[1]'],
+            'mixed keys' => [1, 'json_col->foo[1]->baz'],
+            'null value' => [1, 'json_col->bar'],
+        ];
+    }
+}

--- a/tests/Integration/Database/SqlServer/SqlServerTestCase.php
+++ b/tests/Integration/Database/SqlServer/SqlServerTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SqlServer;
+
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+abstract class SqlServerTestCase extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrations()
+    {
+        if ($this->driver !== 'sqlsrv') {
+            $this->markTestSkipped('Test requires a SQL Server connection.');
+        }
+    }
+}

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteConnectionTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteConnectionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Sqlite;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class DatabaseSqliteConnectionTest extends DatabaseTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        if (getenv('DB_CONNECTION') !== 'testing') {
+            $this->markTestSkipped('Test requires a Sqlite connection.');
+        }
+
+        $app['config']->set('database.default', 'conn1');
+
+        $app['config']->set('database.connections.conn1', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        if (! Schema::hasTable('json_table')) {
+            Schema::create('json_table', function (Blueprint $table) {
+                $table->json('json_col')->nullable();
+            });
+        }
+    }
+
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('json_table');
+    }
+
+    /**
+     * @dataProvider jsonContainsKeyDataProvider
+     */
+    public function testWhereJsonContainsKey($count, $column)
+    {
+        DB::table('json_table')->insert([
+            ['json_col' => '{"foo":{"bar":["baz"]}}'],
+            ['json_col' => '{"foo":{"bar":false}}'],
+            ['json_col' => '{"foo":{}}'],
+            ['json_col' => '{"foo":[{"bar":"bar"},{"baz":"baz"}]}'],
+            ['json_col' => '{"bar":null}'],
+        ]);
+
+        $this->assertSame($count, DB::table('json_table')->whereJsonContainsKey($column)->count());
+    }
+
+    public function jsonContainsKeyDataProvider()
+    {
+        return [
+            'string key' => [4, 'json_col->foo'],
+            'nested key exists' => [2, 'json_col->foo->bar'],
+            'string key missing' => [0, 'json_col->none'],
+            'integer key with arrow ' => [0, 'json_col->foo->bar->0'],
+            'integer key with braces' => [1, 'json_col->foo->bar[0]'],
+            'integer key missing' => [0, 'json_col->foo->bar[1]'],
+            'mixed keys' => [1, 'json_col->foo[1]->baz'],
+            'null value' => [1, 'json_col->bar'],
+        ];
+    }
+}


### PR DESCRIPTION
Resubmit of draft https://github.com/laravel/framework/pull/41756 for new method `whereJsonContainsKey()`. This PR also allows checking for array integer keys, supports SQLite, and runs integration tests on each database driver.

```php
DB::table('users')
    ->whereJsonContainsKey('options->languages')
    ->get();

DB::table('users')
    ->whereJsonDoesntContainKey('options->language->primary')
    ->get();

DB::table('users')
    ->whereJsonContainsKey('options->2fa[0]')
    ->get();

DB::table('users')
    ->whereJsonDoesntContainKey('options->2fa[0][1]')
    ->get();
```