### PR TITLE
[9.x] Add attemptWith for authenticating a user instance

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -424,7 +424,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function attemptWith(AuthenticatableContract $user, array $credentials = [], $remember = false)
     {
-        $this->fireAttemptEvent(['user' => $user, ...$credentials], $remember);
+        $this->fireAttemptEvent(array_merge(['user' => $user], $credentials), $remember);
 
         $this->lastAttempted = $user;
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -415,6 +415,34 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
+     * Attempt to authenticate a user instance with credentials.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  array  $credentials
+     * @param  bool  $remember
+     * @return bool
+     */
+    public function attemptWith(AuthenticatableContract $user, array $credentials = [], $remember = false)
+    {
+        $this->fireAttemptEvent(['user' => $user, ...$credentials], $remember);
+
+        $this->lastAttempted = $user;
+
+        if ($this->hasValidCredentials($user, $credentials)) {
+            $this->login($user, $remember);
+
+            return true;
+        }
+
+        // If the authentication attempt fails we will fire an event so that the user
+        // may be notified of any suspicious attempts to access their account from
+        // an unrecognized user. A developer may listen to this event as needed.
+        $this->fireFailedEvent($user, $credentials);
+
+        return false;
+    }
+
+    /**
      * Determine if the user matches the credentials.
      *
      * @param  mixed  $user

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -115,6 +115,21 @@ class AuthGuardTest extends TestCase
         $this->assertTrue($guard->attempt(['foo']));
     }
 
+    public function testAttemptWithAuthenticatableInstance()
+    {
+        [$session, $provider, $request, $cookie] = $this->getMocks();
+
+        $guard = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        $guard->setDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(Validated::class));
+        $user = $this->createMock(Authenticatable::class);
+        $guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
+        $guard->expects($this->once())->method('login')->with($this->equalTo($user));
+
+        $this->assertTrue($guard->attemptWith($user, ['foo']));
+    }
+
     public function testAttemptReturnsFalseIfUserNotGiven()
     {
         $mock = $this->getGuard();

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentLocalScopesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        tap(new DB)->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ])->bootEloquent();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Model::unsetConnectionResolver();
+    }
+
+    public function testCanCheckExistenceOfLocalScope()
+    {
+        $model = new EloquentLocalScopesTestModel;
+
+        $this->assertTrue($model->hasNamedScope('active'));
+        $this->assertTrue($model->hasNamedScope('type'));
+
+        $this->assertFalse($model->hasNamedScope('nonExistentLocalScope'));
+    }
+
+    public function testLocalScopeIsApplied()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->active();
+
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([true], $query->getBindings());
+    }
+
+    public function testDynamicLocalScopeIsApplied()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->type('foo');
+
+        $this->assertSame('select * from "table" where "type" = ?', $query->toSql());
+        $this->assertEquals(['foo'], $query->getBindings());
+    }
+}
+
+class EloquentLocalScopesTestModel extends Model
+{
+    protected $table = 'table';
+
+    public function scopeActive($query)
+    {
+        $query->where('active', true);
+    }
+
+    public function scopeType($query, $type)
+    {
+        $query->where('type', $type);
+    }
+}

--- a/tests/Database/DatabaseEloquentLocalScopesTest.php
+++ b/tests/Database/DatabaseEloquentLocalScopesTest.php
@@ -52,6 +52,15 @@ class DatabaseEloquentLocalScopesTest extends TestCase
         $this->assertSame('select * from "table" where "type" = ?', $query->toSql());
         $this->assertEquals(['foo'], $query->getBindings());
     }
+
+    public function testLocalScopesCanChained()
+    {
+        $model = new EloquentLocalScopesTestModel;
+        $query = $model->newQuery()->active()->type('foo');
+
+        $this->assertSame('select * from "table" where "active" = ? and "type" = ?', $query->toSql());
+        $this->assertEquals([true, 'foo'], $query->getBindings());
+    }
 }
 
 class EloquentLocalScopesTestModel extends Model

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -181,7 +181,7 @@ class AuthenticationTest extends TestCase
 
         Event::assertDispatched(Attempting::class, function ($event) use ($user, $credentials) {
             $this->assertSame('web', $event->guard);
-            $this->assertEquals(['user' => $user, ...$credentials], $event->credentials);
+            $this->assertEquals(array_merge(['user' => $user], $credentials), $event->credentials);
 
             return true;
         });


### PR DESCRIPTION
Hello Team!

This PR adds an `attemptWith` method in `Illuminate\Auth\SessionGuard` for authenticating a pre-existing authenticatable instance. This feature is really helpful when we already have an existing user instance before we even attempt an authentication.

Use case: Imagine a `User` model has one `Profile` model which has a unique column `employee_number` that is used to authenticate instead of the typical username/email field:

```
$user = User::whereHas('profile', 
    fn ($query) => $query->where('employee_number', request()->employee_number)
)->firstOrFail();

if (Hash::check(request()->password, $user->password)) {
    Auth::login($user, request()->remember);
    // ...
}
```

Instead of manually checking against the hash on the password of an existing user, I thought it would be good to be able to attempt authentication, just like a typical attempt with credentials:
```
$user = User::whereHas('profile', 
    fn ($query) => $query->where('employee_number', request()->employee_number)
)->firstOrFail();

if (Auth::attemptWith($user, request()->only('password'), request()->remember)) {
    // Do something here...
}
```