### PR TITLE
[10.x] Add `or` & `and` methods to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -26,6 +26,10 @@ use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 
+/**
+ * @method $this and(\Closure|string|array $column, mixed $operator = null, mixed $value = null)
+ * @method $this or(\Closure|string|array $column, mixed $operator = null, mixed $value = null)
+ */
 class Builder implements BuilderContract
 {
     use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
@@ -3675,6 +3679,15 @@ class Builder implements BuilderContract
 
         if (str_starts_with($method, 'where')) {
             return $this->dynamicWhere($method, $parameters);
+        }
+
+        $aliases = [
+            'and' => 'where',
+            'or' => 'orWhere',
+        ];
+
+        if ($aliases[$method] ?? false) {
+            return $this->{$aliases[$method]}(...$parameters);
         }
 
         static::throwBadMethodCallException($method);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -934,6 +934,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
     }
 
+    public function testOrAnd()
+    {
+        $model = new EloquentBuilderTestStub();
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()
+            ->where('foo', 1)
+            ->or('bar', '=', 2)
+            ->and('baz', 3);
+        $this->assertEquals('select * from "table" where "foo" = ? or "bar" = ? and "baz" = ?', $query->toSql());
+        $this->assertEquals([1, 2, 3], $query->getBindings());
+    }
+
     public function testSimpleOrWhereNot()
     {
         $model = new EloquentBuilderTestStub();


### PR DESCRIPTION
This is just something fun I had in my mind that wanted to share:) It lets us write eloquent queries more similar to how we write sql and it is closer to English.

```php
$model->where('foo', 1)
      ->or('bar', '=', 2)
      ->and('baz', 3);
```
Thanks for your time.