### PR TITLE
$table must be string

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -26,7 +26,7 @@ class DatabaseNotification extends Model
      *
      * @var string
      */
-    protected $table = 'notifications';
+    protected string $table = 'notifications';
 
     /**
      * The guarded attributes on the model.


### PR DESCRIPTION
Type of Illuminate\Notifications\DatabaseNotification::$table must be string (as in class Illuminate\Database\Eloquent\Model)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
