### PR TITLE
[9.x] Add String isHex() helper method & validation rule

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -389,10 +389,10 @@ class Str
     }
 
     /**
-     * Determine if a given string is a hex (a-f, A-F, 0-9)
+     * Determine if a given string is a hex (a-f, A-F, 0-9).
      *
-     * @param string $value
-     * @param string $prefix
+     * @param  string  $value
+     * @param  string  $prefix
      * @return bool
      */
     public static function isHex($value, $prefix = '')
@@ -402,11 +402,12 @@ class Str
         }
 
         // If prefix was passed, validate that value contains prefix
-        if($prefix !== '' && !static::startsWith($value, $prefix)) {
+        if ($prefix !== '' && ! static::startsWith($value, $prefix)) {
             return false;
         }
-        
+
         $afterPrefix = static::substr($value, static::length($prefix));
+
         return preg_match('/^[0-9a-f]+$/i', $afterPrefix) > 0;
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -389,6 +389,28 @@ class Str
     }
 
     /**
+     * Determine if a given string is a hex (a-f, A-F, 0-9)
+     *
+     * @param string $value
+     * @param string $prefix
+     * @return bool
+     */
+    public static function isHex($value, $prefix = '')
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        // If prefix was passed, validate that value contains prefix
+        if($prefix !== '' && !static::startsWith($value, $prefix)) {
+            return false;
+        }
+        
+        $afterPrefix = static::substr($value, static::length($prefix));
+        return preg_match('/^[0-9a-f]+$/i', $afterPrefix) > 0;
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -304,6 +304,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given string is a hex (a-f, A-F, 0-9)
+     *
+     * @param string $prefix
+     * @return bool
+     */
+    public function isHex($prefix = '')
+    {
+        return Str::isHex($this->value, $prefix);
+    }
+
+    /**
      * Determine if the given string is empty.
      *
      * @return bool

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -304,9 +304,9 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Determine if a given string is a hex (a-f, A-F, 0-9)
+     * Determine if a given string is a hex (a-f, A-F, 0-9).
      *
-     * @param string $prefix
+     * @param  string  $prefix
      * @return bool
      */
     public function isHex($prefix = '')

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2039,6 +2039,22 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a hex string (a-f, A-F, 0-9)
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateHex($attribute, $value, $parameters)
+    {
+        $prefix = empty($parameters)
+            ? ''
+            : $parameters[0];
+
+        return Str::isHex($value, $prefix);
+    }
+
+    /**
      * Get the size of an attribute.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2039,7 +2039,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute is a hex string (a-f, A-F, 0-9)
+     * Validate that an attribute is a hex string (a-f, A-F, 0-9).
      *
      * @param  string  $attribute
      * @param  mixed  $value


### PR DESCRIPTION
This PR proposes a new Str and Stringable helper method `isHex` that validates whether given value is a valid hex string - characters in range of a-f, A-F, 0-9. Method optionally takes a second parameter (`$prefix`) to simplify validating certain strings (like HTML colors `#FFFFFF` or literal string values like `0x1E5`). I've also included a new `hex` validator rule.

Examples:
**True:**
```php
// Ordinary value
Str::isHex('abcdef123456') 

// Prefixed with '0x'
Str::isHex('0x1E5', '0x')

// HTML colour
Str::isHex('#FFFFFF', '#')

// Stringable interface
Str::of('0x1E5')
    ->isHex('0x')

// Validator
Validator::validate([
  'value' => 'abcdef123456'
], [
  'value' => 'hex'
]);

// Validator with optional param
Validator::validate([
  'value' => '0x123'
], [
  'value' => 'hex:0x'
]);
```

**False:**

```php
// Not a string
Str::isHex([])

// Character out of range (g)
Str::isHex('abcdefg123456')

// Character out of range (x), missing prefix
Str::isHex('0x1E5')

// Character out of range (#), missing prefix
Str::isHex('#FFFFFF')
```



<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
