### PR TITLE
[8.x] Fix json_last_error issue with setData

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -74,6 +74,9 @@ class JsonResponse extends BaseJsonResponse
     {
         $this->original = $data;
 
+        // Make sure json_last_error() is cleared...
+        json_decode('[]');
+
         if ($data instanceof Jsonable) {
             $this->data = $data->toJson($this->encodingOptions);
         } elseif ($data instanceof JsonSerializable) {

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -74,7 +74,7 @@ class JsonResponse extends BaseJsonResponse
     {
         $this->original = $data;
 
-        // Make sure json_last_error() is cleared...
+        // Ensure json_last_error() is cleared...
         json_decode('[]');
 
         if ($data instanceof Jsonable) {

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
@@ -26,5 +27,23 @@ class JsonResponseTest extends TestCase
         $this->withoutExceptionHandling();
 
         $this->get('/response');
+    }
+
+    public function testResponseSetDataPassesWithPriorJsonErrors()
+    {
+        $response = new JsonResponse();
+
+        // Trigger json_last_error() to have a non-zero value...
+        json_encode(['a' => acos(2)]);
+
+        $response->setData(new class implements Jsonable
+        {
+            public function toJson($options = 0): string
+            {
+                return "{}";
+            }
+        });
+
+        $this->assertJson($response->getContent());
     }
 }

--- a/tests/Integration/Http/JsonResponseTest.php
+++ b/tests/Integration/Http/JsonResponseTest.php
@@ -40,7 +40,7 @@ class JsonResponseTest extends TestCase
         {
             public function toJson($options = 0): string
             {
-                return "{}";
+                return '{}';
             }
         });
 


### PR DESCRIPTION
This PR fixes an issue where `json_last_error` would already be populated prior to the `setData` call, resulting in an exception on the method while in reality there wasn't any problem.

Fixes https://github.com/laravel/framework/issues/42107