### PR TITLE
[9.x] Provide a method to store a cached result permanently, periodically refreshing it

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -396,18 +396,18 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get an item from the cache, or execute the given Closure and refresh the result when the TTL expires.
      *
-     * @param  string                                              $key
+     * @param  string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
-     * @param  Closure                                             $callback
+     * @param  Closure  $callback
      * @return mixed
      */
     public function refresh($key, $ttl, Closure $callback)
     {
-        $refreshKey = '~' . $key;
-        $value      = $this->get($key);
-        $fresh      = $this->get($refreshKey);
+        $refreshKey = '~'.$key;
+        $value = $this->get($key);
+        $fresh = $this->get($refreshKey);
 
-        if ( ! is_null($value) && ! is_null($fresh)) {
+        if (! is_null($value) && ! is_null($fresh)) {
             return $value;
         }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -394,6 +394,30 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Get an item from the cache, or execute the given Closure and refresh the result when the TTL expires.
+     *
+     * @param  string                                              $key
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  Closure                                             $callback
+     * @return mixed
+     */
+    public function refresh($key, $ttl, Closure $callback)
+    {
+        $refreshKey = '~' . $key;
+        $value      = $this->get($key);
+        $fresh      = $this->get($refreshKey);
+
+        if ( ! is_null($value) && ! is_null($fresh)) {
+            return $value;
+        }
+
+        $this->put($refreshKey, true, value($ttl));
+        $this->forever($key, $value = $callback());
+
+        return $value;
+    }
+
+    /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
      * @param  string  $key

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -73,6 +73,14 @@ interface Repository extends CacheInterface
      */
     public function remember($key, $ttl, Closure $callback);
 
+    /**
+     * Get an item from the cache, or execute the given Closure and refresh the result when the TTL expires.
+     *
+     * @param  string                                              $key
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  Closure                                             $callback
+     * @return mixed
+     */
     public function refresh($key, $ttl, Closure $callback);
 
     /**

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -76,9 +76,9 @@ interface Repository extends CacheInterface
     /**
      * Get an item from the cache, or execute the given Closure and refresh the result when the TTL expires.
      *
-     * @param  string                                              $key
+     * @param  string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
-     * @param  Closure                                             $callback
+     * @param  Closure  $callback
      * @return mixed
      */
     public function refresh($key, $ttl, Closure $callback);

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -73,6 +73,8 @@ interface Repository extends CacheInterface
      */
     public function remember($key, $ttl, Closure $callback);
 
+    public function refresh($key, $ttl, Closure $callback);
+
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *


### PR DESCRIPTION
I'm proposing this addition as a feature to meet the following use case:

Where there is a service such as an HTTP endpoint that our application relies on caching a result for, but the remote service is unreliable or slow. In this case we don't want to clear the cached result after a TTL in case we can't reliably replace it, causing our application to have problems. We do want to try periodically refreshing the result, but if we can't then we prefer to keep the cached version.

This feature caches the result permanently, alongside a separate expiring value. When the expiring value expires we immediately mark the expiring value as valid again, and re-run the closure. The closure may safely fail until the TTL expires again.

A bonus advantage of using this technique is to prevent a stampede of workers all attempting to re-cache an expired value.