### PR TITLE
[9.x] Add Missing AsCommand attribute on `schedule:list`

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -9,12 +9,12 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use ReflectionClass;
 use ReflectionFunction;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Terminal;
 
 #[AsCommand(name: 'schedule:list')]
 class ScheduleListCommand extends Command
 {
-
     /**
      * The console command name.
      *

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -11,14 +11,27 @@ use ReflectionClass;
 use ReflectionFunction;
 use Symfony\Component\Console\Terminal;
 
+#[AsCommand(name: 'schedule:list')]
 class ScheduleListCommand extends Command
 {
+
     /**
      * The console command name.
      *
      * @var string
      */
     protected $signature = 'schedule:list {--timezone= : The timezone that times should be displayed in}';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'schedule:list';
 
     /**
      * The console command description.


### PR DESCRIPTION
After checking the revert on #41982 it does look like `schedule:list` was missed.

Thanks,
Francisco