### PR TITLE
[9.x] Fix TrimStrings middleware with non-UTF8 characters

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -49,11 +49,11 @@ class TrimStrings extends TransformsRequest
      */
     protected function transform($key, $value)
     {
-        if (in_array($key, $this->except, true)) {
+        if (in_array($key, $this->except, true) || ! is_string($value)) {
             return $value;
         }
 
-        return is_string($value) ? preg_replace('~^[\s﻿]+|[\s﻿]+$~u', '', $value) : $value;
+        return preg_replace('~^[\s﻿]+|[\s﻿]+$~u', '', $value) ?? trim($value);
     }
 
     /**

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -41,6 +41,7 @@ class TrimStringsTest extends TestCase
             'foo' => 'ム',
             'bar' => '   だ    ',
             'baz' => '   ム    ',
+            'binary' => "  \xE9 ",
         ]);
         $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
         $request = Request::createFromBase($symfonyRequest);
@@ -52,6 +53,7 @@ class TrimStringsTest extends TestCase
             $this->assertSame('ム', $request->get('foo'));
             $this->assertSame('だ', $request->get('bar'));
             $this->assertSame('ム', $request->get('baz'));
+            $this->assertSame("\xE9", $request->get('binary'));
         });
     }
 }

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -41,7 +41,7 @@ class TrimStringsTest extends TestCase
             'foo' => 'ム',
             'bar' => '   だ    ',
             'baz' => '   ム    ',
-            'binary' => "  \xE9 ",
+            'binary' => " \xE9  ",
         ]);
         $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
         $request = Request::createFromBase($symfonyRequest);


### PR DESCRIPTION
Currently, the `TrimStrings` middleware sets to `null` all requests inputs with a unicode character not in UTF-8, which can be really frustrating to debug

It can be reproduced by using a `POST` request with a body like `foo=abcd%E9`: the `foo` input will just be `null` if the `TrimString` middleware is used.

This issue was introduced in #40600, because `preg_replace` with `u` flag will return `null` for a non-UTF8 input (with `Malformed UTF-8 characters, possibly incorrectly encoded` as `preg_last_error_msg()`)

As a fix, when `preg_replace` return a `null` value, it's simply pass the value to the PHP `trim` function, which was the behavior used by Laravel for years. This doesn’t change the current behavior for valid UTF-8 inputs.