### PR TITLE
[9.x] Make throttle lock acquisition retry configurable for concurrency limiter

### DIFF
--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -58,12 +58,13 @@ class ConcurrencyLimiter
      *
      * @param  int  $timeout
      * @param  callable|null  $callback
-     * @return bool
+     * @param  int  $sleep
+     * @return mixed
      *
      * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException
      * @throws \Throwable
      */
-    public function block($timeout, $callback = null)
+    public function block($timeout, $callback = null, $sleep = 250)
     {
         $starting = time();
 
@@ -74,7 +75,7 @@ class ConcurrencyLimiter
                 throw new LimiterTimeoutException;
             }
 
-            usleep(250 * 1000);
+            usleep($sleep * 1000);
         }
 
         if (is_callable($callback)) {

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiterBuilder.php
@@ -45,6 +45,13 @@ class ConcurrencyLimiterBuilder
     public $timeout = 3;
 
     /**
+     * The number of milliseconds to wait between attempts to acquire the lock.
+     *
+     * @var int
+     */
+    public $sleep = 250;
+
+    /**
      * Create a new builder instance.
      *
      * @param  \Illuminate\Redis\Connections\Connection  $connection
@@ -97,6 +104,19 @@ class ConcurrencyLimiterBuilder
     }
 
     /**
+     * The number of milliseconds to wait between lock acquisition attempts.
+     *
+     * @param  int  $sleep
+     * @return $this
+     */
+    public function sleep($sleep)
+    {
+        $this->sleep = $sleep;
+
+        return $this;
+    }
+
+    /**
      * Execute the given callback if a lock is obtained, otherwise call the failure callback.
      *
      * @param  callable  $callback
@@ -110,7 +130,7 @@ class ConcurrencyLimiterBuilder
         try {
             return (new ConcurrencyLimiter(
                 $this->connection, $this->name, $this->maxLocks, $this->releaseAfter
-            ))->block($this->timeout, $callback);
+            ))->block($this->timeout, $callback, $this->sleep);
         } catch (LimiterTimeoutException $e) {
             if ($failure) {
                 return $failure($e);


### PR DESCRIPTION
This PR is similar to https://github.com/laravel/framework/pull/41516. It allows us to configure the sleep time between lock acquisition attempts but for the concurrency limiter.

Even though 250ms is reasonable, making it configuration brings consistency with the duration limiter.