### PR TITLE
[9.x] Configurable pluralizer language and uncountables

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -3,58 +3,22 @@
 namespace Illuminate\Support;
 
 use Doctrine\Inflector\InflectorFactory;
+use Illuminate\Container\Container;
 
 class Pluralizer
 {
     /**
-     * Uncountable word forms.
+     * Uncountable non-nouns word forms.
+     * Only words not listed on Doctrine/Inflector/Rules/English/Uninflected.php
+     * Unlisted nouns should be primarily requested there.
      *
      * @var string[]
      */
     public static $uncountable = [
-        'audio',
-        'bison',
         'cattle',
-        'chassis',
-        'compensation',
-        'coreopsis',
-        'data',
-        'deer',
-        'education',
-        'emoji',
-        'equipment',
-        'evidence',
-        'feedback',
-        'firmware',
-        'fish',
-        'furniture',
-        'gold',
-        'hardware',
-        'information',
-        'jedi',
         'kin',
-        'knowledge',
-        'love',
-        'metadata',
-        'money',
-        'moose',
-        'news',
-        'nutrition',
-        'offspring',
-        'plankton',
-        'pokemon',
-        'police',
-        'rain',
         'recommended',
         'related',
-        'rice',
-        'series',
-        'sheep',
-        'software',
-        'species',
-        'swine',
-        'traffic',
-        'wheat',
     ];
 
     /**
@@ -133,7 +97,9 @@ class Pluralizer
         static $inflector;
 
         if (is_null($inflector)) {
-            $inflector = InflectorFactory::createForLanguage('english')->build();
+            $app = Container::getInstance();
+            $language = $app->has('config') ? $app['config']->get('app.pluralizer.language', 'english') : 'english';
+            $inflector = InflectorFactory::createForLanguage($language)->build();
         }
 
         return $inflector;

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -7,6 +7,20 @@ use Doctrine\Inflector\InflectorFactory;
 class Pluralizer
 {
     /**
+     * The cached inflector instance.
+     *
+     * @var static
+     */
+    protected static $inflector;
+
+    /**
+     * The language that should be used by the inflector.
+     *
+     * @var string
+     */
+    protected static $language = 'english';
+
+    /**
      * Uncountable non-nouns word forms.
      *
      * Contains words supported by Doctrine/Inflector/Rules/English/Uninflected.php
@@ -19,20 +33,6 @@ class Pluralizer
         'recommended',
         'related',
     ];
-
-    /**
-     * The language that should be used by the inflector.
-     *
-     * @var string
-     */
-    protected static $language = 'english';
-
-    /**
-     * The cached inflector instance.
-     *
-     * @var static
-     */
-    protected static $inflector;
 
     /**
      * Get the plural form of an English word.

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -3,14 +3,13 @@
 namespace Illuminate\Support;
 
 use Doctrine\Inflector\InflectorFactory;
-use Illuminate\Container\Container;
 
 class Pluralizer
 {
     /**
      * Uncountable non-nouns word forms.
-     * Only words not listed on Doctrine/Inflector/Rules/English/Uninflected.php
-     * Unlisted nouns should be primarily requested there.
+     *
+     * Contains words supported by Doctrine/Inflector/Rules/English/Uninflected.php
      *
      * @var string[]
      */
@@ -20,6 +19,20 @@ class Pluralizer
         'recommended',
         'related',
     ];
+
+    /**
+     * The language that should be used by the inflector.
+     *
+     * @var string
+     */
+    protected static $language = 'english';
+
+    /**
+     * The cached inflector instance.
+     *
+     * @var static
+     */
+    protected static $inflector;
 
     /**
      * Get the plural form of an English word.
@@ -94,14 +107,23 @@ class Pluralizer
      */
     public static function inflector()
     {
-        static $inflector;
-
-        if (is_null($inflector)) {
-            $app = Container::getInstance();
-            $language = $app->has('config') ? $app['config']->get('app.pluralizer.language', 'english') : 'english';
-            $inflector = InflectorFactory::createForLanguage($language)->build();
+        if (is_null(static::$inflector)) {
+            static::$inflector = InflectorFactory::createForLanguage(static::$language)->build();
         }
 
-        return $inflector;
+        return static::$inflector;
+    }
+
+    /**
+     * Specify the language that should be used by the inflector.
+     *
+     * @param  string  $language
+     * @return void
+     */
+    public static function useLanguage(string $language)
+    {
+        static::$language = $language;
+
+        static::$inflector = null;
     }
 }

