### PR TITLE
[9.x] ConditionalRules::$rules and $defaultRules accept \Closure

### DIFF
--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -16,14 +16,14 @@ class ConditionalRules
     /**
      * The rules to be added to the attribute.
      *
-     * @var array|string
+     * @var array|string|\Closure
      */
     protected $rules;
 
     /**
      * The rules to be added to the attribute if the condition fails.
      *
-     * @var array|string
+     * @var array|string|\Closure
      */
     protected $defaultRules;
 
@@ -31,8 +31,8 @@ class ConditionalRules
      * Create a new conditional rules instance.
      *
      * @param  callable|bool  $condition
-     * @param  array|string  $rules
-     * @param  array|string  $defaultRules
+     * @param  array|string|\Closure  $rules
+     * @param  array|string|\Closure  $defaultRules
      * @return void
      */
     public function __construct($condition, $rules, $defaultRules = [])

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -21,8 +21,8 @@ class Rule
      * Create a new conditional rule set.
      *
      * @param  callable|bool  $condition
-     * @param  array|string  $rules
-     * @param  array|string  $defaultRules
+     * @param  array|string|\Closure  $rules
+     * @param  array|string|\Closure  $defaultRules
      * @return \Illuminate\Validation\ConditionalRules
      */
     public static function when($condition, $rules, $defaultRules = [])


### PR DESCRIPTION
This PR updates the docblock types in order to match the current supported types.

Closure support is already tested in https://github.com/laravel/framework/blob/93414b1c7c0a56081d96c060bb850ac192d3d323/tests/Validation/ValidationRuleParserTest.php#L23-L28