### PR TITLE
[9.x] Add assertDirectoryEmpty to comment section in Storage facade

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -6,6 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 
 /**
  * @method static \Illuminate\Contracts\Filesystem\Filesystem assertExists(string|array $path)
+ * @method static \Illuminate\Contracts\Filesystem\Filesystem assertDirectoryEmpty(string $path)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem assertMissing(string|array $path)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem cloud()
  * @method static \Illuminate\Contracts\Filesystem\Filesystem build(string|array $root)


### PR DESCRIPTION
There was no auto-complete for IDEs with this assertion.