### PR TITLE
Add strict validation style for validation rule digits_between

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -579,19 +579,30 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'digits_between');
 
-        $length = strlen((string) $value);
-
-        if (((string) $value) === '.') {
+        if (! is_numeric($value)) {
             return false;
         }
 
-        // Make sure there is not more than one dot...
-        if (($length - strlen(str_replace('.', '', (string) $value))) > 1) {
+        if (is_string($value)) {
+            // value must not be a dot or contain more than single dot
+            if ($value === '.' || substr_count($value, '.') > 1) {
+                return false;
+            }
+        } else {
+            $value = strval($value);
+        }
+
+        $length = strlen($value);
+
+        if ($length < $parameters[0] || $length > $parameters[1]) {
             return false;
         }
 
-        return ! preg_match('/[^0-9.]/', $value)
-                    && $length >= $parameters[0] && $length <= $parameters[1];
+        if (isset($parameters[2]) && $parameters[2] === 'strict') {
+            return ! preg_match('/[^0-9]/', $value);
+        }
+
+        return ! preg_match('/[^0-9.]/', $value);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2361,6 +2361,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '2.'], ['foo' => 'digits_between:1,10']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'digits_between:1,10,strict']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '12.3'], ['foo' => 'digits_between:1,10,strict']);
+        $this->assertTrue($v->fails());
     }
 
     public function testValidateSize()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Today I learned that since PR #40278 the validation rule ```digits_between``` allows the value to contain also a dot (```.```). I think it is wrong, because a dot is not a digit. But what is done, is done…
I discussed it in issue #42326 but I failed to persuade Laravel core member to roll back that PR. Breaking changes must be prevented… At least, I was encouraged to make a PR to achieve my goal, so this is it.

I created a third parameter for the validation rule ```digits_between``` – the validation style ```strict```. This is a non-breaking feature and, as written in documentation, can be targeted for 9.x branch.

To validate by using ```strict``` validation style and ensure that the value contains digits only:
```php
$data = [
    'pin' => '1234',
];

$validator = \Illuminate\Support\Facades\Validator::make($data, [
    'pin' => 'digits_between:4,8,strict',
]);

if ($validator->passes()) {
    echo 'Success!';
} else {
    echo 'The PIN number must contain 4-8 digits.';
}
```