### PR TITLE
[9.x] Adds password hash helper for Factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -516,7 +515,7 @@ abstract class Factory
      */
     public function password($password = 'password')
     {
-        return $this->passwords[$password] ??= app('hash')->make($password);
+        return $this->passwords[$password] ??= Container::getInstance()->make('hash')->make($password);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -86,6 +87,13 @@ abstract class Factory
      * @var \Faker\Generator
      */
     protected $faker;
+
+    /**
+     * List of already hashed passwords.
+     *
+     * @var array<string, string>
+     */
+    protected $passwords = [];
 
     /**
      * The default namespace where factories reside.
@@ -498,6 +506,17 @@ abstract class Factory
     public function set($key, $value)
     {
         return $this->state([$key => $value]);
+    }
+
+    /**
+     * Hashes a password only once.
+     *
+     * @param  string  $password
+     * @return string
+     */
+    public function password($password = 'password')
+    {
+        return $this->passwords[$password] ??= app('hash')->make($password);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -739,7 +739,7 @@ class FactoryTestPasswordFactory extends Factory
     public function definition()
     {
         return [
-            'password' => $this->password()
+            'password' => $this->password(),
         ];
     }
 }


### PR DESCRIPTION
## What?

This small method will actually reuses the password hash to avoid creating it for each created model from the Factory. Should have major speedbumps when seeding 1.000+ models in a database. It uses `password` by default, and the application default hasher.

```php
public function definition()
{
    return [
        'name' => $this->faker->name,
        'password' => $this->password(), // "password"
        // ...
    ];
}
```

## How?

It saves the password (when called) into the Factory. This allows to hash a password only once when it makes/creates models.

## TODO?

The [`UserFactory.php` in laravel/laravel](https://github.com/laravel/laravel/blob/9.x/database/factories/UserFactory.php#L24) could be changed too to use the method instead of hard-coding the hash to _bcrypt_.

## BC?

Just adding a method and a property.