### PR TITLE
[9.x] Add option to disable cached view

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -30,16 +30,24 @@ abstract class Compiler
     protected $basePath;
 
     /**
+     * Determines if cached view should be used.
+     *
+     * @var bool
+     */
+    protected $useCache;
+
+    /**
      * Create a new compiler instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $cachePath
      * @param  string  $basePath
+     * @param  bool  $useCache
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(Filesystem $files, $cachePath, $basePath = '')
+    public function __construct(Filesystem $files, $cachePath, $basePath = '', $useCache = true)
     {
         if (! $cachePath) {
             throw new InvalidArgumentException('Please provide a valid cache path.');
@@ -48,6 +56,7 @@ abstract class Compiler
         $this->files = $files;
         $this->cachePath = $cachePath;
         $this->basePath = $basePath;
+        $this->useCache = $useCache;
     }
 
     /**
@@ -69,6 +78,10 @@ abstract class Compiler
      */
     public function isExpired($path)
     {
+        if (! $this->useCache) {
+            return true;
+        }
+
         $compiled = $this->getCompiledPath($path);
 
         // If the compiled file doesn't exist we will indicate that the view is expired

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -30,11 +30,11 @@ abstract class Compiler
     protected $basePath;
 
     /**
-     * Determines if cached view should be used.
+     * Determines if compiled views should be cached.
      *
      * @var bool
      */
-    protected $useCache;
+    protected $shouldCache;
 
     /**
      * Create a new compiler instance.
@@ -42,12 +42,12 @@ abstract class Compiler
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $cachePath
      * @param  string  $basePath
-     * @param  bool  $useCache
+     * @param  bool  $shouldCache
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(Filesystem $files, $cachePath, $basePath = '', $useCache = true)
+    public function __construct(Filesystem $files, $cachePath, $basePath = '', $shouldCache = true)
     {
         if (! $cachePath) {
             throw new InvalidArgumentException('Please provide a valid cache path.');
@@ -56,7 +56,7 @@ abstract class Compiler
         $this->files = $files;
         $this->cachePath = $cachePath;
         $this->basePath = $basePath;
-        $this->useCache = $useCache;
+        $this->shouldCache = $shouldCache;
     }
 
     /**
@@ -78,7 +78,7 @@ abstract class Compiler
      */
     public function isExpired($path)
     {
-        if (! $this->useCache) {
+        if (! $this->shouldCache) {
             return true;
         }
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -89,6 +89,7 @@ class ViewServiceProvider extends ServiceProvider
                 $app['files'],
                 $app['config']['view.compiled'],
                 $app['config']->get('view.relative_hash', false) ? $app->basePath() : '',
+                $app['config']->get('view.use_cache', true),
             ), function ($blade) {
                 $blade->component('dynamic-component', DynamicComponent::class);
             });

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -89,7 +89,7 @@ class ViewServiceProvider extends ServiceProvider
                 $app['files'],
                 $app['config']['view.compiled'],
                 $app['config']->get('view.relative_hash', false) ? $app->basePath() : '',
-                $app['config']->get('view.use_cache', true),
+                $app['config']->get('view.cache', true),
             ), function ($blade) {
                 $blade->component('dynamic-component', DynamicComponent::class);
             });

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -39,6 +39,21 @@ class ViewBladeCompilerTest extends TestCase
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
+    public function testIsExpiredReturnsFalseWhenUseCacheIsTrueAndNoFileModification()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/'.sha1('v2foo').'.php')->andReturn(true);
+        $files->shouldReceive('lastModified')->once()->with('foo')->andReturn(0);
+        $files->shouldReceive('lastModified')->once()->with(__DIR__.'/'.sha1('v2foo').'.php')->andReturn(100);
+        $this->assertFalse($compiler->isExpired('foo'));
+    }
+
+    public function testIsExpiredReturnsTrueWhenUseCacheIsFalse()
+    {
+        $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__, $basePath = '', $useCache = false);
+        $this->assertTrue($compiler->isExpired('foo'));
+    }
+
     public function testCompilePathIsProperlyCreated()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Especially during development its very helpful to disable the cached views. Here are a few use cases:

- Switching domains on local from 127.0.0.1 to local-your-domain.com on local (such as when using ssl certificates)
When switching domains the same compiled view is returned using the old domain in JS, CSS, etc.

- Custom implementation that add modify contents on compile time, such as custom cache busters for JS.
Adding a query string to JS for cache busting done with PHP at compile time.

And many other use cases where view caching might not be desirable on local.

Relates to: https://github.com/laravel/framework/issues/2501

Would enable inside `config/view.php` using

```php
'cache' => App::environment('local') ? false : true
```

