### PR TITLE
[9.x] Translate "and X more errors" message for validator exception

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -88,15 +88,22 @@ class ValidationException extends Exception
         $messages = $validator->errors()->all();
 
         if (! count($messages)) {
-            return 'The given data was invalid.';
+            $message = trans('validation.invalid_data');
+
+            return $message === 'validation.invalid_data'
+                ? 'The given data was invalid.'
+                : $message;
         }
 
         $message = array_shift($messages);
 
         if ($additional = count($messages)) {
             $pluralized = $additional === 1 ? 'error' : 'errors';
+            $and = trans('validation.and');
+            $more = trans('validation.more');
 
-            $message .= " (and {$additional} more {$pluralized})";
+            $message .= " (" .($and === 'validation.and'? 'and': $and) ." {$additional} "
+                    .($more === 'validation.more'? 'more': $more) ." {$pluralized})";
         }
 
         return $message;

--- a/tests/Validation/ValidationExceptionTest.php
+++ b/tests/Validation/ValidationExceptionTest.php
@@ -45,6 +45,7 @@ class ValidationExceptionTest extends TestCase
     protected function getException($data = [], $rules = [])
     {
         $translator = new Translator(new ArrayLoader, 'en');
+        app()->instance('translator', $translator);
         $validator = new Validator($translator, $data, $rules);
 
         return new ValidationException($validator);


### PR DESCRIPTION
# Problem

When building a multilingual website, the user gets an error message with the suffix "and 3 more errors" in the Form Request error messages. So I need to override the `ValidationException` class every time want to use the translated error messages.

# Solution
I have updated the `ValidationException` class in the `summarize` function with the below translatable keys. Therefore, I used the following two translation keys:
- `validation.invalid_data`  to the value message: `The given data was invalid.`
- `validation.additional` to the translation message: `and X more errors`.

You can use these keys in `languages/en.php` as below 

```
[
   ...,
  "validation.invalid_data" => "The given data was invalid.",
  "validation.additional" => "and :additional more :pluralized".
  ...
];
``` 

