### PR TITLE
[9.x] Add getAllTables support for SQLite and SQLServer schema builders

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -246,25 +246,25 @@ class SQLiteGrammar extends Grammar
         return "delete from sqlite_master where type in ('view')";
     }
 
-	/**
-	 * Compile the SQL needed to retrieve all table names.
-	 *
-	 * @return string
-	 */
-	public function compileGetAllTables()
-	{
-		return 'Select type,name from sqlite_master where type = \'table\' and name not like \'sqlite_%\'';
-	}
+    /**
+     * Compile the SQL needed to retrieve all table names.
+     *
+     * @return string
+     */
+    public function compileGetAllTables()
+    {
+        return 'select type, name from sqlite_master where type = \'table\' and name not like \'sqlite_%\'';
+    }
 
-	/**
-	 * Compile the SQL needed to retrieve all view names.
-	 *
-	 * @return string
-	 */
-	public function compileGetAllViews()
-	{
-		return 'select type,name from sqlite_master where type = \'view\'';
-	}
+    /**
+     * Compile the SQL needed to retrieve all view names.
+     *
+     * @return string
+     */
+    public function compileGetAllViews()
+    {
+        return 'select type, name from sqlite_master where type = \'view\'';
+    }
 
     /**
      * Compile the SQL needed to rebuild the database.

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -246,6 +246,26 @@ class SQLiteGrammar extends Grammar
         return "delete from sqlite_master where type in ('view')";
     }
 
+	/**
+	 * Compile the SQL needed to retrieve all table names.
+	 *
+	 * @return string
+	 */
+	public function compileGetAllTables()
+	{
+		return 'Select type,name from sqlite_master where type = \'table\' and name not like \'sqlite_%\'';
+	}
+
+	/**
+	 * Compile the SQL needed to retrieve all view names.
+	 *
+	 * @return string
+	 */
+	public function compileGetAllViews()
+	{
+		return 'select type,name from sqlite_master where type = \'view\'';
+	}
+
     /**
      * Compile the SQL needed to rebuild the database.
      *

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -393,25 +393,25 @@ class SqlServerGrammar extends Grammar
             EXEC sp_executesql @sql;";
     }
 
-	/**
-	 * Compile the SQL needed to retrieve all table names.
-	 *
-	 * @return string
-	 */
-	public function compileGetAllTables()
-	{
-		return "Select name,type from sys.tables where type = 'U'";
-	}
+    /**
+     * Compile the SQL needed to retrieve all table names.
+     *
+     * @return string
+     */
+    public function compileGetAllTables()
+    {
+        return "select name, type from sys.tables where type = 'U'";
+    }
 
-	/**
-	 * Compile the SQL needed to retrieve all view names.
-	 *
-	 * @return string
-	 */
-	public function compileGetAllViews()
-	{
-		return "Select name,type from sys.objects where type = 'V'";
-	}
+    /**
+     * Compile the SQL needed to retrieve all view names.
+     *
+     * @return string
+     */
+    public function compileGetAllViews()
+    {
+        return "select name, type from sys.objects where type = 'V'";
+    }
 
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -393,6 +393,27 @@ class SqlServerGrammar extends Grammar
             EXEC sp_executesql @sql;";
     }
 
