### PR TITLE
Allow to pass a method to call for `mapInto`

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -383,11 +383,16 @@ trait EnumeratesValues
      * @template TMapIntoValue
      *
      * @param  class-string<TMapIntoValue>  $class
+     * @param  string|null  $method
      * @return static<TKey, TMapIntoValue>
      */
-    public function mapInto($class)
+    public function mapInto($class, $method = null)
     {
-        return $this->map(function ($value, $key) use ($class) {
+        return $this->map(function ($value, $key) use ($class, $method) {
+            if ($method) {
+                return $class::$method($value, $key);
+            }
+
             return new $class($value, $key);
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2961,6 +2961,21 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMapIntoWithMethod($collection)
+    {
+        $data = new $collection([
+            'first', 'second',
+        ]);
+
+        $data = $data->mapInto(TestCollectionMapIntoObject::class, 'make');
+
+        $this->assertSame('first-through-make', $data->get(0)->value);
+        $this->assertSame('second-through-make', $data->get(1)->value);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testNth($collection)
     {
         $data = new $collection([
@@ -5184,6 +5199,11 @@ class TestCollectionMapIntoObject
     public function __construct($value)
     {
         $this->value = $value;
+    }
+
+    public static function make($value)
+    {
+        return new static($value.'-through-make');
     }
 }
 


### PR DESCRIPTION
Adds a possibility to use `mapInto` with a static method instead of a constructor.

You may want to have classes where the constructor uses promoted properties or mapping needs some special logic, but still keep the constructor with all the properties instead of just accepting value as a single param. 

This would allow for code like this:


```php
class A {
    public function __construct(
        public string $id,
        public int $amount,
        public Carbon $createdAt,
    ) {
    }

    public static function fromDbRow(array $row): static
    {
        return new static(
            id: $row['id'],
            amount: $row['amount'],
            createdAt: Carbon::parse($row['created_at']),
        );
    }
}

DB::from('table')->get()->mapInto(A::class, 'fromDbRow');
```
