### PR TITLE
[9.x] Stringable exactly not match with other Stringable variable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -214,7 +214,7 @@ class Stringable implements JsonSerializable
      */
     public function exactly($value)
     {
-        return $this->value === $value;
+        return $this->value === (string) $value;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -215,7 +215,7 @@ class Stringable implements JsonSerializable
     public function exactly($value)
     {
         if ($value instanceof Stringable) {
-          $value = $value->toString();
+            $value = $value->toString();
         }
 
         return $this->value === $value;

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -209,7 +209,7 @@ class Stringable implements JsonSerializable
     /**
      * Determine if the string is an exact match with the given value.
      *
-     * @param  string|Stringable  $value
+     * @param  \Illuminate\Support\Stringable|string  $value
      * @return bool
      */
     public function exactly($value)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -209,12 +209,16 @@ class Stringable implements JsonSerializable
     /**
      * Determine if the string is an exact match with the given value.
      *
-     * @param  string  $value
+     * @param  string|Stringable  $value
      * @return bool
      */
     public function exactly($value)
     {
-        return $this->value === (string) $value;
+        if ($value instanceof Stringable) {
+          $value = $value->toString();
+        }
+
+        return $this->value === $value;
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -990,12 +990,12 @@ class SupportStringableTest extends TestCase
 
     public function testExactly()
     {
-      $this->assertTrue($this->stringable('foo')->exactly($this->stringable('foo')));
-      $this->assertTrue($this->stringable('foo')->exactly('foo'));
+        $this->assertTrue($this->stringable('foo')->exactly($this->stringable('foo')));
+        $this->assertTrue($this->stringable('foo')->exactly('foo'));
 
-      $this->assertFalse($this->stringable('Foo')->exactly($this->stringable('foo')));
-      $this->assertFalse($this->stringable('Foo')->exactly('foo'));
-      $this->assertFalse($this->stringable('[]')->exactly([]));
-      $this->assertFalse($this->stringable('0')->exactly(0));
+        $this->assertFalse($this->stringable('Foo')->exactly($this->stringable('foo')));
+        $this->assertFalse($this->stringable('Foo')->exactly('foo'));
+        $this->assertFalse($this->stringable('[]')->exactly([]));
+        $this->assertFalse($this->stringable('0')->exactly(0));
     }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -987,4 +987,15 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo', $this->stringable('foo')->value());
         $this->assertSame('foo', $this->stringable('foo')->toString());
     }
+
+    public function testExactly()
+    {
+      $this->assertTrue($this->stringable('foo')->exactly($this->stringable('foo')));
+      $this->assertTrue($this->stringable('foo')->exactly('foo'));
+
+      $this->assertFalse($this->stringable('Foo')->exactly($this->stringable('foo')));
+      $this->assertFalse($this->stringable('Foo')->exactly('foo'));
+      $this->assertFalse($this->stringable('[]')->exactly([]));
+      $this->assertFalse($this->stringable('0')->exactly(0));
+    }
 }


### PR DESCRIPTION
<!-- DO NOT THROW THIS AWAY -->
<!-- Fill out the FULL versions with patch versions -->

- Laravel Version: 9.5.1
- PHP Version: 8.1
- Database Driver & Version: N/A

### Description:
When need compare two Stringable variables with exactly method. Then false is returned

### Steps To Reproduce:

```php
<?php

$first = \Str::of('name');
$second = \Str::of('name');
$first->exactly($second);
//  => false

// true is expected but false is returned

```


![image](https://user-images.githubusercontent.com/11270546/161881856-151f8c08-cbf7-4a06-afcc-385fb840b5bc.png)


<!-- If possible, please provide a GitHub repository to demonstrate your issue -->
<!-- laravel new bug-report --github="--public" -->

## Solution

- Cast argument to string when argument is Stringable
