### PR TITLE
[9.x] Add incrementQuietly and decrementQuietly database methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -922,6 +922,36 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Increment a column's value by a given amount without raising any events.
+     *
+     * @param  string  $column
+     * @param  float|int  $amount
+     * @param  array  $extra
+     * @return int
+     */
+    protected function incrementQuietly($column, $amount = 1, array $extra = [])
+    {
+        return static::withoutEvents(function () use ($column, $amount, $extra) {
+            return $this->incrementOrDecrement($column, $amount, $extra, 'increment');
+        });
+    }
+
+    /**
+     * Decrement a column's value by a given amount without raising any events.
+     *
+     * @param  string  $column
+     * @param  float|int  $amount
+     * @param  array  $extra
+     * @return int
+     */
+    protected function decrementQuietly($column, $amount = 1, array $extra = [])
+    {
+        return static::withoutEvents(function () use ($column, $amount, $extra) {
+            return $this->incrementOrDecrement($column, $amount, $extra, 'decrement');
+        });
+    }
+
+    /**
      * Save the model and all of its relationships.
      *
      * @return bool


### PR DESCRIPTION
Add incrementQuietly and decrementQuietly database methods to complement the existing saveQuietly method.

saveQuietly updates a model without triggering events, and is documented here:
https://laravel.com/docs/9.x/eloquent#saving-a-single-model-without-events

Complementary incrementQuietly and decrementQuietly methods were not available so I have added them. Also added tests.

Does not break any existing features.
