### PR TITLE
[9.x] Add new ucwords string helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1028,6 +1028,18 @@ class Str
     }
 
     /**
+     * Uppercase the first character of each word in a string.
+     *
+     * @param  string  $string
+     * @param  string|null  $separators
+     * @return string
+     */
+    public static function ucwords($string, $separators = null)
+    {
+        return ucwords($string, $separators ?? " \t\r\n\f\v");
+    }
+
+    /**
      * Get the number of words a string contains.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -857,6 +857,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Uppercase the first character of each word in a string.
+     *
+     * @param  string|null  $separators
+     * @return string
+     */
+    public function ucwords($separators = null)
+    {
+        return Str::ucwords($this->value, $separators);
+    }
+
+    /**
      * Execute the given callback if the string contains a given substring.
      *
      * @param  string|string[]  $needles

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -684,6 +684,14 @@ class SupportStrTest extends TestCase
         $this->assertSame(['Öffentliche', 'Überraschungen'], Str::ucsplit('ÖffentlicheÜberraschungen'));
     }
 
+    public function testUcwords()
+    {
+        $this->assertSame('Laravel Php Framework', Str::ucwords('laravel php framework'));
+        $this->assertSame('Laravel PHP Framework', Str::ucwords('laravel PHP framework'));
+
+        $this->assertSame('Laravel php-Framework', Str::ucwords('laravel php-framework', '-'));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -157,6 +157,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame(['He_llo_', 'World'], $this->stringable('He_llo_World')->ucsplit()->toArray());
     }
 
+    public function testUcwordsOnStringable()
+    {
+        $this->assertSame('Laravel Php Framework', $this->stringable('laravel php framework')->ucwords());
+        $this->assertSame('Laravel PHP Framework', $this->stringable('laravel PHP framework')->ucwords());
+
+        $this->assertSame('Laravel php-Framework', $this->stringable('laravel php-framework')->ucwords('-'));
+    }
+
     public function testWhenEndsWith()
     {
         $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenEndsWith('ark', function ($stringable) {


### PR DESCRIPTION
This PR adds a new ucwords string helper.

Usage

```php
Str:ucwords('laravel php framework')
Str::of('laravel php framework')->ucwords();
str('laravel php framework')->ucwords();
```
`// Outputs: "Laravel Php Framework"`

Why do I think this is usefull?
Lately I had a Stringable class and modified its value like this:

```php
$string = str($name)->lower();
$string = ucwords($string);
$parts = str($string)->ucsplit();
```
It would have been much "sexier" to just use the fluent interface like this.
```php
$parts = str($name)->lower()->ucwords()->ucsplit();
```