### PR TITLE
[9.x] Remove extra argument from the forever method

### DIFF
--- a/src/Illuminate/Cache/CacheLock.php
+++ b/src/Illuminate/Cache/CacheLock.php
@@ -46,7 +46,7 @@ class CacheLock extends Lock
 
         return ($this->seconds > 0)
                 ? $this->store->put($this->name, $this->owner, $this->seconds)
-                : $this->store->forever($this->name, $this->owner, $this->seconds);
+                : $this->store->forever($this->name, $this->owner);
     }
 
     /**


### PR DESCRIPTION
The variable does not make sense. The forever method has only two parameters on the cache contract.