### PR TITLE
Fix exists validation error when the values is an array of records and not just array of ids.

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -784,7 +784,7 @@ trait ValidatesAttributes
         // that the columns being "verified" shares the given attribute's name.
         $column = $this->getQueryColumn($parameters, $attribute);
 
-        $expected = is_array($value) ? count(array_unique($value)) : 1;
+        $expected = is_array($value) ? count(array_unique($value, 3)) : 1;
 
         if (is_array($value)) {
             // Extract only keys from $values if it is an array of objects

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -786,9 +786,33 @@ trait ValidatesAttributes
 
         $expected = is_array($value) ? count(array_unique($value)) : 1;
 
+        if (is_array($value)) {
+            // Extract only keys from $values if it is an array of objects
+            $value = $this->extractExistsValues($value, $column);
+        }
+
         return $this->getExistCount(
             $connection, $table, $column, $value, $parameters
         ) >= $expected;
+    }
+
+    /**
+     * Get only keys for the given values.
+     *
+     * @param array $values
+     * @param $column
+     * @return array
+     */
+    private function extractExistsValues(array $values, $column): array
+    {
+        // Extract only keys from $values if it is an array of objects
+        return array_map(function ($value) use ($column) {
+            if (is_array($value) && Arr::isAssoc($value)) {
+                return $value[$column];
+            }
+
+            return $value;
+        }, $values);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -784,7 +784,7 @@ trait ValidatesAttributes
         // that the columns being "verified" shares the given attribute's name.
         $column = $this->getQueryColumn($parameters, $attribute);
 
-        $expected = is_array($value) ? count(array_unique($value, 3)) : 1;
+        $expected = is_array($value) ? count(array_unique($value, SORT_REGULAR)) : 1;
 
         if (is_array($value)) {
             // Extract only keys from $values if it is an array of objects
@@ -799,7 +799,7 @@ trait ValidatesAttributes
     /**
      * Get only keys for the given values.
      *
-     * @param array $values
+     * @param  array  $values
      * @param $column
      * @return array
      */


### PR DESCRIPTION
Add validation for exists using keys and records.
For example when validating record relationship exists, it assumes that is an array of keys or just a single value.
But the problem comes when I load record whit its relationships:

```php
$user = [
    "id" => 1,
    "name" => "User 1",
    "roles" => [
        [
            "id" => 1,
            "name" => "Role 1"
        ],
        [
            "id" => 2,
            "name" => "Role 2"
        ]
    ],
];
```

In the frontend app I send the record like the previous schema object and in the backend I made a validation for existing roles

```php
$validator = [
    'roles' => 'exists:roles,id'
];
```

The problem occurs when array_unique called in [ValidatesAttributes.php](https://github.com/laravel/framework/blob/9feb9f2ad614f5e5cd06b17b446c08274b7b76fb/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L787) show that it cannot convert array to string, and breaks the Laravel execution.

Now the exists rule will check if the values is an array of keys and an array of records that contains keys.