### PR TITLE
[9.x] Add last() method to Query Builder

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -304,7 +304,7 @@ trait BuildsQueries
      */
     public function last($columns = ['*'])
     {
-        return $this->latest(primaryKey: true)->take(1)->get($columns)->first();
+        return $this->latest(defaultKey: true)->take(1)->get($columns)->first();
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -297,6 +297,17 @@ trait BuildsQueries
     }
 
     /**
+     * Execute the query and get the last result.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     */
+    public function last($columns = ['*'])
+    {
+        return $this->latest()->take(1)->get($columns)->first();
+    }
+
+    /**
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -304,7 +304,7 @@ trait BuildsQueries
      */
     public function last($columns = ['*'])
     {
-        return $this->latest()->take(1)->get($columns)->first();
+        return $this->latest(primaryKey: true)->take(1)->get($columns)->first();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -346,7 +346,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "order by" clause for a timestamp to the query.
+     * Add an "order by" clause for a timestamp or primary key to the query.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -346,7 +346,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "order by" clause for a timestamp or primary key to the query.
+     * Add an "order by" clause for a timestamp or default key to the query.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @return $this
@@ -354,7 +354,7 @@ class Builder implements BuilderContract
     public function latest($column = null, $primaryKey = false)
     {
         if (is_null($column)) {
-            $column = $primaryKey ? $this->model->getKeyName() : $this->model->getCreatedAtColumn() ?? 'created_at';
+            $column = $primaryKey ? $this->defaultKeyName() : $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
         $this->query->latest($column);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -351,10 +351,10 @@ class Builder implements BuilderContract
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @return $this
      */
-    public function latest($column = null, $primaryKey = false)
+    public function latest($column = null, $defaultKey = false)
     {
         if (is_null($column)) {
-            $column = $primaryKey ? $this->defaultKeyName() : $this->model->getCreatedAtColumn() ?? 'created_at';
+            $column = $defaultKey ? $this->defaultKeyName() : $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
         $this->query->latest($column);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -351,10 +351,10 @@ class Builder implements BuilderContract
      * @param  string|\Illuminate\Database\Query\Expression  $column
      * @return $this
      */
-    public function latest($column = null)
+    public function latest($column = null, $primaryKey = false)
     {
         if (is_null($column)) {
-            $column = $this->model->getCreatedAtColumn() ?? 'created_at';
+            $column = $primaryKey ? $this->model->getKeyName() : $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
         $this->query->latest($column);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2248,9 +2248,9 @@ class Builder implements BuilderContract
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @return $this
      */
-    public function latest($column = 'created_at')
+    public function latest($column = 'created_at', $primaryKey = false)
     {
-        return $this->orderBy($column, 'desc');
+        return $this->orderBy($primaryKey ? 'id' : $column, 'desc');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2243,14 +2243,14 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "order by" clause for a timestamp or primary key to the query.
+     * Add an "order by" clause for a timestamp or default key to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @return $this
      */
     public function latest($column = 'created_at', $primaryKey = false)
     {
-        return $this->orderBy($primaryKey ? 'id' : $column, 'desc');
+        return $this->orderBy($primaryKey ? $this->defaultKeyName() : $column, 'desc');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2248,9 +2248,9 @@ class Builder implements BuilderContract
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @return $this
      */
-    public function latest($column = 'created_at', $primaryKey = false)
+    public function latest($column = 'created_at', $defaultKey = false)
     {
-        return $this->orderBy($primaryKey ? $this->defaultKeyName() : $column, 'desc');
+        return $this->orderBy($defaultKey ? $this->defaultKeyName() : $column, 'desc');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2243,7 +2243,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "order by" clause for a timestamp to the query.
+     * Add an "order by" clause for a timestamp or primary key to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @return $this


### PR DESCRIPTION
This pull request adds `last()` method to Eloquent Query Builder classes.

People were using `latest()->first()` and I think it could be helpful.

Also, the use of `latest()->first()` is actually a bad practice when you want the last record of a given table, because it could return unexpected results on records created at same timestamp (literally returning the first of the last).

This PR also solves this, adding an optional parameter to `latest()` method called `primaryKey`. When it is set to true, Eloquent will `getKeyName()` before use `created_at`, while default Query Builder will always use `defaultKeyName()`.

It also works for model relationships, of course.

Examples:

![image](https://user-images.githubusercontent.com/79855605/162340406-9e47d4cb-87d8-4738-81d3-bd78f47438ba.png)
![image](https://user-images.githubusercontent.com/79855605/162340416-f5c7a25a-c9bf-4fd4-949d-ab17961a10ac.png)
![image](https://user-images.githubusercontent.com/79855605/162349872-864250fd-8cb9-4d3d-8a8f-8ac10575341b.png)
