### PR TITLE
[9.x] Add methods to append and prepend jobs to existing chain

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -192,6 +192,32 @@ trait Queueable
     }
 
     /**
+     * Prepend a job to the current chain so that it is run after the currently running job.
+     *
+     * @param   mixed   $job
+     * @return  $this
+     */
+    public function prependToChain($job)
+    {
+        $this->chained = Arr::prepend($this->chained, $this->serializeJob($job));
+
+        return $this;
+    }
+
+    /**
+     * Append a job to the end of the current chain.
+     *
+     * @param   mixed   $job
+     * @return  $this
+     */
+    public function appendToChain($job)
+    {
+        $this->chained = array_merge($this->chained, [$this->serializeJob($job)]);
+
+        return $this;
+    }
+
+    /**
      * Serialize a job for queuing.
      *
      * @param  mixed  $job

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -194,8 +194,8 @@ trait Queueable
     /**
      * Prepend a job to the current chain so that it is run after the currently running job.
      *
-     * @param   mixed   $job
-     * @return  $this
+     * @param  mixed  $job
+     * @return $this
      */
     public function prependToChain($job)
     {
@@ -207,8 +207,8 @@ trait Queueable
     /**
      * Append a job to the end of the current chain.
      *
-     * @param   mixed   $job
-     * @return  $this
+     * @param  mixed  $job
+     * @return $this
      */
     public function appendToChain($job)
     {

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -351,7 +351,7 @@ class JobChainAddingExistingJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
-    /** @var Carbon|null  */
+    /** @var Carbon|null */
     public static $ranAt = null;
 
     public function handle()
@@ -364,7 +364,7 @@ class JobChainAddingAddedJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
-    /** @var Carbon|null  */
+    /** @var Carbon|null */
     public static $ranAt = null;
 
     public function handle()

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
@@ -211,6 +212,38 @@ class JobChainingTest extends TestCase
         $this->assertNull(JobChainingTestThirdJob::$usedQueue);
         $this->assertNull(JobChainingTestThirdJob::$usedConnection);
     }
+
+    public function testChainJobsCanBePrepended()
+    {
+        JobChainAddingPrependingJob::withChain([new JobChainAddingExistingJob])->dispatch();
+
+        $this->assertNotNull(JobChainAddingAddedJob::$ranAt);
+        $this->assertNotNull(JobChainAddingExistingJob::$ranAt);
+        $this->assertTrue(JobChainAddingAddedJob::$ranAt->isBefore(JobChainAddingExistingJob::$ranAt));
+    }
+
+    public function testChainJobsCanBePrependedWithoutExistingChain()
+    {
+        JobChainAddingPrependingJob::dispatch();
+
+        $this->assertNotNull(JobChainAddingAddedJob::$ranAt);
+    }
+
+    public function testChainJobsCanBeAppended()
+    {
+        JobChainAddingAppendingJob::withChain([new JobChainAddingExistingJob])->dispatch();
+
+        $this->assertNotNull(JobChainAddingAddedJob::$ranAt);
+        $this->assertNotNull(JobChainAddingExistingJob::$ranAt);
+        $this->assertTrue(JobChainAddingAddedJob::$ranAt->isAfter(JobChainAddingExistingJob::$ranAt));
+    }
+
+    public function testChainJobsCanBeAppendedWithoutExistingChain()
+    {
+        JobChainAddingAppendingJob::dispatch();
+
+        $this->assertNotNull(JobChainAddingAddedJob::$ranAt);
+    }
 }
 
 class JobChainingTestFirstJob implements ShouldQueue
@@ -291,5 +324,51 @@ class JobChainingTestFailingJob implements ShouldQueue
     public function handle()
     {
         $this->fail();
+    }
+}
+
+class JobChainAddingPrependingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function handle()
+    {
+        $this->prependToChain(new JobChainAddingAddedJob);
+    }
+}
+
+class JobChainAddingAppendingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function handle()
+    {
+        $this->appendToChain(new JobChainAddingAddedJob);
+    }
+}
+
+class JobChainAddingExistingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    /** @var Carbon|null  */
+    public static $ranAt = null;
+
+    public function handle()
+    {
+        static::$ranAt = now();
+    }
+}
+
+class JobChainAddingAddedJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    /** @var Carbon|null  */
+    public static $ranAt = null;
+
+    public function handle()
+    {
+        static::$ranAt = now();
     }
 }


### PR DESCRIPTION
This adds formal methods to append and prepend jobs to an existing chain.

The use case for that is whenever a job within a chain want's to enqueue jobs onto it's own chain without the need to create a new one and wait for successful execution of the "child chain".

This is technically already possible since all the needed properties and methods are public. However having formalized functions for that makes for a better DX.

Please let me know if this is a good idea or a too niche use case. In any way, I'm looking forward to your feedback!

### Practical use case

To give a clearer use case that I came across in my own work. I have a chain that (each bullet = one job):

1.  Downloads a zip file
2. Checks for zip for malware, zipbombs etc.
3. Unpacks the zip
4. Reads the contents and creates a hash over each sub folder
5. Deletes all unzipped files and the zip file itself

Here it's handy to enqueue one new job per sub folder between 4 and 5 since the hashing can take a while which might lead to timeouts. Just starting a new chain would not be a great solution since I'd need to coordinate the cleanup and exception handling all from the 4th job instead of when starting the chain initially.