### PR TITLE
[9.x] Update `schedule:list` colouring output

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -113,7 +113,7 @@ class ScheduleListCommand extends Command
             ));
 
             // Highlight the parameters...
-            $command = preg_replace("#(=['\"]?)([^'\"]+)(['\"]?)#", '$1<fg=yellow;options=bold>$2</>$3', $command);
+            $command = preg_replace("#(php artisan [\w\-:]+) (.+)#", '$1 <fg=yellow;options=bold>$2</>', $command);
 
             return [sprintf(
                 '  <fg=yellow>%s</>  %s<fg=#6C7280>%s %s%s %s</>',


### PR DESCRIPTION
I noticed that the colouring of the parameters was slightly off for the `php artisan schedule:list` command. I changed the regex to mark everything yellow after the command name. Note that I am assuming that command names consist of the following syntax: `[\w\-:]+`, meaning: word-characters (i.e. `[a-zA-Z0-9_]`), dashes `-` and/or colon `:`.

Before and after:
![Before & After](https://i.imgur.com/95mfYCF.png)

I guess it would be nice to highlight `3` and `60` separately but that increases the complexity for little benefit.

