### PR TITLE
[9.x] Set custom host to the serve command with environment variable

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -211,7 +211,7 @@ class ServeCommand extends Command
     protected function getOptions()
     {
         return [
-            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on', '127.0.0.1'],
+            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on', Env::get('SERVER_HOST', '127.0.0.1')],
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', Env::get('SERVER_PORT')],
             ['tries', null, InputOption::VALUE_OPTIONAL, 'The max number of ports to attempt to serve from', 10],
             ['no-reload', null, InputOption::VALUE_NONE, 'Do not reload the development server on .env file changes'],


### PR DESCRIPTION
This PR proposes the ability to set a custom host option for the `php artisan serve` command through a `SERVER_HOST` environment variable similar to the `SERVER_PORT` variable for ports.

This is useful for developers working locally with hostnames such as `example.test` to avoid setting the `--host` option on each `php artisan serve` execution.