### PR TITLE
[9.x] Correct php doc setUser method

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Auth;
 
-use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider;
 
 /**
@@ -88,7 +88,7 @@ trait GuardHelpers
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return $this
      */
-    public function setUser(AuthenticatableContract $user)
+    public function setUser(Authenticatable $user)
     {
         $this->user = $user;
 

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -51,7 +51,7 @@ interface Guard
      * Set the current user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @return void
+     * @return $this
      */
     public function setUser(Authenticatable $user);
 }

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -30,6 +30,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $user->id);
         $this->assertTrue($guard->check());
         $this->assertFalse($guard->guest());
+        $this->assertTrue($guard->hasUser());
         $this->assertSame(1, $guard->id());
     }
 
@@ -48,6 +49,7 @@ class AuthTokenGuardTest extends TestCase
         $this->assertSame(1, $user->id);
         $this->assertTrue($guard->check());
         $this->assertFalse($guard->guest());
+        $this->assertTrue($guard->hasUser());
         $this->assertSame(1, $guard->id());
     }
 


### PR DESCRIPTION
I do not understand the reason for using alias for **Authenticatable** interface !