### PR TITLE
[9.x] Fix ExcludeIf constructor

### DIFF
--- a/src/Illuminate/Validation/Rules/ExcludeIf.php
+++ b/src/Illuminate/Validation/Rules/ExcludeIf.php
@@ -18,10 +18,12 @@ class ExcludeIf
      *
      * @param  callable|bool  $condition
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($condition)
     {
-        if (! is_string($condition)) {
+        if (is_callable($condition) || is_bool($condition)) {
             $this->condition = $condition;
         } else {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');

--- a/tests/Validation/ValidationExcludeIfTest.php
+++ b/tests/Validation/ValidationExcludeIfTest.php
@@ -42,7 +42,7 @@ class ValidationExcludeIfTest extends TestCase
         foreach ([1, 1.1, 'foobar', new stdClass] as $condition) {
             try {
                 new ExcludeIf($condition);
-                $this->fail('The ExcludeIf constructor must not accept ' . gettype($condition));
+                $this->fail('The ExcludeIf constructor must not accept '.gettype($condition));
             } catch (InvalidArgumentException $exception) {
                 $this->assertEquals('The provided condition must be a callable or boolean.', $exception->getMessage());
             }

--- a/tests/Validation/ValidationExcludeIfTest.php
+++ b/tests/Validation/ValidationExcludeIfTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Validation\Rules\ExcludeIf;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class ValidationExcludeIfTest extends TestCase
 {
@@ -34,13 +35,18 @@ class ValidationExcludeIfTest extends TestCase
 
     public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
     {
-        $rule = new ExcludeIf(false);
+        new ExcludeIf(false);
+        new ExcludeIf(true);
+        new ExcludeIf(fn () => true);
 
-        $rule = new ExcludeIf(true);
-
-        $this->expectException(InvalidArgumentException::class);
-
-        $rule = new ExcludeIf('phpinfo');
+        foreach ([1, 1.1, 'foobar', new stdClass] as $condition) {
+            try {
+                new ExcludeIf($condition);
+                $this->fail('The ExcludeIf constructor must not accept ' . gettype($condition));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertEquals('The provided condition must be a callable or boolean.', $exception->getMessage());
+            }
+        }
     }
 
     public function testItReturnedRuleIsNotSerializable()


### PR DESCRIPTION
The `ExcludeIf` constructor only accepts a callable or bool value. But the current check could not ensure that, it accepts either numbers, string, object or anything else. I've just fixed and added missing tests.