### PR TITLE
[8.x] Backport Fix PHP warnings when rendering long blade string (#41956)

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -75,7 +75,7 @@ abstract class Component
         $resolver = function ($view) {
             $factory = Container::getInstance()->make('view');
 
-            return $factory->exists($view)
+            return strlen($view) <= PHP_MAXPATHLEN && $factory->exists($view)
                         ? $view
                         : $this->createBladeViewFromString($factory, $view);
         };

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -14,6 +14,15 @@ class BladeTest extends TestCase
         $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor']));
     }
 
+    public function test_rendering_blade_long_maxpathlen_string()
+    {
+        $longString = str_repeat('a', PHP_MAXPATHLEN);
+
+        $result = Blade::render($longString.'{{ $name }}', ['name' => 'a']);
+
+        $this->assertSame($longString.'a', $result);
+    }
+
     public function test_rendering_blade_component_instance()
     {
         $component = new HelloComponent('Taylor');


### PR DESCRIPTION
This is a backport of bug fix #41956 for Laravel 8. (https://laravel.com/docs/9.x/releases#support-policy) 

Seems like a lot of applicable bug fix PRs that could be sent to v8.x are just going straight to v9.x lately. 😅
