### PR TITLE
[9.x] Set relation parent key when using `forceCreate` on `HasOne` and `HasMany` relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -311,6 +311,19 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Create a new instance of the related model. Allow mass-assignment.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function forceCreate(array $attributes)
+    {
+        $attributes[$this->getForeignKeyName()] = $this->getParentKey();
+
+        return $this->related->forceCreate($attributes);
+    }
+
+    /**
      * Create a Collection of new instances of the related model.
      *
      * @param  iterable  $records

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -55,6 +55,15 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
+    public function testForceCreateMethodProperlyCreatesNewModel()
+    {
+        $relation = $this->getRelation();
+        $created = $this->expectForceCreatedModel($relation, ['name' => 'taylor']);
+
+        $this->assertEquals($created, $relation->forceCreate(['name' => 'taylor']));
+        $this->assertEquals(1, $created->getAttribute('foreign_key'));
+    }
+
     public function testFindOrNewMethodFindsModel()
     {
         $relation = $this->getRelation();
@@ -301,6 +310,18 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $model = $this->expectNewModel($relation, $attributes);
         $model->expects($this->once())->method('save');
+
+        return $model;
+    }
+
+    protected function expectForceCreatedModel($relation, $attributes)
+    {
+        $attributes[$relation->getForeignKeyName()] = $relation->getParentKey();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->with($relation->getForeignKeyName())->andReturn($relation->getParentKey());
+
+        $relation->getRelated()->shouldReceive('forceCreate')->once()->with($attributes)->andReturn($model);
 
         return $model;
     }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -129,6 +129,20 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
+    public function testForceCreateMethodProperlyCreatesNewModel()
+    {
+        $relation = $this->getRelation();
+        $attributes = ['name' => 'taylor', $relation->getForeignKeyName() => $relation->getParentKey()];
+
+        $created = m::mock(Model::class);
+        $created->shouldReceive('getAttribute')->with($relation->getForeignKeyName())->andReturn($relation->getParentKey());
+
+        $relation->getRelated()->shouldReceive('forceCreate')->once()->with($attributes)->andReturn($created);
+
+        $this->assertEquals($created, $relation->forceCreate(['name' => 'taylor']));
+        $this->assertEquals(1, $created->getAttribute('foreign_key'));
+    }
+
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #42273

As explained in issue #42273 when calling several methods that either create or instantiate a related instance from a relation method, the relation parent's key is automatically filled, but not when calling `forceCreate`.

Take this model as an example:

~~~php
class Lesson extends Model
{
    public function questions()
    {
        return $this->hasMany(Question::class);
    }
}
~~~

When calling all these following methods the lesson primary key is set as the new question instance foreign key automatically:

~~~php
$lesson = Lesson::first();

$q1 = $lesson->questions()->create(...);
$q2 = $lesson->questions()->findOrNew(...);
$q3 = $lesson->questions()->firstOrNew(...);
$q4 = $lesson->questions()->make(...);
$q5 = $lesson->questions()->save(new Question(...));
~~~

This behavior is also present in other methods which use the ones listed above such as `updateOrCreate`, `saveMany`, and others.

But when calling `->forceCreate(...)` from a relation, the foreign key is not set, which I agree with issue's #42273 OP, that is not the expected behavior.

Reason it does not work as the other is due to `forceCreate` not being implemented on `HasOneOrMany`, thus it is deferred to the underlying `Builder` which, of course, would not set any additional attributes.

This PR:

- Adds a `forceCreate` method to the `HasOneOrMany` relation class, which adds the relation parent key before actually force creating a related instance
- Adds relevant tests

