### PR TITLE
[8.x] Add multibyte support to string padding helper functions

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -489,7 +489,7 @@ class Str
      */
     public static function padBoth($value, $length, $pad = ' ')
     {
-        return static::mbStrPad($value, $length, $pad, STR_PAD_BOTH);
+        return str_pad($value, strlen($value) - mb_strlen($value) + $length, $pad, STR_PAD_BOTH);
     }
 
     /**
@@ -502,7 +502,7 @@ class Str
      */
     public static function padLeft($value, $length, $pad = ' ')
     {
-        return static::mbStrPad($value, $length, $pad, STR_PAD_LEFT);
+        return str_pad($value, strlen($value) - mb_strlen($value) + $length, $pad, STR_PAD_LEFT);
     }
 
     /**
@@ -515,7 +515,7 @@ class Str
      */
     public static function padRight($value, $length, $pad = ' ')
     {
-        return static::mbStrPad($value, $length, $pad, STR_PAD_RIGHT);
+        return str_pad($value, strlen($value) - mb_strlen($value) + $length, $pad, STR_PAD_RIGHT);
     }
 
     /**
@@ -1021,26 +1021,5 @@ class Str
         static::$snakeCache = [];
         static::$camelCache = [];
         static::$studlyCache = [];
-    }
-
-    /**
-     * Multibyte alternative to native `str_pad` function.
-     * Adapted from https://www.php.net/manual/en/ref.mbstring.php#90611.
-     *
-     * @param  string  $value
-     * @param  int  $length
-     * @param  string  $pad
-     * @param  int  $pad_type
-     * @param  string|null  $encoding
-     * @return string
-     */
-    protected static function mbStrPad($value, $length, $pad = ' ', $pad_type = STR_PAD_RIGHT, $encoding = null)
-    {
-        return str_pad(
-            $value,
-            strlen($value) - mb_strlen($value, $encoding) + $length,
-            $pad,
-            $pad_type,
-        );
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1034,7 +1034,7 @@ class Str
      * @param  string|null  $encoding
      * @return string
      */
-    public static function mbStrPad($value, $length, $pad = ' ', $pad_type = STR_PAD_RIGHT, $encoding = null)
+    protected static function mbStrPad($value, $length, $pad = ' ', $pad_type = STR_PAD_RIGHT, $encoding = null)
     {
         return str_pad(
             $value,

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -489,7 +489,7 @@ class Str
      */
     public static function padBoth($value, $length, $pad = ' ')
     {
-        return str_pad($value, $length, $pad, STR_PAD_BOTH);
+        return static::mbStrPad($value, $length, $pad, STR_PAD_BOTH);
     }
 
     /**
@@ -502,7 +502,7 @@ class Str
      */
     public static function padLeft($value, $length, $pad = ' ')
     {
-        return str_pad($value, $length, $pad, STR_PAD_LEFT);
+        return static::mbStrPad($value, $length, $pad, STR_PAD_LEFT);
     }
 
     /**
@@ -515,7 +515,7 @@ class Str
      */
     public static function padRight($value, $length, $pad = ' ')
     {
-        return str_pad($value, $length, $pad, STR_PAD_RIGHT);
+        return static::mbStrPad($value, $length, $pad, STR_PAD_RIGHT);
     }
 
     /**
@@ -1021,5 +1021,26 @@ class Str
         static::$snakeCache = [];
         static::$camelCache = [];
         static::$studlyCache = [];
+    }
+
+    /**
+     * Multibyte alternative to native `str_pad` function.
+     * Adapted from https://www.php.net/manual/en/ref.mbstring.php#90611
+     *
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
+     * @param  int  $pad_type
+     * @param  string|null  $encoding
+     * @return string
+     */
+    public static function mbStrPad($value, $length, $pad = ' ', $pad_type = STR_PAD_RIGHT, $encoding = null)
+    {
+        return str_pad(
+            $value,
+            strlen($value) - mb_strlen($value, $encoding) + $length,
+            $pad,
+            $pad_type,
+        );
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1025,7 +1025,7 @@ class Str
 
     /**
      * Multibyte alternative to native `str_pad` function.
-     * Adapted from https://www.php.net/manual/en/ref.mbstring.php#90611
+     * Adapted from https://www.php.net/manual/en/ref.mbstring.php#90611.
      *
      * @param  string  $value
      * @param  int  $length

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -609,18 +609,21 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('__Alien___', Str::padBoth('Alien', 10, '_'));
         $this->assertSame('  Alien   ', Str::padBoth('Alien', 10));
+        $this->assertSame('  ❤MultiByte☆   ', Str::padBoth('❤MultiByte☆', 16));
     }
 
     public function testPadLeft()
     {
         $this->assertSame('-=-=-Alien', Str::padLeft('Alien', 10, '-='));
         $this->assertSame('     Alien', Str::padLeft('Alien', 10));
+        $this->assertSame('     ❤MultiByte☆', Str::padLeft('❤MultiByte☆', 16));
     }
 
     public function testPadRight()
     {
         $this->assertSame('Alien-----', Str::padRight('Alien', 10, '-'));
         $this->assertSame('Alien     ', Str::padRight('Alien', 10));
+        $this->assertSame('❤MultiByte☆     ', Str::padRight('❤MultiByte☆', 16));
     }
 
     public function testSwapKeywords(): void

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -828,18 +828,21 @@ class SupportStringableTest extends TestCase
     {
         $this->assertSame('__Alien___', (string) $this->stringable('Alien')->padBoth(10, '_'));
         $this->assertSame('  Alien   ', (string) $this->stringable('Alien')->padBoth(10));
+        $this->assertSame('  ❤MultiByte☆   ', (string) $this->stringable('❤MultiByte☆')->padBoth(16));
     }
 
     public function testPadLeft()
     {
         $this->assertSame('-=-=-Alien', (string) $this->stringable('Alien')->padLeft(10, '-='));
         $this->assertSame('     Alien', (string) $this->stringable('Alien')->padLeft(10));
+        $this->assertSame('     ❤MultiByte☆', (string) $this->stringable('❤MultiByte☆')->padLeft(16));
     }
 
     public function testPadRight()
     {
         $this->assertSame('Alien-----', (string) $this->stringable('Alien')->padRight(10, '-'));
         $this->assertSame('Alien     ', (string) $this->stringable('Alien')->padRight(10));
+        $this->assertSame('❤MultiByte☆     ', (string) $this->stringable('❤MultiByte☆')->padRight(16));
     }
 
     public function testChunk()


### PR DESCRIPTION
This PR adds support for multibyte strings to the `Str::padBoth`, `Str::padLeft`, and `Str::padRight` helper functions.

This is especially useful for localized strings, where accented characters or other multibyte glyphs were incorrectly padded before.

PHP has yet to implement a native `mb_str_pad` function so this PR adds a `Str::mbStrPad` helper function adapted from [a comment on the PHP docs](https://www.php.net/manual/en/ref.mbstring.php#90611). There is an [ongoing 19 year-old PHP request](http://bugs.php.net/bug.php?id=21317) for this native function, but as it is yet to see any progress, it seems appropriate to implement a workaround in the framework.