### PR TITLE
[9.x] withCount() add failing test for example code from docs

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1110,7 +1110,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->withCount(['address', 'foo' => function($query) {
+        $builder = $model->withCount(['address', 'foo' => function ($query) {
             $query->where('active', false);
         }]);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1106,6 +1106,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
+    public function testWithCountAndSecondWhere()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withCount(['address', 'foo' => function($query) {
+            $query->where('active', false);
+        }]);
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "address_count", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "active" = ?) as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
     public function testWithCountAndMergedWheres()
     {
         $model = new EloquentBuilderTestModelParentStub;


### PR DESCRIPTION
Since #41914 the [example from the docs](https://laravel.com/docs/9.x/eloquent-relationships#counting-related-models) no longer works.

```php
use Illuminate\Database\Eloquent\Builder;
 
$posts = Post::withCount(['votes', 'comments' => function (Builder $query) {
    $query->where('content', 'like', 'code%');
}])->get();
 
echo $posts[0]->votes_count;
echo $posts[0]->comments_count;
```

will throw `Undefined array key 1`

This PR adds a failing test to cover the expected behavior.

A possible fix would be to check if the given array is a list `array_values($relations) === $relations`
```php
    public function withCount($relations)
    {
        $relations = is_array($relations) ? $relations : func_get_args();

        if (count($relations) === 2 && array_values($relations) === $relations && $relations[1] instanceof Closure) {
            $relations = [$relations[0] => $relations[1]];
        }

        return $this->withAggregate($relations, '*', 'count');
    }
```