### PR TITLE
[9.x] Assert redirect parameters

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -333,10 +333,11 @@ EOF;
     /**
      * Assert whether the redirect response has a query parameter with a given value
      *
+     * @param  mixed   $value
      * @param  string  $parameterName
      * @return $this
      */
-    public function assertRedirectQueryParameterEquals($parameterName, $value)
+    public function assertRedirectQueryParameterEquals($value, $parameterName)
     {
         PHPUnit::assertTrue(
             $this->isRedirect(),

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -307,6 +307,54 @@ EOF;
     }
 
     /**
+     * Assert whether the redirect response has a non-null query parameter
+     *
+     * @param  string  $parameterName
+     * @return $this
+     */
+    public function assertRedirectQueryParameterNotNull($parameterName)
+    {
+        PHPUnit::assertTrue(
+            $this->isRedirect(),
+            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
+        );
+
+        $location = $this->headers->get('location');
+        $queryString = parse_url($location, PHP_URL_QUERY);
+        $parameters = [];
+        parse_str($queryString, $parameters);
+
+        PHPUnit::assertArrayHasKey($parameterName, $parameters, "Query string does not contain {$parameterName} : {$location}");
+        PHPUnit::assertNotNull($parameters[$parameterName], "Query string {$parameterName} is null : {$location}");
+
+        return $this;
+    }
+
+    /**
+     * Assert whether the redirect response has a query parameter with a given value
+     *
+     * @param  string  $parameterName
+     * @return $this
+     */
+    public function assertRedirectQueryParameterEquals($parameterName, $value)
+    {
+        PHPUnit::assertTrue(
+            $this->isRedirect(),
+            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
+        );
+
+        $location = $this->headers->get('location');
+        $queryString = parse_url($location, PHP_URL_QUERY);
+        $parameters = [];
+        parse_str($queryString, $parameters);
+
+        PHPUnit::assertArrayHasKey($parameterName, $parameters, "Query string does not contain {$parameterName} : {$location}");
+        PHPUnit::assertEquals($parameters[$parameterName], $value, "Query string {$parameterName} is does not match {$value} : {$location}");
+
+        return $this;
+    }
+
+    /**
      * Assert whether the response is redirecting to a given signed route.
      *
      * @param  string|null  $name

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -307,7 +307,7 @@ EOF;
     }
 
     /**
-     * Assert whether the redirect response has a non-null query parameter
+     * Assert whether the redirect response has a non-null query parameter.
      *
      * @param  string  $parameterName
      * @return $this
@@ -331,9 +331,9 @@ EOF;
     }
 
     /**
-     * Assert whether the redirect response has a query parameter with a given value
+     * Assert whether the redirect response has a query parameter with a given value.
      *
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  string  $parameterName
      * @return $this
      */

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1643,6 +1643,54 @@ class TestResponseTest extends TestCase
         $response->assertLocation('https://foo.net');
     }
 
+    public function testAssertRedirectQueryParameterEquals()
+    {
+        app()->instance('url', $url = new UrlGenerator(new RouteCollection(), new Request()));
+
+        $response = TestResponse::fromBaseResponse(
+            (new RedirectResponse($url->to('https://foo.com?foo=bar')))
+        );
+        $response->assertRedirectQueryParameterEquals('foo', 'bar');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $response = TestResponse::fromBaseResponse(
+            (new RedirectResponse($url->to('https://foo.com?foo=baz')))
+        );
+        $response->assertRedirectQueryParameterEquals('foo', 'bar');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $response = TestResponse::fromBaseResponse(
+            (new RedirectResponse($url->to('https://foo.com?bar=baz')))
+        );
+        $response->assertRedirectQueryParameterEquals('foo', 'bar');
+    }
+
+    public function testAssertRedirectQueryParameterNotNull()
+    {
+        app()->instance('url', $url = new UrlGenerator(new RouteCollection(), new Request()));
+
+        $response = TestResponse::fromBaseResponse(
+            (new RedirectResponse($url->to('https://foo.com?foo=bar')))
+        );
+        $response->assertRedirectQueryParameterNotNull('foo');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $response = TestResponse::fromBaseResponse(
+            (new RedirectResponse($url->to('https://foo.com?foo=')))
+        );
+        $response->assertRedirectQueryParameterNotNull('foo');
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $response = TestResponse::fromBaseResponse(
+            (new RedirectResponse($url->to('https://foo.com?bar=baz')))
+        );
+        $response->assertRedirectQueryParameterNotNull('foo');
+    }
+
     public function testAssertRedirectContains()
     {
         $response = TestResponse::fromBaseResponse(

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1650,21 +1650,21 @@ class TestResponseTest extends TestCase
         $response = TestResponse::fromBaseResponse(
             (new RedirectResponse($url->to('https://foo.com?foo=bar')))
         );
-        $response->assertRedirectQueryParameterEquals('foo', 'bar');
+        $response->assertRedirectQueryParameterEquals('bar', 'foo');
 
         $this->expectException(ExpectationFailedException::class);
 
         $response = TestResponse::fromBaseResponse(
             (new RedirectResponse($url->to('https://foo.com?foo=baz')))
         );
-        $response->assertRedirectQueryParameterEquals('foo', 'bar');
+        $response->assertRedirectQueryParameterEquals('bar', 'foo');
 
         $this->expectException(ExpectationFailedException::class);
 
         $response = TestResponse::fromBaseResponse(
             (new RedirectResponse($url->to('https://foo.com?bar=baz')))
         );
-        $response->assertRedirectQueryParameterEquals('foo', 'bar');
+        $response->assertRedirectQueryParameterEquals('bar', 'foo');
     }
 
     public function testAssertRedirectQueryParameterNotNull()


### PR DESCRIPTION
This PR adds a couple of extra assertions to the test response to check a query parameter in a redirect response is set to a given value or is null.

My reason for this is I have a few places where I do something like redirect to :

`https://example.com/?s=123&e=23iud8u13249w9djsdf`

Where the `e=...` will be a random-ish value (or at least not one I can be sure of).  At the moment I can manually do the test, or macro it in.  But I mentioned to a few people on Discord and they seemed to think it was something they'd wanted to do as well.

So this allows :
```
$response = $this->get('https://page-that-redirects-with/?s=123&e=baz');

$response->assertRedirectQueryParameterNotNull('e');
$response->assertRedirectQueryParameterEquals('123', 's');
```
