### PR TITLE
[9.x] Removes core service providers from the skeleton

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -3,12 +3,34 @@
 namespace Illuminate\Support;
 
 use Closure;
+use Illuminate\Auth\AuthServiceProvider;
+use Illuminate\Auth\Passwords\PasswordResetServiceProvider;
+use Illuminate\Broadcasting\BroadcastServiceProvider;
+use Illuminate\Bus\BusServiceProvider;
+use Illuminate\Cache\CacheServiceProvider;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Foundation\CachesConfiguration;
 use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Cookie\CookieServiceProvider;
+use Illuminate\Database\DatabaseServiceProvider;
 use Illuminate\Database\Eloquent\Factory as ModelFactory;
+use Illuminate\Encryption\EncryptionServiceProvider;
+use Illuminate\Filesystem\FilesystemServiceProvider;
+use Illuminate\Foundation\Providers\ConsoleSupportServiceProvider;
+use Illuminate\Foundation\Providers\FoundationServiceProvider;
+use Illuminate\Hashing\HashServiceProvider;
+use Illuminate\Mail\MailServiceProvider;
+use Illuminate\Notifications\NotificationServiceProvider;
+use Illuminate\Pagination\PaginationServiceProvider;
+use Illuminate\Pipeline\PipelineServiceProvider;
+use Illuminate\Queue\QueueServiceProvider;
+use Illuminate\Redis\RedisServiceProvider;
+use Illuminate\Session\SessionServiceProvider;
+use Illuminate\Translation\TranslationServiceProvider;
+use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\ViewServiceProvider;
 
 abstract class ServiceProvider
 {
@@ -403,6 +425,39 @@ abstract class ServiceProvider
         Artisan::starting(function ($artisan) use ($commands) {
             $artisan->resolveCommands($commands);
         });
+    }
+
+    /**
+     * Get the application default providers.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public static function defaultProviders()
+    {
+        return collect([
+            AuthServiceProvider::class,
+            BroadcastServiceProvider::class,
+            BusServiceProvider::class,
+            CacheServiceProvider::class,
+            ConsoleSupportServiceProvider::class,
+            CookieServiceProvider::class,
+            DatabaseServiceProvider::class,
+            EncryptionServiceProvider::class,
+            FilesystemServiceProvider::class,
+            FoundationServiceProvider::class,
+            HashServiceProvider::class,
+            MailServiceProvider::class,
+            NotificationServiceProvider::class,
+            PaginationServiceProvider::class,
+            PipelineServiceProvider::class,
+            QueueServiceProvider::class,
+            RedisServiceProvider::class,
+            PasswordResetServiceProvider::class,
+            SessionServiceProvider::class,
+            TranslationServiceProvider::class,
+            ValidationServiceProvider::class,
+            ViewServiceProvider::class,
+        ]);
     }
 
     /**

--- a/tests/Support/ServiceProviderTest.php
+++ b/tests/Support/ServiceProviderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\ServiceProvider;
+use PHPUnit\Framework\TestCase;
+
+class ServiceProviderTest extends TestCase
+{
+    public function testDefaultProviders()
+    {
+        $defaultProviders = ServiceProvider::defaultProviders();
+
+        $this->assertInstanceOf(Collection::class, $defaultProviders);
+
+        foreach ($defaultProviders as $provider) {
+            $this->assertTrue(class_exists($provider));
+            $this->assertTrue(is_subclass_of($provider, ServiceProvider::class));
+        }
+    }
+}


### PR DESCRIPTION
This PR allows removing core service providers from the `config/app.php` from the skeleton. It implements same design decisions Nuno and Taylor used in the similar PR regarding core class aliases (https://github.com/laravel/framework/pull/40062).

The motivation is exactly the same — these classes are rarely modified by the majority of users, so they can find their new home in the core itself.

An example below shows what the future iteration of the skeleton may look like:
```php
'providers' => ServiceProvider::defaultProviders()->merge([
    App\Providers\AppServiceProvider::class,
    App\Providers\AuthServiceProvider::class,
    // App\Providers\BroadcastServiceProvider::class,
    App\Providers\EventServiceProvider::class,
    App\Providers\RouteServiceProvider::class,

    // ...
])->toArray(),
```

As this is presumably not a breaking change (existing applications may opt for this way of defining service providers only by manually changing the config file), this PR is targeting `9.x` branch, but will gladly switch to `master` if required.