### PR TITLE
[9.x] Fix docblock for the LogManager::flushSharedContext() method

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -475,7 +475,7 @@ class LogManager implements LoggerInterface
     /**
      * Flush the shared context.
      *
-     * @return array
+     * @return $this
      */
     public function flushSharedContext()
     {

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -572,4 +572,17 @@ class LogManagerTest extends TestCase
             'invocation-start' => 1651800456,
         ], $manager->sharedContext());
     }
+
+    public function testFlushSharedContext()
+    {
+        $manager = new LogManager($this->app);
+
+        $manager->shareContext($context = ['foo' => 'bar']);
+
+        $this->assertSame($context, $manager->sharedContext());
+
+        $manager->flushSharedContext();
+
+        $this->assertEmpty($manager->sharedContext());
+    }
 }


### PR DESCRIPTION
- The LogManager::flushSharedContext() method returns $this, not an array. I just fix that.

- Btw, I add a small test for this method that ensures context must be empty after flushing.