### PR TITLE
[9.x] Tweak event:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -61,7 +61,7 @@ class EventListCommand extends Command
 
         $this->line(
             $events->map(fn ($listeners, $event) => [
-                sprintf('  <fg=white>%s</>', $event),
+                sprintf('  <fg=white>%s</>', $this->appendEventInterfaces($event)),
                 collect($listeners)->map(fn ($listener) => sprintf('    <fg=#6C7280>⇂ %s</>', $listener)),
             ])->flatten()->filter()->prepend('')->push('')->toArray()
         );
@@ -95,7 +95,7 @@ class EventListCommand extends Command
         foreach ($this->getRawListeners() as $event => $rawListeners) {
             foreach ($rawListeners as $rawListener) {
                 if (is_string($rawListener)) {
-                    $events[$event][] = $this->appendInterfaces(explode('@', $rawListener));
+                    $events[$event][] = $this->appendListenerInterfaces($rawListener);
                 } elseif ($rawListener instanceof Closure) {
                     $events[$event][] = $this->stringifyClosure($rawListener);
                 } elseif (is_array($rawListener) && count($rawListener) === 2) {
@@ -103,12 +103,50 @@ class EventListCommand extends Command
                         $rawListener[0] = get_class($rawListener[0]);
                     }
 
-                    $events[$event][] = $this->appendInterfaces($rawListener);
+                    $events[$event][] = $this->appendListenerInterfaces(implode('@', $rawListener));
                 }
             }
         }
 
         return $events;
+    }
+
+    /**
+     * Add the event implemented interfaces to the output.
+     *
+     * @param  string  $event
+     * @return string
+     */
+    protected function appendEventInterfaces($event)
+    {
+        $interfaces = class_implements($event);
+
+        if (in_array(ShouldBroadcast::class, $interfaces)) {
+            $event .= ' <fg=bright-blue>(ShouldBroadcast)</>';
+        }
+
+        return $event;
+    }
+
+    /**
+     * Add the listener implemented interfaces to the output.
+     *
+     * @param  string  $listener
+     * @return string
+     */
+    protected function appendListenerInterfaces($listener)
+    {
+        $listener = explode('@', $listener);
+
+        $interfaces = class_implements($listener[0]);
+
+        $listener = implode('@', $listener);
+
+        if (in_array(ShouldQueue::class, $interfaces)) {
+            $listener .= ' <fg=bright-blue>(ShouldQueue)</>';
+        }
+
+        return $listener;
     }
 
     /**
@@ -184,28 +222,5 @@ class EventListCommand extends Command
     public static function resolveEventsUsing($resolver)
     {
         static::$eventsResolver = $resolver;
-    }
-
-    /**
-     * Adds the implemented interfaces.
-     *
-     * @param  array  $listener
-     * @return array
-     */
-    protected function appendInterfaces(array $listener)
-    {
-        $interfaces = class_implements($listener[0]);
-
-        $listener = implode('@', $listener);
-
-        if (in_array(ShouldQueue::class, $interfaces)) {
-            $listener .= ' <fg=bright-blue>(ShouldQueue)</>';
-        }
-
-        if (in_array(ShouldBroadcast::class, $interfaces)) {
-            $listener .= ' <fg=bright-blue>(ShouldBroadcast)</>';
-        }
-
-        return $listener;
     }
 }

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -119,6 +119,10 @@ class EventListCommand extends Command
      */
     protected function appendEventInterfaces($event)
     {
+        if (! class_exists($event)) {
+            return $event;
+        }
+
         $interfaces = class_implements($event);
 
         if (in_array(ShouldBroadcast::class, $interfaces)) {

--- a/tests/Integration/Console/Events/EventListCommandTest.php
+++ b/tests/Integration/Console/Events/EventListCommandTest.php
@@ -30,7 +30,7 @@ class EventListCommandTest extends TestCase
         $this->dispatcher->subscribe(ExampleSubscriber::class);
         $this->dispatcher->listen(ExampleEvent::class, ExampleListener::class);
         $this->dispatcher->listen(ExampleEvent::class, ExampleQueueListener::class);
-        $this->dispatcher->listen(ExampleEvent::class, ExampleBroadcastListener::class);
+        $this->dispatcher->listen(ExampleBroadcastEvent::class, ExampleBroadcastListener::class);
         $this->dispatcher->listen(ExampleEvent::class, fn () => '');
         $closureLineNumber = __LINE__ - 1;
         $unixFilePath = str_replace('\\', '/', __FILE__);
@@ -40,10 +40,11 @@ class EventListCommandTest extends TestCase
             ->expectsOutput('  ExampleSubscriberEventName')
             ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleSubscriber@a')
             ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleSubscriber@b')
+            ->expectsOutput('  Illuminate\Tests\Integration\Console\Events\ExampleBroadcastEvent (ShouldBroadcast)')
+            ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleBroadcastListener')
             ->expectsOutput('  Illuminate\Tests\Integration\Console\Events\ExampleEvent')
             ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleListener')
             ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleQueueListener (ShouldQueue)')
-            ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleBroadcastListener (ShouldBroadcast)')
             ->expectsOutput('    ⇂ Closure at: '.$unixFilePath.':'.$closureLineNumber);
     }
 
@@ -91,6 +92,14 @@ class ExampleEvent
 {
 }
 
+class ExampleBroadcastEvent implements ShouldBroadcast
+{
+    public function broadcastOn()
+    {
+        //
+    }
+}
+
 class ExampleListener
 {
     public function handle()
@@ -105,14 +114,9 @@ class ExampleQueueListener implements ShouldQueue
     }
 }
 
