### PR TITLE
[9:x] Fix typo in  `Event::push`typo fix facade phpdoc

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void forget(string $event)
  * @method static void forgetPushed()
  * @method static void listen(\Closure|string|array $events, \Closure|string|array $listener = null)
- * @method static void push(string $event, array $payload = [])
+ * @method static void push(string $event, object|array $payload = [])
  * @method static void subscribe(object|string $subscriber)
  *
  * @see \Illuminate\Events\Dispatcher


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

when we create an Event class and want to use the push method on it, the second parameter should be an object. because it passes to the listener as an object 
![event](https://user-images.githubusercontent.com/21986853/163678858-cfe03821-1026-4d02-b4db-43e8c1cde9c6.png)

