### PR TITLE
[8.x] Fix assertListening check with auto discovery

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Testing\Fakes;
 use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 use ReflectionFunction;
@@ -60,6 +61,10 @@ class EventFake implements Dispatcher
         foreach ($this->dispatcher->getListeners($expectedEvent) as $listenerClosure) {
             $actualListener = (new ReflectionFunction($listenerClosure))
                         ->getStaticVariables()['listener'];
+
+            if (is_string($actualListener) && Str::endsWith($actualListener, '@handle')) {
+                $actualListener = Str::parseCallback($actualListener)[0];
+            }
 
             if ($actualListener === $expectedListener ||
                 ($actualListener instanceof Closure &&

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -165,11 +165,6 @@ class PostEventSubscriber
             [PostEventSubscriber::class, 'handlePostCreated']
         );
     }
-
-    public function handle($event)
-    {
-        //
-    }
 }
 
 class PostAutoEventSubscriber

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -126,6 +126,7 @@ class EventFakeTest extends TestCase
         Event::fake();
         Event::listen('event', 'listener');
         Event::listen('event', PostEventSubscriber::class);
+        Event::listen('event', 'Illuminate\\Tests\\Integration\\Events\\PostAutoEventSubscriber@handle');
         Event::listen('event', [PostEventSubscriber::class, 'foo']);
         Event::subscribe(PostEventSubscriber::class);
         Event::listen(function (NonImportantEvent $event) {
@@ -134,6 +135,7 @@ class EventFakeTest extends TestCase
 
         Event::assertListening('event', 'listener');
         Event::assertListening('event', PostEventSubscriber::class);
+        Event::assertListening('event', PostAutoEventSubscriber::class);
         Event::assertListening('event', [PostEventSubscriber::class, 'foo']);
         Event::assertListening('post-created', [PostEventSubscriber::class, 'handlePostCreated']);
         Event::assertListening(NonImportantEvent::class, Closure::class);
@@ -162,6 +164,19 @@ class PostEventSubscriber
             'post-created',
             [PostEventSubscriber::class, 'handlePostCreated']
         );
+    }
+
+    public function handle($event)
+    {
+        //
+    }
+}
+
+class PostAutoEventSubscriber
+{
+    public function handle($event)
+    {
+        //
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where `assertListening` wouldn't succeed for listeners with a `handle` method. These are registered like `Listener@handle` which isn't properly parsed in the `assertListening` method.

Fixes https://github.com/laravel/framework/issues/41771