### PR TITLE
[9.x] Added a way to retrieve the first column of the first row from a query

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -352,8 +352,7 @@ class Connection implements ConnectionInterface
             return null;
         }
 
-
-        $record = (array)$record;
+        $record = (array) $record;
 
         if (count($record) > 1) {
             throw new MultipleColumnsSelectedException;

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -335,6 +335,34 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Run a select statement and return the first column of the first row.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @return mixed
+     *
+     * @throws MultipleColumnsSelectedException
+     */
+    public function scalar($query, $bindings = [], $useReadPdo = true)
+    {
+        $record = $this->selectOne($query, $bindings, $useReadPdo);
+
+        if (is_null($record)) {
+            return null;
+        }
+
+
+        $record = (array)$record;
+
+        if (count($record) > 1) {
+            throw new MultipleColumnsSelectedException;
+        }
+
+        return reset($record);
+    }
+
+    /**
      * Run a select statement against the database.
      *
      * @param  string  $query

--- a/src/Illuminate/Database/MultipleColumnsSelectedException.php
+++ b/src/Illuminate/Database/MultipleColumnsSelectedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database;
+
+use RuntimeException;
+
+class MultipleColumnsSelectedException extends RuntimeException
+{
+    //
+}

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -60,14 +60,14 @@ class DatabaseConnectionTest extends TestCase
     public function testScalarCallsSelectOneAndReturnsSingleResult()
     {
         $connection = $this->getMockConnection(['selectOne']);
-        $connection->expects($this->once())->method('selectOne')->with('select count(*) from tbl')->willReturn((object)['count(*)' => 5]);
+        $connection->expects($this->once())->method('selectOne')->with('select count(*) from tbl')->willReturn((object) ['count(*)' => 5]);
         $this->assertSame(5, $connection->scalar('select count(*) from tbl'));
     }
 
     public function testScalarThrowsExceptionIfMultipleColumnsAreSelected()
     {
         $connection = $this->getMockConnection(['selectOne']);
-        $connection->expects($this->once())->method('selectOne')->with('select a, b from tbl')->willReturn((object)['a' => 'a', 'b' => 'b']);
+        $connection->expects($this->once())->method('selectOne')->with('select a, b from tbl')->willReturn((object) ['a' => 'a', 'b' => 'b']);
         $this->expectException(MultipleColumnsSelectedException::class);
         $connection->scalar('select a, b from tbl');
     }

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\TransactionBeginning;
 use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionRolledBack;
+use Illuminate\Database\MultipleColumnsSelectedException;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
@@ -54,6 +55,28 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection(['select']);
         $connection->expects($this->once())->method('select')->with('foo', ['bar' => 'baz'])->willReturn(['foo']);
         $this->assertSame('foo', $connection->selectOne('foo', ['bar' => 'baz']));
+    }
+
+    public function testScalarCallsSelectOneAndReturnsSingleResult()
+    {
+        $connection = $this->getMockConnection(['selectOne']);
+        $connection->expects($this->once())->method('selectOne')->with('select count(*) from tbl')->willReturn((object)['count(*)' => 5]);
+        $this->assertSame(5, $connection->scalar('select count(*) from tbl'));
+    }
+
+    public function testScalarThrowsExceptionIfMultipleColumnsAreSelected()
+    {
+        $connection = $this->getMockConnection(['selectOne']);
+        $connection->expects($this->once())->method('selectOne')->with('select a, b from tbl')->willReturn((object)['a' => 'a', 'b' => 'b']);
+        $this->expectException(MultipleColumnsSelectedException::class);
+        $connection->scalar('select a, b from tbl');
+    }
+
+    public function testScalarReturnsNullIfUnderlyingSelectReturnsNoRows()
+    {
+        $connection = $this->getMockConnection(['selectOne']);
+        $connection->expects($this->once())->method('selectOne')->with('select foo from tbl where 0=1')->willReturn(null);
+        $this->assertNull($connection->scalar('select foo from tbl where 0=1'));
     }
 
     public function testSelectProperlyCallsPDO()


### PR DESCRIPTION
Currently there is no clean way to retrieve the first column of the first row of a more complex raw query.
For example

```sql
SELECT COUNT(CASE WHEN food = 'burger' THEN 1 END) FROM menu_items;
```

The quickest way I know, without using the Query Builder's `value()` method is:

```php
DB::selectOne("SELECT COUNT(CASE WHEN food = 'burger' THEN 1 END) AS burgers FROM menu_items;")->burgers
```

This PR adds `DB::scalar()`, so you can retrieve the result without aliasing the column and referencing the alias:

```php
DB::scalar("SELECT COUNT(CASE WHEN food = 'burger' THEN 1 END) FROM menu_items;")
// returns the count directly
```

If multiple columns are selected, an exception is thrown (`MultipleColumnsSelectedException`).