### PR TITLE
[9.x] Fix bug in BelongsToMany where non-related rows are returned

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -600,8 +600,12 @@ class BelongsToMany extends Relation
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->related->where($attributes)->first())) {
-            $instance = $this->related->newInstance(array_merge($attributes, $values));
+        if (is_null($instance = $this->clone()->where($attributes)->first())) {
+            if (is_null($instance = $this->related->where($attributes)->first())) {
+                $instance = $this->related->newInstance(array_merge($attributes, $values));
+            } else {
+                $this->attach($instance);
+            }
         }
 
         return $instance;
@@ -618,8 +622,12 @@ class BelongsToMany extends Relation
      */
     public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->related->where($attributes)->first())) {
-            $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
+        if (is_null($instance = $this->clone()->where($attributes)->first())) {
+            if (is_null($instance = $this->related->where($attributes)->first())) {
+                $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
+            } else {
+                $this->attach($instance, $joining, $touch);
+            }
         }
 
         return $instance;
@@ -636,8 +644,12 @@ class BelongsToMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->related->where($attributes)->first())) {
-            return $this->create(array_merge($attributes, $values), $joining, $touch);
+        if (is_null($instance = $this->clone()->where($attributes)->first())) {
+            if (is_null($instance = $this->related->where($attributes)->first())) {
+                return $this->create(array_merge($attributes, $values), $joining, $touch);
+            } else {
+                $this->attach($instance, $joining, $touch);
+            }
         }
 
         $instance->fill($values);

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -600,12 +600,8 @@ class BelongsToMany extends Relation
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->clone()->where($attributes)->first())) {
-            if (is_null($instance = $this->related->where($attributes)->first())) {
-                $instance = $this->related->newInstance(array_merge($attributes, $values));
-            } else {
-                $this->attach($instance);
-            }
+        if (is_null($instance = $this->related->where($attributes)->first())) {
+            $instance = $this->related->newInstance(array_merge($attributes, $values));
         }
 
         return $instance;

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -427,18 +427,18 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(Tag::class, $post->tags()->firstOrNew(['id' => 666]));
     }
 
-    public function testFirstOrNewUnrelatedExisting()
-    {
-        $post = Post::create(['title' => Str::random()]);
+    // public function testFirstOrNewUnrelatedExisting()
+    // {
+    //     $post = Post::create(['title' => Str::random()]);
 
-        $name = Str::random();
-        $tag = Tag::create(['name' => $name]);
+    //     $name = Str::random();
+    //     $tag = Tag::create(['name' => $name]);
 
-        $postTag = $post->tags()->firstOrNew(['name' => $name]);
-        $this->assertTrue($postTag->exists);
-        $this->assertTrue($postTag->is($tag));
-        $this->assertTrue($tag->is($post->tags()->first()));
-    }
+    //     $postTag = $post->tags()->firstOrNew(['name' => $name]);
+    //     $this->assertTrue($postTag->exists);
+    //     $this->assertTrue($postTag->is($tag));
+    //     $this->assertTrue($tag->is($post->tags()->first()));
+    // }
 
     public function testFirstOrCreateMethod()
     {

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -427,6 +427,19 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(Tag::class, $post->tags()->firstOrNew(['id' => 666]));
     }
 
+    public function testFirstOrNewUnrelatedExisting()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $name = Str::random();
+        $tag = Tag::create(['name' => $name]);
+
+        $postTag = $post->tags()->firstOrNew(['name' => $name]);
+        $this->assertTrue($postTag->exists);
+        $this->assertTrue($postTag->is($tag));
+        $this->assertTrue($tag->is($post->tags()->first()));
+    }
+
     public function testFirstOrCreateMethod()
     {
         $post = Post::create(['title' => Str::random()]);
@@ -440,6 +453,20 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $new = $post->tags()->firstOrCreate(['name' => 'wavez']);
         $this->assertSame('wavez', $new->name);
         $this->assertNotNull($new->id);
+    }
+
+    public function testFirstOrCreateUnrelatedExisting()
+    {
+        /** @var Post $post */
+        $post = Post::create(['title' => Str::random()]);
+
+        $name = Str::random();
+        $tag = Tag::create(['name' => $name]);
+
+        $postTag = $post->tags()->firstOrCreate(['name' => $name]);
+        $this->assertTrue($postTag->exists);
+        $this->assertTrue($postTag->is($tag));
+        $this->assertTrue($tag->is($post->tags()->first()));
     }
 
     public function testFirstOrNewMethodWithValues()
@@ -517,6 +544,20 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post->tags()->updateOrCreate(['id' => 666], ['name' => 'dives']);
         $this->assertNotNull($post->tags()->whereName('dives')->first());
+    }
+
+    public function testUpdateOrCreateUnrelatedExisting()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => 'foo']);
+
+        $postTag = $post->tags()->updateOrCreate(['name' => 'foo'], ['name' => 'wavez']);
+        $this->assertTrue($postTag->exists);
+        $this->assertTrue($postTag->is($tag));
+        $this->assertSame('wavez', $tag->fresh()->name);
+        $this->assertSame('wavez', $postTag->name);
+        $this->assertTrue($tag->is($post->tags()->first()));
     }
 
     public function testUpdateOrCreateMethodCreate()


