### PR TITLE
[9.x] Fix original is equivalent

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,13 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.83.10...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.83.11...8.x)
+
+
+## [v8.83.11 (2022-05-03)](https://github.com/laravel/framework/compare/v8.83.10...v8.83.11)
+
+### Fixed
+- Fix refresh during down in the stub ([#42217](https://github.com/laravel/framework/pull/42217))
+- Fix deprecation issue with translator ([#42216](https://github.com/laravel/framework/pull/42216))
 
 
 ## [v8.83.10 (2022-04-27)](https://github.com/laravel/framework/compare/v8.83.9...v8.83.10)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1941,6 +1941,9 @@ trait HasAttributes
      */
     public function originalIsEquivalent($key)
     {
+	    if($this->isRelation($key))
+		    return true;
+		
         if (! array_key_exists($key, $this->original)) {
             return false;
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1941,9 +1941,10 @@ trait HasAttributes
      */
     public function originalIsEquivalent($key)
     {
-	    if($this->isRelation($key))
+	    if($this->isRelation($key)) {
 		    return true;
-		
+	    }
+
         if (! array_key_exists($key, $this->original)) {
             return false;
         }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -298,6 +298,19 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Create a new instance of the related model. Allow mass-assignment.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function forceCreate(array $attributes = [])
+    {
+        $attributes[$this->getForeignKeyName()] = $this->getParentKey();
+
+        return $this->related->forceCreate($attributes);
+    }
+
+    /**
      * Create a Collection of new instances of the related model.
      *
      * @param  iterable  $records

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
 use Symfony\Component\VarDumper\VarDumper;
 
 class PendingRequest
@@ -984,15 +985,21 @@ class PendingRequest
      *
      * @param  \GuzzleHttp\Psr7\RequestInterface  $request
      * @param  array  $options
-     * @return \Closure
+     * @return \GuzzleHttp\Psr7\RequestInterface
      */
     public function runBeforeSendingCallbacks($request, array $options)
     {
-        return tap($request, function ($request) use ($options) {
-            $this->beforeSendingCallbacks->each(function ($callback) use ($request, $options) {
-                call_user_func(
+        return tap($request, function (&$request) use ($options) {
+            $this->beforeSendingCallbacks->each(function ($callback) use (&$request, $options) {
+                $callbackResult = call_user_func(
                     $callback, (new Request($request))->withData($options['laravel_data']), $options, $this
                 );
+
+                if ($callbackResult instanceof RequestInterface) {
+                    $request = $callbackResult;
+                } elseif ($callbackResult instanceof Request) {
+                    $request = $callbackResult->toPsrRequest();
+                }
             });
         });
     }

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -55,6 +55,15 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
+    public function testForceCreateMethodProperlyCreatesNewModel()
+    {
+        $relation = $this->getRelation();
+        $created = $this->expectForceCreatedModel($relation, ['name' => 'taylor']);
+
+        $this->assertEquals($created, $relation->forceCreate(['name' => 'taylor']));
+        $this->assertEquals(1, $created->getAttribute('foreign_key'));
+    }
+
     public function testFindOrNewMethodFindsModel()
     {
         $relation = $this->getRelation();
@@ -301,6 +310,18 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $model = $this->expectNewModel($relation, $attributes);
         $model->expects($this->once())->method('save');
+
+        return $model;
+    }
+
+    protected function expectForceCreatedModel($relation, $attributes)
+    {
+        $attributes[$relation->getForeignKeyName()] = $relation->getParentKey();
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->with($relation->getForeignKeyName())->andReturn($relation->getParentKey());
+
+        $relation->getRelated()->shouldReceive('forceCreate')->once()->with($attributes)->andReturn($model);
 
         return $model;
     }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -129,6 +129,20 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertEquals($created, $relation->create(['name' => 'taylor']));
     }
 
+    public function testForceCreateMethodProperlyCreatesNewModel()
+    {
+        $relation = $this->getRelation();
+        $attributes = ['name' => 'taylor', $relation->getForeignKeyName() => $relation->getParentKey()];
+
+        $created = m::mock(Model::class);
+        $created->shouldReceive('getAttribute')->with($relation->getForeignKeyName())->andReturn($relation->getParentKey());
+
+        $relation->getRelated()->shouldReceive('forceCreate')->once()->with($attributes)->andReturn($created);
+
+        $this->assertEquals($created, $relation->forceCreate(['name' => 'taylor']));
+        $this->assertEquals(1, $created->getAttribute('foreign_key'));
+    }
+
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1080,4 +1080,26 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('https://example.com');
     }
+
+    public function testItCanAddAuthorizationHeaderIntoRequestUsingBeforeSendingCallback()
+    {
+        $this->factory->fake();
+
+        $this->factory->beforeSending(function (Request $request) {
+            $requestLine = sprintf(
+                '%s %s HTTP/%s',
+                $request->toPsrRequest()->getMethod(),
+                $request->toPsrRequest()->getUri()->withScheme('')->withHost(''),
+                $request->toPsrRequest()->getProtocolVersion()
+            );
+
+            return $request->toPsrRequest()->withHeader('Authorization', 'Bearer '.$requestLine);
+        })->get('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return
+                $request->url() === 'http://foo.com/json' &&
+                $request->hasHeader('Authorization', 'Bearer GET /json HTTP/1.1');
+        });
+    }
 }


### PR DESCRIPTION
Relationships seem to be spilling over as attributes. They are being picked up as `dirty` always and then the framework is attempting an Update statement on them. The columns don't exist in the specified tables, thus it errors out.

Assuming that Relationships have no reason to be in attributes in the first place, this does not fix the root cause of the issue, but patches the problem.

This PR is made to bring this to your attention, I'm not sure how to replicate the problem in a separate repository.

Please let me know what I can do to shed some light on this issue so we can get this resolved.

<img width="1138" alt="Screenshot 2022-05-07 at 20 16 16" src="https://user-images.githubusercontent.com/5844176/167264865-64710b5e-6da9-4637-ab35-d83eea7ee7a2.png">
<img width="952" alt="Screenshot 2022-05-07 at 20 16 03" src="https://user-images.githubusercontent.com/5844176/167264867-cbe1222f-9df9-4e83-b0e6-caf6d45e1df4.png">
<img width="644" alt="Screenshot 2022-05-07 at 20 15 40" src="https://user-images.githubusercontent.com/5844176/167264868-81dc969f-3205-4d8d-a1f0-5caaa2da8ce9.png">

