### PR TITLE
[9.x] Add `is_string` check to `QueriesRelationships@requalifyWhereTables`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -783,7 +783,7 @@ trait QueriesRelationships
     {
         return collect($wheres)->map(function ($where) use ($from, $to) {
             return collect($where)->map(function ($value) use ($from, $to) {
-                return str_starts_with($value, $from.'.')
+                return is_string($value) && str_starts_with($value, $from.'.')
                     ? $to.'.'.Str::afterLast($value, '.')
                     : $value;
             });

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1292,6 +1292,20 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
+    public function testWithAggregateAndSelfRelationConstrain()
+    {
+        EloquentBuilderTestStub::resolveRelationUsing('children', function ($model) {
+            return $model->hasMany(EloquentBuilderTestStub::class, 'parent_id', 'id')->where('enum_value', new stdClass);
+        });
+
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+
+        $builder = $model->withCount('children');
+
+        $this->assertSame('select "table".*, (select count(*) from "table" as "laravel_reserved_0" where "table"."id" = "laravel_reserved_0"."parent_id" and "enum_value" = ?) as "children_count" from "table"', $builder->toSql());
+    }
+
     public function testWithExists()
     {
         $model = new EloquentBuilderTestModelParentStub;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1300,10 +1300,11 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $model = new EloquentBuilderTestStub;
         $this->mockConnectionForModel($model, '');
+        $relationHash = $model->children()->getRelationCountHash(false);
 
         $builder = $model->withCount('children');
 
-        $this->assertSame('select "table".*, (select count(*) from "table" as "laravel_reserved_0" where "table"."id" = "laravel_reserved_0"."parent_id" and "enum_value" = ?) as "children_count" from "table"', $builder->toSql());
+        $this->assertSame(vsprintf('select "table".*, (select count(*) from "table" as "%s" where "table"."id" = "%s"."parent_id" and "enum_value" = ?) as "children_count" from "table"', [$relationHash, $relationHash]), $builder->toSql());
     }
 
     public function testWithExists()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


Closes #42338

This PR:

- Adds a `is_string()` check before a `str_starts_with()` on `QueriesRelationships@requalifyWhereTables`
- Adds a test case which would fail without this patch

Notes:

- The `QueriesRelationships@requalifyWhereTables` was added by PR #42100 which tried to fix table prefixing issues when using self-referencing relations
- There is no need to check non-string values, as the idea is to prefix values used in `whereColumn`, or other that could reference related tables
- The added test case used a `new stdClass` as enums are not available in PHP 8. As it tests the generated SQL statement, the `stdClass` instance never acutually gets bound to PDO.


EDIT: added information about added test case. Please read 3rd note about it.