### PR TITLE
[9.x] Add default value to RedisManager connections

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -47,9 +47,9 @@ class RedisManager implements Factory
     /**
      * The Redis connections.
      *
-     * @var mixed
+     * @var array
      */
-    protected $connections;
+    protected $connections = [];
 
     /**
      * Indicates whether event dispatcher is set on connections.


### PR DESCRIPTION
Everywhere in the codebase RedisManager's `$connections` property is used as an array. But it doesn't even have a default value (so it's null). The getter `getConnections()` has an array return-type hint, but still this method may return uninitialised null value
