### PR TITLE
[9.x] Add `containsItems` Collection method to determine if it contains a specific amount of items

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -645,6 +645,16 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if the collection contains specified amount of items.
+     *
+     * @return bool
+     */
+    public function containsItems($amount)
+    {
+        return $this->count() === $amount;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -638,6 +638,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if the collection contains specified amount of items.
+     *
+     * @return bool
+     */
+    public function containsItems($amount)
+    {
+        return $this->take($amount + 1)->count() === $amount;
+    }
+
+    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -831,6 +831,16 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse((new $collection([1, 2]))->containsOneItem());
     }
 
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testContainsItems($collection)
+    {
+        $this->assertFalse((new $collection([]))->containsItems(2));
+        $this->assertTrue((new $collection([1, 2, 3]))->containsItems(3));
+        $this->assertFalse((new $collection([1, 2]))->containsItems(3));
+    }
+
     public function testIterable()
     {
         $c = new Collection(['foo']);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -533,6 +533,13 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testContainsItemsIsLazy()
+    {
+        $this->assertEnumerates(3, function ($collection) {
+            $collection->containsItems(2);
+        });
+    }
+
     public function testJoinIsLazy()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
This PR introduces the method `containsItems()` to Collection and LazyCollection. Example below.

Currently you can already determine if a collection contains a single item by calling the method `containsOneItem()`.

The reason of this implementation is because I think it would be useful, especially for lazy collections (and for consistency), to have a similar method to be called on a collection which contains of more than 1 item.

Because of the naming convention I decided to go with `containsItems()`. But `itemsCount()` could be an alternative, which describes the method better.

### LazyCollection

```php
// Instead of ..

if ($lazyCollection->take(3 + 1)->count() === 3) {
   // do something..
}

// You can..

if ($lazyCollection->containsItems(3)) {
   // do something..
}
```

### Collection

```php
// Intead of..

if ($collection->count() === 3) {
   // do something..
}

// You can..

if ($collection->containsItems(3)) {
   // do something..
}
```

Thanks!