### PR TITLE
[9.x] Fix PHP warnings when rendering long blade string

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -74,7 +74,7 @@ abstract class Component
         $resolver = function ($view) {
             $factory = Container::getInstance()->make('view');
 
-            return $factory->exists($view)
+            return strlen($view) <= PHP_MAXPATHLEN && $factory->exists($view)
                         ? $view
                         : $this->createBladeViewFromString($factory, $view);
         };

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -14,12 +14,13 @@ class BladeTest extends TestCase
         $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor']));
     }
 
-    public function test_rendering_blade_long_maxpathlen_string() {
+    public function test_rendering_blade_long_maxpathlen_string()
+    {
         $longString = str_repeat('a', PHP_MAXPATHLEN);
 
-        $result = Blade::render($longString .'{{ $name }}', ['name' => 'a']);
+        $result = Blade::render($longString.'{{ $name }}', ['name' => 'a']);
 
-        $this->assertSame($longString . 'a', $result);
+        $this->assertSame($longString.'a', $result);
     }
 
     public function test_rendering_blade_component_instance()

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -14,6 +14,14 @@ class BladeTest extends TestCase
         $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor']));
     }
 
+    public function test_rendering_blade_long_maxpathlen_string() {
+        $longString = str_repeat('a', PHP_MAXPATHLEN);
+
+        $result = Blade::render($longString .'{{ $name }}', ['name' => 'a']);
+
+        $this->assertSame($longString . 'a', $result);
+    }
+
     public function test_rendering_blade_component_instance()
     {
         $component = new HelloComponent('Taylor');


### PR DESCRIPTION
`\Illuminate\View\Component::resolveView` checks the string for being a file
```php
$factory->exists($view) ? $view : $this->createBladeViewFromString($factory, $view);
```
by calling `\Illuminate\Filesystem\Filesystem::exists` method, which is a pure standard `file_exists` function. 

PHP has a hard limit on path length as defined by the constant [PHP_MAXPATHLEN](https://www.php.net/manual/en/reserved.constants.php) which depends on the operating system (Windows 260 characters, Unix: as specified in the c-runtime - on Linux this is `PATH_MAX` in limits.h being 4096).

PHP detects the program is trying to check plain file existence and calls `php_check_open_basedir`

1. https://github.com/php/php-src/blob/master/ext/standard/filestat.c#L757

If the PHP configuration has no `open_basedir` value, then another method `virtual_file_ex` will be called:

1. https://github.com/php/php-src/blob/master/main/fopen_wrappers.c#L282
2. https://github.com/php/php-src/blob/master/ext/standard/filestat.c#L767
3. https://github.com/php/php-src/blob/master/Zend/zend_virtual_cwd.c#L1008

But `virtual_file_ex` doesn't throw warnings, just returns `false`.

If `open_basedir` is configured, `php_check_open_basedir_ex` is called, it cares about `open_basedir` and [throws a warning](https://github.com/php/php-src/blob/master/main/fopen_wrappers.c#L290), otherwise `file_exists` just returns false. The program behavior depends of `open_basedir` setting.

Although it's OK in the PHP design paradigm, users meet problems from time to time having this warning, see https://github.com/laravel/framework/issues/32254 https://github.com/laravel/framework/issues/41745 https://github.com/livewire/livewire/issues/918

This PR adds PHP_MAXPATHLEN check before calling `file_exists`.

Although I can add a test case for different open_basedir states, it will affect other tests running in parallel, and considering the issue is rare, I don't think there is a sense to make a custom php.ini environment for the case. 