### PR TITLE
[9.x] Add Eloquent local scopes tests

### DIFF
--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentLocalScopesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        tap(new DB)->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ])->bootEloquent();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Model::unsetConnectionResolver();
+    }
+
+    public function testCanCheckExistenceOfLocalScope()
+    {
+        $model = new EloquentLocalScopesTestModel;
+
+        $this->assertTrue($model->hasNamedScope('active'));
+        $this->assertTrue($model->hasNamedScope('type'));
+
+        $this->assertFalse($model->hasNamedScope('nonExistentLocalScope'));
+    }
+
+    public function testLocalScopeIsApplied()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->active();
+
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([true], $query->getBindings());
+    }
+
+    public function testDynamicLocalScopeIsApplied()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->type('foo');
+
+        $this->assertSame('select * from "table" where "type" = ?', $query->toSql());
+        $this->assertEquals(['foo'], $query->getBindings());
+    }
+}
+
+class EloquentLocalScopesTestModel extends Model
+{
+    protected $table = 'table';
+
+    public function scopeActive($query)
+    {
+        $query->where('active', true);
+    }
+
+    public function scopeType($query, $type)
+    {
+        $query->where('type', $type);
+    }
+}

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -52,6 +52,15 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $this->assertSame('select * from "table" where "type" = ?', $query->toSql());
         $this->assertEquals(['foo'], $query->getBindings());
     }
+
+    public function testLocalScopesCanChained()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->active()->type('foo');
+
+        $this->assertSame('select * from "table" where "active" = ? and "type" = ?', $query->toSql());
+        $this->assertEquals([true, 'foo'], $query->getBindings());
+    }
 }
 
 class EloquentLocalScopesTestModel extends Model


### PR DESCRIPTION
While waiting for #42111, I thought it would be good to add more test coverage to Eloquent local scopes. 

This test, like the one for global scope, asserts against the query string to ensure we are getting the correct query formatting and bindings when using static and dynamic local scopes.