### PR TITLE
[9.x] Update PHPDoc for the paginator interface

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -15,7 +15,7 @@ interface Paginator
     /**
      * Add a set of query string values to the paginator.
      *
-     * @param  array|string  $key
+     * @param  array|string|null  $key
      * @param  string|null  $value
      * @return $this
      */
@@ -25,7 +25,7 @@ interface Paginator
      * Get / set the URL fragment to be appended to URLs.
      *
      * @param  string|null  $fragment
-     * @return $this|string
+     * @return $this|string|null
      */
     public function fragment($fragment = null);
 


### PR DESCRIPTION
If you change from `Illuminate\Pagination\CursorPaginator` to `Illuminate\Pagination\LengthAwarePaginator`. 
The IDE warns you that it is not allowed to pass null values in the appends and fragment function.

The `Illuminate\Pagination\LengthAwarePaginator` extends the `Illuminate\Pagination\AbstractPaginator`.
The `Illuminate\Pagination\AbstractPaginator` allows null values.

https://github.com/laravel/framework/blob/9.x/src/Illuminate\Pagination\AbstractPaginator.php#L189-L224

But the `Illuminate\Contracts\Pagination\Paginator` interface does not allow this.

https://github.com/laravel/framework/blob/9.x/src/Illuminate\Contracts\Pagination\Paginator.php#L15-L30
