### PR TITLE
[9.x] Allow Schema::enum to accept an Enum class

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1032,11 +1032,15 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array  $allowed
+     * @param  array|string  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, array|string $allowed)
     {
+        if (is_string($allowed) && function_exists('enum_exists') && enum_exists($allowed)) {
+            $allowed = array_map(fn($case) => $case->value, $allowed::cases());
+        }
+
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 

--- a/tests/Integration/Database/SchemaBlueprintEnumTest.php
+++ b/tests/Integration/Database/SchemaBlueprintEnumTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+include_once 'Enums.php';
+
+class SchemaBlueprintEnumTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('enums_table', function (Blueprint $table) {
+            $table->increments('id');
+            $table->enum('string_status', StringStatus::class)->nullable();
+            $table->enum('integer_status', IntegerStatus::class)->nullable();
+        });
+    }
+
+    public function testEnumClassAllowed()
+    {
+        $this->assertTrue(Schema::hasColumns('enums_table', ['string_status', 'integer_status']));
+    }
+
+}


### PR DESCRIPTION
This allows a cleaner syntax to define enum column in migrations.

Example
```php
$table->enum('status', Status::class);
```
