### PR TITLE
[9.x] Fix PHP 8.2 deprecation

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -199,7 +199,7 @@ trait SoftDeletes
      */
     public function getDeletedAtColumn()
     {
-        return defined('static::DELETED_AT') ? static::DELETED_AT : 'deleted_at';
+        return defined(static::class.'::DELETED_AT') ? static::DELETED_AT : 'deleted_at';
     }
 
     /**


### PR DESCRIPTION
Seemingly this syntax is going to be deprecated in PHP 8.2. "static::method"
The proper way is to replace it with static::class.'method'

https://php.watch/versions/8.2/partially-supported-callable-deprecation

The changed line is covered in tests.