### PR TITLE
[9.x] Added `preserveAttributeNames` for form requests

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -127,7 +127,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * If the attributes' names are to be preserved, merge any attributes
      * that have explicitly been defined on the request.
      *
-     * @return array|int[]|string[]
+     * @return array<string,string>
      */
     protected function gatherAttributes()
     {

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -67,6 +67,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $stopOnFirstFailure = false;
 
     /**
+     * Indicates whether the attribute names should be preserved in validation error messages.
+     *
+     * @var bool
+     */
+    protected $preserveAttributeNames = false;
+
+    /**
      * The validator instance.
      *
      * @var \Illuminate\Contracts\Validation\Validator
@@ -111,8 +118,25 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         return $factory->make(
             $this->validationData(), $this->container->call([$this, 'rules']),
-            $this->messages(), $this->attributes()
+            $this->messages(), $this->gatherAttributes()
         )->stopOnFirstFailure($this->stopOnFirstFailure);
+    }
+
+    /**
+     * Gather the attributes that will be used for validation error messages.
+     * If the attributes' names are to be preserved, merge any attributes
+     * that have explicitly been defined on the request.
+     *
+     * @return array|int[]|string[]
+     */
+    protected function gatherAttributes()
+    {
+        $defaultAttributes = $this->preserveAttributeNames ? array_combine(
+            array_keys($this->rules()),
+            array_keys($this->rules()),
+        ) : [];
+
+        return array_merge($defaultAttributes, $this->attributes());
     }
 
     /**


### PR DESCRIPTION
Hi! This PR proposes a new boolean `preserveAttributeNames` field that can be used in form requests to keep the exact field name in validation messages.

For a bit more context, at the moment, I'm building out an API and I have a validation rule that requires a field to be a valid URL. When the error message is returned, I get a response that looks similar to this (but in JSON format):

```php
[
    'errors' => [
        'destination_url' => [
            'The destination url must be a valid URL.',
        ],
    ],
    'message' => 'The destination url must be a valid URL.',
]
```

The `destination_url` key still contains the underscores, but I'd quite like to keep the underscore in the validation message too.

So, to keep the underscore, I could toggle the `preserveAttributeNames` field on my form request like so:

```php
class MyRequest extends FormRequest
{
    protected $preserveAttributeNames = true;

    public function rules()
    {
        return [
            'destination_url' => 'url|required',
        ];
    }
}
```

Now, by doing this, the error message would look like this instead:
```php
[
    'errors' => [
        'destination_url' => [
            'The destination_url must be a valid URL.',
        ],
    ],
    'message' => 'The destination_url must be a valid URL.',
]
```

You can still also override these attributes in the request. So, for example, if you wanted to preserve all of the names override the name for an `email` field, your request might look like this:

```php
class MyRequest extends FormRequest
{
    protected $preserveAttributeNames = true;

    public function rules()
    {
        return [
            'destination_url' => 'url|required',
            'email' => 'email|required',
        ];
    }

    public function attributes()
    {
        return [
            'email' => 'email address',
        ];
    }
}
```

So, now `destination_url` would be preserved with the underscore, but `email` would be returned as `email address` in the error message.

I'm already using this same kind of approach in a couple of other projects, so I thought I'd PR it just in case you think it could be useful for other developers. I tried having a quick go at putting some tests together for it but I seemed to be struggling quite a bit with the correct set up, sorry.

If this is something you think might be worth merging, please let me know if there are any changes you might want me to make 😄