### PR TITLE
[9.x] Factory fails to eval models and factories when returned from closure

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -448,21 +448,21 @@ abstract class Factory
     protected function expandAttributes(array $definition)
     {
         return collect($definition)
-            ->map(function ($attribute, $key) {
+            ->map($evaluateRelations = function ($attribute) {
                 if ($attribute instanceof self) {
                     $attribute = $attribute->create()->getKey();
                 } elseif ($attribute instanceof Model) {
                     $attribute = $attribute->getKey();
                 }
 
-                $definition[$key] = $attribute;
-
                 return $attribute;
             })
-            ->map(function ($attribute, $key) use (&$definition) {
+            ->map(function ($attribute, $key) use (&$definition, $evaluateRelations) {
                 if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
                     $attribute = $attribute($definition);
                 }
+
+                $attribute = $evaluateRelations($attribute);
 
                 $definition[$key] = $attribute;
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -137,6 +137,18 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame('taylor-options', $user->options);
     }
 
+    public function test_expanded_closure_attribute_returning_a_factory_is_resolved()
+    {
+        $post = FactoryTestPostFactory::new()->create([
+            'title' => 'post',
+            'user_id' => fn ($attributes) => FactoryTestUserFactory::new([
+                'options' => $attributes['title'].'-options',
+            ]),
+        ]);
+
+        $this->assertEquals('post-options', $post->user->options);
+    }
+
     public function test_make_creates_unpersisted_model_instance()
     {
         $user = FactoryTestUserFactory::new()->makeOne();


### PR DESCRIPTION
Since v9.12.0, due to the changes made in https://github.com/laravel/framework/pull/42241, model factories now fail to evaluate both models and factories when they are returned from a closure.

This is due to [models and factories now being resolved first](https://github.com/DarkGhostHunter/framework/blob/d41ff818c293c93e1a4613d4c228ebd7f214aa32/src/Illuminate/Database/Eloquent/Factories/Factory.php#L452-L456) and [closures second](https://github.com/DarkGhostHunter/framework/blob/d41ff818c293c93e1a4613d4c228ebd7f214aa32/src/Illuminate/Database/Eloquent/Factories/Factory.php#L463-L465).

To fix this issue, while maintaining the functionality added in https://github.com/laravel/framework/pull/42241, the [resolution of models and factories](https://github.com/DarkGhostHunter/framework/blob/d41ff818c293c93e1a4613d4c228ebd7f214aa32/src/Illuminate/Database/Eloquent/Factories/Factory.php#L452-L456) would need to be repeated again [after resolving closures](https://github.com/DarkGhostHunter/framework/blob/d41ff818c293c93e1a4613d4c228ebd7f214aa32/src/Illuminate/Database/Eloquent/Factories/Factory.php#L466).

A rudimentary example:
```php
class PostFactory extends Factory
{
    public function definition()
    {
        return [
            'title' => 'post',
            'user_id' => function (array $attributes) {
                return User::factory(['options' => $attributes['title'].'-options']);
            },
        ];
    }
}
```

In the latest release, the code above would throw an exception - occurring when the database driver attempts to bind a factory object the query statement ([see failing test](https://github.com/laravel/framework/runs/6382418037?check_suite_focus=true#step:8:144)).

```
Error: Object of class \Database\Factories\PostFactory could not be converted to string
```