### PR TITLE
[9.x] Add the ability to use alias when performing upsert via MySQL

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -200,12 +200,24 @@ class MySqlGrammar extends Grammar
      */
     public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
-        $sql = $this->compileInsert($query, $values).' on duplicate key update ';
+        $useUpsertAlias = $query->connection->getConfig('use_upsert_alias');
 
-        $columns = collect($update)->map(function ($value, $key) {
-            return is_numeric($key)
-                ? $this->wrap($value).' = values('.$this->wrap($value).')'
-                : $this->wrap($key).' = '.$this->parameter($value);
+        $sql = $this->compileInsert($query, $values);
+
+        if ($useUpsertAlias) {
+            $sql .= ' as laravel_upsert_alias';
+        }
+
+        $sql .= ' on duplicate key update';
+
+        $columns = collect($update)->map(function ($value, $key) use ($useUpsertAlias) {
+            if (! is_numeric($key)) {
+                return $this->wrap($key).' = '.$this->parameter($value);
+            }
+
+            return $useUpsertAlias
+                ? $this->wrap($value).' = `laravel_upsert_alias`.`'.$this->wrap($value).'`'
+                : $this->wrap($value).' = values('.$this->wrap($value).')';
         })->implode(', ');
 
         return $sql.$columns;

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -200,11 +200,11 @@ class MySqlGrammar extends Grammar
      */
     public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
-        $sql = $this->compileInsert($query, $values).' on duplicate key update ';
+        $sql = $this->compileInsert($query, $values).' as laravel_upsert_key on duplicate key update ';
 
         $columns = collect($update)->map(function ($value, $key) {
             return is_numeric($key)
-                ? $this->wrap($value).' = values('.$this->wrap($value).')'
+                ? $this->wrap($value).' = '.$this->wrap('laravel_upsert_key.'.$value)
                 : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -216,7 +216,7 @@ class MySqlGrammar extends Grammar
             }
 
             return $useUpsertAlias
-                ? $this->wrap($value).' = `laravel_upsert_alias`.`'.$this->wrap($value).'`'
+                ? $this->wrap($value).' = '.$this->wrap('laravel_upsert_alias').'.'.$this->wrap($value)
                 : $this->wrap($value).' = values('.$this->wrap($value).')';
         })->implode(', ');
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -208,7 +208,7 @@ class MySqlGrammar extends Grammar
             $sql .= ' as laravel_upsert_alias';
         }
 
-        $sql .= ' on duplicate key update';
+        $sql .= ' on duplicate key update ';
 
         $columns = collect($update)->map(function ($value, $key) use ($useUpsertAlias) {
             if (! is_numeric($key)) {

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -200,11 +200,11 @@ class MySqlGrammar extends Grammar
      */
     public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update)
     {
-        $sql = $this->compileInsert($query, $values).' as laravel_upsert_key on duplicate key update ';
+        $sql = $this->compileInsert($query, $values).' on duplicate key update ';
 
         $columns = collect($update)->map(function ($value, $key) {
             return is_numeric($key)
-                ? $this->wrap($value).' = '.$this->wrap('laravel_upsert_key.'.$value)
+                ? $this->wrap($value).' = values('.$this->wrap($value).')'
                 : $this->wrap($key).' = '.$this->parameter($value);
         })->implode(', ');
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2491,7 +2491,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpsertMethod()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) as laravel_upsert_key on duplicate key update `email` = `laravel_upsert_key`.`email`, `name` = `laravel_upsert_key`.`name`', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `email` = values(`email`), `name` = values(`name`)', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
         $this->assertEquals(2, $result);
 
@@ -2514,7 +2514,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpsertMethodWithUpdateColumns()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) as laravel_upsert_key on duplicate key update `name` = `laravel_upsert_key`.`name`', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `name` = values(`name`)', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
         $this->assertEquals(2, $result);
 
@@ -2926,7 +2926,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPreservedAreAppliedByUpsert()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`) values (?) as laravel_upsert_key on duplicate key update `email` = `laravel_upsert_key`.`email`', ['foo']);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`) values (?) on duplicate key update `email` = values(`email`)', ['foo']);
         $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2491,7 +2491,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpsertMethod()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `email` = values(`email`), `name` = values(`name`)', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) as laravel_upsert_key on duplicate key update `email` = `laravel_upsert_key`.`email`, `name` = `laravel_upsert_key`.`name`', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email');
         $this->assertEquals(2, $result);
 
@@ -2514,7 +2514,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testUpsertMethodWithUpdateColumns()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) on duplicate key update `name` = values(`name`)', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`, `name`) values (?, ?), (?, ?) as laravel_upsert_key on duplicate key update `name` = `laravel_upsert_key`.`name`', ['foo', 'bar', 'foo2', 'bar2'])->andReturn(2);
         $result = $builder->from('users')->upsert([['email' => 'foo', 'name' => 'bar'], ['name' => 'bar2', 'email' => 'foo2']], 'email', ['name']);
         $this->assertEquals(2, $result);
 
@@ -2926,7 +2926,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPreservedAreAppliedByUpsert()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`) values (?) on duplicate key update `email` = values(`email`)', ['foo']);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into `users` (`email`) values (?) as laravel_upsert_key on duplicate key update `email` = `laravel_upsert_key`.`email`', ['foo']);
         $builder->beforeQuery(function ($builder) {
             $builder->from('users');
         });


### PR DESCRIPTION
### Why?

Laravel's upsert default behaviour uses the `values()` function that is deprecated and MySQL >= 8.0.20 _will throw a warning_ when using the `values()` function in `upsert`:
> Beginning with MySQL 8.0.20, an INSERT ... SELECT ... ON DUPLICATE KEY UPDATE statement that uses VALUES() in the UPDATE clause, like this one, throws a warning:

[Reference](https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html)

---

### Expected behaviour

MySQL >= 8.0.20 does not throw any warnings when using `Model::upsert()`.

---

### How?

Update the behaviour of [MySqlGrammar@compileUpsert](https://github.com/laravel/framework/blob/0ce1f410175fe2130dae5e251337e8ab96b2bfac/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php#L201) to use the alias (instead of `values`) in the upsert query when it is configured in the new `database.{mysql-database}.use_upsert_alias` config value.

---

### Why can't we update it to always use aliases?

The alias in `upsert` is only supported beginning with MySQL 8.0.19, so it won't work with earlier versions:
> Beginning with MySQL 8.0.19, it is possible to use an alias for the row, with, optionally, one or more of its columns to be inserted, following the VALUES or SET clause, and preceded by the AS keyword. Using the row alias new, the statement shown previously using VALUES() to access the new column values can be written in the form shown here:

[Reference](https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html)

---

As the other option, a fourth parameter (instead of adding a new config values) `(bool $useAlias = false)` can be added to the method to make `upsert` use the alias.