### PR TITLE
[9.x] Allow Setting Delay Via withDealy Method In Queued Events

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -586,8 +586,12 @@ class Dispatcher implements DispatcherContract
                     ? $listener->viaQueue()
                     : $listener->queue ?? null;
 
-        isset($listener->delay)
-                    ? $connection->laterOn($queue, $listener->delay, $job)
+        $delay = method_exists($listener, 'withDelay')
+                    ? $listener->withDelay()
+                    : $listener->delay ?? null;
+
+        isset($delay)
+                    ? $connection->laterOn($queue, $delay, $job)
                     : $connection->pushOn($queue, $job);
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -390,6 +390,8 @@ class QueueFake extends QueueManager implements Queue
      */
     public function laterOn($queue, $delay, $job, $data = '')
     {
+        $job->delay($delay);
+
         return $this->push($job, $data, $queue);
     }
 


### PR DESCRIPTION
This PR will fix setting $delay property in queued handlers with Queueable trait. Unable to set delay property when using Queueable trait in queued event handler. 
Similar issue was fixed in [this](https://github.com/laravel/framework/pull/32770) for queue property.


