### PR TITLE
[9.x] Fixed docblock for json property

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -16,7 +16,7 @@ class AssertableJsonString implements ArrayAccess, Countable
     /**
      * The original encoded json.
      *
-     * @var \Illuminate\Contracts\Support\Jsonable|\JsonSerializable|array
+     * @var \Illuminate\Contracts\Support\Jsonable|\JsonSerializable|array|string
      */
     public $json;
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When testing API Feature, if I try to use json_decode on this property, Intellisense will mark as error, but when executed, no problems are detected.

```php

class DummyTest extends TestCase 
{
    /** @test */
    public function some_test() 
    {
        $someData = [
            'test' => true
        ];
        $response = $this->json('POST', "SomeUrlWithResourceOnResponse", $someData);
        $json = json_decode($response->decodeResponseJson()->json); // Here Intellisense will mark as error
        $response->assertCreated();
    }
}
```