### PR TITLE
[9.x] Adds collect() helper on TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1005,6 +1005,17 @@ EOF;
     }
 
     /**
+     * Get the JSON decoded body of the response as a collection.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key = null)
+    {
+        return Collection::make($this->json($key));
+    }
+
+    /**
      * Assert that the response view equals the given value.
      *
      * @param  string  $value


### PR DESCRIPTION
This PR adds missing ``` collect() ``` helper method to ``` src/Illuminate/Testing/TestResponse.php ```, the same as we already use in ```  src/Illuminate/Http/Client/Response.php```.

It will help writing test responses in the same way as real ones and easily transform them into collections.
