### PR TITLE
[9.x] Use arrow functions

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -286,9 +286,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      */
     public function transaction(Closure $callback)
     {
-        return $this->connection->transaction(function () use ($callback) {
-            return $callback();
-        });
+        return $this->connection->transaction(fn () => $callback());
     }
 
     /**

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -91,8 +91,6 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      */
     public function giveConfig($key, $default = null)
     {
-        $this->give(function ($container) use ($key, $default) {
-            return $container->get('config')->get($key, $default);
-        });
+        $this->give(fn ($container) => $container->get('config')->get($key, $default));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -296,9 +296,7 @@ abstract class Factory
      */
     public function lazy(array $attributes = [], ?Model $parent = null)
     {
-        return function () use ($attributes, $parent) {
-            return $this->create($attributes, $parent);
-        };
+        return fn () => $this->create($attributes, $parent);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -726,8 +726,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function __get($key)
     {
-        return Arr::get($this->all(), $key, function () use ($key) {
-            return $this->route($key);
-        });
+        return Arr::get($this->all(), $key, fn () => $this->route($key));
     }
 }

--- a/src/Illuminate/Pagination/PaginationState.php
+++ b/src/Illuminate/Pagination/PaginationState.php
@@ -12,13 +12,9 @@ class PaginationState
      */
     public static function resolveUsing($app)
     {
-        Paginator::viewFactoryResolver(function () use ($app) {
-            return $app['view'];
-        });
+        Paginator::viewFactoryResolver(fn () => $app['view']);
 
-        Paginator::currentPathResolver(function () use ($app) {
-            return $app['request']->url();
-        });
+        Paginator::currentPathResolver(fn () => $app['request']->url());
 
         Paginator::currentPageResolver(function ($pageName = 'page') use ($app) {
             $page = $app['request']->input($pageName);
@@ -30,9 +26,7 @@ class PaginationState
             return 1;
         });
 
-        Paginator::queryStringResolver(function () use ($app) {
-            return $app['request']->query();
-        });
+        Paginator::queryStringResolver(fn () => $app['request']->query());
 
         CursorPaginator::currentCursorResolver(function ($cursorName = 'cursor') use ($app) {
             return Cursor::fromEncoded($app['request']->input($cursorName));

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -96,8 +96,6 @@ class Env
 
                 return $value;
             })
-            ->getOrCall(function () use ($default) {
-                return value($default);
-            });
+            ->getOrCall(fn () => value($default));
     }
 }

--- a/src/Illuminate/Testing/ParallelRunner.php
+++ b/src/Illuminate/Testing/ParallelRunner.php
@@ -135,9 +135,7 @@ class ParallelRunner implements RunnerInterface
     {
         collect(range(1, $this->options->processes()))->each(function ($token) use ($callback) {
             tap($this->createApplication(), function ($app) use ($callback, $token) {
-                ParallelTesting::resolveTokenUsing(function () use ($token) {
-                    return $token;
-                });
+                ParallelTesting::resolveTokenUsing(fn () => $token);
 
                 $callback($app);
             })->flush();

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -381,9 +381,7 @@ class Validator implements ValidatorContract
      */
     public function after($callback)
     {
-        $this->after[] = function () use ($callback) {
-            return $callback($this);
-        };
+        $this->after[] = fn () => $callback($this);
 
         return $this;
     }


### PR DESCRIPTION
Replaces:
```php
function () use ($variable) {
    return $variable;
}
```
with:
```php
fn () => $variable;
```