### PR TITLE
[8.x] Fix array keys from cached routes

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -252,11 +252,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             })
             ->map(function (Collection $routes) {
                 return $routes->mapWithKeys(function (Route $route) {
-                    if ($domain = $route->getDomain()) {
-                        return [$domain.'/'.$route->uri => $route];
-                    }
-
-                    return [$route->uri => $route];
+                    return [$route->getDomain().$route->uri => $route];
                 })->all();
             })
             ->all();

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -527,13 +527,13 @@ class CompiledRouteCollectionTest extends TestCase
 
         $this->assertEquals([
             'HEAD' => [
-                'foo.localhost/same/path' => $routes['foo_domain'],
-                'bar.localhost/same/path' => $routes['bar_domain'],
+                'foo.localhostsame/path' => $routes['foo_domain'],
+                'bar.localhostsame/path' => $routes['bar_domain'],
                 'same/path' => $routes['no_domain'],
             ],
             'GET' => [
-                'foo.localhost/same/path' => $routes['foo_domain'],
-                'bar.localhost/same/path' => $routes['bar_domain'],
+                'foo.localhostsame/path' => $routes['foo_domain'],
+                'bar.localhostsame/path' => $routes['bar_domain'],
                 'same/path' => $routes['no_domain'],
             ],
         ], $this->collection()->getRoutesByMethod());


### PR DESCRIPTION
Introduced by https://github.com/laravel/framework/pull/35714.
Removed the slash to match the same array key as in
src/Illuminate/Routing/RouteCollection.php:60

We noticed a different result when we used route caching for in this code piece:

```
$url = parse_url($requestUri, PHP_URL_PATH);

 if (!is_string($url)) {
        return true;
 }

$routeKey = '{tenant}.' . trim(config('app.domain')) . trim($url, '/');

$routes = Route::getRoutes()->get($requestMethod);

return array_key_exists($routeKey, $routes);
```

Only routes with a specified domain where affected and a the result array of "->get('GET')" would not have the same array keys. Check next example with uri "test" and domain "{tenant}.laravel.test", this would give these two different results if you use cached router or not:

 "{tenant}.laravel.test/test" => cached
 "{tenant}.laravel.testtest" => not cached

The check for the existing of a domain is not necessary because the "->getDomain" function can return `null` as well and wil result in empty string (just like it behaves in the non compiled RouteCollection).

If approved & merged, I can cherry-pick it for 9.x release as well.