### PR TITLE
[9.x] Revert some `Carbon::setTestNow()` removals

### DIFF
--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -44,6 +44,8 @@ class CacheArrayStoreTest extends TestCase
 
     public function testItemsCanExpire()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $store = new ArrayStore;
 
         $store->put('foo', 'bar', 10);
@@ -113,6 +115,8 @@ class CacheArrayStoreTest extends TestCase
 
     public function testExpiredKeysAreIncrementedLikeNonExistingKeys()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $store = new ArrayStore;
 
         $store->put('foo', 999, 10);
@@ -172,6 +176,8 @@ class CacheArrayStoreTest extends TestCase
 
     public function testCanAcquireLockAgainAfterExpiry()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $store = new ArrayStore;
         $lock = $store->lock('foo', 10);
         $lock->acquire();

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -12,6 +12,13 @@ use PHPUnit\Framework\TestCase;
 
 class CacheFileStoreTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
+
     public function testNullIsReturnedIfFileDoesntExist()
     {
         $files = $this->mockFilesystem();
@@ -189,6 +196,8 @@ class CacheFileStoreTest extends TestCase
 
     public function testIncrementExpiredKeys()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $filePath = $this->getCachePath('foo');
         $files = $this->mockFilesystem();
         $now = Carbon::now()->getTimestamp();
@@ -265,6 +274,8 @@ class CacheFileStoreTest extends TestCase
 
     public function testIncrementDoesNotExtendCacheLife()
     {
+        Carbon::setTestNow(Carbon::now());
+
         $files = $this->mockFilesystem();
         $expiration = Carbon::now()->addSeconds(50)->getTimestamp();
         $initialValue = $expiration.serialize(1);

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -311,7 +311,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
      */
     public function testUpdateModelAfterSoftDeleting()
     {
-        $now = Carbon::now();
+        Carbon::setTestNow($now = Carbon::now());
         $this->createUsers();
 
         /** @var \Illuminate\Tests\Database\SoftDeletesTestUser $userModel */

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -62,6 +62,7 @@ class DatabaseEloquentTimestampsTest extends TestCase
         $this->schema()->drop('users');
         $this->schema()->drop('users_created_at');
         $this->schema()->drop('users_updated_at');
+        Carbon::setTestNow(null);
     }
 
     /**
@@ -69,7 +70,8 @@ class DatabaseEloquentTimestampsTest extends TestCase
      */
     public function testUserWithCreatedAtAndUpdatedAt()
     {
-        $now = Carbon::now();
+        Carbon::setTestNow($now = Carbon::now());
+
         $user = UserWithCreatedAndUpdated::create([
             'email' => 'test@test.com',
         ]);
@@ -80,7 +82,8 @@ class DatabaseEloquentTimestampsTest extends TestCase
 
     public function testUserWithCreatedAt()
     {
-        $now = Carbon::now();
+        Carbon::setTestNow($now = Carbon::now());
+
         $user = UserWithCreated::create([
             'email' => 'test@test.com',
         ]);
@@ -90,7 +93,8 @@ class DatabaseEloquentTimestampsTest extends TestCase
 
     public function testUserWithUpdatedAt()
     {
-        $now = Carbon::now();
+        Carbon::setTestNow($now = Carbon::now());
+
         $user = UserWithUpdated::create([
             'email' => 'test@test.com',
         ]);

--- a/tests/Integration/Cookie/CookieTest.php
+++ b/tests/Integration/Cookie/CookieTest.php
@@ -14,6 +14,13 @@ use Orchestra\Testbench\TestCase;
 
 class CookieTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+    }
+
     public function test_cookie_is_sent_back_with_proper_expire_time_when_should_expire_on_close()
     {
         $this->app['config']->set('session.expire_on_close', true);
@@ -36,6 +43,7 @@ class CookieTest extends TestCase
             return 'hello world';
         })->middleware('web');
 
+        Carbon::setTestNow(Carbon::now());
         $response = $this->get('/');
         $this->assertCount(2, $response->headers->getCookies());
         $this->assertEquals(Carbon::now()->getTimestamp() + 60, ($response->headers->getCookies()[1])->getExpiresTime());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -39,6 +39,7 @@ class ValidationValidatorTest extends TestCase
     {
         parent::tearDown();
 
+        Carbon::setTestNow(null);
         m::close();
     }
 
@@ -4143,8 +4144,6 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => new Carbon('2018-01-01')], ['x' => 'date_equals:tomorrow']);
         $this->assertTrue($v->fails());
-
-        Carbon::setTestNow(null);
     }
 
     public function testBeforeAndAfter()


### PR DESCRIPTION
Revert about half of cleanup PR https://github.com/laravel/framework/pull/40790 that removed "useless" calls to `Carbon::setTestNow()`. Now some tests are non-deterministic and can intermittently fail for new PRs being submitted:

e.g., https://github.com/laravel/framework/runs/5798854285

```
1) Illuminate\Tests\Cache\CacheFileStoreTest::testIncrementDoesNotExtendCacheLife
Expectation failed for method name is "put" when invoked 1 time(s)
Parameter 1 for invocation Illuminate\Filesystem\Filesystem::put('D:\a\framework\framework\test...da8a33', '1648892146i:2;', true) does not match expected value.
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1648892145i:2;'
+'1648892146i:2;'
```

The mocked cache expiry was unexpectedly 1 second in the future.

---

* `Carbon::setTestNow(Carbon::now())` keeps time-based mocks and assertions deterministic. Otherwise if the clock's second ticks over mid-test, assertions and mockery checks can be run on an unexpected time of day.
* tests/Validation/ValidationValidatorTest.php
   * Avoid putting `Carbon::setTestNow(null)` at the end of the test case method. If that test fails, `Carbon::setTestNow(new Carbon('2018-01-01'))` is now leaking into subsequent tests.
   * Worst case, wrap it in a `try { /* assertions */ } finally { Carbon::setTestNow(null); }`.