### PR TITLE
[9.x] Allow cleanup of databases when using parallel tests

### DIFF
--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -64,7 +64,7 @@ trait TestDatabases
 
         ParallelTesting::tearDownProcess(function () {
             $this->whenNotUsingInMemoryDatabase(function ($database) {
-                if (ParallelTesting::option('cleanup_databases')) {
+                if (ParallelTesting::option('drop_databases')) {
                     Schema::dropDatabaseIfExists(
                         $this->testDatabase($database)
                     );

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -61,6 +61,16 @@ trait TestDatabases
                 });
             }
         });
+
+        ParallelTesting::tearDownProcess(function () {
+            $this->whenNotUsingInMemoryDatabase(function ($database) {
+                if (ParallelTesting::option('cleanup_databases')) {
+                    Schema::dropDatabaseIfExists(
+                        $this->testDatabase($database)
+                    );
+                }
+            });
+        });
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The number of created database can get very high when having several laravel projects that use parallel testing. This option allows laravel to clean up after itself when the process is finished dropping all created databases used for the tests.
