### PR TITLE
[9.x] Adds support to `HEAD` in route. `Route::head($uri, $action);`

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -14,6 +14,15 @@ interface Registrar
     public function get($uri, $action);
 
     /**
+     * Register a new HEAD route with the router.
+     *
+     * @param  string  $uri
+     * @param  array|string|callable  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function head($uri, $action = null);
+
+    /**
      * Register a new POST route with the router.
      *
      * @param  string  $uri

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -151,6 +151,18 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Register a new HEAD route with the router.
+     *
+     * @param  string  $uri
+     * @param  array|string|callable|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function head($uri, $action = null)
+    {
+        return $this->addRoute('HEAD', $uri, $action);
+    }
+
+    /**
      * Register a new POST route with the router.
      *
      * @param  string  $uri

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -10,6 +10,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route delete(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route fallback(array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route get(string $uri, array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route head(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route|null getCurrentRoute()
  * @method static \Illuminate\Routing\RouteCollectionInterface getRoutes()
  * @method static \Illuminate\Routing\Route match(array|string $methods, string $uri, array|string|callable|null $action = null)


### PR DESCRIPTION
Hello, I need to create a route with the HEAD method to update a token, I saw that laravel did not have this support.

Here's a PR adding this feature. Please let me know if anything is missing and if this functionality can come in.

Thanks

` Route::head($uri, $action); `