### PR TITLE
[9.x] Fix null name for email address

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -220,13 +220,17 @@ class Message
         if (is_array($address)) {
             $type = lcfirst($type);
 
-            $addresses = collect($address)->map(function (string|array $address, $key) {
+            $addresses = collect($address)->map(function ($address, $key) {
                 if (is_string($key) && is_string($address)) {
                     return new Address($key, $address);
                 }
 
                 if (is_array($address)) {
                     return new Address($address['email'] ?? $address['address'], $address['name'] ?? null);
+                }
+
+                if (is_null($address)) {
+                    return new Address($key);
                 }
 
                 return $address;


### PR DESCRIPTION
This PR fixes an issue where a user may have defined a null name for their address/email key/value combination. Technically this is a userland issue but since this was handled gracefully before we should do this as well in Laravel v9.

See #40895