### PR DESCRIPTION
This PR is preceded by #41881 and #42049 .

Since Laravel 9.0, the methods `firstOrNew()`, `firstOrCreate()` and `updateOrCreate()` received a slight update in behaviour (3e66eb75ae379f14eb760a19071a07134de797e3) where related instance existence is now determined using a clean `$this->related->` query instead of the previous `$this->` relation query implementation. This introduced an inconsistency in these methods in comparison to the other `BelongsToMany` methods, where a possibility is introduced that these 3 methods return (or update) a row that is **not** (was not, is not, will not be) related to the base model. This PR addresses this issue.

---

First, this PR adds 3 tests that (as far as I understand [Taylor's comment](https://github.com/laravel/framework/pull/41881#issuecomment-1092921740)) describes why the changes in 3e66eb75ae379f14eb760a19071a07134de797e3 were made. This concerns the entirety of the three new tests, except the last assertion of each test. These assertions succeed in the current Laravel 9.* .

**Note that this is based on my understanding of the issue, I have not found a reference to the actually issue back then.** (Are any references available?)

Second, this PR contains 3 new assertions (the last one of each test mentioned here-above) that fail on the current Laravel 9.*, but which should probably succeed in order for these methods to be consistent with other similar methods. I think this at least is the case for `firstOrCreate()` and `updateOrCreate()`. I am not entirely sure on `firstOrNew()`, more on that below.

Thirdly, this PR contains changes to the implementations of the 3 methods that make sure the 3 new assertions succeed.

---

**Updated [Motivation](https://github.com/laravel/framework/pull/41881#issuecomment-1093033906)**
Consider that any method on the `BelongsToMany` relationship returning a model, returns a model that is related to the base model. This was the case in Laravel 8.*, the three methods either:

- return (or update) an already existing related model
- create and attach a new related model (except for `firstOrNew`, which cannot `attach()` due to no primary key being available)

Note that for the `*OrCreate` methods, we always end up in a state where the returned related model is actually related to the base model. Since Laravel 9.*, one new possibility is introduced; the three methods can:

- return an existing model from the related table, that is not attached to the base model

To my understanding, the calling site cannot distinguish this new situation from the first situation where an already existing related method is returned. Hence, to ensure in a mutating call site that the model from the related table really will be related to the base model, one should always manually call `attach()`, even if the row was in fact already related. In a retrieving call site, I am not sure what one could do when an existing non-related model is returned.


**`firstOrCreate()`**
My understanding of `firstOrCreate` is that you will always receive a related model instance that already was related ('first') or is newly related ('create') to the base model. In case a new related record is created, `attach()` is explicitly called. Hence I would assume that in case an existing unrelated model is returned, it should be explicitly `attach()`ed as well.

**`firstOrNew()`**
Similar arguments hold for `firstOrNew`. Also consider for example the similar method `findOrNew()`, which only returns existing models that are actually related (unlike the current `firstOrNew()` implementation). However, compared to `firstOrCreate()`, `firstOrNew()` is more nuanced: `first` returns the first related model, `OrNew` returns a new unsaved model that cannot be related since it is unsaved. In our new case (returning an existing unrelated model) one can follow two thoughts:

- it should be attached to be consistent with `first`
- it should not be attached to be consistent with `OrNew`

As not attaching leads to the call site ending up with no indication whether the model is actually attached or not, I would vote for consistency with `first` here.

Do note however, that when `attach()`ing here, we have no access to `$joining` and `$touch` variables like we do in the other method.

**`updateOrCreate`**
Consider that `$model->relation()->update()` will always only update rows that are related. Changing it into `$model->relation()->updateOrCreate()` introduces the possibility that (without clear indication) a row is being updated that is not related to the model at all. One could argue that also in this case (similar to `firstOrCreate()`), the implementation should automatically `attach()` a related model if it is not related already.

---

**Alternatives**
While I am convinced that the three proposed tests indicate a problem in behaviour, I am not convinced that my proposed implementation is actually the best improvement.

One objection would be, it adds a potential extra query to be executed. This could be circumvented by performing a query on `$this->related->` and adding an extra select which determines whether the row is related or not. However, this might add a little too much complexity.

~~Looking at all different cases here, I ultimately feel that perhaps the new behaviour of returning (and attaching) unrelated rows should probably deserve their own dedicated methods, like `firstOrCreateAndAttach()` and `updateOrCreateAndAttach()` or something like that, leaving the existing `Or` methods like they were in Laravel 8.*. However, I do understand that might be a matter of taste.~~


**Conclusion**
Long story short, I am concerned that these three methods currently violate the invariant that all similar BelongsToMany methods always act on related data, and these three now do not behave in this same way. I can see what the intention behind the change might have been, but maybe that should have required a different solution? Currently I feel the behaviour can be rather unexpected, especially in some edge cases that are not unlikely to occur in applications. It could lead to hard-to-find bugs and/or vulnerabilities. I certainly do not want to push through any opinion of mine, but I would appreciate if you would give this issue a good thought, to make sure these methods (as seen as part of the greater whole) are evolving in the right direction.
