### PR TITLE
[9.x] Display CallbackEvent description in schedule:list

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -75,6 +75,9 @@ class ScheduleListCommand extends Command
                 if (class_exists($event->description)) {
                     $command = $event->description;
                     $description = '';
+                } else if($event->description) {
+                    $command = $event->description;
+                    $description = 'Closure at: '.$this->getClosureLocation($event);
                 } else {
                     $command = 'Closure at: '.$this->getClosureLocation($event);
                 }

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -75,7 +75,7 @@ class ScheduleListCommand extends Command
                 if (class_exists($event->description)) {
                     $command = $event->description;
                     $description = '';
-                } else if($event->description) {
+                } else if ($event->description) {
                     $command = $event->description;
                     $description = 'Closure at: '.$this->getClosureLocation($event);
                 } else {

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -75,7 +75,7 @@ class ScheduleListCommand extends Command
                 if (class_exists($event->description)) {
                     $command = $event->description;
                     $description = '';
-                } else if ($event->description) {
+                } elseif ($event->description) {
                     $command = $event->description;
                     $description = 'Closure at: '.$this->getClosureLocation($event);
                 } else {

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -39,23 +39,32 @@ class ScheduleListCommandTest extends TestCase
         $closureLineNumber = __LINE__ - 1;
         $closureFilePath = __FILE__;
 
+        $this->schedule->call(fn () => '')->everyMinute()->name('Foo closure description');
+
         $this->artisan(ScheduleListCommand::class)
             ->assertSuccessful()
             ->expectsOutput('  0 0     1 1-12/3 *  php artisan foo:command .... Next Due: 3 months from now')
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
-            ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
+            ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Foo closure description .... Next Due: 1 minute from now');
     }
 
     public function testDisplayScheduleInVerboseMode()
     {
         $this->schedule->command(FooCommand::class)->everyMinute();
 
+        $this->schedule->call(fn () => '')->everyMinute()->description('Foo closure description');
+        $closureLineNumber = __LINE__ - 1;
+        $closureFilePath = __FILE__;
+
         $this->artisan(ScheduleListCommand::class, ['-v' => true])
             ->assertSuccessful()
-            ->expectsOutputToContain('Next Due: '.now()->setMinutes(1)->format('Y-m-d H:i:s P'))
-            ->expectsOutput('             ⇁ This is the description of the command.');
+            ->expectsOutputToContain('Next Due: ')
+            ->expectsOutput('             ⇁ This is the description of the command.')
+            ->expectsOutput('  * * * * *  Foo closure description .... Next Due: '.now()->setMinutes(1)->format('Y-m-d H:i:s P'))
+            ->expectsOutput('             ⇁ Closure at: '.$closureFilePath.':'.$closureLineNumber);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Before the redesign of `php artisan schedule:list`, the description for anonymous closures was displayed - giving the developer a possibility to differentiate between callbacks. After the redesign the description was moved to `-v` and an addition was made to display the closure location as command name.

Having a list of closure locations doesn't help much if you have a lot of closures:
```
 * * * * *  Closure at: app\Console\Kernel.php:32 ............... Next Due: 48 minutes from now
 * * * * *  Closure at: app\Console\Kernel.php:48 ............... Next Due: 48 minutes from now
 * * * * *  Closure at: app\Console\Kernel.php:70 ............... Next Due: 48 minutes from now
 * * * * *  Closure at: app\Console\Kernel.php:83 ............... Next Due: 48 minutes from now
 * * * * *  Closure at: app\Console\Kernel.php:102 ............ Next Due: 48 minutes from now
 * * * * *  Closure at: app\Console\Kernel.php:123 ............ Next Due: 48 minutes from now
 * * * * *  Closure at: app\Console\Kernel.php:168 ............ Next Due: 48 minutes from now
```

# What changed?
Calling `$schedule->call()` without a description produces the closure location, as before.

If you set a description it will take priority over the location and the location will be pushed to verbose output `-v`
```php
$this->schedule->call(fn () => '')->everyMinute()->name('Foo closure description');
```

`php artisan schedule:list` produces:
```
 * * * * *  Foo closure description ............... Next Due: 48 minutes from now
```

And `php artisan schedule:list -v` output is:
```
 * * * * *  Foo closure description ............... Next Due: 2022-04-08 03:00:00 +00:00
             ⇁ Closure at: app\Console\Kernel.php:32
```

This adds a lot more readbility to the first example:
```
 * * * * *  Foo closure description ............................ Next Due: 48 minutes from now
 * * * * *  Perform foo bar .................................... Next Due: 48 minutes from now
 * * * * *  Perform some foo job................................. Next Due: 48 minutes from now
 * * * * *  Perform some foo job 2 ............................ Next Due: 48 minutes from now
 * * * * *  Perform some foo job 3 ............................ Next Due: 48 minutes from now
 * * * * *  Perform some foo job 4 ............................ Next Due: 48 minutes from now
 * * * * *  Perform some foo job 5 ............................ Next Due: 48 minutes from now
```

# Reason for PR
The expected output should be the most readable form of the commands, that is probably the description if it exists. The verbose output should contain more detailed information that will guide the developer to troubleshooting - that would be the location of the closure.