### PR TITLE
[9.x] Delete replication withoutTrashed method 

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -185,7 +185,7 @@ trait DatabaseRule
     /**
      * Only soft deleted models during the existence check.
      *
-     * @param string $deletedAtColumn
+     * @param  string  $deletedAtColumn
      * @return $this
      */
     public function onlyTrashed($deletedAtColumn = 'deleted_at')

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -170,6 +170,32 @@ trait DatabaseRule
     }
 
     /**
+     * Ignore soft deleted models during the existence check.
+     *
+     * @param  string  $deletedAtColumn
+     * @return $this
+     */
+    public function withoutTrashed($deletedAtColumn = 'deleted_at')
+    {
+        $this->whereNull($deletedAtColumn);
+
+        return $this;
+    }
+
+    /**
+     * Only soft deleted models during the existence check.
+     *
+     * @param string $deletedAtColumn
+     * @return $this
+     */
+    public function onlyTrashed($deletedAtColumn = 'deleted_at')
+    {
+        $this->whereNotNull($deletedAtColumn);
+
+        return $this;
+    }
+
+    /**
      * Register a custom query callback.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Validation/Rules/Exists.php
+++ b/src/Illuminate/Validation/Rules/Exists.php
@@ -9,19 +9,6 @@ class Exists
     use Conditionable, DatabaseRule;
 
     /**
-     * Ignore soft deleted models during the existence check.
-     *
-     * @param  string  $deletedAtColumn
-     * @return $this
-     */
-    public function withoutTrashed($deletedAtColumn = 'deleted_at')
-    {
-        $this->whereNull($deletedAtColumn);
-
-        return $this;
-    }
-
-    /**
      * Convert the rule to a validation string.
      *
      * @return string

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -57,18 +57,6 @@ class Unique
         return $this;
     }
 
-    /**
-     * Ignore soft deleted models during the unique check.
-     *
-     * @param  string  $deletedAtColumn
-     * @return $this
-     */
-    public function withoutTrashed($deletedAtColumn = 'deleted_at')
-    {
-        $this->whereNull($deletedAtColumn);
-
-        return $this;
-    }
 
     /**
      * Convert the rule to a validation string.

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -57,7 +57,6 @@ class Unique
         return $this;
     }
 
-
     /**
      * Convert the rule to a validation string.
      *

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -38,7 +38,7 @@ class RepositoryTest extends TestCase
             ],
             'a.b' => 'c',
             'a' => [
-                'b.c' => 'd'
+                'b.c' => 'd',
             ]
         ]);
 
@@ -48,17 +48,17 @@ class RepositoryTest extends TestCase
     public function testGetValueWhenKeyContainDot()
     {
         $this->assertSame(
-            $this->repository->get("a.b") ,"c"
+            $this->repository->get('a.b'), 'c'
         );
         $this->assertNull(
-            $this->repository->get("a.b.c")
+            $this->repository->get('a.b.c')
         );
     }
 
     public function testGetBooleanValue()
     {
         $this->assertTrue(
-            $this->repository->get("boolean")
+            $this->repository->get('boolean')
         );
     }
 

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -39,7 +39,7 @@ class RepositoryTest extends TestCase
             'a.b' => 'c',
             'a' => [
                 'b.c' => 'd',
-            ]
+            ],
         ]);
 
         parent::setUp();

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -24,6 +24,7 @@ class RepositoryTest extends TestCase
             'bar' => 'baz',
             'baz' => 'bat',
             'null' => null,
+            'boolean' => true,
             'associate' => [
                 'x' => 'xxx',
                 'y' => 'yyy',
@@ -35,9 +36,30 @@ class RepositoryTest extends TestCase
             'x' => [
                 'z' => 'zoo',
             ],
+            'a.b' => 'c',
+            'a' => [
+                'b.c' => 'd'
+            ]
         ]);
 
         parent::setUp();
+    }
+
+    public function testGetValueWhenKeyContainDot()
+    {
+        $this->assertSame(
+            $this->repository->get("a.b") ,"c"
+        );
+        $this->assertNull(
+            $this->repository->get("a.b.c")
+        );
+    }
+
+    public function testGetBooleanValue()
+    {
+        $this->assertTrue(
+            $this->repository->get("boolean")
+        );
     }
 
     public function testConstruct()

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -211,6 +211,17 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertSame('exists:table,NULL,softdeleted_at,"NULL"', (string) $rule);
     }
 
+    public function testItOnlySoftDeletes()
+    {
+        $rule = new Exists('table');
+        $rule->onlyTrashed();
+        $this->assertSame('exists:table,NULL,deleted_at,"NOT_NULL"', (string) $rule);
+
+        $rule = new Exists('table');
+        $rule->onlyTrashed('softdeleted_at');
+        $this->assertSame('exists:table,NULL,softdeleted_at,"NOT_NULL"', (string) $rule);
+    }
+
     protected function createSchema()
     {
         $this->schema('default')->create('users', function ($table) {

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -84,13 +84,40 @@ class ValidationUniqueRuleTest extends TestCase
 
     public function testItIgnoresSoftDeletes()
     {
+        $rule = new Unique('table', 'column');
+        $rule->withoutTrashed();
+        $this->assertSame('unique:table,column,NULL,id,deleted_at,"NULL"', (string) $rule);
+
+        $rule = new Unique('table', 'column');
+        $rule->withoutTrashed('soft_deleted_at');
+        $this->assertSame('unique:table,column,NULL,id,soft_deleted_at,"NULL"', (string) $rule);
+
         $rule = new Unique('table');
         $rule->withoutTrashed();
         $this->assertSame('unique:table,NULL,NULL,id,deleted_at,"NULL"', (string) $rule);
 
         $rule = new Unique('table');
-        $rule->withoutTrashed('softdeleted_at');
-        $this->assertSame('unique:table,NULL,NULL,id,softdeleted_at,"NULL"', (string) $rule);
+        $rule->withoutTrashed('soft_deleted_at');
+        $this->assertSame('unique:table,NULL,NULL,id,soft_deleted_at,"NULL"', (string) $rule);
+    }
+
+    public function testItOnlySoftDeletes()
+    {
+        $rule = new Unique('table', 'column');
+        $rule->onlyTrashed();
+        $this->assertSame('unique:table,column,NULL,id,deleted_at,"NOT_NULL"', (string) $rule);
+
+        $rule = new Unique('table', 'column');
+        $rule->onlyTrashed('soft_deleted_at');
+        $this->assertSame('unique:table,column,NULL,id,soft_deleted_at,"NOT_NULL"', (string) $rule);
+
+        $rule = new Unique('table');
+        $rule->onlyTrashed();
+        $this->assertSame('unique:table,NULL,NULL,id,deleted_at,"NOT_NULL"', (string) $rule);
+
+        $rule = new Unique('table');
+        $rule->onlyTrashed('soft_deleted_at');
+        $this->assertSame('unique:table,NULL,NULL,id,soft_deleted_at,"NOT_NULL"', (string) $rule);
     }
 }
 


### PR DESCRIPTION
The withoutTrashed method seems to be replicated in the following two classes:

1. Illuminate/Validation/Rules/Exists
2. Illuminate/Validation/Rules/Unique

It is better to transfer this method to a DatabaseRule trait .