### PR TITLE
[9.x] Better handling for DateTime classes when using `mapInto()`

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -388,6 +388,10 @@ trait EnumeratesValues
     public function mapInto($class)
     {
         return $this->map(function ($value, $key) use ($class) {
+            if ($class == 'DateTime' || in_array('DateTime', class_parents($class))) {
+                return new $class($value);
+            }
+
             return new $class($value, $key);
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -23,6 +23,9 @@ use ReflectionClass;
 use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use UnexpectedValueException;
+use Illuminate\Support\Carbon as IlluminateCarbon;
+use Carbon\Carbon;
+use DateTime;
 
 class SupportCollectionTest extends TestCase
 {
@@ -2956,6 +2959,31 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame('first', $data->get(0)->value);
         $this->assertSame('second', $data->get(1)->value);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapIntoCanHandleDateClasses($collection)
+    {
+        $baseCollection = new $collection([
+            '2021-01-01', '2022-01-01',
+        ]);
+
+        $data1 = $baseCollection->mapInto(IlluminateCarbon::class);
+
+        $this->assertSame((new IlluminateCarbon('2021-01-01'))->toIso8601String(), $data1->get(0)->toIso8601String());
+        $this->assertSame((new IlluminateCarbon('2022-01-01'))->toIso8601String(), $data1->get(1)->toIso8601String());
+
+        $data2 = $baseCollection->mapInto(Carbon::class);
+
+        $this->assertSame((new Carbon('2021-01-01'))->toIso8601String(), $data2->get(0)->toIso8601String());
+        $this->assertSame((new Carbon('2022-01-01'))->toIso8601String(), $data2->get(1)->toIso8601String());
+
+        $data3 = $baseCollection->mapInto(DateTime::class);
+
+        $this->assertSame((new DateTime('2021-01-01'))->format(DateTime::ISO8601), $data3->get(0)->format(DateTime::ISO8601));
+        $this->assertSame((new DateTime('2022-01-01'))->format(DateTime::ISO8601), $data3->get(1)->format(DateTime::ISO8601));
     }
 
     /**


### PR DESCRIPTION
This PR will resolve an issue that occur when mapping any collection values to date classes, for example:

```php
$mappedMonths = collect(['2022-01-01', '2022-02-01', '2022-03-01'])->mapInto(Carbon::class);
```

when debugging the `$mappedMonths` variable, it will show the timezone for every date is increased by each date key in `$mappedMonths` array, for example:
```php
// Croped from the Carbon objects...
date: 2022-01-01 00:00:00.0 +00:00 
date: 2022-01-01 00:00:00.0 +01:00 
date: 2022-01-01 00:00:00.0 +02:00 
```
And when mapping to `DateTime` class, it will throw an exception: `Argument #2 ($timezone) must be of type ?DateTimeZone, int given`