### PR TITLE
[8.x] Add method to determine if a Collection contains a specific amount of items

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -619,6 +619,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if the collection contains specified amount of items.
+     *
+     * @return bool
+     */
+    public function containsItems($amount)
+    {
+        return $this->count() === $amount;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -600,6 +600,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if the collection contains specified amount of items.
+     *
+     * @return bool
+     */
+    public function containsItems($amount)
+    {
+        return $this->take($amount)->count() === $amount;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -606,7 +606,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      */
     public function containsItems($amount)
     {
-        return $this->take($amount)->count() === $amount;
+        return $this->take($amount + 1)->count() === $amount;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -826,6 +826,16 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse((new $collection([1, 2]))->containsOneItem());
     }
 
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testContainsItems($collection)
+    {
+        $this->assertFalse((new $collection([]))->containsItems(2));
+        $this->assertTrue((new $collection([1, 2, 3]))->containsItems(3));
+        $this->assertFalse((new $collection([1, 2]))->containsItems(3));
+    }
+
     public function testIterable()
     {
         $c = new Collection(['foo']);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -540,6 +540,13 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testContainsItemsIsLazy()
+    {
+        $this->assertEnumerates(3, function ($collection) {
+            $collection->containsItems(3);
+        });
+    }
+
     public function testJoinIsLazy()
     {
         $this->assertEnumeratesOnce(function ($collection) {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -543,7 +543,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     public function testContainsItemsIsLazy()
     {
         $this->assertEnumerates(3, function ($collection) {
-            $collection->containsItems(3);
+            $collection->containsItems(2);
         });
     }
 


### PR DESCRIPTION
This PR introduces the method `containsItems()` to Collection and LazyCollection. Example below.

Currently you can already check if a Collection contains a single item by calling `containsOneItem()` on a Collection.
I believe it would be useful (and for consistency) to have a similar method to be called on a Collection which contains of more than 1 item.

### LazyCollection

```php
// Instead of ..

if ($lazyCollection->take(3 + 1)->count() === 3) {
   // do something..
}

// You can..

if ($lazyCollection->containsItems(3) {
   // do something..
}
```

### Collection

```php
// Intead of..

if ($collection->count() === 3) {
   // do something..
}

// You can..

if ($collection->containsItems(3) {
   // do something..
}
```

Thanks!