### PR TITLE
[9.x] Trim zwnbsp

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -53,7 +53,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return is_string($value) ? preg_replace('~^\s+|\s+$|^(﻿)+|(﻿)+$~iu', '', $value) : $value;
+        return is_string($value) ? preg_replace('~^[\s﻿]+|[\s﻿]+$~iu', '', $value) : $value;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -53,7 +53,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return is_string($value) ? preg_replace('~^\s+|\s+$~iu', '', $value) : $value;
+        return is_string($value) ? preg_replace('~^\s+|\s+$|^(﻿)+|(﻿)+$~iu', '', $value) : $value;
     }
 
     /**

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -34,7 +34,9 @@ class TrimStringsTest extends TestCase
         $middleware = new TrimStrings;
         $symfonyRequest = new SymfonyRequest([
             // Here has some NBSP, but it still display to space.
+            // Please note, do not edit in browser
             'abc' => '   123    ',
+            'zwnbsp' => '﻿  ha  ﻿﻿',
             'xyz' => 'だ',
             'foo' => 'ム',
             'bar' => '   だ    ',
@@ -45,6 +47,7 @@ class TrimStringsTest extends TestCase
 
         $middleware->handle($request, function (Request $request) {
             $this->assertSame('123', $request->get('abc'));
+            $this->assertSame('ha', $request->get('zwnbsp'));
             $this->assertSame('だ', $request->get('xyz'));
             $this->assertSame('ム', $request->get('foo'));
             $this->assertSame('だ', $request->get('bar'));


### PR DESCRIPTION
"ZWNBSP" mean "Zero Width No-Break SPace"

The '\s' does not include it

![image](https://user-images.githubusercontent.com/20262949/163115964-ba577355-0636-49b7-a126-b841d59c5b78.png)
