### PR TITLE
[9.x] add findOr method to Query/Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2555,6 +2555,29 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Execute a query for a single record by ID or call a callback.
+     *
+     * @param  mixed  $id
+     * @param  \Closure|array  $columns
+     * @param  \Closure|null  $callback
+     * @return mixed|static
+     */
+    public function findOr($id, $columns = ['*'], Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        if (! is_null($data = $this->find($id, $columns))) {
+            return $data;
+        }
+
+        return $callback();
+    }
+
+    /**
      * Get a single column's value from the first result of a query.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2136,9 +2136,9 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('first')->with(['column'])->andReturn($data)->once();
         $builder->shouldReceive('first')->andReturn(null)->once();
 
-        $this->assertSame($data, $builder->findOr(1, fn() => 'callback result'));
-        $this->assertSame($data, $builder->findOr(1, ['column'], fn() => 'callback result'));
-        $this->assertSame('callback result', $builder->findOr(1, fn() => 'callback result'));
+        $this->assertSame($data, $builder->findOr(1, fn () => 'callback result'));
+        $this->assertSame($data, $builder->findOr(1, ['column'], fn () => 'callback result'));
+        $this->assertSame('callback result', $builder->findOr(1, fn () => 'callback result'));
     }
 
     public function testFirstMethodReturnsFirstResult()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2128,6 +2128,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $results);
     }
 
+    public function testFindOrReturnsFirstResultByID()
+    {
+        $builder = $this->getMockQueryBuilder();
+        $data = m::mock(stdClass::class);
+        $builder->shouldReceive('first')->andReturn($data)->once();
+        $builder->shouldReceive('first')->with(['column'])->andReturn($data)->once();
+        $builder->shouldReceive('first')->andReturn(null)->once();
+
+        $this->assertSame($data, $builder->findOr(1, fn() => 'callback result'));
+        $this->assertSame($data, $builder->findOr(1, ['column'], fn() => 'callback result'));
+        $this->assertSame('callback result', $builder->findOr(1, fn() => 'callback result'));
+    }
+
     public function testFirstMethodReturnsFirstResult()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR adds a findOr() method to the Query Builder. It is similar with #42092 

Example usage:

``` 
$data = \DB::table('something')->findOr($id, fn () => throw new CustomException);
$data = \DB::table('something')->findOr($id, fn () => (object) ['id=>'0', 'name'=>'N/A']);
```

Edit: I updated the example as it was wrong.
Probably there are other usage cases.
