### PR TITLE
[9.x] Set visible, hidden, appended, fillable and guarded attributes on the new model instance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -511,9 +511,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $model->setAppends($this->appends);
 
-        $model->mergeFillable($this->fillable);
+        $model->fillable($this->fillable);
 
-        $model->mergeGuarded($this->guarded);
+        $model->guard($this->guarded);
 
         $model->fill((array) $attributes);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -482,7 +482,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Create a new instance of the given model.
+     * Create a new instance of the model.
      *
      * @param  array  $attributes
      * @param  bool  $exists
@@ -504,6 +504,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $model->setTable($this->getTable());
 
         $model->mergeCasts($this->casts);
+
+        $model->setVisible($this->visible);
+
+        $model->setHidden($this->hidden);
+
+        $model->setAppends($this->appends);
+
+        $model->mergeFillable($this->fillable);
+
+        $model->mergeGuarded($this->guarded);
 
         $model->fill((array) $attributes);
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -307,6 +307,51 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('date', $newInstance->getCasts()['foo']);
     }
 
+    public function testNewInstanceReturnsNewInstanceWithAppendsSet()
+    {
+        $model = new EloquentModelStub;
+        $model->append(['appendable']);
+        $newInstance = $model->newInstance();
+
+        $this->assertTrue($newInstance->hasAppended('appendable'));
+    }
+
+    public function testNewInstanceReturnsNewInstanceWithHiddenSet()
+    {
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+        $model->setHidden(['age', 'id']);
+        $newInstance = $model->newInstance();
+
+        $this->assertSame($model->getHidden(), $newInstance->getHidden());
+    }
+
+    public function testNewInstanceReturnsNewInstanceWithVisibleSet()
+    {
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+        $model->setVisible(['name', 'age']);
+        $newInstance = $model->newInstance();
+
+        $this->assertSame($model->getVisible(), $newInstance->getVisible());
+    }
+
+    public function testNewInstanceReturnsNewInstanceWithMergedFillable()
+    {
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+        $model->mergeFillable(['name', 'age']);
+        $newInstance = $model->newInstance();
+
+        $this->assertSame($model->getFillable(), $newInstance->getFillable());
+    }
+
+    public function testNewInstanceReturnsNewInstanceWithMergedGuarded()
+    {
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+        $model->mergeGuarded(['id']);
+        $newInstance = $model->newInstance();
+
+        $this->assertSame($model->getGuarded(), $newInstance->getGuarded());
+    }
+
     public function testCreateMethodSavesNewModel()
     {
         $_SERVER['__eloquent.saved'] = false;


### PR DESCRIPTION
The new model instance should have the same visible, hidden, appended, fillable, and guarded attributes as the model.

Before this PR, retrieved records using a model that has dynamic hidden or appended attributes doesn't hide/append these attributes respectively:

```php
(new User)->makeHidden('email')->append('is_admin')->all()->toArray();

/* Before this PR
[
  [
    "id" => 1,
    "name" => "Taylor Otwell",
    "email" => "taylor@otwell.com",
    "created_at" => "2021-03-10T12:53:35.000000Z",
    "updated_at" => "2021-03-10T12:53:35.000000Z",
  ],
  [
    "id" => 2,
    "name" => "Hafez Divandari",
    "email" => "hafezdivandari@gmail.com",
    "created_at" => "2022-03-10T12:53:35.000000Z",
    "updated_at" => "2022-03-10T12:53:35.000000Z",
  ],
]
/*

/* After this PR
[
  [
    "id" => 1,
    "name" => "Taylor Otwell",
    "is_admin" => true,
    "created_at" => "2021-03-10T12:53:35.000000Z",
    "updated_at" => "2021-03-10T12:53:35.000000Z",
  ],
  [
    "id" => 2,
    "name" => "Hafez Divandari",
    "is_admin" => false,
    "created_at" => "2022-03-10T12:53:35.000000Z",
    "updated_at" => "2022-03-10T12:53:35.000000Z",
  ],
]
/*
```
