### PR TITLE
[9.x] Ability to get method bindings from the container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1277,6 +1277,16 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Get the container's method bindings.
+     *
+     * @return array
+     */
+    public function getMethodBindings()
+    {
+        return $this->methodBindings;
+    }
+
+    /**
      * Get the alias for an abstract if available.
      *
      * @param  string  $abstract

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1378,6 +1378,7 @@ class Container implements ArrayAccess, ContainerContract
         $this->instances = [];
         $this->abstractAliases = [];
         $this->scopedInstances = [];
+        $this->methodBindings = [];
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -404,16 +404,21 @@ class ContainerTest extends TestCase
         $container->bind('ConcreteStub', function () {
             return new ContainerConcreteStub;
         }, true);
+        $container->bindMethod('testMethod', function () {
+            return new ContainerConcreteStub;
+        });
         $container->alias('ConcreteStub', 'ContainerConcreteStub');
         $container->make('ConcreteStub');
         $this->assertTrue($container->resolved('ConcreteStub'));
         $this->assertTrue($container->isAlias('ContainerConcreteStub'));
         $this->assertArrayHasKey('ConcreteStub', $container->getBindings());
+        $this->assertArrayHasKey('testMethod', $container->getMethodBindings());
         $this->assertTrue($container->isShared('ConcreteStub'));
         $container->flush();
         $this->assertFalse($container->resolved('ConcreteStub'));
         $this->assertFalse($container->isAlias('ContainerConcreteStub'));
         $this->assertEmpty($container->getBindings());
+        $this->assertEmpty($container->getMethodBindings());
         $this->assertFalse($container->isShared('ConcreteStub'));
     }
 


### PR DESCRIPTION
### Why?
There might be a case when you may want to get method bindings from the container, in the same way as basic bindings. Additionally, it probably makes sense to flush them as other variables.