### PR TITLE
[9.x] Added `has` and `missing` methods to ValidatedInput

### DIFF
--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -103,7 +103,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Check if the validated input contains one or many keys.
      *
-     * @param  array|mixed  $keys
+     * @param  mixed  $keys
      * @return bool
      */
     public function has($keys)

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -103,7 +103,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Check if the validated input contains one or many keys.
      *
-     * @param $keys
+     * @param  array|mixed  $keys
      * @return bool
      */
     public function has($keys)
@@ -122,7 +122,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Check if the validated input does not contain one or many keys.
      *
-     * @param $keys
+     * @param  array|mixed  $keys
      * @return bool
      */
     public function doesntHave($keys)

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -101,7 +101,7 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Check if the validated input contains one or many keys.
+     * Determine if the validated input has one or more keys.
      *
      * @param  mixed  $keys
      * @return bool
@@ -120,12 +120,12 @@ class ValidatedInput implements ValidatedData
     }
 
     /**
-     * Check if the validated input does not contain one or many keys.
+     * Determine if the validated input is missing one or more keys.
      *
      * @param  mixed  $keys
      * @return bool
      */
-    public function doesntHave($keys)
+    public function missing($keys)
     {
         return ! $this->has($keys);
     }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -19,7 +19,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Create a new validated input container.
      *
-     * @param array $input
+     * @param  array  $input
      * @return void
      */
     public function __construct(array $input)
@@ -30,7 +30,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get a subset containing the provided keys with values from the input data.
      *
-     * @param array|mixed $keys
+     * @param  array|mixed  $keys
      * @return array
      */
     public function only($keys)
@@ -55,7 +55,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get all of the input except for a specified array of items.
      *
-     * @param array|mixed $keys
+     * @param  array|mixed  $keys
      * @return array
      */
     public function except($keys)
@@ -72,7 +72,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Merge the validated input with the given array of additional data.
      *
-     * @param array $items
+     * @param  array  $items
      * @return static
      */
     public function merge(array $items)
@@ -176,7 +176,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Remove an input key.
      *
-     * @param string $name
+     * @param  string  $name
      * @return void
      */
     public function __unset($name)
@@ -187,7 +187,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Determine if an item exists at an offset.
      *
-     * @param mixed $key
+     * @param  mixed  $key
      * @return bool
      */
     public function offsetExists($key): bool
@@ -198,7 +198,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get an item at a given offset.
      *
-     * @param mixed $key
+     * @param  mixed  $key
      * @return mixed
      */
     public function offsetGet($key): mixed
@@ -209,8 +209,8 @@ class ValidatedInput implements ValidatedData
     /**
      * Set the item at a given offset.
      *
-     * @param mixed $key
-     * @param mixed $value
+     * @param  mixed  $key
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($key, $value): void
@@ -225,7 +225,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Unset the item at a given offset.
      *
-     * @param string $key
+     * @param  string  $key
      * @return void
      */
     public function offsetUnset($key): void

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -19,7 +19,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Create a new validated input container.
      *
-     * @param  array  $input
+     * @param array $input
      * @return void
      */
     public function __construct(array $input)
@@ -30,7 +30,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get a subset containing the provided keys with values from the input data.
      *
-     * @param  array|mixed  $keys
+     * @param array|mixed $keys
      * @return array
      */
     public function only($keys)
@@ -55,7 +55,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get all of the input except for a specified array of items.
      *
-     * @param  array|mixed  $keys
+     * @param array|mixed $keys
      * @return array
      */
     public function except($keys)
@@ -72,7 +72,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Merge the validated input with the given array of additional data.
      *
-     * @param  array  $items
+     * @param array $items
      * @return static
      */
     public function merge(array $items)
