### PR TITLE
[9.x] Revert "Fixes return type of request function (#42006)"

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -636,7 +636,7 @@ if (! function_exists('request')) {
      *
      * @param  array|string|null  $key
      * @param  mixed  $default
-     * @return mixed
+     * @return mixed|\Illuminate\Http\Request|string|array|null
      */
     function request($key = null, $default = null)
     {


### PR DESCRIPTION
This PR returns autocompletion for `\Illuminate\Http\Request` in the `request()` helper function.

The addition of `mixed` to the previous return type complements the previous change in #42006.
