### PR TITLE
[9.x] Add custom segments on "remember me" recaller

### DIFF
--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -49,7 +49,20 @@ class Recaller
      */
     public function hash()
     {
-        return explode('|', $this->recaller, 3)[2];
+        return explode('|', $this->recaller, 4)[2];
+    }
+
+    /**
+     * Get the custom segments from the recaller.
+     *
+     * @return array
+     */
+    public function customSegments()
+    {
+        $segments = explode('|', $this->recaller);
+        array_splice($segments, 0, 3);
+
+        return $segments;
     }
 
     /**
@@ -81,6 +94,6 @@ class Recaller
     {
         $segments = explode('|', $this->recaller);
 
-        return count($segments) === 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
+        return count($segments) >= 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
     }
 }


### PR DESCRIPTION
Actually `Recaller` only admit 3 segments, `id`,`token`,`hash`,
If we create a custom session class extending `SessionGuard`, or we change the `remember me` cookie on login, we need a way to get the extra data from recaller
This is useful when you have a multi company login, or when needs an extra id/value to rebuild the session
https://github.com/laravel/framework/discussions/42067
