### PR TITLE
[9.x] Fix casting nulls in AsCollection and AsArrayObject casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php
@@ -30,7 +30,11 @@ class AsArrayObject implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => json_encode($value)];
+                if (! is_null($value)) {
+                    return [$key => json_encode($value)];
+                }
+
+                return null;
             }
 
             public function serialize($model, string $key, $value, array $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsCollection.php
@@ -31,7 +31,11 @@ class AsCollection implements Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                return [$key => json_encode($value)];
+                if (! is_null($value)) {
+                    return [$key => json_encode($value)];
+                }
+
+                return null;
             }
         };
     }

--- a/tests/Integration/Database/DatabaseCustomCastsTest.php
+++ b/tests/Integration/Database/DatabaseCustomCastsTest.php
@@ -126,6 +126,25 @@ class DatabaseCustomCastsTest extends DatabaseTestCase
             $model->array_object_json->toArray()
         );
     }
+
+    public function test_custom_casting_nullable_values_null()
+    {
+        $model = new TestEloquentModelWithCustomCastsNullable();
+
+        $model->array_object = null;
+        $model->array_object_json = null;
+        $model->collection = null;
+        $model->stringable = null;
+        $model->save();
+
+        $this->assertDatabaseHas(TestEloquentModelWithCustomCastsNullable::class, [
+            'id' => $model->id,
+            'array_object' => null,
+            'array_object_json' => null,
+            'collection' => null,
+            'stringable' => null,
+        ]);
+    }
 }
 
 class TestEloquentModelWithCustomCasts extends Model


### PR DESCRIPTION
These 2 casts actually set `"null"` in database instead of `null`.

Looking at https://laravel.com/docs/9.x/upgrade#custom-casts-and-null, it looks like these custom casts need to be updated.

This behaviour is actually already implemented in `AsEncryptedArrayObject` and `AsEncryptedCollection`
