### PR TITLE
[9.x] Revert "Standardize `withCount()` & `withExists()` eager loading aggregates."

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -622,13 +622,7 @@ trait QueriesRelationships
      */
     public function withCount($relations)
     {
-        $relations = is_array($relations) ? $relations : func_get_args();
-
-        if (count($relations) === 2 && $relations[1] instanceof Closure) {
-            $relations = [$relations[0] => $relations[1]];
-        }
-
-        return $this->withAggregate($relations, '*', 'count');
+        return $this->withAggregate(is_array($relations) ? $relations : func_get_args(), '*', 'count');
     }
 
     /**
@@ -682,18 +676,12 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the existence of related models.
      *
-     * @param  mixed  $relations
+     * @param  string|array  $relation
      * @return $this
      */
-    public function withExists($relations)
+    public function withExists($relation)
     {
-        $relations = is_array($relations) ? $relations : func_get_args();
-
-        if (count($relations) === 2 && $relations[1] instanceof Closure) {
-            $relations = [$relations[0] => $relations[1]];
-        }
-
-        return $this->withAggregate($relations, '*', 'exists');
+        return $this->withAggregate($relation, '*', 'exists');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1110,22 +1110,11 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $sql = 'select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"';
+        $builder = $model->select('id')->withCount(['activeFoo' => function ($q) {
+            $q->where('bam', '>', 'qux');
+        }]);
 
-        $wheres = function ($query) {
-            $query->where('bam', '>', 'qux');
-        };
-
-        $builder = $model->select('id')->withCount(['activeFoo' => $wheres]);
-
-        $this->assertSame($sql, $builder->toSql());
-        $this->assertEquals(['qux', true], $builder->getBindings());
-
-        $model = new EloquentBuilderTestModelParentStub;
-
-        $builder = $model->select('id')->withCount('activeFoo', $wheres);
-
-        $this->assertSame($sql, $builder->toSql());
+        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -1205,17 +1194,9 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $sql = 'select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"';
-
         $builder = $model->withCount(['foo as foo_bar', 'foo']);
 
-        $this->assertSame($sql, $builder->toSql());
-
-        $model = new EloquentBuilderTestModelParentStub;
-
-        $builder = $model->withCount('foo as foo_bar', 'foo');
-
-        $this->assertSame($sql, $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithExists()
@@ -1240,22 +1221,11 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $wheres = function ($query) {
-            $query->where('bam', '>', 'qux');
-        };
+        $builder = $model->select('id')->withExists(['activeFoo' => function ($q) {
+            $q->where('bam', '>', 'qux');
+        }]);
 
-        $sql = 'select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"';
-
-        $builder = $model->select('id')->withExists(['activeFoo' => $wheres]);
-
-        $this->assertSame($sql, $builder->toSql());
-        $this->assertEquals(['qux', true], $builder->getBindings());
-
-        $model = new EloquentBuilderTestModelParentStub;
-
-        $builder = $model->select('id')->withExists('activeFoo', $wheres);
-
-        $this->assertSame($sql, $builder->toSql());
+        $this->assertSame('select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -1313,17 +1283,9 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $sql = 'select "eloquent_builder_test_model_parent_stubs".*, exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"';
-
         $builder = $model->withExists(['foo as foo_bar', 'foo']);
 
-        $this->assertSame($sql, $builder->toSql());
-
-        $model = new EloquentBuilderTestModelParentStub;
-
-        $builder = $model->withExists('foo as foo_bar', 'foo');
-
-        $this->assertSame($sql, $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testHasWithConstraintsAndHavingInSubquery()


### PR DESCRIPTION
Reverts laravel/framework#41914