### PR TITLE
[9.x] Helper data_set() can create new elements as objects

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -95,9 +95,10 @@ if (! function_exists('data_set')) {
      * @param  string|array  $key
      * @param  mixed  $value
      * @param  bool  $overwrite
+     * @param  bool  $likeArray
      * @return mixed
      */
-    function data_set(&$target, $key, $value, $overwrite = true)
+    function data_set(&$target, $key, $value, $overwrite = true, $likeArray = true)
     {
         $segments = is_array($key) ? $key : explode('.', $key);
 
@@ -108,7 +109,7 @@ if (! function_exists('data_set')) {
 
             if ($segments) {
                 foreach ($target as &$inner) {
-                    data_set($inner, $segments, $value, $overwrite);
+                    data_set($inner, $segments, $value, $overwrite, $likeArray);
                 }
             } elseif ($overwrite) {
                 foreach ($target as &$inner) {
@@ -118,20 +119,20 @@ if (! function_exists('data_set')) {
         } elseif (Arr::accessible($target)) {
             if ($segments) {
                 if (! Arr::exists($target, $segment)) {
-                    $target[$segment] = [];
+                    $target[$segment] = $likeArray ? [] : new stdClass();
                 }
 
-                data_set($target[$segment], $segments, $value, $overwrite);
+                data_set($target[$segment], $segments, $value, $overwrite, $likeArray);
             } elseif ($overwrite || ! Arr::exists($target, $segment)) {
                 $target[$segment] = $value;
             }
         } elseif (is_object($target)) {
             if ($segments) {
                 if (! isset($target->{$segment})) {
-                    $target->{$segment} = [];
+                    $target->{$segment} = $likeArray ? [] : new stdClass();
                 }
 
-                data_set($target->{$segment}, $segments, $value, $overwrite);
+                data_set($target->{$segment}, $segments, $value, $overwrite, $likeArray);
             } elseif ($overwrite || ! isset($target->{$segment})) {
                 $target->{$segment} = $value;
             }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -326,6 +326,48 @@ class SupportHelpersTest extends TestCase
         ], $data);
     }
 
+    public function testDataSetWithNewElementAsArray()
+    {
+        $dataArray = [];
+        $dataObject = new stdClass();
+
+        data_set($dataArray, 'person.name', 'John', true, true);
+        data_set($dataObject, 'person.name', 'John', true, true);
+
+        $this->assertEquals([
+            'person' => [
+                'name' => 'John'
+            ]
+        ], $dataArray);
+
+        $this->assertEquals((object) [
+            'person' => [
+                'name' => 'John'
+            ]
+        ], $dataObject);
+    }
+
+    public function testDataSetWithNewElementAsObject()
+    {
+        $dataArray = [];
+        $dataObject = new stdClass();
+
+        data_set($dataArray, 'person.name', 'John', true, false);
+        data_set($dataObject, 'person.name', 'John', true, false);
+
+        $this->assertEquals([
+            'person' => (object) [
+                'name' => 'John'
+            ]
+        ], $dataArray);
+
+        $this->assertEquals((object) [
+            'person' => (object) [
+                'name' => 'John'
+            ]
+        ], $dataObject);
+    }
+
     public function testHead()
     {
         $array = ['a', 'b', 'c'];


### PR DESCRIPTION
Sometimes you have an empty object that you want to add layered nested elements to as objects using helper data_set(). Currently, you can only get this structure as an associative array, like so:

```php
$data = new stdClass();

data_set($data, 'user.name', 'foo', true);

```

and $data will contain the structure like this:

```php
{#3506
    +"user": [
        "name" => "foo",
    ],
}


```


Changes allow you to get this structure as an object:

```php
$data = new stdClass();

data_set($data, 'user.name', 'foo', true, false);

```

and $data will contain the structure like this:

```php
{#3506
    +"user": {#3507
       +"name": "foo",
    },
}