### PR TITLE
[9.x] Add closure based exceptions testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Closure;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Testing\Assert;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -16,6 +18,63 @@ trait InteractsWithExceptionHandling
      * @var \Illuminate\Contracts\Debug\ExceptionHandler|null
      */
     protected $originalExceptionHandler;
+
+    /**
+     * Assert that the given test throws an exception with the given message.
+     *
+     * @param  \Closure  $test
+     * @param  class-string<\Throwable>  $expectedClass
+     * @param  string|null  $expectedMessage
+     * @return $this
+     */
+    protected function assertThrows(Closure $test, string $expectedClass = Throwable::class, ?string $expectedMessage = null)
+    {
+        try {
+            $test();
+            $thrown = false;
+        } catch (Throwable $exception) {
+            $thrown = $exception instanceof $expectedClass;
+            $actualMessage = $exception->getMessage();
+        }
+
+        if (! $thrown) {
+            Assert::fail(
+                sprintf(
+                    'Failed asserting that exception of type "%s" is thrown.',
+                    $expectedClass
+                )
+            );
+        }
+
+        if (isset($expectedMessage)) {
+            if (! isset($actualMessage)) {
+                Assert::fail(
+                    sprintf(
+                        'Failed asserting that exception of type "%s" with message "%s" is thrown.',
+                        $expectedClass,
+                        $expectedMessage
+                    )
+                );
+            } else {
+                Assert::assertEquals($expectedMessage, $actualMessage);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given test throws an exception with the given message.
+     *
+     * @param  \Closure  $test
+     * @param  string  $expectedMessage
+     * @param  class-string<\Throwable>  $expectedClass
+     * @return $this
+     */
+    protected function assertThrowsWithMessage(Closure $test, string $expectedMessage, string $expectedClass = Throwable::class)
+    {
+        return $this->assertThrows($test, (string) $expectedClass, $expectedMessage);
+    }
 
     /**
      * Restore exception handling.

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -20,63 +20,6 @@ trait InteractsWithExceptionHandling
     protected $originalExceptionHandler;
 
     /**
-     * Assert that the given test throws an exception with the given message.
-     *
-     * @param  \Closure  $test
-     * @param  class-string<\Throwable>  $expectedClass
-     * @param  string|null  $expectedMessage
-     * @return $this
-     */
-    protected function assertThrows(Closure $test, string $expectedClass = Throwable::class, ?string $expectedMessage = null)
-    {
-        try {
-            $test();
-            $thrown = false;
-        } catch (Throwable $exception) {
-            $thrown = $exception instanceof $expectedClass;
-            $actualMessage = $exception->getMessage();
-        }
-
-        if (! $thrown) {
-            Assert::fail(
-                sprintf(
-                    'Failed asserting that exception of type "%s" is thrown.',
-                    $expectedClass
-                )
-            );
-        }
-
-        if (isset($expectedMessage)) {
-            if (! isset($actualMessage)) {
-                Assert::fail(
-                    sprintf(
-                        'Failed asserting that exception of type "%s" with message "%s" is thrown.',
-                        $expectedClass,
-                        $expectedMessage
-                    )
-                );
-            } else {
-                Assert::assertEquals($expectedMessage, $actualMessage);
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Assert that the given test throws an exception with the given message.
-     *
-     * @param  \Closure  $test
-     * @param  string  $expectedMessage
-     * @param  class-string<\Throwable>  $expectedClass
-     * @return $this
-     */
-    protected function assertThrowsWithMessage(Closure $test, string $expectedMessage, string $expectedClass = Throwable::class)
-    {
-        return $this->assertThrows($test, (string) $expectedClass, $expectedMessage);
-    }
-
-    /**
      * Restore exception handling.
      *
      * @return $this
@@ -123,8 +66,7 @@ trait InteractsWithExceptionHandling
             $this->originalExceptionHandler = app(ExceptionHandler::class);
         }
 
-        $this->app->instance(ExceptionHandler::class, new class($this->originalExceptionHandler, $except) implements ExceptionHandler
-        {
+        $this->app->instance(ExceptionHandler::class, new class($this->originalExceptionHandler, $except) implements ExceptionHandler {
             protected $except;
             protected $originalHandler;
 
@@ -203,6 +145,52 @@ trait InteractsWithExceptionHandling
                 (new ConsoleApplication)->renderThrowable($e, $output);
             }
         });
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given callback throws an exception with the given message when invoked.
+     *
+     * @param  \Closure  $test
+     * @param  class-string<\Throwable>  $expectedClass
+     * @param  string|null  $expectedMessage
+     * @return $this
+     */
+    protected function assertThrows(Closure $test, string $expectedClass = Throwable::class, ?string $expectedMessage = null)
+    {
+        try {
+            $test();
+
+            $thrown = false;
+        } catch (Throwable $exception) {
+            $thrown = $exception instanceof $expectedClass;
+
+            $actualMessage = $exception->getMessage();
+        }
+
+        if (! $thrown) {
+            Assert::fail(
+                sprintf(
+                    'Failed asserting that exception of type "%s" is thrown.',
+                    $expectedClass
+                )
+            );
+        }
+
+        if (isset($expectedMessage)) {
+            if (! isset($actualMessage)) {
+                Assert::fail(
+                    sprintf(
+                        'Failed asserting that exception of type "%s" with message "%s" is thrown.',
+                        $expectedClass,
+                        $expectedMessage
+                    )
+                );
+            } else {
+                Assert::assertStringContainsString($expectedMessage, $actualMessage);
+            }
+        }
 
         return $this;
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -419,45 +419,6 @@ class FoundationExceptionsHandlerTest extends TestCase
             Assert::fail('assertThrows failed: non matching message are thrown.');
         }
     }
-
-    public function testAssertExceptionIsThrownWithMessage()
-    {
-        $this->assertThrowsWithMessage(function () {
-            throw new Exception('Some message.');
-        }, 'Some message.');
-        $this->assertThrowsWithMessage(function () {
-            throw new CustomException('Some message.');
-        }, 'Some message.');
-        $this->assertThrowsWithMessage(function () {
-            throw new CustomException('Some message.');
-        }, 'Some message.', CustomException::class);
-
-        try {
-            $this->assertThrowsWithMessage(function () {
-                throw new Exception('Some message.');
-            }, 'Some message.', CustomException::class);
-            $testFailed = true;
-        } catch (AssertionFailedError $exception) {
-            $testFailed = false;
-        }
-
-        if ($testFailed) {
-            Assert::fail('assertThrowsWithMessage failed: non matching exceptions are thrown.');
-        }
-
-        try {
-            $this->assertThrowsWithMessage(function () {
-                throw new Exception('Some message.');
-            }, 'Other message.', Exception::class);
-            $testFailed = true;
-        } catch (AssertionFailedError $exception) {
-            $testFailed = false;
-        }
-
-        if ($testFailed) {
-            Assert::fail('assertThrowsWithMessage failed: non matching message are thrown.');
-        }
-    }
 }
 
 class CustomException extends Exception

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -10,17 +10,20 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithExceptionHandling;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\MessageBag;
+use Illuminate\Testing\Assert;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use InvalidArgumentException;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use OutOfRangeException;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -34,6 +37,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 class FoundationExceptionsHandlerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
+    use InteractsWithExceptionHandling;
 
     protected $config;
 
@@ -366,6 +370,93 @@ class FoundationExceptionsHandlerTest extends TestCase
         };
 
         $this->assertNull($handler->getErrorView(new HttpException(404)));
+    }
+
+    public function testAssertExceptionIsThrown()
+    {
+        $this->assertThrows(function () {
+            throw new Exception;
+        });
+        $this->assertThrows(function () {
+            throw new CustomException;
+        });
+        $this->assertThrows(function () {
+            throw new CustomException;
+        }, CustomException::class);
+        $this->assertThrows(function () {
+            throw new Exception('Some message.');
+        }, expectedMessage: 'Some message.');
+        $this->assertThrows(function () {
+            throw new CustomException('Some message.');
+        }, expectedMessage: 'Some message.');
+        $this->assertThrows(function () {
+            throw new CustomException('Some message.');
+        }, expectedClass: CustomException::class, expectedMessage: 'Some message.');
+
+        try {
+            $this->assertThrows(function () {
+                throw new Exception;
+            }, CustomException::class);
+            $testFailed = true;
+        } catch (AssertionFailedError $exception) {
+            $testFailed = false;
+        }
+
+        if ($testFailed) {
+            Assert::fail('assertThrows failed: non matching exceptions are thrown.');
+        }
+
+        try {
+            $this->assertThrows(function () {
+                throw new Exception('Some message.');
+            }, expectedClass: Exception::class, expectedMessage: 'Other message.');
+            $testFailed = true;
+        } catch (AssertionFailedError $exception) {
+            $testFailed = false;
+        }
+
+        if ($testFailed) {
+            Assert::fail('assertThrows failed: non matching message are thrown.');
+        }
+    }
+
+    public function testAssertExceptionIsThrownWithMessage()
+    {
+        $this->assertThrowsWithMessage(function () {
+            throw new Exception('Some message.');
+        }, 'Some message.');
+        $this->assertThrowsWithMessage(function () {
+            throw new CustomException('Some message.');
+        }, 'Some message.');
+        $this->assertThrowsWithMessage(function () {
+            throw new CustomException('Some message.');
+        }, 'Some message.', CustomException::class);
+
+        try {
+            $this->assertThrowsWithMessage(function () {
+                throw new Exception('Some message.');
+            }, 'Some message.', CustomException::class);
+            $testFailed = true;
+        } catch (AssertionFailedError $exception) {
+            $testFailed = false;
+        }
+
+        if ($testFailed) {
+            Assert::fail('assertThrowsWithMessage failed: non matching exceptions are thrown.');
+        }
+
+        try {
+            $this->assertThrowsWithMessage(function () {
+                throw new Exception('Some message.');
+            }, 'Other message.', Exception::class);
+            $testFailed = true;
+        } catch (AssertionFailedError $exception) {
+            $testFailed = false;
+        }
+
+        if ($testFailed) {
+            Assert::fail('assertThrowsWithMessage failed: non matching message are thrown.');
+        }
     }
 }
 


### PR DESCRIPTION
Hi all,

This adds new ways to test exception handling using closures.

```php
// Ensure that an exception is thrown
$this->assertThrows(fn () => throw Exception(''));

// Ensure that a specific type of exception is thrown
$this->assertThrows(
    fn () => (new SomeActionThatThrowsExceptions)->execute(), 
    CustomException::class
);

// Ensure that an exception is thrown with a specific message
$this->assertThrows(fn () => throw Exception('My message'), Exception::class, 'My message');

// Ensure that no exceptions are thrown
$this->assertDoesntThrow(
    fn () => (new SomeActionThatWorksFine)->execute()
);

// Ensure that a specific type of exception is thrown with the given message
$this->assertThrowsWithMessage(
    fn () => (new SomeActionThatThrowsExceptionsWithCustomMessage)->execute(), 
    'My custom exception message'
);

```