### PR TITLE
[10.x] Remove instance return from setUser

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -86,13 +86,11 @@ trait GuardHelpers
      * Set the current user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @return $this
+     * @return void
      */
     public function setUser(AuthenticatableContract $user)
     {
         $this->user = $user;
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -896,7 +896,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * Set the current user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @return $this
+     * @return void
      */
     public function setUser(AuthenticatableContract $user)
     {
@@ -905,8 +905,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $this->loggedOut = false;
 
         $this->fireAuthenticatedEvent($user);
-
-        return $this;
     }
 
     /**

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -222,7 +222,8 @@ class AuthGuardTest extends TestCase
     public function testAuthenticateReturnsUserWhenUserIsNotNull()
     {
         $user = m::mock(Authenticatable::class);
-        $this->getGuard()->setUser($user);
+        $guard = $this->getGuard();
+        $guard->setUser($user);
 
         $this->assertEquals($user, $guard->authenticate());
     }
@@ -250,7 +251,8 @@ class AuthGuardTest extends TestCase
     public function testHasUserReturnsTrueWhenUserIsNotNull()
     {
         $user = m::mock(Authenticatable::class);
-        $this->getGuard()->setUser($user);
+        $guard = $this->getGuard();
+        $guard->setUser($user);
 
         $this->assertTrue($guard->hasUser());
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -222,7 +222,7 @@ class AuthGuardTest extends TestCase
     public function testAuthenticateReturnsUserWhenUserIsNotNull()
     {
         $user = m::mock(Authenticatable::class);
-        $guard = $this->getGuard()->setUser($user);
+        $this->getGuard()->setUser($user);
 
         $this->assertEquals($user, $guard->authenticate());
     }
@@ -250,7 +250,7 @@ class AuthGuardTest extends TestCase
     public function testHasUserReturnsTrueWhenUserIsNotNull()
     {
         $user = m::mock(Authenticatable::class);
-        $guard = $this->getGuard()->setUser($user);
+        $this->getGuard()->setUser($user);
 
         $this->assertTrue($guard->hasUser());
     }


### PR DESCRIPTION
Alternative for #42017. The return here isn't needed. The contract already indicates this should be a void return. Right now IDE's warn about this so it's best that we match the type of the contract.
