### PR TITLE
[9.x] Fix order of file list on different CPU architectures is inconsistent

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -722,10 +722,10 @@ class FilesystemAdapter implements CloudFilesystemContract
             ->filter(function (StorageAttributes $attributes) {
                 return $attributes->isFile();
             })
+            ->sortByPath()
             ->map(function (StorageAttributes $attributes) {
                 return $attributes->path();
             })
-            ->sortByPath()
             ->toArray();
     }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -725,6 +725,7 @@ class FilesystemAdapter implements CloudFilesystemContract
             ->map(function (StorageAttributes $attributes) {
                 return $attributes->path();
             })
+            ->sortByPath()
             ->toArray();
     }
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -446,4 +446,16 @@ class FilesystemAdapterTest extends TestCase
 
         $this->fail('Exception was not thrown.');
     }
+
+    public function testGetAllFiles()
+    {
+        $this->filesystem->write('body.txt', 'Hello World');
+        $this->filesystem->write('file1.txt', 'Hello World');
+        $this->filesystem->write('file.txt', 'Hello World');
+        $this->filesystem->write('existing.txt', 'Dear Kate');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $this->assertSame($filesystemAdapter->files(),['body.txt','existing.txt','file.txt','file1.txt']);
+    }
 }


### PR DESCRIPTION
#42122 

The flysystem document explains your question.
https://flysystem.thephpleague.com/docs/usage/directory-listings/#:~:text=In%20V1%20directory,more%20memory%20performant.
I have tested on three computers (iMac intel, Macbook Pro M1, Linux) and found that there are three sequences.

This will cause the file list obtained by the user to be inconsistent on different computers.

```php
 public function testGetAllFiles()
    {
        $this->filesystem->write('body.txt', 'Hello World');
        $this->filesystem->write('file1.txt', 'Hello World');
        $this->filesystem->write('file.txt', 'Hello World');
        $this->filesystem->write('existing.txt', 'Dear Kate');
        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);

        $this->assertSame($filesystemAdapter->files(),['file.txt','file1.txt','body.txt','existing.txt']);
    }
// This test can pass before PR.
```
*The test results before this PR*
`Array &0 (
    0 => 'file.txt'
    1 => 'file1.txt'
    2 => 'body.txt'
    3 => 'existing.txt'
)`

*The test results after this PR*
`Array &0 (
    0 => 'body.txt'
    1 => 'existing.txt'
    2 => 'file.txt'
    3 => 'file1.txt'
)`