### PR TITLE
[9.x] Fix `EventFake::assertListening()` for asserting string-based observer listeners

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -65,8 +65,12 @@ class EventFake implements Dispatcher
             if (is_string($actualListener) && Str::contains($actualListener, '@')) {
                 $actualListener = Str::parseCallback($actualListener);
 
-                if (is_string($expectedListener) && ! Str::contains($expectedListener, '@')) {
-                    $expectedListener = [$expectedListener, 'handle'];
+                if (is_string($expectedListener)) {
+                    if (Str::contains($expectedListener, '@')) {
+                        $expectedListener = Str::parseCallback($expectedListener);
+                    } else {
+                        $expectedListener = [$expectedListener, 'handle'];
+                    }
                 }
             }
 

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -133,6 +133,10 @@ class EventFakeTest extends TestCase
             // do something
         });
 
+        Post::observe(new PostObserver);
+
+        ($post = new Post)->save();
+
         Event::assertListening('event', 'listener');
         Event::assertListening('event', PostEventSubscriber::class);
         Event::assertListening('event', PostAutoEventSubscriber::class);
@@ -140,12 +144,21 @@ class EventFakeTest extends TestCase
         Event::assertListening('post-created', [PostEventSubscriber::class, 'handlePostCreated']);
         Event::assertListening('post-deleted', [PostEventSubscriber::class, 'handlePostDeleted']);
         Event::assertListening(NonImportantEvent::class, Closure::class);
+        Event::assertListening('eloquent.saving: ' . Post::class, PostObserver::class.'@saving');
+        Event::assertListening('eloquent.saving: ' . Post::class, [PostObserver::class, 'saving']);
     }
 }
 
 class Post extends Model
 {
     public $table = 'posts';
+
+    public function save(array $options = [])
+    {
+        if ($this->fireModelEvent('saving') === false) {
+            return false;
+        }
+    }
 }
 
 class NonImportantEvent

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -144,8 +144,8 @@ class EventFakeTest extends TestCase
         Event::assertListening('post-created', [PostEventSubscriber::class, 'handlePostCreated']);
         Event::assertListening('post-deleted', [PostEventSubscriber::class, 'handlePostDeleted']);
         Event::assertListening(NonImportantEvent::class, Closure::class);
-        Event::assertListening('eloquent.saving: ' . Post::class, PostObserver::class.'@saving');
-        Event::assertListening('eloquent.saving: ' . Post::class, [PostObserver::class, 'saving']);
+        Event::assertListening('eloquent.saving: '.Post::class, PostObserver::class.'@saving');
+        Event::assertListening('eloquent.saving: '.Post::class, [PostObserver::class, 'saving']);
     }
 }
 


### PR DESCRIPTION
Follow-up to #42193

Widening the matching mechanism for string-based assertions (from `Str::endsWith('@handle')` to `Str::contains('@')`) allowed the underlying logic to unexpectedly handle Observer event assertions, transforming the `$actualListener` from a string to an array without also transforming the `$expectedListener` from a string to an array (where the assertion is a string).

(NB: This wasn't breaking any production code, only some tests that used string-based event listener assertion for observers instead of array-based assertion)

This was missed due to a lack of testing around Observer listener assertion in the EventFake test suite. So this PR contains new tests to cover this scenario.

It addresses the issue by explicitly parsing a string-based `$expectedListener` assertion when the `$actualListener` is also a string (now always converted to an array as of #42193), so that the `$expectedListener` correctly matches the parsed `$actualListener`.

```php
// $actualListener         $expectedListener
Model::observe(new Observer)  'Observer@method'

// Before fix
['Observer', 'method'] === 'Observer@method'
// => false, failing test

// After fix
['Observer', 'method'] === ['Observer', 'method']
// true, pass
```