### PR TITLE
[9.x] Adds message to DetectsLostConnections for MySQL RDS

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -45,6 +45,7 @@ trait DetectsLostConnections
             'The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.',
             'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again',
             'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Name or service not known',
+            'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo for',
             'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected',
             'SQLSTATE[HY000] [2002] Connection timed out',
             'SSL: Connection timed out',


### PR DESCRIPTION
We are encountering errors like the below intermittently on vapor it would be great if Laravel attempts a retry when this happens. Similar to #42377.

Please find example message below of what we have been seeing:

`
SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo for xyz.xyz.eu-west-2.rds.amazonaws.com failed: Try again
`