### PR TITLE
[9.x] Add a hook to the PendingMail send method to allow developers to access the returned SentMessage object

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailable.php
+++ b/src/Illuminate/Contracts/Mail/Mailable.php
@@ -10,7 +10,7 @@ interface Mailable
      * Send the message using the given mailer.
      *
      * @param  \Illuminate\Contracts\Mail\Factory|\Illuminate\Contracts\Mail\Mailer  $mailer
-     * @return void
+     * @return \Illuminate\Mail\SentMessage|null
      */
     public function send($mailer);
 

--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -25,7 +25,7 @@ interface Mailer
      *
      * @param  string  $text
      * @param  mixed  $callback
-     * @return void
+     * @return \Illuminate\Mail\SentMessage|null
      */
     public function raw($text, $callback);
 

--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -35,7 +35,7 @@ interface Mailer
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @param  array  $data
      * @param  \Closure|string|null  $callback
-     * @return void
+     * @return \Illuminate\Mail\SentMessage|null
      */
     public function send($view, array $data = [], $callback = null);
 }

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -121,7 +121,18 @@ class PendingMail
      */
     public function send(MailableContract $mailable)
     {
-        $this->mailer->send($this->fill($mailable));
+        $this->sendHook($mailable);
+    }
+
+    /**
+     * Forward the send call.
+     *
+     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     * @return \Illuminate\Mail\SentMessage|null
+     */
+    public function sendHook(MailableContract $mailable)
+    {
+        return $this->mailer->send($this->fill($mailable));
     }
 
     /**

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -117,20 +117,9 @@ class PendingMail
      * Send a new mailable message instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
-     * @return void
-     */
-    public function send(MailableContract $mailable)
-    {
-        $this->sendHook($mailable);
-    }
-
-    /**
-     * Forward the send call.
-     *
-     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
      * @return \Illuminate\Mail\SentMessage|null
      */
-    public function sendHook(MailableContract $mailable)
+    public function send(MailableContract $mailable)
     {
         return $this->mailer->send($this->fill($mailable));
     }


### PR DESCRIPTION
# Type: Improvement

# Summary

As per the docs the `send`, `html`, `raw`, and `plain` methods on the `Illuminate\Mail\Mailer` class now return a `Illuminate\Mail\SentMessage` instance. However, the developer doesn't have access to this returned instance when using method chaining, e.g. `Mailer::to('test@somedomain.com')->send($mailable)`. The `to`, `cc` and `bcc` methods on the `Mailer` class all return a `PendingMail` class which doesn't return the `SentMessage` instance. This PR proposes to add an intermediate `public` method call so that one may access the returned `SentMessage` object without going through other complex methods.

# Issue

## Details

As mentioned above, when using the `Mail` facade or using a `Mailer` instance directly, typically one would expect as per the `send` method signature to have a `SentMessage` object returned by the call. However, when we chain any of the methods `to`, `cc` or `bcc` available on the `Mailer` class before sending the mail via `send` we end up calling the `send` method on the `PendingMail` class. The `send` method on the `PendingMail` class doesn't return anything. For example `Mail::to($user)->send($mailable) is processed as follows:

The call to `Mail::to()` is:

```php
   /**
   * Begin the process of mailing a mailable class instance.
   *
   * @param  mixed  $users
   * @return \Illuminate\Mail\PendingMail
   */
   public function to($users)
   {
       return (new PendingMail($this))->to($users);
   }
```

So a `PendingMail` class is returned. The next call `send` is actually called on the `PendingMail` class which has a `send` method as follows:

```php
    /**
     * Send a new mailable message instance.
     *
     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
     * @return void
     */
    public function send(MailableContract $mailable)
    {
       $this->mailer->send($this->fill($mailable));
    }
```

Therefore the `SentMessage` object is not accessible in a easy manner. This is true whether we use the `Mail` facade or use a actual instance of the `Mailer` class. As soon as a call is made to `to()`, `cc()` or `bcc` this issue will pop up.

## Alternate Solution 1: Listen for the `MessageSent` event via a `Listener`

Problem with this approach is that we end up listening to all `MessageSent` event. For example, say we want the `X-SES-Message-Id` which is returned when using the `ses` mailer. 
-  This is inefficient as we are listening to all mail sent events, even ones which are sent via different mailers. 
-  Further, we need to check whether the header is present.
- A missing header tells us nothing. Was the header missing because there was a problem with SES or did we use a different mailer. 

This issue becomes worse for package developers who want to implement their own mailers without changing the core mailers of the framework. The package is listening to all `MessageSent` events even the ones that weren't sent by it's own mailer.

## Alternate Solution 2: Call the `send` method on `Mailer` directly

Example: `Mail::send($mailable)`

Well, the problem with this approach is we can say goodbye to using `to()`, `cc()` or `bcc` since they return `PendingMail` class. Now these fields can be set on the `Mailable` class. However, from a package developer's perspective they have to notify the user that their 
-  `Mailer` is special and can't use these core Laravel methods.
-  The end-user has to set these fields on the `Mailable`.

## Alternate Solution 3: Re-Implement the functionality manually

Basically extend the `PendingMail` class through the container and work it out that way. Notice I didn't write the steps since even writing them is going to be long. Not to mention, this is extra work for a simple returned object which the `Mailer` class is sending by default.

# Proposed Solution

Add an intermediate `public` method call (a hook into the sending mail process) `sendHook()` which can be called instead of `send` when the developer needs access to the returned `SentMessage` object. 

Instead of:

```php
    /**
     * Send a new mailable message instance.
     *
     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
     * @return void
     */
    public function send(MailableContract $mailable)
    {
       $this->mailer->send($this->fill($mailable));
    }
```

we use this:

```php
    /**
     * Send a new mailable message instance.
     *
     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
     * @return void
     */
    public function send(MailableContract $mailable)
    {
        $this->sendHook($mailable);
    }

    /**
     * Forward the send call.
     *
     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
     * @return \Illuminate\Mail\SentMessage|null
     */
    public function sendHook(MailableContract $mailable)
    {
        return $this->mailer->send($this->fill($mailable));
    }
```

## Impact

None. Developers can continue using the `Mail` facade or `Mailer` class as they have been. Anyone who needs access to the returned `SentMessage` object can simply call the `sendHook()` method.