### PR TITLE
[9.x] Add EloquentTokenRepository

### DIFF
--- a/src/Illuminate/Auth/Passwords/EloquentTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/EloquentTokenRepository.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Illuminate\Auth\Passwords;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Illuminate\Auth\Passwords\TokenRepositoryInterface;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+
+class EloquentTokenRepository implements TokenRepositoryInterface
+{
+    /**
+     * The Hasher implementation.
+     *
+     * @var \Illuminate\Contracts\Hashing\Hasher
+     */
+    protected $hasher;
+
+    /**
+     * The Eloquent model.
+     *
+     * @var string
+     */
+    protected $model;
+
+    /**
+     * The hashing key.
+     *
+     * @var string
+     */
+    protected $hashKey;
+
+    /**
+     * The number of seconds a token should last.
+     *
+     * @var int
+     */
+    protected $expires;
+
+    /**
+     * Minimum number of seconds before re-redefining the token.
+     *
+     * @var int
+     */
+    protected $throttle;
+
+    /**
+     * Create a new token repository instance.
+     *
+     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
+     * @param  string  $model
+     * @param  string  $hashKey
+     * @param  int  $expires
+     * @param  int  $throttle
+     * @return void
+     */
+    public function __construct(
+        HasherContract $hasher,
+        $model,
+        $hashKey,
+        $expires = 60,
+        $throttle = 60
+    ) {
+        $this->model = $model;
+        $this->hasher = $hasher;
+        $this->hashKey = $hashKey;
+        $this->expires = $expires * 60;
+        $this->throttle = $throttle;
+    }
+
+    /**
+     * Create a new token record.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return string
+     */
+    public function create(CanResetPasswordContract $user)
+    {
+        $email = $user->getEmailForPasswordReset();
+
+        $this->deleteExisting($user);
+
+        // We will create a new, random token for the user so that we can e-mail them
+        // a safe link to the password reset form. Then we will insert a record in
+        // the database so that we can verify the token within the actual reset.
+        $token = $this->createNewToken();
+
+        $this->createModel()->create($this->getPayload($email, $token));
+
+        return $token;
+    }
+
+    /**
+     * Delete all existing reset tokens from the database.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return int
+     */
+    protected function deleteExisting(CanResetPasswordContract $user)
+    {
+        return $this->newModelQuery()->where('email', $user->getEmailForPasswordReset())->delete();
+    }
+
+    /**
+     * Build the record payload for the table.
+     *
+     * @param  string  $email
+     * @param  string  $token
+     * @return array
+     */
+    protected function getPayload($email, $token)
+    {
+        return ['email' => $email, 'token' => $this->hasher->make($token)];
+    }
+
+    /**
+     * Determine if a token record exists and is valid.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param  string  $token
+     * @return bool
+     */
+    public function exists(CanResetPasswordContract $user, $token)
+    {
+        $record = $this->newModelQuery()->where(
+            'email',
+            $user->getEmailForPasswordReset()
+        )->first();
+
+        return $record &&
+            !$this->tokenExpired($record['created_at']) &&
+            $this->hasher->check($token, $record['token']);
+    }
+
+    /**
+     * Determine if the token has expired.
+     *
+     * @param  string  $createdAt
+     * @return bool
+     */
+    protected function tokenExpired($createdAt)
+    {
+        return Carbon::parse($createdAt)->addSeconds($this->expires)->isPast();
+    }
+
+    /**
+     * Determine if the given user recently created a password reset token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return bool
+     */
+    public function recentlyCreatedToken(CanResetPasswordContract $user)
+    {
+        $record = $this->newModelQuery()->where(
+            'email',
+            $user->getEmailForPasswordReset()
+        )->first();
+
+        return $record && $this->tokenRecentlyCreated($record['created_at']);
+    }
+
+    /**
+     * Determine if the token was recently created.
+     *
+     * @param  string  $createdAt
+     * @return bool
+     */
+    protected function tokenRecentlyCreated($createdAt)
+    {
+        if ($this->throttle <= 0) {
+            return false;
+        }
+
+        return Carbon::parse($createdAt)->addSeconds(
+            $this->throttle
+        )->isFuture();
+    }
+
+    /**
+     * Delete a token record by user.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return void
+     */
+    public function delete(CanResetPasswordContract $user)
+    {
+        $this->deleteExisting($user);
+    }
+
+    /**
+     * Delete expired tokens.
+     *
+     * @return void
+     */
+    public function deleteExpired()
+    {
+        $expiredAt = Carbon::now()->subSeconds($this->expires);
+
+        $this->newModelQuery()->where('created_at', '<', $expiredAt)->delete();
+    }
+
+    /**
+     * Create a new token for the user.
+     *
+     * @return string
+     */
+    public function createNewToken()
+    {
+        return hash_hmac('sha256', Str::random(40), $this->hashKey);
+    }
+
+    /**
+     * Get a new query builder for the model instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function newModelQuery($model = null)
+    {
+        return is_null($model)
+            ? $this->createModel()->newQuery()
+            : $model->newQuery();
+    }
+
+    /**
+     * Create a new instance of the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function createModel()
+    {
+        $class = '\\' . ltrim($this->model, '\\');
+
+        return new $class;
+    }
+
+    /**
+     * Gets the hasher implementation.
+     *
+     * @return \Illuminate\Contracts\Hashing\Hasher
+     */
+    public function getHasher()
+    {
+        return $this->hasher;
+    }
+
+    /**
+     * Sets the hasher implementation.
+     *
+     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
+     * @return $this
+     */
+    public function setHasher(HasherContract $hasher)
+    {
+        $this->hasher = $hasher;
+
+        return $this;
+    }
+
+    /**
+     * Gets the name of the Eloquent user model.
+     *
+     * @return string
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+
+    /**
+     * Sets the name of the Eloquent user model.
+     *
+     * @param  string  $model
+     * @return $this
+     */
+    public function setModel($model)
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Auth/Passwords/EloquentTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/EloquentTokenRepository.php
@@ -2,11 +2,10 @@
 
 namespace Illuminate\Auth\Passwords;
 
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
-use Illuminate\Auth\Passwords\TokenRepositoryInterface;
-use Illuminate\Contracts\Hashing\Hasher as HasherContract;
-use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
 class EloquentTokenRepository implements TokenRepositoryInterface
 {
@@ -129,7 +128,7 @@ class EloquentTokenRepository implements TokenRepositoryInterface
         )->first();
 
         return $record &&
-            !$this->tokenExpired($record['created_at']) &&
+            ! $this->tokenExpired($record['created_at']) &&
             $this->hasher->check($token, $record['token']);
     }
 
