### PR TITLE
[9.x] Defers expanding callables on Factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -447,21 +447,28 @@ abstract class Factory
      */
     protected function expandAttributes(array $definition)
     {
-        return collect($definition)->map(function ($attribute, $key) use (&$definition) {
-            if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
-                $attribute = $attribute($definition);
-            }
+        return collect($definition)
+            ->map(function ($attribute, $key) {
+                if ($attribute instanceof self) {
+                    $attribute = $attribute->create()->getKey();
+                } elseif ($attribute instanceof Model) {
+                    $attribute = $attribute->getKey();
+                }
 
-            if ($attribute instanceof self) {
-                $attribute = $attribute->create()->getKey();
-            } elseif ($attribute instanceof Model) {
-                $attribute = $attribute->getKey();
-            }
+                $definition[$key] = $attribute;
 
-            $definition[$key] = $attribute;
+                return $attribute;
+            })
+            ->map(function ($attribute, $key) use (&$definition) {
+                if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
+                    $attribute = $attribute($definition);
+                }
 
-            return $attribute;
-        })->all();
+                $definition[$key] = $attribute;
+                
+                return $attribute;
+            })
+            ->all();
     }
 
     /**


### PR DESCRIPTION
## What?

When defining attributes on a Factory, this small fix will _defer_ callables to be resolved after all other non-callables are set in the definition array.

This makes this code safe to work with:

```php
public function definition()
{
    return [
        'first' => fn ($attributes) => $attributes['last'] + 1, // 4
        'last' => 3
    ];
}
```

1. `last` is resolved first.
2. `first` will be resolved last.

This avoids making the developer having to push callables to the end of the definition array.