### PR TITLE
[10.x] Standardize `withCount()` & `withExists()` eager loading aggregates.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -618,10 +618,15 @@ trait QueriesRelationships
      * Add subselect queries to count the relations.
      *
      * @param  mixed  $relations
+     * @param  string|\Closure|null  $callback
      * @return $this
      */
-    public function withCount($relations)
+    public function withCount($relations, $callback = null)
     {
+        if ($callback instanceof Closure) {
+            $relations = [$relations => $callback];
+        }
+
         return $this->withAggregate(is_array($relations) ? $relations : func_get_args(), '*', 'count');
     }
 
@@ -676,12 +681,17 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the existence of related models.
      *
-     * @param  string|array  $relation
+     * @param  mixed  $relations
+     * @param  string|\Closure|null  $callback
      * @return $this
      */
-    public function withExists($relation)
+    public function withExists($relations, $callback = null)
     {
-        return $this->withAggregate($relation, '*', 'exists');
+        if ($callback instanceof Closure) {
+            $relations = [$relations => $callback];
+        }
+
+        return $this->withAggregate(is_array($relations) ? $relations : func_get_args(), '*', 'exists');
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1201,13 +1201,19 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testWithCountAndMergedWheres()
     {
+        $sql = 'select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"';
+        $wheres = function ($query) {
+            $query->where('bam', '>', 'qux');
+        };
+
         $model = new EloquentBuilderTestModelParentStub;
+        $builder = $model->select('id')->withCount(['activeFoo' => $wheres]);
+        $this->assertSame($sql, $builder->toSql());
+        $this->assertEquals(['qux', true], $builder->getBindings());
 
-        $builder = $model->select('id')->withCount(['activeFoo' => function ($q) {
-            $q->where('bam', '>', 'qux');
-        }]);
-
-        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $model = new EloquentBuilderTestModelParentStub;
+        $builder = $model->select('id')->withCount('activeFoo', $wheres);
+        $this->assertSame($sql, $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -1285,11 +1291,15 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testWithCountMultipleAndPartialRename()
     {
+        $sql = 'select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"';
+
         $model = new EloquentBuilderTestModelParentStub;
-
         $builder = $model->withCount(['foo as foo_bar', 'foo']);
+        $this->assertSame($sql, $builder->toSql());
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $model = new EloquentBuilderTestModelParentStub;
+        $builder = $model->withCount('foo as foo_bar', 'foo');
+        $this->assertSame($sql, $builder->toSql());
     }
 
     public function testWithExists()
@@ -1312,13 +1322,19 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testWithExistsAndMergedWheres()
     {
+        $sql = 'select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"';
+        $wheres = function ($query) {
+            $query->where('bam', '>', 'qux');
+        };
+
         $model = new EloquentBuilderTestModelParentStub;
+        $builder = $model->select('id')->withExists(['activeFoo' => $wheres]);
+        $this->assertSame($sql, $builder->toSql());
+        $this->assertEquals(['qux', true], $builder->getBindings());
 
-        $builder = $model->select('id')->withExists(['activeFoo' => function ($q) {
-            $q->where('bam', '>', 'qux');
-        }]);
-
-        $this->assertSame('select "id", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $model = new EloquentBuilderTestModelParentStub;
+        $builder = $model->select('id')->withExists('activeFoo', $wheres);
+        $this->assertSame($sql, $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -1374,11 +1390,15 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function testWithExistsMultipleAndPartialRename()
     {
+        $sql = 'select "eloquent_builder_test_model_parent_stubs".*, exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"';
+
         $model = new EloquentBuilderTestModelParentStub;
-
         $builder = $model->withExists(['foo as foo_bar', 'foo']);
+        $this->assertSame($sql, $builder->toSql());
 
-        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", exists(select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_exists" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $model = new EloquentBuilderTestModelParentStub;
+        $builder = $model->withExists('foo as foo_bar', 'foo');
+        $this->assertSame($sql, $builder->toSql());
     }
 
     public function testHasWithConstraintsAndHavingInSubquery()


### PR DESCRIPTION
🔴 There has been an attempt to add this functionality in #41914 but got reverted in #41943 due to a bug in the code. I figured I'd modify the function signatures to match the `with()` function and send it to `10.x` instead.

## What does this PR do?

- Standardizes the way you can eager load your `withCount()` & `withExists()` aggregates.
- Adds logic to existing tests to support this functionality☝🏼.

## Why do we need this?
### Before this PR
There are 3 different ways to pass parameters in `with...()` functions:
1. Passing relation strings (internally will check `is_array($relations) ? $relations : func_get_args()`).
2. Passing an array of relations (with or without a closure as the value).
3. Passing the first parameter as a relation string and second argument as a closure.

If we compare the `with()`, `withCount()` & `withExists` functions, this is what each of them currently support:
- `with()`: 1, 2 & 3.
- `withCount()`: 1 & 2.
- `withExists()`: 1 (with only 1 relation 😞) & 2.

The reason why I am writing this PR is because I ran into a situation where I assumed that since I was able to do it with one of these methods, why shouldn't I be able to do the same with any of the other 2 methods.

### With this PR
The 3 functions mentioned above will support all 3 different ways to pass the params.