### PR TITLE
[9.x] Add Eloquent `->toggle()` function for Boolean Attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1488,6 +1488,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Toggle a boolean attribute.
+     *
+     * @param  string $attribute
+     * @return static
+     */
+    public function toggle($attribute)
+    {
+        $this->{$attribute} = ! $this->{$attribute};
+
+        return $this;
+    }
+
+    /**
      * Convert the model instance to JSON.
      *
      * @param  int  $options

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1495,7 +1495,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function toggle($attribute)
     {
-        $this->{$attribute} = ! $this->{$attribute};
+        $this->setAttribute($attribute, ! $this->getAttribute($attribute));
 
         return $this;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -69,6 +69,19 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame(json_encode(['name' => 'taylor']), $attributes['list_items']);
     }
 
+    public function testToggleBooleanAttributes()
+    {
+        $model = new EloquentModelStub;
+        $model->boolean_attribute = true;
+
+        $this->assertTrue($model->boolean_attribute);
+
+        $returnedModel = $model->toggle('boolean_attribute');
+
+        $this->assertFalse($model->boolean_attribute);
+        $this->assertSame($model, $returnedModel);
+    }
+
     public function testSetAttributeWithNumericKey()
     {
         $model = new EloquentDateModelStub;


### PR DESCRIPTION
This PR adds a little function called `->toggle()` to Eloquent models. The use case is toggling boolean values in an expressive way. 

There's not a lot to explain, so here are a few examples:

```php
$user = User::create([
    'is_active' => false,
]);

// Before
$user->is_active = true; 

// Or:
$user->is_active = ! $user->is_active;

// After:
$user->toggle('is_active');

// You can directly save the model:
$user->toggle('is_active')->save();
```

(Regarding the position of the function, I now put it into the base `Model` class, but if you think that is more fitting, you can of course also put it in the HasAttributes trait.)