### PR TITLE
[9.x] Keep original exception to preserve the exception trace

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -88,11 +88,7 @@ trait ManagesTransactions
                 $this->getName(), $this->transactions
             );
 
-            throw new DeadlockException(
-                $e->getMessage(),
-                $e->getCode(),
-                $e->getPrevious()
-            );
+            throw new DeadlockException($e->getMessage(), $e->getCode(), $e);
         }
 
         // If there was an exception we will rollback this transaction and then we


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

While commenting on issue #42317 I noted `ManagesTransactions@handleTransactionException` discards the exception being handled when wrapping it into the new `DeadlockException`, by passing `$e->previous()` instead of the handled exception.

Passing the actual exception as the `$previous` parameter to the new `DeadlockException` being thrown, would preserve the actual stack trace and allow to assess why the original exception was thrown.

This PR:

- Modifies `ManagesTransactions@handleTransactionException` to use the actual exception being handled instead of its `->getPrevious()` result.
