### PR TITLE
[9.x] Add override flag to rememberForever

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -312,7 +312,9 @@ class Repository implements ArrayAccess, CacheContract
             // this operation should work with a total "atomic" implementation of it.
             if (method_exists($this->store, 'add')) {
                 return $this->store->add(
-                    $this->itemKey($key), $value, $seconds
+                    $this->itemKey($key),
+                    $value,
+                    $seconds
                 );
             }
         }
@@ -410,17 +412,20 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  string  $key
      * @param  \Closure  $callback
+     * @param  bool $override
      * @return mixed
      */
-    public function rememberForever($key, Closure $callback)
+    public function rememberForever($key, Closure $callback, $override = false)
     {
-        $value = $this->get($key);
+        if (!$override) {
+            $value = $this->get($key);
 
-        // If the item exists in the cache we will just return this immediately
-        // and if not we will execute the given Closure and cache the result
-        // of that forever so it is available for all subsequent requests.
-        if (! is_null($value)) {
-            return $value;
+            // If the item exists in the cache we will just return this immediately
+            // and if not we will execute the given Closure and cache the result
+            // of that forever so it is available for all subsequent requests.
+            if (! is_null($value)) {
+                return $value;
+            }
         }
 
         $this->forever($key, $value = $callback());

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -412,12 +412,12 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  string  $key
      * @param  \Closure  $callback
-     * @param  bool $override
+     * @param  bool  $override
      * @return mixed
      */
     public function rememberForever($key, Closure $callback, $override = false)
     {
-        if (!$override) {
+        if (! $override) {
             $value = $this->get($key);
 
             // If the item exists in the cache we will just return this immediately

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -312,9 +312,7 @@ class Repository implements ArrayAccess, CacheContract
             // this operation should work with a total "atomic" implementation of it.
             if (method_exists($this->store, 'add')) {
                 return $this->store->add(
-                    $this->itemKey($key),
-                    $value,
-                    $seconds
+                    $this->itemKey($key), $value, $seconds
                 );
             }
         }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -143,6 +143,13 @@ class CacheRepositoryTest extends TestCase
             return 'bar';
         });
         $this->assertSame('bar', $result);
+        // override flag test
+        $repo->getStore()->shouldReceive('get')->never();
+        $repo->getStore()->shouldReceive('forever')->once()->with('foo', 'barbar');
+        $result = $repo->rememberForever('foo', function () {
+            return 'barbar';
+        }, true);
+        $this->assertSame('barbar', $result);
     }
 
     public function testPuttingMultipleItemsInCache()


### PR DESCRIPTION
This pull request allows to override an existing forever cache with a flag instead of a separate call to `forget`.

```php
Cache::rememberForever($key, Closure $callback, $override = false)
```

### Use case:
A landing page accesses this cache on every hit but an asynchronous process updates it and wants to set it as well not just forget the key because calculating the new cache value is expensive and increases cache hits if the async process does it instead of the first page hit after the cache key got forgotten.

Before / After comparison of updating a forever remembered cache value:

### Before
```php
if ($override) {
    Cache::forget('first_model');
}
return Cache::rememberForever(
    'first_model',
    fn () => Model::first()
);
```
### After
```php
return Cache::rememberForever(
    'first_model',
    fn () => Model::first(),
    true //override flag
);
```

### Benefits:
- Convenience
- Removing a unnecessary look up call, which rememberForever always does because it doesn't know about the override yet.