### PR TITLE
[9.x] Added definition of hex whitespace symbol on Str::squish()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -889,7 +889,7 @@ class Str
      */
     public static function squish($value)
     {
-        return preg_replace('~\s+~u', ' ', preg_replace('~^\s+|\s+$~u', '', $value));
+        return preg_replace('~(\s|\x{3164})+~u', ' ', preg_replace('~^\s+|\s+$~u', '', $value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -553,6 +553,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('ム', Str::squish('ム'));
         $this->assertSame('だ', Str::squish('   だ    '));
         $this->assertSame('ム', Str::squish('   ム    '));
+        $this->assertSame('laravel php framework', Str::squish('laravelㅤㅤㅤphpㅤframework'));
     }
 
     public function testStudly()


### PR DESCRIPTION
For example,

```
aㅤb >> a b
aㅤㅤb >> a b
```

![image](https://user-images.githubusercontent.com/10347617/162767534-5862b6da-b8a3-46f4-bfb6-8b433acfe4bc.png)
