### PR TITLE
[9.x] Add AssertCount() in NotificationFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -206,6 +206,22 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
     }
 
     /**
+     * Assert the total count of notification that were sent.
+     *
+     * @param  int  $expectedCount
+     * @return void
+     */
+    public function assertCount($expectedCount)
+    {
+        $actualCount = count($this->notifications);
+
+        PHPUnit::assertSame(
+            $expectedCount, $actualCount,
+            "Expected {$expectedCount} notifications to be sent, but {$actualCount} were sent."
+        );
+    }
+
+    /**
      * Assert the total amount of times a notification was sent.
      *
      * @param  int  $expectedCount

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -213,7 +213,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
      */
     public function assertCount($expectedCount)
     {
-        $actualCount = count($this->notifications);
+        $actualCount = collect($this->notifications)->flatten(3)->count();
 
         PHPUnit::assertSame(
             $expectedCount, $actualCount,


### PR DESCRIPTION
This adds a `Notification::assertCount(4)` method on the NotificationFake class. 

Main use case is to assert that X notifications were sent when sending multiple notifications of different Notification Classes.

I'm not sure if I am missing something obvious here but I couldn't find an assertion for just validating the number of notifications that were sent.