### PR TITLE
[9.x] Support nested relationships in whenLoaded

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -189,16 +189,23 @@ trait ConditionallyLoadsAttributes
             $default = new MissingValue;
         }
 
-        if (! $this->resource->relationLoaded($relationship)) {
-            return value($default);
+        /** @var \Illuminate\Database\Eloquent\Model $child */
+        $target = $this->resource;
+
+        foreach (explode('.', $relationship) as $relation) {
+            if ($target === null || ! $target->relationLoaded($relation)) {
+                return value($default);
+            }
+
+            $target = $target->getRelation($relation);
         }
 
         if (func_num_args() === 1) {
-            return $this->resource->{$relationship};
+            return $target;
         }
 
-        if ($this->resource->{$relationship} === null) {
-            return;
+        if ($target === null) {
+            return null;
         }
 
         return value($value);

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationship.php
@@ -13,6 +13,9 @@ class PostResourceWithOptionalRelationship extends PostResource
             'author_name' => $this->whenLoaded('author', function () {
                 return $this->author->name;
             }),
+            'nested' => $this->whenLoaded('deeply.nested.relation', function () {
+                return $this->deeply->nested->relation->value;
+            }),
         ];
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -293,6 +293,18 @@ class ResourceTest extends TestCase
 
             $post->setRelation('author', new Author(['name' => 'jrrmartin']));
 
+            $target = $post;
+
+            foreach (['deeply', 'nested', 'relation'] as $relation) {
+                $model = new class extends \Illuminate\Database\Eloquent\Model
+                {
+                    //
+                };
+
+                $target->setRelation($relation, $model->setAttribute('value', $relation));
+                $target = $model;
+            }
+
             return new PostResourceWithOptionalRelationship($post);
         });
 
@@ -307,6 +319,7 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'author' => ['name' => 'jrrmartin'],
                 'author_name' => 'jrrmartin',
+                'nested' => 'relation',
             ],
         ]);
     }
@@ -320,6 +333,10 @@ class ResourceTest extends TestCase
             ]);
 
             $post->setRelation('author', null);
+            $post->setRelation('deeply', new class extends \Illuminate\Database\Eloquent\Model
+            {
+                //
+            });
 
             return new PostResourceWithOptionalRelationship($post);
         });


### PR DESCRIPTION
I believe the reason this wasn't already implemented is because it only makes sense for relationships that return a Model instead of a Collection. But in the first case, e.g. `Post::with(['user.profile])`, I figured it would be handy. Unless there's a relation returning a collection in between, e.g. `Post::with(['comments.user'])`,  it would still work for a deeply nested Collection relationship value.