### PR TITLE
[9.x] Add doesntExpectOutputToContain assertion method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -23,7 +23,7 @@ trait InteractsWithConsole
     public $expectedOutput = [];
 
     /**
-     * All of the expected text to be present on the output.
+     * All of the expected text to be present in the output.
      *
      * @var array
      */
@@ -37,7 +37,7 @@ trait InteractsWithConsole
     public $unexpectedOutput = [];
 
     /**
-     * All the text that isn't expected to be displayed.
+     * All of the text that is not expected to be present in the output.
      *
      * @var array
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -37,6 +37,13 @@ trait InteractsWithConsole
     public $unexpectedOutput = [];
 
     /**
+     * All the text that isn't expected to be displayed.
+     *
+     * @var array
+     */
+    public $unexpectedOutputSubstrings = [];
+
+    /**
      * All of the expected output tables.
      *
      * @var array

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -168,6 +168,19 @@ class PendingCommand
     }
 
     /**
+     * Specify that the given string shouldn't be contained in the command output.
+     *
+     * @param  string  $string
+     * @return $this
+     */
+    public function doesntExpectOutputToContain($string)
+    {
+        $this->test->unexpectedOutputSubstrings[$string] = false;
+
+        return $this;
+    }
+
+    /**
      * Specify a table that should be printed when the command runs.
      *
      * @param  array  $headers
@@ -331,6 +344,10 @@ class PendingCommand
         if ($output = array_search(true, $this->test->unexpectedOutput)) {
             $this->test->fail('Output "'.$output.'" was printed.');
         }
+
+        if ($output = array_search(true, $this->test->unexpectedOutputSubstrings)) {
+            $this->test->fail('Output "'.$output.'" was printed.');
+        }
     }
 
     /**
@@ -407,6 +424,14 @@ class PendingCommand
                 });
         }
 
+        foreach ($this->test->unexpectedOutputSubstrings as $text => $displayed) {
+            $mock->shouldReceive('doWrite')
+                 ->withArgs(fn ($output) => str_contains($output, $text))
+                 ->andReturnUsing(function () use ($text) {
+                     $this->test->unexpectedOutputSubstrings[$text] = true;
+                 });
+        }
+
         return $mock;
     }
 
@@ -420,6 +445,7 @@ class PendingCommand
         $this->test->expectedOutput = [];
         $this->test->expectedOutputSubstrings = [];
         $this->test->unexpectedOutput = [];
+        $this->test->unexpectedOutputSubstrings = [];
         $this->test->expectedTables = [];
         $this->test->expectedQuestions = [];
         $this->test->expectedChoices = [];

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -73,6 +73,16 @@ class ArtisanCommandTest extends TestCase
              ->assertExitCode(0);
     }
 
+    public function test_console_command_that_fails_from_unexpected_output_substring()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Output "Taylor Otwell" was printed.');
+
+        $this->artisan('contains')
+             ->doesntExpectOutputToContain('Taylor Otwell')
+             ->assertExitCode(0);
+    }
+
     public function test_console_command_that_fails_from_missing_output()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
This PR adds the new Command assertion method `doesntExpectOutputToContain`

**Usage**
```php
Artisan::command('contains', function () {
    $this->line('My name is Taylor Otwell');
});

$this->artisan('contains')
    ->doesntExpectOutputToContain('Taylor Otwell')
```

**Why do I think this is usefull?**
Lately I had to check for a String which wasn't included in the Output of a Command and I was suprised that there are the methods `expectsOutput`, `doesntExpectOutput` and `expectsOutputToContain` but no `doesntExpectOutputToContain`.

So here it is 😄