### PR TITLE
[9.x] Add Arr::cycle() method for cycling classes in a loop

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -91,8 +91,8 @@ class Arr
     /**
      * Cycle through items in an array.
      *
-     * @param array $array
-     * @param int $position
+     * @param  array  $array
+     * @param  int  $position
      * @return mixed
      */
     public static function cycle($array, $position)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -89,6 +89,20 @@ class Arr
     }
 
     /**
+     * Cycle through items in an array.
+     *
+     * @param array $array
+     * @param int $position
+     * @return mixed
+     */
+    public static function cycle($array, $position)
+    {
+        $array = array_values(static::wrap($array));
+
+        return $array[$position % count($array)];
+    }
+
+    /**
      * Divide an array into two arrays. One with keys and the other with values.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -97,7 +97,7 @@ class Arr
      */
     public static function cycle($array, $position)
     {
-        $array = array_values(static::wrap($array));
+        $array = static::wrap($array);
 
         return $array[$position % count($array)];
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -90,6 +90,21 @@ class SupportArrTest extends TestCase
         $this->assertSame([[]], Arr::crossJoin());
     }
 
+    public function testCycle()
+    {
+        $array = ['a', 'b', 'c', 'd', 'e'];
+        $this->assertEquals('a', Arr::cycle($array, 0));
+        $this->assertEquals('b', Arr::cycle($array, 1));
+        $this->assertEquals('c', Arr::cycle($array, 2));
+        $this->assertEquals('d', Arr::cycle($array, 3));
+        $this->assertEquals('e', Arr::cycle($array, 4));
+        $this->assertEquals('a', Arr::cycle($array, 5));
+        $this->assertEquals('b', Arr::cycle($array, 6));
+        $this->assertEquals('c', Arr::cycle($array, 7));
+        $this->assertEquals('d', Arr::cycle($array, 8));
+        $this->assertEquals('e', Arr::cycle($array, 9));
+    }
+
     public function testDivide()
     {
         [$keys, $values] = Arr::divide(['name' => 'Desk']);


### PR DESCRIPTION
This adds an `Arr::cycle()` method that makes it easy to cycle through classes in a loop. It behaves identically to [Twig's cycle method](https://twig.symfony.com/doc/3.x/functions/cycle.html).

It can be used like this in a Blade template:

```
@foreach ($objects as $object)
    <div class="{{ Arr::cycle(['foo', 'bar', 'baz', 'qux'], $loop->index) }}"></div>
@endforeach
```

Which would output this:

```
<div class="foo"></div>
<div class="bar"></div>
<div class="baz"></div>
<div class="qux"></div>
<div class="foo"></div>
<div class="bar"></div>
<div class="baz"></div>
<div class="qux"></div>
...
```