### PR TITLE
[9.x] Added new email validation rule messages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis-phpredis/phpredis@5.3.5, igbinary, msgpack, lzf, zstd, lz4, memcached
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis-phpredis/phpredis@5.3.5, igbinary, msgpack, lzf, zstd, lz4, memcached, intl
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
@@ -122,7 +122,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached, intl
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis-phpredis/phpredis@5.3.5, igbinary, msgpack, lzf, zstd, lz4, memcached, intl
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis-phpredis/phpredis@5.3.5, igbinary, msgpack, lzf, zstd, lz4, memcached
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -234,10 +234,9 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      */
     protected function fail($messages)
     {
-        $messages = collect(Arr::wrap($messages))->map(function ($message)
-        {
+        $messages = collect(Arr::wrap($messages))->map(function ($message) {
             return $this->validator->getTranslator()->get($message);
-        } )->all();
+        })->all();
 
         $this->messages = array_merge($this->messages, $messages);
 

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -7,11 +7,11 @@ use Egulias\EmailValidator\Validation\DNSCheckValidation;
 use Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation;
 use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Egulias\EmailValidator\Validation\RFCValidation;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Validation\Concerns\FilterEmailValidation;
 use InvalidArgumentException;
@@ -19,6 +19,7 @@ use InvalidArgumentException;
 class Email implements Rule, DataAwareRule, ValidatorAwareRule
 {
     use Conditionable;
+
     /**
      * The data under validation.
      *
@@ -48,35 +49,35 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
     public static $defaultCallback;
 
     /**
-     * The default validation rule
+     * The default validation rule.
      *
      * @var bool
      */
     protected $rfc = false;
 
     /**
-     * If NoRFCWarningsValidation should be used
+     * If NoRFCWarningsValidation should be used.
      *
      * @var bool
      */
     protected $strict = false;
 
     /**
-     * If DNSCheckValidation should be used
+     * If DNSCheckValidation should be used.
      *
      * @var bool
      */
     protected $dns = false;
 
     /**
-     * If SpoofCheckValidation should be used
+     * If SpoofCheckValidation should be used.
      *
      * @var bool
      */
     protected $spoof = false;
 
     /**
-     * If FilterEmailValidation should be used
+     * If FilterEmailValidation should be used.
      *
      * @var bool
      */
@@ -110,35 +111,35 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
 
             $email_validator = new EmailValidator;
 
-            if ($this->rfc && !$email_validator->isValid($value, new RFCValidation)) {
+            if ($this->rfc && ! $email_validator->isValid($value, new RFCValidation)) {
                 $validator->errors()->add(
                     $attribute,
                     $this->getErrorMessage('validation.email.rfc')
                 );
             }
 
-            if ($this->strict && !$email_validator->isValid($value, new NoRFCWarningsValidation)) {
+            if ($this->strict && ! $email_validator->isValid($value, new NoRFCWarningsValidation)) {
                 $validator->errors()->add(
                     $attribute,
                     $this->getErrorMessage('validation.email.strict')
                 );
             }
 
-            if ($this->dns && !$email_validator->isValid($value, new DNSCheckValidation)) {
+            if ($this->dns && ! $email_validator->isValid($value, new DNSCheckValidation)) {
                 $validator->errors()->add(
                     $attribute,
                     $this->getErrorMessage('validation.email.dns')
                 );
             }
 
-            if ($this->spoof && !$email_validator->isValid($value, new SpoofCheckValidation)) {
+            if ($this->spoof && ! $email_validator->isValid($value, new SpoofCheckValidation)) {
                 $validator->errors()->add(
                     $attribute,
                     $this->getErrorMessage('validation.email.spoof')
                 );
             }
 
-            if ($this->filter && !$email_validator->isValid($value, new FilterEmailValidation)) {
+            if ($this->filter && ! $email_validator->isValid($value, new FilterEmailValidation)) {
                 $validator->errors()->add(
                     $attribute,
                     $this->getErrorMessage('validation.email.filter')
@@ -233,12 +234,12 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      */
     protected function fail($messages)
     {
-        $messages = collect( Arr::wrap( $messages ) )->map( function( $message )
+        $messages = collect(Arr::wrap($messages))->map( function( $message )
         {
-            return $this->validator->getTranslator()->get( $message );
+            return $this->validator->getTranslator()->get($message);
         } )->all();
 
-        $this->messages = array_merge( $this->messages, $messages );
+        $this->messages = array_merge($this->messages, $messages);
 
         return false;
     }

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
+use Egulias\EmailValidator\Validation\Extra\SpoofCheckValidation;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
+use Egulias\EmailValidator\Validation\RFCValidation;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Validation\Concerns\FilterEmailValidation;
+use InvalidArgumentException;
+
+class Email implements Rule, DataAwareRule, ValidatorAwareRule
+{
+    use Conditionable;
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Contracts\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * Additional validation rules that should be merged into the default rules during validation.
+     *
+     * @var array
+     */
+    protected $customRules = [];
+
+    /**
+     * The callback that will generate the "default" version of the password rule.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultCallback;
+
+    /**
+     * The default validation rule
+     *
+     * @var bool
+     */
+    protected $rfc = false;
+
+    /**
+     * If NoRFCWarningsValidation should be used
+     *
+     * @var bool
+     */
+    protected $strict = false;
+
+    /**
+     * If DNSCheckValidation should be used
+     *
+     * @var bool
+     */
+    protected $dns = false;
+
+    /**
+     * If SpoofCheckValidation should be used
+     *
+     * @var bool
+     */
+    protected $spoof = false;
+
+    /**
+     * If FilterEmailValidation should be used
+     *
+     * @var bool
+     */
+    protected $filter = false;
+
+    public function __construct()
+    {
+        $this->rfc = true;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->messages = [];
+
+        $validator = Validator::make(
+            $this->data,
+            [$attribute => array_merge(['string'], $this->customRules)],
+            $this->validator->customMessages,
+            $this->validator->customAttributes
+        )->after(function ($validator) use($attribute, $value) {
+            if (! is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
+                return;
+            }
+
+            $email_validator = new EmailValidator;
+
+            if ($this->rfc && !$email_validator->isValid($value, new RFCValidation)) {
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.email.rfc')
+                );
+            }
+
+            if ($this->strict && !$email_validator->isValid($value, new NoRFCWarningsValidation)) {
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.email.strict')
+                );
+            }
+
+            if ($this->dns && !$email_validator->isValid($value, new DNSCheckValidation)) {
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.email.dns')
+                );
+            }
+
+            if ($this->spoof && !$email_validator->isValid($value, new SpoofCheckValidation)) {
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.email.spoof')
+                );
+            }
+
+            if ($this->filter && !$email_validator->isValid($value, new FilterEmailValidation)) {
+                $validator->errors()->add(
+                    $attribute,
+                    $this->getErrorMessage('validation.email.filter')
+                );
+            }
+        });
+
+        if ($validator->fails()) {
+            return $this->fail($validator->messages()->all());
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Get the translated password error message.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function getErrorMessage($key)
+    {
+        $messages = [
+            'validation.email.rfc' => 'The :attribute must be a valid email address.',
+            'validation.email.strict' => 'The :attribute must be a valid email address.',
+            'validation.email.dns' => 'The :attribute does not have a valid domain.',
+            'validation.email.spoof' => 'The :attribute appears to be spoofed.',
+            'validation.email.filter' => 'The :attribute must pass the filter.',
+        ];
+
+        if (($message = $this->validator->getTranslator()->get($key)) !== $key) {
+            return $message;
+        }
+
+        return $messages[$key];
+    }
+
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Set the performing validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Specify additional validation rules that should be merged with the default rules during validation.
+     *
+     * @param  string|array  $rules
+     * @return $this
+     */
+    public function rules($rules)
+    {
+        $this->customRules = Arr::wrap($rules);
+
+        return $this;
+    }
+
+    /**
+     * Adds the given failures, and return false.
+     *
+     * @param  array|string  $messages
+     * @return bool
+     */
+    protected function fail($messages)
+    {
+        $messages = collect( Arr::wrap( $messages ) )->map( function( $message )
+        {
+            return $this->validator->getTranslator()->get( $message );
+        } )->all();
+
+        $this->messages = array_merge( $this->messages, $messages );
+
+        return false;
+    }
+
+    /**
+     * Set the default callback to be used for determining a password's default rules.
+     *
+     * If no arguments are passed, the default password rule configuration will be returned.
+     *
+     * @param  static|callable|null  $callback
+     * @return static|null
+     */
+    public static function defaults($callback = null)
+    {
+        if (is_null($callback)) {
+            return static::default();
+        }
+
+        if (! is_callable($callback) && ! $callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of '.static::class);
+        }
+
+        static::$defaultCallback = $callback;
+    }
+
+    /**
+     * Get the default configuration of the password rule.
+     *
+     * @return static
+     */
+    public static function default()
+    {
+        $email = is_callable(static::$defaultCallback)
+            ? call_user_func(static::$defaultCallback)
+            : static::$defaultCallback;
+
+        return $email instanceof Rule ? $email : static::rfc();
+    }
+
+    public static function rfc()
+    {
+        return new static();
+    }
+
+    public function strict()
+    {
+        $this->strict = true;
+
+        return $this;
+    }
+
+    public function dns()
+    {
+        $this->dns = true;
+
+        return $this;
+    }
+
+    public function spoof()
+    {
+        $this->spoof = true;
+
+        return $this;
+    }
+
+    public function filter()
+    {
+        $this->filter = true;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Validation/Rules/Email.php
+++ b/src/Illuminate/Validation/Rules/Email.php
@@ -104,7 +104,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
             [$attribute => array_merge(['string'], $this->customRules)],
             $this->validator->customMessages,
             $this->validator->customAttributes
-        )->after(function ($validator) use($attribute, $value) {
+        )->after(function ($validator) use ($attribute, $value) {
             if (! is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
                 return;
             }
@@ -234,7 +234,7 @@ class Email implements Rule, DataAwareRule, ValidatorAwareRule
      */
     protected function fail($messages)
     {
-        $messages = collect(Arr::wrap($messages))->map( function( $message )
+        $messages = collect(Arr::wrap($messages))->map(function ($message)
         {
             return $this->validator->getTranslator()->get($message);
         } )->all();

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -66,14 +66,14 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     protected $symbols = false;
 
     /**
-     * If the password should has not been compromised in data leaks.
+     * If the password should not have been compromised in data leaks.
      *
      * @var bool
      */
     protected $uncompromised = false;
 
     /**
-     * The number of times a password can appear in data leaks before being consider compromised.
+     * The number of times a password can appear in data leaks before being considered compromised.
      *
      * @var int
      */

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -46,7 +46,7 @@ class ValidationEmailRuleTest extends TestCase
     public function testRfc()
     {
         $this->fails(Email::rfc(), ['foo@.com'], [
-            'The my email must be a valid email address.'
+            'The my email must be a valid email address.',
         ]);
 
         $this->passes(Email::rfc(), ['foo@gmail.com']);
@@ -54,11 +54,11 @@ class ValidationEmailRuleTest extends TestCase
 
     public function testStrict()
     {
-        $this->fails(Email::rfc()->strict(), ['foo@bar' ], [
+        $this->fails(Email::rfc()->strict(), ['foo@bar'], [
             'The my email must be a valid email address.',
         ]);
 
-        $this->fails(Email::rfc()->strict(), ['foo()@bar.com' ], [
+        $this->fails(Email::rfc()->strict(), ['foo()@bar.com'], [
             'The my email must be a valid email address.',
         ]);
 
@@ -67,7 +67,7 @@ class ValidationEmailRuleTest extends TestCase
 
     public function testDns()
     {
-        $this->fails(Email::rfc()->dns(), ['foo@example.com' ], [
+        $this->fails(Email::rfc()->dns(), ['foo@example.com'], [
             'The my email does not have a valid domain.',
         ]);
 
@@ -76,7 +76,7 @@ class ValidationEmailRuleTest extends TestCase
 
     public function testSpoof()
     {
-        $this->fails(Email::rfc()->spoof(), ['Кириллица@example.com' ], [
+        $this->fails(Email::rfc()->spoof(), ['Кириллица@example.com'], [
             'The my email appears to be spoofed.',
         ]);
 
@@ -85,7 +85,7 @@ class ValidationEmailRuleTest extends TestCase
 
     public function testFilter()
     {
-        $this->fails(Email::rfc()->filter(), ['foö@example.com' ], [
+        $this->fails(Email::rfc()->filter(), ['foö@example.com'], [
             'The my email must pass the filter.',
         ]);
 
@@ -94,7 +94,7 @@ class ValidationEmailRuleTest extends TestCase
 
     public function testMultiple()
     {
-        $this->fails(Email::rfc()->strict()->dns()->spoof()->filter(), ['Кириfoö()@example.com' ], [
+        $this->fails(Email::rfc()->strict()->dns()->spoof()->filter(), ['Кириfoö()@example.com'], [
             'The my email must be a valid email address.',
             'The my email does not have a valid domain.',
             'The my email appears to be spoofed.',

--- a/tests/Validation/ValidationEmailRuleTest.php
+++ b/tests/Validation/ValidationEmailRuleTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\Email;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationEmailRuleTest extends TestCase
+{
+    public function testString()
+    {
+        $this->fails(Email::rfc(), [['foo' => 'bar'], ['foo']], [
+            'validation.string',
+        ]);
+
+        $this->fails(Email::rfc(), [1234567, 545], [
+            'validation.string',
+        ]);
+    }
+
+    public function testConditional()
+    {
+        $is_privileged_user = true;
+        $rule = (new Email)->when($is_privileged_user, function ($rule) {
+            $rule->strict();
+        });
+
+        $this->fails($rule, ['aaaaaaaa', 'foo()@bar.com'], [
+            'The my email must be a valid email address.',
+        ]);
+
+        $is_privileged_user = false;
+        $rule = (new Email)->when($is_privileged_user, function ($rule) {
+            $rule->strict();
+        });
+
+        $this->passes($rule, ['foo@example.com', 'bär@example.com']);
+    }
+
+    public function testRfc()
+    {
+        $this->fails(Email::rfc(), ['foo@.com'], [
+            'The my email must be a valid email address.'
+        ]);
+
+        $this->passes(Email::rfc(), ['foo@gmail.com']);
+    }
+
+    public function testStrict()
+    {
+        $this->fails(Email::rfc()->strict(), ['foo@bar' ], [
+            'The my email must be a valid email address.',
+        ]);
+
+        $this->fails(Email::rfc()->strict(), ['foo()@bar.com' ], [
+            'The my email must be a valid email address.',
+        ]);
+
+        $this->passes(Email::rfc()->strict(), ['foo@example.com']);
+    }
+
+    public function testDns()
+    {
+        $this->fails(Email::rfc()->dns(), ['foo@example.com' ], [
+            'The my email does not have a valid domain.',
+        ]);
+
+        $this->passes(Email::rfc()->dns(), ['foo@gmail.com']);
+    }
+
+    public function testSpoof()
+    {
+        $this->fails(Email::rfc()->spoof(), ['Кириллица@example.com' ], [
+            'The my email appears to be spoofed.',
+        ]);
+
+        $this->passes(Email::rfc()->spoof(), ['foo@gmail.com']);
+    }
+
+    public function testFilter()
+    {
+        $this->fails(Email::rfc()->filter(), ['foö@example.com' ], [
+            'The my email must pass the filter.',
+        ]);
+
+        $this->passes(Email::rfc()->filter(), ['foo@gmail.com']);
+    }
+
+    public function testMultiple()
+    {
+        $this->fails(Email::rfc()->strict()->dns()->spoof()->filter(), ['Кириfoö()@example.com' ], [
+            'The my email must be a valid email address.',
+            'The my email does not have a valid domain.',
+            'The my email appears to be spoofed.',
+            'The my email must pass the filter.',
+        ]);
+
+        $this->passes(Email::rfc()->strict()->dns()->spoof()->filter(), ['foo@gmail.com']);
+    }
+
+    protected function passes($rule, $values)
+    {
+        $this->assertValidationRules($rule, $values, true, []);
+    }
+
+    protected function fails($rule, $values, $messages)
+    {
+        $this->assertValidationRules($rule, $values, false, $messages);
+    }
+
+    protected function assertValidationRules($rule, $values, $result, $messages)
+    {
+        foreach ($values as $value) {
+            $v = new Validator(
+                resolve('translator'),
+                ['my_email' => $value],
+                ['my_email' => is_object($rule) ? clone $rule : $rule]
+            );
+
+            $this->assertSame($result, $v->passes());
+
+            $this->assertSame(
+                $result ? [] : ['my_email' => $messages],
+                $v->messages()->toArray()
+            );
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+
+        Email::$defaultCallback = null;
+    }
+}


### PR DESCRIPTION
Added Email validation rule. This makes it possible to give different error messages for different errors.

Using the following e-mailadress: `Кириfoö()@example.com`.
**Current behavior**
With the current email validation:
```php
'email' => 'email:rfc,strict,dns,spoof,filter'
```
When it fails it will only return
>The :attribute must be a valid email address.

**New behavior**
With the new email validation:
```php
'email' => [Email::rfc()->strict()->dns()->spoof()->filter()]
```
When it fails it wil return:
```php
[
       'The email must be a valid email address.',
       'The email does not have a valid domain.',
       'The email appears to be spoofed.',
       'The email must pass the filter.',
]
```

The behavior is taken from the [Password rule](https://laravel.com/docs/9.x/validation#validating-passwords).
