### PR TITLE
[9.x] Fixes return type of request function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -636,7 +636,7 @@ if (! function_exists('request')) {
      *
      * @param  array|string|null  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return mixed|\Illuminate\Contracts\Foundation\Application|\Illuminate\Http\Request
      */
     function request($key = null, $default = null)
     {


### PR DESCRIPTION
Adds \Illuminate\Contracts\Foundation\Application|\Illuminate\Http\Request to PHPDoc in order IDE to suggest autocompletion, for example: ``` request()->ip()```
