### PR TITLE
[9.x] Add the functionality to create signed routes with actions

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -343,10 +343,10 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Create a signed route URL for an action.
      *
-     * @param string|array $name
-     * @param mixed $parameters
-     * @param \DateTimeInterface|\DateInterval|int|null $expiration
-     * @param bool $absolute
+     * @param  string|array  $name
+     * @param  mixed  $parameters
+     * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
+     * @param  bool  $absolute
      * @return string
      */
     public function signedRouteForAction(
@@ -388,14 +388,14 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      *  Encapsulation of reused parameter logic for creating signed routes.
      *
-     * @param mixed $parameters
-     * @param \DateTimeInterface|\DateInterval|int|null $expiration
+     * @param  mixed  $parameters
+     * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
      * @return array
      */
     protected function validateAndPrepareSignedRouteParameters(
         mixed $parameters,
         \DateTimeInterface|\DateInterval|int|null $expiration = null
-    ) : array {
+    ): array {
         $this->ensureSignedRouteParametersAreNotReserved(
             $parameters = Arr::wrap($parameters)
         );
@@ -412,7 +412,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Encapsulation of reused signature hash logic for creating signed routes.
      *
-     * @param string $url
+     * @param string  $url
      * @return string
      */
     protected function createSignatureRouteParameterForUrl(string $url): string
@@ -440,17 +440,17 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Create a temporary signed route URL for an action.
      *
-     * @param string|array $name
-     * @param \DateTimeInterface|\DateInterval|int $expiration
-     * @param mixed $parameters
-     * @param bool $absolute
+     * @param  string|array  $name
+     * @param  \DateTimeInterface|\DateInterval|int  $expiration
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
      * @return string
      */
     public function temporarySignedRouteForAction(
-        string|array                         $name,
+        string|array $name,
         \DateTimeInterface|\DateInterval|int $expiration,
-        mixed                                $parameters = [],
-        bool                                 $absolute = true
+        mixed $parameters = [],
+        bool $absolute = true
     ): string {
         return $this->signedRouteForAction($name, $parameters, $expiration, $absolute);
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -421,7 +421,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         return hash_hmac('sha256', $url, $key);
     }
-    
+
     /**
      * Create a temporary signed route URL for a named route.
      *

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -349,12 +349,8 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  bool  $absolute
      * @return string
      */
-    public function signedRouteForAction(
-        string|array $name,
-        mixed $parameters = [],
-        \DateTimeInterface|\DateInterval|int|null $expiration = null,
-        bool $absolute = true,
-    ): string {
+    public function signedRouteForAction($name, $parameters = [], $expiration = null, $absolute = true)
+    {
         $preaperedParameters = $this->validateAndPrepareSignedRouteParameters($parameters, $expiration);
 
         return $this->action($name, $preaperedParameters + [
@@ -392,10 +388,8 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
      * @return array
      */
-    protected function validateAndPrepareSignedRouteParameters(
-        mixed $parameters,
-        \DateTimeInterface|\DateInterval|int|null $expiration = null
-    ): array {
+    protected function validateAndPrepareSignedRouteParameters($parameters, $expiration = null)
+    {
         $this->ensureSignedRouteParametersAreNotReserved(
             $parameters = Arr::wrap($parameters)
         );
@@ -415,7 +409,7 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  string  $url
      * @return string
      */
-    protected function createSignatureRouteParameterForUrl(string $url): string
+    protected function createSignatureRouteParameterForUrl($url): string
     {
         $key = call_user_func($this->keyResolver);
 
@@ -445,12 +439,8 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  bool  $absolute
      * @return string
      */
-    public function temporarySignedRouteForAction(
-        string|array $name,
-        \DateTimeInterface|\DateInterval|int $expiration,
-        mixed $parameters = [],
-        bool $absolute = true
-    ): string {
+    public function temporarySignedRouteForAction($name, $expiration, $parameters = [], $absolute = true)
+    {
         return $this->signedRouteForAction($name, $parameters, $expiration, $absolute);
     }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -412,7 +412,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Encapsulation of reused signature hash logic for creating signed routes.
      *
-     * @param string  $url
+     * @param  string  $url
      * @return string
      */
     protected function createSignatureRouteParameterForUrl(string $url): string

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -421,8 +421,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         return hash_hmac('sha256', $url, $key);
     }
-
-
+    
     /**
      * Create a temporary signed route URL for a named route.
      *


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
# Add the functionality to create signed routes with actions

## Purpose

Currently it is only possible to create `signed routes` and `temporary signed routes` by using the route name.
This PR adds the possibility to create those routes by using `actions`

As our company relies heavily on actions for routing we thought that others might also benefit from this functionality.

## Implementation

The implementation is heavily based on the given logic of the UrlGenerator->signedRouter function
Some of the code was encapsulated to avoid duplication. I tried my best to find a reasonable naming :)

For the new functions I added strict typing but, kept the old methods params as is for compatibility reasons.

The tests are also heavily based on the signedRoute logic