### PR TITLE
[9.x] fix array keys from cached routes (#42078)

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -252,11 +252,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             })
             ->map(function (Collection $routes) {
                 return $routes->mapWithKeys(function (Route $route) {
-                    if ($domain = $route->getDomain()) {
-                        return [$domain.'/'.$route->uri => $route];
-                    }
-
-                    return [$route->uri => $route];
+                    return [$route->getDomain().$route->uri => $route];
                 })->all();
             })
             ->all();

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -527,13 +527,13 @@ class CompiledRouteCollectionTest extends TestCase
 
         $this->assertEquals([
             'HEAD' => [
-                'foo.localhost/same/path' => $routes['foo_domain'],
-                'bar.localhost/same/path' => $routes['bar_domain'],
+                'foo.localhostsame/path' => $routes['foo_domain'],
+                'bar.localhostsame/path' => $routes['bar_domain'],
                 'same/path' => $routes['no_domain'],
             ],
             'GET' => [
-                'foo.localhost/same/path' => $routes['foo_domain'],
-                'bar.localhost/same/path' => $routes['bar_domain'],
+                'foo.localhostsame/path' => $routes['foo_domain'],
+                'bar.localhostsame/path' => $routes['bar_domain'],
                 'same/path' => $routes['no_domain'],
             ],
         ], $this->collection()->getRoutesByMethod());


### PR DESCRIPTION
Cherry-pick of https://github.com/laravel/framework/pull/42078