### PR TITLE
[9.x] Use View Contract instead of implementation

### DIFF
--- a/src/Illuminate/Testing/TestComponent.php
+++ b/src/Illuminate/Testing/TestComponent.php
@@ -25,7 +25,7 @@ class TestComponent
      * Create a new test component instance.
      *
      * @param  \Illuminate\View\Component  $component
-     * @param  \Illuminate\View\View  $view
+     * @param  \Illuminate\Contracts\View\View  $view
      * @return void
      */
     public function __construct($component, $view)

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -5,7 +5,7 @@ namespace Illuminate\Testing;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
-use Illuminate\View\View;
+use Illuminate\Contracts\View\View;
 
 class TestView
 {
@@ -14,7 +14,7 @@ class TestView
     /**
      * The original view.
      *
-     * @var \Illuminate\View\View
+     * @var \Illuminate\Contracts\View\View
      */
     protected $view;
 
@@ -28,7 +28,7 @@ class TestView
     /**
      * Create a new test view instance.
      *
-     * @param  \Illuminate\View\View  $view
+     * @param  \Illuminate\Contracts\View\View  $view
      * @return void
      */
     public function __construct(View $view)

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Testing;
 
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
-use Illuminate\Contracts\View\View;
 
 class TestView
 {


### PR DESCRIPTION
Laravel allows to use custom implementations of `Illuminate\Contracts\View\View`. This PR is a simple fix for PHPDoc to underline this fact