### PR TITLE
[9.x] Fixes return type of request function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -636,7 +636,7 @@ if (! function_exists('request')) {
      *
      * @param  array|string|null  $key
      * @param  mixed  $default
-     * @return \Illuminate\Http\Request|string|array|null
+     * @return mixed
      */
     function request($key = null, $default = null)
     {


### PR DESCRIPTION
This PR offers changing return type of request function to ```mixed``` in order to avoid IDE warning on incompatible types. 

While making route model binding, for example:
```
Route::get('/{form}', [IndexController::class, 'show'])
    ->name('project.show');
```
and accessing it: ``` $form = request('form'); ``` IDE shows warning:

```
Incompatible types: Expected property of type '\App\Models\Form', 'array|\Illuminate\Contracts\Foundation\Application|\Illuminate\Http\Request|null|string' provided
```
