### PR TITLE
[9.x] Alphabetically order list of stubs to public

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -46,8 +46,8 @@ class StubPublishCommand extends Command
         }
 
         $files = [
-            __DIR__.'/stubs/cast.stub' => $stubsPath.'/cast.stub',
             __DIR__.'/stubs/cast.inbound.stub' => $stubsPath.'/cast.inbound.stub',
+            __DIR__.'/stubs/cast.stub' => $stubsPath.'/cast.stub',
             __DIR__.'/stubs/console.stub' => $stubsPath.'/console.stub',
             __DIR__.'/stubs/event.stub' => $stubsPath.'/event.stub',
             __DIR__.'/stubs/job.queued.stub' => $stubsPath.'/job.queued.stub',
@@ -64,8 +64,8 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/policy.stub' => $stubsPath.'/policy.stub',
             __DIR__.'/stubs/provider.stub' => $stubsPath.'/provider.stub',
             __DIR__.'/stubs/request.stub' => $stubsPath.'/request.stub',
-            __DIR__.'/stubs/resource-collection.stub' => $stubsPath.'/resource-collection.stub',
             __DIR__.'/stubs/resource.stub' => $stubsPath.'/resource.stub',
+            __DIR__.'/stubs/resource-collection.stub' => $stubsPath.'/resource-collection.stub',
             __DIR__.'/stubs/rule.stub' => $stubsPath.'/rule.stub',
             __DIR__.'/stubs/scope.stub' => $stubsPath.'/scope.stub',
             __DIR__.'/stubs/test.stub' => $stubsPath.'/test.stub',


### PR DESCRIPTION
A simple PR to alphabetically order list of stubs to public.

BTW: do you know, why other stubs are not in this list? Initially, I wanted to create a PR to publish all/more stubs (extend this list), but decided to start from this simple one and ask this question (probably maintainers don't want to publish all available stubs for some reason)