### PR TITLE
[9.x] Update Container.php

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -59,14 +59,14 @@ class Container implements ArrayAccess, ContainerContract
     protected $scopedInstances = [];
 
     /**
-     * The registered type aliases.
+     * The registered abstract type aliases.
      *
      * @var string[]
      */
     protected $aliases = [];
 
     /**
-     * The registered aliases keyed by the abstract name.
+     * The registered abstract type keyed by the alias name.
      *
      * @var array[]
      */
@@ -548,21 +548,21 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Alias a type to a different name.
      *
-     * @param  string  $abstract
      * @param  string  $alias
+     * @param  string  $abstract
      * @return void
      *
      * @throws \LogicException
      */
-    public function alias($abstract, $alias)
+    public function alias($alias, $abstract)
     {
         if ($alias === $abstract) {
             throw new LogicException("[{$abstract}] is aliased to itself.");
         }
 
-        $this->aliases[$alias] = $abstract;
+        $this->aliases[$abstract] = $alias;
 
-        $this->abstractAliases[$abstract][] = $alias;
+        $this->abstractAliases[$alias][] = $abstract;
     }
 
     /**


### PR DESCRIPTION
Some parameter names are semantically inaccurate

We should correct the naming to increase code readability

For example:

For the `alias()` method as below

It's easy to think that `$alias` stands for alias name

But `$abstract` actually stands for alias name

The reading experience was terrible, So we need to correct it

```php
/**
     * Alias a type to a different name.
     *
     * @param  string  $abstract
     * @param  string  $alias
     * @return void
     *
     * @throws \LogicException
     */
    public function alias($abstract, $alias)
    {
        if ($alias === $abstract) {
            throw new LogicException("[{$abstract}] is aliased to itself.");
        }

        $this->aliases[$alias] = $abstract;

        $this->abstractAliases[$abstract][] = $alias;
    }
```