### PR TITLE
[9.x] Add inbound option to CastMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class CastMakeCommand extends GeneratorCommand
 {
@@ -45,7 +46,9 @@ class CastMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return $this->resolveStubPath('/stubs/cast.stub');
+        return $this->option('inbound')
+                    ? $this->resolveStubPath('/stubs/cast.inbound.stub')
+                    : $this->resolveStubPath('/stubs/cast.stub');
     }
 
     /**
@@ -70,5 +73,17 @@ class CastMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Casts';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['inbound', 'i', InputOption::VALUE_OPTIONAL, 'Generate an inbound cast class'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -83,7 +83,7 @@ class CastMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['inbound', 'i', InputOption::VALUE_OPTIONAL, 'Generate an inbound cast class'],
+            ['inbound', null, InputOption::VALUE_OPTIONAL, 'Generate an inbound cast class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/cast.inbound.stub
+++ b/src/Illuminate/Foundation/Console/stubs/cast.inbound.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+
+class {{ class }} implements CastsInboundAttributes
+{
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return $value;
+    }
+}


### PR DESCRIPTION
Hi all! It's me, again.

I know, maybe 3 PR in a so short time is too much, but I'm working on a quite big project, and while I'm developing features, I'm also trying to find some little common patterns that maybe can be helpful to the rest of the community as well. One of those is the ability to generate inbound cast classes with the `make:cast` command. I saw that previously someone tried to add this feature, but the [PR](https://github.com/laravel/framework/pull/39054) wasn't merged.

I'm finding this, in my case obviously, very helpful, because I'm using a lot of Inbound Casts, and maybe someone else could benefit from this.

I also tried to write tests, but I didn't manage to find where the tests for generators commands are. So if you are going to merge this, I will be grateful if you can suggest to me where to find them.

Thanks a lot again for your time!