### PR TITLE
[9.x] Allow passing key/value arrays to getArguments and getOptions

### DIFF
--- a/src/Illuminate/Console/Concerns/HasParameters.php
+++ b/src/Illuminate/Console/Concerns/HasParameters.php
@@ -21,7 +21,7 @@ trait HasParameters
             if ($arguments instanceof InputArgument) {
                 $this->getDefinition()->addArgument($arguments);
             } else {
-                $this->addArgument(...array_values($arguments));
+                $this->addArgument(...$arguments);
             }
         }
 
@@ -29,7 +29,7 @@ trait HasParameters
             if ($options instanceof InputOption) {
                 $this->getDefinition()->addOption($options);
             } else {
-                $this->addOption(...array_values($options));
+                $this->addOption(...$options);
             }
         }
     }

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -65,6 +65,12 @@ class CommandTest extends TestCase
                 return [
                     new InputArgument('argument-one', InputArgument::REQUIRED, 'first test argument'),
                     ['argument-two', InputArgument::OPTIONAL, 'a second test argument'],
+                    [
+                        'name' => 'argument-three',
+                        'description' => 'a third test argument',
+                        'mode' => InputArgument::OPTIONAL,
+                        'default' => 'third-argument-default',
+                    ],
                 ];
             }
 
@@ -73,6 +79,12 @@ class CommandTest extends TestCase
                 return [
                     new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
                     ['option-two', 't', InputOption::VALUE_REQUIRED, 'second test option'],
+                    [
+                        'name' => 'option-three',
+                        'description' => 'a third test option',
+                        'mode' => InputOption::VALUE_OPTIONAL,
+                        'default' => 'third-option-default',
+                    ],
                 ];
             }
         };
@@ -92,8 +104,10 @@ class CommandTest extends TestCase
 
         $this->assertSame('test-first-argument', $command->argument('argument-one'));
         $this->assertSame('test-second-argument', $command->argument('argument-two'));
+        $this->assertSame('third-argument-default', $command->argument('argument-three'));
         $this->assertSame('test-first-option', $command->option('option-one'));
         $this->assertSame('test-second-option', $command->option('option-two'));
+        $this->assertSame('third-option-default', $command->option('option-three'));
     }
 
     public function testTheInputSetterOverwrite()


### PR DESCRIPTION
Allow passing key/value arrays to getArguments and getOptions on Artisan commands for a slightly easier interface.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
