### PR TITLE
[9.x] Support 'IS' and 'IS NOT' PostgreSQL operators

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -199,7 +199,7 @@ class Builder implements BuilderContract
     public $operators = [
         '=', '<', '>', '<=', '>=', '<>', '!=', '<=>',
         'like', 'like binary', 'not like', 'ilike',
-        '&', '|', '^', '<<', '>>', '&~',
+        '&', '|', '^', '<<', '>>', '&~', 'is', 'is not',
         'rlike', 'not rlike', 'regexp', 'not regexp',
         '~', '~*', '!~', '!~*', 'similar to',
         'not similar to', 'not ilike', '~~*', '!~~*',


### PR DESCRIPTION
It is not possible to use the IS or IS NOT operators for example in the whereRelation() function.
The problem is that the `Illuminate\Database\Query\Builder` does not support these operators.
It would work if these operators were included in this array.

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Query/Builder.php#L199-L206

The `whereRelation()` calls internally the `where()` function inside the `Illuminate\Database\Query\Builder`, which changes unsupported operators to `=`.

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Query/Builder.php#L739-L741

This is the reason why some queries raises an SQL exception.
For example for a query like this `SELECT * FROM table WHERE xy IS TRUE`
This is because Postgres uses real boolean values and in some cases you cannot use `= 1`.

Mentioned in the discussion: #42101