### PR TITLE
[9.x] Add custom segments on "remember me" for session rebuild

### DIFF
--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -49,7 +49,7 @@ class Recaller
      */
     public function hash()
     {
-        return explode('|', $this->recaller, 3)[2];
+        return explode('|', $this->recaller, 4)[2];
     }
 
     /**

--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -49,20 +49,7 @@ class Recaller
      */
     public function hash()
     {
-        return explode('|', $this->recaller, 4)[2];
-    }
-
-    /**
-     * Get the custom segments from the recaller.
-     *
-     * @return array
-     */
-    public function customSegments()
-    {
-        $segments = explode('|', $this->recaller);
-        array_splice($segments, 0, 3);
-
-        return $segments;
+        return explode('|', $this->recaller, 3)[2];
     }
 
     /**
@@ -95,5 +82,15 @@ class Recaller
         $segments = explode('|', $this->recaller);
 
         return count($segments) >= 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
+    }
+
+    /**
+     * Get the recaller's segments.
+     *
+     * @return array
+     */
+    public function segments()
+    {
+        return explode('|', $this->recaller);
     }
 }

--- a/src/Illuminate/Auth/Recaller.php
+++ b/src/Illuminate/Auth/Recaller.php
@@ -49,7 +49,20 @@ class Recaller
      */
     public function hash()
     {
-        return explode('|', $this->recaller, 3)[2];
+        return explode('|', $this->recaller, 4)[2];
+    }
+
+    /**
+     * Get the custom segments from the recaller.
+     *
+     * @return array
+     */
+    public function customSegments()
+    {
+        $segments = explode('|', $this->recaller);
+        array_splice($segments, 0, 3);
+
+        return $segments;
     }
 
     /**
@@ -81,6 +94,6 @@ class Recaller
     {
         $segments = explode('|', $this->recaller);
 
-        return count($segments) === 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
+        return count($segments) >= 3 && trim($segments[0]) !== '' && trim($segments[1]) !== '';
     }
 }


### PR DESCRIPTION
Closes #42271

Actually `Recaller` only admit 3 segments, `id`,`token`,`hash`,
If we create a custom session class extending `SessionGuard`, or we change the `remember me` cookie on login, we need a way to get the extra data from recaller, this is useful when you have a multi company login, or when needs an extra id/value to rebuild the session,

**Example:** company is a manyToMany relation with user, on login user pick wich company use for session, on "remember me" laravel rebuild the user session **but not the company**, of course i can create another cookie for rebuild the picked company or another company selector after session rebuild, but would be great if the recaller can handle that extra id/ids

**keeps same functionality, but adds option for more segments, really small not breaking change**

-----
https://github.com/laravel/framework/issues/42271#issuecomment-1118611261
>How are you setting these custom segments?

Login, custom session guard, or auth macro

>Why do you need them at all?

Rebuild the picked login company on session with remember me

>Why not store them in a database table associated with the user?

User can be logged on two or more companies at the same time(using different browsers, or with incognito mode, different computers, etc)

----
