### PR TITLE
[9.x] PHPDoc Route facade macro

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -37,6 +37,7 @@ namespace Illuminate\Support\Facades;
  * @method static string|null currentRouteName()
  * @method static void apiResources(array $resources, array $options = [])
  * @method static void bind(string $key, string|callable $binder)
+ * @method static void macro(string $name, object|callable $macro)
  * @method static void model(string $key, string $class, \Closure|null $callback = null)
  * @method static void pattern(string $key, string $pattern)
  * @method static void resources(array $resources, array $options = [])


### PR DESCRIPTION
Adding `macro` PHPDoc for the `Route` facade. 

Larastan is complaining about it.