### PR TITLE
[9.x] Add startingAt and endingAt to console scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -38,6 +38,20 @@ class Event
     public $expression = '* * * * *';
 
     /**
+     * When to start the scheduled event.
+     *
+     * @var \Illuminate\Support\Carbon
+     */
+    public $startingAt;
+
+    /**
+     * When to end the scheduled event.
+     *
+     * @var \Illuminate\Support\Carbon
+     */
+    public $endingAt;
+
+    /**
      * The timezone the date should be evaluated on.
      *
      * @var \DateTimeZone|string

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -40,14 +40,14 @@ class Event
     /**
      * When to start the scheduled event.
      *
-     * @var \Illuminate\Support\Carbon
+     * @var \Illuminate\Support\Carbon|null
      */
     public $startingAt;
 
     /**
      * When to end the scheduled event.
      *
-     * @var \Illuminate\Support\Carbon
+     * @var \Illuminate\Support\Carbon|null
      */
     public $endingAt;
 

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -22,7 +22,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to start running at a specific datetime.
      *
-     * @param \DateTime|string $end
+     * @param \DateTime|string $start
      * @return $this
      */
     public function startingAt($start)

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -20,6 +20,32 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to start running at a specific datetime.
+     *
+     * @param DateTime|string $end
+     * @return $this
+     */
+    public function startingAt(DateTime $start)
+    {
+        $start = Carbon::parse($start)->timezone($this->timezone);
+
+        return $this->when(fn () => Carbon::now($this->timezone) >= $start);
+    }
+
+    /**
+     * Schedule the event to stop running at a specific datetime.
+     *
+     * @param DateTime|string $end
+     * @return $this
+     */
+    public function endingAt($end)
+    {
+        $end = Carbon::parse($end)->timezone($this->timezone);
+
+        return $this->when(fn () => Carbon::now($this->timezone) < $end);
+    }
+
+    /**
      * Schedule the event to run between start and end time.
      *
      * @param  string  $startTime

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -22,12 +22,12 @@ trait ManagesFrequencies
     /**
      * Schedule the event to start running at a specific datetime.
      *
-     * @param DateTime|string $end
+     * @param \DateTime|string $end
      * @return $this
      */
-    public function startingAt(DateTime $start)
+    public function startingAt($start)
     {
-        $start = Carbon::parse($start)->timezone($this->timezone);
+        $start = Carbon::parse($start, $this->timezone);
 
         return $this->when(fn () => Carbon::now($this->timezone) >= $start);
     }
