### PR TITLE
[9.x] Add Eloquent local scopes tests

### DIFF
--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentLocalScopesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        tap(new DB)->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ])->bootEloquent();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Model::unsetConnectionResolver();
+    }
+
+    public function testCanCheckExistenceOfLocalScope()
+    {
+        $model = new EloquentLocalScopesTestModel;
+
+        $this->assertTrue($model->hasNamedScope('active'));
+        $this->assertTrue($model->hasNamedScope('type'));
+
+        $this->assertFalse($model->hasNamedScope('nonExistentLocalScope'));
+    }
+
+    public function testLocalScopeIsApplied()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->active();
+
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([true], $query->getBindings());
+    }
+
+    public function testDynamicLocalScopeIsApplied()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->type('foo');
+
+        $this->assertSame('select * from "table" where "type" = ?', $query->toSql());
+        $this->assertEquals(['foo'], $query->getBindings());
+    }
+}
+
+class EloquentLocalScopesTestModel extends Model
+{
+    protected $table = 'table';
+
+    public function scopeActive($query)
+    {
+        $query->where('active', true);
+    }
+
+    public function scopeType($query, $type)
+    {
+        $query->where('type', $type);
+    }
+}


### PR DESCRIPTION
This PR adds couple of tests to Eloquent local scope feature. Covers both static and dynamic local scopes.