### PR TITLE
Validation: Support top-level rules via an unnamed attribute (i.e. `"" => ...`)

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -705,6 +705,10 @@ class Validator implements ValidatorContract
             return true;
         }
 
+        if ($attribute === '') {
+            return true;
+        }
+
         return $this->presentOrRuleIsImplicit($rule, $attribute, $value) &&
                $this->passesOptionalCheck($attribute) &&
                $this->isNotNullIfMarkedAsNullable($rule, $attribute) &&
@@ -1074,6 +1078,10 @@ class Validator implements ValidatorContract
      */
     protected function getValue($attribute)
     {
+        if ($attribute === '') {
+            return $this->data;
+        }
+
         return Arr::get($this->data, $attribute);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Background 

When validating data structures that are nested inside a request, you are able to specify rules by addressing the attribute that holds the structure e.g.

```php
$data = [
   'person' => [
       'first_name' => 'John',
       'last_name' => 'Appleseed',
    ],
];

$rules = [
   'person' => [
      'array:first_name,last_name',  // Only allow these two properties.
      new MyPersonValidatorRule(), // ...or this custom rule will accept the value of "person"
    ],
   'person.first_name' => 'string|required|min:1|max:255',
   'person.last_name' => 'string|required|min:1|max:255',
];
```

But if you wish to achieve something similar for the entire (i.e. top-level) data itself, there is no way to achieve this except for adding a `Validator#after(...)` callback.

This would be how you could do it:

```php
$data = [
   'first_name' => 'John',
   'last_name' => 'Appleseed',
];

$rules = [
   'first_name' => 'string|required|min:1|max:255',
   'last_name' => 'string|required|min:1|max:255',
];

$validator = $factory->make($data, $rules);
$validator->after(static function (Validator $validator) {
    $attributes = $validator->attributes();
    // Do validation here.
});
```

## Proposal: Support attachment of validation rules for entire data structure purely through rules array

I propose the ability to specify rules for the entire data structure as parts of the rule spec array, just like you are able to if the data structure is nested:

```php
$data = [
   'first_name' => 'John',
   'last_name' => 'Appleseed',
];

$rules = [
   '' => [ // <- Use empty string as array key to attach rules at top-level, e.g.:
       'array:first_name,last_name',
       new MyPersonValidationRule(), // ...or this custom rule will accept the entire data
   ],
   'first_name' => 'string|required|min:1|max:255',
   'last_name' => 'string|required|min:1|max:255',
];

$validator = $factory->make($data, $rules);
```

### Why

Consistency. For example, in the case of having `MyPersonValidatorRule()`, I should be able to use it no matter where the "person" data structure appears, even if the data itself is the "person" data. Sure, using the callback can work, but you lose the beauty of using `Rule` objects, which neatly encapsulates the data necessary e.g. `passes($attribute, $value): bool`.

Here is scenario to illustrate:

```php
$rules = [
   '' => [ // <- Use empty string as array key to attach rules at top-level, e.g.:
       new MyPersonValidationRule(), // ...or this custom rule will accept the entire data
   ],
   'first_name' => 'string|required|min:1|max:255',
   'last_name' => 'string|required|min:1|max:255',
   'siblings' => 'array|max:5',
   'siblings.*' => new MyPersonValidationRule(),
];
```

^^^ The `MyPersonValidationRule` is re-used at both top-level and the `siblings` level, without requiring a special `$validator->after(...)` callback that would only duplicate much of what the custom rule already does.

## Backwards Compatibility

This should be backwards-compatible, because rules attached via `"" => ...` are currently ignored. That is also why I chose to use that as the top-level key vs something like `.`, which would not guarantee backwards compatibility.


