### PR TITLE
[8.x] Fix/phpredis hmget

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -115,7 +115,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             $dictionary = $dictionary[0];
         }
 
-        return array_values($this->command('hmget', [$key, $dictionary]));
+        return $this->command('hmget', [$key, $dictionary]);
     }
 
     /**

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -434,21 +434,36 @@ class RedisConnectionTest extends TestCase
         }
     }
 
-    public function testItGetsMultipleHashFields()
+    public function testItGetsMultipleHashFieldsUsingPredis()
     {
-        foreach ($this->connections() as $redis) {
-            $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
+        $redis = $this->connections()['predis'];
+        $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving']);
 
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', 'name', 'hobby')
-            );
+        $this->assertEquals(['mohamed', 'diving'],
+            $redis->hmget('hash', 'name', 'hobby')
+        );
 
-            $this->assertEquals(['mohamed', 'diving'],
-                $redis->hmget('hash', ['name', 'hobby'])
-            );
+        $this->assertEquals(['mohamed', 'diving'],
+            $redis->hmget('hash', ['name', 'hobby'])
+        );
 
-            $redis->flushall();
-        }
+        $redis->flushall();
+    }
+
+    public function testItGetsMultipleHashFieldsUsingPhpRedis()
+    {
+        $redis = $this->connections()['phpredis'];
+        $redis->hmset('hash', ['name' => 'mohamed', 'hobby' => 'diving', 'friend' => 'timndus']);
+
+        $this->assertEquals(['name' => 'mohamed', 'friend' => 'timndus'],
+            $redis->hmget('hash', 'name', 'friend')
+        );
+
+        $this->assertEquals(['name' => 'mohamed', 'friend' => 'timndus'],
+            $redis->hmget('hash', ['name', 'friend'])
+        );
+
+        $redis->flushall();
     }
 
     public function testItGetsMultipleKeys()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
First of all, there is a difference between the Redis HMGET command result and the PhpRedis client HMGET result.
Redis HMGET returns only the values of the hash:
```
redis:6379> HSET myhash field1 "Hello"
(integer) 1
redis:6379> HSET myhash field2 "World"
(integer) 1
redis:6379> HMGET myhash field1 field2 nofield
1) "Hello"
2) "World"
3) (nil)
```
But PhpRedis returns values **and keys**:
```
$redis->hSet('h', 'field1', 'value1');
$redis->hSet('h', 'field2', 'value2');
$redis->hMGet('h', ['field1', 'field2']); /* returns ['field1' => 'value1', 'field2' => 'value2'] */
```
To handle this, the current approach tries to manipulate the result of PhpRedis HMGET and extract only the values from it(using array_values function), which is works perfectly till we use pipeline (and of course transactions).
https://github.com/laravel/framework/blob/016b0c1801f4c6b0bb79b0d82791f4853ed19fc5/src/Illuminate/Redis/Connections/PhpRedisConnection.php#L117
When using pipeline the problem is the current approach tries to manipulate data before executing the EXEC command which results in the following error described in the issue https://github.com/laravel/framework/issues/42375

`array_values(): Argument #1 ($array) must be of type array, Redis given`


We can simply solve this by passing exact result we got from the PhpRedis client
----
My solution probably is wrong because I see the main developer tries to provide a identical interface for PhpRedis and Predis but my solution forced me to separate the HMGET tests for PhpRedis and Predis
I think they(PhpRedis) should be responsible for keeping the client compatible with the latest Redis changes, not us(Laravel).
