### PR TITLE
Enabled configuring the composer path in the app.php config

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1411,11 +1411,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
             return $this->namespace;
         }
 
-        $composer = json_decode(file_get_contents($this->basePath('composer.json')), true);
+        $config = include $this->configPath('app.php');
+        $composerPath = $this->basePath($config['composer_path'] ?? '');
+        $composer = json_decode(file_get_contents($composerPath.DIRECTORY_SEPARATOR.'composer.json'), true);
 
         foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
             foreach ((array) $path as $pathChoice) {
-                if (realpath($this->path()) === realpath($this->basePath($pathChoice))) {
+                if (realpath($this->path()) === realpath($composerPath.DIRECTORY_SEPARATOR.$pathChoice)) {
                     return $this->namespace = $namespace;
                 }
             }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -378,9 +378,11 @@ class FoundationApplicationTest extends TestCase
     {
         $app1 = new Application(realpath(__DIR__.'/fixtures/laravel1'));
         $app2 = new Application(realpath(__DIR__.'/fixtures/laravel2'));
+        $app3 = new Application(realpath(__DIR__.'/fixtures/laravel3'));
 
         $this->assertSame('Laravel\\One\\', $app1->getNamespace());
         $this->assertSame('Laravel\\Two\\', $app2->getNamespace());
+        $this->assertSame('Laravel\\Three\\', $app3->getNamespace());
     }
 
     public function testCachePathsResolveToBootstrapCacheDirectory()

--- a/tests/Foundation/fixtures/composer.json
+++ b/tests/Foundation/fixtures/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Laravel\\Three\\": "laravel3/app/"
+        }
+    }
+}

--- a/tests/Foundation/fixtures/laravel1/config/app.php
+++ b/tests/Foundation/fixtures/laravel1/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'composer_path' => ''
+];

--- a/tests/Foundation/fixtures/laravel2/config/app.php
+++ b/tests/Foundation/fixtures/laravel2/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'composer_path' => ''
+];

--- a/tests/Foundation/fixtures/laravel3/config/app.php
+++ b/tests/Foundation/fixtures/laravel3/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'composer_path' => '..'
+];


### PR DESCRIPTION
Hi all, 

this is my first pull request ever and while I have been using Laravel for some time, I have a limited knowledge of the framework itself. However, I did not just want to request something without a suggestion. 

Assuming a project as a structure like so (or any other where composer.json does not rest in the Laravel base path) 

.../composer.json
.../src/Application/Domain
.../src/Presentation/Backend
.../src/Presentation/Frontend
.../src/Infrastructure/Laravel 

It is generally possible to declare blade, js, ... file in the Presentation folders and configure the config/view.php to find them or webpack/mix to compile to the desired folders in /public. Also the scripts in the composer file can be easily adjusted to the individual needs. 

However, some artisan commands, e.g. route:list will not work since they will use the getNamespace() function in Illuminate/Foundation/Application which assumes composer.json to be at the base path of the Laravel installation. 

To my knowledge this cannot be configured. 

Leaving composer.json in the Laravel folder is not an option, since for example Forge will assume a composer at the "true project root". 

My suggested solution enables a developer to add a composer_path variable to the config/app.php, specifying the relative path to the composer file from the Laravel base path. I modified the test for the method to include such a scenario. The namespace will be discovered correctly and the artisan commands will work. 

The proposed implementation should not harm any existing installations, therefore I requested to merge with 9.x

I am a bit afraid that the proposed solution is "hacky" since I do not fully understand how the Application class is used. 
For example, it seems like an alternative to implement a property $composerPath and corresponding accessors comparable to useStoragePath, useDatabasePath, ... but I don't understand how/when they would be set. 
Of course I am willing to learn and improve the PR. 

Also I am not aware if there are other situations where the assumption of composer.json being at the Laravel base path is being made. 

Thank you! 
