### PR TITLE
[9.x] Add 'hex' validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2039,6 +2039,31 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a hex string.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    public function validateHex($attribute, $value, $parameters)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        if (! empty($parameters)) {
+            if (! Str::startsWith($value, $parameters[0])) {
+                return false;
+            }
+
+            $value = Str::substr($value, Str::length($parameters[0]));
+        }
+
+        return preg_match('/^[0-9a-f]+$/i', $value) > 0;
+    }
+
+    /**
      * Get the size of an attribute.
      *
      * @param  string  $attribute


### PR DESCRIPTION
This is a proposal of a single new `hex` validation rule that checks whether a string has all characters in range of a-f, A-F, 0-9. Second optional parameter is a prefix to add a simple way of handling html colours or literal hex values.

It's an implementation of the proposal https://github.com/laravel/framework/issues/9988 and also solution to a real problem i've had while working on a project. 

**Examples:**
```php
// Simple value
Validator::validate([
  'value' => 'abcdef123456'
], [
  'value' => 'hex'
]);

// Optional param - literal hex value
Validator::validate([
  'value' => '0x123'
], [
  'value' => 'hex:0x'
]);

// Optional param - HTML colour
Validator::validate([
  'value' => '#FFFFFF'
], [
  'value' => 'hex:#'
]);
```

This PR is also a followup to my previous https://github.com/laravel/framework/pull/41807. I agree that particular string helper might not have been the most frequently used method but a simple validation rule surely will be quite handy.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
