### PR TITLE
[10.x] leverage native php 8.1 array_is_list

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -28,7 +28,7 @@ trait ConditionallyLoadsAttributes
             if (is_numeric($key) && $value instanceof MergeValue) {
                 return $this->mergeData(
                     $data, $index, $this->filter($value->data),
-                    array_values($value->data) === $value->data
+                    array_is_list($value->data)
                 );
             }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -716,7 +716,7 @@ class Mailable implements MailableContract, Renderable
     protected function normalizeRecipient($recipient)
     {
         if (is_array($recipient)) {
-            if (array_values($recipient) === $recipient) {
+            if (array_is_list($recipient)) {
                 return (object) array_map(function ($email) {
                     return compact('email');
                 }, $recipient);


### PR DESCRIPTION
check array is list 

from:
```
array_values($value->data) === $value->data
```
to:
```
array_is_list($value->data)
```
https://php.watch/versions/8.1/array_is_list
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
