### PR TITLE
[9.x] Add AWS S3 delete multiple files using deleteObjects method

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -49,7 +49,8 @@ class AwsS3V3Adapter extends FilesystemAdapter
         }
 
         return $this->client->getObjectUrl(
-            $this->config['bucket'], $this->prefixer->prefixPath($path)
+            $this->config['bucket'],
+            $this->prefixer->prefixPath($path)
         );
     }
 
@@ -69,7 +70,9 @@ class AwsS3V3Adapter extends FilesystemAdapter
         ], $options));
 
         $uri = $this->client->createPresignedRequest(
-            $command, $expiration, $options
+            $command,
+            $expiration,
+            $options
         )->getUri();
 
         // If an explicit base URL has been set on the disk configuration then we will use
@@ -80,6 +83,34 @@ class AwsS3V3Adapter extends FilesystemAdapter
         }
 
         return (string) $uri;
+    }
+
+    /**
+     * Delete multiple files at a given paths.
+     *
+     * @param  array  $paths
+     * @return bool
+     */
+    public function deleteMultiple(array $paths)
+    {
+        $success = true;
+
+        $delete = $this->client->deleteObjects([
+            'Bucket' => $this->config['bucket'],
+            'Delete' => [
+                'Objects' => collect($paths)->map(function ($path) {
+                    return [
+                        'Key' => $path,
+                    ];
+                })->toArray(),
+            ],
+        ]);
+
+        if (! $delete) {
+            $success = false;
+        }
+
+        return $success;
     }
 
     /**

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -49,8 +49,7 @@ class AwsS3V3Adapter extends FilesystemAdapter
         }
 
         return $this->client->getObjectUrl(
-            $this->config['bucket'],
-            $this->prefixer->prefixPath($path)
+            $this->config['bucket'], $this->prefixer->prefixPath($path)
         );
     }
 
@@ -70,9 +69,7 @@ class AwsS3V3Adapter extends FilesystemAdapter
         ], $options));
 
         $uri = $this->client->createPresignedRequest(
-            $command,
-            $expiration,
-            $options
+            $command, $expiration, $options
         )->getUri();
 
         // If an explicit base URL has been set on the disk configuration then we will use

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -91,8 +91,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         $this->config = $config;
 
         $this->prefixer = new PathPrefixer(
-            $config['root'] ?? '',
-            $config['directory_separator'] ?? DIRECTORY_SEPARATOR
+            $config['root'] ?? '', $config['directory_separator'] ?? DIRECTORY_SEPARATOR
         );
     }
 
@@ -111,8 +110,7 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         foreach ($paths as $path) {
             PHPUnit::assertTrue(
-                $this->exists($path),
-                "Unable to find a file or directory at path [{$path}]."
+                $this->exists($path), "Unable to find a file or directory at path [{$path}]."
             );
 
             if (! is_null($content)) {
@@ -143,8 +141,7 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         foreach ($paths as $path) {
             PHPUnit::assertFalse(
-                $this->exists($path),
-                "Found unexpected file or directory at path [{$path}]."
+                $this->exists($path), "Found unexpected file or directory at path [{$path}]."
             );
         }
 
@@ -160,8 +157,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function assertDirectoryEmpty($path)
     {
         PHPUnit::assertEmpty(
-            $this->allFiles($path),
-            "Directory [{$path}] is not empty."
+            $this->allFiles($path), "Directory [{$path}] is not empty."
         );
 
         return $this;
@@ -275,9 +271,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         $filename = $name ?? basename($path);
 
         $disposition = $response->headers->makeDisposition(
-            $disposition,
-            $filename,
-            $this->fallbackName($filename)
+            $disposition, $filename, $this->fallbackName($filename)
         );
 
         $response->headers->replace($headers + [
@@ -391,9 +385,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         // they provide better performance than alternatives. Once we write the file this
         // stream will get closed automatically by us so the developer doesn't have to.
         $result = $this->put(
-            $path = trim($path.'/'.$name, '/'),
-            $stream,
-            $options
+            $path = trim($path.'/'.$name, '/'), $stream, $options
         );
 
         if (is_resource($stream)) {
@@ -696,9 +688,7 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         if ($this->temporaryUrlCallback) {
             return $this->temporaryUrlCallback->bindTo($this, static::class)(
-                $path,
-                $expiration,
-                $options
+                $path, $expiration, $options
             );
         }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -91,7 +91,8 @@ class FilesystemAdapter implements CloudFilesystemContract
         $this->config = $config;
 
         $this->prefixer = new PathPrefixer(
-            $config['root'] ?? '', $config['directory_separator'] ?? DIRECTORY_SEPARATOR
+            $config['root'] ?? '',
+            $config['directory_separator'] ?? DIRECTORY_SEPARATOR
         );
     }
 
@@ -110,7 +111,8 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         foreach ($paths as $path) {
             PHPUnit::assertTrue(
-                $this->exists($path), "Unable to find a file or directory at path [{$path}]."
+                $this->exists($path),
+                "Unable to find a file or directory at path [{$path}]."
             );
 
             if (! is_null($content)) {
@@ -141,7 +143,8 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         foreach ($paths as $path) {
             PHPUnit::assertFalse(
-                $this->exists($path), "Found unexpected file or directory at path [{$path}]."
+                $this->exists($path),
+                "Found unexpected file or directory at path [{$path}]."
             );
         }
 
@@ -157,7 +160,8 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function assertDirectoryEmpty($path)
     {
         PHPUnit::assertEmpty(
-            $this->allFiles($path), "Directory [{$path}] is not empty."
+            $this->allFiles($path),
+            "Directory [{$path}] is not empty."
         );
 
         return $this;
@@ -271,7 +275,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         $filename = $name ?? basename($path);
 
         $disposition = $response->headers->makeDisposition(
-            $disposition, $filename, $this->fallbackName($filename)
+            $disposition,
+            $filename,
+            $this->fallbackName($filename)
         );
 
         $response->headers->replace($headers + [
@@ -385,7 +391,9 @@ class FilesystemAdapter implements CloudFilesystemContract
         // they provide better performance than alternatives. Once we write the file this
         // stream will get closed automatically by us so the developer doesn't have to.
         $result = $this->put(
-            $path = trim($path.'/'.$name, '/'), $stream, $options
+            $path = trim($path.'/'.$name, '/'),
+            $stream,
+            $options
         );
 
         if (is_resource($stream)) {
@@ -487,6 +495,21 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         return $success;
+    }
+
+    /**
+     * Delete multiple files at a given paths.
+     *
+     * @param  array  $paths
+     * @return bool
+     */
+    public function deleteMultiple(array $paths)
+    {
+        if (method_exists($this->adapter, 'deleteMultiple')) {
+            return $this->adapter->deleteMultiple($paths);
+        }
+
+        throw new RuntimeException('This driver does not support deleting multiple files.');
     }
 
     /**
@@ -673,7 +696,9 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         if ($this->temporaryUrlCallback) {
             return $this->temporaryUrlCallback->bindTo($this, static::class)(
-                $path, $expiration, $options
+                $path,
+                $expiration,
+                $options
             );
         }
 


### PR DESCRIPTION
Hi,

I needed to delete 100+ files on AWS s3. the `Storage::disk('s3')->delete()` delete a single file so if i loop through the 100+ files and do the `Storage::disk('s3')->delete($file)` it will do 100+ request to s3 for 100+ files.

So I searched and I find out that AWS s3 allows you to delete multiple files using the AWS client `deleteObjects` method which accepts an array of object paths e.g `['path/to/file1', 'path/to/file2']`. using this it just took 2 secs to delete 100+ files. 

more info: https://docs.aws.amazon.com/AmazonS3/latest/userguide/example_s3_DeleteObjects_section.html

I first implemented this as a macro on the Storage facade in my projects. but I think this should be in laravel by default :)

Thanks,
Anees