### PR TITLE
[9.x] Add the ability to steal atomic locks

### DIFF
--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -51,6 +51,27 @@ class ArrayLock extends Lock
     }
 
     /**
+     * Attempt to steal an existing lock.
+     *
+     * @return bool
+     */
+    public function steal()
+    {
+        $expiration = $this->store->locks[$this->name]['expiresAt'] ?? Carbon::now()->addSecond();
+
+        if (!$this->exists() || !$expiration->isFuture()) {
+            return false;
+        }
+
+        $this->store->locks[$this->name] = [
+            'owner' => $this->owner,
+            'expiresAt' => $this->seconds === 0 ? null : Carbon::now()->addSeconds($this->seconds),
+        ];
+
+        return true;
+    }
+
+    /**
      * Determine if the current lock exists.
      *
      * @return bool

--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -88,11 +88,11 @@ class ArrayLock extends Lock
      */
     public function release()
     {
-        if (! $this->exists()) {
+        if (!$this->exists()) {
             return false;
         }
 
-        if (! $this->isOwnedByCurrentProcess()) {
+        if (!$this->isOwnedByCurrentProcess()) {
             return false;
         }
 

--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -59,7 +59,7 @@ class ArrayLock extends Lock
     {
         $expiration = $this->store->locks[$this->name]['expiresAt'] ?? Carbon::now()->addSecond();
 
-        if (!$this->exists() || !$expiration->isFuture()) {
+        if (! $this->exists() || ! $expiration->isFuture()) {
             return false;
         }
 
@@ -88,11 +88,11 @@ class ArrayLock extends Lock
      */
     public function release()
     {
-        if (!$this->exists()) {
+        if (! $this->exists()) {
             return false;
         }
 
-        if (!$this->isOwnedByCurrentProcess()) {
+        if (! $this->isOwnedByCurrentProcess()) {
             return false;
         }
 

--- a/src/Illuminate/Cache/CacheLock.php
+++ b/src/Illuminate/Cache/CacheLock.php
@@ -50,6 +50,28 @@ class CacheLock extends Lock
     }
 
     /**
+     * Attempt to steal an existing lock.
+     *
+     * @return bool
+     */
+    public function steal()
+    {
+        if (method_exists($this->store, 'replace') && $this->seconds > 0) {
+            return $this->store->replace(
+                $this->name, $this->owner, $this->seconds
+            );
+        }
+
+        if (is_null($this->store->get($this->name))) {
+            return false;
+        }
+
+        return ($this->seconds > 0)
+                ? $this->store->put($this->name, $this->owner, $this->seconds)
+                : $this->store->forever($this->name, $this->owner);
+    }
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -135,9 +135,9 @@ class DatabaseLock extends Lock
     {
         if ($this->isOwnedByCurrentProcess()) {
             $this->connection->table($this->table)
-                             ->where('key', $this->name)
-                             ->where('owner', $this->owner)
-                             ->delete();
+                        ->where('key', $this->name)
+                        ->where('owner', $this->owner)
+                        ->delete();
 
             return true;
         }
@@ -153,8 +153,8 @@ class DatabaseLock extends Lock
     public function forceRelease()
     {
         $this->connection->table($this->table)
-                         ->where('key', $this->name)
-                         ->delete();
+                    ->where('key', $this->name)
+                    ->delete();
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -117,7 +117,7 @@ class DatabaseLock extends Lock
     /**
      * Clear expired locks from database table, if lottery hits.
      *
-     * @return int
+     * @return void
      */
     protected function clearExpiredLocks()
     {

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -70,9 +70,9 @@ class DatabaseLock extends Lock
                 ->where(function ($query) {
                     return $query->where('owner', $this->owner)->orWhere('expiration', '<=', time());
                 })->update([
-                'owner' => $this->owner,
-                'expiration' => $this->expiresAt(),
-            ]);
+                    'owner' => $this->owner,
+                    'expiration' => $this->expiresAt(),
+                ]);
 
             $acquired = $updated >= 1;
         }
@@ -135,9 +135,9 @@ class DatabaseLock extends Lock
     {
         if ($this->isOwnedByCurrentProcess()) {
             $this->connection->table($this->table)
-                ->where('key', $this->name)
-                ->where('owner', $this->owner)
-                ->delete();
+                             ->where('key', $this->name)
+                             ->where('owner', $this->owner)
+                             ->delete();
 
             return true;
         }
@@ -153,8 +153,8 @@ class DatabaseLock extends Lock
     public function forceRelease()
     {
         $this->connection->table($this->table)
-            ->where('key', $this->name)
-            ->delete();
+                         ->where('key', $this->name)
+                         ->delete();
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -165,6 +165,29 @@ class DatabaseStore implements LockProvider, Store
     }
 
     /**
+     * Replace an item in the cache if the key exists.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  int  $seconds
+     * @return bool
+     */
+    public function replace($key, $value, $seconds)
+    {
+        $key = $this->prefix.$key;
+        $value = $this->serialize($value);
+        $expiration = $this->getTime() + $seconds;
+
+        return $this->table()
+            ->where('key', $key)
+            ->where('expiration', '<=', $this->getTime())
+            ->update([
+                'value' => $value,
+                'expiration' => $expiration,
+            ]) >= 1;
+    }
+
+    /**
      * Increment the value of an item in the cache.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/DynamoDbLock.php
+++ b/src/Illuminate/Cache/DynamoDbLock.php
@@ -40,6 +40,18 @@ class DynamoDbLock extends Lock
     }
 
     /**
+     * Attempt to steal an existing lock.
+     *
+     * @return bool
+     */
+    public function steal()
+    {
+        return $this->dynamo->replace(
+            $this->name, $this->owner, $this->seconds
+        );
+    }
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -97,7 +97,7 @@ class DynamoDbStore implements LockProvider, Store
             'ConsistentRead' => false,
             'Key' => [
                 $this->keyAttribute => [
-                    'S' => $this->prefix . $key,
+                    'S' => $this->prefix.$key,
                 ],
             ],
         ]);
@@ -306,7 +306,7 @@ class DynamoDbStore implements LockProvider, Store
             'TableName' => $this->table,
             'Item' => [
                 $this->keyAttribute => [
-                    'S' => $this->prefix . $key,
+                    'S' => $this->prefix.$key,
                 ],
                 $this->valueAttribute => [
                     $this->type($value) => $this->serialize($value),

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -97,7 +97,7 @@ class DynamoDbStore implements LockProvider, Store
             'ConsistentRead' => false,
             'Key' => [
                 $this->keyAttribute => [
-                    'S' => $this->prefix.$key,
+                    'S' => $this->prefix . $key,
                 ],
             ],
         ]);

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -66,6 +66,13 @@ abstract class Lock implements LockContract
     abstract public function acquire();
 
     /**
+     * Attempt to steal an existing lock.
+     *
+     * @return bool
+     */
+    abstract public function steal();
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/MemcachedLock.php
+++ b/src/Illuminate/Cache/MemcachedLock.php
@@ -40,6 +40,18 @@ class MemcachedLock extends Lock
     }
 
     /**
+     * Attempt to steal an existing lock.
+     *
+     * @return bool
+     */
+    public function steal()
+    {
+        return $this->memcached->replace(
+            $this->name, $this->owner, $this->seconds
+        );
+    }
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/NoLock.php
+++ b/src/Illuminate/Cache/NoLock.php
@@ -15,6 +15,16 @@ class NoLock extends Lock
     }
 
     /**
+     * Attempt to steal an existing lock.
+     *
+     * @return bool
+     */
+    public function steal()
+    {
+        return true;
+    }
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -42,6 +42,20 @@ class RedisLock extends Lock
     }
 
     /**
+     * Attempt to steal an existing lock.
+     *
+     * @return bool
+     */
+    public function steal()
+    {
+        if ($this->seconds > 0) {
+            return $this->redis->set($this->name, $this->owner, 'EX', $this->seconds, 'XX') == true;
+        } else {
+            return $this->redis->set($this->name, $this->owner, null, null, 'XX') == true;
+        }
+    }
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -273,4 +273,22 @@ class CacheArrayStoreTest extends TestCase
 
         $this->assertFalse($wannabeOwner->release());
     }
+
+    public function testLocksCanBeStolen()
+    {
+        $store = new ArrayStore;
+
+        $firstLock = $store->lock('foo', 1);
+        $this->assertTrue($firstLock->acquire());
+
+        $secondLock = $store->lock('foo', 10);
+        $this->assertTrue($secondLock->steal());
+        $this->assertFalse($firstLock->release());
+
+        sleep(2);
+        $this->assertFalse($store->lock('foo')->acquire());
+
+        $this->assertTrue($secondLock->release());
+        $this->assertTrue($store->lock('foo')->acquire());
+    }
 }

--- a/tests/Integration/Cache/FileCacheLockTest.php
+++ b/tests/Integration/Cache/FileCacheLockTest.php
@@ -95,4 +95,22 @@ class FileCacheLockTest extends TestCase
 
         $this->assertTrue(Cache::lock('foo')->get());
     }
