### PR TITLE
[9.x] Add the beforeRefreshingDatabase function to the Testing/RefreshDatabase trait 

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -16,6 +16,8 @@ trait RefreshDatabase
      */
     public function refreshDatabase()
     {
+        $this->beforeRefreshingDatabase();
+
         $this->usingInMemoryDatabase()
                         ? $this->refreshInMemoryDatabase()
                         : $this->refreshTestDatabase();
@@ -124,6 +126,16 @@ trait RefreshDatabase
     {
         return property_exists($this, 'connectionsToTransact')
                             ? $this->connectionsToTransact : [null];
+    }
+
+    /**
+     * Perform any work that should take place before the database has started refreshing.
+     *
+     * @return void
+     */
+    protected function beforeRefreshingDatabase()
+    {
+        // ...
     }
 
     /**


### PR DESCRIPTION
# Type: Improvement
This pull request adds `beforeRefreshingDatabase` to `Testing/RefreshDatabase` trait.
## Use Case
When using the `refreshDatabase` trait in my feature tests, I needed to run the `php artisan db:wipe --database another-database-connection` before the migrations were run, or the migrations kept failing with "table already exists" - because the other database wasn't wiped beforehand. With the added `beforeRefreshingDatabase` function, I was able to wipe out the other database in any of my tests like this:
```
class DataExportTest extends TestCase
{
    use RefreshDatabase;

    protected $seed = true;

    protected function beforeRefreshingDatabase()
    {
        $this->artisan('db:wipe --database another-database-connection');
    }

    public function test_prepare_some_data()
    {
        ...
    }
}

```
I think this function could be useful to other developers as well, because it allows for running just about anything before the database is refreshed.