### PR TITLE
[9.x] Allow appending query strings to paginators globally

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -127,7 +127,7 @@ abstract class AbstractPaginator implements Htmlable
      *
      * @var bool
      */
-    protected static bool $appendsQueryString = false;
+    protected static $appendsQueryString = false;
 
     /**
      * Determine if the given value is a valid page number.
@@ -655,7 +655,7 @@ abstract class AbstractPaginator implements Htmlable
     /**
      * Indicate if all query string values should be appended to the paginator.
      *
-     * @param  bool|\Closure  $value
+     * @param  \Closure|bool  $value
      * @return void
      */
     public static function appendQueryString($value = true)

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -123,6 +123,13 @@ abstract class AbstractPaginator implements Htmlable
     public static $defaultSimpleView = 'pagination::simple-tailwind';
 
     /**
+     * Indicates if all query string values should be appended to the paginator.
+     *
+     * @var bool
+     */
+    protected static bool $appendsQueryString = false;
+
+    /**
      * Determine if the given value is a valid page number.
      *
      * @param  int  $page
@@ -643,6 +650,17 @@ abstract class AbstractPaginator implements Htmlable
     {
         static::defaultView('pagination::bootstrap-5');
         static::defaultSimpleView('pagination::simple-bootstrap-5');
+    }
+
+    /**
+     * Indicate if all query string values should be appended to the paginator.
+     *
+     * @param  bool|\Closure  $value
+     * @return void
+     */
+    public static function appendQueryString($value = true)
+    {
+        static::$appendsQueryString = value($value);
     }
 
     /**

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -51,6 +51,10 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
+
+        if (static::$appendsQueryString) {
+            $this->withQueryString();
+        }
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -42,6 +42,10 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
 
         $this->setItems($items);
+
+        if (static::$appendsQueryString) {
+            $this->withQueryString();
+        }
     }
 
     /**

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -75,4 +75,22 @@ class PaginatorTest extends TestCase
         $this->assertInstanceOf(Paginator::class, $p);
         $this->assertSame(['1', '2', '3'], $p->items());
     }
+
+    public function testPaginatorAppendsQueryString()
+    {
+        Paginator::appendQueryString();
+        Paginator::queryStringResolver(fn () => ['key1' => 'foo', 'key2' => 'bar']);
+
+        $p = new Paginator(
+            items: ['item1', 'item2', 'item3'],
+            perPage: 2,
+            currentPage: 1,
+            options: ['path' => 'http://website.com/test']
+        );
+
+        $this->assertSame($p->nextPageUrl(), 'http://website.com/test?key1=foo&key2=bar&page=2');
+
+        Paginator::appendQueryString(false);
+        Paginator::queryStringResolver(fn () => []);
+    }
 }


### PR DESCRIPTION
This PR adds a new `Paginator::appendQueryString()` method that appends query strings by default to all `Paginator` instances. This method can be added in a service provider. 

I needed this because I call `->withQueryString` on basically all my paginators. My main use case is paginating and filtering with query strings using Inertia.