### PR TITLE
Added exists method to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -361,6 +361,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if at least one item exists
+     *
+     * @return bool
+     */
+    public function exists()
+    {
+        return $this->count() > 0;
+    }
+
+    /**
      * Run a filter over each of the items.
      *
      * @param (callable(TValue, TKey): bool)|null  $callback

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -396,6 +396,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if at least one item exists
+     *
+     * @return bool
+     */
+    public function exists()
+    {
+        return $this->take(1)->count() > 0;
+    }
+
+    /**
      * Run a filter over each of the items.
      *
      * @param  (callable(TValue): bool)|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2081,6 +2081,21 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testExists($collection)
+    {
+        $c = new $collection([1, 2, 3]);
+        $this->assertTrue($c->exists());
+
+        $c = new $collection([1]);
+        $this->assertTrue($c->exists());
+
+        $c = new $collection([]);
+        $this->assertFalse($c->exists());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testPluckWithArrayAndObjectValues($collection)
     {
         $data = new $collection([(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);


### PR DESCRIPTION
This PR will add exists() method to Collection and LazyCollection like Query/Builder

```php
$collection = collect([1, 2, 3, 4]);
 
$filtered = $collection->filter(function ($value, $key) {
    return $value > 2;
})->exists();  // will return TRUE

$filtered = $collection->filter(function ($value, $key) {
    return $value > 5;
})->exists();  // will return FALSE

```

It also can be used on result of Eloquent as collection

```php
$users = Subscription::where('is_active', 1)->get();

if( $users->exists() ) {
      $activeUsers = $users;
     // do something
} else {
      throw new NoActiveUserFoundException;
}

```
Instead of
```php
$users = Subscription::where('is_active', 1)->get();

if( $users->count() > 0 ) {
      $activeUsers = $users;
     // do something
} else {
      throw new NoActiveUserFoundException;
}

```

The main purpose is to having same existence check method for both Collection and Eloquent
