### PR TITLE
[9.x] Adds alphabetical word count validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2039,6 +2039,53 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the number of alphabetical words is greater than a minimum value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateWordsMin($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'min');
+
+        return str_word_count($value) >= $parameters[0];
+    }
+
+    /**
+     * Validate the number of alphabetical words is between a set of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateWordsBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'between');
+
+        $count = str_word_count($value);
+
+        return $count >= $parameters[0] && $count <= $parameters[1];
+    }
+
+    /**
+     * Validate the count of alphabetical words is less than a maximum value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateWordsMax($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'max');
+
+        return str_word_count($value) <= $parameters[0];
+    }
+
+    /**
      * Get the size of an attribute.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -6479,6 +6479,55 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
+    public function testValidatesWordsMin()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo bar'], ['foo' => 'words_min:3']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo bar baz'], ['foo' => 'words_min:3']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testValidatesWordsBetween()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo bar'], ['foo' => 'words_between:3,4']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo bar baz'], ['foo' => 'words_between:3,4']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo bar baz quz'], ['foo' => 'words_between:3,4']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo bar baz quz qux'], ['foo' => 'words_between:3,4']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidatesWordsMax()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => ''], ['foo' => 'words_max:2']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo'], ['foo' => 'words_max:2']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo bar'], ['foo' => 'words_max:2']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'foo bar baz'], ['foo' => 'words_max:2']);
+        $this->assertFalse($v->passes());
+    }
+
     public function providesPassingExcludeIfData()
     {
         return [


### PR DESCRIPTION
## What?

Adds validation rules to count alphabetic words in a field for minimum, maximum and between two amounts.

```php
public function contact(Request $request)
{
    $request->validate([
        'title' => 'required|words_between:2,10',
        'body' => 'required|words_min:100',
        'subject' => 'required|words_max:1',
    ]);

    // ...
}
```

## How?

It's just a `str_word_count()` call underneath.

> For other languages, the `ext-intl` extension may be needed an a little rewrite as this [answer](https://stackoverflow.com/a/22465204) says, and Laravel doesn't require it. Could be expanded with an additional parameter to define the locale.

## BC?

None, I don't expect somebody using `words_*` as a rule.