### PR TITLE
[9.x] Include full stack trace in deprecation

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -68,7 +68,7 @@ class HandleExceptions
     public function handleError($level, $message, $file = '', $line = 0, $context = [])
     {
         if ($this->isDeprecation($level)) {
-            return $this->handleDeprecation($level, $message, $file, $line);
+            return $this->handleDeprecation($message, $file, $line);
         }
 
         if (error_reporting() & $level) {
@@ -79,13 +79,12 @@ class HandleExceptions
     /**
      * Reports a deprecation to the "deprecations" logger.
      *
-     * @param  int  $level
      * @param  string  $message
      * @param  string  $file
      * @param  int  $line
      * @return void
      */
-    public function handleDeprecation($level, $message, $file, $line)
+    public function handleDeprecation($message, $file, $line)
     {
         if (! class_exists(LogManager::class)
             || ! static::$app->hasBeenBootstrapped()
@@ -102,8 +101,8 @@ class HandleExceptions
 
         $this->ensureDeprecationLoggerIsConfigured();
 
-        with($logger->channel('deprecations'), function ($log) use ($level, $message, $file, $line) {
-            $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
+        with($logger->channel('deprecations'), function ($log) use ($message, $file, $line) {
+            $log->warning((string) new ErrorException($message, 0, E_DEPRECATED, $file, $line));
         });
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -68,7 +68,7 @@ class HandleExceptions
     public function handleError($level, $message, $file = '', $line = 0, $context = [])
     {
         if ($this->isDeprecation($level)) {
-            return $this->handleDeprecation($message, $file, $line);
+            return $this->handleDeprecation($level, $message, $file, $line);
         }
 
         if (error_reporting() & $level) {
@@ -79,12 +79,13 @@ class HandleExceptions
     /**
      * Reports a deprecation to the "deprecations" logger.
      *
+     * @param  int  $level
      * @param  string  $message
      * @param  string  $file
      * @param  int  $line
      * @return void
      */
-    public function handleDeprecation($message, $file, $line)
+    public function handleDeprecation($level, $message, $file, $line)
     {
         if (! class_exists(LogManager::class)
             || ! static::$app->hasBeenBootstrapped()
@@ -101,10 +102,8 @@ class HandleExceptions
 
         $this->ensureDeprecationLoggerIsConfigured();
 
-        with($logger->channel('deprecations'), function ($log) use ($message, $file, $line) {
-            $log->warning(sprintf('%s in %s on line %s',
-                $message, $file, $line
-            ));
+        with($logger->channel('deprecations'), function ($log) use ($level, $message, $file, $line) {
+            $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
         });
     }
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Log\LogManager;
+use Illuminate\Support\Str;
 use Mockery as m;
 use Monolog\Handler\NullHandler;
 use PHPUnit\Framework\TestCase;
@@ -50,11 +51,20 @@ class HandleExceptionsTest extends TestCase
         $this->app->instance(LogManager::class, $logger);
 
         $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
-        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
-            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
-            '/home/user/laravel/routes/web.php',
-            17
-        ));
+        $logger->shouldReceive('warning')->with(
+            m::on(fn(string $message) => (bool) preg_match(
+                <<<REGEXP
+                #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
+                Stack trace:
+                \#0 /.*/helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
+                \#1 /.*/HandleExceptions\.php\(.*\): with.*
+                \#2 /.*/HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
+                \#3 /.*/HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
+                [\s\S]*#i
+                REGEXP,
+                $message
+            ))
+        );
 
         $this->handleExceptions->handleError(
             E_DEPRECATED,
@@ -70,11 +80,20 @@ class HandleExceptionsTest extends TestCase
         $this->app->instance(LogManager::class, $logger);
 
         $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
-        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
-            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
-            '/home/user/laravel/routes/web.php',
-            17
-        ));
+        $logger->shouldReceive('warning')->with(
+            m::on(fn(string $message) => (bool) preg_match(
+                <<<REGEXP
+                #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
+                Stack trace:
+                \#0 /.*/helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
+                \#1 /.*/HandleExceptions\.php\(.*\): with.*
+                \#2 /.*/HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
+                \#3 /.*/HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
+                [\s\S]*#i
+                REGEXP,
+                $message
+            ))
+        );
 
         $this->handleExceptions->handleError(
             E_USER_DEPRECATED,

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -56,10 +56,10 @@ class HandleExceptionsTest extends TestCase
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
                 Stack trace:
-                \#0 .*/helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
-                \#1 .*/HandleExceptions\.php\(.*\): with.*
-                \#2 .*/HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
-                \#3 .*/HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
+                \#0 .*helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
+                \#1 .*HandleExceptions\.php\(.*\): with.*
+                \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
+                \#3 .*HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
                 [\s\S]*#i
                 REGEXP,
                 $message
@@ -85,10 +85,10 @@ class HandleExceptionsTest extends TestCase
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
                 Stack trace:
-                \#0 .*/helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
-                \#1 .*/HandleExceptions\.php\(.*\): with.*
-                \#2 .*/HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
-                \#3 .*/HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
+                \#0 .*helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
+                \#1 .*HandleExceptions\.php\(.*\): with.*
+                \#2 .*HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
+                \#3 .*HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
                 [\s\S]*#i
                 REGEXP,
                 $message

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -56,10 +56,10 @@ class HandleExceptionsTest extends TestCase
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
                 Stack trace:
-                \#0 /.*/helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
-                \#1 /.*/HandleExceptions\.php\(.*\): with.*
-                \#2 /.*/HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
-                \#3 /.*/HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
+                \#0 .*/helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
+                \#1 .*/HandleExceptions\.php\(.*\): with.*
+                \#2 .*/HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
+                \#3 .*/HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
                 [\s\S]*#i
                 REGEXP,
                 $message
@@ -85,10 +85,10 @@ class HandleExceptionsTest extends TestCase
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
                 Stack trace:
-                \#0 /.*/helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
-                \#1 /.*/HandleExceptions\.php\(.*\): with.*
-                \#2 /.*/HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
-                \#3 /.*/HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
+                \#0 .*/helpers.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions.*
+                \#1 .*/HandleExceptions\.php\(.*\): with.*
+                \#2 .*/HandleExceptions\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleDeprecation.*
+                \#3 .*/HandleExceptionsTest\.php\(.*\): Illuminate\\\\Foundation\\\\Bootstrap\\\\HandleExceptions->handleError.*
                 [\s\S]*#i
                 REGEXP,
                 $message


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Closes #42189

Adds full stack trace into deprecations log, similar to other PHP errors.