### PR TITLE
Deep copy functionality on Collection and LazyCollection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "league/commonmark": "^2.2",
         "league/flysystem": "^3.0",
         "monolog/monolog": "^2.0",
+        "myclabs/deep-copy": "^1.11",
         "nesbot/carbon": "^2.53.1",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
+use Illuminate\Support\Traits\HasDeepCopy;
 use Illuminate\Support\Traits\Macroable;
 use stdClass;
 use Traversable;
@@ -22,7 +23,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * @use \Illuminate\Support\Traits\EnumeratesValues<TKey, TValue>
      */
-    use EnumeratesValues, Macroable;
+    use EnumeratesValues, Macroable, HasDeepCopy;
 
     /**
      * The items contained in the collection.
@@ -1709,4 +1710,5 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
 }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
-use DeepCopy\DeepCopy;
 use Generator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -5,9 +5,11 @@ namespace Illuminate\Support;
 use ArrayIterator;
 use Closure;
 use DateTimeInterface;
+use DeepCopy\DeepCopy;
 use Generator;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Support\Traits\EnumeratesValues;
+use Illuminate\Support\Traits\HasDeepCopy;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use IteratorAggregate;
@@ -25,7 +27,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * @use \Illuminate\Support\Traits\EnumeratesValues<TKey, TValue>
      */
-    use EnumeratesValues, Macroable;
+    use EnumeratesValues, Macroable, HasDeepCopy;
 
     /**
      * The source from which to generate items.

--- a/src/Illuminate/Support/Traits/HasDeepCopy.php
+++ b/src/Illuminate/Support/Traits/HasDeepCopy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use DeepCopy\DeepCopy;
+
+trait HasDeepCopy
+{
+    /**
+     * Returns a deep copy of the object
+     *
+     * @return object
+     */
+    public function deepCopy()
+    {
+        $copier = new DeepCopy();
+        return $copier->copy($this);
+    }
+}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5046,6 +5046,24 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDeepCopy($collection)
+    {
+        $quantity = 1;
+        $changedQuantity = 20;
+        $data = $collection::make([
+            'foo' => new TestDeepCopyObject($quantity),
+        ]);
+
+        $deepCopyData = $data->deepCopy();
+        $deepCopyData->get("foo")->changeQuantity($changedQuantity);
+
+        $this->assertSame($data->get("foo")->quantity(), $quantity);
+        $this->assertSame($deepCopyData->get("foo")->quantity(), $changedQuantity);
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array
@@ -5190,4 +5208,24 @@ class TestCollectionMapIntoObject
 class TestCollectionSubclass extends Collection
 {
     //
+}
+
+class TestDeepCopyObject
+{
+    private int $quantity;
+
+    public function __construct(int $quantity)
+    {
+        $this->quantity = $quantity;
+    }
+
+    public function quantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function changeQuantity(int $quantity)
+    {
+        $this->quantity = $quantity;
+    }
 }


### PR DESCRIPTION
This PR adds the functionality of creating a deep copy of a Collection instance. This means that new references are created for the objects inside the Collection. A deep copy is useful when the Collection contains non built-in types, since `clone` will only make new references of built-int types. So for example here:
```
$testObject = new TestObject();
$testObject->quantity = 1;
$collection = new Collection(array($testObject));
$clonedCollection = clone $collection;
$clonedCollection->changeQuantity(2);

class TestObject 
{
     public int $quantity;
}
```
What happens is that both the quantity of the `$clonedCollection` and the `$collection` instances have been changed to 2, as they share the same reference of `$testObject`. To solve this, you can map over the instances yourself and return a cloned version:

```
$collection->map(function (TestObject $testObject) 
{
      return clone $testObject;
});
```
But this will not work if `TestObject` has instances of non built-in types. So therefore, a better solution in my opinion is to have a deepCopy function on a Collection instance. A deep copy will make sure that new references are made for every instance, even for non built-in types and works for nested objects. I did not implement the deep copy logic myself, but use the library from myclabs/deep-copy. 

The end user can then use the following:
```
$deepCopiedCollection = $collection->deepCopy();
```
Let me know what you think! 
