### PR TITLE
[9.x] ColumnDefinition for always() was missing parameter

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Fluent;
 
 /**
  * @method $this after(string $column) Place the column "after" another column (MySQL)
- * @method $this always() Used as a modifier for generatedAs() (PostgreSQL)
+ * @method $this always(bool $value = true) Used as a modifier for generatedAs() (PostgreSQL)
  * @method $this autoIncrement() Set INTEGER columns as auto-increment (primary key)
  * @method $this change() Change the column
  * @method $this charset(string $charset) Specify a character set for the column (MySQL)


### PR DESCRIPTION
The `always` column modifier for PostgreSQL is missing its parameter in the docblock. Depending on the boolean parameter, the behavior is different:

* `true`: The column is an identity column managed by the database, raising an error on user provided data (`generated always as [...]`)
* `false`: The column is a generated column managed by the database, allowing to overwrite the generated value (`generated by default as [...]`)