### PR TITLE
[9.x] Add test for assertChained in BusFake

### DIFF
--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Support\Testing\Fakes\BusFake;
 use Mockery as m;
@@ -376,6 +377,19 @@ class SupportTestingBusFakeTest extends TestCase
         }
     }
 
+    public function testAssertChained()
+    {
+        $this->fake->chain([
+            new ChainedJobStub,
+            new OtherBusJobStub,
+        ])->dispatch();
+
+        $this->fake->assertChained([
+            ChainedJobStub::class,
+            OtherBusJobStub::class,
+        ]);
+    }
+
     public function testAssertDispatchedWithIgnoreClass()
     {
         $dispatcher = m::mock(QueueingDispatcher::class);
@@ -445,6 +459,11 @@ class SupportTestingBusFakeTest extends TestCase
 class BusJobStub
 {
     //
+}
+
+class ChainedJobStub
+{
+    use Queueable;
 }
 
 class OtherBusJobStub


### PR DESCRIPTION
There was no test for assertChained() in Bus faker