### PR TITLE
[9.x] Add `@routeIs()` blade directive 

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -337,4 +337,25 @@ trait CompilesConditionals
     {
         return "<?php if{$condition}: echo 'disabled'; endif; ?>";
     }
+
+    /**
+     * Compile a route-is into valid PHP.
+     *
+     * @param  string|array  $route
+     * @return string
+     */
+    protected function compileRouteIs($route)
+    {
+        return "<?php if(request()->routeIs($route)): ?>";
+    }
+
+    /**
+     * Compile an end-route-is block into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndRouteIs()
+    {
+        return '<?php endif; ?>';
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -346,7 +346,7 @@ trait CompilesConditionals
      */
     protected function compileRouteIs($patterns)
     {
-        return "<?php if (request()->routeIs{$patterns}): ?>";
+        return "<?php if(request()->routeIs{$patterns}): ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -344,9 +344,9 @@ trait CompilesConditionals
      * @param  string|array  $route
      * @return string
      */
-    protected function compileRouteIs($route)
+    protected function compileRouteIs($patterns)
     {
-        return "<?php if(request()->routeIs($route)): ?>";
+        return "<?php if (request()->routeIs{$patterns}): ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -346,7 +346,7 @@ trait CompilesConditionals
      */
     protected function compileRouteIs($patterns)
     {
-        return "<?php if(request()->routeIs{$patterns}): ?>";
+        return "<?php if (request()->routeIs{$patterns}): ?>";
     }
 
     /**

--- a/tests/View/Blade/BladeRouteIsTest.php
+++ b/tests/View/Blade/BladeRouteIsTest.php
@@ -6,8 +6,8 @@ class BladeRouteIsTest extends AbstractBladeTestCase
 {
     public function testRouteIsCompiled()
     {
-        $string = '@routeIs(foo) bar @endRouteIs';
-        $expected = '<?php if(request()->routeIs(foo)): ?> bar <?php endif; ?>';
+        $string = '@routeIs(\'foo\', \'bar\') baz @endrouteIs';
+        $expected = '<?php if (request()->routeIs(\'foo\', \'bar\')): ?> baz <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladeRouteIsTest.php
+++ b/tests/View/Blade/BladeRouteIsTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeRouteIsTest extends AbstractBladeTestCase
+{
+    public function testRouteIsCompiled()
+    {
+        $string = '@routeIs(foo) bar @endRouteIs';
+        $expected = '<?php if(request()->routeIs(foo)): ?> bar <?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
The use-case to use the `@routeIs() `

    1. If you want to check the route and do something if route is set to that route name


instead of doing 

`<li class="nav-item @if(request()->routeIs('home')) active @endif">`

you can do 

` <li class="nav-item @routeIs('foo') active @endrouteIs">`

you can also pass in array

` <li class="nav-item @routeIs(['foo','bar']) active @endrouteIs">`

or maybe just do something 

```
@routeIs('foo','bar')

// do something

@endrouteIs
```
