### PR TITLE
[9.x] Return success constant instead of 0

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -27,6 +27,6 @@ class {{ class }} extends Command
      */
     public function handle()
     {
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
I believe returning self::SUCCESS instead of 0 communicates better to the developer and helps to enforce a correct use of output integers (0 meaning 'good' instead of the php falsey 0).
