### PR TITLE
[9.x] Improve password checks

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -99,7 +99,11 @@ class DatabaseUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        $credentials = $this->credentialsWithoutPassword($credentials);
+        $credentials = array_filter(
+            $credentials,
+            fn ($key) => ! str_contains($key, 'password'),
+            ARRAY_FILTER_USE_KEY
+        );
 
         if (empty($credentials)) {
             return;
@@ -143,17 +147,6 @@ class DatabaseUserProvider implements UserProvider
         if (! is_null($user)) {
             return new GenericUser((array) $user);
         }
-    }
-
-    /**
-     * Remove password values from credentials array.
-     *
-     * @param  array  $credentials
-     * @return array
-     */
-    protected function credentialsWithoutPassword(array $credentials): array
-    {
-        return array_filter($credentials, fn ($key) => ! str_contains($key, 'password'), ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -99,9 +99,9 @@ class DatabaseUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        if (empty($credentials) ||
-           (count($credentials) === 1 &&
-            array_key_exists('password', $credentials))) {
+        $credentials = $this->credentialsWithoutPassword($credentials);
+
+        if (empty($credentials)) {
             return;
         }
 
@@ -143,6 +143,17 @@ class DatabaseUserProvider implements UserProvider
         if (! is_null($user)) {
             return new GenericUser((array) $user);
         }
+    }
+
+    /**
+     * Remove password values from credentials array.
+     *
+     * @param  array  $credentials
+     * @return array
+     */
+    protected function credentialsWithoutPassword(array $credentials): array
+    {
+        return array_filter($credentials, fn ($key) => ! str_contains($key, 'password'), ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -134,17 +134,6 @@ class EloquentUserProvider implements UserProvider
     }
 
     /**
-     * Remove password values from credentials array.
-     *
-     * @param  array  $credentials
-     * @return array
-     */
-    protected function credentialsWithoutPassword(array $credentials): array
-    {
-        return array_filter($credentials, fn ($key) => ! str_contains($key, 'password'), ARRAY_FILTER_USE_KEY);
-    }
-
-    /**
      * Validate a user against the given credentials.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -105,9 +105,9 @@ class EloquentUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        if (empty($credentials) ||
-           (count($credentials) === 1 &&
-            str_contains($this->firstCredentialKey($credentials), 'password'))) {
+        $credentials = $this->credentialsWithoutPassword($credentials);
+
+        if (empty($credentials)) {
             return;
         }
 
@@ -117,10 +117,6 @@ class EloquentUserProvider implements UserProvider
         $query = $this->newModelQuery();
 
         foreach ($credentials as $key => $value) {
-            if (str_contains($key, 'password')) {
-                continue;
-            }
-
             if (is_array($value) || $value instanceof Arrayable) {
                 $query->whereIn($key, $value);
             } elseif ($value instanceof Closure) {
@@ -134,14 +130,14 @@ class EloquentUserProvider implements UserProvider
     }
 
     /**
-     * Get the first key from the credential array.
+     * Remove password values from credentials array.
      *
      * @param  array  $credentials
-     * @return string|null
+     * @return array
      */
-    protected function firstCredentialKey(array $credentials)
+    protected function credentialsWithoutPassword(array $credentials): array
     {
-        return array_key_first($credentials);
+        return array_filter($credentials, fn ($key) => ! str_contains($key, 'password'), ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -105,7 +105,11 @@ class EloquentUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        $credentials = $this->credentialsWithoutPassword($credentials);
+        $credentials = array_filter(
+            $credentials,
+            fn ($key) => ! str_contains($key, 'password'),
+            ARRAY_FILTER_USE_KEY
+        );
 
         if (empty($credentials)) {
             return;

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -135,6 +135,19 @@ class AuthDatabaseUserProviderTest extends TestCase
         $this->assertNull($user);
     }
 
+    public function testRetrieveByCredentialsWithMultiplyPasswordsReturnsNull()
+    {
+        $conn = m::mock(Connection::class);
+        $hasher = m::mock(Hasher::class);
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = $provider->retrieveByCredentials([
+            'password' => 'dayle',
+            'password2' => 'night'
+        ]);
+
+        $this->assertNull($user);
+    }
+
     public function testCredentialValidation()
     {
         $conn = m::mock(Connection::class);

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -117,6 +117,17 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertSame('bar', $user);
     }
 
+    public function testRetrieveByCredentialsWithMultiplyPasswordsReturnsNull()
+    {
+        $provider = $this->getProviderMock();
+        $user = $provider->retrieveByCredentials([
+            'password' => 'dayle',
+            'password2' => 'night'
+        ]);
+
+        $this->assertNull($user);
+    }
+
     public function testCredentialValidation()
     {
         $hasher = m::mock(Hasher::class);


### PR DESCRIPTION
It also fixes a possible collision when credentials contains only "password" values.
```
$provider->retrieveByCredentials(['password' => 'dayle', 'password2' => 'night']);
```
As a result of the code above, the first record will be retrieved from the table in the database.