### PR TITLE
[8.x] Backport - Fix trashed implicitBinding with child with no softdelete

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -43,7 +43,7 @@ class ImplicitRouteBinding
                         : 'resolveRouteBinding';
 
             if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
-                $childRouteBindingMethod = $route->allowsTrashedBindings()
+                $childRouteBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';
 


### PR DESCRIPTION
Backport of  https://github.com/laravel/framework/pull/41282. Soft delete support for parent/child implicit binding was introduced in 8.x.