### PR TITLE
[9.x] Fix typo in `SessionGuard::attemptWhen` phpdoc

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -391,7 +391,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @param  array  $credentials
      * @param  array|callable  $callbacks
-     * @param  false  $remember
+     * @param  bool  $remember
      * @return bool
      */
     public function attemptWhen(array $credentials = [], $callbacks = null, $remember = false)


### PR DESCRIPTION
Fix PhpStan

```
Parameter #3 $remember of static method Illuminate\Auth\SessionGuard::attemptWhen() expects false, true given.
```