+
+    public function testLocksCanBeStolen()
+    {
+        Cache::lock('foo')->forceRelease();
+
+        $firstLock = Cache::lock('foo', 1);
+        $this->assertTrue($firstLock->acquire());
+
+        $secondLock = Cache::lock('foo', 10);
+        $this->assertTrue($secondLock->steal());
+        $this->assertFalse($firstLock->release());
+
+        sleep(2);
+        $this->assertFalse(Cache::lock('foo')->acquire());
+
+        $this->assertTrue($secondLock->release());
+        $this->assertTrue(Cache::lock('foo')->acquire());
+    }
 }


### PR DESCRIPTION
This PR adds the ability to steal atomic locks, for all current cache stores.

A stolen lock is a lock that changes owner (instantly) and has a new expiration. The previous owner loses control of the lock and can't release it. Some may think we can already do that, by force releasing a lock and taking a new one, but this introduces race conditions where the lock stealer could force release the previous owner's lock but can't acquire a new lock if a process manages to acquire a new lock before it. Lock stealing is instantaneous.

Lock stealing has many uses in the wild, and in my case this is groundwork for my next PR, which will enable easy debouncing of queue jobs. Think like unique jobs, but instead of dropping duplicates, only the latest job will be kept, and includes a delay. This will help greatly reduce job repetition in some cases.