### PR TITLE
[9.x] Adds `add()` to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -267,7 +267,7 @@ trait InteractsWithInput
         $key = is_array($key) ? $key : [$key => $value];
 
         foreach ($key as $index => $value) {
-            $data->has($key) || $data->set($key, $value);
+            $data->has($index) || $data->set($index, $value);
         }
 
         return $this;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -250,20 +250,24 @@ trait InteractsWithInput
     /**
      * Adds an input key with a value only if it's not set.
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  mixed   $value
      * @return $this
      */
-    public function add($key, $value)
+    public function add($key, $value = null)
     {
-        if ($this->missing($key)) {
-            if ($this->getRealMethod() === 'GET') {
-                $this->query->set($key, $value);
-            } elseif($this->isJson()) {
-                $this->json()->set($key, $value);
-            } else {
-                $this->request->set($key, $value);
-            }
+        if ($this->getRealMethod() === 'GET') {
+            $data = $this->query;
+        } elseif($this->isJson()) {
+            $data = $this->json();
+        } else {
+            $data = $this->request;
+        }
+
+        $key = is_array($key) ? $key : [$key => $value];
+
+        foreach ($key as $index => $value) {
+            $data->has($key) || $data->set($key, $value);
         }
 
         return $this;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -248,6 +248,28 @@ trait InteractsWithInput
     }
 
     /**
+     * Adds an input key with a value only if it's not set.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return $this
+     */
+    public function add($key, $value)
+    {
+        if ($this->missing($key)) {
+            if ($this->getRealMethod() === 'GET') {
+                $this->query->set($key, $value);
+            } elseif($this->isJson()) {
+                $this->json()->set($key, $value);
+            } else {
+                $this->request->set($key, $value);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Get all of the input and files for the request.
      *
      * @param  array|mixed|null  $keys

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -258,7 +258,7 @@ trait InteractsWithInput
     {
         if ($this->getRealMethod() === 'GET') {
             $data = $this->query;
-        } else if($this->isJson()) {
+        } elseif ($this->isJson()) {
             $data = $this->json();
         } else {
             $data = $this->request;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -251,14 +251,14 @@ trait InteractsWithInput
      * Adds an input key with a value only if it's not set.
      *
      * @param  array|string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return $this
      */
     public function add($key, $value = null)
     {
         if ($this->getRealMethod() === 'GET') {
             $data = $this->query;
-        } elseif($this->isJson()) {
+        } else if($this->isJson()) {
             $data = $this->json();
         } else {
             $data = $this->request;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -620,7 +620,7 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
 
-        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz');
+        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz']);
 
         $this->assertSame('bar', $request->foo);
         $this->assertSame('Taylor', $request->name);
@@ -630,7 +630,7 @@ class HttpRequestTest extends TestCase
 
         $request = Request::create('/', 'POST', ['name' => 'Taylor', 'age' => null]);
 
-        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz');
+        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz']);
 
         $this->assertSame('bar', $request->foo);
         $this->assertSame('Taylor', $request->name);
@@ -641,7 +641,7 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'POST', ['name' => 'Taylor', 'age' => null]);
         $request->headers->set('Content-Type', 'application/json');
 
-        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz');
+        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz']);
 
         $this->assertSame('bar', $request->foo);
         $this->assertSame('Taylor', $request->name);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -620,9 +620,7 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
 
-        $request->add('foo', 'bar');
-        $request->add('name', 'baz');
-        $request->add('age', 'quz');
+        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz');
 
         $this->assertSame('bar', $request->foo);
         $this->assertSame('Taylor', $request->name);
@@ -632,9 +630,7 @@ class HttpRequestTest extends TestCase
 
         $request = Request::create('/', 'POST', ['name' => 'Taylor', 'age' => null]);
 
-        $request->add('foo', 'bar');
-        $request->add('name', 'baz');
-        $request->add('age', 'quz');
+        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz');
 
         $this->assertSame('bar', $request->foo);
         $this->assertSame('Taylor', $request->name);
@@ -645,9 +641,7 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'POST', ['name' => 'Taylor', 'age' => null]);
         $request->headers->set('Content-Type', 'application/json');
 
-        $request->add('foo', 'bar');
-        $request->add('name', 'baz');
-        $request->add('age', 'quz');
+        $request->add(['foo' => 'bar', 'name' => 'baz', 'age' => 'quz');
 
         $this->assertSame('bar', $request->foo);
         $this->assertSame('Taylor', $request->name);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -626,7 +626,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Taylor', $request->name);
         $this->assertNull($request->age);
 
-        $this->assertSame('bar', $request->query->get('foo')));
+        $this->assertSame('bar', $request->query->get('foo'));
 
         $request = Request::create('/', 'POST', ['name' => 'Taylor', 'age' => null]);
 
@@ -636,7 +636,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Taylor', $request->name);
         $this->assertNull($request->age);
 
-        $this->assertSame('bar', $request->request->get('foo')));
+        $this->assertSame('bar', $request->request->get('foo'));
 
         $request = Request::create('/', 'POST', ['name' => 'Taylor', 'age' => null]);
         $request->headers->set('Content-Type', 'application/json');
@@ -647,7 +647,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame('Taylor', $request->name);
         $this->assertNull($request->age);
 
-        $this->assertSame('bar', $request->json('foo')));
+        $this->assertSame('bar', $request->json('foo'));
     }
 
     public function testAllMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -616,6 +616,46 @@ class HttpRequestTest extends TestCase
         $this->assertSame('foo', $request['id']);
     }
 
+    public function testAddMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
+
+        $request->add('foo', 'bar');
+        $request->add('name', 'baz');
+        $request->add('age', 'quz');
+
+        $this->assertSame('bar', $request->foo);
+        $this->assertSame('Taylor', $request->name);
+        $this->assertNull($request->age);
+
+        $this->assertSame('bar', $request->query->get('foo')));
+
+        $request = Request::create('/', 'POST', ['name' => 'Taylor', 'age' => null]);
+
+        $request->add('foo', 'bar');
+        $request->add('name', 'baz');
+        $request->add('age', 'quz');
+
+        $this->assertSame('bar', $request->foo);
+        $this->assertSame('Taylor', $request->name);
+        $this->assertNull($request->age);
+
+        $this->assertSame('bar', $request->request->get('foo')));
+
+        $request = Request::create('/', 'POST', ['name' => 'Taylor', 'age' => null]);
+        $request->headers->set('Content-Type', 'application/json');
+
+        $request->add('foo', 'bar');
+        $request->add('name', 'baz');
+        $request->add('age', 'quz');
+
+        $this->assertSame('bar', $request->foo);
+        $this->assertSame('Taylor', $request->name);
+        $this->assertNull($request->age);
+
+        $this->assertSame('bar', $request->json('foo')));
+    }
+
     public function testAllMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);


### PR DESCRIPTION
## What?

Adds the `add()` method to the `Request` instance. It will fill an input if the key doesn't exist, otherwise it will be left alone.

```php
// BEFORE
public function something(Request $request)
{
    // Add the timestamp if the request doesn't have it.
    if ($request->missing('timestamp')) {
        $request->request->set('timestamp', now()->getTimestamp());
    }

    $request->validate([
        'timestamp' => 'required|date:U',
    ]);

    // ...
}
```

```php
// AFTER
public function something(Request $request)
{
    // Add the timestamp if the request doesn't have it.
    $request->add('timestamp', now()->getTimestamp());

    $request->validate([
        'timestamp' => 'required|date:U',
    ]);

    // ...
}
```

This allows to easily set default values to the request when these keys are not present. 

> It will put the value where it's expected by the type of request. In other words, it will add the values to the Query if it's a `GET` request, or the parameter bag otherwise — it will add it to the JSON parameters if it's a JSON request.

It should work even inside a `FormRequest` instance.

```php
protected function prepareForValidation()
{
    $this->add([
        // ...
    ]);
}
```

## BC?

Nope, not expecting the user has macro'ed `add()` to the Request.