### PR TITLE
[9.x] Removes redundant uncountable words and change language for pluralizer ruleset

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use Illuminate\Container\Container;
 use Doctrine\Inflector\InflectorFactory;
 
 class Pluralizer
@@ -77,7 +78,8 @@ class Pluralizer
         static $inflector;
 
         if (is_null($inflector)) {
-            $inflector = InflectorFactory::createForLanguage('english')->build();
+            $app = Container::getInstance();
+            $inflector = InflectorFactory::createForLanguage( $app['config']->get('app.pluralizer_ruleset', 'english') )->build();
         }
 
         return $inflector;

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -9,53 +9,8 @@ class Pluralizer
     /**
      * Uncountable word forms.
      *
-     * @var string[]
+     * New uncuntable words should be added to: https://github.com/doctrine/inflector/blob/2.0.x/lib/Doctrine/Inflector/Rules/English/Uninflected.php
      */
-    public static $uncountable = [
-        'audio',
-        'bison',
-        'cattle',
-        'chassis',
-        'compensation',
-        'coreopsis',
-        'data',
-        'deer',
-        'education',
-        'emoji',
-        'equipment',
-        'evidence',
-        'feedback',
-        'firmware',
-        'fish',
-        'furniture',
-        'gold',
-        'hardware',
-        'information',
-        'jedi',
-        'kin',
-        'knowledge',
-        'love',
-        'metadata',
-        'money',
-        'moose',
-        'news',
-        'nutrition',
-        'offspring',
-        'plankton',
-        'pokemon',
-        'police',
-        'rain',
-        'recommended',
-        'related',
-        'rice',
-        'series',
-        'sheep',
-        'software',
-        'species',
-        'swine',
-        'traffic',
-        'wheat',
-    ];
 
     /**
      * Get the plural form of an English word.
@@ -70,7 +25,7 @@ class Pluralizer
             $count = count($count);
         }
 
-        if ((int) abs($count) === 1 || static::uncountable($value) || preg_match('/^(.*)[A-Za-z0-9\x{0080}-\x{FFFF}]$/u', $value) == 0) {
+        if ((int) abs($count) === 1 || preg_match('/^(.*)[A-Za-z0-9\x{0080}-\x{FFFF}]$/u', $value) == 0) {
             return $value;
         }
 
@@ -90,17 +45,6 @@ class Pluralizer
         $singular = static::inflector()->singularize($value);
 
         return static::matchCase($singular, $value);
-    }
-
-    /**
-     * Determine if the given value is uncountable.
-     *
-     * @param  string  $value
-     * @return bool
-     */
-    protected static function uncountable($value)
-    {
-        return in_array(strtolower($value), static::$uncountable);
     }
 
     /**


### PR DESCRIPTION
Hi!

As seen in https://github.com/doctrine/inflector/blob/2.0.x/lib/Doctrine/Inflector/RulesetInflector.php#L37
when inflecting a word, either pluralizing or singularizing, Inflector calls $ruleset->getUninflected()->matches($word)
to check if the inflected word is in https://github.com/doctrine/inflector/blob/2.0.x/lib/Doctrine/Inflector/Rules/English/Uninflected.php
or the corresponding language Uninflected file, if it is, it returns the very same word, unchanged.

There are only 7 words not directly listed there, those beeing: `'cattle', 'firmware', 'hardware', 'kin', 'recommended', 'related', 'software'`, from those, `yield new Pattern('\w+ware$')` on [line 42](https://github.com/doctrine/inflector/blob/2.0.x/lib/Doctrine/Inflector/Rules/English/Uninflected.php#L42) matches firm... hard... and soft...ware.

I already created a pull request to add those there https://github.com/doctrine/inflector/pull/194

There's really no reason to keep them. New words should be requested on that Uninflected file, for all the available languages.

Now, as for the language ruleset, I'm not really sure if it's allowed to call `Container::getInstance()` inside Illuminate/Support, the only other file that does this is [Traits/Localizable.php](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Support/Traits/Localizable.php) but it works fine locally on my machine.

With that, we can add a 'pluralizer_ruleset' config on app.php to choose between `'english', 'french', 'norwegian-bokmal', 'portuguese', 'spanish', 'turkish'`

I believe this change is backward compatible with older versions, i tested on my 8.x version