### PR TITLE
[9.x] Use assertStringContainsString in MailMarkdownTest

### DIFF
--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -27,7 +27,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->render('view', []);
 
-        $this->assertNotFalse(strpos($result, '<html></html>'));
+        $this->assertStringContainsString('<html></html>', $result);
     }
 
     public function testRenderFunctionReturnsHtmlWithCustomTheme()
@@ -44,7 +44,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->render('view', []);
 
-        $this->assertNotFalse(strpos($result, '<html></html>'));
+        $this->assertStringContainsString('<html></html>', $result);
     }
 
     public function testRenderFunctionReturnsHtmlWithCustomThemeWithMailPrefix()
@@ -61,7 +61,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->render('view', []);
 
-        $this->assertNotFalse(strpos($result, '<html></html>'));
+        $this->assertStringContainsString('<html></html>', $result);
     }
 
     public function testRenderTextReturnsText()


### PR DESCRIPTION
In MailMarkdownTest, we can use `assertStringContainsString` that is more readable than:

```
$this->assertNotFalse(strpos($result, '<html></html>'));
```
