### PR TITLE
[9.x] Improve FormRequest stub type annotation

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -19,7 +19,7 @@ class {{ class }} extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function rules()
     {


### PR DESCRIPTION
PHPStan error message:
```
Method App\Http\Requests\RegisterRequest::rules() return type has no value type specified in iterable type array.
💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
```