### PR TITLE
[9.x] Fix deprecation with empty rules

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -97,7 +97,7 @@ class ValidationRuleParser
         return array_map(
             [$this, 'prepareRule'],
             $rule,
-            array_fill(array_key_first($rule), count($rule), $attribute)
+            array_fill((int) array_key_first($rule), count($rule), $attribute)
         );
     }
 

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -55,6 +55,13 @@ class ValidationRuleParserTest extends TestCase
         ], $rules);
     }
 
+    public function testEmptyRulesCanBeExploded()
+    {
+        $parser = new ValidationRuleParser(['foo' => 'bar']);
+
+        $this->assertIsObject($parser->explode(['foo' => []]));
+    }
+
     public function testConditionalRulesWithDefault()
     {
         $rules = ValidationRuleParser::filterConditionalRules([


### PR DESCRIPTION
Fix deprecation for parsing empty validation rules.

See https://github.com/laravel/framework/issues/42203