### PR TITLE
[9.x] Set the cause of lost connection

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -170,7 +170,7 @@ trait ManagesTransactions
     protected function handleBeginTransactionException(Throwable $e)
     {
         if ($this->causedByLostConnection($e)) {
-            $this->reconnect();
+            $this->reconnect($e->getMessage());
 
             $this->getPdo()->beginTransaction();
         } else {

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -809,7 +809,7 @@ class Connection implements ConnectionInterface
     protected function tryAgainIfCausedByLostConnection(QueryException $e, $query, $bindings, Closure $callback)
     {
         if ($this->causedByLostConnection($e->getPrevious())) {
-            $this->reconnect();
+            $this->reconnect($e->getPrevious());
 
             return $this->runQueryCallback($query, $bindings, $callback);
         }
@@ -820,11 +820,12 @@ class Connection implements ConnectionInterface
     /**
      * Reconnect to the database.
      *
+     * @param  string  $cause
      * @return mixed|false
      *
      * @throws \Illuminate\Database\LostConnectionException
      */
-    public function reconnect()
+    public function reconnect($cause = '')
     {
         if (is_callable($this->reconnector)) {
             $this->doctrineConnection = null;
@@ -832,7 +833,7 @@ class Connection implements ConnectionInterface
             return call_user_func($this->reconnector, $this);
         }
 
-        throw new LostConnectionException('Lost connection and no reconnector available.');
+        throw new LostConnectionException('Lost connection and no reconnector available.', $cause);
     }
 
     /**
@@ -843,7 +844,7 @@ class Connection implements ConnectionInterface
     protected function reconnectIfMissingConnection()
     {
         if (is_null($this->pdo)) {
-            $this->reconnect();
+            $this->reconnect('Missing PDO connection.');
         }
     }
 

--- a/src/Illuminate/Database/LostConnectionException.php
+++ b/src/Illuminate/Database/LostConnectionException.php
@@ -6,5 +6,13 @@ use LogicException;
 
 class LostConnectionException extends LogicException
 {
-    //
+    public function __construct($message, private string $cause)
+    {
+        parent::__construct($message);
+    }
+
+    public function getRootCause()
+    {
+        return $this->cause;
+    }
 }


### PR DESCRIPTION
Now that the #42102 is accepted, I think it is also needed to have the root cause of the losing connection in the report logs to properly debug the situation.
Since there is a huge list of various reasons mentioned in the `causedByLostConnection` method.
But currently, the framework is swallowing it.
```
            'server has gone away',
            'no connection to the server',
            'Lost connection',
            'is dead or not enabled',
            'Error while sending',
            'decryption failed or bad record mac',
            'server closed the connection unexpectedly',
            'SSL connection has been closed unexpectedly',
            'Error writing data to the connection',
       .........

```
- unfortunately, this change is not backward-compatible in theory since the signature of the method is changing and may cause trouble in case the method is overridden in a subclass.

- Callers of the `reconnect` method are not affected since the $message parameter has a default value.