### PR TITLE
[9.x] Fix database events PHPDoc so it uses ConnectionInterface instead of Connection

### DIFF
--- a/src/Illuminate/Database/Events/ConnectionEvent.php
+++ b/src/Illuminate/Database/Events/ConnectionEvent.php
@@ -14,14 +14,14 @@ abstract class ConnectionEvent
     /**
      * The database connection instance.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Illuminate\Database\ConnectionInterface
      */
     public $connection;
 
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @return void
      */
     public function __construct($connection)

--- a/src/Illuminate/Database/Events/QueryExecuted.php
+++ b/src/Illuminate/Database/Events/QueryExecuted.php
@@ -28,7 +28,7 @@ class QueryExecuted
     /**
      * The database connection instance.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Illuminate\Database\ConnectionInterface
      */
     public $connection;
 
@@ -45,7 +45,7 @@ class QueryExecuted
      * @param  string  $sql
      * @param  array  $bindings
      * @param  float|null  $time
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @return void
      */
     public function __construct($sql, $bindings, $time, $connection)

--- a/src/Illuminate/Database/Events/SchemaDumped.php
+++ b/src/Illuminate/Database/Events/SchemaDumped.php
@@ -7,7 +7,7 @@ class SchemaDumped
     /**
      * The database connection instance.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Illuminate\Database\ConnectionInterface
      */
     public $connection;
 
@@ -28,7 +28,7 @@ class SchemaDumped
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @param  string  $path
      * @return void
      */

--- a/src/Illuminate/Database/Events/SchemaLoaded.php
+++ b/src/Illuminate/Database/Events/SchemaLoaded.php
@@ -7,7 +7,7 @@ class SchemaLoaded
     /**
      * The database connection instance.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Illuminate\Database\ConnectionInterface
      */
     public $connection;
 
@@ -28,7 +28,7 @@ class SchemaLoaded
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @param  string  $path
      * @return void
      */

--- a/src/Illuminate/Database/Events/StatementPrepared.php
+++ b/src/Illuminate/Database/Events/StatementPrepared.php
@@ -7,7 +7,7 @@ class StatementPrepared
     /**
      * The database connection instance.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Illuminate\Database\ConnectionInterface
      */
     public $connection;
 
@@ -21,7 +21,7 @@ class StatementPrepared
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @param  \PDOStatement  $statement
      * @return void
      */


### PR DESCRIPTION
I was getting PHPDoc warnings in PhpStorm when trying to create a new class that extends `Illuminate\Database\Events\ConnectionEvent` because I was trying to pass `Illuminate\Database\ConnectionInterface` 
in the first argument of the constructor when the event was expecting a `Illuminate\Database\Connection`. 

This is probably incorrect and `Illuminate\Database\Events\ConnectionEvent` should be expecting a `Illuminate\Database\ConnectionInterface`.

I have fixed other events in `Illuminate\Database\Events` as well for consistency.