### PR TITLE
[9.x] Update Encrypter.php

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -148,6 +148,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public function decrypt($payload, $unserialize = true)
     {
+        $payload = strval($payload);
         $payload = $this->getJsonPayload($payload);
 
         $iv = base64_decode($payload['iv']);

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -148,8 +148,7 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     public function decrypt($payload, $unserialize = true)
     {
-        $payload = strval($payload);
-        $payload = $this->getJsonPayload($payload);
+        $payload = $this->getJsonPayload((string) $payload);
 
         $iv = base64_decode($payload['iv']);
 


### PR DESCRIPTION
enforce decrypt payload to string, fix for below error

`base64_decode(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/laravel/framework/src/Illuminate/Encryption/Encrypter.php on line 208`

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
