### PR TITLE
[9.x] Allow to use custom log level in exception handler reporting

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -66,11 +66,11 @@ class Handler implements ExceptionHandlerContract
     protected $reportCallbacks = [];
 
     /**
-     * A map of exceptions with the corresponding custom log level.
+     * A map of exceptions with their corresponding custom log levels.
      *
      * @var array<string, string>
      */
-    protected $reportLogLevels = [];
+    protected $levels = [];
 
     /**
      * The callbacks that should be used during rendering.
@@ -223,9 +223,9 @@ class Handler implements ExceptionHandlerContract
      * @param  string  $level
      * @return $this
      */
-    public function useLogLevel($type, $level)
+    public function level($type, $level)
     {
-        $this->reportLogLevels[$type] = $level;
+        $this->levels[$type] = $level;
 
         return $this;
     }
@@ -263,7 +263,7 @@ class Handler implements ExceptionHandlerContract
             throw $e;
         }
 
-        $level = Arr::first($this->reportLogLevels, function ($level, $type) use ($e) {
+        $level = Arr::first($this->levels, function ($level, $type) use ($e) {
             return $e instanceof $type;
         }, LogLevel::ERROR);
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -219,9 +219,8 @@ class Handler implements ExceptionHandlerContract
     /**
      * Set the log level for the given exception type.
      *
-     * @param class-string<\Throwable> $type
-     * @param string $level
-     *
+     * @param  class-string<\Throwable>  $type
+     * @param  string  $level
      * @return $this
      */
     public function useLogLevel($type, $level)

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Tests\Foundation;
 
-use InvalidArgumentException;
-use OutOfRangeException;
 use Exception;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
@@ -20,8 +18,10 @@ use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
+use InvalidArgumentException;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
+use OutOfRangeException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -106,8 +106,8 @@ class FoundationExceptionsHandlerTest extends TestCase
         $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Error message', m::hasKey('exception')])->once();
         $logger->shouldReceive('log')->withArgs([LogLevel::WARNING, 'Warning message', m::hasKey('exception')])->once();
 
-        $this->handler->useLogLevel(InvalidArgumentException::class, LogLevel::CRITICAL);
-        $this->handler->useLogLevel(OutOfRangeException::class, LogLevel::WARNING);
+        $this->handler->level(InvalidArgumentException::class, LogLevel::CRITICAL);
+        $this->handler->level(OutOfRangeException::class, LogLevel::WARNING);
 
         $this->handler->report(new InvalidArgumentException('Critical message'));
         $this->handler->report(new RuntimeException('Error message'));

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use InvalidArgumentException;
+use OutOfRangeException;
 use Exception;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
@@ -22,6 +24,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use RuntimeException;
 use stdClass;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
@@ -72,7 +75,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')])->once();
+        $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Exception message', m::hasKey('exception')])->once();
 
         $this->handler->report(new RuntimeException('Exception message'));
     }
@@ -81,7 +84,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldReceive('error')->withArgs(['Exception message', m::subset(['foo' => 'bar'])])->once();
+        $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Exception message', m::subset(['foo' => 'bar'])])->once();
 
         $this->handler->report(new ContextProvidingException('Exception message'));
     }
@@ -90,9 +93,36 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')])->once();
+        $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Exception message', m::hasKey('exception')])->once();
 
         $this->handler->report(new UnReportableException('Exception message'));
+    }
+
+    public function testHandlerReportsExceptionWithCustomLogLevel()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('log')->withArgs([LogLevel::CRITICAL, 'Critical message', m::hasKey('exception')])->once();
+        $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Error message', m::hasKey('exception')])->once();
+        $logger->shouldReceive('log')->withArgs([LogLevel::WARNING, 'Warning message', m::hasKey('exception')])->once();
+
+        $this->handler->useLogLevel(InvalidArgumentException::class, LogLevel::CRITICAL);
+        $this->handler->useLogLevel(OutOfRangeException::class, LogLevel::WARNING);
+
+        $this->handler->report(new InvalidArgumentException('Critical message'));
+        $this->handler->report(new RuntimeException('Error message'));
+        $this->handler->report(new OutOfRangeException('Warning message'));
+    }
+
+    public function testHandlerIgnoresNotReportableExceptions()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldNotReceive('log');
+
+        $this->handler->ignore(RuntimeException::class);
+
+        $this->handler->report(new RuntimeException('Exception message'));
     }
 
     public function testHandlerCallsReportMethodWithDependencies()
@@ -103,7 +133,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldNotReceive('error');
+        $logger->shouldNotReceive('log');
 
         $this->handler->report(new ReportableException('Exception message'));
     }
@@ -115,7 +145,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldNotReceive('error');
+        $logger->shouldNotReceive('log');
 
         $this->handler->reportable(new CustomReporter($reporter));
 
@@ -265,7 +295,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldNotReceive('error');
+        $logger->shouldNotReceive('log');
 
         $this->handler->report(new SuspiciousOperationException('Invalid method override "__CONSTRUCT"'));
     }
@@ -282,7 +312,7 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldNotReceive('error');
+        $logger->shouldNotReceive('log');
 
         $this->handler->report(new RecordsNotFoundException);
     }


### PR DESCRIPTION
This PR adds a new property `$reportLogLevels` and corresponding method `useLogLevel()` to the exception handler. These allow the user to configure different log levels for any exception. This will make it easier to report `PDOException`s as _critical_ and known/common user exceptions as _debug_ or whatever you want.

solves #41921 