### PR TITLE
[9.x] Revert "[9.x] Fix HasAttributes::mutateAttributeForArray when accessing non-cached attribute"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -667,8 +667,6 @@ trait HasAttributes
             $value = $value instanceof DateTimeInterface
                         ? $this->serializeDate($value)
                         : $value;
-        } elseif ($this->hasAttributeGetMutator($key)) {
-            $value = $this->mutateAttributeMarkedAttribute($key, $value);
         } else {
             $value = $this->mutateAttribute($key, $value);
         }


### PR DESCRIPTION
Reverts laravel/framework#42130