### PR TITLE
[9.x] Fixed PendingMail send() method

### DIFF
--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -117,11 +117,11 @@ class PendingMail
      * Send a new mailable message instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
-     * @return void
+     * @return \Illuminate\Mail\SentMessage|null
      */
     public function send(MailableContract $mailable)
     {
-        $this->mailer->send($this->fill($mailable));
+        return $this->mailer->send($this->fill($mailable));
     }
 
     /**


### PR DESCRIPTION
As per the laravel 9.x documentation `Mail::send()` should return the `Illuminate\Mail\SentMessage` instance. However because of method chaining, after a call to methods like `to()`, `cc()`, etc we are working with a `PendingMail` object. The `send()` method on the `PendingMail` class correctly routes the call to the underlying mailer but doesn't return the result of the call, hence breaking the return type. This PR attempts to fix this issue.

Relevant documentation: `https://laravel.com/docs/9.x/upgrade#symfony-mailer`
>  The send, html, text, and plain methods no longer return the number of recipients that received the message. Instead, an instance of Illuminate\Mail\SentMessage is returned.