### PR TITLE
[9.x] Fix HasAttributes::mutateAttributeForArray when accessing non-cached attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -667,6 +667,8 @@ trait HasAttributes
             $value = $value instanceof DateTimeInterface
                         ? $this->serializeDate($value)
                         : $value;
+        } elseif ($this->hasAttributeGetMutator($key)) {
+            $value = $this->mutateAttributeMarkedAttribute($key, $value);
         } else {
             $value = $this->mutateAttribute($key, $value);
         }


### PR DESCRIPTION
Currently there is no check for `hasAttributeGetMutator` in the `HasAttributes::mutateAttributeForArray` method. 

This causes serializing a model to an array to fail when an attribute is specified in the appends array, as it falls back trying to retrieve the value via `mutateAttribute`. `mutateAttribute` utilizes the previous standard `getFirstNameAttribute` vs the new `firstName(): Attribute` approach referred to in 
https://laravel.com/docs/9.x/eloquent-mutators.