### PR TITLE
[9.x] Add common base class for paginators

### DIFF
--- a/src/Illuminate/Pagination/AbstractBasePaginator.php
+++ b/src/Illuminate/Pagination/AbstractBasePaginator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+abstract class AbstractBasePaginator
+{
+    //
+}

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -19,7 +19,7 @@ use Traversable;
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractCursorPaginator implements Htmlable
+abstract class AbstractCursorPaginator extends AbstractBasePaginator implements Htmlable
 {
     use ForwardsCalls, Tappable;
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -13,7 +13,7 @@ use Traversable;
 /**
  * @mixin \Illuminate\Support\Collection
  */
-abstract class AbstractPaginator implements Htmlable
+abstract class AbstractPaginator extends AbstractBasePaginator implements Htmlable
 {
     use ForwardsCalls, Tappable;
 


### PR DESCRIPTION
This is a sort of retry of #41204 and #41199.

-------

Currently the paginator classes does not have a common base class. Because of this, there are a big portion of code duplication that could be prevented by using a base class.

My former PRs were closed, because the refacoring was too big and might had some potentional bugs.

In this PR I just added the empty base class, and if it's merged, then we can slowly start a step-by-step refactoring without the risk that a big code chage holds.