### PR TITLE
[9.x] Add new TestResponse helper: assertJsonMissingPath

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -212,6 +212,19 @@ class AssertableJsonString implements ArrayAccess, Countable
     }
 
     /**
+     * Assert that the response does not contain the given path.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function assertMissingPath($path)
+    {
+        PHPUnit::assertFalse(Arr::has($this->json(), $path));
+
+        return $this;
+    }
+
+    /**
      * Assert that the expected value and type exists at the given path in the response.
      *
      * @param  string  $path

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -811,6 +811,19 @@ EOF;
     }
 
     /**
+     * Assert that the response does not contain the given path.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function assertJsonMissingPath(string $path)
+    {
+        $this->decodeResponseJson()->assertMissingPath($path);
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has a given JSON structure.
      *
      * @param  array|null  $structure

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -981,7 +981,6 @@ class TestResponseTest extends TestCase
 
     public function testAssertJsonMissingPathCanFail()
     {
-
         $this->expectException(AssertionFailedError::class);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
@@ -991,7 +990,6 @@ class TestResponseTest extends TestCase
 
     public function testAssertJsonMissingPathCanFail2()
     {
-
         $this->expectException(AssertionFailedError::class);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
@@ -1001,7 +999,6 @@ class TestResponseTest extends TestCase
 
     public function testAssertJsonMissingPathCanFail3()
     {
-
         $this->expectException(AssertionFailedError::class);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -967,6 +967,48 @@ class TestResponseTest extends TestCase
         $response->assertJsonMissingExact(['id' => 20, 'foo' => 'bar']);
     }
 
+    public function testAssertJsonMissingPath()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        // With simple key
+        $response->assertJsonMissingPath('missing');
+
+        // With nested key
+        $response->assertJsonMissingPath('foobar.missing');
+        $response->assertJsonMissingPath('numeric_keys.0');
+    }
+
+    public function testAssertJsonMissingPathCanFail()
+    {
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonMissingPath('foo');
+    }
+
+    public function testAssertJsonMissingPathCanFail2()
+    {
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonMissingPath('foobar.foobar_foo');
+    }
+
+    public function testAssertJsonMissingPathCanFail3()
+    {
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonMissingPath('numeric_keys.3');
+    }
+
     public function testAssertJsonValidationErrors()
     {
         $data = [


### PR DESCRIPTION
This PR adds a new `assertJsonMissingPath()` HTTP Testing helper.  
It's very useful to check that a path does dot exist, regardless of its content, especially for deep nested data.

```php
$this->getJson('/users/1')
    ->assertOk()
    ->assertJsonMissingPath('email'); // Never return the user email

$this->getJson('/articles')
    ->assertOk()
    ->assertJsonMissingPath('data.0.internalTags');
```

Currently the only *similar* option is to use `assertJsonMissing` but you have to create the whole nested structure and know the data that should be inside and could be a pain sometimes, for example if wanting to check that an array does not exist and you don't know the order of its items.
