### PR TITLE
Support type hinting when resolving manually

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -679,12 +679,13 @@ if (! function_exists('rescue')) {
 
 if (! function_exists('resolve')) {
     /**
-     * Resolve a service from the container.
-     *
-     * @param  string  $name
-     * @param  array  $parameters
-     * @return mixed
-     */
+    * Resolve a service from the container.
+    *
+    * @param    class-string<T>  $name
+    * @param    array            $parameters
+    * @return   T
+    * @template T
+    */
     function resolve($name, array $parameters = [])
     {
         return app($name, $parameters);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -679,13 +679,13 @@ if (! function_exists('rescue')) {
 
 if (! function_exists('resolve')) {
     /**
-    * Resolve a service from the container.
-    *
-    * @param    class-string<T>  $name
-    * @param    array            $parameters
-    * @return   T
-    * @template T
-    */
+     * Resolve a service from the container.
+     *
+     * @param    class-string<T>  $name
+     * @param    array            $parameters
+     * @return   T
+     * @template T
+     */
     function resolve($name, array $parameters = [])
     {
         return app($name, $parameters);


### PR DESCRIPTION
When it's impracticable to resolve a service via a constructor, using the `resolve()` function (or similar) must be used. This works, but makes it hard to find usage of the service and benefit from type hints without manually docblocking the service, which may be missed.

## Existing

```php 
// Having to manually docblock a service each time it's resolved to benefit from
// type hinting, clicking through in an IDE, finding usage etc.

/** @var MyServiceInterface $myService */
$myService = resolve(MyServiceInterface::class);

$myService->doThatThing();
```

## Proposed
```php
// $myService is inferred as an instance of MyServiceInterface automatically
$myService = resolve(MyServiceInterface::class);

// This also allows calls directly on the resolve() function result with type hinting
resolve(MyServiceInterface::class)->doThatThing();
```
Docs: https://phpstan.org/writing-php-code/phpdoc-types#class-string

This will not work if using string names and not class names for services in the container, for example `router`. It might be worth having another function which is exclusively used for services in the container which are bound using class names.

**_This does not change any PHP code, just docblock comments on the `resolve()` function._**
