### PR TITLE
WhereIn helper for querying relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -386,6 +386,36 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a basic whereIn clause to a relationship query.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  array  $value
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereRelationIn($relation, $column, $value = null)
+    {
+        return $this->whereHas($relation, function ($query) use ($column, $value) {
+            $query->whereIn($column, $value);
+        });
+    }
+
+    /**
+     * Add an "orWhereIn" clause to a relationship query.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Database\Query\Expression  $column
+     * @param  array  $value
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function orWhereRelationIn($relation, $column, $value = null)
+    {
+        return $this->orWhereHas($relation, function ($query) use ($column, $value) {
+            $query->orWhereIn($column, $value);
+        });
+    }
+
+    /**
      * Add a polymorphic relationship condition to the query with a where clause.
      *
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo|string  $relation

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -60,9 +60,9 @@ class EloquentWhereHasTest extends DatabaseTestCase
 
     public function testWhereRelationIn()
     {
-        $users = User::whereRelationIn('posts', 'public', [true , false])->get();
+        $users = User::whereRelationIn('posts', 'public', [true, false])->get();
 
-        $this->assertEquals([1,2], $users->pluck('id')->all());
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
     public function testOrWhereRelationIn()

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -60,14 +60,14 @@ class EloquentWhereHasTest extends DatabaseTestCase
 
     public function testWhereRelationIn()
     {
-        $users = User::whereRelationIn('posts', 'public', [true,false])->get();
+        $users = User::whereRelationIn('posts', 'public', [true , false])->get();
 
         $this->assertEquals([1,2], $users->pluck('id')->all());
     }
 
     public function testOrWhereRelationIn()
     {
-        $users = User::orWhereRelationIn('posts', 'public', [true])->orWhereRelationIn('posts', 'public', [false])->get();
+        $users = User::whereRelationIn('posts', 'public', [true])->orWhereRelationIn('posts', 'public', [false])->get();
 
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -58,6 +58,20 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals([1, 2], $users->pluck('id')->all());
     }
 
+    public function testWhereRelationIn()
+    {
+        $users = User::whereRelationIn('posts', 'public', [true,false])->get();
+
+        $this->assertEquals([1,2], $users->pluck('id')->all());
+    }
+
+    public function testOrWhereRelationIn()
+    {
+        $users = User::orWhereRelationIn('posts', 'public', [true])->orWhereRelationIn('posts', 'public', [false])->get();
+
+        $this->assertEquals([1, 2], $users->pluck('id')->all());
+    }
+
     public function testNestedWhereRelation()
     {
         $texts = User::whereRelation('posts.texts', 'content', 'test')->get();


### PR DESCRIPTION
Simple `whereIn` helpers for `whereHas()`.

```
**whereRelationIn helper**
// Before:

User::whereHas('posts', function ($query) {
    $query->whereIn('public', [true,false]);
})->get();

// After

User::whereRelationIn('posts', 'public', [true,false])->get();

```

```
**orWhereRelationIn helper**
// Before:

User::whereHas('posts', function ($query) {
    $query->whereIn('public', [true] )->orWhereIn('public', [false] );
})->get();

// After

User::whereRelationIn('posts', 'public', [true])->orWhereRelationIn('posts', 'public', [false])->get();

```

**Breaking changes**
There is no breaking changes these are just simple helpers.
