### PR TITLE
Make additional error message translatable inside ValidationException class.

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -96,9 +96,9 @@ class ValidationException extends Exception
         if ($additional = count($messages)) {
             $pluralized = $additional === 1 ? 'error' : 'errors';
 
-            $message .= __(" (and :additional more :pluralized)", [
+            $message .= __(' (and :additional more :pluralized)', [
                 'additional' => $additional,
-                'pluralized' => $pluralized
+                'pluralized' => $pluralized,
             ]);
         }
 

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -96,7 +96,10 @@ class ValidationException extends Exception
         if ($additional = count($messages)) {
             $pluralized = $additional === 1 ? 'error' : 'errors';
 
-            $message .= " (and {$additional} more {$pluralized})";
+            $message .= __(" (and :additional more :pluralized)", [
+                'additional' => $additional,
+                'pluralized' => $pluralized
+            ]);
         }
 
         return $message;


### PR DESCRIPTION
This PR only wraps plain string in translate function making it translatable inside project.

When an validation error occurs this exception is thrown and `message` filed is sent with it in an JSON response. I am using this message to display an alert to my end users. But I noticed that string that is being added by Laravel at the end of 1st validation error is not translatable. It is plain string and therefore I could not make it localized and display it differently for different languages my end user has selected.

Having all this in mind, and after some nice people at Laravel discord suggested that I should make PR, I made this PR in order to enable this "feature". 

I have never made an PR to any bigger open-source project, so forgive me if I missed any details. :)

Regards,

Dusan

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
