### PR TITLE
[9.x] Facade accessor auto resolve

### DIFF
--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -52,13 +52,5 @@ namespace Illuminate\Support\Facades;
  */
 class App extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'app';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -37,16 +37,6 @@ use RuntimeException;
 class Auth extends Facade
 {
     /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'auth';
-    }
-
-    /**
      * Register the typical authentication routes for an application.
      *
      * @param  array  $options

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -28,13 +28,5 @@ namespace Illuminate\Support\Facades;
  */
 class Cache extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'cache';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -14,13 +14,5 @@ namespace Illuminate\Support\Facades;
  */
 class Config extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'config';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -33,14 +33,4 @@ class Cookie extends Facade
     {
         return static::$app['request']->cookie($key, $default);
     }
-
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'cookie';
-    }
 }

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -39,13 +39,5 @@ namespace Illuminate\Support\Facades;
  */
 class DB extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'db';
-    }
+
 }

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -39,5 +39,5 @@ namespace Illuminate\Support\Facades;
  */
 class DB extends Facade
 {
-
+    //
 }

--- a/src/Illuminate/Support/Facades/Date.php
+++ b/src/Illuminate/Support/Facades/Date.php
@@ -90,18 +90,6 @@ class Date extends Facade
     const DEFAULT_FACADE = DateFactory::class;
 
     /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     *
-     * @throws \RuntimeException
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'date';
-    }
-
-    /**
      * Resolve the facade root instance from the container.
      *
      * @param  string  $name

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -28,6 +28,13 @@ abstract class Facade
     protected static $resolvedInstance;
 
     /**
+     * The resolved names.
+     *
+     * @var array
+     */
+    protected static $resolvedNames;
+
+    /**
      * Indicates if the resolved instance should be cached.
      *
      * @var bool
@@ -200,7 +207,11 @@ abstract class Facade
      */
     protected static function getFacadeAccessor()
     {
-        return strtolower(class_basename(get_called_class()));
+        if(isset(static::$resolvedNames[static::class])) {
+            return static::$resolvedNames[static::class];
+        }
+
+        return static::$resolvedNames[static::class] = strtolower(class_basename(static::class));
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -197,12 +197,10 @@ abstract class Facade
      * Get the registered name of the component.
      *
      * @return string
-     *
-     * @throws \RuntimeException
      */
     protected static function getFacadeAccessor()
     {
-        throw new RuntimeException('Facade does not implement getFacadeAccessor method.');
+        return strtolower(class_basename(get_called_class()));
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -13,13 +13,5 @@ namespace Illuminate\Support\Facades;
  */
 class Hash extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'hash';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -24,13 +24,5 @@ namespace Illuminate\Support\Facades;
  */
 class Log extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'log';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -51,14 +51,4 @@ class Queue extends Facade
 
         return $fake;
     }
-
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'queue';
-    }
 }

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -23,13 +23,5 @@ namespace Illuminate\Support\Facades;
  */
 class Redirect extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'redirect';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -12,13 +12,5 @@ namespace Illuminate\Support\Facades;
  */
 class Redis extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'redis';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -91,13 +91,5 @@ namespace Illuminate\Support\Facades;
  */
 class Request extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'request';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -33,13 +33,5 @@ namespace Illuminate\Support\Facades;
  */
 class Session extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'session';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -27,13 +27,5 @@ namespace Illuminate\Support\Facades;
  */
 class URL extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'url';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -15,13 +15,5 @@ namespace Illuminate\Support\Facades;
  */
 class Validator extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'validator';
-    }
+    //
 }

--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -18,13 +18,5 @@ namespace Illuminate\Support\Facades;
  */
 class View extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
-    {
-        return 'view';
-    }
+    //
 }


### PR DESCRIPTION
Hello, 

I've hit this many times in my personal projects and also have seen it in the core and common packages. for most Facades, the accessor name is the same as the class name. it would be good if the facade can resolve that automatically instead of defining the `getFacadeAccessor` just to return the class name in lower case. also, detecting from the class name is very common in laravel as it's used in Factory to detect the model name. and in Eloquent to detect the table name.

Before
```php
class Hash extends Facade
{
    /**
     * Get the registered name of the component.
     *
     * @return string
     */
    protected static function getFacadeAccessor()
    {
        return 'hash';
    }
}
```

After
```php
class Hash extends Facade
{
    //
}
```