--- a/tests/Integration/Support/PluralizerPortugueseTest.php
+++ b/tests/Integration/Support/PluralizerPortugueseTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support;
+
+use Illuminate\Support\Str;
+use Orchestra\Testbench\TestCase;
+
+class PluralizerPortugueseTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.pluralizer.language', 'portuguese');
+    }
+
+    public function testBasicSingular()
+    {
+        $this->assertSame('herói', Str::singular('heróis'));
+        $this->assertSame('irmão', Str::singular('irmãos'));
+        $this->assertSame('chafariz', Str::singular('chafarizes'));
+        $this->assertSame('colher', Str::singular('colheres'));
+        $this->assertSame('modelo', Str::singular('modelos'));
+        $this->assertSame('venda', Str::singular('vendas'));
+        $this->assertSame('usuário', Str::singular('usuários'));
+        $this->assertSame('comissão', Str::singular('comissões'));
+    }
+
+    public function testIrregulars()
+    {
+        $this->assertSame('males', Str::plural('mal'));
+        $this->assertSame('lápis', Str::singular('lápis'));
+    }
+
+    public function testBasicPlural()
+    {
+        $this->assertSame('fênix', Str::plural('fênix'));
+        $this->assertSame('palavras', Str::plural('palavra'));
+        $this->assertSame('modelos', Str::plural('modelo'));
+        $this->assertSame('vendas', Str::plural('venda'));
+        $this->assertSame('usuários', Str::plural('usuário'));
+        $this->assertSame('comissões', Str::plural('comissão'));
+    }
+
+    public function testCaseSensitiveSingularUsage()
+    {
+        $this->assertSame('Criança', Str::singular('Crianças'));
+        $this->assertSame('CIDADÃO', Str::singular('CIDADÃOS'));
+    }
+
+    public function testCaseSensitiveSingularPlural()
+    {
+        $this->assertSame('Crianças', Str::plural('Criança'));
+        $this->assertSame('CIDADÃOS', Str::plural('CIDADÃO'));
+        $this->assertSame('Testes', Str::plural('Teste'));
+    }
+
+    public function testPluralAppliedForStringEndingWithNumericCharacter()
+    {
+        $this->assertSame('Usuário1s', Str::plural('Usuário1'));
+        $this->assertSame('Usuário2s', Str::plural('Usuário2'));
+        $this->assertSame('Usuário3s', Str::plural('Usuário3'));
+    }
+
+    public function testPluralSupportsArrays()
+    {
+        $this->assertSame('usuários', Str::plural('usuário', []));
+        $this->assertSame('usuário', Str::plural('usuário', ['um']));
+        $this->assertSame('usuários', Str::plural('usuário', ['um', 'dois']));
+    }
+
+    public function testPluralSupportsCollections()
+    {
+        $this->assertSame('usuários', Str::plural('usuário', collect()));
+        $this->assertSame('usuário', Str::plural('usuário', collect(['um'])));
+        $this->assertSame('usuários', Str::plural('usuário', collect(['um', 'dois'])));
+    }
+
+    public function testPluralStudlySupportsArrays()
+    {
+        $this->assertPluralStudly('AlgumUsuários', 'AlgumUsuário', []);
+        $this->assertPluralStudly('AlgumUsuário', 'AlgumUsuário', ['um']);
+        $this->assertPluralStudly('AlgumUsuários', 'AlgumUsuário', ['um', 'dois']);
+    }
+
+    public function testPluralStudlySupportsCollections()
+    {
+        $this->assertPluralStudly('AlgumUsuários', 'AlgumUsuário', collect());
+        $this->assertPluralStudly('AlgumUsuário', 'AlgumUsuário', collect(['um']));
+        $this->assertPluralStudly('AlgumUsuários', 'AlgumUsuário', collect(['um', 'dois']));
+    }
+
+    private function assertPluralStudly($expected, $value, $count = 2)
+    {
+        $this->assertSame($expected, Str::pluralStudly($value, $count));
+    }
+}

--- a/tests/Integration/Support/PluralizerPortugueseTest.php
+++ b/tests/Integration/Support/PluralizerPortugueseTest.php
@@ -2,14 +2,24 @@
 
 namespace Illuminate\Tests\Integration\Support;
 
+use Illuminate\Support\Pluralizer;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 
 class PluralizerPortugueseTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app)
+    public function setUp(): void
     {
-        $app['config']->set('app.pluralizer.language', 'portuguese');
+        parent::setUp();
+
+        Pluralizer::useLanguage('portuguese');
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Pluralizer::useLanguage('english');
     }
 
     public function testBasicSingular()


### PR DESCRIPTION
Hello!

As said previously on https://github.com/laravel/framework/pull/41891, Pluralizer already handles all the uncountable words, so maintaining a list of those here is really redundant, the only words not listed there were already merged https://github.com/doctrine/inflector/pull/194, with the exception of _recommended_ and _related_ for not being nouns, so i added the recommendation on the comments to request new nouns there, and keep this array for edge cases only. And while they don't release the 2.0.5 version with this merge, _cattle_ and _kin_ also stayed, avoiding any breaking changes.

As for the language configuration, i finally understood the errors on the last PR!
The tests on `tests/Database` use the Pluralizer as it's an essential part of Eloquent, however, their testcases (and the pluralizer test too) extend `PHPUnit\Framework\TestCase` instead of `Orchestra\Testbench\TestCase`, not bootstrapping the application, so it's useless to setup a `getEnvironmentSetUp($app)` function there. All the tests on features that depend on the Pluralizer and don't bootstrap the app will always throw an error saying the `config` class doesn't exist.

I used a simple `$app->has('config')` to check if the instance has this class, to get the config, otherwise it returns the default english version, acting as a fallback if the pluralizer is used outside Laravel, bypassing that error. A more elegant way to check if an Instance exists is most welcome of course.

I'm being insistent on this because I really believe this feature will be very useful for a lot of non-english speaking developers making apps on their languages. Me, personally, I'm using a modified version of Laravel with this.

It might be nice to also add new Orchestra's testcases for the Pluralizer with the other languages, i could contribute with the portuguese test. Inside `tests/Integration/Support` maybe?

I set the config path to `'app.pluralizer.language'`, grouping all the pluralizer related configs in one array in case someone finds a way to further extend the pluralizer with custom rules or custom words that might be set from the configs files.