### PR TITLE
[9.x] Fix pushMiddlewareToGroup not working on Provider in My Package

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -952,9 +952,10 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  array  $middleware
      * @return $this
      */
-    public function middlewareGroup($name, array $middleware)
+    public function middlewareGroup($name, array $middlewares)
     {
-        $this->middlewareGroups[$name] = $middleware;
+        foreach ($middlewares as $middleware)
+            $this->pushMiddlewareToGroup($name, $middleware);
 
         return $this;
     }


### PR DESCRIPTION
<!-- DO NOT THROW THIS AWAY -->
<!-- Fill out the FULL versions with patch versions -->

- Laravel Version: 9.8.1
- PHP Version: 8.0.5
- Database Driver & Version: mariadb

### Description:
In continuation of bug https://github.com/laravel/framework/issues/36604. I found the reason for this bug.
We want to dynamically connect Middleware in our package in the Service Provider:

    public function boot(Router $router)
    {
        // Push middleware to web group
        $router->pushMiddlewareToGroup('web', MyMiddleware::class);
    }

But the Middleware is not executed if the package name starts with the letters a-k.

### Reason:

In the /Illuminate/Foundation/Http/Kernel.php file, the syncMiddlewareToRouter method overwrites the Middleware list in the Router

    protected function syncMiddlewareToRouter()
    {
        $this->router->middlewarePriority = $this->middlewarePriority;

        foreach ($this->middlewareGroups as $key => $middleware) {
            $this->router->middlewareGroup($key, $middleware);
        }

        foreach ($this->routeMiddleware as $key => $middleware) {
            $this->router->aliasMiddleware($key, $middleware);
        }
    }

In the /Illuminate/Routing/Router.php file the middlewareGroup method

    public function middlewareGroup($name, array $middleware)
    {
        $this->middlewareGroups[$name] = $middleware;

        return $this;
    }

The syncMiddlewareToRouter method is called in prependToMiddlewarePriority which calls /laravel/sanctum/src/SanctumServiceProvider.php after my ServiceProvider

Service providers are named in alphabetical order. If the package name starts with letters a-k Middleware Group is overwritten. If the package name begins with the letters m-z, everything works.

### Solution:

If rewriting the middleware group is not required, then you can change the middlewareGroup method in /Illuminate/Routing/Router.php

    public function middlewareGroup($name, array $middlewares)
    {
        foreach ($middlewares as $middleware)
            $this->pushMiddlewareToGroup($name, $middleware);

        return $this;
    }

Please add to the framework if I'm right.
