### PR TITLE
[9.x] Add expressive, relative date methods to builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1312,7 +1312,7 @@ class Builder implements BuilderContract
     {
         $type = 'Basic';
         $operator = $not ? '>=' : '<';
-        $value = Carbon::now()->format('Y-m-d h:i:s');
+        $value = Carbon::now()->format('Y-m-d H:i:s');
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
@@ -1420,7 +1420,7 @@ class Builder implements BuilderContract
     {
         $type = 'Basic';
         $operator = $not ? '<=' : '>';
-        $value = Carbon::now()->format('Y-m-d h:i:s');
+        $value = Carbon::now()->format('Y-m-d H:i:s');
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1452,7 +1452,7 @@ class Builder implements BuilderContract
      */
     public function orWhereFuture($columns, $now = null)
     {
-        return $this->whereFuture($columns, $now , 'or');
+        return $this->whereFuture($columns, $now, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1304,15 +1304,20 @@ class Builder implements BuilderContract
      * Add a where clause to determine if "date" column is in the past to the query.
      *
      * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function wherePast($columns, $boolean = 'and', $not = false)
+    public function wherePast($columns, $now = null, $boolean = 'and', $not = false)
     {
         $type = 'Basic';
         $operator = $not ? '>=' : '<';
-        $value = Carbon::now()->format('Y-m-d H:i:s.u');
+        $value = $now ?? Carbon::now();
+
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->format('Y-m-d H:i:s.u');
+        }
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
@@ -1326,33 +1331,36 @@ class Builder implements BuilderContract
      * Add an "or where" clause to determine if "date" column is in the past to the query.
      *
      * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
      * @return $this
      */
-    public function orWherePast($columns)
+    public function orWherePast($columns, $now = null)
     {
-        return $this->wherePast($columns, 'or');
+        return $this->wherePast($columns, $now, 'or');
     }
 
     /**
      * Add a where clause to determine if "date" column is not in the past to the query.
      *
      * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
      * @return $this
      */
-    public function whereNotPast($columns)
+    public function whereNotPast($columns, $now = null)
     {
-        return $this->wherePast($columns, 'and', true);
+        return $this->wherePast($columns, $now, 'and', true);
     }
 
     /**
      * Add an "or where" clause to determine if "date" column is in the past to the query.
      *
      * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
      * @return $this
      */
-    public function orWhereNotPast($columns)
+    public function orWhereNotPast($columns, $now = null)
     {
-        return $this->wherePast($columns, 'or', true);
+        return $this->wherePast($columns, $now, 'or', true);
     }
 
     /**
@@ -1412,15 +1420,20 @@ class Builder implements BuilderContract
      * Add a where clause to determine if "date" column is in the future to the query.
      *
      * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function whereFuture($columns, $boolean = 'and', $not = false)
+    public function whereFuture($columns, $now = null, $boolean = 'and', $not = false)
     {
         $type = 'Basic';
         $operator = $not ? '<=' : '>';
-        $value = Carbon::now()->format('Y-m-d H:i:s.u');
+        $value = $now ?? Carbon::now();
+
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->format('Y-m-d H:i:s.u');
+        }
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
@@ -1434,33 +1447,36 @@ class Builder implements BuilderContract
      * Add an "or where" clause to determine if "date" column is in the future to the query.
      *
      * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
      * @return $this
      */
-    public function orWhereFuture($columns)
+    public function orWhereFuture($columns, $now = null)
     {
-        return $this->whereFuture($columns, 'or');
+        return $this->whereFuture($columns, $now , 'or');
     }
 
     /**
      * Add a where clause to determine if "date" column is not in the future to the query.
      *
      * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
      * @return $this
      */
-    public function whereNotFuture($columns)
+    public function whereNotFuture($columns, $now = null)
     {
-        return $this->whereFuture($columns, 'and', true);
+        return $this->whereFuture($columns, $now, 'and', true);
     }
 
     /**
      * Add an "or where" clause to determine if "date" column is in the future to the query.
      *
      * @param  string|array  $columns
+     * @param  \DateTimeInterface|string|null  $now
      * @return $this
      */
-    public function orWhereNotFuture($columns)
+    public function orWhereNotFuture($columns, $now = null)
     {
-        return $this->whereFuture($columns, 'or', true);
+        return $this->whereFuture($columns, $now, 'or', true);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
@@ -1297,6 +1298,169 @@ class Builder implements BuilderContract
     public function orWhereNotNull($column)
     {
         return $this->whereNotNull($column, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if "date" column is in the past to the query.
+     *
+     * @param  string|array  $columns
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function wherePast($columns, $boolean = 'and', $not = false)
+    {
+        $type = 'Basic';
+        $operator = $not ? '>=' : '<';
+        $value = Carbon::now()->format('Y-m-d h:i:s');
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+            $this->addBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to determine if "date" column is in the past to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWherePast($columns)
+    {
+        return $this->wherePast($columns, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if "date" column is not in the past to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function whereNotPast($columns)
+    {
+        return $this->wherePast($columns, 'and', true);
+    }
+
+    /**
+     * Add an "or where" clause to determine if "date" column is in the past to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereNotPast($columns)
+    {
+        return $this->wherePast($columns, 'or', true);
+    }
+
+    /**
+     * Add a "where date" clause to determine if "date" column is today to the query.
+     *
+     * @param  string|array  $columns
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereToday($columns, $boolean = 'and', $not = false)
+    {
+        $operator = $not ? '!=' : '=';
+        $value = Carbon::now()->format('Y-m-d');
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where date" clause to determine if "date" column is today to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereToday($columns)
+    {
+        return $this->whereToday($columns, 'or');
+    }
+
+    /**
+     * Add a "where date" clause to determine if "date" column is not today to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function whereNotToday($columns)
+    {
+        return $this->whereToday($columns, 'and', true);
+    }
+
+    /**
+     * Add an "or where date" clause to determine if "date" column is not today to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereNotToday($columns)
+    {
+        return $this->whereToday($columns, 'or', true);
+    }
+
+    /**
+     * Add a where clause to determine if "date" column is in the future to the query.
+     *
+     * @param  string|array  $columns
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereFuture($columns, $boolean = 'and', $not = false)
+    {
+        $type = 'Basic';
+        $operator = $not ? '<=' : '>';
+        $value = Carbon::now()->format('Y-m-d h:i:s');
+
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
+            $this->addBinding($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause to determine if "date" column is in the future to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereFuture($columns)
+    {
+        return $this->whereFuture($columns, 'or');
+    }
+
+    /**
+     * Add a where clause to determine if "date" column is not in the future to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function whereNotFuture($columns)
+    {
+        return $this->whereFuture($columns, 'and', true);
+    }
+
+    /**
+     * Add an "or where" clause to determine if "date" column is in the future to the query.
+     *
+     * @param  string|array  $columns
+     * @return $this
+     */
+    public function orWhereNotFuture($columns)
+    {
+        return $this->whereFuture($columns, 'or', true);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1312,7 +1312,7 @@ class Builder implements BuilderContract
     {
         $type = 'Basic';
         $operator = $not ? '>=' : '<';
-        $value = Carbon::now()->format('Y-m-d H:i:s');
+        $value = Carbon::now()->format('Y-m-d H:i:s.u');
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');
@@ -1420,7 +1420,7 @@ class Builder implements BuilderContract
     {
         $type = 'Basic';
         $operator = $not ? '<=' : '>';
-        $value = Carbon::now()->format('Y-m-d H:i:s');
+        $value = Carbon::now()->format('Y-m-d H:i:s.u');
 
         foreach (Arr::wrap($columns) as $column) {
             $this->wheres[] = compact('type', 'column', 'boolean', 'operator', 'value');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1303,7 +1303,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
     }
 
-    public function testPassingArrayToWherePastMySQL()
+    public function testPassingArrayToWhereTodayMySQL()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
@@ -1318,7 +1318,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
     }
 
-    public function testWhereNotPastMySQL()
+    public function testWhereNotTodayMySQL()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
@@ -1333,7 +1333,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
     }
 
-    public function testPassingArrayToWhereNotPastMySQL()
+    public function testPassingArrayToWhereNotTodayMySQL()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
@@ -1363,7 +1363,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
     }
 
-    public function testPassingArrayToWherePastSqlServer()
+    public function testPassingArrayToWhereTodaySqlServer()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
@@ -1378,7 +1378,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
     }
 
-    public function testWhereNotPastSqlServer()
+    public function testWhereNotTodaySqlServer()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
@@ -1393,7 +1393,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
     }
 
-    public function testPassingArrayToWhereNotPastSqlServer()
+    public function testPassingArrayToWhereNotTodaySqlServer()
     {
         Carbon::setTestNow('2022-04-20 12:34:56.123456');
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1241,6 +1241,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-20 23:45:06.123456'], $builder->getBindings());
+
+        $now = Carbon::create(2021, 1, 2, 3, 4, 56);
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->wherePast('published_at', $now);
+        $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
+        $this->assertEquals([0 => '2021-01-02 03:04:56.000000'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at', $now);
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => '2021-01-02 03:04:56.000000'], $builder->getBindings());
     }
 
     public function testPassingArrayToWherePast()
@@ -1256,6 +1268,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ? or "held_at" < ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456', 2 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+
+        $now = Carbon::create(2021, 12, 31, 5, 6, 7);
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->wherePast(['published_at', 'held_at'], $now);
+        $this->assertSame('select * from "posts" where "published_at" < ? and "held_at" < ?', $builder->toSql());
+        $this->assertEquals([0 => '2021-12-31 05:06:07.000000', 1 => '2021-12-31 05:06:07.000000'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast(['published_at', 'held_at'], $now);
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ? or "held_at" < ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => '2021-12-31 05:06:07.000000', 2 => '2021-12-31 05:06:07.000000'], $builder->getBindings());
     }
 
     public function testWhereNotPast()
@@ -1271,6 +1295,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+
+        $now = Carbon::create(2021, 1, 2, 3, 4, 56);
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->whereNotPast('published_at', $now);
+        $this->assertSame('select * from "posts" where "published_at" >= ?', $builder->toSql());
+        $this->assertEquals([0 => '2021-01-02 03:04:56.000000'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast('published_at', $now);
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => '2021-01-02 03:04:56.000000'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotPast()
@@ -1286,6 +1322,31 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ? or "held_at" >= ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456', 2 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
+
+        $now = Carbon::create(2021, 11, 22, 3, 45, 6);
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->whereNotPast(['published_at', 'held_at'], $now);
+        $this->assertSame('select * from "posts" where "published_at" >= ? and "held_at" >= ?', $builder->toSql());
+        $this->assertEquals([0 => '2021-11-22 03:45:06.000000', 1 => '2021-11-22 03:45:06.000000'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast(['published_at', 'held_at'], $now);
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ? or "held_at" >= ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => '2021-11-22 03:45:06.000000', 2 => '2021-11-22 03:45:06.000000'], $builder->getBindings());
+    }
+
+    public function testWherePastPassingNowAsString()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->wherePast('published_at', '2022-04-22');
+        $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
+        $this->assertEquals(['2022-04-22'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at', 'some-point-in-time');
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
+        $this->assertEquals([1, 'some-point-in-time'], $builder->getBindings());
     }
 
     public function testWhereTodayMySQL()
@@ -1421,6 +1482,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-22 21:01:23.123456'], $builder->getBindings());
+
+        $now = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2022-04-22 23:11:09.987654');
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->whereFuture('published_at', $now);
+        $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
+        $this->assertEquals(['2022-04-22 23:11:09.987654'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at', $now);
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
+        $this->assertEquals([1, '2022-04-22 23:11:09.987654'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereFuture()
@@ -1436,6 +1509,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ? or "held_at" > ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456', 2 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+
+        $now = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2022-04-22 23:11:09.987654');
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->whereFuture(['published_at', 'held_at'], $now);
+        $this->assertSame('select * from "posts" where "published_at" > ? and "held_at" > ?', $builder->toSql());
+        $this->assertEquals(['2022-04-22 23:11:09.987654', '2022-04-22 23:11:09.987654'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture(['published_at', 'held_at'], $now);
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ? or "held_at" > ?', $builder->toSql());
+        $this->assertEquals([1, '2022-04-22 23:11:09.987654', '2022-04-22 23:11:09.987654'], $builder->getBindings());
     }
 
     public function testWhereNotFuture()
@@ -1451,6 +1536,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+
+        $now = Carbon::create(2021, 2, 3, 4, 5, 6);
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->whereNotFuture('published_at', $now);
+        $this->assertSame('select * from "posts" where "published_at" <= ?', $builder->toSql());
+        $this->assertEquals([0 => '2021-02-03 04:05:06.000000'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture('published_at', $now);
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ?', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => '2021-02-03 04:05:06.000000'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotFuture()
@@ -1466,6 +1563,31 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ? or "held_at" <= ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456', 2 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
+
+        $now = Carbon::create(2021, 2, 3, 4, 5, 6);
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->whereNotFuture(['published_at', 'held_at'], $now);
+        $this->assertSame('select * from "posts" where "published_at" <= ? and "held_at" <= ?', $builder->toSql());
+        $this->assertEquals(['2021-02-03 04:05:06.000000', '2021-02-03 04:05:06.000000'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture(['published_at', 'held_at'], $now);
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ? or "held_at" <= ?', $builder->toSql());
+        $this->assertEquals([1, '2021-02-03 04:05:06.000000', '2021-02-03 04:05:06.000000'], $builder->getBindings());
+    }
+
+    public function testPassingStringToWhereFuture()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->whereFuture('published_at', '2022-04-22 23:11:09');
+        $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
+        $this->assertEquals(['2022-04-22 23:11:09'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at', 'date-string');
+        $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
+        $this->assertEquals([1, 'date-string'], $builder->getBindings());
     }
 
     public function testGroupBys()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1230,242 +1230,242 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWherePast()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast('published_at');
         $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20 12:34:56"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 12:34:56'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20 12:34:56"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56'], $builder->getBindings());
     }
 
     public function testPassingArrayToWherePast()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" < ? and "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20 12:34:56", 1 => "2022-04-20 12:34:56"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 12:34:56', 1 => '2022-04-20 12:34:56'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ? or "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20 12:34:56", 2 => "2022-04-20 12:34:56"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56', 2 => '2022-04-20 12:34:56'], $builder->getBindings());
     }
 
     public function testWhereNotPast()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotPast('published_at');
         $this->assertSame('select * from "posts" where "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20 12:34:56"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 12:34:56'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20 12:34:56"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotPast()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotPast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" >= ? and "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20 12:34:56", 1 => "2022-04-20 12:34:56"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 12:34:56', 1 => '2022-04-20 12:34:56'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ? or "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20 12:34:56", 2 => "2022-04-20 12:34:56"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56', 2 => '2022-04-20 12:34:56'], $builder->getBindings());
     }
 
     public function testWhereTodayMySQL()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->whereToday('published_at');
         $this->assertSame('select * from `posts` where date(`published_at`) = ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereToday('published_at');
         $this->assertSame('select * from `posts` where `id` = ? or date(`published_at`) = ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
     }
 
     public function testPassingArrayToWherePastMySQL()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->whereToday(['published_at', 'held_at']);
         $this->assertSame('select * from `posts` where date(`published_at`) = ? and date(`held_at`) = ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20", 1 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20', 1 => '2022-04-20'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereToday(['published_at', 'held_at']);
         $this->assertSame('select * from `posts` where `id` = ? or date(`published_at`) = ? or date(`held_at`) = ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20", 2 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
     }
 
     public function testWhereNotPastMySQL()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->whereNotToday('published_at');
         $this->assertSame('select * from `posts` where date(`published_at`) != ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotToday('published_at');
         $this->assertSame('select * from `posts` where `id` = ? or date(`published_at`) != ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotPastMySQL()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->whereNotToday(['published_at', 'held_at']);
         $this->assertSame('select * from `posts` where date(`published_at`) != ? and date(`held_at`) != ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20", 1 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20', 1 => '2022-04-20'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotToday(['published_at', 'held_at']);
         $this->assertSame('select * from `posts` where `id` = ? or date(`published_at`) != ? or date(`held_at`) != ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20", 2 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
     }
 
     public function testWhereTodaySqlServer()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->whereToday('published_at');
         $this->assertSame('select * from [posts] where cast([published_at] as date) = ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereToday('published_at');
         $this->assertSame('select * from [posts] where [id] = ? or cast([published_at] as date) = ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
     }
 
     public function testPassingArrayToWherePastSqlServer()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->whereToday(['published_at', 'held_at']);
         $this->assertSame('select * from [posts] where cast([published_at] as date) = ? and cast([held_at] as date) = ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20", 1 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20', 1 => '2022-04-20'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereToday(['published_at', 'held_at']);
         $this->assertSame('select * from [posts] where [id] = ? or cast([published_at] as date) = ? or cast([held_at] as date) = ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20", 2 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
     }
 
     public function testWhereNotPastSqlServer()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->whereNotToday('published_at');
         $this->assertSame('select * from [posts] where cast([published_at] as date) != ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotToday('published_at');
         $this->assertSame('select * from [posts] where [id] = ? or cast([published_at] as date) != ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotPastSqlServer()
     {
-        Carbon::setTestNow("2022-04-20 12:34:56");
+        Carbon::setTestNow('2022-04-20 12:34:56');
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->whereNotToday(['published_at', 'held_at']);
         $this->assertSame('select * from [posts] where cast([published_at] as date) != ? and cast([held_at] as date) != ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-20", 1 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20', 1 => '2022-04-20'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotToday(['published_at', 'held_at']);
         $this->assertSame('select * from [posts] where [id] = ? or cast([published_at] as date) != ? or cast([held_at] as date) != ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-20", 2 => "2022-04-20"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20', 2 => '2022-04-20'], $builder->getBindings());
     }
 
     public function testWhereFuture()
     {
-        Carbon::setTestNow("2022-04-22 01:23:45");
+        Carbon::setTestNow('2022-04-22 01:23:45');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture('published_at');
         $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-22 01:23:45"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 01:23:45'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-22 01:23:45"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereFuture()
     {
-        Carbon::setTestNow("2022-04-22 01:23:45");
+        Carbon::setTestNow('2022-04-22 01:23:45');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" > ? and "held_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-22 01:23:45", 1 => "2022-04-22 01:23:45"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 01:23:45', 1 => '2022-04-22 01:23:45'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ? or "held_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-22 01:23:45", 2 => "2022-04-22 01:23:45"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45', 2 => '2022-04-22 01:23:45'], $builder->getBindings());
     }
 
     public function testWhereNotFuture()
     {
-        Carbon::setTestNow("2022-04-22 01:23:45");
+        Carbon::setTestNow('2022-04-22 01:23:45');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotFuture('published_at');
         $this->assertSame('select * from "posts" where "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-22 01:23:45"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 01:23:45'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-22 01:23:45"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotFuture()
     {
-        Carbon::setTestNow("2022-04-22 01:23:45");
+        Carbon::setTestNow('2022-04-22 01:23:45');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" <= ? and "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => "2022-04-22 01:23:45", 1 => "2022-04-22 01:23:45"], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 01:23:45', 1 => '2022-04-22 01:23:45'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ? or "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => "2022-04-22 01:23:45", 2 => "2022-04-22 01:23:45"], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45', 2 => '2022-04-22 01:23:45'], $builder->getBindings());
     }
 
     public function testGroupBys()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1230,17 +1230,17 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWherePast()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 23:45:06');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast('published_at');
         $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 12:34:56'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 23:45:06'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 23:45:06'], $builder->getBindings());
     }
 
     public function testPassingArrayToWherePast()
@@ -1410,17 +1410,17 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereFuture()
     {
-        Carbon::setTestNow('2022-04-22 01:23:45');
+        Carbon::setTestNow('2022-04-22 21:01:23');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture('published_at');
         $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 01:23:45'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 21:01:23'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 21:01:23'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereFuture()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1230,67 +1230,67 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWherePast()
     {
-        Carbon::setTestNow('2022-04-20 23:45:06');
+        Carbon::setTestNow('2022-04-20 23:45:06.123456');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast('published_at');
         $this->assertSame('select * from "posts" where "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 23:45:06'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 23:45:06.123456'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 23:45:06'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 23:45:06.123456'], $builder->getBindings());
     }
 
     public function testPassingArrayToWherePast()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->wherePast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" < ? and "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 12:34:56', 1 => '2022-04-20 12:34:56'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 12:34:56.123456', 1 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWherePast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" < ? or "held_at" < ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56', 2 => '2022-04-20 12:34:56'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456', 2 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
     }
 
     public function testWhereNotPast()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotPast('published_at');
         $this->assertSame('select * from "posts" where "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 12:34:56'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotPast()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotPast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" >= ? and "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-20 12:34:56', 1 => '2022-04-20 12:34:56'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-20 12:34:56.123456', 1 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotPast(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" >= ? or "held_at" >= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56', 2 => '2022-04-20 12:34:56'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-20 12:34:56.123456', 2 => '2022-04-20 12:34:56.123456'], $builder->getBindings());
     }
 
     public function testWhereTodayMySQL()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->whereToday('published_at');
@@ -1305,7 +1305,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testPassingArrayToWherePastMySQL()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->whereToday(['published_at', 'held_at']);
@@ -1320,7 +1320,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereNotPastMySQL()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->whereNotToday('published_at');
@@ -1335,7 +1335,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testPassingArrayToWhereNotPastMySQL()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('posts')->whereNotToday(['published_at', 'held_at']);
@@ -1350,7 +1350,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereTodaySqlServer()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->whereToday('published_at');
@@ -1365,7 +1365,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testPassingArrayToWherePastSqlServer()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->whereToday(['published_at', 'held_at']);
@@ -1380,7 +1380,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereNotPastSqlServer()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->whereNotToday('published_at');
@@ -1395,7 +1395,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testPassingArrayToWhereNotPastSqlServer()
     {
-        Carbon::setTestNow('2022-04-20 12:34:56');
+        Carbon::setTestNow('2022-04-20 12:34:56.123456');
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('posts')->whereNotToday(['published_at', 'held_at']);
@@ -1410,62 +1410,62 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereFuture()
     {
-        Carbon::setTestNow('2022-04-22 21:01:23');
+        Carbon::setTestNow('2022-04-22 21:01:23.123456');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture('published_at');
         $this->assertSame('select * from "posts" where "published_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 21:01:23'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 21:01:23.123456'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 21:01:23'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 21:01:23.123456'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereFuture()
     {
-        Carbon::setTestNow('2022-04-22 01:23:45');
+        Carbon::setTestNow('2022-04-22 01:23:45.123456');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" > ? and "held_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 01:23:45', 1 => '2022-04-22 01:23:45'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 01:23:45.123456', 1 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" > ? or "held_at" > ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45', 2 => '2022-04-22 01:23:45'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456', 2 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
     }
 
     public function testWhereNotFuture()
     {
-        Carbon::setTestNow('2022-04-22 01:23:45');
+        Carbon::setTestNow('2022-04-22 01:23:45.123456');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotFuture('published_at');
         $this->assertSame('select * from "posts" where "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 01:23:45'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture('published_at');
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
     }
 
     public function testPassingArrayToWhereNotFuture()
     {
-        Carbon::setTestNow('2022-04-22 01:23:45');
+        Carbon::setTestNow('2022-04-22 01:23:45.123456');
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->whereNotFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "published_at" <= ? and "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => '2022-04-22 01:23:45', 1 => '2022-04-22 01:23:45'], $builder->getBindings());
+        $this->assertEquals([0 => '2022-04-22 01:23:45.123456', 1 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('id', '=', 1)->orWhereNotFuture(['published_at', 'held_at']);
         $this->assertSame('select * from "posts" where "id" = ? or "published_at" <= ? or "held_at" <= ?', $builder->toSql());
-        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45', 2 => '2022-04-22 01:23:45'], $builder->getBindings());
+        $this->assertEquals([0 => 1, 1 => '2022-04-22 01:23:45.123456', 2 => '2022-04-22 01:23:45.123456'], $builder->getBindings());
     }
 
     public function testGroupBys()


### PR DESCRIPTION
This adds expressive query builder methods for checking relative dates. Date math can be mind bending. Hopefully these continue to improve the developer experience for Laravel artisans by removing the need to think about the logic and pass the current date.

**Before**
```php
$previousPosts = Post::where('published_at', '<', now())->get();
$currentPosts = Post::whereDate('published_at', '=', now())->get();
$pendingPosts = Post::where('published_at', '>', now())->get();
```

**After**
```php
$previousPosts = Post::wherePast('published_at')->get();
$currentPosts = Post::whereToday('published_at')->get();
$pendingPosts = Post::whereFuture('published_at')->get();
```

**Note:** Currently the implementation uses Carbon to create the date value. This could be changed to use a _raw_ expression, such as `NOW()`. However, this may increase the complexity of the code given the varying RDBMS support for such methods.