### PR TITLE
[9.x] Remove unused private method

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -554,19 +554,6 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Apply a prefix to the given key if necessary.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    private function applyPrefix($key)
-    {
-        $prefix = (string) $this->client->getOption(Redis::OPT_PREFIX);
-
-        return $prefix.$key;
-    }
-
-    /**
      * Pass other method calls down to the underlying client.
      *
      * @param  string  $method


### PR DESCRIPTION
This private method is not called anywhere in the class or the used trait.
There is also no dynamic call like: `$this->$methodName`  in the class or the used trait.

