### PR TITLE
[9.x] Fix breaking change introduced in #41914

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -618,10 +618,15 @@ trait QueriesRelationships
      * Add subselect queries to count the relations.
      *
      * @param  mixed  $relations
+     * @param  string|\Closure|null  $callback
      * @return $this
      */
-    public function withCount($relations)
+    public function withCount($relations, $callback = null)
     {
+        if ($callback instanceof Closure) {
+            $relations = [$relations => $callback];
+        }
+
         return $this->withAggregate(is_array($relations) ? $relations : func_get_args(), '*', 'count');
     }
 
@@ -676,12 +681,17 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the existence of related models.
      *
-     * @param  string|array  $relation
+     * @param  mixed  $relations
+     * @param  string|\Closure|null  $callback
      * @return $this
      */
-    public function withExists($relation)
+    public function withExists($relations, $callback = null)
     {
-        return $this->withAggregate($relation, '*', 'exists');
+        if ($callback instanceof Closure) {
+            $relations = [$relations => $callback];
+        }
+
+        return $this->withAggregate(is_array($relations) ? $relations : func_get_args(), '*', 'exists');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1110,11 +1110,22 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->select('id')->withCount(['activeFoo' => function ($q) {
-            $q->where('bam', '>', 'qux');
-        }]);
+        $sql = 'select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"';
 
-        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $wheres = function ($query) {
+            $query->where('bam', '>', 'qux');
+        };
+
+        $builder = $model->select('id')->withCount(['activeFoo' => $wheres]);
+
+        $this->assertSame($sql, $builder->toSql());
+        $this->assertEquals(['qux', true], $builder->getBindings());
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->select('id')->withCount('activeFoo', $wheres);
+
+        $this->assertSame($sql, $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -1194,9 +1205,17 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
+        $sql = 'select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"';
+
         $builder = $model->withCount(['foo as foo_bar', 'foo']);
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame($sql, $builder->toSql());
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withCount('foo as foo_bar', 'foo');
+
+        $this->assertSame($sql, $builder->toSql());
     }
 
     public function testWithExists()
@@ -1221,11 +1240,22 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->select('id')->withExists(['activeFoo' => function ($q) {
-            $q->where('bam', '>', 'qux');
-        }]);
+        $wheres = function ($query) {
+            $query->where('bam', '>', 'qux');
+        };
 
-        $this->assertSame('select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $sql = 'select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"';
+
+        $builder = $model->select('id')->withExists(['activeFoo' => $wheres]);
+
+        $this->assertSame($sql, $builder->toSql());
+        $this->assertEquals(['qux', true], $builder->getBindings());
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->select('id')->withExists('activeFoo', $wheres);
+
+        $this->assertSame($sql, $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -1283,9 +1313,17 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
+        $sql = 'select "eloquent_builder_test_model_parent_stubs".*, exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"';
+
         $builder = $model->withExists(['foo as foo_bar', 'foo']);
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame($sql, $builder->toSql());
+
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->withExists('foo as foo_bar', 'foo');
+
+        $this->assertSame($sql, $builder->toSql());
     }
 
     public function testHasWithConstraintsAndHavingInSubquery()


### PR DESCRIPTION
Fixes breaking changes introduced in #41914 .

As mentioned by @nuernbergerA

@taylorotwell  Now I matched the `withCount()` & `withExists()` function signature to the `with()` function signature. It is no longer a breaking change.

Sorry about that.