+	/**
+	 * Compile the SQL needed to retrieve all table names.
+	 *
+	 * @return string
+	 */
+	public function compileGetAllTables()
+	{
+		return "Select name,type from sys.tables where type = 'U'";
+	}
+
+	/**
+	 * Compile the SQL needed to retrieve all view names.
+	 *
+	 * @return string
+	 */
+	public function compileGetAllViews()
+	{
+		return "Select name,type from sys.objects where type = 'V'";
+	}
+
+
     /**
      * Create the column definition for a char type.
      *

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -30,6 +30,30 @@ class SQLiteBuilder extends Builder
             : true;
     }
 
+	/**
+	 * Get all of the table names for the database.
+	 *
+	 * @return array
+	 */
+	public function getAllTables()
+	{
+		return $this->connection->select(
+			$this->grammar->compileGetAllTables()
+		);
+	}
+
+	/**
+	 * Get all of the view names for the database.
+	 *
+	 * @return array
+	 */
+	public function getAllViews()
+	{
+		return $this->connection->select(
+			$this->grammar->compileGetAllViews()
+		);
+	}
+
     /**
      * Drop all tables from the database.
      *

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -30,30 +30,6 @@ class SQLiteBuilder extends Builder
             : true;
     }
 
-	/**
-	 * Get all of the table names for the database.
-	 *
-	 * @return array
-	 */
-	public function getAllTables()
-	{
-		return $this->connection->select(
-			$this->grammar->compileGetAllTables()
-		);
-	}
-
-	/**
-	 * Get all of the view names for the database.
-	 *
-	 * @return array
-	 */
-	public function getAllViews()
-	{
-		return $this->connection->select(
-			$this->grammar->compileGetAllViews()
-		);
-	}
-
     /**
      * Drop all tables from the database.
      *
@@ -88,6 +64,30 @@ class SQLiteBuilder extends Builder
         $this->connection->select($this->grammar->compileDisableWriteableSchema());
 
         $this->connection->select($this->grammar->compileRebuild());
+    }
+
+    /**
+     * Get all of the table names for the database.
+     *
+     * @return array
+     */
+    public function getAllTables()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllTables()
+        );
+    }
+
+    /**
+     * Get all of the view names for the database.
+     *
+     * @return array
+     */
+    public function getAllViews()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllViews()
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -30,30 +30,6 @@ class SqlServerBuilder extends Builder
         );
     }
 
-    /**
-     * Drop all tables from the database.
-     *
-     * @return array
-     */
-    public function getAllTables()
-    {
-		return $this->connection->select(
-			$this->grammar->compileGetAllTables()
-		);
-    }
-
-	/**
-	 * Get all of the view names for the database.
-	 *
-	 * @return array
-	 */
-	public function getAllViews()
-	{
-		return $this->connection->select(
-			$this->grammar->compileGetAllViews()
-		);
-	}
-
 	/**
      * Drop all tables from the database.
      *
@@ -74,5 +50,29 @@ class SqlServerBuilder extends Builder
     public function dropAllViews()
     {
         $this->connection->statement($this->grammar->compileDropAllViews());
+    }
+
+    /**
+     * Drop all tables from the database.
+     *
+     * @return array
+     */
+    public function getAllTables()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllTables()
+        );
+    }
+
+    /**
+     * Get all of the view names for the database.
+     *
+     * @return array
+     */
+    public function getAllViews()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllViews()
+        );
     }
 }

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -33,6 +33,30 @@ class SqlServerBuilder extends Builder
     /**
      * Drop all tables from the database.
      *
+     * @return array
+     */
+    public function getAllTables()
+    {
+		return $this->connection->select(
+			$this->grammar->compileGetAllTables()
+		);
+    }
+
+	/**
+	 * Get all of the view names for the database.
+	 *
+	 * @return array
+	 */
+	public function getAllViews()
+	{
+		return $this->connection->select(
+			$this->grammar->compileGetAllViews()
+		);
+	}
+
+	/**
+     * Drop all tables from the database.
+     *
      * @return void
      */
     public function dropAllTables()

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\SqlServer;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use stdClass;
+
+class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
+{
+	protected function getEnvironmentSetUp($app)
+	{
+		if (getenv('DB_CONNECTION') !== 'sqlsrv') {
+			$this->markTestSkipped('Test requires a SQLServer connection.');
+		}
+
+		$this->driver = 'sqlsrv';
+	}
+
+	protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+	{
+		Schema::create('users', function (Blueprint $table) {
+			$table->integer('id');
+			$table->string('name');
+			$table->string('age');
+			$table->enum('color', ['red', 'blue']);
+		});
+	}
+
+	protected function destroyDatabaseMigrations()
+	{
+		Schema::drop('users');
+	}
+
+	public function testGetAllTablesAndColumnListing()
+	{
+		$tables = Schema::getAllTables();
+
+		$this->assertCount(2, $tables);
+		$tableProperties = array_values((array) $tables[0]);
+		$this->assertEquals(['migrations', 'U '], $tableProperties);
+
+		$this->assertInstanceOf(stdClass::class, $tables[1]);
+
+		$tableProperties = array_values((array) $tables[1]);
+		$this->assertEquals(['users', 'U '], $tableProperties);
+
+		$columns = Schema::getColumnListing('users');
+
+		foreach (['id', 'name', 'age', 'color'] as $column) {
+			$this->assertContains($column, $columns);
+		}
+
+		Schema::create('posts', function (Blueprint $table) {
+			$table->integer('id');
+			$table->string('title');
+		});
+		$tables = Schema::getAllTables();
+		$this->assertCount(3, $tables);
+		Schema::drop('posts');
+	}
+
+	public function testGetAllViews()
+	{
+		DB::connection('sqlsrv')->statement(<<<SQL
+CREATE VIEW users_view
+AS 
+SELECT name,age from users;
+SQL);
+
+		$tableView = Schema::getAllViews();
+
+		$this->assertCount(1, $tableView);
+		$this->assertInstanceOf(stdClass::class, $obj = array_values($tableView)[0]);
+		$this->assertEquals('users_view', $obj->name);
+		$this->assertEquals('V ', $obj->type);
+
+		DB::connection('sqlsrv')->statement(<<<SQL
+DROP VIEW IF EXISTS users_view;
+SQL);
+
+		$this->assertEmpty(Schema::getAllViews());
+	}
+}

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerSchemaBuilderTest.php
@@ -9,77 +9,77 @@ use stdClass;
 
 class DatabaseSqlServerSchemaBuilderTest extends SqlServerTestCase
 {
-	protected function getEnvironmentSetUp($app)
-	{
-		if (getenv('DB_CONNECTION') !== 'sqlsrv') {
-			$this->markTestSkipped('Test requires a SQLServer connection.');
-		}
+    protected function getEnvironmentSetUp($app)
+    {
+        if (getenv('DB_CONNECTION') !== 'sqlsrv') {
+            $this->markTestSkipped('Test requires a SQLServer connection.');
+        }
 
-		$this->driver = 'sqlsrv';
-	}
+        $this->driver = 'sqlsrv';
+    }
 
-	protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
-	{
-		Schema::create('users', function (Blueprint $table) {
-			$table->integer('id');
-			$table->string('name');
-			$table->string('age');
-			$table->enum('color', ['red', 'blue']);
-		});
-	}
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('name');
+            $table->string('age');
+            $table->enum('color', ['red', 'blue']);
+        });
+    }
 
