### PR TITLE
[9.x] Add withoutEagerLoads() method to Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1547,6 +1547,16 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Flush the relationships being eagerly loaded.
+     *
+     * @return $this
+     */
+    public function withoutEagerLoads()
+    {
+        return $this->setEagerLoads([]);
+    }
+
+    /**
      * Get the default key name of the table.
      *
      * @return string

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -666,6 +666,19 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['foo'], $results);
     }
 
+    public function testEagerLoadRelationsCanBeFlushed()
+    {
+        $builder = m::mock(Builder::class.'[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
+
+        $builder->setEagerLoads(['foo']);
+
+        $this->assertSame(['foo'], $builder->getEagerLoads());
+
+        $builder->withoutEagerLoads();
+
+        $this->assertEmpty($builder->getEagerLoads());
+    }
+
     public function testRelationshipEagerLoadProcess()
     {
         $builder = m::mock(Builder::class.'[getRelation]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
This PR just adds the `withoutEagerLoads` method to the `Eloquent\Builder` class.

```php
// Before
$query->setEagerLoads([]);

// After
$query->withoutEagerLoads();
```