### PR TITLE
Make the order ascending parameter case insensitive

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1332,8 +1332,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
                 $prop = $comparison[0];
 
-                $ascending = Arr::get($comparison, 1, true) === true ||
-                             Arr::get($comparison, 1, true) === 'asc';
+                $ascending = $this->computeAscending($comparison);
 
                 $result = 0;
 
@@ -1358,6 +1357,31 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         });
 
         return new static($items);
+    }
+
+    /**
+     * Computes the comparison order direction.
+     *
+     * @param  array  $comparisons
+     * @return bool
+     */
+    protected function computeAscending(array $comparison)
+    {
+        $ascending = Arr::get($comparison, 1, true);
+
+        if ($ascending === true) {
+            return $ascending;
+        }
+
+        if (! is_string($ascending)) {
+            return false;
+        }
+
+        if (strtolower($ascending) === 'asc') {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1842,6 +1842,17 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSortByCallableStringCaseInsensitive($collection)
+    {
+        $data = new $collection([['sort' => 2], ['sort' => 1]]);
+        $data = $data->sortBy([['sort', 'aSc']]);
+
+        $this->assertEquals([['sort' => 1], ['sort' => 2]], array_values($data->all()));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortByAlwaysReturnsAssoc($collection)
     {
         $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);


### PR DESCRIPTION
When using the collection sorting method the following is not supported and default to a descending ordering

```php
$result = LazyCollection::make($csv)
    ->sortBy([['annee', 'ASC'], ['nombre', 'ASC']])
    ->slice(3, 2)
```

The current PR enable support for case insensitve `asc` value. 

Of note, `desc` is already case insensitive as the current code only check for the scrict lowecased `asc` value. Any other value is treated as `desc`.
