### PR TITLE
[9.x] Add IndexDefinition Fluent class

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -540,7 +540,7 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string|null  $name
      * @param  string|null  $algorithm
-     * @return \Illuminate\Support\Fluent
+     * @return \Illuminate\Database\Schema\IndexDefinition
      */
     public function primary($columns, $name = null, $algorithm = null)
     {
@@ -553,7 +553,7 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string|null  $name
      * @param  string|null  $algorithm
-     * @return \Illuminate\Support\Fluent
+     * @return \Illuminate\Database\Schema\IndexDefinition
      */
     public function unique($columns, $name = null, $algorithm = null)
     {
@@ -566,7 +566,7 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string|null  $name
      * @param  string|null  $algorithm
-     * @return \Illuminate\Support\Fluent
+     * @return \Illuminate\Database\Schema\IndexDefinition
      */
     public function index($columns, $name = null, $algorithm = null)
     {
@@ -579,7 +579,7 @@ class Blueprint
      * @param  string|array  $columns
      * @param  string|null  $name
      * @param  string|null  $algorithm
-     * @return \Illuminate\Support\Fluent
+     * @return \Illuminate\Database\Schema\IndexDefinition
      */
     public function fullText($columns, $name = null, $algorithm = null)
     {
@@ -591,7 +591,7 @@ class Blueprint
      *
      * @param  string|array  $columns
      * @param  string|null  $name
-     * @return \Illuminate\Support\Fluent
+     * @return \Illuminate\Database\Schema\IndexDefinition
      */
     public function spatialIndex($columns, $name = null)
     {
@@ -603,7 +603,7 @@ class Blueprint
      *
      * @param  string  $expression
      * @param  string  $name
-     * @return \Illuminate\Support\Fluent
+     * @return \Illuminate\Database\Schema\IndexDefinition
      */
     public function rawIndex($expression, $name)
     {

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Database\Schema;
+
+use Illuminate\Support\Fluent;
+
+/**
+ * @method $this algorithm(string $algorithm) Specify an algorithm for the index (MySQL/PostgreSQL)
+ * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
+ */
+class IndexDefinition extends Fluent
+{
+    //
+}


### PR DESCRIPTION
Currently, the migration blueprint is returning specific fluent classes with doctypes to support static analysis of the code and provide an IDE with knowledge for effective auto-suggestions. The `ColumnDefinition`, `ForeignIdColumnDefinition` and `ForeignKeyDefinition` export doctypes for all modifiers available on columns, but the same support is missing for index modifiers.

The `IndexDefinition` class is adding doctypes and therefore IDE and PHPStan support for all index modifiers currently supported by Laravel. This change is backwards-compliant, as it is only narrowing the return type in the doctypes. Every code expecting a `Fluent` object will still work because `IndexDefinition` is a child of `Fluent` – like the former named definition classes.