### PR TITLE
[9.x] Added some tests for `has` method to SessionStoreTest

### DIFF
--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -441,6 +441,21 @@ class SessionStoreTest extends TestCase
         $this->assertSame('foo', $session->getName());
     }
 
+    public function testKeyHas()
+    {
+        $session = $this->getSession();
+        $session->put('first_name', 'Mehdi');
+        $session->put('last_name', 'Rajabi');
+
+        $this->assertTrue($session->has('first_name'));
+        $this->assertTrue($session->has('last_name'));
+        $this->assertTrue($session->has('first_name', 'last_name'));
+        $this->assertTrue($session->has(['first_name', 'last_name']));
+
+        $this->assertFalse($session->has('first_name', 'foo'));
+        $this->assertFalse($session->has('foo', 'bar'));
+    }
+
     public function testKeyExists()
     {
         $session = $this->getSession();


### PR DESCRIPTION

method `session()->has()` does not have tests with multiple arguments and array parameter 

I wrote tests and added to SessionStoreTest
