### PR TITLE
[9.x] Fix ViewErrorBag for JSON session serialization

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -713,7 +713,8 @@ class Store implements Session
     /**
      * Prepare error bag instance for JSON serialization.
      */
-    private function prepareErrorBagForSerialization() {
+    private function prepareErrorBagForSerialization()
+    {
         if ($this->serialization !== 'json' || $this->missing('errors')) {
             return;
         }
@@ -730,7 +731,8 @@ class Store implements Session
     /**
      * Rebuilds a ViewErrorBag instance from JSON.
      */
-    private function rebuildErrorBag() {
+    private function rebuildErrorBag()
+    {
         if ($this->serialization !== 'json' || $this->missing('errors')) {
             return;
         }

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -5,7 +5,9 @@ namespace Illuminate\Session;
 use Closure;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
+use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
+use Illuminate\Support\ViewErrorBag;
 use SessionHandlerInterface;
 use stdClass;
 
@@ -94,6 +96,8 @@ class Store implements Session
     protected function loadSession()
     {
         $this->attributes = array_merge($this->attributes, $this->readFromHandler());
+
+        $this->rebuildErrorBag();
     }
 
     /**
@@ -137,6 +141,8 @@ class Store implements Session
     public function save()
     {
         $this->ageFlashData();
+
+        $this->prepareErrorBagForSerialization();
 
         $this->handler->write($this->getId(), $this->prepareForStorage(
             $this->serialization === 'json' ? json_encode($this->attributes) : serialize($this->attributes)
@@ -702,5 +708,42 @@ class Store implements Session
         if ($this->handlerNeedsRequest()) {
             $this->handler->setRequest($request);
         }
+    }
+
+    /**
+     * Prepare error bag instance for JSON serialization.
+     */
+    private function prepareErrorBagForSerialization() {
+        if ($this->serialization !== 'json' || $this->missing('errors')) {
+            return;
+        }
+
+        $errors = [];
+
+        foreach ($this->attributes['errors']->getBags() as $key => $value) {
+            $errors[$key] = ['format' => $value->getFormat(), 'messages' => $value->getMessages()];
+        }
+
+        $this->attributes['errors'] = $errors;
+    }
+
+    /**
+     * Rebuilds a ViewErrorBag instance from JSON.
+     */
+    private function rebuildErrorBag() {
+        if ($this->serialization !== 'json' || $this->missing('errors')) {
+            return;
+        }
+
+        $errorBag = new ViewErrorBag;
+
+        foreach ($this->get('errors') as $key => $value) {
+            $messageBag = new MessageBag($value['messages']);
+            $messageBag->setFormat($value['format']);
+
+            $errorBag->put($key, $messageBag);
+        }
+
+        $this->put('errors', $errorBag);
     }
 }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -4,8 +4,10 @@ namespace Illuminate\Tests\Session;
 
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Session\CookieSessionHandler;
+use Illuminate\Support\MessageBag;
 use Illuminate\Session\Store;
 use Illuminate\Support\Str;
+use Illuminate\Support\ViewErrorBag;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -493,19 +495,90 @@ class SessionStoreTest extends TestCase
         $this->assertSame('foo', $result);
     }
 
-    public function getSession()
+    public function testValidationErrorsCanBeSerializedAsJson()
+    {
+        $session = $this->getSession('json');
+        $session->getHandler()->shouldReceive('read')->once()->andReturn(serialize([]));
+        $session->start();
+        $session->put('errors', $errorBag = new ViewErrorBag); 
+        $messageBag = new MessageBag([
+            'first_name' => [
+                'Your first name is required',
+                'Your first name must be at least 1 character',
+            ],
+        ]);
+        $messageBag->setFormat('<p>:message</p>');
+        $errorBag->put('default', $messageBag);
+
+        $session->getHandler()->shouldReceive('write')->once()->with(
+            $this->getSessionId(),
+            json_encode([
+                '_token' => $session->token(),
+                'errors' => [
+                    'default' => [
+                        'format' => '<p>:message</p>',
+                        'messages' => [
+                            'first_name' => [
+                                'Your first name is required', 
+                                'Your first name must be at least 1 character',
+                            ],
+                        ],
+                    ],
+                ],
+                '_flash' => [
+                    'old' => [],
+                    'new' => [],
+                ],
+            ])
+        );
+        $session->save();
+
+        $this->assertFalse($session->isStarted());
+    }
+
+    public function testValidationErrorsCanBeReadAsJson()
+    {
+        $session = $this->getSession('json');
+        $session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(json_encode([
+            'errors' => [
+                'default' => [
+                    'format' => '<p>:message</p>',
+                    'messages' => [
+                        'first_name' => [
+                            'Your first name is required', 
+                            'Your first name must be at least 1 character',
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+        $session->start();
+
+        $errors = $session->get('errors');
+
+        $this->assertInstanceOf(ViewErrorBag::class, $errors);
+        $this->assertInstanceOf(MessageBag::class, $errors->getBags()['default']);
+        $this->assertEquals('<p>:message</p>', $errors->getBags()['default']->getFormat());
+        $this->assertEquals(['first_name' => [
+            'Your first name is required', 
+            'Your first name must be at least 1 character',
+        ]], $errors->getBags()['default']->getMessages());
+    }
+
+    public function getSession($serialization = 'php')
     {
         $reflection = new ReflectionClass(Store::class);
 
-        return $reflection->newInstanceArgs($this->getMocks());
+        return $reflection->newInstanceArgs($this->getMocks($serialization));
     }
 
-    public function getMocks()
+    public function getMocks($serialization = 'json')
     {
         return [
             $this->getSessionName(),
             m::mock(SessionHandlerInterface::class),
             $this->getSessionId(),
+            $serialization,
         ];
     }
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -4,8 +4,8 @@ namespace Illuminate\Tests\Session;
 
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Session\CookieSessionHandler;
-use Illuminate\Support\MessageBag;
 use Illuminate\Session\Store;
+use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\ViewErrorBag;
 use Mockery as m;
@@ -500,7 +500,7 @@ class SessionStoreTest extends TestCase
         $session = $this->getSession('json');
         $session->getHandler()->shouldReceive('read')->once()->andReturn(serialize([]));
         $session->start();
-        $session->put('errors', $errorBag = new ViewErrorBag); 
+        $session->put('errors', $errorBag = new ViewErrorBag);
         $messageBag = new MessageBag([
             'first_name' => [
                 'Your first name is required',
@@ -519,7 +519,7 @@ class SessionStoreTest extends TestCase
                         'format' => '<p>:message</p>',
                         'messages' => [
                             'first_name' => [
-                                'Your first name is required', 
+                                'Your first name is required',
                                 'Your first name must be at least 1 character',
                             ],
                         ],
@@ -545,7 +545,7 @@ class SessionStoreTest extends TestCase
                     'format' => '<p>:message</p>',
                     'messages' => [
                         'first_name' => [
-                            'Your first name is required', 
+                            'Your first name is required',
                             'Your first name must be at least 1 character',
                         ],
                     ],
@@ -560,7 +560,7 @@ class SessionStoreTest extends TestCase
         $this->assertInstanceOf(MessageBag::class, $errors->getBags()['default']);
         $this->assertEquals('<p>:message</p>', $errors->getBags()['default']->getFormat());
         $this->assertEquals(['first_name' => [
-            'Your first name is required', 
+            'Your first name is required',
             'Your first name must be at least 1 character',
         ]], $errors->getBags()['default']->getMessages());
     }


### PR DESCRIPTION
The `json` session serialization format added in Laravel 9 (https://github.com/laravel/framework/pull/40595) doesn't work for flashed validation errors since those are serialized from the ViewErrorBag instance. `ViewErrorBag` does not implement JsonSerializable and more importantly need to be recreated when reading the session data back.

This PR intends to resolve this by storing the necessary information as an array, and rehydrating the instance after reading the session data back. This tries to implement the suggestion by Taylor here: https://github.com/laravel/laravel/pull/5796#issuecomment-1030098327

Note that this changes nothing unless `$serialization === 'json'`.

Fixes https://github.com/laravel/framework/issues/40773
Related to https://github.com/laravel/framework/pull/41850