### PR TITLE
[9.x] Make Validation exception messages translatable

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -88,15 +88,14 @@ class ValidationException extends Exception
         $messages = $validator->errors()->all();
 
         if (! count($messages)) {
-            return 'The given data was invalid.';
+            return trans('The given data was invalid.');
         }
 
         $message = array_shift($messages);
-
         if ($additional = count($messages)) {
-            $pluralized = $additional === 1 ? 'error' : 'errors';
-
-            $message .= " (and {$additional} more {$pluralized})";
+            $message .= $additional === 1
+                ? trans(' (and :additional more error)', ['additional' => $additional])
+                : trans(' (and :additional more errors)', ['additional' => $additional]);
         }
 
         return $message;

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -61,4 +61,13 @@ class ValidationExceptionTest extends TestCase
 
         return new ValidationException($validator);
     }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
 }

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -2,9 +2,12 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\ValidationServiceProvider;
 use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
@@ -44,8 +47,17 @@ class ValidationExceptionTest extends TestCase
 
     protected function getException($data = [], $rules = [])
     {
-        $translator = new Translator(new ArrayLoader, 'en');
-        $validator = new Validator($translator, $data, $rules);
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+        (new ValidationServiceProvider($container))->register();
+        $validator = new Validator(resolve('translator'), $data, $rules);
 
         return new ValidationException($validator);
     }


### PR DESCRIPTION
Hello Laravel team,

I'm currently testing my application after I upgraded to Laravel 9. I found a "new" behavior on the validation exception message. It included `(and x more errors)`. This confused me a lot because my applications validation errors where fully translated. I dug deeper into the issue and found the following code added to Laravel 9.

```php
protected static function summarize($validator)
{
  $messages = $validator->errors()->all();

  if (! count($messages)) {
    return 'The given data was invalid.';
  }

  $message = array_shift($messages);

  if ($additional = count($messages)) {
    $pluralized = $additional === 1 ? 'error' : 'errors';

    $message .= " (and {$additional} more {$pluralized})";
  }

  return $message;
}
```

I always thought about the `The given data was invalid.` part to be translatable but it didn't appeared in my application. Now the message is the first error with the addition of ` (and {$additional} more {$pluralized})` I got a mix of German and English in my validation exception messages that I return to my client. That isn't a nice experience.

With my PR I'm changing the message to be translatable in the singular and pluralized form. I changed the way the message is build because in my opinion it is much better to have 2 translatable sentences for this use case instead translating `error` and `errors` before including it in the translation as a parameter.

I really hope I did the right thing for the test part, because I never used the container part. I looked it up on the `tests/Validation/ValidationEnumRuleTest.php` class which only includes another translation.