-	protected function destroyDatabaseMigrations()
-	{
-		Schema::drop('users');
-	}
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('users');
+    }
 
-	public function testGetAllTablesAndColumnListing()
-	{
-		$tables = Schema::getAllTables();
+    public function testGetAllTablesAndColumnListing()
+    {
+        $tables = Schema::getAllTables();
 
-		$this->assertCount(2, $tables);
-		$tableProperties = array_values((array) $tables[0]);
-		$this->assertEquals(['migrations', 'U '], $tableProperties);
+        $this->assertCount(2, $tables);
+        $tableProperties = array_values((array) $tables[0]);
+        $this->assertEquals(['migrations', 'U '], $tableProperties);
 
-		$this->assertInstanceOf(stdClass::class, $tables[1]);
+        $this->assertInstanceOf(stdClass::class, $tables[1]);
 
-		$tableProperties = array_values((array) $tables[1]);
-		$this->assertEquals(['users', 'U '], $tableProperties);
+        $tableProperties = array_values((array) $tables[1]);
+        $this->assertEquals(['users', 'U '], $tableProperties);
 
-		$columns = Schema::getColumnListing('users');
+        $columns = Schema::getColumnListing('users');
 
-		foreach (['id', 'name', 'age', 'color'] as $column) {
-			$this->assertContains($column, $columns);
-		}
+        foreach (['id', 'name', 'age', 'color'] as $column) {
+            $this->assertContains($column, $columns);
+        }
 
-		Schema::create('posts', function (Blueprint $table) {
-			$table->integer('id');
-			$table->string('title');
-		});
-		$tables = Schema::getAllTables();
-		$this->assertCount(3, $tables);
-		Schema::drop('posts');
-	}
+        Schema::create('posts', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('title');
+        });
+        $tables = Schema::getAllTables();
+        $this->assertCount(3, $tables);
+        Schema::drop('posts');
+    }
 
