### PR TITLE
[10.x] Enables Factory Model definition recursive resolving

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Definition.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Definition.php
@@ -38,12 +38,12 @@ class Definition implements ArrayAccess
     }
 
     /**
-     * Expands the definition attribute to its final value.
+     * Expands an attribute value to its final value.
      *
      * @param  mixed  $value
      * @return mixed
      */
-    public function expand($value)
+    protected function expand($value)
     {
         return match(true) {
             $value instanceof Factory => $value->create()->getKey(),
@@ -54,7 +54,7 @@ class Definition implements ArrayAccess
     }
 
     /**
-     * Get an expanded attribute from this instance.
+     * Get an attribute final value from this instance.
      *
      * @param  string  $key
      * @param  mixed  $default
@@ -70,7 +70,7 @@ class Definition implements ArrayAccess
     }
 
     /**
-     * Return all expanded attributes of this definition instance.
+     * Return all expanded attributes of this definition instance as an array.
      *
      * @return array<string, mixed>
      */
@@ -84,7 +84,7 @@ class Definition implements ArrayAccess
     }
 
     /**
-     * Merges attributes on top of the definition attributes.
+     * Merges attributes on top of the current definition attributes.
      *
      * @param  static|array<string, mixed>  $attributes
      * @return $this
@@ -190,7 +190,7 @@ class Definition implements ArrayAccess
     }
 
     /**
-     * Create a new definition instance if it's not.
+     * Wraps an iterable of attributes into a Definition instance.
      *
      * @param  static|iterable<string, mixed>  $attributes
      * @return static

--- a/src/Illuminate/Database/Eloquent/Factories/Definition.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Definition.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Definition implements ArrayAccess
 {
     /**
-     * Attributes to fill the model
+     * Attributes to fill into the model.
      *
      * @var array<string, mixed>
      */
@@ -48,7 +48,7 @@ class Definition implements ArrayAccess
         return match (true) {
             $value instanceof Factory => $value->create()->getKey(),
             $value instanceof Model => $value->getKey(),
-            is_callable($value) && !is_string($value) && !is_array($value) => $value($this),
+            is_callable($value) && ! is_string($value) && ! is_array($value) => $value($this),
             default => $value,
         };
     }

