### PR TITLE
[9.x] Make password rule errors translatable

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -305,7 +305,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             if ($this->mixedCase && ! preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {
                 $validator->errors()->add(
                     $attribute,
-                    $this->getErrorMessage('validation.password.mixedCase')
+                    $this->getErrorMessage('validation.password.mixed')
                 );
             }
 
@@ -356,6 +356,29 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Get the translated password error message.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function getErrorMessage($key)
+    {
+        $messages = [
+            'validation.password.mixed' => 'The :attribute must contain at least one uppercase and one lowercase letter.',
+            'validation.password.letters' => 'The :attribute must contain at least one letter.',
+            'validation.password.symbols' => 'The :attribute must contain at least one symbol.',
+            'validation.password.numbers' => 'The :attribute must contain at least one number.',
+            'validation.password.uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
+        ];
+
+        if (($message = $this->validator->getTranslator()->get($key)) !== $key) {
+            return $message;
+        }
+
+        return $messages[$key];
+    }
+
+    /**
      * Adds the given failures, and return false.
      *
      * @param  array|string  $messages
@@ -370,28 +393,5 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         $this->messages = array_merge($this->messages, $messages);
 
         return false;
-    }
-
-    /**
-     * Returns the translated error message.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    protected function getErrorMessage($key)
-    {
-        $messages = [
-            'validation.password.mixedCase' => 'The :attribute must contain at least one uppercase and one lowercase letter.',
-            'validation.password.letters' => 'The :attribute must contain at least one letter.',
-            'validation.password.symbols' => 'The :attribute must contain at least one symbol.',
-            'validation.password.numbers' => 'The :attribute must contain at least one number.',
-            'validation.password.uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
-        ];
-
-        if (($message = $this->validator->getTranslator()->get($key)) !== $key) {
-            return $message;
-        }
-
-        return $messages[$key];
     }
 }

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -303,19 +303,31 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             $value = (string) $value;
 
             if ($this->mixedCase && ! preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {
-                $validator->errors()->add($attribute, 'The :attribute must contain at least one uppercase and one lowercase letter.');
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.password.mixedCase')
+                );
             }
 
             if ($this->letters && ! preg_match('/\pL/u', $value)) {
-                $validator->errors()->add($attribute, 'The :attribute must contain at least one letter.');
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.password.letters')
+                );
             }
 
             if ($this->symbols && ! preg_match('/\p{Z}|\p{S}|\p{P}/u', $value)) {
-                $validator->errors()->add($attribute, 'The :attribute must contain at least one symbol.');
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.password.symbols')
+                );
             }
 
             if ($this->numbers && ! preg_match('/\pN/u', $value)) {
-                $validator->errors()->add($attribute, 'The :attribute must contain at least one number.');
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.password.numbers')
+                );
             }
         });
 
@@ -327,9 +339,7 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             'value' => $value,
             'threshold' => $this->compromisedThreshold,
         ])) {
-            return $this->fail(
-                'The given :attribute has appeared in a data leak. Please choose a different :attribute.'
-            );
+            return $this->fail($this->getErrorMessage('validation.password.uncompromised'));
         }
 
         return true;
@@ -360,5 +370,28 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         $this->messages = array_merge($this->messages, $messages);
 
         return false;
+    }
+
+    /**
+     * Returns the translated error message.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function getErrorMessage($key)
+    {
+        $messages = [
+            'validation.password.mixedCase' => 'The :attribute must contain at least one uppercase and one lowercase letter.',
+            'validation.password.letters' => 'The :attribute must contain at least one letter.',
+            'validation.password.symbols' => 'The :attribute must contain at least one symbol.',
+            'validation.password.numbers' => 'The :attribute must contain at least one number.',
+            'validation.password.uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
+        ];
+
+        if (($message = $this->validator->getTranslator()->get($key)) !== $key) {
+            return $message;
+        }
+
+        return $messages[$key];
     }
 }


### PR DESCRIPTION
Right now, the only way to translate password errors is to set messages into a JSON file.
And we can't use lang/{language}/validation.php in our system to translate error messages.

With this change, we will be able to use PHP files to use translation.

For example, we can change the lang/en/validation.php file into:
```php

return [
    'password' => [
         'mixedCase' => 'The :attribute must contain at least one uppercase and one lowercase letter.',
         'letters' => 'The :attribute must contain at least one letter.',
         'symbols' => 'The :attribute must contain at least one symbol.',
         'numbers' => 'The :attribute must contain at least one number.',
         'uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
    ],
];
```

These changes do not break any old changes, and old users still can use JSON files to translate this message.

If it will be merged, I'll add these messages to `lang/en/validation.php` in laravel/laravel repo.

And we don't need to create `en.json` file anymore.
