### PR TITLE
[9.x] Add a `findOr` method to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -499,6 +499,29 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Find a model by its primary key or call a callback.
+     *
+     * @param  mixed  $id
+     * @param  \Closure|array  $columns
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|mixed
+     */
+    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        if (! is_null($model = $this->find($id, $columns))) {
+            return $model;
+        }
+
+        return $callback();
+    }
+
+    /**
      * Get the first record matching the attributes or instantiate it.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -712,6 +712,38 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Find a related model by its primary key or call a callback.
+     *
+     * @param  mixed  $id
+     * @param  \Closure|array  $columns
+     * @param  \Closure|null  $callback
+     *
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
+     */
+    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        $result = $this->find($id, $columns);
+
+        $id = $id instanceof Arrayable ? $id->toArray() : $id;
+
+        if (is_array($id)) {
+            if (count($result) === count(array_unique($id))) {
+                return $result;
+            }
+        } elseif (! is_null($result)) {
+            return $result;
+        }
+
+        return $callback();
+    }
+
+    /**
      * Add a basic where clause to the query, and return the first result.
      *
      * @param  \Closure|string|array  $column

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -717,7 +717,6 @@ class BelongsToMany extends Relation
      * @param  mixed  $id
      * @param  \Closure|array  $columns
      * @param  \Closure|null  $callback
-     *
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
      */
     public function findOr($id, $columns = ['*'], Closure $callback = null)

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -389,6 +389,38 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Find a related model by its primary key or call a callback.
+     *
+     * @param  mixed  $id
+     * @param  \Closure|array  $columns
+     * @param  \Closure|null  $callback
+     *
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
+     */
+    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        $result = $this->find($id, $columns);
+
+        $id = $id instanceof Arrayable ? $id->toArray() : $id;
+
+        if (is_array($id)) {
+            if (count($result) === count(array_unique($id))) {
+                return $result;
+            }
+        } elseif (! is_null($result)) {
+            return $result;
+        }
+
+        return $callback();
+    }
+
+    /**
      * Get the results of the relationship.
      *
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -394,7 +394,6 @@ class HasManyThrough extends Relation
      * @param  mixed  $id
      * @param  \Closure|array  $columns
      * @param  \Closure|null  $callback
-     *
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|mixed
      */
     public function findOr($id, $columns = ['*'], Closure $callback = null)

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -154,6 +154,75 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->findOrFail(new Collection([1, 2]), ['column']);
     }
 
