### PR TITLE
[9.x] Improve Unicode support on `Str::squish()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -889,7 +889,7 @@ class Str
      */
     public static function squish($value)
     {
-        return preg_replace('/\s+/', ' ', trim($value));
+        return preg_replace('~\s+~u', ' ', preg_replace('~^\s+|\s+$~u', '', $value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -547,6 +547,12 @@ class SupportStrTest extends TestCase
             php
             framework
         '));
+        $this->assertSame('laravel php framework', Str::squish('   laravel   php   framework   '));
+        $this->assertSame('123', Str::squish('   123    '));
+        $this->assertSame('だ', Str::squish('だ'));
+        $this->assertSame('ム', Str::squish('ム'));
+        $this->assertSame('だ', Str::squish('   だ    '));
+        $this->assertSame('ム', Str::squish('   ム    '));
     }
 
     public function testStudly()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -620,6 +620,12 @@ class SupportStringableTest extends TestCase
             with
             spaces
         ')->squish());
+        $this->assertSame('laravel php framework', (string) $this->stringable('   laravel   php   framework   ')->squish());
+        $this->assertSame('123', (string) $this->stringable('   123    ')->squish());
+        $this->assertSame('だ', (string) $this->stringable('だ')->squish());
+        $this->assertSame('ム', (string) $this->stringable('ム')->squish());
+        $this->assertSame('だ', (string) $this->stringable('   だ    ')->squish());
+        $this->assertSame('ム', (string) $this->stringable('   ム    ')->squish());
     }
 
     public function testStart()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Similar to what was done in PR #40600 this PR:

- Improves Unicode support on the newly added `Str::squish()` and its `Stringable` counterpart.
- Adds tests from similar to the `TrimStrings` ones that would fail if without this PR
