### PR TITLE
[9.x] Standardize `withCount()` & `withExists()` eager loading aggregates.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -622,7 +622,13 @@ trait QueriesRelationships
      */
     public function withCount($relations)
     {
-        return $this->withAggregate(is_array($relations) ? $relations : func_get_args(), '*', 'count');
+        $relations = is_array($relations) ? $relations : func_get_args();
+
+        if (count($relations) === 2 && $relations[1] instanceof Closure) {
+            $relations = [$relations[0] => $relations[1]];
+        }
+
+        return $this->withAggregate($relations, '*', 'count');
     }
 
     /**
@@ -676,12 +682,18 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the existence of related models.
      *
-     * @param  string|array  $relation
+     * @param  mixed  $relations
      * @return $this
      */
-    public function withExists($relation)
+    public function withExists($relations)
     {
-        return $this->withAggregate($relation, '*', 'exists');
+        $relations = is_array($relations) ? $relations : func_get_args();
+
+        if (count($relations) === 2 && $relations[1] instanceof Closure) {
+            $relations = [$relations[0] => $relations[1]];
+        }
+
+        return $this->withAggregate($relations, '*', 'exists');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1110,11 +1110,22 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->select('id')->withCount(['activeFoo' => function ($q) {
-            $q->where('bam', '>', 'qux');
-        }]);
+        $sql = 'select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"';
 
-        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $wheres = function ($query) {
+            $query->where('bam', '>', 'qux');
+        };
+
+        $builder = $model->select('id')->withCount(['activeFoo' => $wheres]);
+
+        $this->assertSame($sql, $builder->toSql());
+        $this->assertEquals(['qux', true], $builder->getBindings());
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->select('id')->withCount('activeFoo', $wheres);
+
+        $this->assertSame($sql, $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -1194,9 +1205,17 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
+        $sql = 'select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"';
+
         $builder = $model->withCount(['foo as foo_bar', 'foo']);
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame($sql, $builder->toSql());
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withCount('foo as foo_bar', 'foo');
+
+        $this->assertSame($sql, $builder->toSql());
     }
 
     public function testWithExists()
@@ -1221,11 +1240,22 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->select('id')->withExists(['activeFoo' => function ($q) {
-            $q->where('bam', '>', 'qux');
-        }]);
+        $wheres = function ($query) {
+            $query->where('bam', '>', 'qux');
+        };
 
-        $this->assertSame('select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $sql = 'select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"';
+
+        $builder = $model->select('id')->withExists(['activeFoo' => $wheres]);
+
+        $this->assertSame($sql, $builder->toSql());
+        $this->assertEquals(['qux', true], $builder->getBindings());
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->select('id')->withExists('activeFoo', $wheres);
+
+        $this->assertSame($sql, $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -1283,9 +1313,17 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
+        $sql = 'select "eloquent_builder_test_model_parent_stubs".*, exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"';
+
         $builder = $model->withExists(['foo as foo_bar', 'foo']);
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame($sql, $builder->toSql());
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withExists('foo as foo_bar', 'foo');
+
+        $this->assertSame($sql, $builder->toSql());
     }
 
     public function testHasWithConstraintsAndHavingInSubquery()


### PR DESCRIPTION
## What does this PR do?

- Standardizes the way you can eager load your `withCount()` & `withExists()` aggregates.
- Adds asserts to existing tests to support this functionality☝🏼.

## Why do we need this?
### Before this PR
There are 3 different ways to pass parameters in `with...()` functions:
1. Passing relation strings (internally will check `is_array($relations) ? $relations : func_get_args()`).
2. Passing an array of relations (with or without a closure as the value).
3. Passing the first parameter as a relation string and second argument as a closure.

If we compare the `with()`, `withCount()` & `withExists` functions, this is what each of them currently support:
- `with()`: 1, 2 & 3.
- `withCount()`: 1 & 2.
- `withExists()`: 1 (with only 1 relation 😞) & 2.

The reason why I am writing this PR is because I ran into a situation where I supposed that since I was able to do it with one of these methods, why shouldn't I be able to do the same with any of the other 2 methods (that's where I got disappointed 😞).

I did notice that it would probably be best practice and most efficient to have way 1 & 3 removed and only support way 2. But that would result in some breaking changes (LMK if it sounds interesting and I will make a PR for 10.x).

### With this PR
The 3 functions mentioned above will support all 3 different ways to pass the params.
🔴 The only caveat I might see is that the `with()` function includes a second parameter in it's signature (`@param  string|\Closure|null  $callback`) while the other 2 don't.
