### PR TITLE
[9.x] Fix bug in BelongsToMany where non-related rows are returned

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -600,7 +600,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->related->where($attributes)->first())) {
+        if (is_null($instance = $this->clone()->where($attributes)->first())) {
             $instance = $this->related->newInstance(array_merge($attributes, $values));
         }
 
@@ -618,7 +618,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->related->where($attributes)->first())) {
+        if (is_null($instance = $this->clone()->where($attributes)->first())) {
             $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
         }
 
@@ -636,7 +636,7 @@ class BelongsToMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->related->where($attributes)->first())) {
+        if (is_null($instance = $this->clone()->where($attributes)->first())) {
             return $this->create(array_merge($attributes, $values), $joining, $touch);
         }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -427,6 +427,18 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(Tag::class, $post->tags()->firstOrNew(['id' => 666]));
     }
 
+    public function testFirstOrNewWithoutExistingRelated()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $name = Str::random();
+        $tag = Tag::create(['name' => $name]);
+
+        $new = $post->tags()->firstOrNew(['name' => $name]);
+        $this->assertSame($name, $new->name);
+        $this->assertFalse($tag->is($new));
+    }
+
     public function testFirstOrCreateMethod()
     {
         $post = Post::create(['title' => Str::random()]);
@@ -440,6 +452,20 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $new = $post->tags()->firstOrCreate(['name' => 'wavez']);
         $this->assertSame('wavez', $new->name);
         $this->assertNotNull($new->id);
+    }
+
+    public function testFirstOrCreateWithoutExistingRelated()
+    {
+        /** @var Post $post */
+        $post = Post::create(['title' => Str::random()]);
+
+        $name = Str::random();
+        $tag = Tag::create(['name' => $name]);
+
+        $new = $post->tags()->firstOrCreate(['name' => $name]);
+        $this->assertSame($name, $new->name);
+        $this->assertNotNull($new->id);
+        $this->assertFalse($tag->is($new));
     }
 
     public function testFirstOrNewMethodWithValues()
@@ -517,6 +543,18 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post->tags()->updateOrCreate(['id' => 666], ['name' => 'dives']);
         $this->assertNotNull($post->tags()->whereName('dives')->first());
+    }
+
+    public function testUpdateOrCreateWithoutExistingRelated()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => 'foo']);
+
+        $new = $post->tags()->updateOrCreate(['name' => 'foo'], ['name' => 'wavez']);
+        $this->assertSame('foo', $tag->fresh()->name);
+        $this->assertSame('wavez', $new->name);
+        $this->assertFalse($tag->is($new));
     }
 
     public function testUpdateOrCreateMethodCreate()


### PR DESCRIPTION
While working on a [new package](https://gitlab.com/marcovo/laravel-dag-model) for laravel, I encountered a failing test on laravel 9.x with no apparent reason. After digging a bit deeper, I came to understand that `firstOrNew()`, `firstOrCreate()` and `updateOrCreate()` were not doing what I expected.

**Expected behaviour**
These three methods only return or affect related rows that are in fact related to the current model.

**Actual behaviour**
The `firstOr*` methods will return any row in the related table, not subject to the relation constraint. Likewise, the `updateOrCreate` method updates any one row in the related table, not subject to the relation constraint. In all cases, any passed `$attributes` are correctly used, it is the relation constraint that is missing.

**Fix**
In commit 3e66eb75ae379f14eb760a19071a07134de797e3 a change in laravel 9 was introduced where the lookup would be done using `$this->related` instead of `$this`. This PR changes this to `$this->clone()`. Three tests are added which fail on the current 9.x version, and are fixed using this PR.

Targetting 9.x because 8.x does not use the `$this->related` approach.

**Considerations**
In commit 3e66eb75ae379f14eb760a19071a07134de797e3, no tests are added backing the change to use `$this->related` instead of `$this`. I can imagine it has something to do with not wanting to pollute the current query builder with the additional `where()` method? In that case I'm confident this PR is still compatible, otherwise you might want to double check.
