### PR TITLE
[9.x] Deprecation stack trace config option

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -68,7 +68,7 @@ class HandleExceptions
     public function handleError($level, $message, $file = '', $line = 0, $context = [])
     {
         if ($this->isDeprecation($level)) {
-            return $this->handleDeprecation($message, $file, $line);
+            return $this->handleDeprecationError($message, $file, $line, $level);
         }
 
         if (error_reporting() & $level) {
@@ -83,8 +83,24 @@ class HandleExceptions
      * @param  string  $file
      * @param  int  $line
      * @return void
+     *
+     * @deprecated Use doDeprecation instead.
      */
     public function handleDeprecation($message, $file, $line)
+    {
+        $this->handleDeprecationError($message, $file, $line);
+    }
+
+    /**
+     * Reports a deprecation to the "deprecations" logger.
+     *
+     * @param  string  $message
+     * @param  string  $file
+     * @param  int  $line
+     * @param  int  $level
+     * @return void
+     */
+    public function handleDeprecationError($message, $file, $line, $level = E_DEPRECATED)
     {
         if (! class_exists(LogManager::class)
             || ! static::$app->hasBeenBootstrapped()
@@ -101,8 +117,8 @@ class HandleExceptions
 
         $this->ensureDeprecationLoggerIsConfigured();
 
-        with($logger->channel('deprecations'), function ($log) use ($message, $file, $line) {
-            $log->warning((string) new ErrorException($message, 0, E_DEPRECATED, $file, $line));
+        with($logger->channel('deprecations'), function ($log) use ($message, $file, $line, $level) {
+            $log->warning((string) new ErrorException($message, 0, $level, $file, $line));
         });
     }
 

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -50,8 +50,33 @@ class HandleExceptionsTest extends TestCase
         $this->app->instance(LogManager::class, $logger);
 
         $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
+        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        ));
+
+        $this->handleExceptions->handleError(
+            E_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+    }
+
+    public function testPhpDeprecationsWithStackTraces()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->app->instance(LogManager::class, $logger);
+
+        $this->config->set('logging.deprecations', [
+            'channel' => 'null',
+            'trace' => true,
+        ]);
+
+        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
         $logger->shouldReceive('warning')->with(
-            m::on(fn (string $message) => (bool) preg_match(
+            m::on(fn(string $message) => (bool) preg_match(
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
                 Stack trace:
@@ -79,8 +104,33 @@ class HandleExceptionsTest extends TestCase
         $this->app->instance(LogManager::class, $logger);
 
         $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
+        $logger->shouldReceive('warning')->with(sprintf('%s in %s on line %s',
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        ));
+
+        $this->handleExceptions->handleError(
+            E_USER_DEPRECATED,
+            'str_contains(): Passing null to parameter #2 ($needle) of type string is deprecated',
+            '/home/user/laravel/routes/web.php',
+            17
+        );
+    }
+
+    public function testUserDeprecationsWithStackTraces()
+    {
+        $logger = m::mock(LogManager::class);
+        $this->app->instance(LogManager::class, $logger);
+
+        $this->config->set('logging.deprecations', [
+            'channel' => 'null',
+            'trace' => true,
+        ]);
+
+        $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
         $logger->shouldReceive('warning')->with(
-            m::on(fn (string $message) => (bool) preg_match(
+            m::on(fn(string $message) => (bool) preg_match(
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
                 Stack trace:

--- a/tests/Foundation/Bootstrap/HandleExceptionsTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceptionsTest.php
@@ -76,7 +76,7 @@ class HandleExceptionsTest extends TestCase
 
         $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
         $logger->shouldReceive('warning')->with(
-            m::on(fn(string $message) => (bool) preg_match(
+            m::on(fn (string $message) => (bool) preg_match(
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
                 Stack trace:
@@ -130,7 +130,7 @@ class HandleExceptionsTest extends TestCase
 
         $logger->shouldReceive('channel')->with('deprecations')->andReturnSelf();
         $logger->shouldReceive('warning')->with(
-            m::on(fn(string $message) => (bool) preg_match(
+            m::on(fn (string $message) => (bool) preg_match(
                 <<<REGEXP
                 #ErrorException: str_contains\(\): Passing null to parameter \#2 \(\\\$needle\) of type string is deprecated in /home/user/laravel/routes/web\.php:17
                 Stack trace:


### PR DESCRIPTION
This is a follow-up to #42191 to make deprecation error stack traces opt-in rather than enabled by default. Enabling these by default could potentially bloat logs a lot. By making it an opt-in behavior, we still grant users 
the ability to enable these traces for more concrete information where a deprecation happened.

It's fully BC with the current logging config file.
