### PR TITLE
[9.x] Add assertJsonKeyEquals() to response assertions

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -60,6 +60,20 @@ class AssertableJsonString implements ArrayAccess, Countable
     }
 
     /**
+     * Assert that the value of given key is equal to the expected value.
+     *
+     * @param  string  $key
+     * @param  string  $expected
+     * @return $this
+     */
+    public function assertKeyEquals($key, $expected)
+    {
+        $this->assertPath($key, $expected);
+
+        return $this;
+    }
+
+    /**
      * Assert that the response JSON has the expected count of items at the given key.
      *
      * @param  int  $count

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -745,6 +745,20 @@ EOF;
     }
 
     /**
+     * Assert that the value of given key is equal to the expected value.
+     *
+     * @param  string  $key
+     * @param  string  $expected
+     * @return $this
+     */
+    public function assertJsonKeyEquals($key, $expected)
+    {
+        $this->decodeResponseJson()->assertKeyEquals($key, $expected);
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the exact given JSON.
      *
      * @param  array  $data


### PR DESCRIPTION
There is a method in the JSON assertions called `assertPath` which in my opinion it is not clear for developers.
`assertJsonKeyEquals()` may be a good alias for this method to make it more readable and more understandable.
As a developer, when I saw `assertPath` first I didn't have any idea about this method.
I guess this alias has a better developer experience.