### PR TITLE
[9.x] Throw LostDbConnectionException

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -453,9 +453,7 @@ class Connection implements ConnectionInterface
     {
         $statement->setFetchMode($this->fetchMode);
 
-        $this->event(new StatementPrepared(
-            $this, $statement
-        ));
+        $this->event(new StatementPrepared($this, $statement));
 
         return $statement;
     }
@@ -823,9 +821,9 @@ class Connection implements ConnectionInterface
     /**
      * Reconnect to the database.
      *
-     * @return void
+     * @return mixed|false
      *
-     * @throws \LogicException
+     * @throws LostDbConnectionException
      */
     public function reconnect()
     {
@@ -835,7 +833,7 @@ class Connection implements ConnectionInterface
             return call_user_func($this->reconnector, $this);
         }
 
-        throw new LogicException('Lost connection and no reconnector available.');
+        throw new LostDbConnectionException('Lost connection and no reconnector available.');
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -823,7 +823,7 @@ class Connection implements ConnectionInterface
      *
      * @return mixed|false
      *
-     * @throws LostDbConnectionException
+     * @throws \Illuminate\Database\LostConnectionException
      */
     public function reconnect()
     {
@@ -833,7 +833,7 @@ class Connection implements ConnectionInterface
             return call_user_func($this->reconnector, $this);
         }
 
-        throw new LostDbConnectionException('Lost connection and no reconnector available.');
+        throw new LostConnectionException('Lost connection and no reconnector available.');
     }
 
     /**

--- a/src/Illuminate/Database/LostConnectionException.php
+++ b/src/Illuminate/Database/LostConnectionException.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database;
 
 use LogicException;
 
-class LostDbConnectionException extends LogicException
+class LostConnectionException extends LogicException
 {
     //
 }

--- a/src/Illuminate/Database/LostDbConnectionException.php
+++ b/src/Illuminate/Database/LostDbConnectionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database;
+
+use LogicException;
+
+class LostDbConnectionException extends LogicException
+{
+    //
+}


### PR DESCRIPTION
Throwing a specific exception in case of a lost db connection allows framework users to have a global catcher and report the exception separately from all other LogicExceptions.

- I think this is fully backward compatible since the new exception is a subclass of the `LogicException`. (if not wrong)
