### PR TITLE
[9.x] Add a test for UrlGenerator::toRoute() method

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -209,7 +209,7 @@ class UrlGenerator implements UrlGeneratorContract
         }
 
         $tail = implode('/', array_map(
-            'rawurlencode', (array) $this->formatParameters($extra))
+            'rawurlencode', $this->formatParameters($extra))
         );
 
         // Once we have the scheme we will compile the "tail" by collapsing the values
@@ -478,7 +478,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function toRoute($route, $parameters, $absolute)
     {
-        $parameters = collect(Arr::wrap($parameters))->map(function ($value, $key) use ($route) {
+        $parameters = collect()->wrap($parameters)->map(function ($value, $key) use ($route) {
             return $value instanceof UrlRoutable && $route->bindingFieldFor($key)
                     ? $value->{$route->bindingFieldFor($key)}
                     : $value;
@@ -535,15 +535,11 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatParameters($parameters)
     {
-        $parameters = Arr::wrap($parameters);
-
-        foreach ($parameters as $key => $parameter) {
-            if ($parameter instanceof UrlRoutable) {
-                $parameters[$key] = $parameter->getRouteKey();
-            }
-        }
-
-        return $parameters;
+        return collect()->wrap($parameters)->mapWithKeys(function ($parameter, $key) {
+            return $parameter instanceof UrlRoutable
+                ? [$key => $parameter->getRouteKey()]
+                : [$key => $parameter];
+        })->all();
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -815,7 +815,8 @@ class RoutingUrlGeneratorTest extends TestCase
         $routes->add($route);
 
         $parameters = [
-            'user' => new class implements UrlRoutable {
+            'user' => new class implements UrlRoutable
+            {
                 public $id = 1;
 
                 public function getRouteKey()
@@ -837,7 +838,7 @@ class RoutingUrlGeneratorTest extends TestCase
                 {
                     // Do nothing
                 }
-            }
+            },
         ];
 
         $this->assertSame('/users/1', $url->toRoute($route, $parameters, false));


### PR DESCRIPTION
UrlGenerator::toRoute() method will resolve each UrlRoutable parameter before passing parsed results to further actions. I just add a simple test to ensure it works properly. Btw, a few minor changes are included.