@@ -230,7 +229,7 @@ class EloquentTokenRepository implements TokenRepositoryInterface
      */
     public function createModel()
     {
-        $class = '\\' . ltrim($this->model, '\\');
+        $class = '\\'.ltrim($this->model, '\\');
 
         return new $class;
     }

--- a/tests/Auth/AuthEloquentTokenRepositoryTest.php
+++ b/tests/Auth/AuthEloquentTokenRepositoryTest.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Tests\Auth;
 
-use stdClass;
-use Mockery as m;
-use Illuminate\Support\Carbon;
-use PHPUnit\Framework\TestCase;
-use Illuminate\Contracts\Hashing\Hasher;
-use Illuminate\Contracts\Auth\CanResetPassword;
 use Illuminate\Auth\Passwords\EloquentTokenRepository;
+use Illuminate\Contracts\Auth\CanResetPassword;
+use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Support\Carbon;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class AuthEloquentTokenRepositoryTest extends TestCase
 {
@@ -192,25 +192,11 @@ class AuthEloquentTokenRepositoryTest extends TestCase
     {
         $hasher = m::mock(Hasher::class);
 
-        // $repo = $this->getMockBuilder(EloquentTokenRepository::class)->setConstructorArgs([$hasher, 'model', 'key'])->getMock();
-
-        // $repo = $this->createMock(EloquentTokenRepository::class);
-        // $repo = $this->getMockBuilder(EloquentTokenRepository::class)->onlyMethods(['create', 'createModel', 'getHasher'])->setConstructorArgs([$hasher, 'model', 'key'])->getMock();
         $repo = $this->getMockBuilder(EloquentTokenRepository::class)
-            ->onlyMethods(['createModel',])
+            ->onlyMethods(['createModel'])
             ->setConstructorArgs([$hasher, 'model', 'key'])
             ->getMock();
 
-        // $repo->method('getHasher')->willReturn($hasher);
-
-        // $repo->shouldReceive('getHasher')->andReturn($hasher);
-
         return $repo;
-
-        return new EloquentTokenRepository(
-            m::mock(Hasher::class),
-            'model',
-            'key'
-        );
     }
 }

