### PR TITLE
[9.x] Add a new way of defining local scopes on Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -439,8 +439,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             } elseif ($totallyGuarded) {
                 throw new MassAssignmentException(sprintf(
                     'Add [%s] to fillable property to allow mass assignment on [%s].',
-                    $key,
-                    get_class($this)
+                    $key, get_class($this)
                 ));
             }
         }
@@ -1621,8 +1620,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         ];
 
         $attributes = Arr::except(
-            $this->getAttributes(),
-            $except ? array_unique(array_merge($except, $defaults)) : $defaults
+            $this->getAttributes(), $except ? array_unique(array_merge($except, $defaults)) : $defaults
         );
 
         return tap(new static, function ($instance) use ($attributes) {

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -47,6 +47,10 @@ class ScopeMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
+        if ($this->option('local')) {
+            return $this->resolveStubPath('/stubs/scope.local.stub');
+        }
+
         return $this->resolveStubPath('/stubs/scope.stub');
     }
 

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -77,4 +77,16 @@ class ScopeMakeCommand extends GeneratorCommand
     {
         return is_dir(app_path('Models')) ? $rootNamespace.'\\Models\\Scopes' : $rootNamespace.'\Scopes';
     }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['local', 'l', InputOption::VALUE_NONE, 'Generate a local scope class.'],
+        ];
+    }
 }

--- a/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ScopeMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 #[AsCommand(name: 'make:scope')]
 class ScopeMakeCommand extends GeneratorCommand

--- a/src/Illuminate/Foundation/Console/stubs/scope.local.stub
+++ b/src/Illuminate/Foundation/Console/stubs/scope.local.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Scope;
+
+class {{ class }}
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  mixed|null  $value
+     * @return void
+     */
+    public function apply(Builder $builder, $value)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/scope.local.stub
+++ b/src/Illuminate/Foundation/Console/stubs/scope.local.stub
@@ -3,7 +3,6 @@
 namespace {{ namespace }};
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Scope;
 
 class {{ class }}
 {

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentLocalScopesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        tap(new DB)->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ])->bootEloquent();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Model::unsetConnectionResolver();
+    }
+
+    public function testCanCheckExistenceOfLocalScope()
+    {
+        $model = new EloquentLocalScopesTestModel;
+
+        $this->assertTrue($model->hasNamedScope('active'));
+        $this->assertTrue($model->hasNamedScope('type'));
+
+        $this->assertFalse($model->hasNamedScope('nonExistentLocalScope'));
+    }
+
+    public function testLocalScopeIsApplied()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->active();
+
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([true], $query->getBindings());
+    }
+
+    public function testDynamicLocalScopeIsApplied()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->type('foo');
+
+        $this->assertSame('select * from "table" where "type" = ?', $query->toSql());
+        $this->assertEquals(['foo'], $query->getBindings());
+    }
+}
+
+class EloquentLocalScopesTestModel extends Model
+{
+    protected $table = 'table';
+
+    public function scopeActive($query)
+    {
+        $query->where('active', true);
+    }
+
+    public function scopeType($query, $type)
+    {
+        $query->where('type', $type);
+    }
+}

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -71,6 +71,15 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $this->assertSame('select * from "table" where "price" = ?', $query->toSql());
         $this->assertEquals([1000], $query->getBindings());
     }
+
+    public function testClassAndMethodBasedLocalScopesAreChainable()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->type('foo')->price(1000);
+
+        $this->assertSame('select * from "table" where "type" = ? and "price" = ?', $query->toSql());
+        $this->assertEquals(['foo', 1000], $query->getBindings());
+    }
 }
 
 class EloquentLocalScopesTestModel extends Model

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -52,6 +52,15 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $this->assertSame('select * from "table" where "type" = ?', $query->toSql());
         $this->assertEquals(['foo'], $query->getBindings());
     }
+
+    public function testLocalScopesCanChained()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->active()->type('foo');
+
+        $this->assertSame('select * from "table" where "active" = ? and "type" = ?', $query->toSql());
+        $this->assertEquals([true, 'foo'], $query->getBindings());
+    }
 }
 
 class EloquentLocalScopesTestModel extends Model


### PR DESCRIPTION
Hi Team,

Following the changes in how we define Eloquent model accessors and mutators, I am putting forward these proposals on how we can define local scopes as well.

Currently, we are defining local scopes like this:

```
class Ticket extends Model
{
    public class scopePrice($builder, $value)
    {
        $builder->where('price', $value);
    }
}
```
# Proposal 1
Which is currently the changes in this PR - we can define local scopes in the model within the static `$scopes` array, like so:

```
class Ticket extends Model
{
    protected static $scopes = [
        'price' => Price::class,
    ];
}
```

Then, we can use the artisan `make:scope` command to generate a local scope class by adding the `--local` option.

```
$ php artisan make:scope Price --local
```

This will generate the local scope class with an `apply()` method that accepts the Builder instance as the first argument, and `$value` as the second argument for dynamic local scopes.

```
use Illuminate\Database\Eloquent\Builder;

class Price
{
    public function apply(Builder $builder, $value)
    {
        $builder->where('price', $value);
    }
}
```

# Proposal 2
Which I can submit a separate PR for - we can define a `scope()` method in the model class that will return an instance of a local scope class, where the scopes can be defined as public methods.

```
class Ticket extends Model
{
    public function scope($builder) : LocalScope
    {
        return new TicketScope($builder);
    }
}

```

The scope class can then extend an abstract class defined in Laravel to ensure that it will always accept the builder instance as its dependency through the constructor
```
abstract class LocalScope
{
    protected $builder;

    public function __construct(Builder $builder)
    {
        $this->builder = $builder;
    }
}

class TicketScope extends LocalScope
{
    public function price($value)
    {
        $this->builder->where('price', $value);
    }

    // Other named scopes can be define here...
}
```

Like the first proposal, we can use the artisan `make:scope` command to generate a local scope class by adding the `--local` option.

```
$ php artisan make:scope TicketScope --local
```

Or we can have both because it's always good to have options, so why not.