-	public function testGetAllViews()
-	{
-		DB::connection('sqlsrv')->statement(<<<SQL
+    public function testGetAllViews()
+    {
+        DB::connection('sqlsrv')->statement(<<<SQL
 CREATE VIEW users_view
-AS 
+AS
 SELECT name,age from users;
 SQL);
 
-		$tableView = Schema::getAllViews();
+        $tableView = Schema::getAllViews();
 
-		$this->assertCount(1, $tableView);
-		$this->assertInstanceOf(stdClass::class, $obj = array_values($tableView)[0]);
-		$this->assertEquals('users_view', $obj->name);
-		$this->assertEquals('V ', $obj->type);
+        $this->assertCount(1, $tableView);
+        $this->assertInstanceOf(stdClass::class, $obj = array_values($tableView)[0]);
+        $this->assertEquals('users_view', $obj->name);
+        $this->assertEquals('V ', $obj->type);
 
-		DB::connection('sqlsrv')->statement(<<<SQL
+        DB::connection('sqlsrv')->statement(<<<SQL
 DROP VIEW IF EXISTS users_view;
 SQL);
 
-		$this->assertEmpty(Schema::getAllViews());
-	}
+        $this->assertEmpty(Schema::getAllViews());
+    }
 }

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -10,83 +10,83 @@ use stdClass;
 
 class DatabaseSqliteSchemaBuilderTest extends DatabaseTestCase
 {
-	protected function getEnvironmentSetUp($app)
-	{
-		if (getenv('DB_CONNECTION') !== 'testing') {
-			$this->markTestSkipped('Test requires a Sqlite connection.');
-		}
+    protected function getEnvironmentSetUp($app)
+    {
+        if (getenv('DB_CONNECTION') !== 'testing') {
+            $this->markTestSkipped('Test requires a Sqlite connection.');
+        }
 
-		$app['config']->set('database.default', 'conn1');
+        $app['config']->set('database.default', 'conn1');
 
-		$app['config']->set('database.connections.conn1', [
-			'driver' => 'sqlite',
-			'database' => ':memory:',
-			'prefix' => '',
-		]);
-	}
+        $app['config']->set('database.connections.conn1', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
 
-	protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
-	{
-		Schema::create('users', function (Blueprint $table) {
-			$table->integer('id');
-			$table->string('name');
-			$table->string('age');
-			$table->enum('color', ['red', 'blue']);
-		});
-	}
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('name');
+            $table->string('age');
+            $table->enum('color', ['red', 'blue']);
+        });
+    }
 
-	protected function destroyDatabaseMigrations()
-	{
-		Schema::drop('users');
-	}
+    protected function destroyDatabaseMigrations()
+    {
+        Schema::drop('users');
+    }
 
-	public function testGetAllTablesAndColumnListing()
-	{
-		$tables = Schema::getAllTables();
+    public function testGetAllTablesAndColumnListing()
+    {
+        $tables = Schema::getAllTables();
 
-		$this->assertCount(2, $tables);
-		$tableProperties = array_values((array) $tables[0]);
-		$this->assertEquals(['table', 'migrations'], $tableProperties);
+        $this->assertCount(2, $tables);
+        $tableProperties = array_values((array) $tables[0]);
+        $this->assertEquals(['table', 'migrations'], $tableProperties);
 
-		$this->assertInstanceOf(stdClass::class, $tables[1]);
+        $this->assertInstanceOf(stdClass::class, $tables[1]);
 
-		$tableProperties = array_values((array) $tables[1]);
-		$this->assertEquals(['table', 'users'], $tableProperties);
+        $tableProperties = array_values((array) $tables[1]);
+        $this->assertEquals(['table', 'users'], $tableProperties);
 
-		$columns = Schema::getColumnListing('users');
+        $columns = Schema::getColumnListing('users');
 
-		foreach (['id', 'name', 'age', 'color'] as $column) {
-			$this->assertContains($column, $columns);
-		}
+        foreach (['id', 'name', 'age', 'color'] as $column) {
+            $this->assertContains($column, $columns);
+        }
 
-		Schema::create('posts', function (Blueprint $table) {
-			$table->integer('id');
-			$table->string('title');
-		});
-		$tables = Schema::getAllTables();
-		$this->assertCount(3, $tables);
-		Schema::drop('posts');
-	}
+        Schema::create('posts', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('title');
+        });
+        $tables = Schema::getAllTables();
+        $this->assertCount(3, $tables);
+        Schema::drop('posts');
+    }
 
