### PR TITLE
[9.x] Add `value()` collection method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -322,6 +322,22 @@ trait EnumeratesValues
     }
 
     /**
+     * Get a single key's value from the first matching item in the collection.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function value($key, $default = null)
+    {
+        if ($value = $this->firstWhere($key)) {
+            return data_get($value, $key, $default);
+        }
+
+        return $default;
+    }
+
+    /**
      * Determine if the collection is not empty.
      *
      * @return bool

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -334,7 +334,7 @@ trait EnumeratesValues
             return data_get($value, $key, $default);
         }
 
-        return $default;
+        return value($default);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1124,6 +1124,26 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testValue($collection)
+    {
+        $c = new $collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
+
+        $this->assertEquals('Hello', $c->value('name'));
+        $this->assertEquals('World', $c->where('id', 2)->value('name'));
+
+        $c = new $collection([
+            ['id' => 1, 'pivot' => ['value' => 'foo']],
+            ['id' => 2, 'pivot' => ['value' => 'bar']],
+        ]);
+
+        $this->assertEquals(['value' => 'foo'], $c->value('pivot'));
+        $this->assertEquals('foo', $c->value('pivot.value'));
+        $this->assertEquals('bar', $c->where('id', 2)->value('pivot.value'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testBetween($collection)
     {
         $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);


### PR DESCRIPTION
## Description

This PR adds the `collect($items)->value($key)` method, which operates similarly to Eloquent's `$query->value($column)` method, allowing you to fetch a single key's first matching value from a collection.

## Example

Let's say we have a `Book` model with a relationship named "metadata".

This `metadata()` relationship has a pivot table, containing the metadata's `value`.

In this application, users can attach specific metadata to books, and then assign their own value via the pivot table.

With the `value()` collection method, we can take the eager loaded metadata, filter by the metadata `key`, and then retrieve the first matching `pivot.value`:

```php
// John Doe
$author = $book->metadata->where('key', 'author')->value('pivot.value');
```

---

Let me know if you'd like anything adjusted or changed. Thanks for your time! 🙏 

No hard feelings on closure ❤️ 