### PR TITLE
[9.x] Support PHPStan 1.6.x when validation is extended

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -12,7 +12,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceAcceptedIf($message, $attribute, $rule, $parameters)
@@ -30,7 +30,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceDeclinedIf($message, $attribute, $rule, $parameters)
@@ -48,7 +48,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceBetween($message, $attribute, $rule, $parameters)
@@ -62,7 +62,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceDateFormat($message, $attribute, $rule, $parameters)
@@ -76,7 +76,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceDifferent($message, $attribute, $rule, $parameters)
@@ -90,7 +90,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceDigits($message, $attribute, $rule, $parameters)
@@ -104,7 +104,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceDigitsBetween($message, $attribute, $rule, $parameters)
@@ -118,7 +118,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceMin($message, $attribute, $rule, $parameters)
@@ -132,7 +132,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceMax($message, $attribute, $rule, $parameters)
@@ -146,7 +146,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceMultipleOf($message, $attribute, $rule, $parameters)
@@ -160,7 +160,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceIn($message, $attribute, $rule, $parameters)
@@ -178,7 +178,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceNotIn($message, $attribute, $rule, $parameters)
@@ -192,7 +192,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceInArray($message, $attribute, $rule, $parameters)
@@ -206,7 +206,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceRequiredArrayKeys($message, $attribute, $rule, $parameters)
@@ -224,7 +224,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceMimetypes($message, $attribute, $rule, $parameters)
@@ -238,7 +238,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceMimes($message, $attribute, $rule, $parameters)
@@ -252,7 +252,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceRequiredWith($message, $attribute, $rule, $parameters)
@@ -266,7 +266,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceRequiredWithAll($message, $attribute, $rule, $parameters)
@@ -280,7 +280,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceRequiredWithout($message, $attribute, $rule, $parameters)
@@ -294,7 +294,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceRequiredWithoutAll($message, $attribute, $rule, $parameters)
@@ -308,7 +308,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceSize($message, $attribute, $rule, $parameters)
@@ -322,7 +322,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
@@ -340,7 +340,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
@@ -358,7 +358,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
@@ -376,7 +376,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
@@ -394,7 +394,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
@@ -412,7 +412,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceRequiredUnless($message, $attribute, $rule, $parameters)
@@ -434,7 +434,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceProhibitedIf($message, $attribute, $rule, $parameters)
@@ -452,7 +452,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceProhibitedUnless($message, $attribute, $rule, $parameters)
@@ -474,7 +474,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceProhibits($message, $attribute, $rule, $parameters)
@@ -488,7 +488,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceSame($message, $attribute, $rule, $parameters)
@@ -502,7 +502,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceBefore($message, $attribute, $rule, $parameters)
@@ -520,7 +520,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceBeforeOrEqual($message, $attribute, $rule, $parameters)
@@ -534,7 +534,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceAfter($message, $attribute, $rule, $parameters)
@@ -548,7 +548,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceAfterOrEqual($message, $attribute, $rule, $parameters)
@@ -562,7 +562,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceDateEquals($message, $attribute, $rule, $parameters)
@@ -576,7 +576,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceDimensions($message, $attribute, $rule, $parameters)
@@ -598,7 +598,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceEndsWith($message, $attribute, $rule, $parameters)
@@ -616,7 +616,7 @@ trait ReplacesAttributes
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return string
      */
     protected function replaceStartsWith($message, $attribute, $rule, $parameters)

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -143,7 +143,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateBefore($attribute, $value, $parameters)
@@ -158,7 +158,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateBeforeOrEqual($attribute, $value, $parameters)
@@ -173,7 +173,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateAfter($attribute, $value, $parameters)
@@ -188,7 +188,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateAfterOrEqual($attribute, $value, $parameters)
@@ -203,7 +203,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @param  string  $operator
      * @return bool
      */
