### PR TITLE
[9.x] Add handling of object being passed into old method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -2,17 +2,24 @@
 
 namespace Illuminate\Http\Concerns;
 
+use Illuminate\Support\Arr;
+use Illuminate\Database\Eloquent\Model;
+
 trait InteractsWithFlashData
 {
     /**
      * Retrieve an old input item.
      *
      * @param  string|null  $key
-     * @param  string|array|null  $default
+     * @param  \Illuminate\Database\Eloquent\Model|string|array|null  $default
      * @return string|array|null
      */
     public function old($key = null, $default = null)
     {
+		if ($default instanceof Model && Arr::has($default->getAttributes(), $key)) {
+			$default = $default->getAttribute($key);
+		}
+
         return $this->hasSession() ? $this->session()->getOldInput($key, $default) : $default;
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -15,7 +15,7 @@ trait InteractsWithFlashData
      */
     public function old($key = null, $default = null)
     {
-        $default = $default instanceof Model ? $default->getAttribute($key) : $default;
+        $default = $default instanceof Model ? $default->{$key} : $default;
 
         return $this->hasSession() ? $this->session()->getOldInput($key, $default) : $default;
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -13,9 +13,9 @@ trait InteractsWithFlashData
      */
     public function old($key = null, $default = null)
     {
-        if (method_exists($default, 'getAttribute')) {
-            $default = $default->getAttribute($key);
-        }
+        $default = is_object($default) && method_exists($default, 'getAttribute')
+            ? $default->getAttribute($key)
+            : $default;
 
         return $this->hasSession() ? $this->session()->getOldInput($key, $default) : $default;
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -15,7 +15,7 @@ trait InteractsWithFlashData
      */
     public function old($key = null, $default = null)
     {
-        $default = $default instanceof Model ? $default->{$key} : $default;
+        $default = $default instanceof Model ? $default->getAttribute($key) : $default;
 
         return $this->hasSession() ? $this->session()->getOldInput($key, $default) : $default;
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -2,23 +2,20 @@
 
 namespace Illuminate\Http\Concerns;
 
-use Illuminate\Support\Arr;
-use Illuminate\Database\Eloquent\Model;
-
 trait InteractsWithFlashData
 {
     /**
      * Retrieve an old input item.
      *
      * @param  string|null  $key
-     * @param  \Illuminate\Database\Eloquent\Model|string|array|null  $default
+     * @param  object|string|array|null  $default
      * @return string|array|null
      */
     public function old($key = null, $default = null)
     {
-		if ($default instanceof Model && Arr::has($default->getAttributes(), $key)) {
-			$default = $default->getAttribute($key);
-		}
+        if (method_exists($default, 'getAttribute')) {
+            $default = $default->getAttribute($key);
+        }
 
         return $this->hasSession() ? $this->session()->getOldInput($key, $default) : $default;
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithFlashData.php
@@ -2,20 +2,20 @@
 
 namespace Illuminate\Http\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
+
 trait InteractsWithFlashData
 {
     /**
      * Retrieve an old input item.
      *
      * @param  string|null  $key
-     * @param  object|string|array|null  $default
+     * @param  \Illuminate\Database\Eloquent\Model|string|array|null  $default
      * @return string|array|null
      */
     public function old($key = null, $default = null)
     {
-        $default = is_object($default) && method_exists($default, 'getAttribute')
-            ? $default->getAttribute($key)
-            : $default;
+        $default = $default instanceof Model ? $default->getAttribute($key) : $default;
 
         return $this->hasSession() ? $this->session()->getOldInput($key, $default) : $default;
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -8,11 +8,11 @@ use Illuminate\Routing\Route;
 use Illuminate\Session\Store;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -960,7 +960,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame(['bar'], $request->old('foo', ['bar']));
     }
 
-	public function testOldMethodCanGetDefaultValueFromModel()
+    public function testOldMethodCanGetDefaultValueFromObjectIfHasGetAttributeMethod()
     {
         $request = Request::create('/');
         $model = m::mock(Price::class);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -948,6 +949,18 @@ class HttpRequestTest extends TestCase
         $session->shouldReceive('getOldInput')->once()->with('foo', 'bar')->andReturn('boom');
         $request->setLaravelSession($session);
         $this->assertSame('boom', $request->old('foo', 'bar'));
+    }
+
+	public function testOldMethodCanGetDefaultValueFromModel()
+    {
+        $request = Request::create('/');
+		$model = m::mock(Price::class);
+		$model->shouldReceive('getAttributes')->once()->withNoArgs()->andReturn(['name' => 'foobar']);
+		$model->shouldReceive('getAttribute')->once()->with('name')->andReturn('foobar');
+        $session = m::mock(Store::class);
+        $session->shouldReceive('getOldInput')->once()->with('name', 'foobar')->andReturn('foobar');
+        $request->setLaravelSession($session);
+        $this->assertSame('foobar', $request->old('name', $model));
     }
 
     public function testFlushMethodCallsSession()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -954,9 +954,8 @@ class HttpRequestTest extends TestCase
 	public function testOldMethodCanGetDefaultValueFromModel()
     {
         $request = Request::create('/');
-		$model = m::mock(Price::class);
-		$model->shouldReceive('getAttributes')->once()->withNoArgs()->andReturn(['name' => 'foobar']);
-		$model->shouldReceive('getAttribute')->once()->with('name')->andReturn('foobar');
+        $model = m::mock(Price::class);
+        $model->shouldReceive('getAttribute')->once()->with('name')->andReturn('foobar');
         $session = m::mock(Store::class);
         $session->shouldReceive('getOldInput')->once()->with('name', 'foobar')->andReturn('foobar');
         $request->setLaravelSession($session);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -960,7 +960,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame(['bar'], $request->old('foo', ['bar']));
     }
 
-    public function testOldMethodCanGetDefaultValueFromObjectIfHasGetAttributeMethod()
+    public function testOldMethodCanGetDefaultValueFromModelByKey()
     {
         $request = Request::create('/');
         $model = m::mock(Price::class);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -951,6 +951,15 @@ class HttpRequestTest extends TestCase
         $this->assertSame('boom', $request->old('foo', 'bar'));
     }
 
+    public function testOldMethodCallsSessionWhenDefaultIsArray()
+    {
+        $request = Request::create('/');
+        $session = m::mock(Store::class);
+        $session->shouldReceive('getOldInput')->once()->with('foo', ['bar'])->andReturn(['bar']);
+        $request->setLaravelSession($session);
+        $this->assertSame(['bar'], $request->old('foo', ['bar']));
+    }
+
 	public function testOldMethodCanGetDefaultValueFromModel()
     {
         $request = Request::create('/');


### PR DESCRIPTION
Hey Guys!

This PR allows users to pass in a Model as the default parameter to the old helper function.

If you had a form to update a username. You might set the value to something like this:

```php
<input type="text" name="name" value="{{ old('name', $user->name) }}">
```

This will find the old value in the request or, default to the `$user->name` value which is being pulled from the User model if there is no old value.

This PR changes this to allow the following

```php
<input type="text" name="name" value="{{ old('name', $user) }}">
```

The method has been updated to check if the default value being passed is an instance of a Model and gets the attribute based on the key

As many developers will follow cruddy conventions, and have their attributes named the same as their input names, so they can mass insert, I believe this would streamline form creation (if only slightly) 

I have added a test to cover this behaviour, and I have also added a test to cover setting the default as an array, to ensure no existing behaviour is broken by this change.

An alternate approach I considered would be to add a new helper method, (though, not sure what the name would be, `oldAttribute($class, $key)` maybe?) , which would do this behaviour independently of the old helper method. I'd be happy to scope this out if this approach would be preferred.

 Thanks for looking :)

