### PR TITLE
[9.x] Fix time mocking in CacheRepositoryTest

### DIFF
--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -264,7 +264,7 @@ class CacheRepositoryTest extends TestCase
     public function dataProviderTestGetSeconds()
     {
         return [
-            [Carbon::now()->addMinutes(5)],
+            [Carbon::parse($this->getTestDate())->addMinutes(5)],
             [(new DateTime($this->getTestDate()))->modify('+5 minutes')],
             [(new DateTimeImmutable($this->getTestDate()))->modify('+5 minutes')],
             [new DateInterval('PT5M')],

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -23,6 +23,13 @@ use PHPUnit\Framework\TestCase;
 
 class CacheRepositoryTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::parse($this->getTestDate()));
+    }
+
     protected function tearDown(): void
     {
         m::close();
@@ -256,8 +263,6 @@ class CacheRepositoryTest extends TestCase
 
     public function dataProviderTestGetSeconds()
     {
-        Carbon::setTestNow(Carbon::parse($this->getTestDate()));
-
         return [
             [Carbon::now()->addMinutes(5)],
             [(new DateTime($this->getTestDate()))->modify('+5 minutes')],

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -279,8 +279,6 @@ class CacheRepositoryTest extends TestCase
      */
     public function testGetSeconds($duration)
     {
-        Carbon::setTestNow(Carbon::parse($this->getTestDate()));
-
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('put')->once()->with($key = 'foo', $value = 'bar', 300);
         $repo->put($key, $value, $duration);


### PR DESCRIPTION
`setTestNow()` should not be done in `dataProvider`. dataProvider in general shouldn't modify any state as they are triggered by PHPUnit in early steps and not related to the tests done with this provider.

For this case (`CacheRepositoryTest`) the time should be always mocked, else stuff like `$repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 602)` can't be guaranteed because few microseconds elapsed since `Carbon::now()->addMinutes(10)->addSeconds(2)` was called.

Relates to #41810, #40790