### PR TITLE
[9.x] Ensure middleware group exists

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -946,6 +946,19 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Ensure a middleware group is defined.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    protected function ensureMiddlewareGroup($name)
+    {
+        if (! $this->hasMiddlewareGroup($name)) {
+            $this->middlewareGroups[$name] = [];
+        }
+    }
+
+    /**
      * Register a group of middleware.
      *
      * @param  string  $name
@@ -954,6 +967,8 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function middlewareGroup($name, array $middleware)
     {
+        $this->ensureMiddlewareGroup($name);
+
         foreach ($middleware as $m) {
             $this->pushMiddlewareToGroup($name, $m);
         }
@@ -972,7 +987,9 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function prependMiddlewareToGroup($group, $middleware)
     {
-        if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group])) {
+        $this->ensureMiddlewareGroup($group);
+
+        if (! in_array($middleware, $this->middlewareGroups[$group])) {
             array_unshift($this->middlewareGroups[$group], $middleware);
         }
 
@@ -990,9 +1007,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function pushMiddlewareToGroup($group, $middleware)
     {
-        if (! array_key_exists($group, $this->middlewareGroups)) {
-            $this->middlewareGroups[$group] = [];
-        }
+        $this->ensureMiddlewareGroup($group);
 
         if (! in_array($middleware, $this->middlewareGroups[$group])) {
             $this->middlewareGroups[$group][] = $middleware;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #42159 

After PR #42004 the behavior of method `Illuminate\Routing\Router@middlewareGroup` was slightly changed, as before it would define a middleware group even if the group was empty, e.g. the group had an empty array of middleware.

After the aforementioned PR, a middleware group with an empty array does not actually add a corresponding middleware group to the stack, thus when running a route with that empty middleware group, the dispatcher would try to instantiate a middleware named as the group which will fail, as reported in #42159 .

This PR:

- Adds a new protected method named `ensureMiddlewareGroup`, which will check if a middleware group is defined, and if not will add it.
- Modify the methods: `middlewareGroup`, `prependMiddlewareToGroup` and `pushMiddlewareToGroup` to use the method above


To reproduce the error described in issue #42159 one could use the following steps:

1. Create a new laravel app
2. Ensure it uses Laravel version 9.10.0
3. Add an empty middleware group to the app's HTTP kernel (for example, named `public`)
4. Define a route that uses the middleware defined as above
5. Access the defined route through the browser

After applying the changes proposed in this PR, the route will work.