--- a/tests/Auth/AuthEloquentTokenRepositoryTest.php
+++ b/tests/Auth/AuthEloquentTokenRepositoryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use stdClass;
+use Mockery as m;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Contracts\Auth\CanResetPassword;
+use Illuminate\Auth\Passwords\EloquentTokenRepository;
+
+class AuthEloquentTokenRepositoryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function testCreateInsertsNewRecordIntoTable()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $query->shouldReceive('create')->once()->andReturn('bar');
+        $query->shouldReceive('delete')->once();
+
+        $repo = $this->getRepo();
+        $repo->getHasher()->shouldReceive('make')->once()->andReturn('hashed-token');
+        $repo->expects($this->any())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->times(2)->andReturn('email');
+
+        $results = $repo->create($user);
+
+        $this->assertIsString($results);
+        $this->assertGreaterThan(1, strlen($results));
+    }
+
+    public function testExistReturnsFalseIfNoRowFoundForUser()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $query->shouldReceive('first')->once()->andReturn(null);
+
+        $repo = $this->getRepo();
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertFalse($repo->exists($user, 'token'));
+    }
+
+    public function testExistReturnsFalseIfRecordIsExpired()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $date = Carbon::now()->subSeconds(300000)->toDateTimeString();
+        $query->shouldReceive('first')->once()->andReturn(['created_at' => $date, 'token' => 'hashed-token']);
+
+        $repo = $this->getRepo();
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertFalse($repo->exists($user, 'token'));
+    }
+
+    public function testExistReturnsTrueIfValidRecordExists()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $date = Carbon::now()->subMinutes(10)->toDateTimeString();
+        $query->shouldReceive('first')->once()->andReturn(['created_at' => $date, 'token' => 'hashed-token']);
+
+        $repo = $this->getRepo();
+        $repo->getHasher()->shouldReceive('check')->once()->with('token', 'hashed-token')->andReturn(true);
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertTrue($repo->exists($user, 'token'));
+    }
+
+    public function testExistReturnsFalseIfInvalidToken()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $date = Carbon::now()->subMinutes(10)->toDateTimeString();
+        $query->shouldReceive('first')->once()->andReturn(['created_at' => $date, 'token' => 'hashed-token']);
+
+        $repo = $this->getRepo();
+        $repo->getHasher()->shouldReceive('check')->once()->with('wrong-token', 'hashed-token')->andReturn(false);
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertFalse($repo->exists($user, 'wrong-token'));
+    }
+
+    public function testRecentlyCreatedReturnsFalseIfNoRowFoundForUser()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $query->shouldReceive('first')->once()->andReturn(null);
+
+        $repo = $this->getRepo();
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertFalse($repo->recentlyCreatedToken($user));
+    }
+
+    public function testRecentlyCreatedReturnsTrueIfRecordIsRecentlyCreated()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $date = Carbon::now()->subSeconds(59)->toDateTimeString();
+        $query->shouldReceive('first')->once()->andReturn(['created_at' => $date, 'token' => 'hashed-token']);
+
+        $repo = $this->getRepo();
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertTrue($repo->recentlyCreatedToken($user));
+    }
+
+    public function testRecentlyCreatedReturnsFalseIfValidRecordExists()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $date = Carbon::now()->subSeconds(61)->toDateTimeString();
+        $query->shouldReceive('first')->once()->andReturn(['created_at' => $date, 'token' => 'hashed-token']);
+
+        $repo = $this->getRepo();
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertFalse($repo->recentlyCreatedToken($user));
+    }
+
+    public function testDeleteMethodDeletesByToken()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $query->shouldReceive('delete')->once();
+
+        $repo = $this->getRepo();
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $repo->delete($user);
+    }
+
+    public function testDeleteExpiredMethodDeletesExpiredTokens()
+    {
+        $query = m::mock(stdClass::class);
+        $query->shouldReceive('newQuery')->once()->andReturn($query);
+        $query->shouldReceive('where')->once()->with('created_at', '<', m::any())->andReturn($query);
+        $query->shouldReceive('delete')->once();
+
+        $repo = $this->getRepo();
+        $repo->expects($this->once())->method('createModel')->willReturn($query);
+
+        $repo->deleteExpired();
+    }
+
+    protected function getRepo()
+    {
+        $hasher = m::mock(Hasher::class);
+
+        // $repo = $this->getMockBuilder(EloquentTokenRepository::class)->setConstructorArgs([$hasher, 'model', 'key'])->getMock();
+
+        // $repo = $this->createMock(EloquentTokenRepository::class);
+        // $repo = $this->getMockBuilder(EloquentTokenRepository::class)->onlyMethods(['create', 'createModel', 'getHasher'])->setConstructorArgs([$hasher, 'model', 'key'])->getMock();
+        $repo = $this->getMockBuilder(EloquentTokenRepository::class)
+            ->onlyMethods(['createModel',])
+            ->setConstructorArgs([$hasher, 'model', 'key'])
+            ->getMock();
+
+        // $repo->method('getHasher')->willReturn($hasher);
+
+        // $repo->shouldReceive('getHasher')->andReturn($hasher);
+
+        return $repo;
+
+        return new EloquentTokenRepository(
+            m::mock(Hasher::class),
+            'model',
+            'key'
+        );
+    }
+}


### PR DESCRIPTION

Recently I encountered a situation where I needed to customize the password reset table. It would be handy to have Eloquent Model support way.

At the same time, I think it's a missing piece for Laravel.

After this pull request, you can use the `PasswordReset` model, just give a little change in the config:

```php
// config/auth.php

    'passwords' => [
        'users' => [
            'provider' => 'users',
            // 'table' => 'password_resets',
            'model' => \App\Models\PasswordReset::class,
            'expire' => 60,
            'throttle' => 60,
        ],
    ],
```
