### PR TITLE
[9.x] Make it so non-existent jobs run down the failed path instead of crashing

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -112,6 +112,10 @@ class CallQueuedHandler
      */
     protected function dispatchThroughMiddleware(Job $job, $command)
     {
+        if($command instanceof \__PHP_Incomplete_Class) {
+            throw new \Exception('Tried running job that has no matching class ' . json_encode($command));
+        }
+
         return (new Pipeline($this->container))->send($command)
                 ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
                 ->then(function ($command) use ($job) {
@@ -255,6 +259,11 @@ class CallQueuedHandler
         if (! $command instanceof ShouldBeUniqueUntilProcessing) {
             $this->ensureUniqueJobLockIsReleased($command);
         }
+
+        if($command instanceof \__PHP_Incomplete_Class) {
+            return;
+        }
+
 
         $this->ensureFailedBatchJobIsRecorded($uuid, $command, $e);
         $this->ensureChainCatchCallbacksAreInvoked($uuid, $command, $e);

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -112,8 +112,8 @@ class CallQueuedHandler
      */
     protected function dispatchThroughMiddleware(Job $job, $command)
     {
-        if($command instanceof \__PHP_Incomplete_Class) {
-            throw new \Exception('Tried running job that has no matching class ' . json_encode($command));
+        if ($command instanceof \__PHP_Incomplete_Class) {
+            throw new \Exception('Tried running job that has no matching class '.json_encode($command));
         }
 
         return (new Pipeline($this->container))->send($command)
@@ -260,10 +260,9 @@ class CallQueuedHandler
             $this->ensureUniqueJobLockIsReleased($command);
         }
 
-        if($command instanceof \__PHP_Incomplete_Class) {
+        if ($command instanceof \__PHP_Incomplete_Class) {
             return;
         }
-
 
         $this->ensureFailedBatchJobIsRecorded($uuid, $command, $e);
         $this->ensureChainCatchCallbacksAreInvoked($uuid, $command, $e);


### PR DESCRIPTION
Hi,

the issue that this is solving is that if you have a queued job (ie in SQS), that you have deleted (or renamed), the runner that picks up the job will fail with an Error.

That means that instead of going down the failed job path and dequeuing the job, it will crash, and keep retrying the job over and over again (in our case 361k times before we ran out of error log allowance).

This makes it instead fail with an Exception and go down the failed job path, so the job dequeues and doesn't keep retrying.


For us this happened to a job that was queued before a deployment in which it was renamed.