### PR TITLE
[9.x] Test default attribute values for custom JSON cast 

### DIFF
--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -136,6 +136,19 @@ class TestEloquentModelWithCustomCasts extends Model
      * @var string[]
      */
     protected $guarded = [];
+    
+    
+    /**
+     * The model's default values for attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'array_object_json' => [
+            'name' => 'Bob',
+            'age' => 0
+        ],
+    ];
 
     /**
      * The attributes that should be cast to native types.


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

<!-- DO NOT THROW THIS AWAY -->
<!-- Fill out the FULL versions with patch versions -->

- Laravel Version: 9.6.0
- PHP Version: 8.1.2
- Database Driver & Version: MySQL Community Server 8.0.23


### Description:

I've discovered an error that doesn't allow usage of [default values](https://laravel.com/docs/9.x/eloquent#default-attribute-values) & custom JSON cast together. This pull request is a test case for an error. Not a fix yet. 

A fatal error is caused every time a new instance of the model is being created. 

```
TypeError: json_decode(): Argument #1 ($json) must be of type string, array given

/var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:1186
/var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:1958
/var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:1905
/var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php:1839
/var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php:50
/var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1153
/var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1003
/var/www/tests/Feature/DatabaseCustomCastsTest.php:41
```

![image](https://user-images.githubusercontent.com/9198896/161730104-a59d5d69-fe33-466f-96b8-3fd2d49a766d.png)


### Steps To Reproduce:

I've created this pull request with a test for this bug. Notice the added attributes to the already written test by Laravel. 

Change: https://github.com/laravel/framework/blob/60d60c5e4032702c95bc93fea1c3102587e8bd20/tests/Integration/Database/DatabaseCustomCastsTest.php

Cheers!
