### PR TITLE
[9.x] Add whereBetweenDate() method to filter two dates with a different formats

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1333,7 +1333,7 @@ class Builder implements BuilderContract
      */
     public function whereBetweenDate($column, iterable $values, $boolean = 'and')
     {
-        return $this->whereBetween( "date($column)", $values, $boolean);
+        return $this->whereBetween("date($column)", $values, $boolean);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1324,6 +1324,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where between for two dates with different formats.
+     *
+     * @param  string  $column
+     * @param  iterable  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereBetweenDate($column, iterable $values, $boolean = 'and')
+    {
+        return $this->whereBetween( "date($column)", $values, $boolean);
+    }
+
+    /**
      * Add an "or where date" statement to the query.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -693,11 +693,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($period->toArray(), $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $begin   = now()->format('Y-m-d');
-        $end     = now()->addDay()->format('Y-m-d');
-        $builder->select('*')->from('users')->whereBetweenDate('created_at', [$begin,$end]);
+        $begin = now()->format('Y-m-d');
+        $end = now()->addDay()->format('Y-m-d');
+        $builder->select('*')->from('users')->whereBetweenDate('created_at', [$begin, $end]);
         $this->assertSame('select * from "users" where "date(created_at)" between ? and ?', $builder->toSql());
-        $this->assertEquals([$begin,$end], $builder->getBindings());
+        $this->assertEquals([$begin, $end], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -693,6 +693,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($period->toArray(), $builder->getBindings());
 
         $builder = $this->getBuilder();
+        $begin   = now()->format('Y-m-d');
+        $end     = now()->addDay()->format('Y-m-d');
+        $builder->select('*')->from('users')->whereBetweenDate('created_at', [$begin,$end]);
+        $this->assertSame('select * from "users" where "date(created_at)" between ? and ?', $builder->toSql());
+        $this->assertEquals([$begin,$end], $builder->getBindings());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));
         $this->assertSame('select * from "users" where "id" between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());


### PR DESCRIPTION
PR: Add whereBetweenDate() method to filter two dates with different formats.

The use case to use the `whereBetweenDate()` to filter two dates with this format `Y-m-d -> 2022-04-29` and the column on the database is a timestamp or DateTime ` 2022-04-29 16:05:00 `  if using `whereBetween()` that will return inaccurate data because will match with two dates with different format to solve this need to cast the column on the database to data using function date.


## Example : 
### using `whereBetween()`

Query Builder : 

```php
 $checklists= DB::table('checklists')
            ->select('id','created_at')
            ->whereBetween('created_at', ['2022-04-17','2022-04-18'])
            ->get();
```

Eloquent : 
```php 
 $checklists= Checklist::select('id','created_at')
        ->whereBetween('created_at', ['2022-04-17','2022-04-18'])
        ->get()
```

SQL :
```sql 
SELECT 
   id ,created_at
FROM 
   checklists
where
   created_at between '2022-04-17' and '2022-04-18';   
```

Output : 

![image](https://user-images.githubusercontent.com/37311945/165990551-3ddba2b3-a944-4f07-b9f9-6e161896a27e.png)



### using `whereBetweenDate()`

Query Builder : 
```php
 $checklists= DB::table('checklists')
        ->select('id','created_at')
        ->whereBetweenDate('created_at', ['2022-04-17','2022-04-18'])
        ->get();
```

Eloquent  : 
```php 
 $checklists= Checklist::select('id','created_at')
        ->whereBetweenDate('created_at', ['2022-04-17','2022-04-18'])
        ->get()
```

SQL : 
```sql 
SELECT 
  id ,created_at
FROM 
  checklists
where
  date(created_at) between '2022-04-17' and '2022-04-18';   
```

Output  : 
![image](https://user-images.githubusercontent.com/37311945/165990486-d9bb1c0b-2047-4de0-b0fa-07a3a0998d63.png)

So I made this PR and added a new method `whereBetweenDate()` that casts the Timestamp or DateTime column to date and shows the exact values. `whereBetweenDate()` is useful when filtering data between two dates in different or the same formats.




