### PR TITLE
[9.x] Throw deadlock exception

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Concerns;
 
 use Closure;
+use Illuminate\Database\DeadlockException;
 use RuntimeException;
 use Throwable;
 
@@ -87,7 +88,11 @@ trait ManagesTransactions
                 $this->getName(), $this->transactions
             );
 
-            throw $e;
+            throw new DeadlockException(
+                $e->getMessage(),
+                $e->getCode(),
+                $e->getPrevious()
+            );
         }
 
         // If there was an exception we will rollback this transaction and then we
@@ -226,8 +231,7 @@ trait ManagesTransactions
     {
         $this->transactions = max(0, $this->transactions - 1);
 
-        if ($this->causedByConcurrencyError($e) &&
-            $currentAttempt < $maxAttempts) {
+        if ($this->causedByConcurrencyError($e) && $currentAttempt < $maxAttempts) {
             return;
         }
 

--- a/src/Illuminate/Database/DeadlockException.php
+++ b/src/Illuminate/Database/DeadlockException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database;
+
+use PDOException;
+
+class DeadlockException extends PDOException
+{
+    //
+}


### PR DESCRIPTION
Here Laravel checks and makes sure that the exception is due to a deadlock but eventually rethrows the generic PDOexception, then the developer must manually redetect it again as a deadlock in the application layer.
So it is more convenient to have a dedicated meaningful exception for it.