### PR TITLE
[9.x] Using getForeignKey to determine the foreign key column on BelongsTo relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -203,11 +203,10 @@ trait HasRelationships
 
         $instance = $this->newRelatedInstance($related);
 
-        // If no foreign key was supplied, we can use a backtrace to guess the proper
-        // foreign key name by using the name of the relationship function, which
-        // when combined with an "_id" should conventionally match the columns.
+        // If no foreign key was supplied, we will call the getForeignKey method
+        // on related model instance
         if (is_null($foreignKey)) {
-            $foreignKey = Str::snake($relation).'_'.$instance->getKeyName();
+            $foreignKey = $instance->getForeignKey();
         }
 
         // Once we have the foreign key names we'll just create a new Eloquent query


### PR DESCRIPTION
Hi everyone,
in BelongsTo relationship method if there is no foreignKey specified, foreignKey will be made by the same logic in getForeignKey method from `Illuminate\Database\Eloquent` class.
if i override getForeignKey method on my model, it doesn't affect BelongsTo relationship because it is overriding.
so i just call getForeignKey method of related model instead of guessing related foreign key column name.

before
```php
// If no foreign key was supplied, we can use a backtrace to guess the proper
// foreign key name by using the name of the relationship function, which
// when combined with an "_id" should conventionally match the columns.
if (is_null($foreignKey)) {
    $foreignKey = Str::snake($relation).'_'.$instance->getKeyName();
}
```
after
```php
// If no foreign key was supplied, we will call the getForeignKey method
// on related model instance
if (is_null($foreignKey)) {
    $foreignKey = $instance->getForeignKey();
}
```
in the end, it doesn't break any features.
