### PR TITLE
[8.x] Fix seeder property for in-memory tests

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -24,6 +24,7 @@ class MigrateCommand extends BaseCommand
                 {--schema-path= : The path to a schema dump file}
                 {--pretend : Dump the SQL queries that would be run}
                 {--seed : Indicates if the seed task should be re-run}
+                {--seeder= : The class name of the root seeder}
                 {--step : Force the migrations to be run so they can be rolled back individually}';
 
     /**
@@ -89,7 +90,10 @@ class MigrateCommand extends BaseCommand
             // seed task to re-populate the database, which is convenient when adding
             // a migration and a seed at the same time, as it is only this command.
             if ($this->option('seed') && ! $this->option('pretend')) {
-                $this->call('db:seed', ['--force' => true]);
+                $this->call('db:seed', [
+                    '--class' => $this->option('seeder') ?: 'Database\\Seeders\\DatabaseSeeder',
+                    '--force' => true,
+                ]);
             }
         });
 

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -56,6 +56,7 @@ trait RefreshDatabase
     {
         return [
             '--seed' => $this->shouldSeed(),
+            '--seeder' => $this->seeder(),
         ];
     }
 


### PR DESCRIPTION
This PR fixes an issue when using the `$seeder` property on in-memory tests. Before this, no root seeder could be set but now, a defined root seeder is properly passed to the migrate command.

Fixes https://github.com/laravel/framework/issues/41863