### PR TITLE
[9.x] Add missing supported param type (as PHPDoc)

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -217,7 +217,7 @@ trait InteractsWithIO
      *
      * @param  array  $headers
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
-     * @param  string  $tableStyle
+     * @param  \Symfony\Component\Console\Helper\TableStyle|string  $tableStyle
      * @param  array  $columnStyles
      * @return void
      */


### PR DESCRIPTION
`\Illuminate\Console\Concerns\InteractsWithIO::table()` can accept `\Symfony\Component\Console\Helper\TableStyle` instances also as 3rd argument (e.g.  developer can implement a custom Markdown style)