+    public function testFindOrMethod()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->andReturn('int');
+        $builder->setModel($model);
+        $builder->getQuery()->shouldReceive('where')->with('foo_table.foo', '=', 1)->twice();
+        $builder->getQuery()->shouldReceive('where')->with('foo_table.foo', '=', 2)->once();
+        $builder->shouldReceive('first')->andReturn($model)->once();
+        $builder->shouldReceive('first')->with(['column'])->andReturn($model)->once();
+        $builder->shouldReceive('first')->andReturn(null)->once();
+
+        $this->assertSame($model, $builder->findOr(1, fn () => 'callback result'));
+        $this->assertSame($model, $builder->findOr(1, ['column'], fn () => 'callback result'));
+        $this->assertSame('callback result', $builder->findOr(2, fn () => 'callback result'));
+    }
+
+    public function testFindOrMethodWithMany()
+    {
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $model1 = $this->getMockModel();
+        $model2 = $this->getMockModel();
+        $builder->setModel($model1);
+        $builder->getQuery()->shouldReceive('whereIn')->with('foo_table.foo', [1, 2])->twice();
+        $builder->getQuery()->shouldReceive('whereIn')->with('foo_table.foo', [1, 2, 3])->once();
+        $builder->shouldReceive('get')->andReturn(new Collection([$model1, $model2]))->once();
+        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model1, $model2]))->once();
+        $builder->shouldReceive('get')->andReturn(null)->once();
+
+        $result = $builder->findOr([1, 2], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame($model1, $result[0]);
+        $this->assertSame($model2, $result[1]);
+
+        $result = $builder->findOr([1, 2], ['column'], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame($model1, $result[0]);
+        $this->assertSame($model2, $result[1]);
+
+        $result = $builder->findOr([1, 2, 3], fn () => 'callback result');
+        $this->assertSame('callback result', $result);
+    }
+
+    public function testFindOrMethodWithManyUsingCollection()
+    {
+        $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
+        $model1 = $this->getMockModel();
+        $model2 = $this->getMockModel();
+        $builder->setModel($model1);
+        $builder->getQuery()->shouldReceive('whereIn')->with('foo_table.foo', [1, 2])->twice();
+        $builder->getQuery()->shouldReceive('whereIn')->with('foo_table.foo', [1, 2, 3])->once();
+        $builder->shouldReceive('get')->andReturn(new Collection([$model1, $model2]))->once();
+        $builder->shouldReceive('get')->with(['column'])->andReturn(new Collection([$model1, $model2]))->once();
+        $builder->shouldReceive('get')->andReturn(null)->once();
+
+        $result = $builder->findOr(new Collection([1, 2]), fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame($model1, $result[0]);
+        $this->assertSame($model2, $result[1]);
+
+        $result = $builder->findOr(new Collection([1, 2]), ['column'], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame($model1, $result[0]);
+        $this->assertSame($model2, $result[1]);
+
+        $result = $builder->findOr(new Collection([1, 2, 3]), fn () => 'callback result');
+        $this->assertSame('callback result', $result);
+    }
+
     public function testFirstOrFailMethodThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -201,6 +201,80 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::first()->posts()->findOrFail(new Collection([1, 2]));
     }
 
+    public function testFindOrMethod()
+    {
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+                                 ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr(1, fn () => 'callback result');
+        $this->assertInstanceOf(HasManyThroughTestPost::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertSame('A title', $result->title);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr(1, ['posts.id'], fn () => 'callback result');
+        $this->assertInstanceOf(HasManyThroughTestPost::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertNull($result->title);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr(2, fn () => 'callback result');
+        $this->assertSame('callback result', $result);
+    }
+
+    public function testFindOrMethodWithMany()
+    {
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+                                 ->posts()->createMany([
+                                     ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                                     ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+                                 ]);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr([1, 2], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(1, $result[0]->id);
+        $this->assertSame(2, $result[1]->id);
+        $this->assertSame('A title', $result[0]->title);
+        $this->assertSame('Another title', $result[1]->title);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr([1, 2], ['posts.id'], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(1, $result[0]->id);
+        $this->assertSame(2, $result[1]->id);
+        $this->assertNull($result[0]->title);
+        $this->assertNull($result[1]->title);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr([1, 2, 3], fn () => 'callback result');
+        $this->assertSame('callback result', $result);
+    }
+
+    public function testFindOrMethodWithManyUsingCollection()
+    {
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+                                 ->posts()->createMany([
+                                     ['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                                     ['id' => 2, 'title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+                                 ]);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr(new Collection([1, 2]), fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(1, $result[0]->id);
+        $this->assertSame(2, $result[1]->id);
+        $this->assertSame('A title', $result[0]->title);
+        $this->assertSame('Another title', $result[1]->title);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr(new Collection([1, 2]), ['posts.id'], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(1, $result[0]->id);
+        $this->assertSame(2, $result[1]->id);
+        $this->assertNull($result[0]->title);
+        $this->assertNull($result[1]->title);
+
+        $result = HasManyThroughTestCountry::first()->posts()->findOr(new Collection([1, 2, 3]), fn () => 'callback result');
+        $this->assertSame('callback result', $result);
+    }
+
     public function testFirstRetrievesFirstRecord()
     {
         $this->seedData();

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -413,6 +413,77 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertInstanceOf(Tag::class, $post->tags()->findOrNew(666));
     }
 
+    public function testFindOrMethod()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $post->tags()->create(['name' => Str::random()]);
+
+        $result = $post->tags()->findOr(1, fn () => 'callback result');
+        $this->assertInstanceOf(Tag::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertNotNull($result->name);
+
+        $result = $post->tags()->findOr(1, ['id'], fn () => 'callback result');
+        $this->assertInstanceOf(Tag::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertNull($result->name);
+
+        $result = $post->tags()->findOr(2, fn () => 'callback result');
+        $this->assertSame('callback result', $result);
+    }
+
+    public function testFindOrMethodWithMany()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $post->tags()->createMany([
+            ['name' => Str::random()],
+            ['name' => Str::random()],
+        ]);
+
+        $result = $post->tags()->findOr([1, 2], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(1, $result[0]->id);
+        $this->assertSame(2, $result[1]->id);
+        $this->assertNotNull($result[0]->name);
+        $this->assertNotNull($result[1]->name);
+
+        $result = $post->tags()->findOr([1, 2], ['id'], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(1, $result[0]->id);
+        $this->assertSame(2, $result[1]->id);
+        $this->assertNull($result[0]->name);
+        $this->assertNull($result[1]->name);
+
+        $result = $post->tags()->findOr([1, 2, 3], fn () => 'callback result');
+        $this->assertSame('callback result', $result);
+    }
+
+    public function testFindOrMethodWithManyUsingCollection()
+    {
+        $post = Post::create(['title' => Str::random()]);
+        $post->tags()->createMany([
+            ['name' => Str::random()],
+            ['name' => Str::random()],
+        ]);
+
+        $result = $post->tags()->findOr(new Collection([1, 2]), fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(1, $result[0]->id);
+        $this->assertSame(2, $result[1]->id);
+        $this->assertNotNull($result[0]->name);
+        $this->assertNotNull($result[1]->name);
+
+        $result = $post->tags()->findOr(new Collection([1, 2]), ['id'], fn () => 'callback result');
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertSame(1, $result[0]->id);
+        $this->assertSame(2, $result[1]->id);
+        $this->assertNull($result[0]->name);
+        $this->assertNull($result[1]->name);
+
+        $result = $post->tags()->findOr(new Collection([1, 2, 3]), fn () => 'callback result');
+        $this->assertSame('callback result', $result);
+    }
+
     public function testFirstOrNewMethod()
     {
         $post = Post::create(['title' => Str::random()]);


### PR DESCRIPTION
This PR adds a `findOr()` method to the Eloquent Builder and Relations. This matches the existing `firstOr()` methods.

A typical scenario where this method is useful is when a resource route (e.g. `/posts/1`) cannot find a model that is *not* part of the URL, and so a `findOrFail()` returning a 404 is not appropriate.

Example usage:

```php
User::findOr(1, fn () => throw new RuntimeException);
User::findOr(1, fn () => abort(403));
User::findOr(1, fn () => 'return something');
```

The method also supports passing columns as the second argument:

```php
User::findOr(1, ['columns'], fn () => '...');
```

It also works on `HasMany`, `HasManyThrough`, `BelongsToMany`, `MorphMany`, and `MorphToMany` relations:

```php
$user->posts()->findOr(1, fn () => '...');
```