### PR TITLE
[9.x] Make sure the prefix override behaviours are the same between phpredis and predis drivers

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -23,9 +23,15 @@ class PhpRedisConnector implements Connector
      */
     public function connect(array $config, array $options)
     {
-        $connector = function () use ($config, $options) {
+        $formattedOptions = Arr::pull($config, 'options', []);
+
+        if (isset($config['prefix'])) {
+            $formattedOptions['prefix'] = $config['prefix'];
+        }
+
+        $connector = function () use ($config, $options, $formattedOptions) {
             return $this->createClient(array_merge(
-                $config, $options, Arr::pull($config, 'options', [])
+                $config, $options, $formattedOptions
             ));
         };
 

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Redis\RedisManager;
 use PHPUnit\Framework\TestCase;
+use Redis;
 
 class RedisConnectorTest extends TestCase
 {
@@ -206,5 +207,89 @@ class RedisConnectorTest extends TestCase
         $predisClient = $predis->connection()->client();
         $parameters = $predisClient->getConnection()->getSentinelConnection()->getParameters();
         $this->assertEquals($host, $parameters->host);
+    }
+
+    public function testPrefixOverrideBehaviour()
+    {
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
+
+        $predis1 = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'scheme' => 'tls',
+                'host' => $host,
+                'port' => $port,
+                'database' => 5,
+                'timeout' => 0.5,
+                'options' => [
+                    'prefix' => 'test_default_options_',
+                ],
+            ],
+        ]);
+        $predisClient1 = $predis1->client();
+        $this->assertEquals('test_default_options_', $predisClient1->getOptions()->prefix->getPrefix());
+
+        $predis2 = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'scheme' => 'tls',
+                'host' => $host,
+                'port' => $port,
+                'database' => 5,
+                'timeout' => 0.5,
+                'options' => [
+                    'prefix' => 'test_default_options_',
+                ],
+                'prefix' => 'test_default_config_',
+            ],
+        ]);
+        $predisClient2 = $predis2->client();
+        $this->assertEquals('test_default_config_', $predisClient2->getOptions()->prefix->getPrefix());
+
+        $phpRedis1 = new RedisManager(new Application, 'phpredis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'scheme' => 'tcp',
+                'host' => $host,
+                'port' => $port,
+                'database' => 5,
+                'timeout' => 0.5,
+                'options' => [
+                    'prefix' => 'test_default_options_',
+                ],
+            ],
+        ]);
+        $phpRedisClient1 = $phpRedis1->connection()->client();
+        $this->assertEquals('test_default_options_', $phpRedisClient1->getOption(Redis::OPT_PREFIX));
+
+        $phpRedis2 = new RedisManager(new Application, 'phpredis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'scheme' => 'tcp',
+                'host' => $host,
+                'port' => $port,
+                'database' => 5,
+                'timeout' => 0.5,
+                'options' => [
+                    'prefix' => 'test_default_options_',
+                ],
+                'prefix' => 'test_default_config_',
+            ],
+        ]);
+        $phpRedisClient2 = $phpRedis2->connection()->client();
+        $this->assertEquals('test_default_config_', $phpRedisClient2->getOption(Redis::OPT_PREFIX));
     }
 }


### PR DESCRIPTION
Yesterday I was doing research for the company (mainly to do with Redis prefix options) and I found that there are two problems with the implementation of the `\Illuminate\Redis\Connectors\PhpRedisConnector::connect` method.

The first issue is that we use `Arr::pull` to pull the options from the config array, like so:
```php
$connector = function () use ($config, $options, $formattedOptions) {
    return $this->createClient(array_merge(
        $config, $options, Arr::pull($config, 'options', [])
    ));
};
```

The issue with this code is that the `Arr::pull` won't take effect and the final array from the array_merge will contain the `options` key, as I can show you here in a simple dd snippet:
```php
$config = [
    'host' => 'redis.com',
    'options' => [
        'prefix' => 'config_redis_',
    ],
];

$options = [
    'prefix' => 'redis_'
];

dd(array_merge($config, $options, Arr::pull($config, 'options', [])));
```

The output is
```php
[
  "host" => "redis.com"
  "options" => array:1 [
    "prefix" => "config_redis_"
  ]
  "prefix" => "config_redis_"
]
```

This PR will make sure that we pull out the options key from the config so that we don't merge it into the final array. This is merely just a DX touch.

Secondly, I found that in the `\Illuminate\Redis\Connectors\PredisConnector::connect` method, we have the code to override the prefix inside the `options` key of each redis config with the config's prefix key itself.

This means for predis driver, the prefix for this config will be `config_`:
```php
[
    'scheme' => 'tcp',
    'host' => $host,
    'port' => $port,
    'database' => 5,
    'timeout' => 0.5,
    'options' => [
        'prefix' => 'config_options_',
    ],
    'prefix' => 'config_',
]
```

However, if you use phpredis driver, the prefix that will be used in the connector is `config_options_`.

This PR makes sure that the prefix override behaviour of the phpredis is working in the same way with the predis connector. This means such config would resolves in the prefix = `config_`.