### PR TITLE
[9.x] Fix base query for relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -317,7 +317,7 @@ abstract class Relation implements BuilderContract
      */
     public function toBase()
     {
-        return $this->query->getQuery();
+        return $this->query->applyScopes()->getQuery();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -123,6 +123,19 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertCount(1, $query->get());
     }
 
+    public function testSoftDeletesAreNotRetrievedFromRelationshipBaseQuery()
+    {
+        [, $abigail] = $this->createUsers();
+
+        $abigail->posts()->create(['title' => 'Foo']);
+        $abigail->posts()->create(['title' => 'Bar'])->delete();
+
+        $query = $abigail->posts()->toBase();
+
+        $this->assertInstanceOf(Builder::class, $query);
+        $this->assertCount(1, $query->get());
+    }
+
     public function testSoftDeletesAreNotRetrievedFromBuilderHelpers()
     {
         $this->createUsers();
@@ -867,13 +880,17 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
     /**
      * Helpers...
+     *
+     * @return \Illuminate\Tests\Database\SoftDeletesTestUser[]
      */
     protected function createUsers()
     {
         $taylor = SoftDeletesTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
-        SoftDeletesTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        $abigail = SoftDeletesTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
 
         $taylor->delete();
+
+        return [$taylor, $abigail];
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where scopes (like soft deletes) weren't applied when the base query of a relationship was retrieved. Previously, in Laravel v8, this was still applied properly.

Fixes https://github.com/laravel/framework/issues/41885