### PR TITLE
[9.x] Add return type declarations to migration stubs

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('{{ table }}', function (Blueprint $table) {
             $table->id();
@@ -24,7 +24,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('{{ table }}');
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         //
     }
@@ -21,7 +21,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         //
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
             //
@@ -23,7 +23,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
             //


### PR DESCRIPTION
PHP 7 added support for return type declarations, but Laravel stubs still don't use them. 

Return type declarations specify the type of the value that will be returned from a function. The returned value must be of the correct type, otherwise a TypeError will be thrown.

I think this is necessary change in all other Laravel stubs as well.