@@ -98,6 +98,36 @@ class ValidatedInput implements ValidatedData
     public function all()
     {
         return $this->input;
+    }
+
+    /**
+     * Check if the validated input contains one or many keys.
+     *
+     * @param $keys
+     * @return bool
+     */
+    public function has($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        foreach ($keys as $key) {
+            if (! array_key_exists($key, $this->input)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the validated input does not contain one or many keys.
+     *
+     * @param $keys
+     * @return bool
+     */
+    public function doesntHave($keys)
+    {
+        return ! $this->has($keys);
     }
 
     /**
@@ -146,7 +176,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Remove an input key.
      *
-     * @param  string  $name
+     * @param string $name
      * @return void
      */
     public function __unset($name)
@@ -157,7 +187,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Determine if an item exists at an offset.
      *
-     * @param  mixed  $key
+     * @param mixed $key
      * @return bool
      */
     public function offsetExists($key): bool
@@ -168,7 +198,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get an item at a given offset.
      *
-     * @param  mixed  $key
+     * @param mixed $key
      * @return mixed
      */
     public function offsetGet($key): mixed
@@ -179,8 +209,8 @@ class ValidatedInput implements ValidatedData
     /**
      * Set the item at a given offset.
      *
-     * @param  mixed  $key
-     * @param  mixed  $value
+     * @param mixed $key
+     * @param mixed $value
      * @return void
      */
     public function offsetSet($key, $value): void
@@ -195,7 +225,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Unset the item at a given offset.
      *
-     * @param  string  $key
+     * @param string $key
      * @return void
      */
     public function offsetUnset($key): void

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -111,7 +111,7 @@ class ValidatedInput implements ValidatedData
         $keys = is_array($keys) ? $keys : func_get_args();
 
         foreach ($keys as $key) {
-            if (! array_key_exists($key, $this->input)) {
+            if (! Arr::has($this->input, $key)) {
                 return false;
             }
         }

--- a/src/Illuminate/Support/ValidatedInput.php
+++ b/src/Illuminate/Support/ValidatedInput.php
@@ -30,7 +30,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get a subset containing the provided keys with values from the input data.
      *
-     * @param  array|mixed  $keys
+     * @param  mixed  $keys
      * @return array
      */
     public function only($keys)
@@ -55,7 +55,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Get all of the input except for a specified array of items.
      *
-     * @param  array|mixed  $keys
+     * @param  mixed  $keys
      * @return array
      */
     public function except($keys)
@@ -122,7 +122,7 @@ class ValidatedInput implements ValidatedData
     /**
      * Check if the validated input does not contain one or many keys.
      *
-     * @param  array|mixed  $keys
+     * @param  mixed  $keys
      * @return bool
      */
     public function doesntHave($keys)

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -36,9 +36,9 @@ class ValidatedInputTest extends TestCase
         $inputA = new ValidatedInput(['name' => 'Taylor']);
 
         $this->assertEquals(true, $inputA->has('name'));
-        $this->assertEquals(true, $inputA->doesntHave('votes'));
-        $this->assertEquals(true, $inputA->doesntHave(['votes']));
-        $this->assertEquals(false, $inputA->doesntHave('name'));
+        $this->assertEquals(true, $inputA->missing('votes'));
+        $this->assertEquals(true, $inputA->missing(['votes']));
+        $this->assertEquals(false, $inputA->missing('name'));
 
         $inputB = new ValidatedInput(['name' => 'Taylor', 'votes' => 100]);
 

--- a/tests/Support/ValidatedInputTest.php
+++ b/tests/Support/ValidatedInputTest.php
@@ -30,4 +30,18 @@ class ValidatedInputTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $input->except(['votes']));
         $this->assertEquals(['name' => 'Taylor', 'votes' => 100], $input->all());
     }
+
+    public function test_input_existence()
+    {
+        $inputA = new ValidatedInput(['name' => 'Taylor']);
+
+        $this->assertEquals(true, $inputA->has('name'));
+        $this->assertEquals(true, $inputA->doesntHave('votes'));
+        $this->assertEquals(true, $inputA->doesntHave(['votes']));
+        $this->assertEquals(false, $inputA->doesntHave('name'));
+
+        $inputB = new ValidatedInput(['name' => 'Taylor', 'votes' => 100]);
+
+        $this->assertEquals(true, $inputB->has(['name', 'votes']));
+    }
 }


### PR DESCRIPTION
This PR introduces two new methods to the `Illuminate\Support\ValidatedInput` class.

- `has($keys)`
- `missing($keys)`

These two methods are used to check the existence of validated input easily. For example, now with the `$request->safe()` method, I could now do:

```php
$validatedName = $request->safe()->has('name'); // True
$validatedAge = $request->safe()->has('age') // False

$validatedName = $request->safe()->missing('name'); // False
$validatedAge = $request->safe()->missing('age') // True
```

You can also provide an array, and it will validate each key...

```php
$validatedName = $request->safe()->has(['name', 'age']);
```