-class ExampleBroadcastListener implements ShouldBroadcast
+class ExampleBroadcastListener
 {
     public function handle()
-    {
-        //
-    }
-
-    public function broadcastOn()
     {
         //
     }

--- a/tests/Integration/Console/Events/EventListCommandTest.php
+++ b/tests/Integration/Console/Events/EventListCommandTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Console\Events;
 
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Console\EventListCommand;
 use Orchestra\Testbench\TestCase;
@@ -27,9 +29,11 @@ class EventListCommandTest extends TestCase
     {
         $this->dispatcher->subscribe(ExampleSubscriber::class);
         $this->dispatcher->listen(ExampleEvent::class, ExampleListener::class);
+        $this->dispatcher->listen(ExampleEvent::class, ExampleQueueListener::class);
+        $this->dispatcher->listen(ExampleEvent::class, ExampleBroadcastListener::class);
         $this->dispatcher->listen(ExampleEvent::class, fn () => '');
         $closureLineNumber = __LINE__ - 1;
-        $closureFilePath = __FILE__;
+        $unixFilePath = str_replace('\\', '/', __FILE__);
 
         $this->artisan(EventListCommand::class)
             ->assertSuccessful()
@@ -38,7 +42,9 @@ class EventListCommandTest extends TestCase
             ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleSubscriber@b')
             ->expectsOutput('  Illuminate\Tests\Integration\Console\Events\ExampleEvent')
             ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleListener')
-            ->expectsOutput('    ⇂ Closure at: '.$closureFilePath.':'.$closureLineNumber);
+            ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleQueueListener (ShouldQueue)')
+            ->expectsOutput('    ⇂ Illuminate\Tests\Integration\Console\Events\ExampleBroadcastListener (ShouldBroadcast)')
+            ->expectsOutput('    ⇂ Closure at: '.$unixFilePath.':'.$closureLineNumber);
     }
 
     public function testDisplayFilteredEvent()
@@ -89,5 +95,25 @@ class ExampleListener
 {
     public function handle()
     {
+    }
+}
+
+class ExampleQueueListener implements ShouldQueue
+{
+    public function handle()
+    {
+    }
+}
+
+class ExampleBroadcastListener implements ShouldBroadcast
+{
+    public function handle()
+    {
+        //
+    }
+
+    public function broadcastOn()
+    {
+        //
     }
 }


### PR DESCRIPTION
- It enforces forward-slash for closure file paths on windows.
- It shows implemented interfaces for classy listeners `(ShouldQueue)` and `(ShouldBroadcast)`.

This snapshot is taken on windows:
![image](https://user-images.githubusercontent.com/6961695/164518276-239b76b8-59f5-4122-ad1d-47cd04de9592.png)
