### PR TITLE
[9.x] Use instance instead of singleton bindings in FoundationExceptionHandlerTest

### DIFF
--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -7,7 +7,6 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler;
@@ -52,16 +51,12 @@ class FoundationExceptionsHandlerTest extends TestCase
 
         $this->container = Container::setInstance(new Container);
 
-        $this->container->singleton('config', function () {
-            return $this->config;
-        });
+        $this->container->instance('config', $this->config);
 
-        $this->container->singleton(ResponseFactoryContract::class, function () {
-            return new ResponseFactory(
-                m::mock(Factory::class),
-                m::mock(Redirector::class)
-            );
-        });
+        $this->container->instance(ResponseFactoryContract::class, new ResponseFactory(
+            m::mock(ViewFactory::class),
+            m::mock(Redirector::class)
+        ));
 
         $this->handler = new Handler($this->container);
     }
@@ -322,9 +317,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $viewFactory = m::mock(stdClass::class);
         $viewFactory->shouldReceive('exists')->with('errors::502')->andReturn(true);
 
-        $this->container->singleton(ViewFactory::class, function () use ($viewFactory) {
-            return $viewFactory;
-        });
+        $this->container->instance(ViewFactory::class, $viewFactory);
 
         $handler = new class($this->container) extends Handler
         {
@@ -343,9 +336,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $viewFactory->shouldReceive('exists')->once()->with('errors::502')->andReturn(false);
         $viewFactory->shouldReceive('exists')->once()->with('errors::5xx')->andReturn(true);
 
-        $this->container->singleton(ViewFactory::class, function () use ($viewFactory) {
-            return $viewFactory;
-        });
+        $this->container->instance(ViewFactory::class, $viewFactory);
 
         $handler = new class($this->container) extends Handler
         {
@@ -364,9 +355,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $viewFactory->shouldReceive('exists')->once()->with('errors::404')->andReturn(false);
         $viewFactory->shouldReceive('exists')->once()->with('errors::4xx')->andReturn(false);
 
-        $this->container->singleton(ViewFactory::class, function () use ($viewFactory) {
-            return $viewFactory;
-        });
+        $this->container->instance(ViewFactory::class, $viewFactory);
 
         $handler = new class($this->container) extends Handler
         {


### PR DESCRIPTION
In FoundationExceptionHandlerTest, a few singleton bindings that can be replaced by instance bindings. It makes code a bit more readable because each service registration has been done in one single line.