### PR TITLE
[9.x] Catch permission exception when creating directory

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -779,7 +779,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->createDirectory($path);
-        } catch (UnableToCreateDirectory $e) {
+        } catch (UnableToCreateDirectory | UnableToSetVisibility $e) {
             throw_if($this->throwsExceptions(), $e);
 
             return false;

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -344,7 +344,7 @@ class FilesystemAdapter implements CloudFilesystemContract
             is_resource($contents)
                 ? $this->driver->writeStream($path, $contents, $options)
                 : $this->driver->write($path, $contents, $options);
-        } catch (UnableToWriteFile $e) {
+        } catch (UnableToWriteFile|UnableToSetVisibility $e) {
             throw_if($this->throwsExceptions(), $e);
 
             return false;
@@ -581,7 +581,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->writeStream($path, $resource, $options);
-        } catch (UnableToWriteFile $e) {
+        } catch (UnableToWriteFile|UnableToSetVisibility $e) {
             throw_if($this->throwsExceptions(), $e);
 
             return false;
@@ -779,7 +779,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         try {
             $this->driver->createDirectory($path);
-        } catch (UnableToCreateDirectory | UnableToSetVisibility $e) {
+        } catch (UnableToCreateDirectory|UnableToSetVisibility $e) {
             throw_if($this->throwsExceptions(), $e);
 
             return false;


### PR DESCRIPTION
Flysystem v3 throws an exception when attempting to create a directory that already exists, and the correct permissions cannot be set.

I have added the `['throws' => false]` in my disks on the `config/filesystems.php` file.

For example, running `Storage::makeDirectory('test')` from artisan (console kernel) creates the `test` directory with the console user and appropriate permissions.
Then, running `Storage::makeDirectory('test')` from the web (http kernel), throws an exception because the directory exists, and attemps to change the permissions, while the web user is not the same as the console user, so it fails.

```
League\Flysystem\UnableToSetVisibility Unable to set visibility for file test. 
    vendor/league/flysystem/src/UnableToSetVisibility.php:33 League\Flysystem\UnableToSetVisibility::atLocation
    vendor/league/flysystem/src/Local/LocalFilesystemAdapter.php:422 League\Flysystem\Local\LocalFilesystemAdapter::setPermissions
    vendor/league/flysystem/src/Local/LocalFilesystemAdapter.php:320 League\Flysystem\Local\LocalFilesystemAdapter::createDirectory
    vendor/league/flysystem/src/Filesystem.php:96 League\Flysystem\Filesystem::createDirectory
    vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemAdapter.php:781 Illuminate\Filesystem\FilesystemAdapter::makeDirectory
```

Since Laravel allows to return false instead of throwing exceptions, this exception should be handled.

The same exception is already handled in the `Storage::setVisibility()` method.

Also, it should probably be handled in the `writeStream` and `put` methods?