### PR TITLE
[9.x] Skip parameter parsing for raw post body in HTTP Client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -895,6 +895,10 @@ class PendingRequest
      */
     protected function parseRequestData($method, $url, array $options)
     {
+        if ($this->bodyFormat === 'body') {
+            return [];
+        }
+
         $laravelData = $options[$this->bodyFormat] ?? $options['query'] ?? [];
 
         $urlString = Str::of($url);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -152,6 +152,21 @@ class HttpClientTest extends TestCase
         $this->factory->withBody($body, 'application/json')->send('get', 'http://foo.com/api');
     }
 
+    public function testSendRequestBodyWithManyAmpersands()
+    {
+        $body = str_repeat('A thousand &. ', 10000);
+
+        $fakeRequest = function (Request $request) use ($body) {
+            self::assertSame($body, $request->body());
+
+            return ['my' => 'response'];
+        };
+
+        $this->factory->fake($fakeRequest);
+
+        $this->factory->withBody($body, 'text/plain')->send('post', 'http://foo.com/api');
+    }
+
     public function testUrlsCanBeStubbedByPath()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -154,7 +154,7 @@ class HttpClientTest extends TestCase
 
     public function testSendRequestBodyWithManyAmpersands()
     {
-        $body = str_repeat('A thousand &. ', 10000);
+        $body = str_repeat('A thousand &. ', 1000);
 
         $fakeRequest = function (Request $request) use ($body) {
             self::assertSame($body, $request->body());


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/42349
Related to https://github.com/laravel/framework/issues/36976

When sending an `Http::withBody()` using the Http client, the raw body is parsed as query/form parameters. This seems wrong and is both unnecessary work and risks hitting the default limit of 1000 "input variables" in php.

```php
Http::withBody(str_repeat('A thousand &. ', 1000), 'text/plain')->post('https://some-url.com');
```

```
ErrorException

parse_str(): Input variables exceeded 1000. To increase the limit change max_input_vars in php.ini.
```

The limit of 1000 is quite easily hit by sending HTML, XML or similar text. 

The suggested solution here skips all parameter parsing of the body, also saving a fair bit of work. All tests pass, but is there a specific reason to parse the body this way, or might that have been introduced by mistake in order to parse query and form-data parameters?

Our use case is sending user-provided HTML to an external service (for text analysis) and while being very rare, we sometimes see the 1000 limit being hit via Bugsnag.

_Thanks to @pelmered for suggestion of simplified flow (early return)._