### PR TITLE
[9.x] Fix ExcludeIf regression to use Closure over is_callable()

### DIFF
--- a/src/Illuminate/Validation/Rules/ExcludeIf.php
+++ b/src/Illuminate/Validation/Rules/ExcludeIf.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Closure;
 use InvalidArgumentException;
 
 class ExcludeIf
@@ -16,14 +17,14 @@ class ExcludeIf
     /**
      * Create a new exclude validation rule based on a condition.
      *
-     * @param  callable|bool  $condition
+     * @param  \Closure|bool  $condition
      * @return void
      *
      * @throws \InvalidArgumentException
      */
     public function __construct($condition)
     {
-        if (is_callable($condition) || is_bool($condition)) {
+        if ($condition instanceof Closure || is_bool($condition)) {
             $this->condition = $condition;
         } else {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');

--- a/tests/Validation/ValidationExcludeIfTest.php
+++ b/tests/Validation/ValidationExcludeIfTest.php
@@ -39,7 +39,7 @@ class ValidationExcludeIfTest extends TestCase
         new ExcludeIf(true);
         new ExcludeIf(fn () => true);
 
-        foreach ([1, 1.1, 'foobar', new stdClass] as $condition) {
+        foreach ([1, 1.1, 'phpinfo', new stdClass] as $condition) {
             try {
                 new ExcludeIf($condition);
                 $this->fail('The ExcludeIf constructor must not accept '.gettype($condition));


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/laravel/framework/pull/41931. In the original test, the string `phpinfo` was being pass into the constructor. After the rewrite, this check was changed to `foobar`.

```php
// Original Test
$this->expectException(InvalidArgumentException::class);

$rule = new ExcludeIf('phpinfo');
```

Why this matters is that `is_callable('phpinfo')` will evaluate to `TRUE` as it is a function in the global namespace. This switches the check from `is_callable($condition)` to the more strict `$condition instanceof Closure` and updates the test to check the string `phpinfo` once again.