### PR TITLE
[8.x] Fix refresh during down

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -69,6 +69,10 @@ if (isset($data['retry'])) {
     header('Retry-After: '.$data['retry']);
 }
 
+if (isset($data['refresh'])) {
+    header('Refresh: '.$data['refresh']);
+}
+
 echo $data['template'];
 
 exit;


### PR DESCRIPTION
This PR fixes an issue where the Refresh header was not set when an application is down with a specific template. There was a missing header at the bottom of the maintenance file.

Fixes #42208
