### PR TITLE
[10.x] Queueable event listeners should be dispatched within bus dispatcher

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -580,12 +580,12 @@ class Dispatcher implements DispatcherContract
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
         $job->onConnection(method_exists($listener, 'viaConnection')
-                ? $listener->viaConnection()
-                : $listener->connection ?? null);
+                    ? $listener->viaConnection()
+                    : $listener->connection ?? null);
 
         $job->onQueue(method_exists($listener, 'viaQueue')
-                ? $listener->viaQueue()
-                : $listener->queue ?? null);
+                    ? $listener->viaQueue()
+                    : $listener->queue ?? null);
 
         if (isset($listener->delay)) {
             $job->delay($listener->delay);

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -580,12 +580,12 @@ class Dispatcher implements DispatcherContract
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
         $job->onConnection(method_exists($listener, 'viaConnection')
-            ? $listener->viaConnection()
-            : $listener->connection ?? null);
+                ? $listener->viaConnection()
+                : $listener->connection ?? null);
 
         $job->onQueue(method_exists($listener, 'viaQueue')
-            ? $listener->viaQueue()
-            : $listener->queue ?? null);
+                ? $listener->viaQueue()
+                : $listener->queue ?? null);
 
         if (isset($listener->delay)) {
             $job->delay($listener->delay);

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -579,15 +579,13 @@ class Dispatcher implements DispatcherContract
     {
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
-        $connection = method_exists($listener, 'viaConnection')
+        $job->onConnection(method_exists($listener, 'viaConnection')
             ? $listener->viaConnection()
-            : $listener->connection ?? null;
+            : $listener->connection ?? null);
 
-        $queue = method_exists($listener, 'viaQueue')
+        $job->onQueue(method_exists($listener, 'viaQueue')
             ? $listener->viaQueue()
-            : $listener->queue ?? null;
-
-        $job->onConnection($connection)->onQueue($queue);
+            : $listener->queue ?? null);
 
         if (isset($listener->delay)) {
             $job->delay($listener->delay);

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Events;
 
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -14,6 +13,6 @@ class EventServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('events', fn (Application $app): Dispatcher => new Dispatcher($app));
+        $this->app->singleton('events', fn ($app): Dispatcher => new Dispatcher($app));
     }
 }

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Events;
 
-use Illuminate\Contracts\Queue\Factory as QueueFactoryContract;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -14,10 +14,6 @@ class EventServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('events', function ($app) {
-            return (new Dispatcher($app))->setQueueResolver(function () use ($app) {
-                return $app->make(QueueFactoryContract::class);
-            });
-        });
+        $this->app->singleton('events', fn (Application $app): Dispatcher => new Dispatcher($app));
     }
 }


### PR DESCRIPTION
In the current implementation of the event dispatcher, queueable event listeners are dispatched directly through the Queue object, but since the event dispatcher already depends on `illuminate/bus` and for consistency queueable event listeners has to dispatch through bus dispatcher, so that changes and customization of the job dispatching do not require changes in two places - in the event dispatcher and the job dispatcher.