### PR TITLE
[8.x] Add missing onLastPage to CursorPaginator

### DIFF
--- a/src/Illuminate/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Pagination/CursorPaginator.php
@@ -122,6 +122,16 @@ class CursorPaginator extends AbstractCursorPaginator implements Arrayable, Arra
     }
 
     /**
+     * Determine if the paginator is on the last page.
+     *
+     * @return bool
+     */
+    public function onLastPage()
+    {
+        return ! $this->hasMorePages();
+    }
+
+    /**
      * Get the instance as an array.
      *
      * @return array

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -76,6 +76,24 @@ class CursorPaginatorTest extends TestCase
         $this->assertSame([['id' => 6], ['id' => 7]], $p->items());
     }
 
+    public function testLengthAwarePaginatorisOnFirstAndLastPage()
+    {
+        $paginator = new CursorPaginator([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4]], 2, null, [
+            'parameters' => ['id'],
+        ]);
+
+        $this->assertTrue($paginator->onFirstPage());
+        $this->assertFalse($paginator->onLastPage());
+
+        $cursor = new Cursor(['id' => 3]);
+        $paginator = new CursorPaginator([['id' => 3], ['id' => 4]], 2, $cursor, [
+            'parameters' => ['id'],
+        ]);
+
+        $this->assertFalse($paginator->onFirstPage());
+        $this->assertTrue($paginator->onLastPage());
+    }
+
     protected function getCursor($params, $isNext = true)
     {
         return (new Cursor($params, $isNext))->encode();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #42296

As stated on issue #42296 the docs on `CursorPaginator``s available methods states it has a `onLastPage` method, but the implementation of that method is missing on `Illuminate\Pagination\CursorPaginator` and its parent abstract class.

This PR:

- Adds the missing `onLastPage` implementation to `Illuminate\Pagination\CursorPaginator`
- Adds a test case covering both `onLastPage` and `onFirstPage`
