### PR TITLE
[9.x] Allow objects to be passed to the database query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3571,6 +3571,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Apply the criteria to a given query builder.
+     *
+     * @param  \Illuminate\Database\Query\Criteria  $criteria
+     * @return \Illuminate\Contracts\Database\Query\Builder
+     */
+    public function applyCriteria(Criteria $criteria)
+    {
+        return $criteria->apply($this);
+    }
+
+    /**
      * Get a scalar type value from an unknown type of input.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Database/Query/Criteria.php
+++ b/src/Illuminate/Database/Query/Criteria.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Contracts\Database\Query\Builder;
+
+interface Criteria
+{
+    /**
+     * Apply the criteria to a given query builder.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Builder  $builder
+     * @return \Illuminate\Contracts\Database\Query\Builder
+     */
+    public function apply(Builder $builder);
+}

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Query\Criteria;
 use Illuminate\Database\QueryException;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
 use Illuminate\Pagination\Cursor;
@@ -1941,6 +1942,17 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('primary', $pivot->taxonomy);
     }
 
+    public function testModelRetrievalWithCriteriaClass()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $this->assertEquals(2, EloquentTestUser::count());
+
+        $this->assertFalse(EloquentTestUser::query()->applyCriteria(new WhereEmail('taylorotwell@gmail.com'))->doesntExist());
+        $this->assertTrue(EloquentTestUser::query()->applyCriteria(new WhereEmail('mohamed@laravel.com'))->doesntExist());
+    }
+
     /**
      * Helpers...
      */
@@ -2235,5 +2247,20 @@ class EloquentTouchingComment extends Eloquent
     public function post()
     {
         return $this->belongsTo(EloquentTouchingPost::class, 'post_id');
+    }
+}
+
+class WhereEmail implements Criteria
+{
+    protected $email;
+
+    public function __construct($email)
+    {
+        $this->email = $email;
+    }
+
+    public function apply($q)
+    {
+        return $q->where('email', $this->email);
     }
 }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1949,8 +1949,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertEquals(2, EloquentTestUser::count());
 
-        $this->assertFalse(EloquentTestUser::query()->applyCriteria(new WhereEmail('taylorotwell@gmail.com'))->doesntExist());
-        $this->assertTrue(EloquentTestUser::query()->applyCriteria(new WhereEmail('mohamed@laravel.com'))->doesntExist());
+        $this->assertFalse(EloquentTestUser::applyCriteria(new WhereEmail('taylorotwell@gmail.com'))->doesntExist());
+        $this->assertTrue(EloquentTestUser::applyCriteria(new WhereEmail('mohamed@laravel.com'))->doesntExist());
     }
 
     /**


### PR DESCRIPTION
This pull request allows users to pass an object to the database query builder. This might be helpful to encapsulate a complex query logic into an object using predefined classes.

Something similar to: https://www.martinfowler.com/eaaCatalog/queryObject.html

We can implement similar functionality using Eloquent scope functions. But scopes are only available in Eloquent models. The intention of this approach is to move business logic from a query builder to a business class. (Create query by referring to classes and fields rather than tables and columns)

Example of filtering user records:

```php
DB::table('users')
    ->applyCriteria(new FilterCriteria(auth()->user(), new FilterData('taylor')))
    ->get()

// or

User::applyCriteria(new FilterCriteria(auth()->user(), new FilterData('taylor')))->get()

class FilterData {
    public $name;
}

class FilterCriteria implements Criteria
{
    public function __construct(
       protected User $user, 
       protected FilterData $filters
    ) {
    }

    public function apply($q)
    {
        $q->where('name', 'like', $this->filters->name.'%');
        
        if ($this->user->isAdmin()) {
            $q->applyCriteria(new VisibleToAdminCriteria($this->user));
            
            return $q;
        }
        
        return $q;
    }
}
```
