### PR TITLE
[9.x] Fix assert that exception is thrown without message

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -170,14 +170,10 @@ trait InteractsWithExceptionHandling
             $actualMessage = $exception->getMessage();
         }
 
-        if (! $thrown) {
-            Assert::fail(
-                sprintf(
-                    'Failed asserting that exception of type "%s" is thrown.',
-                    $expectedClass
-                )
-            );
-        }
+        Assert::assertTrue(
+            $thrown,
+            sprintf('Failed asserting that exception of type "%s" is thrown.', $expectedClass)
+        );
 
         if (isset($expectedMessage)) {
             if (! isset($actualMessage)) {


### PR DESCRIPTION
Hi,
This fixes #42155.
With previous implementation, no assertions were made when the specified exception is thrown but no expected message specified leading to the message "This test did not perform any assertions".

Thanks to @christophrumpel for the heads up.
