### PR TITLE
[9.x] Fix error introduced in #40701

### DIFF
--- a/src/Illuminate/Routing/Exceptions/StreamedResponseException.php
+++ b/src/Illuminate/Routing/Exceptions/StreamedResponseException.php
@@ -25,7 +25,7 @@ class StreamedResponseException extends RuntimeException
     {
         $this->originalException = $originalException;
 
-        parent::__construct($originalException->message);
+        parent::__construct($originalException->getMessage());
     }
 
     /**


### PR DESCRIPTION
Hey, this PR just fixes a small bug in the change not render exception inside a streamed download.  
Currently it accesses the `->message` property of a `Throwable`, which is not defined in the interface and is (in my case) protected, which results in a new error.
This PR just changes that to the defined `->getMessage()` of a `Throwable`.
