### PR TITLE
[9.x] Set the foreign ID for a related model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -935,11 +935,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // To sync all of the relationships to the database, we will simply spin through
         // the relationships and save each model via this "push" method, which allows
         // us to recurse into all of these nested relations for the model instance.
-        foreach ($this->relations as $models) {
+        foreach ($this->relations as $relation => $models) {
             $models = $models instanceof Collection
                         ? $models->all() : [$models];
 
             foreach (array_filter($models) as $model) {
+                $model->setAttribute($this->$relation()->getForeignKeyName(), $this->$relation()->getParentKey());
+
                 if (! $model->push()) {
                     return false;
                 }


### PR DESCRIPTION
Set the foreign ID for related models when using `$model->push()`. Related to #4641.

This allows you to create a new model and its relations in one go:

```php
$checkout = $user->checkouts()->make();

$checkout->carts->push($checkout->carts()->make(['amount' => '1000', 'currency' => 'EUR']));
$checkout->carts->push($checkout->carts()->make(['amount' => '750', 'currency' => 'EUR']));

$checkout->calculate(); // Use the set relations to calculate the checkout totals for example

$checkout->push();
```