### PR TITLE
localization nested json language file when lang key called

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -106,7 +106,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        $line = data_get($this->loaded['*']['*'][$locale], $key);
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -106,7 +106,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = data_get($this->loaded['*']['*'][$locale], $key);
+        $line = $this->loaded['*']['*'][$locale][$key] ?? data_get($this->loaded['*']['*'][$locale], $key);
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a


### PR DESCRIPTION
In my case I have nested json in translations:

```
{
    "form": {
        "create": "Create project",
        "edit": "Edit project",
        "show": "Show project",
        "edit_specific": "Edit Project: #{modelId}",
        "go_back": "Back to projects"
    }
}
```

but when I call `__('form.create')` returns `form.create`, after these changes will return current translation (`Create Project`).

Also works correctly when we have translation string with dot notation 