### PR TITLE
[9.x] Restore v8 behaviour of base query for relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -307,7 +307,7 @@ abstract class Relation implements BuilderContract
      */
     public function getBaseQuery()
     {
-        return $this->toBase();
+        return $this->query->getQuery();
     }
 
     /**
@@ -317,7 +317,7 @@ abstract class Relation implements BuilderContract
      */
     public function toBase()
     {
-        return $this->query->applyScopes()->getQuery();
+        return $this->query->toBase();
     }
 
     /**


### PR DESCRIPTION
As [commented on #41918](https://github.com/laravel/framework/pull/41918#issuecomment-1095118868) I found a new inconsistency in the Laravel 8.x and 9.x implementation with the fix by @driesvints.

In Laravel v8 the implementation for getBaseQuery was:

```php
public function getBaseQuery()
{
    return $this->query->getQuery();
}
```

With the recently merged fix it's now the following which is different (it's now applying the scope!):

```php
public function getBaseQuery()
{
    return $this->toBase();
}

public function toBase()
{
    return $this->query->applyScopes()->getQuery();
}
```

I restored the *exact* behavior of Laravel 8.x that `getBaseQuery` and `toBase` are both operating directly on the `Eloquent\Builder` object. So any change in `Eloquent\Builder::toBase()` is also automatically reflected on `Relationship::toBase()` as in Laravel 8.x.