### PR TITLE
[8.x] All guzzle errors should be wrapped

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Http\Client;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
@@ -705,7 +704,7 @@ class PendingRequest
 
                     $this->dispatchResponseReceivedEvent($response);
                 });
-            } catch (ConnectException $e) {
+            } catch (TransferException $e) {
                 $this->dispatchConnectionFailedEvent();
 
                 throw new ConnectionException($e->getMessage(), 0, $e);


### PR DESCRIPTION
Guzzle Request exception that don't have a response should be wrapped
as well. Most logical exception is the ConnectionException from Laravel
to be thrown because RequestException expects a response (and there is
no response in these cases)