### PR TITLE
[9.x] Fix translation null replacement value deprecation warning

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -217,6 +217,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $shouldReplace = [];
 
         foreach ($replace as $key => $value) {
+            $value ??= '';
             $shouldReplace[':'.Str::ucfirst($key)] = Str::ucfirst($value);
             $shouldReplace[':'.Str::upper($key)] = Str::upper($value);
             $shouldReplace[':'.$key] = $value;

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -213,6 +213,14 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
     }
 
+    public function testNullReplacementValueIsTreatedAsEmptyString()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message baz', '*')->andReturn([]);
+        $this->assertSame('foo  baz', $t->get('foo :message baz', ['message' => null]));
+    }
+
     protected function getLoader()
     {
         return m::mock(Loader::class);


### PR DESCRIPTION
### Description

This PR fixes https://github.com/laravel/framework/issues/42204 by treating a `null` replacement value as an empty string `''`, which mimics what is already happenning under the hood.

I have added the `testNullReplacementValueIsTreatedAsEmptyString` test to check for this case.
