### PR TITLE
[8.x] Enable to modify HTTP Client request headers when using beforeSending() callback

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -984,7 +984,7 @@ class PendingRequest
      *
      * @param  \GuzzleHttp\Psr7\RequestInterface  $request
      * @param  array  $options
-     * @return \Closure
+     * @return \GuzzleHttp\Psr7\RequestInterface
      */
     public function runBeforeSendingCallbacks($request, array $options)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
 use Symfony\Component\VarDumper\VarDumper;
 
 class PendingRequest
@@ -988,11 +989,17 @@ class PendingRequest
      */
     public function runBeforeSendingCallbacks($request, array $options)
     {
-        return tap($request, function ($request) use ($options) {
-            $this->beforeSendingCallbacks->each(function ($callback) use ($request, $options) {
-                call_user_func(
+        return tap($request, function (&$request) use ($options) {
+            $this->beforeSendingCallbacks->each(function ($callback) use (&$request, $options) {
+                $callbackResult = call_user_func(
                     $callback, (new Request($request))->withData($options['laravel_data']), $options, $this
                 );
+
+                if ($callbackResult instanceof RequestInterface) {
+                    $request = $callbackResult;
+                } elseif ($callbackResult instanceof Request) {
+                    $request = $callbackResult->toPsrRequest();
+                }
             });
         });
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1080,4 +1080,26 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('https://example.com');
     }
+
+    public function testItCanAddAuthorizationHeaderIntoRequestUsingBeforeSendingCallback()
+    {
+        $this->factory->fake();
+
+        $this->factory->beforeSending(function (Request $request) {
+            $requestLine = sprintf(
+                '%s %s HTTP/%s',
+                $request->toPsrRequest()->getMethod(),
+                $request->toPsrRequest()->getUri()->withScheme('')->withHost(''),
+                $request->toPsrRequest()->getProtocolVersion()
+            );
+
+            return $request->toPsrRequest()->withHeader('Authorization', 'Bearer '.$requestLine);
+        })->get('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return
+                $request->url() === 'http://foo.com/json' &&
+                $request->hasHeader('Authorization', 'Bearer GET /json HTTP/1.1');
+        });
+    }
 }


### PR DESCRIPTION
Basically, I'm trying to add a request header when sending an HTTP request using HTTP Client from Laravel. But I want to make this thing dynamically since it requires the targeted URL as the header data and it will be used in many further HTTP request. So I decide to use the `Http::beforeSending()` method and take the given ``Illuminate\Http\Client\Request`` parameter to get the URL as the example shown below.
```php
<?PHP

use Illuminate\Http\Client\PendingRequest;
use Illuminate\Http\Client\Request;
use Illuminate\Support\Facades\Http;

Http::beforeSending(function (Request $request, array $options, PendingRequest $pendingRequest) {
    $requestLine = sprintf(
        '%s %s HTTP/%s',
        $request->toPsrRequest()->getMethod(),
        $request->toPsrRequest()->getUri()->withScheme('')->withHost(''),
        $request->toPsrRequest()->getProtocolVersion()
    );

    // this way doesn't work as I mention below.
    $pendingRequest->withHeaders(['Authorization' => 'Bearer '.$requestLine]);

    // this way works, but need some changes in the HTTP client.
    return $request->toPsrRequest()->withHeader('Authorization', 'Bearer '.$requestLine);
})->get('http://foo.com/json');
```

The problem is the request header wasn't changed at all since the ``PendingRequest::runBeforeSendingCallbacks()`` used to run this callback doesn't bring that into the real HTTP request as I expect. Using ``PendingRequest::withHeaders()`` also doesn't work because the actual HTTP Request was already created, so any modification that comes from the ``PendingRequest`` instance is useless.

This PR will fix that problem, so every registered ``beforeSending`` callback on the HTTP Client that returns a ``GuzzleHttp\Psr7\RequestInterface`` or ``Illuminate\Http\Client\Request`` value will be applied to the HTTP request instance.