### PR TITLE
[9.x] Avoid deprecated const DateTimeInterface::ISO8601

### DIFF
--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -106,7 +106,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
                 'exception' => $result['exception']['S'],
                 'failed_at' => Carbon::createFromTimestamp(
                     (int) $result['failed_at']['N']
-                )->format(DateTimeInterface::ISO8601),
+                )->format(DateTimeInterface::ATOM),
             ];
         })->all();
     }
@@ -139,7 +139,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
             'exception' => $result['Item']['exception']['S'],
             'failed_at' => Carbon::createFromTimestamp(
                 (int) $result['Item']['failed_at']['N']
-            )->format(DateTimeInterface::ISO8601),
+            )->format(DateTimeInterface::ATOM),
         ];
     }
 

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -94,7 +94,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
                 'queue' => 'queue',
                 'payload' => 'payload',
                 'exception' => 'exception',
-                'failed_at' => Carbon::createFromTimestamp($time)->format(DateTimeInterface::ISO8601),
+                'failed_at' => Carbon::createFromTimestamp($time)->format(DateTimeInterface::ATOM),
             ],
         ], $response);
     }
@@ -135,7 +135,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
                 'queue' => 'queue',
                 'payload' => 'payload',
                 'exception' => 'exception',
-                'failed_at' => Carbon::createFromTimestamp($time)->format(DateTimeInterface::ISO8601),
+                'failed_at' => Carbon::createFromTimestamp($time)->format(DateTimeInterface::ATOM),
             ], $response
         );
     }


### PR DESCRIPTION
This fixes the use of a deprecated const DateTimeInterface::ISO886 and switched to DateTimeInterface::ATOM

The const ISO8601 was left for backward compatibility and it's recommended to use ATOM const added since php 7.2