### PR TITLE
[9.x] Copy locale and defaultLocale from original request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -421,9 +421,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->headers->replace($from->headers->all());
 
-        $request->locale = $from->locale;
+        $request->locale = $from->getLocale();
 
-        $request->defaultLocale = $from->defaultLocale;
+        $request->defaultLocale = $from->getDefaultLocale();
 
         $request->setJson($from->json());
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -421,6 +421,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->headers->replace($from->headers->all());
 
+        $request->locale = $from->locale;
+
+        $request->defaultLocale = $from->defaultLocale;
+
         $request->setJson($from->json());
 
         if ($from->hasSession() && $session = $from->session()) {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -421,9 +421,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->headers->replace($from->headers->all());
 
-        $request->locale = $from->getLocale();
+        $request->setLocale($from->getLocale());
 
-        $request->defaultLocale = $from->getDefaultLocale();
+        $request->setDefaultLocale($from->getDefaultLocale());
 
         $request->setJson($from->json());
 


### PR DESCRIPTION
When a `FormRequest` is created from the original request, the values `locale` and `defaultLocale` won't be copied over.
Hopefully this will be a correct pull request to solve the problem.