-	public function testGetAllViews()
-	{
-		DB::connection('conn1')->statement(<<<SQL
+    public function testGetAllViews()
+    {
+        DB::connection('conn1')->statement(<<<SQL
 CREATE VIEW users_view
-AS 
+AS
 SELECT name,age from users;
 SQL);
 
-		$tableView = Schema::getAllViews();
+        $tableView = Schema::getAllViews();
 
-		$this->assertCount(1, $tableView);
-		$this->assertInstanceOf(stdClass::class, $obj = array_values($tableView)[0]);
-		$this->assertEquals('users_view', $obj->name);
-		$this->assertEquals('view', $obj->type);
+        $this->assertCount(1, $tableView);
+        $this->assertInstanceOf(stdClass::class, $obj = array_values($tableView)[0]);
+        $this->assertEquals('users_view', $obj->name);
+        $this->assertEquals('view', $obj->type);
 
-		DB::connection('conn1')->statement(<<<SQL
+        DB::connection('conn1')->statement(<<<SQL
 DROP VIEW IF EXISTS users_view;
 SQL);
 
-		$this->assertEmpty(Schema::getAllViews());
-	}
+        $this->assertEmpty(Schema::getAllViews());
+    }
 }

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteSchemaBuilderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Sqlite;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use stdClass;
+
+class DatabaseSqliteSchemaBuilderTest extends DatabaseTestCase
+{
+	protected function getEnvironmentSetUp($app)
+	{
+		if (getenv('DB_CONNECTION') !== 'testing') {
+			$this->markTestSkipped('Test requires a Sqlite connection.');
+		}
+
+		$app['config']->set('database.default', 'conn1');
+
+		$app['config']->set('database.connections.conn1', [
+			'driver' => 'sqlite',
+			'database' => ':memory:',
+			'prefix' => '',
+		]);
+	}
+
+	protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+	{
+		Schema::create('users', function (Blueprint $table) {
+			$table->integer('id');
+			$table->string('name');
+			$table->string('age');
+			$table->enum('color', ['red', 'blue']);
+		});
+	}
+
+	protected function destroyDatabaseMigrations()
+	{
+		Schema::drop('users');
+	}
+
+	public function testGetAllTablesAndColumnListing()
+	{
+		$tables = Schema::getAllTables();
+
+		$this->assertCount(2, $tables);
+		$tableProperties = array_values((array) $tables[0]);
+		$this->assertEquals(['table', 'migrations'], $tableProperties);
+
+		$this->assertInstanceOf(stdClass::class, $tables[1]);
+
+		$tableProperties = array_values((array) $tables[1]);
+		$this->assertEquals(['table', 'users'], $tableProperties);
+
+		$columns = Schema::getColumnListing('users');
+
+		foreach (['id', 'name', 'age', 'color'] as $column) {
+			$this->assertContains($column, $columns);
+		}
+
+		Schema::create('posts', function (Blueprint $table) {
+			$table->integer('id');
+			$table->string('title');
+		});
+		$tables = Schema::getAllTables();
+		$this->assertCount(3, $tables);
+		Schema::drop('posts');
+	}
+
+	public function testGetAllViews()
+	{
+		DB::connection('conn1')->statement(<<<SQL
+CREATE VIEW users_view
+AS 
+SELECT name,age from users;
+SQL);
+
+		$tableView = Schema::getAllViews();
+
+		$this->assertCount(1, $tableView);
+		$this->assertInstanceOf(stdClass::class, $obj = array_values($tableView)[0]);
+		$this->assertEquals('users_view', $obj->name);
+		$this->assertEquals('view', $obj->type);
+
+		DB::connection('conn1')->statement(<<<SQL
+DROP VIEW IF EXISTS users_view;
+SQL);
+
+		$this->assertEmpty(Schema::getAllViews());
+	}
+}


### PR DESCRIPTION
This PR adds support for calling `\Illuminate\Support\Facades\Schema::getAllTables()` on SQLite and SQLServer connections.

I'm returning the `name` and `type` columns to maintain consistency with what's already being returned when using the MySQL or Postgres connections.

P.S. 
This being my 1st Laravel contribution, please go easy on me if I've done something incorrectly here. 😉 
