### PR TITLE
Upgrade PHPStan to 1.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "mockery/mockery": "^1.4.4",
         "orchestra/testbench-core": "^7.1",
         "pda/pheanstalk": "^4.0",
-        "phpstan/phpstan": "^1.4.7",
+        "phpstan/phpstan": "^1.6.0",
         "phpunit/phpunit": "^9.5.8",
         "predis/predis": "^1.1.9",
         "symfony/cache": "^6.0"

--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -1,4 +1,5 @@
 parameters:
+  editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
   paths:
     - src
   level: 0
@@ -18,3 +19,5 @@ parameters:
   excludePaths:
     - "src/Illuminate/Testing/ParallelRunner.php"
     - "src/Illuminate/Testing/Constraints/ArraySubset.php"
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/phpstan.types.neon.dist
+++ b/phpstan.types.neon.dist
@@ -1,4 +1,7 @@
 parameters:
+  editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
   paths:
     - types
   level: max
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon


### PR DESCRIPTION
Upgrading PHPStan to 1.6.x can reduce memory usage by 50-70%
https://phpstan.org/blog/phpstan-1-6-0-with-conditional-return-types#:~:text=Lower%20memory%20consumption
opening-file-in-an-editor It can quickly locate problems in PHPStorm.
https://phpstan.org/user-guide/output-format#opening-file-in-an-editor