### PR TITLE
[9.x] Narrow down $internalDontReport type

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -89,7 +89,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * A list of the internal exception types that should not be reported.
      *
-     * @var string[]
+     * @var array<int, class-string<\Throwable>>
      */
     protected $internalDontReport = [
         AuthenticationException::class,


### PR DESCRIPTION
Small change to specify (and match `$dontReport`) the type of `$internalDontReport` in the exception handler.