### PR TITLE
[9.x] Nested Resource routes shorter URL method

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -202,6 +202,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Indicate that a nested resource routes should have the attributes only.
+     *
+     * @param  bool  $attronly
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function attributeOnly($attronly = true)
+    {
+        $this->options['attronly'] = $attronly;
+
+        return $this;
+    }
+
+    /**
      * Define the callable that should be invoked on a missing model exception.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -203,13 +203,17 @@ class PendingResourceRegistration
 
     /**
      * Indicate that a nested resource routes should have the attributes only.
+     * And sets the scoped fields.
      *
+     * @param  array  $fields
      * @param  bool  $attronly
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
-    public function attributeOnly($attronly = true)
+    public function attributeOnly(array $fields = [], $attronly = true)
     {
         $this->options['attronly'] = $attronly;
+
+        $this->scoped($fields);
 
         return $this;
     }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -182,7 +182,7 @@ class ResourceRegistrar
      */
     protected function addResourceIndex($name, $base, $controller, $options)
     {
-        $uri = $this->getResourceUri($name);
+        $uri = $this->getResourceUri($name, $options);
 
         unset($options['missing']);
 
@@ -202,7 +202,7 @@ class ResourceRegistrar
      */
     protected function addResourceCreate($name, $base, $controller, $options)
     {
-        $uri = $this->getResourceUri($name).'/'.static::$verbs['create'];
+        $uri = $this->getResourceUri($name, $options).'/'.static::$verbs['create'];
 
         unset($options['missing']);
 
@@ -222,7 +222,7 @@ class ResourceRegistrar
      */
     protected function addResourceStore($name, $base, $controller, $options)
     {
-        $uri = $this->getResourceUri($name);
+        $uri = $this->getResourceUri($name, $options);
 
         unset($options['missing']);
 
@@ -244,7 +244,7 @@ class ResourceRegistrar
     {
         $name = $this->getShallowName($name, $options);
 
-        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+        $uri = $this->getResourceUri($name, $options).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'show', $options);
 
@@ -264,7 +264,7 @@ class ResourceRegistrar
     {
         $name = $this->getShallowName($name, $options);
 
-        $uri = $this->getResourceUri($name).'/{'.$base.'}/'.static::$verbs['edit'];
+        $uri = $this->getResourceUri($name, $options).'/{'.$base.'}/'.static::$verbs['edit'];
 
         $action = $this->getResourceAction($name, $controller, 'edit', $options);
 
@@ -284,7 +284,7 @@ class ResourceRegistrar
     {
         $name = $this->getShallowName($name, $options);
 
-        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+        $uri = $this->getResourceUri($name, $options).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'update', $options);
 
@@ -304,7 +304,7 @@ class ResourceRegistrar
     {
         $name = $this->getShallowName($name, $options);
 
-        $uri = $this->getResourceUri($name).'/{'.$base.'}';
+        $uri = $this->getResourceUri($name, $options).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'destroy', $options);
 
@@ -347,9 +347,10 @@ class ResourceRegistrar
      * Get the base resource URI for a given resource.
      *
      * @param  string  $resource
+     * @param  array  $options
      * @return string
      */
-    public function getResourceUri($resource)
+    public function getResourceUri($resource, $options)
     {
         if (! str_contains($resource, '.')) {
             return $resource;
@@ -360,7 +361,7 @@ class ResourceRegistrar
         // paths however they need to, as some do not have any parameters at all.
         $segments = explode('.', $resource);
 
-        $uri = $this->getNestedResourceUri($segments);
+        $uri = $this->getNestedResourceUri($segments, $options);
 
         return str_replace('/{'.$this->getResourceWildcard(end($segments)).'}', '', $uri);
     }
@@ -369,16 +370,23 @@ class ResourceRegistrar
      * Get the URI for a nested resource segment array.
      *
      * @param  array  $segments
+     * @param  array  $options
      * @return string
      */
-    protected function getNestedResourceUri(array $segments)
+    protected function getNestedResourceUri(array $segments, $options)
     {
         // We will spin through the segments and create a place-holder for each of the
         // resource segments, as well as the resource itself. Then we should get an
         // entire string for the resource URI that contains all nested resources.
-        return implode('/', array_map(function ($s) {
-            return $s.'/{'.$this->getResourceWildcard($s).'}';
-        }, $segments));
+        if(isset($options['attronly']) && $options['attronly']){
+            return implode('/', array_map(function ($s) {
+                return '{'.$this->getResourceWildcard($s).'}';
+            }, $segments));
+        } else {
+            return implode('/', array_map(function ($s) {
+                return $s.'/{'.$this->getResourceWildcard($s).'}';
+            }, $segments));
+        }
     }
 
     /**


### PR DESCRIPTION
Hi!

This PR proposes a new method to a resource route, making nested resources URLs shorter
Use cases might be something like:
For a `Route::resource('states.cities')` for example, instead of a `/states/{state}/cities/{city}` URL, one might want something like `cities/{state:abbreviation}/{city:name}` (Eg. `cities/CA/losAngeles`), without the need to separately define all the action routes:
```
index => (GET) cities/{state:abbreviation}
create => (GET) cities/{state:abbreviation}/create
store =>(POST) cities/{state:abbreviation}
show => (GET) cities/{state:abbreviation}/{city:name}
edit => (GET) cities/{state:abbreviation}/{city:name}/edit
[...]
```
With this, it's possible to set all the resource routes with a single:
`Route::resource('cities/states.cities')->attributeOnly(['state' => 'abbreviation', 'city' => 'name'])`

As this URL format probably only makes sense if used with slugs on the URL, it also calls the scoped function inside

I couldn't think of a better name for the method, it's kinda of a shallow URL i guess, but Shallow is already in use so...
Please feel free to think of a better name for the method.

Should be fully compatible with 8.x too