### PR TITLE
[9.x] Re-order messages variable in Password::getErrorMessage() method

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -300,8 +300,6 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
                 return;
             }
 
-            $value = (string) $value;
-
             if ($this->mixedCase && ! preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {
                 $validator->errors()->add(
                     $attribute,
@@ -363,6 +361,10 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
      */
     protected function getErrorMessage($key)
     {
+        if (($message = $this->validator->getTranslator()->get($key)) !== $key) {
+            return $message;
+        }
+
         $messages = [
             'validation.password.mixed' => 'The :attribute must contain at least one uppercase and one lowercase letter.',
             'validation.password.letters' => 'The :attribute must contain at least one letter.',
@@ -370,10 +372,6 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             'validation.password.numbers' => 'The :attribute must contain at least one number.',
             'validation.password.uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
         ];
-
-        if (($message = $this->validator->getTranslator()->get($key)) !== $key) {
-            return $message;
-        }
 
         return $messages[$key];
     }


### PR DESCRIPTION
In Password::getErrorMessage() method, the $messages variable is only necessary if developers don't define their custom messages in locale files. So, it shouldn't be initialized on the top of this method block.