### PR TITLE
[9.x] Remove redundant collection

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -62,7 +62,7 @@ class TransformsRequest
             $data[$key] = $this->cleanValue($keyPrefix.$key, $value);
         }
 
-        return collect($data)->all();
+        return $data;
     }
 
     /**


### PR DESCRIPTION
The `TransformRequests` middleware has a redundant collection, where an array is being cast into a collection using `collect()`, and then the collection is cast into an array using `all()`.

This thing is a remnant from https://github.com/laravel/framework/pull/36002, because before that the arrays were manipulated using collections. But since that PR, the collection is not doing anything, so it's safe to remove.