### PR TITLE
Get value of backed enums in schema builder default value

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -302,6 +302,11 @@ abstract class Grammar extends BaseGrammar
             return $value;
         }
 
+        if($value instanceof \BackedEnum)
+        {
+            return $value->value;
+        }
+
         return is_bool($value)
                     ? "'".(int) $value."'"
                     : "'".(string) $value."'";

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -599,6 +600,19 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testAddingEnumConvertsToValue()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo', 100)->nullable()->default(TestEnum::test);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `foo` varchar(100) null default test', $statements[0]);
     }
 
     public function testAddingText()


### PR DESCRIPTION
A very small scratching my own itch PR - but working with enums it bugged me that I have to reference the enum value when it's used as a schema default:
`$table->string('status')->default(Status::PENDING->value);`

This PR makes this nicer looking version work:
`$table->string('status')->default(Status::PENDING);`

Test would be logical to inline with the similar tests above, but I think it has to be separated to only run under PHP 8.1 .