### PR TITLE
[9.x] Add `->set()` method to factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -484,7 +484,7 @@ abstract class Factory
     }
 
     /**
-     * Put a specific key in the model definition.
+     * Set a single model attribute.
      *
      * @param  string|int  $key
      * @param  mixed  $value

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -486,8 +486,8 @@ abstract class Factory
     /**
      * Put a specific key in the model definition.
      *
-     * @param string|int $key
-     * @param mixed $value
+     * @param  string|int  $key
+     * @param  mixed  $value
      * @return static
      */
     public function set($key, $value)

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -484,6 +484,18 @@ abstract class Factory
     }
 
     /**
+     * Put a specific key in the model definition.
+     *
+     * @param string|int $key
+     * @param mixed $value
+     * @return static
+     */
+    public function set($key, $value)
+    {
+        return $this->state([$key => $value]);
+    }
+
+    /**
      * Add a new sequenced state transformation to the model definition.
      *
      * @param  array  $sequence

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -108,6 +108,10 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertInstanceOf(Eloquent::class, $user);
         $this->assertSame('Taylor Otwell', $user->name);
 
+        $user = FactoryTestUserFactory::new()->set('name', 'Taylor Otwell')->create();
+        $this->assertInstanceOf(Eloquent::class, $user);
+        $this->assertSame('Taylor Otwell', $user->name);
+
         $users = FactoryTestUserFactory::new()->createMany([
             ['name' => 'Taylor Otwell'],
             ['name' => 'Jeffrey Way'],


### PR DESCRIPTION
Lately I've been writing unit-tests for the models of an application that did not have many tests yet. In that application many scopes were used. 

I noticed that I was often creating models like this, where you just need to make one little change every time:

```php
EloquentModel::factory()
    ->create(['name' => 'foo']);

EloquentModel::factory()
    ->someMethod()
    ->create(['country' => 'NL']);
```

I figured out that the tests would look a lot cleaner if we could just get rid of those single-item arrays, so I came up with a small method called `->set()`. This method is in my eyes easier and more expressive than `->create(['foo' => 'bar'])`, because it is immediately clear that we're setting only a single property here. 

```php
EloquentModel::factory()
    ->set('name', 'foo')
    ->create();

EloquentModel::factory()
    ->someMethod()
    ->set('country', 'NL')
    ->create();
```

Another option would be to name the method `->put()`, in line with the similar collection method (but personally I prefer `->set()`).