### PR TITLE
[9.x] Arr::forget() for nested ArrayAccess objects

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -285,7 +285,7 @@ class Arr
             while (count($parts) > 1) {
                 $part = array_shift($parts);
 
-                if (isset($array[$part]) && is_array($array[$part])) {
+                if (isset($array[$part]) && static::accessible($array[$part])) {
                     $array = &$array[$part];
                 } else {
                     continue 2;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3506,6 +3506,33 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => 'bar'], $c->all());
     }
 
+    public function testPullRemovesItemFromNestedCollection()
+    {
+        $nestedCollection = new Collection([
+            new Collection([
+                'value',
+                new Collection([
+                    'bar' => 'baz',
+                    'test' => 'value',
+                ]),
+            ]),
+            'bar',
+        ]);
+
+        $nestedCollection->pull('0.1.test');
+
+        $actualArray = $nestedCollection->toArray();
+        $expectedArray = [
+            [
+                'value',
+                ['bar' => 'baz'],
+            ],
+            'bar',
+        ];
+
+        $this->assertEquals($expectedArray, $actualArray);
+    }
+
     public function testPullReturnsDefault()
     {
         $c = new Collection([]);


### PR DESCRIPTION
Currently, calling `Collection::pull()` using a dot notatation key when dealing with nested `ArrayAccess::class` objects would result in the correct value being returned but it would not remove the key/value from the objects afterwards.
This is because the original call is forwarded to `Arr::pull()`, which calls `Arr::forget()`, and in [Arr::forget()](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/Arr.php#L288) line 288 the conditional tests only for the value being an array through `is_array`. 
Changing this part of the conditional to `Arr::accessible()` makes the method return not only the correct value but also remove the corresponding key when dealing with nested `ArrayAccess::class` objects.

If I am not mistaken this change should be fully backward compatible.

If there is anything I overlooked please let me know!

