### PR TITLE
[8.x] Fix multiple dots for digits_between rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -582,6 +582,11 @@ trait ValidatesAttributes
 
         $length = strlen((string) $value);
 
+        // Make sure only one dot at max is present...
+        if (($length - strlen(str_replace('.', '', (string) $value))) > 1) {
+            return false;
+        }
+
         return ! preg_match('/[^0-9.]/', $value)
                     && $length >= $parameters[0] && $length <= $parameters[1];
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -582,6 +582,10 @@ trait ValidatesAttributes
 
         $length = strlen((string) $value);
 
+        if (((string) $value) === '.') {
+            return false;
+        }
+
         // Make sure only one dot at max is present...
         if (($length - strlen(str_replace('.', '', (string) $value))) > 1) {
             return false;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -586,7 +586,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        // Make sure only one dot at max is present...
+        // Make sure there is not more than one dot...
         if (($length - strlen(str_replace('.', '', (string) $value))) > 1) {
             return false;
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2299,6 +2299,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '...'], ['foo' => 'digits_between:1,10']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->fails());
     }
 
     public function testValidateSize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2294,7 +2294,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'digits_between:1,10']);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($trans, ['foo' => '123.456.7'], ['foo' => 'digits_between:1,10']);
+        $v = new Validator($trans, ['foo' => '123.456.789'], ['foo' => 'digits_between:1,10']);
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['foo' => '...'], ['foo' => 'digits_between:1,10']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2290,6 +2290,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '0.9876'], ['foo' => 'digits_between:1,5']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '...'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->fails());
     }
 
     public function testValidateSize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2302,6 +2302,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '.'], ['foo' => 'digits_between:1,10']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.2'], ['foo' => 'digits_between:0,10']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '2.'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateSize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2294,6 +2294,9 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'digits_between:1,10']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['foo' => '123.456.7'], ['foo' => 'digits_between:1,10']);
+        $this->assertTrue($v->fails());
+
         $v = new Validator($trans, ['foo' => '...'], ['foo' => 'digits_between:1,10']);
         $this->assertTrue($v->fails());
     }


### PR DESCRIPTION
This makes the `digits_between` rule a bit more strict by validating for multiple dots in a number (`2.2.3`, `2..3`, `...`).

Fixes https://github.com/laravel/framework/issues/42326