### PR TITLE
[9.x] Direct routes for resource controller methods

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -334,6 +334,90 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Route a resource to a controller index method.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function index($name, $controller)
+    {
+        return $this->resource($name, $controller, ['only' => __FUNCTION__]);
+    }
+
+    /**
+     * Route a resource to a controller store method.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function store($name, $controller)
+    {
+        return $this->resource($name, $controller, ['only' => __FUNCTION__]);
+    }
+
+    /**
+     * Route a resource to a controller create method.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function create($name, $controller)
+    {
+        return $this->resource($name, $controller, ['only' => __FUNCTION__]);
+    }
+
+    /**
+     * Route a resource to a controller show method.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function show($name, $controller)
+    {
+        return $this->resource($name, $controller, ['only' => __FUNCTION__]);
+    }
+
+    /**
+     * Route a resource to a controller update method.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function update($name, $controller)
+    {
+        return $this->resource($name, $controller, ['only' => __FUNCTION__]);
+    }
+
+    /**
+     * Route a resource to a controller destroy method.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function destroy($name, $controller)
+    {
+        return $this->resource($name, $controller, ['only' => __FUNCTION__]);
+    }
+
+    /**
+     * Route a resource to a controller edit method.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function edit($name, $controller)
+    {
+        return $this->resource($name, $controller, ['only' => __FUNCTION__]);
+    }
+
+    /**
      * Register an array of API resource controllers.
      *
      * @param  array  $resources

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -3,6 +3,13 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @method static \Illuminate\Routing\Route index($name, $controller)
+ * @method static \Illuminate\Routing\Route store($name, $controller)
+ * @method static \Illuminate\Routing\Route create($name, $controller)
+ * @method static \Illuminate\Routing\Route show($name, $controller)
+ * @method static \Illuminate\Routing\Route update($name, $controller)
+ * @method static \Illuminate\Routing\Route destroy($name, $controller)
+ * @method static \Illuminate\Routing\Route edit($name, $controller)
  * @method static \Illuminate\Routing\PendingResourceRegistration apiResource(string $name, string $controller, array $options = [])
  * @method static \Illuminate\Routing\PendingResourceRegistration resource(string $name, string $controller, array $options = [])
  * @method static \Illuminate\Routing\Route any(string $uri, array|string|callable|null $action = null)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Add methods to the `Illuminate\Routing\Router` class that target routes generated by the `resource` method individually.

 The `resource` method is very convenient since it makes for us conventional routes and avoid us some typos, but it feels like an overkill when the resource is touched by only one or two methods. I know about the `except` and `only` chainable methods but I still feel that this PR offers a terse syntax :)

```php
// Doing
Route::create('entity', EntityController::class);
Route::update('entity', EntityController::class);

// Instead of:
Route::resource('entity', EntityController::class)->only(['create', 'store']);
```