### PR TITLE
[8.0] Fix SFTP file system in queue or long running tasks

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -25,7 +25,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function registerNativeFilesystem()
     {
-        $this->app->singleton('files', function () {
+        $this->app->scoped('files', function () {
             return new Filesystem;
         });
     }
@@ -39,11 +39,11 @@ class FilesystemServiceProvider extends ServiceProvider
     {
         $this->registerManager();
 
-        $this->app->singleton('filesystem.disk', function ($app) {
+        $this->app->scoped('filesystem.disk', function ($app) {
             return $app['filesystem']->disk($this->getDefaultDriver());
         });
 
-        $this->app->singleton('filesystem.cloud', function ($app) {
+        $this->app->scoped('filesystem.cloud', function ($app) {
             return $app['filesystem']->disk($this->getCloudDriver());
         });
     }
@@ -55,7 +55,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function registerManager()
     {
-        $this->app->singleton('filesystem', function ($app) {
+        $this->app->scoped('filesystem', function ($app) {
             return new FilesystemManager($app);
         });
     }


### PR DESCRIPTION
Making the file system scoped makes sure that the file system gets cleaned up and reset after a queue job.
This forces for example the SFTP connection to close and reset so that you don't experience: `Message: Connection closed prematurely`

Possibly adds overhead for users who are using the queue extensively with cloud filesystems as they might need to reconnect on every Job. But it will make the framework behave more consistently.


There is only 1 major problem: `Storage::` facade is globally cached and wont be refreshed, so you can't use this or this should also be cleared with:

```
        Storage::clearResolvedInstances();
```