### PR TITLE
Fixes helpers request return PHPDoc

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -636,7 +636,7 @@ if (! function_exists('request')) {
      *
      * @param  array|string|null  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return mixed|\Illuminate\Http\Request
      */
     function request($key = null, $default = null)
     {


### PR DESCRIPTION
Adds \Illuminate\Http\Request to request() in PHPDoc return type.
because i need my IDE to suggest autocompletion.
eg:  request()->ip()

Reference documentation:
[PHPDoc Definition of a 'Type'](https://docs.phpdoc.org/3.0/guide/references/phpdoc/types.html#multiple-types)
Many tags use a Type as part of their definition (such as the @return tag). These types differ from the official PHP definition to be able to represent all kinds of data.
Please note that mixed is also a single type and with this keyword it is possible to indicate that each array element contains any possible type.