### PR TITLE
[9.x] Use arrow functions in BusFake class

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -351,9 +351,7 @@ class BusFake implements QueueingDispatcher
      */
     protected function assertDispatchedWithChainOfObjects($command, $expectedChain, $callback)
     {
-        $chain = collect($expectedChain)->map(function ($job) {
-            return serialize($job);
-        })->all();
+        $chain = collect($expectedChain)->map(fn ($job) => serialize($job))->all();
 
         PHPUnit::assertTrue(
             $this->dispatched($command, $callback)->filter(function ($job) use ($chain) {
@@ -394,9 +392,7 @@ class BusFake implements QueueingDispatcher
      */
     protected function isChainOfObjects($chain)
     {
-        return ! collect($chain)->contains(function ($job) {
-            return ! is_object($job);
-        });
+        return ! collect($chain)->contains(fn ($job) => ! is_object($job));
     }
 
     /**
@@ -443,9 +439,7 @@ class BusFake implements QueueingDispatcher
             return true;
         };
 
-        return collect($this->commands[$command])->filter(function ($command) use ($callback) {
-            return $callback($command);
-        });
+        return collect($this->commands[$command])->filter(fn ($command) => $callback($command));
     }
 
     /**
@@ -465,9 +459,7 @@ class BusFake implements QueueingDispatcher
             return true;
         };
 
-        return collect($this->commandsSync[$command])->filter(function ($command) use ($callback) {
-            return $callback($command);
-        });
+        return collect($this->commandsSync[$command])->filter(fn ($command) => $callback($command));
     }
 
     /**
@@ -487,9 +479,7 @@ class BusFake implements QueueingDispatcher
             return true;
         };
 
-        return collect($this->commandsAfterResponse[$command])->filter(function ($command) use ($callback) {
-            return $callback($command);
-        });
+        return collect($this->commandsAfterResponse[$command])->filter(fn ($command) => $callback($command));
     }
 
     /**
@@ -504,9 +494,7 @@ class BusFake implements QueueingDispatcher
             return collect();
         }
 
-        return collect($this->batches)->filter(function ($batch) use ($callback) {
-            return $callback($batch);
-        });
+        return collect($this->batches)->filter(fn ($batch) => $callback($batch));
     }
 
     /**


### PR DESCRIPTION
In some cases using arrow functions can make code more readable.