### PR TITLE
[8.x] Fix PruneCommand finding its usage within other traits

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -87,7 +87,9 @@ class PruneCommand extends Command
     protected function models()
     {
         if (! empty($models = $this->option('model'))) {
-            return collect($models);
+            return collect($models)->filter(function ($model) {
+                return class_exists($model);
+            })->values();
         }
 
         $except = $this->option('except');
@@ -111,6 +113,8 @@ class PruneCommand extends Command
                 });
             })->filter(function ($model) {
                 return $this->isPrunable($model);
+            })->filter(function ($model) {
+                return class_exists($model);
             })->values();
     }
 

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -92,6 +92,16 @@ No prunable [Illuminate\Tests\Database\NonPrunableTestModel] records found.
 EOF, str_replace("\r", '', $output->fetch()));
     }
 
+    public function testNonPrunableTestWithATrait()
+    {
+        $output = $this->artisan(['--model' => NonPrunableTrait::class]);
+
+        $this->assertEquals(<<<'EOF'
+No prunable models found.
+
+EOF, str_replace("\r", '', $output->fetch()));
+    }
+
     public function testTheCommandMayBePretended()
     {
         $db = new DB;
@@ -226,4 +236,9 @@ class PrunableTestModelWithoutPrunableRecords extends Model
 class NonPrunableTestModel extends Model
 {
     // ..
+}
+
+trait NonPrunableTrait
+{
+    use Prunable;
 }


### PR DESCRIPTION
This addresses an edge case i think, where using the `Prunable` trait within another trait (due to several reasons like modifying behaviour, removing duplication, etc..) was breaking the PruneCommand from behaving properly, since the trait was being detected as a class.

Signed-off-by: Bruno Gaspar <brunofgaspar1@gmail.com>
