### PR TITLE
[9.x] 'current_password' validation rule will use the guard UserProvider

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -447,7 +447,6 @@ trait ValidatesAttributes
     protected function validateCurrentPassword($attribute, $value, $parameters)
     {
         $auth = $this->container->make('auth');
-        $hasher = $this->container->make('hash');
 
         $guard = $auth->guard(Arr::first($parameters));
 
@@ -455,7 +454,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return $hasher->check($value, $guard->user()->getAuthPassword());
+        return $guard->getProvider()->validateCredentials($guard->user(), ['password' => $value]);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8,7 +8,7 @@ use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
-use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ImplicitRule;
@@ -900,11 +900,8 @@ class ValidationValidatorTest extends TestCase
         $auth->shouldReceive('guard')->andReturn($auth);
         $auth->shouldReceive('guest')->andReturn(true);
 
-        $hasher = m::mock(Hasher::class);
-
         $container = m::mock(Container::class);
         $container->shouldReceive('make')->with('auth')->andReturn($auth);
-        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
 
         $trans = $this->getTranslator();
         $trans->shouldReceive('get')->andReturnArg(0);
@@ -918,17 +915,17 @@ class ValidationValidatorTest extends TestCase
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword');
 
+        $userProvider = m::mock(UserProvider::class);
+        $userProvider->shouldReceive('validateCredentials')->andReturn(false);
+
         $auth = m::mock(Guard::class);
         $auth->shouldReceive('guard')->andReturn($auth);
+        $auth->shouldReceive('getProvider')->andReturn($userProvider);
         $auth->shouldReceive('guest')->andReturn(false);
         $auth->shouldReceive('user')->andReturn($user);
 
-        $hasher = m::mock(Hasher::class);
-        $hasher->shouldReceive('check')->andReturn(false);
-
         $container = m::mock(Container::class);
         $container->shouldReceive('make')->with('auth')->andReturn($auth);
-        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
 
         $trans = $this->getTranslator();
         $trans->shouldReceive('get')->andReturnArg(0);
@@ -942,17 +939,17 @@ class ValidationValidatorTest extends TestCase
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword');
 
+        $userProvider = m::mock(UserProvider::class);
+        $userProvider->shouldReceive('validateCredentials')->andReturn(true);
+
         $auth = m::mock(Guard::class);
         $auth->shouldReceive('guard')->andReturn($auth);
+        $auth->shouldReceive('getProvider')->andReturn($userProvider);
         $auth->shouldReceive('guest')->andReturn(false);
         $auth->shouldReceive('user')->andReturn($user);
 
-        $hasher = m::mock(Hasher::class);
-        $hasher->shouldReceive('check')->andReturn(true);
-
         $container = m::mock(Container::class);
         $container->shouldReceive('make')->with('auth')->andReturn($auth);
-        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
 
         $trans = $this->getTranslator();
         $trans->shouldReceive('get')->andReturnArg(0);
@@ -966,17 +963,17 @@ class ValidationValidatorTest extends TestCase
         $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword');
 
+        $userProvider = m::mock(UserProvider::class);
+        $userProvider->shouldReceive('validateCredentials')->andReturn(true);
+
         $auth = m::mock(Guard::class);
         $auth->shouldReceive('guard')->with('custom')->andReturn($auth);
+        $auth->shouldReceive('getProvider')->andReturn($userProvider);
         $auth->shouldReceive('guest')->andReturn(false);
         $auth->shouldReceive('user')->andReturn($user);
 
-        $hasher = m::mock(Hasher::class);
-        $hasher->shouldReceive('check')->andReturn(true);
-
         $container = m::mock(Container::class);
         $container->shouldReceive('make')->with('auth')->andReturn($auth);
-        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
 
         $trans = $this->getTranslator();
         $trans->shouldReceive('get')->andReturnArg(0);


### PR DESCRIPTION
When an application uses a different logic then hashing for storing the passwords for example when upgrading a legacy app to laravel and the two apps must coexist while the migration is in progress (i did this before) or in my case the client wants the passwords to be reversible so in my case I'm encrypting the passwords instead of hashing them the `current_password` validation rule will fail because it assumes that the passwords are hashed.

This PR updates the password validation to use the `validateCredentials()` method on the `UserProvider` used by the guard instead of checking the hash.

This fully backward compatible.