### PR TITLE
[9.x] Fix empty paths for server.php

### DIFF
--- a/src/Illuminate/Foundation/resources/server.php
+++ b/src/Illuminate/Foundation/resources/server.php
@@ -3,7 +3,7 @@
 $publicPath = getcwd();
 
 $uri = urldecode(
-    parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
+    parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
 );
 
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the


### PR DESCRIPTION
This PR fixes an issue where an url has an empty path segment and a non-trailing slash ending. When using artisan serve, the urlencode function in `server.php` will receive `null` which isn't valid anymore on PHP 8.1. 
Instead, what we'll do is pass an empty string if that happens. Since the url couldn't be parsed, we give an empty string, which is an url that will definitely not exist (root is `/`) and it will properly show the 404 
page.

Fixes #41929
