### PR TITLE
[9.x] Added "withoutForeignKeyConstraints" method to Builder

### DIFF
--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -12,6 +12,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Database\Schema\Builder enableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder rename(string $from, string $to)
  * @method static \Illuminate\Database\Schema\Builder table(string $table, \Closure $callback)
+ * @method static \Illuminate\Database\Schema\Builder withoutForeignKeyConstraints(\Closure $callback)
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
  * @method static bool dropColumns(string $table, array $columns)


### PR DESCRIPTION
Heavily inspired by "withoutEvents" method.

Meant to simplify the common pattern in which foreign keys are disabled, something is done and they are enabled back again.

**Before**
```php
Schema::disableForeignKeyConstraints();
myFunction();
Schema::enableForeignKeyConstraints();
```

**After**
```php
Schema::withoutForeignKeyConstraints(function () {
    myFunction();
});
```