### PR TITLE
[9.x] Fix type mismatch on Pusher::validate_channels()

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -123,7 +123,7 @@ class PusherBroadcaster extends Broadcaster
 
         try {
             $channels->chunk(100)->each(function ($channels) use ($event, $payload, $parameters) {
-                $this->pusher->trigger($channels, $event, $payload, $parameters);
+                $this->pusher->trigger($channels->toArray(), $event, $payload, $parameters);
             });
         } catch (ApiErrorException $e) {
             throw new BroadcastException(


### PR DESCRIPTION

 - Laravel 9.12.0
 - Pusher 7.0

This PR fixes an issue with the most recent version of Pusher package.

After PR #42287, the argument passed on to `Pusher\Pusher::trigger()` was changed to a Collection. But since version 7.0 Pusher requires an argument of type array down the stack.

Trying to broadcast an event using Pusher 7.0 on Laravel 9.12.0 raises the following error:

`Pusher\\Pusher::validate_channels(): Argument #1 ($channels) must be of type array, Illuminate\\Support\\Collection given, called in /vendor/pusher/pusher-php-server/src/Pusher.php on line 341`

