### PR TITLE
Replace the magic number by a constant in the handle Command function…

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -25,8 +25,8 @@ class {{ class }} extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
The `php artisan make:command` maker builds a command class with a default `return 0` in the handle function.

Let's not use magic numbers and use the constants provided by Symfony Command instead.
Makes the code clearer, and points the develop to the existence of the other constants ::FAILURE and ::INVALID

As PHP 8 is now a pre-requesite to use Laravel, let's type-hint new created things. 