### PR TITLE
[9.x] add `firstOrThrow()` and `findOrThrow()` methods to eloquent query builders

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -483,6 +483,31 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Find a model by its primary key or throw the given exception.
+     *
+     * @param  mixed  $id
+     * @param  array|\Exception  $columns
+     * @param  \Exception|null  $exception
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
+     *
+     * @throws \Exception
+     */
+    public function findOrThrow($id, $columns = ['*'], $exception = null)
+    {
+        if ($columns instanceof Exception) {
+            $exception = $columns;
+
+            $columns = ['*'];
+        }
+
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch (ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
      * Find a model by its primary key or return fresh model instance.
      *
      * @param  mixed  $id
@@ -584,6 +609,30 @@ class Builder implements BuilderContract
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->model));
+    }
+
+    /**
+     * Execute the query and get the first result or throw the given exception.
+     *
+     * @param  array|\Exception  $columns
+     * @param  \Exception|null  $exception
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Exception
+     */
+    public function firstOrThrow($columns = ['*'], $exception = null)
+    {
+        if ($columns instanceof Exception) {
+            $exception = $columns;
+
+            $columns = ['*'];
+        }
+
+        try {
+            return $this->firstOrFail($columns);
+        } catch (ModelNotFoundException) {
+            throw $exception;
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -486,15 +486,15 @@ class Builder implements BuilderContract
      * Find a model by its primary key or throw the given exception.
      *
      * @param  mixed  $id
-     * @param  array|\Exception  $columns
-     * @param  \Exception|null  $exception
+     * @param  array|\Exception|class-string<\Exception>  $columns
+     * @param  \Exception|class-string<\Exception>|null  $exception
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
      *
      * @throws \Exception
      */
     public function findOrThrow($id, $columns = ['*'], $exception = null)
     {
-        if ($columns instanceof Exception) {
+        if ($columns instanceof Exception || is_string($columns)) {
             $exception = $columns;
 
             $columns = ['*'];
@@ -502,7 +502,11 @@ class Builder implements BuilderContract
 
         try {
             return $this->findOrFail($id, $columns);
-        } catch (ModelNotFoundException) {
+        } catch (ModelNotFoundException $modelNotFoundException) {
+            if (is_string($exception)) {
+                $exception = new $exception(previous: $modelNotFoundException);
+            }
+
             throw $exception;
         }
     }
@@ -614,15 +618,15 @@ class Builder implements BuilderContract
     /**
      * Execute the query and get the first result or throw the given exception.
      *
-     * @param  array|\Exception  $columns
-     * @param  \Exception|null  $exception
+     * @param  array|\Exception|class-string<\Exception>  $columns
+     * @param  \Exception|class-string<\Exception>|null  $exception
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Exception
      */
     public function firstOrThrow($columns = ['*'], $exception = null)
     {
-        if ($columns instanceof Exception) {
+        if ($columns instanceof Exception || is_string($columns)) {
             $exception = $columns;
 
             $columns = ['*'];
@@ -630,7 +634,11 @@ class Builder implements BuilderContract
 
         try {
             return $this->firstOrFail($columns);
-        } catch (ModelNotFoundException) {
+        } catch (ModelNotFoundException $modelNotFoundException) {
+            if (is_string($exception)) {
+                $exception = new $exception(previous: $modelNotFoundException);
+            }
+
             throw $exception;
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Closure;
+use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -720,6 +721,31 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Find a related model by its primary key or throw the given exception.
+     *
+     * @param  mixed  $id
+     * @param  array|\Exception  $columns
+     * @param  \Exception|null  $exception
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     *
+     * @throws \Exception
+     */
+    public function findOrThrow($id, $columns = ['*'], $exception = null)
+    {
+        if ($columns instanceof Exception) {
+            $exception = $columns;
+
+            $columns = ['*'];
+        }
+
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch (ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
      * Find a related model by its primary key or call a callback.
      *
      * @param  mixed  $id
@@ -792,6 +818,30 @@ class BelongsToMany extends Relation
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->related));
+    }
+
+    /**
+     * Execute the query and get the first result or throw the given exception.
+     *
+     * @param  array|\Exception  $columns
+     * @param  \Exception|null  $exception
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Exception
+     */
+    public function firstOrThrow($columns = ['*'], $exception = null)
+    {
+        if ($columns instanceof Exception) {
+            $exception = $columns;
+
+            $columns = ['*'];
+        }
+
+        try {
+            return $this->firstOrFail($columns);
+        } catch (ModelNotFoundException) {
+            throw $exception;
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -724,15 +724,15 @@ class BelongsToMany extends Relation
      * Find a related model by its primary key or throw the given exception.
      *
      * @param  mixed  $id
-     * @param  array|\Exception  $columns
-     * @param  \Exception|null  $exception
+     * @param  array|\Exception|class-string<\Exception>  $columns
+     * @param  \Exception|class-string<\Exception>|null  $exception
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
      *
      * @throws \Exception
      */
     public function findOrThrow($id, $columns = ['*'], $exception = null)
     {
-        if ($columns instanceof Exception) {
+        if ($columns instanceof Exception || is_string($columns)) {
             $exception = $columns;
 
             $columns = ['*'];
@@ -740,7 +740,11 @@ class BelongsToMany extends Relation
 
         try {
             return $this->findOrFail($id, $columns);
-        } catch (ModelNotFoundException) {
+        } catch (ModelNotFoundException $modelNotFoundException) {
+            if (is_string($exception)) {
+                $exception = new $exception(previous: $modelNotFoundException);
+            }
+
             throw $exception;
         }
     }
@@ -823,15 +827,15 @@ class BelongsToMany extends Relation
     /**
      * Execute the query and get the first result or throw the given exception.
      *
-     * @param  array|\Exception  $columns
-     * @param  \Exception|null  $exception
+     * @param  array|\Exception|class-string<\Exception>  $columns
+     * @param  \Exception|class-string<\Exception>|null  $exception
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Exception
      */
     public function firstOrThrow($columns = ['*'], $exception = null)
     {
-        if ($columns instanceof Exception) {
+        if ($columns instanceof Exception || is_string($columns)) {
             $exception = $columns;
 
             $columns = ['*'];
@@ -839,7 +843,11 @@ class BelongsToMany extends Relation
 
         try {
             return $this->firstOrFail($columns);
-        } catch (ModelNotFoundException) {
+        } catch (ModelNotFoundException $modelNotFoundException) {
+            if (is_string($exception)) {
+                $exception = new $exception(previous: $modelNotFoundException);
+            }
+
             throw $exception;
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Closure;
+use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -303,6 +304,30 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Execute the query and get the first result or throw the given exception.
+     *
+     * @param  array|\Exception  $columns
+     * @param  \Exception|null  $exception
+     * @return \Illuminate\Database\Eloquent\Model|static
+     *
+     * @throws \Exception
+     */
+    public function firstOrThrow($columns = ['*'], $exception = null)
+    {
+        if ($columns instanceof Exception) {
+            $exception = $columns;
+
+            $columns = ['*'];
+        }
+
+        try {
+            return $this->firstOrFail($columns);
+        } catch (ModelNotFoundException) {
+            throw $exception;
+        }
+    }
+
+    /**
      * Execute the query and get the first result or call a callback.
      *
      * @param  \Closure|array  $columns
@@ -386,6 +411,31 @@ class HasManyThrough extends Relation
         }
 
         throw (new ModelNotFoundException)->setModel(get_class($this->related), $id);
+    }
+
+    /**
+     * Find a related model by its primary key or throw the given exception.
+     *
+     * @param  mixed  $id
+     * @param  array|\Exception  $columns
+     * @param  \Exception|null  $exception
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     *
+     * @throws \Exception
+     */
+    public function findOrThrow($id, $columns = ['*'], $exception = null)
+    {
+        if ($columns instanceof Exception) {
+            $exception = $columns;
+
+            $columns = ['*'];
+        }
+
+        try {
+            return $this->findOrFail($id, $columns);
+        } catch (ModelNotFoundException) {
+            throw $exception;
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -306,15 +306,15 @@ class HasManyThrough extends Relation
     /**
      * Execute the query and get the first result or throw the given exception.
      *
-     * @param  array|\Exception  $columns
-     * @param  \Exception|null  $exception
+     * @param  array|\Exception|class-string<\Exception>  $columns
+     * @param  \Exception|class-string<\Exception>|null  $exception
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Exception
      */
     public function firstOrThrow($columns = ['*'], $exception = null)
     {
-        if ($columns instanceof Exception) {
+        if ($columns instanceof Exception || is_string($columns)) {
             $exception = $columns;
 
             $columns = ['*'];
@@ -322,7 +322,11 @@ class HasManyThrough extends Relation
 
         try {
             return $this->firstOrFail($columns);
-        } catch (ModelNotFoundException) {
+        } catch (ModelNotFoundException $modelNotFoundException) {
+            if (is_string($exception)) {
+                $exception = new $exception(previous: $modelNotFoundException);
+            }
+
             throw $exception;
         }
     }
@@ -417,15 +421,15 @@ class HasManyThrough extends Relation
      * Find a related model by its primary key or throw the given exception.
      *
      * @param  mixed  $id
-     * @param  array|\Exception  $columns
-     * @param  \Exception|null  $exception
+     * @param  array|\Exception|class-string<\Exception>  $columns
+     * @param  \Exception|class-string<\Exception>|null  $exception
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
      *
      * @throws \Exception
      */
     public function findOrThrow($id, $columns = ['*'], $exception = null)
     {
-        if ($columns instanceof Exception) {
+        if ($columns instanceof Exception || is_string($columns)) {
             $exception = $columns;
 
             $columns = ['*'];
@@ -433,7 +437,11 @@ class HasManyThrough extends Relation
 
         try {
             return $this->findOrFail($id, $columns);
-        } catch (ModelNotFoundException) {
+        } catch (ModelNotFoundException $modelNotFoundException) {
+            if (is_string($exception)) {
+                $exception = new $exception(previous: $modelNotFoundException);
+            }
+
             throw $exception;
         }
     }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 {
@@ -166,6 +167,16 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::first()->posts()->firstOrFail();
     }
 
+    public function testFirstOrThrowThrowsGivenException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->firstOrThrow(new HttpException(409, 'message'));
+    }
+
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -199,6 +210,38 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                                  ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
 
         HasManyThroughTestCountry::first()->posts()->findOrFail(new Collection([1, 2]));
+    }
+
+    public function testFindOrThrowThrowsGivenException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrThrow(1, new HttpException(409, 'message'));
+    }
+
+    public function testFindOrThrowWithManyThrowsGivenException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrThrow([1, 2], new HttpException(409, 'message'));
+    }
+
+    public function testFindOrThrowWithManyUsingCollectionThrowsGivenException()
+    {
+        $this->expectException(HttpException::class);
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
+            ->posts()->create(['id' => 1, 'title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrThrow(new Collection([1, 2]), new HttpException(409, 'message'));
     }
 
     public function testFindOrMethod()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -647,6 +647,21 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::findOrFail(new Collection([1, 1, 2, 3]));
     }
 
+    public function testFindOrThrow()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $single = EloquentTestUser::findOrThrow(1, new Exception('message'));
+        $multiple = EloquentTestUser::findOrThrow([1, 2], new Exception('message'));
+
+        $this->assertInstanceOf(EloquentTestUser::class, $single);
+        $this->assertSame('taylorotwell@gmail.com', $single->email);
+        $this->assertInstanceOf(Collection::class, $multiple);
+        $this->assertInstanceOf(EloquentTestUser::class, $multiple[0]);
+        $this->assertInstanceOf(EloquentTestUser::class, $multiple[1]);
+    }
+
     public function testOneToOneRelationship()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
This PR adds `firstOrThrow()` and `findOrThrow()` methods to the eloquent query builders as an alternative to `firstOr(fn() => throw new Exception)` to throw any custom exception.
This is based on #42243 - as I believe that this custom exception method is the most flexible solution for the named "problem".