### PR TITLE
[9.x] Add replaceAssocArray to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -577,6 +577,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Replace the given keys with their associated values.
+     *
+     * @param  array<string, string>  $search
+     * @return static
+     */
+    public function replaceAssocArray(array $search)
+    {
+        return new static(str_replace(array_keys($search), array_values($search), $this->value));
+    }
+
+    /**
      * Replace the first occurrence of a given value in the string.
      *
      * @param  string  $search

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -739,6 +739,17 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', ['x' => 'foo', 'y' => 'bar']));
     }
 
+    public function testReplaceAssocArray()
+    {
+        $replace = [
+            'a' => 'a_a',
+            'b' => 'b_b',
+            'c' => 'c_c',
+        ];
+
+        $this->assertSame('a_a/b_b/c_c', $this->stringable('a/b/c')->replaceAssocArray($replace)->toString());
+    }
+
     public function testReplaceFirst()
     {
         $this->assertSame('fooqux foobar', (string) $this->stringable('foobar foobar')->replaceFirst('bar', 'qux'));


### PR DESCRIPTION
This allows performing a multi search-replace with a single call.

```php
$search = [
  'a' => 'with_a',
  'b' => 'with_b',
];

$stringable->replaceAssocArray($seach);
```