@@ -35,12 +35,12 @@ trait ManagesFrequencies
     /**
      * Schedule the event to stop running at a specific datetime.
      *
-     * @param DateTime|string $end
+     * @param \DateTime|string $end
      * @return $this
      */
     public function endingAt($end)
     {
-        $end = Carbon::parse($end)->timezone($this->timezone);
+        $end = Carbon::parse($end, $this->timezone);
 
         return $this->when(fn () => Carbon::now($this->timezone) < $end);
     }

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 
 trait ManagesFrequencies
 {
+
     /**
      * The Cron expression representing the event's frequency.
      *
@@ -27,9 +28,9 @@ trait ManagesFrequencies
      */
     public function startingAt($start)
     {
-        $start = Carbon::parse($start, $this->timezone);
+        $this->startingAt = Carbon::parse($start, $this->timezone);
 
-        return $this->when(fn () => Carbon::now($this->timezone) >= $start);
+        return $this->when(fn () => Carbon::now($this->timezone) >= $this->startingAt);
     }
 
     /**
@@ -40,9 +41,9 @@ trait ManagesFrequencies
      */
     public function endingAt($end)
     {
-        $end = Carbon::parse($end, $this->timezone);
+        $this->endingAt = Carbon::parse($end, $this->timezone);
 
-        return $this->when(fn () => Carbon::now($this->timezone) < $end);
+        return $this->when(fn () => Carbon::now($this->timezone) < $this->endingAt);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Carbon;
 
 trait ManagesFrequencies
 {
-
     /**
      * The Cron expression representing the event's frequency.
      *

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -92,7 +92,7 @@ class ScheduleListCommand extends Command
 
             if ($event->endingAt && Carbon::now()->setTimezone($event->timezone) > $event->endingAt) {
                 $nextDueDate = $event->endingAt;
-                $nextDueDateLabel = 'Ended At:';
+                $nextDueDateLabel = 'Ended:';
             }
 
             $nextDueDate = $this->output->isVerbose()

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -91,6 +91,33 @@ class ConsoleScheduledEventTest extends TestCase
         $this->assertTrue($event->isDue($app));
     }
 
+    public function testStartingEndingChecks()
+    {
+        $app = m::mock(Application::class.'[isDownForMaintenance,environment]');
+        $app->shouldReceive('isDownForMaintenance')->andReturn(false);
+        $app->shouldReceive('environment')->andReturn('production');
+
+        Carbon::setTestNow(Carbon::now());
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->startingAt(Carbon::now()->subDay())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->startingAt(Carbon::now()->subDay()->toDateString())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertFalse($event->startingAt(Carbon::now()->addDay())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->endingAt(Carbon::now()->addDay())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertTrue($event->endingAt(Carbon::now()->addDay()->toDateString())->filtersPass($app));
+
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
+        $this->assertFalse($event->endingAt(Carbon::now()->subDay())->filtersPass($app));
+    }
+
     public function testTimeBetweenChecks()
     {
         $app = m::mock(Application::class.'[isDownForMaintenance,environment]');

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -15,7 +15,7 @@ class ScheduleListCommandTest extends TestCase
     {
         parent::setUp();
 
-        Carbon::setTestNow(now()->startOfYear());
+        Carbon::setTestNow(Carbon::parse('2022-01-01'));
         ScheduleListCommand::resolveTerminalWidthUsing(fn () => 80);
 
         $this->schedule = $this->app->make(Schedule::class);
@@ -34,6 +34,10 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
         $this->schedule->job(FooJob::class)->everyMinute();
+        $this->schedule->command('startAtPast')->mondays()->startingAt(Carbon::now()->subMonth());
+        $this->schedule->command('startAtFuture')->mondays()->startingAt(Carbon::now()->addMonth());
+        $this->schedule->command('endAtPast')->mondays()->endingAt(Carbon::now()->subMonth());
+        $this->schedule->command('endAtFuture')->mondays()->endingAt(Carbon::now()->addMonth());
 
         $this->schedule->call(fn () => '')->everyMinute();
         $closureLineNumber = __LINE__ - 1;
@@ -45,6 +49,10 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      1  php artisan startAtPast ...... Next Due: 2 days from now')
+            ->expectsOutput('  * *     * *      1  php artisan startAtFuture ... Next Due: 1 month from now')
+            ->expectsOutput('  * *     * *      1  php artisan endAtPast ............ Ended At: 1 month ago')
+            ->expectsOutput('  * *     * *      1  php artisan endAtFuture ...... Next Due: 2 days from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }
 

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -51,7 +51,7 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      1  php artisan startAtPast ...... Next Due: 2 days from now')
             ->expectsOutput('  * *     * *      1  php artisan startAtFuture ... Next Due: 1 month from now')
-            ->expectsOutput('  * *     * *      1  php artisan endAtPast ............ Ended At: 1 month ago')
+            ->expectsOutput('  * *     * *      1  php artisan endAtPast ............... Ended: 1 month ago')
             ->expectsOutput('  * *     * *      1  php artisan endAtFuture ...... Next Due: 2 days from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }


### PR DESCRIPTION
This finishes off the initial work on #41579 by adding support to `artisan schedule:list` output.

This PR adds the `startingAt()` and `endingAt()` helper functions to the Artisan scheduler, for the situations where you want to start running a command only after or before a given date. The functions accept a DateTime or string, which is parsed to a Carbon instance.

Tests are attached to check that:

* startingAt in the past passes filters
* startingAt in the future does not pass filters
* endingAt in the future passes filters
* endingAt in the past does not pass filters

Additionally the output of `artisan schedule:list` has been modified to support `endingAt` and `startingAt`. For a future `startingAt` date, it will use this as the starting date for calculating the next run date, based on the cron expression. For a past `endingAt` date, it will display the date that the schedule ended.

For example, a schedule of:

```php
$schedule->command('startingAtPast')->mondays()->startingAt('2020-01-01');
$schedule->command('startingAtFuture')->mondays()->startingAt('2023-01-01');
$schedule->command('endingAtPast')->mondays()->endingAt('2020-01-01');
$schedule->command('endingAtFuture')->mondays()->endingAt('2023-01-01');
```

An output will be displayed of:
```
  * * * * 1  php artisan startingAtPast .............. Next Due: 1 day from now
  * * * * 1  php artisan startingAtFuture ......... Next Due: 8 months from now
  * * * * 1  php artisan endingAtPast ...................... Ended: 2 years ago
  * * * * 1  php artisan endingAtFuture .............. Next Due: 1 day from now
```




If this PR is merged I can make a pull request to the docs repo to add relevant documentation.