### PR TITLE
[8.x] Fix schedule:work command Artisan binary name

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -38,7 +38,11 @@ class ScheduleWorkCommand extends Command
 
             if (Carbon::now()->second === 0 &&
                 ! Carbon::now()->startOfMinute()->equalTo($lastExecutionStartedAt)) {
-                $executions[] = $execution = new Process([PHP_BINARY, static::artisanBinary(), 'schedule:run']);
+                $executions[] = $execution = new Process([
+                    PHP_BINARY,
+                    defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
+                    'schedule:run'
+                ]);
 
                 $execution->start();
 
@@ -64,15 +68,5 @@ class ScheduleWorkCommand extends Command
                 }
             }
         }
-    }
-
-    /**
-     * Get the name of the Artisan binary.
-     * 
-     * @return string
-     */
-    protected static function artisanBinary()
-    {
-        return defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan';
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -38,7 +38,7 @@ class ScheduleWorkCommand extends Command
 
             if (Carbon::now()->second === 0 &&
                 ! Carbon::now()->startOfMinute()->equalTo($lastExecutionStartedAt)) {
-                $executions[] = $execution = new Process([PHP_BINARY, 'artisan', 'schedule:run']);
+                $executions[] = $execution = new Process([PHP_BINARY, static::artisanBinary(), 'schedule:run']);
 
                 $execution->start();
 
@@ -64,5 +64,15 @@ class ScheduleWorkCommand extends Command
                 }
             }
         }
+    }
+
+    /**
+     * Get the name of the Artisan binary.
+     * 
+     * @return string
+     */
+    protected static function artisanBinary()
+    {
+        return defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan';
     }
 }


### PR DESCRIPTION
Currently the `schedule:work` command assumes the Artisan binary is called `artisan` and fails to execute the `schedule:run` command if that's not the case.

```console
root@a529d380561a:/var/www/html# php cli schedule:work
Schedule worker started successfully.

[2022-04-21T16:35:00+00:00] Execution #1 output:
Could not open input file: artisan
```

This PR addresses the issue by utilizing the `ARTISAN_BINARY` constant.