### PR TITLE
[9.x] Fix bug where runInBackground would cause commands not to run.

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -184,7 +184,7 @@ class CallbackEvent extends Event
      */
     public function mutexName()
     {
-        return 'framework/schedule-'.sha1($this->description);
+        return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->command);
     }
 
     /**


### PR DESCRIPTION
When adding runInBackground and withoutOverlapping the mutex name is based on description when running the Scheduler, and when the schedule:finish command starts we are basing the mutex on expression+command signature, this causes commands not to be executed. 

This behaviour is reproducible is you try to modify a scheduled event 

foreach ($schedule->events() as $event) {
        if ($event instanceof Event && !$event instanceof CallbackEvent) {
            $event->runInBackground()->withoutOverlapping();
        }
    }

I think mutexNames should be based on the same thing, and imo expression+command makes more sense.