--- a/src/Illuminate/Database/Eloquent/Factories/Definition.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Definition.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factories;
+
+use ArrayAccess;
+use Illuminate\Database\Eloquent\Model;
+
+class Definition implements ArrayAccess
+{
+    /**
+     * Attributes to fill the model
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [];
+
+    /**
+     * If the attributes has been expended.
+     *
+     * @var bool
+     */
+    protected $expanded = false;
+
+    /**
+     * Create a new definition instance.
+     *
+     * @param  iterable<string, mixed>  $attributes
+     * @return void
+     */
+    public function __construct($attributes = [])
+    {
+        foreach ($attributes as $key => $value) {
+            $this->attributes[$key] = $value;
+        }
+    }
+
+    /**
+     * Get the raw definition attributes from this instance.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Expands the definition attribute to its final value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function expand($value)
+    {
+        return match(true) {
+            $value instanceof Factory => $value->create()->getKey(),
+            $value instanceof Model => $value->getKey(),
+            is_callable($value) && !is_string($value) && !is_array($value) => $value($this),
+            default => $value,
+        };
+    }
+
+    /**
+     * Get an expanded attribute from this instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if (array_key_exists($key, $this->attributes)) {
+            return $this->attributes[$key] = $this->expand($this->attributes[$key]);
+        }
+
+        return value($default, $this);
+    }
+
+    /**
+     * Return all expanded attributes of this definition instance.
+     *
+     * @return array<string, mixed>
+     */
+    public function all()
+    {
+        foreach ($this->attributes as $key => $value) {
+            $this->attributes[$key] = $this->expand($value);
+        }
+
+        return $this->attributes;
+    }
+
+    /**
+     * Merges attributes on top of the definition attributes.
+     *
+     * @param  static|array<string, mixed>  $attributes
+     * @return $this
+     */
+    public function merge($attributes)
+    {
+        $this->attributes = array_merge(
+            $this->attributes, $attributes instanceof static ? $attributes->getAttributes() : $attributes
+        );
+
+        return $this;
+    }
+
+    /**
+     * Dynamically retrieve the value of an attribute.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->get($key);
+    }
+
+    /**
+     * Dynamically set the value of an attribute.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        $this->offsetSet($key, $value);
+    }
+
+    /**
+     * Dynamically check if an attribute is set.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return $this->offsetExists($key);
+    }
+
+
+    /**
+     * Dynamically unset an attribute.
+     *
+     * @param  mixed  $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        $this->offsetUnset($key);
+    }
+
+    /**
+     * Determine if the given offset exists.
+     *
+     * @param  mixed  $offset
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->attributes[$offset]);
+    }
+
+    /**
+     * Get the value for a given offset.
+     *
+     * @param  mixed  $offset
+     * @return mixed
+     */
+    public function offsetGet($offset): mixed
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * Set the value at the given offset.
+     *
+     * @param  mixed  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->attributes[$offset] = $value;
+    }
+
+    /**
+     * Unset the value at the given offset.
+     *
+     * @param  mixed  $offset
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->attributes[$offset]);
+    }
+
+    /**
+     * Create a new definition instance if it's not.
+     *
+     * @param  static|iterable<string, mixed>  $attributes
+     * @return static
+     */
+    public static function wrap($attributes = [])
+    {
+        return $attributes instanceof static ? $attributes : new static($attributes);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Factories/Definition.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Definition.php
@@ -45,7 +45,7 @@ class Definition implements ArrayAccess
      */
     protected function expand($value)
     {
-        return match(true) {
+        return match (true) {
             $value instanceof Factory => $value->create()->getKey(),
             $value instanceof Model => $value->getKey(),
             is_callable($value) && !is_string($value) && !is_array($value) => $value($this),

--- a/src/Illuminate/Database/Eloquent/Factories/Definition.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Definition.php
@@ -15,13 +15,6 @@ class Definition implements ArrayAccess
     protected $attributes = [];
 
     /**
-     * If the attributes has been expended.
-     *
-     * @var bool
-     */
-    protected $expanded = false;
-
-    /**
      * Create a new definition instance.
      *
      * @param  iterable<string, mixed>  $attributes

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -139,17 +139,6 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_expanded_closure_attributes_are_resolved_recursively()
     {
-        $user = FactoryTestUserFactory::new()->create([
-            'name' => function () {
-                return 'taylor';
-            },
-            'options' => function ($attributes) {
-                return $attributes['name'].'-options';
-            },
-        ]);
-
-        $this->assertSame('taylor-options', $user->options);
-
         $user = FactoryTestUserFactory::new()->make([
             'surname' => function ($attributes) {
                 return $attributes['options'].'-otwell';


### PR DESCRIPTION
## What?

Factory definition now allows to expand attributes in any order. Developers can safely use callables, as these are resolved only when needed.

Before, the developer had to manually alter the order of the definition attributes, ensuring functions where last defined and always called final values first, or called the raw function with the attributes as a workaround (which could break if definition changed order). Also it added some edge cases for functions returning random values.

```php
public function definition()
{
    // Before
    return [
        'second' => fn ($attributes) => $attributes['first']($attributes) . '+2',
        'third' => fn ($attributes) => $attributes['second']($attributes) . '+3',
        'first' => fn () => rand(1, 10),
    ];

    // ['second' => '2+2', 'third' => '5+3', 'first' => '5']
    
    // After
    return [
        'first' => fn() => rand(1, 10),
        'second' => fn($attributes) => $attributes['first'] . +2, 
        'third' => fn($attributes) => $attributes['second'] . +3, 
    ]

    // ['first' => '4', 'second' => '4+2', 'third' => '4+3']
}
```

## How?

This introduces de `Definition` class, which takes care of storing the attributes to define. It uses `ArrayAccess` to maximize compatibility, but works like the `Fluent` class minus the `Arrayable` and `Jsonable` to avoid mistakes.

When an attribute is retrieved from this instance, its resolved when it's a _callable_, Model or Factory (like always has been) automatically. Non-final values are only resolved **once** to control values generated at random, or making definition inherently slower (like querying the database multiple times).

For this to work:

1. `getExpandedAttributes()` was edited to _wrap_ the definition into a `Definition` instance.
2. `getRawAttributes()` was deleted as it no longer serves purpose.
2. `expandAttributes()` was deleted as it no longer serves purpose.

## BC?

There are three breaking changes:

1. Since callables now receive a `Definition` instance, type-hinting the `$attributes` as an `array` will throw an error. This is reinforced [in the docs](https://laravel.com/docs/9.x/database-testing).

```php
return [
    // Error
    'foo' => function (array $attributes) {
        // ...
    }
]
```

2. Since the `expandAttributes()` is never called, there is no attribute manipulation. Extending this method now doesn't make any difference.

```php
protected function expandAttributes(array $attributes)
{
    // This is never executed.
}
```

4. Since the `getRawAttributes()` is never called, there is no attribute manipulation. Extending this method now doesn't make any difference.

```php
protected function getRawAttributes(?Model $parent)
{
    // This is never executed.
}
```

PD: Happy Mother's day 💖