### PR TITLE
[9.x] Use config session domain for maintenance cookie

### DIFF
--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -20,7 +20,7 @@ class MaintenanceModeBypassCookie
         return new Cookie('laravel_maintenance', base64_encode(json_encode([
             'expires_at' => $expiresAt->getTimestamp(),
             'mac' => hash_hmac('sha256', $expiresAt->getTimestamp(), $key),
-        ])), $expiresAt);
+        ])), $expiresAt, config('session.path'), config('session.domain'));
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Changes the code proposed in #35036.

The current maintenance cookie only applies to the domain the secret request was sent to. This causes problems for multi subdomain setups as you would need to send that request to each subdomain to get the proper cookies even though they are all served by the same Laravel application. This PR simply hooks the cookie up to the already used config for session domains to fix the problem.