### PR TITLE
[9.x] Add new DetectLostConnections for Vapor with Octane and Proxy RDS

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -58,6 +58,7 @@ trait DetectsLostConnections
             'SQLSTATE[08006] [7] could not translate host name',
             'TCP Provider: Error code 0x274C',
             'SQLSTATE[HY000] [2002] No such file or directory',
+            'SSL: Operation timed out',
         ]);
     }
 }


### PR DESCRIPTION
As we're receiving a lot of Sentry errors since we moved our Vapor application to Octane

I create this PR to ensure that these queries get retried before we ignore this kind of exceptions from being reported to our Sentry.

**Example:**

![image](https://user-images.githubusercontent.com/2331052/168273198-e8ef69c9-daf2-48d6-bb12-fcbc6e7faac4.png)

```
Illuminate\Database\QueryException
PDO::prepare(): SSL: Operation timed out (SQL: select * from `processes` where (exists (select * from `workspaces` where `processes`.`workspace_id` = `workspaces`.`id` and (`workspaces`.`id` = ... or `workspaces`.`slug` = ...) and `workspaces`.`deleted_at` is null) and `is_shared` = 1 and `slug` like %-preview) and `processes`.`deleted_at` is null order by `created_at` desc limit 31)
```