### PR TITLE
[9.x] Add `whereBetweenDate()` , `whereNotBetweenDate()` ,`whereTimestampBetweenDate()` and `whereNotTimestampBetweenDate()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Query;
 use BackedEnum;
 use Carbon\CarbonPeriod;
 use Closure;
+use DateTime;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
@@ -1215,7 +1216,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where between for two dates with different formats to the query.
+     * Add a where between if database column is DateTime and values is Date.
      *
      * @param  string  $column
      * @param  array  $values
@@ -1225,7 +1226,25 @@ class Builder implements BuilderContract
      */
     public function whereBetweenDate($column, array $values, $boolean = 'and', $not = false)
     {
-        $type = 'betweenDate';
+        $type = 'between';
+
+        $begin = reset($values);
+        $end = end($values);
+
+        if (!$begin instanceof DateTimeInterface && !$begin instanceof Expression) {
+            $begin = new DateTime($begin);
+        }
+        if (!$end instanceof DateTimeInterface && !$end instanceof Expression) {
+            $end = new DateTime($end);
+        }
+        if ($begin instanceof DateTimeInterface && !$begin instanceof Expression) {
+            $begin = $begin->format('Y-m-d H:i:s');
+        }
+        if ($end instanceof DateTimeInterface && !$end instanceof Expression) {
+            $end = $end->format('Y-m-d 23:59:59');
+        }
+
+        $values = [$begin, $end];
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1333,7 +1333,7 @@ class Builder implements BuilderContract
      */
     public function whereBetweenDate($column, iterable $values, $boolean = 'and')
     {
-        return $this->whereBetween( "date($column)", $values, $boolean);
+        return $this->whereBetween("date($column)", $values, $boolean);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1262,11 +1262,12 @@ class Builder implements BuilderContract
     /**
      * Add a where between if the column is Timestamp and values is Date that will format the values Y-m-d 00:00:00 to Y-m-d 23:59:59 to get exact result.
      *
-     * @param string $column
-     * @param array $values
-     * @param string $boolean
-     * @param bool $not
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
+     *
      * @throws \Exception
      */
     public function whereTimestampBetweenDate($column, array $values, $boolean = 'and', $not = false)
@@ -1297,10 +1298,11 @@ class Builder implements BuilderContract
     /**
      * Add a where not between if the column is Timestamp and values is Date that will format the values Y-m-d 00:00:00 to Y-m-d 23:59:59 to get exact result.
      *
-     * @param string $column
-     * @param array $values
-     * @param string $boolean
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
      * @return $this
+     *
      * @throws \Exception
      */
     public function whereNotTimestampBetweenDate($column, iterable $values, $boolean = 'and')

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1231,16 +1231,16 @@ class Builder implements BuilderContract
         $begin = reset($values);
         $end = end($values);
 
-        if (!$begin instanceof DateTimeInterface && !$begin instanceof Expression) {
+        if (! $begin instanceof DateTimeInterface && ! $begin instanceof Expression) {
             $begin = new DateTime($begin);
         }
-        if (!$end instanceof DateTimeInterface && !$end instanceof Expression) {
+        if (! $end instanceof DateTimeInterface && ! $end instanceof Expression) {
             $end = new DateTime($end);
         }
-        if ($begin instanceof DateTimeInterface && !$begin instanceof Expression) {
+        if ($begin instanceof DateTimeInterface && ! $begin instanceof Expression) {
             $begin = $begin->format('Y-m-d H:i:s');
         }
-        if ($end instanceof DateTimeInterface && !$end instanceof Expression) {
+        if ($end instanceof DateTimeInterface && ! $end instanceof Expression) {
             $end = $end->format('Y-m-d 23:59:59');
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1260,6 +1260,53 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where between if the column is Timestamp and values is Date that will format the values Y-m-d 00:00:00 to Y-m-d 23:59:59 to get exact result.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereTimestampBetweenDate($column, array $values, $boolean = 'and', $not = false)
+    {
+        $type = 'between';
+
+        $begin = reset($values);
+        $end = end($values);
+
+        if (!$begin instanceof DateTimeInterface) {
+            $begin = new \DateTime($begin);
+        }
+        if (!$end instanceof DateTimeInterface) {
+            $end = new \DateTime($end);
+        }
+
+        $begin = $begin->format('Y-m-d 00:00:00');
+        $end = $end->format('Y-m-d 23:59:59');
+        $values = [$begin, $end];
+
+        $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
+
+        $this->addBinding($this->cleanBindings($values));
+
+        return $this;
+    }
+
+    /**
+     * Add a where not between if the column is Timestamp and values is Date that will format the values Y-m-d 00:00:00 to Y-m-d 23:59:59 to get exact result.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotTimestampBetweenDate($column, iterable $values, $boolean = 'and')
+    {
+        return $this->whereTimestampBetweenDate($column, $values, $boolean, true);
+    }
+
+    /**
      * Add an or where between statement to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1237,7 +1237,7 @@ class Builder implements BuilderContract
             $end = $end->format('Y-m-d');
         }
 
-        $values=[$begin,$end];
+        $values = [$begin, $end];
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1215,6 +1215,43 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where between for two dates with different formats to the query.
+     *
+     * @param string $column
+     * @param array $values
+     * @param string $boolean
+     * @param bool $not
+     * @return $this
+     */
+    public function whereBetweenDate($column, array $values, $boolean = 'and', $not = false)
+    {
+        $type = 'betweenDate';
+
+        if ($values instanceof CarbonPeriod) {
+            $values = $values->toArray();
+        }
+
+        $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
+
+        $this->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'where');
+
+        return $this;
+    }
+
+    /**
+     * Add a where not between for two dates with different formats to the query.
+     *
+     * @param string $column
+     * @param array $values
+     * @param string $boolean
+     * @return $this
+     */
+    public function whereNotBetweenDate($column, iterable $values, $boolean = 'and')
+    {
+        return $this->whereBetweenDate($column, $values, $boolean, true);
+    }
+
+    /**
      * Add an or where between statement to the query.
      *
      * @param  string  $column
@@ -1323,18 +1360,6 @@ class Builder implements BuilderContract
         return $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
     }
 
-    /**
-     * Add a where between for two dates with different formats.
-     *
-     * @param  string  $column
-     * @param  iterable  $values
-     * @param  string  $boolean
-     * @return $this
-     */
-    public function whereBetweenDate($column, iterable $values, $boolean = 'and')
-    {
-        return $this->whereBetween("date($column)", $values, $boolean);
-    }
 
     /**
      * Add an "or where date" statement to the query.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1215,7 +1215,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where between if database column is DateTime and values is Date.
+     * Add a where date between statement to the query that casting the column to date.
      *
      * @param  string  $column
      * @param  array  $values
@@ -1247,7 +1247,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add a where not between for two dates with different formats to the query.
+     * Add a where date not between statement to the query that casting the column to date.
      *
      * @param  string  $column
      * @param  array  $values

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1227,13 +1227,9 @@ class Builder implements BuilderContract
     {
         $type = 'betweenDate';
 
-        if ($values instanceof CarbonPeriod) {
-            $values = $values->toArray();
-        }
-
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
 
-        $this->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'where');
+        $this->addBinding($this->cleanBindings($values));
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -5,7 +5,6 @@ namespace Illuminate\Database\Query;
 use BackedEnum;
 use Carbon\CarbonPeriod;
 use Closure;
-use DateTime;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
@@ -1226,25 +1225,19 @@ class Builder implements BuilderContract
      */
     public function whereBetweenDate($column, array $values, $boolean = 'and', $not = false)
     {
-        $type = 'between';
+        $type = 'betweenDate';
 
         $begin = reset($values);
         $end = end($values);
 
-        if (! $begin instanceof DateTimeInterface && ! $begin instanceof Expression) {
-            $begin = new DateTime($begin);
+        if ($begin instanceof DateTimeInterface) {
+            $begin = $begin->format('Y-m-d');
         }
-        if (! $end instanceof DateTimeInterface && ! $end instanceof Expression) {
-            $end = new DateTime($end);
-        }
-        if ($begin instanceof DateTimeInterface && ! $begin instanceof Expression) {
-            $begin = $begin->format('Y-m-d H:i:s');
-        }
-        if ($end instanceof DateTimeInterface && ! $end instanceof Expression) {
-            $end = $end->format('Y-m-d 23:59:59');
+        if ($end instanceof DateTimeInterface) {
+            $end = $end->format('Y-m-d');
         }
 
-        $values = [$begin, $end];
+        $values=[$begin,$end];
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1262,11 +1262,12 @@ class Builder implements BuilderContract
     /**
      * Add a where between if the column is Timestamp and values is Date that will format the values Y-m-d 00:00:00 to Y-m-d 23:59:59 to get exact result.
      *
-     * @param  string  $column
-     * @param  array  $values
-     * @param  string  $boolean
-     * @param  bool  $not
+     * @param string $column
+     * @param array $values
+     * @param string $boolean
+     * @param bool $not
      * @return $this
+     * @throws \Exception
      */
     public function whereTimestampBetweenDate($column, array $values, $boolean = 'and', $not = false)
     {
@@ -1275,10 +1276,10 @@ class Builder implements BuilderContract
         $begin = reset($values);
         $end = end($values);
 
-        if (!$begin instanceof DateTimeInterface) {
+        if (! $begin instanceof DateTimeInterface) {
             $begin = new \DateTime($begin);
         }
-        if (!$end instanceof DateTimeInterface) {
+        if (! $end instanceof DateTimeInterface) {
             $end = new \DateTime($end);
         }
 
@@ -1296,10 +1297,11 @@ class Builder implements BuilderContract
     /**
      * Add a where not between if the column is Timestamp and values is Date that will format the values Y-m-d 00:00:00 to Y-m-d 23:59:59 to get exact result.
      *
-     * @param  string  $column
-     * @param  array  $values
-     * @param  string  $boolean
+     * @param string $column
+     * @param array $values
+     * @param string $boolean
      * @return $this
+     * @throws \Exception
      */
     public function whereNotTimestampBetweenDate($column, iterable $values, $boolean = 'and')
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1324,6 +1324,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where between for two dates with different formats.
+     *
+     * @param  string  $column
+     * @param  iterable  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereBetweenDate($column, iterable $values, $boolean = 'and')
+    {
+        return $this->whereBetween( "date($column)", $values, $boolean);
+    }
+
+    /**
      * Add an "or where date" statement to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1217,10 +1217,10 @@ class Builder implements BuilderContract
     /**
      * Add a where between for two dates with different formats to the query.
      *
-     * @param string $column
-     * @param array $values
-     * @param string $boolean
-     * @param bool $not
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereBetweenDate($column, array $values, $boolean = 'and', $not = false)
@@ -1241,9 +1241,9 @@ class Builder implements BuilderContract
     /**
      * Add a where not between for two dates with different formats to the query.
      *
-     * @param string $column
-     * @param array $values
-     * @param string $boolean
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
      * @return $this
      */
     public function whereNotBetweenDate($column, iterable $values, $boolean = 'and')
@@ -1359,7 +1359,6 @@ class Builder implements BuilderContract
 
         return $this->addDateBasedWhere('Date', $column, $operator, $value, $boolean);
     }
-
 
     /**
      * Add an "or where date" statement to the query.

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -405,6 +405,24 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "between date" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBetweenDate(Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+
+        $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+
+        return 'date('.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -405,24 +405,6 @@ class Grammar extends BaseGrammar
     }
 
     /**
-     * Compile a "between" where clause if the column type is DateTime or timestamp and the values have a different format date with it.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $where
-     * @return string
-     */
-    protected function whereBetweenDate(Builder $query, $where)
-    {
-        $between = $where['not'] ? 'not between' : 'between';
-
-        $min = $this->wrap(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
-
-        $max = $this->wrap(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
-
-        return 'date('.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
-    }
-
-    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -407,8 +407,8 @@ class Grammar extends BaseGrammar
     /**
      * Compile a "between" where clause if the column type is DateTime or timestamp and the values have a different format date with it.
      *
-     * @param \Illuminate\Database\Query\Builder $query
-     * @param array $where
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function whereBetweenDate(Builder $query, $where)
@@ -419,7 +419,7 @@ class Grammar extends BaseGrammar
 
         $max = $this->wrap(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
 
-        return 'date(' . $this->wrap($where['column']) . ') ' . $between . ' ' . $min . ' and ' . $max;
+        return 'date('.$this->wrap($where['column']).') '.$between.' '.$min.' and '.$max;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -405,6 +405,24 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a "between" where clause if the column type is DateTime or timestamp and the values have a different format date with it.
+     *
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param array $where
+     * @return string
+     */
+    protected function whereBetweenDate(Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->wrap(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+
+        $max = $this->wrap(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+
+        return 'date(' . $this->wrap($where['column']) . ') ' . $between . ' ' . $min . ' and ' . $max;
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -68,6 +68,24 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a "between date" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBetweenDate(Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+
+        $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+
+        return $this->wrap($where['column']).'::date ' . $between . ' ' . $min . ' and ' . $max;
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -82,7 +82,7 @@ class PostgresGrammar extends Grammar
 
         $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
 
-        return $this->wrap($where['column']).'::date ' . $between . ' ' . $min . ' and ' . $max;
+        return $this->wrap($where['column']).'::date '.$between.' '.$min.' and '.$max;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -43,6 +43,24 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "between date" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBetweenDate(Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+
+        $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+
+        return "strftime('%Y-%m-%d', {$this->wrap($where['column'])}) $between cast({$min} as text) and cast({$max} as text)";
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -127,7 +127,7 @@ class SqlServerGrammar extends Grammar
 
         $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
 
-        return 'cast('. $this->wrap($where['column']).' as date) ' . $between . ' ' . $min . ' and ' . $max;
+        return 'cast('.$this->wrap($where['column']).' as date) '.$between.' '.$min.' and '.$max;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -113,6 +113,24 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile a "between date" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereBetweenDate(Builder $query, $where)
+    {
+        $between = $where['not'] ? 'not between' : 'between';
+
+        $min = $this->parameter(is_array($where['values']) ? reset($where['values']) : $where['values'][0]);
+
+        $max = $this->parameter(is_array($where['values']) ? end($where['values']) : $where['values'][1]);
+
+        return 'cast('. $this->wrap($where['column']).' as date) ' . $between . ' ' . $min . ' and ' . $max;
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -693,11 +693,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($period->toArray(), $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $begin   = now()->format('Y-m-d');
-        $end     = now()->addDay()->format('Y-m-d');
-        $builder->select('*')->from('users')->whereBetweenDate('created_at', [$begin,$end]);
+        $begin = now()->format('Y-m-d');
+        $end = now()->addDay()->format('Y-m-d');
+        $builder->select('*')->from('users')->whereBetweenDate('created_at', [$begin, $end]);
         $this->assertSame('select * from "users" where "date(created_at)" between ? and ?', $builder->toSql());
-        $this->assertEquals([$begin,$end], $builder->getBindings());
+        $this->assertEquals([$begin, $end], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -773,6 +773,39 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['2022-05-04', '2022-05-05'], $builder->getBindings());
     }
 
+    public function testWhereTimestampBetweenDate()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimestampBetweenDate('created_at', ['2022-05-04', '2022-05-05']);
+        $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
+        $this->assertEquals(['2022-05-04 00:00:00', '2022-05-05 23:59:59'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotTimestampBetweenDate('created_at', ['2022-05-04', '2022-05-05']);
+        $this->assertSame('select * from "users" where "created_at" not between ? and ?', $builder->toSql());
+        $this->assertEquals(['2022-05-04 00:00:00', '2022-05-05 23:59:59'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimestampBetweenDate('created_at', [Now(), Now()->addDay()]);
+        $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
+        $this->assertEquals([Now()->format('Y-m-d 00:00:00'), Now()->addDay()->format('Y-m-d 23:59:59')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotTimestampBetweenDate('created_at', [Now(), Now()->addDay()]);
+        $this->assertSame('select * from "users" where "created_at" not between ? and ?', $builder->toSql());
+        $this->assertEquals([Now()->format('Y-m-d 00:00:00'), Now()->addDay()->format('Y-m-d 23:59:59')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereTimestampBetweenDate('created_at', ['2022-05-04 00:00:00', Now()->addDay()]);
+        $this->assertSame('select * from "users" where "created_at" between ? and ?', $builder->toSql());
+        $this->assertEquals(['2022-05-04 00:00:00', Now()->addDay()->format('Y-m-d 23:59:59')], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotTimestampBetweenDate('created_at', ['2022-05-04 00:00:00', Now()->addDay()]);
+        $this->assertSame('select * from "users" where "created_at" not between ? and ?', $builder->toSql());
+        $this->assertEquals(['2022-05-04 00:00:00', Now()->addDay()->format('Y-m-d 23:59:59')], $builder->getBindings());
+    }
+
     public function testWhereBetweenColumns()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -693,11 +693,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($period->toArray(), $builder->getBindings());
 
         $builder = $this->getBuilder();
-        $begin = now()->format('Y-m-d');
-        $end = now()->addDay()->format('Y-m-d');
-        $builder->select('*')->from('users')->whereBetweenDate('created_at', [$begin, $end]);
-        $this->assertSame('select * from "users" where "date(created_at)" between ? and ?', $builder->toSql());
-        $this->assertEquals([$begin, $end], $builder->getBindings());
+        $builder->select('*')->from('users')->whereBetweenDate('created_at', ['2022-05-04', '2022-05-05']);
+        $this->assertSame('select * from "users" where date("created_at") between "2022-05-04" and "2022-05-05"', $builder->toSql());
+        $this->assertEquals(['2022-05-04', '2022-05-05'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotBetweenDate('created_at', ['2022-05-04', '2022-05-05']);
+        $this->assertSame('select * from "users" where date("created_at") not between "2022-05-04" and "2022-05-05"', $builder->toSql());
+        $this->assertEquals(['2022-05-04', '2022-05-05'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -693,6 +693,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals($period->toArray(), $builder->getBindings());
 
         $builder = $this->getBuilder();
+        $begin   = now()->format('Y-m-d');
+        $end     = now()->addDay()->format('Y-m-d');
+        $builder->select('*')->from('users')->whereBetweenDate('created_at', [$begin,$end]);
+        $this->assertSame('select * from "users" where "date(created_at)" between ? and ?', $builder->toSql());
+        $this->assertEquals([$begin,$end], $builder->getBindings());
+
+        $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', collect([1, 2]));
         $this->assertSame('select * from "users" where "id" between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());


### PR DESCRIPTION
📌 Same PR #42194 but with the usual approach.

PR: Add whereBetweenDate() and whereNotBetweenDate() to filter two dates with a different formats.

The use-case to use the `whereBetweenDate()`  and `whereNotBetweenDate()` : 

- If you have a column type is DateTime or Timestamp `YYYY-MM-DD hh:mm:ss` and the values you searching on it have a different format as date `YYYY-MM-DD`.


Using `whereBetween()` or  `whereNotBetween()` on previous use-case will return not the exact data we searching on it because SQL will match with a different format to solve this we need to **cast** the column to data format using `date` function 

SQL :
```sql 
-- Before
select * from checklists where created_at between '2022-04-17' and '2022-04-18';   
select * from checklists where created_at not between '2022-04-17' and '2022-04-18';   
-- After 
select * from checklists where date(created_at) between '2022-04-17' and '2022-04-18';   
select * from checklists where date(created_at) not between '2022-04-17' and '2022-04-18';   
```

# Example


### Using `whereBetween()` or `whereNotBetween()`
```php
// Query Builder 
 DB::table('checklists')->whereBetween('created_at', ['2022-04-17','2022-04-18'])->get();
 DB::table('checklists')->whereNotBetween('created_at', ['2022-04-17','2022-04-18'])->get();
// Eloquent 
Checklist::whereBetween('created_at', ['2022-04-17','2022-04-18'])->get();
Checklist::whereNotBetween('created_at', ['2022-04-17','2022-04-18'])->get();
```

Output for using `whereBetween()` from '2022-04-17' to '2022-04-18': 

![image](https://user-images.githubusercontent.com/37311945/165990551-3ddba2b3-a944-4f07-b9f9-6e161896a27e.png)


### Using `whereBetweenDate()` or `whereNotBetweenDate()`
```php
// Query Builder 
 DB::table('checklists')->whereBetweenDate('created_at', ['2022-04-17','2022-04-18'])->get();
 DB::table('checklists')->whereNotBetweenDate('created_at', ['2022-04-17','2022-04-18'])->get();
// Eloquent 
Checklist::whereBetweenDate('created_at', ['2022-04-17','2022-04-18'])->get();
Checklist::whereNotBetweenDate('created_at', ['2022-04-17','2022-04-18'])->get();
```

Output for using `whereBetweenDate()` from '2022-04-17' to '2022-04-18': 

![image](https://user-images.githubusercontent.com/37311945/165990486-d9bb1c0b-2047-4de0-b0fa-07a3a0998d63.png)



