### PR TITLE
add ``cache_if`` and ``cache_unless`` helpers

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -418,3 +418,37 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('cache_if')) {
+    /**
+     * Cache the given callback if the given condition is true.
+     *
+     * @param bool $condition
+     * @param string $key
+     * @param DateInterval|DateTimeInterface|int $ttl
+     * @param Closure $callback
+     * @return mixed
+     */
+    function cache_if($condition, $key, $ttl, $callback) {
+        if ($condition) {
+            return \Illuminate\Support\Facades\Cache::remember($key, $ttl, $callback);
+        }
+
+        return $callback();
+    }
+}
+
+if (! function_exists('cache_unless')) {
+    /**
+     * Cache the given callback if the given condition is false.
+     *
+     * @param bool $condition
+     * @param string $key
+     * @param DateInterval|DateTimeInterface|int $ttl
+     * @param Closure $callback
+     * @return mixed
+     */
+    function cache_unless($condition, $key, $ttl, $callback) {
+        return cache_if(! $condition, $key, $ttl, $callback);
+    }
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Stringable;
 use IteratorAggregate;
@@ -22,6 +23,23 @@ class SupportHelpersTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+    }
+
+    public function testCacheIf()
+    {
+        $time = time();
+
+        cache_if(true, 'test-cache-if-true', 3, function () use ($time) {
+            return $time;
+        });
+
+        $this->assertSame(Cache::get('test-cache-if-true'), $time);
+
+        cache_if(false, 'test-cache-if-false', 3, function () use ($time) {
+            return $time;
+        });
+
+        $this->assertNotSame(Cache::get('test-cache-if-true'), $time);
     }
 
     public function testE()


### PR DESCRIPTION
If a developer wants a data to be cached only when the required comparison is true, they can write cleaner code with the ``cache_if`` or ``cache_unless`` function.

example usage:

```php
cache_if(app()->isProduction(), 'users', now()->addSeconds(30), function () {
    return User::all();
});
```