### PR TITLE
[9.x] Add auto language fallback to less specific localization

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -325,7 +325,19 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     protected function localeArray($locale)
     {
-        return array_filter([$locale ?: $this->locale, $this->fallback]);
+        $locales = [];
+        if (preg_match_all('/[-_]?(?:[a-zA-Z0-9]+)+/', $locale ?: $this->locale, $matches) > 1) {
+            $parts = $matches[0];
+            for ($i = count($parts); $i > 1; $i--) {
+                $locales[] = implode('', array_slice($parts, 0, $i));
+            }
+            $locales[] = $parts[0];
+        } else {
+            $locales[] = $locale ?: $this->locale;
+        }
+        $locales[] = $this->fallback;
+
+        return array_filter($locales);
     }
 
     /**

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -221,6 +221,30 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo ', $t->get('foo :message', ['message' => null]));
     }
 
+    public function testMultiLanguageFallbacks()
+    {
+        $t = new Translator($this->getLoader(), 'en-US');
+        $t->setFallback('fr');
+        $t->getLoader()->shouldReceive('load')->once()->with('en-US', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en-US', 'bar', 'foo')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('fr', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en-US'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testMultiLanguageCustomFallbacks()
+    {
+        $t = new Translator($this->getLoader(), 'en_US');
+        $t->getLoader()->shouldReceive('load')->once()->with('en_US-custom', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en_US', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en_US-custom', 'bar', 'foo')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en_US', 'bar', 'foo')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en_US-custom'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
     protected function getLoader()
     {
         return m::mock(Loader::class);


### PR DESCRIPTION
Hi everyone,

A bit of context first: as my team is preparing to undertake a huge effort on localization we've been looking for specialized software and personal online and we figured out that the vast majority charge either by word or "target translation key" (as key x language). 

Here's our problem: we plan to support locales like `en_US` and `en_GB` that would have most of the translations keys exactly the same, having those fallback to `en` could reduce drastically the number of strings in the end. As this is currently possible using the current fallback config when we add `pt_BR` and `pt_PT` to the mix suddenly there's no way to have those fallback to `pt`. 

This proposal adds auto fallback when the locale is something like `en_US` or `en-US` to a less specific `en`. It could also fallback something like `en_US-custom` to `en_US` then `en`.

As a downside, I realize that this could add several CPU cycles to process the regular expression and even worse, a lot more of I/O.