@@ -354,7 +354,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateArray($attribute, $value, $parameters = [])
@@ -375,7 +375,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateRequiredArrayKeys($attribute, $value, $parameters)
@@ -398,7 +398,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateBetween($attribute, $value, $parameters)
@@ -441,7 +441,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     protected function validateCurrentPassword($attribute, $value, $parameters)
@@ -489,7 +489,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateDateFormat($attribute, $value, $parameters)
@@ -516,7 +516,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateDateEquals($attribute, $value, $parameters)
@@ -531,7 +531,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateDifferent($attribute, $value, $parameters)
@@ -556,7 +556,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateDigits($attribute, $value, $parameters)
@@ -572,7 +572,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateDigitsBetween($attribute, $value, $parameters)
@@ -590,7 +590,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateDimensions($attribute, $value, $parameters)
@@ -620,7 +620,7 @@ trait ValidatesAttributes
     /**
      * Test if the given width and height fail any conditions.
      *
-     * @param  array  $parameters
+     * @param  array<string,string>  $parameters
      * @param  int  $width
      * @param  int  $height
      * @return bool
@@ -638,7 +638,7 @@ trait ValidatesAttributes
     /**
      * Determine if the given parameters fail a dimension ratio check.
      *
-     * @param  array  $parameters
+     * @param  array<string,string>  $parameters
      * @param  int  $width
      * @param  int  $height
      * @return bool
@@ -663,7 +663,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateDistinct($attribute, $value, $parameters)
@@ -722,7 +722,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateEmail($attribute, $value, $parameters)
@@ -761,7 +761,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateExists($attribute, $value, $parameters)
@@ -789,7 +789,7 @@ trait ValidatesAttributes
      * @param  string  $table
      * @param  string  $column
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return int
      */
     protected function getExistCount($connection, $table, $column, $value, $parameters)
@@ -816,7 +816,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateUnique($attribute, $value, $parameters)
@@ -860,7 +860,7 @@ trait ValidatesAttributes
      * Get the excluded ID column and value for the unique rule.
      *
      * @param  string|null  $idColumn
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return array
      */
     protected function getUniqueIds($idColumn, $parameters)
@@ -896,7 +896,7 @@ trait ValidatesAttributes
     /**
      * Get the extra conditions for a unique rule.
      *
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return array
      */
     protected function getUniqueExtra($parameters)
@@ -937,7 +937,7 @@ trait ValidatesAttributes
     /**
      * Get the column name for an exists / unique query.
      *
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @param  string  $attribute
      * @return bool
      */
@@ -1015,7 +1015,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateGt($attribute, $value, $parameters)
@@ -1050,7 +1050,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateLt($attribute, $value, $parameters)
@@ -1085,7 +1085,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateGte($attribute, $value, $parameters)
@@ -1120,7 +1120,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateLte($attribute, $value, $parameters)
@@ -1167,7 +1167,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateIn($attribute, $value, $parameters)
@@ -1190,7 +1190,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateInArray($attribute, $value, $parameters)
@@ -1295,7 +1295,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateMax($attribute, $value, $parameters)
@@ -1314,7 +1314,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateMimes($attribute, $value, $parameters)
@@ -1339,7 +1339,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateMimetypes($attribute, $value, $parameters)
@@ -1361,7 +1361,7 @@ trait ValidatesAttributes
      * Check if PHP uploads are explicitly allowed.
      *
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     protected function shouldBlockPhpUpload($value, $parameters)
@@ -1384,7 +1384,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateMin($attribute, $value, $parameters)
@@ -1399,7 +1399,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateMultipleOf($attribute, $value, $parameters)
@@ -1434,7 +1434,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateNotIn($attribute, $value, $parameters)
@@ -1471,7 +1471,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateRegex($attribute, $value, $parameters)
@@ -1490,7 +1490,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateNotRegex($attribute, $value, $parameters)
@@ -1728,7 +1728,7 @@ trait ValidatesAttributes
     /**
      * Prepare the values and the other value for validation.
      *
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return array
      */
     public function parseDependentRuleParameters($parameters)
@@ -1898,7 +1898,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateSame($attribute, $value, $parameters)
@@ -1915,7 +1915,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateSize($attribute, $value, $parameters)
@@ -1942,7 +1942,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateStartsWith($attribute, $value, $parameters)
@@ -1955,7 +1955,7 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return bool
      */
     public function validateEndsWith($attribute, $value, $parameters)
@@ -2104,7 +2104,7 @@ trait ValidatesAttributes
     /**
      * Parse named parameters to $key => $value items.
      *
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @return array
      */
     public function parseNamedParameters($parameters)
@@ -2122,7 +2122,7 @@ trait ValidatesAttributes
      * Require a certain number of parameters to be present.
      *
      * @param  int  $count
-     * @param  array  $parameters
+     * @param  array<int,string>  $parameters
      * @param  string  $rule
      * @return void
      *


### PR DESCRIPTION
I extended Laravel Validation and implemented some validation rule that fit my business. When I upgraded PHPStan 1.6.1, I encountered the following problems.

### PHPStan 1.6.x error message:
`No value type specified in iterable type`
When I solve this `No value type specified in iterable type` PHPStan error in my code, it will trigger another error,
`Parameter #4 $parameters (array<string>) of method                     
UserExtends\Illuminate\Validation\Validator::replaceRequiredIf()      
should be contravariant with parameter $parameters (array) of method   
Illuminate\Validation\Validator::replaceRequiredIf() `

 So I think this PR should specify  key and value type of array.