### PR TITLE
[9.x] Apply same syntax of startsWith on endsWith

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -259,10 +259,7 @@ class Str
     public static function endsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if (
-                $needle !== '' && $needle !== null
-                && str_ends_with($haystack, $needle)
-            ) {
+            if ((string) $needle !== '' && str_ends_with($haystack, $needle)) {
                 return true;
             }
         }


### PR DESCRIPTION
Hey guys, this is my first time ever contributing to an oss project. I've been looking for the first project and recently have chosen Laravel :)

There are two related functions, `startsWith()` and `endsWith()`, with quite similar behavior. Despite that, the syntax on the conditional is a bit different.

This PR improves the `endsWith()` using the same syntax on the `startsWith()` conditional.

```php
// Illuminate/Support/Str.php:902
if ((string) $needle !== '' && str_starts_with($haystack, $needle)) {
```