### PR TITLE
[9.x] Add str() and string() to request object

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -542,4 +542,28 @@ trait InteractsWithInput
 
         return $this;
     }
+
+    /**
+     * Retrieve input from the request as a stringable.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     */
+    public function str($key, $default = null)
+    {
+        return $this->string($key, $default);
+    }
+
+    /**
+     * Retrieve input from the request as a stringable.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     */
+    public function string($key, $default = null)
+    {
+        return str($this->input($key, $default));
+    }
 }


### PR DESCRIPTION
This PR adds `str()` and `string()` methods to the Request class.

## Usage

```php
// use Illuminate\Http\Request;
public function index(Request $request)
{
	// instead of 
	$names = str($request->input('name'))->explode(',');

	// we can write
	$names = $request->str('name')->explode(',');
}
```

## Real world example

```php
// use App\Models\User;
// use Illuminate\Http\Request;

public function index(Request $request)
{
	User::query()->when($request->has('filters'), function ($query) use ($request) {
		
		// instead of
		$filters = $request->input('filters');

		foreach (explode(',' $filters) as $filter) {
			[$column, $value] = str($filter)->explode(':');

			$query->where($this->sanitize($column), $value);
		}

		// we can write
		$request->str('filters')->explode(',')->each(function ($filter) use ($query) {
			[$column, $value] = str($filter)->explode(':');

			$query->where($this->sanitize($column), $value);
		});

	});
}
```

It's a bit shorter, and an expressive way to interact with `Illuminate\Support\Stringable` from a request.