### PR TITLE
[8.x] Corrects the use of "failed_jobs" instead of "job_batches" in BatchedTableCommand

### DIFF
--- a/src/Illuminate/Queue/Console/BatchesTableCommand.php
+++ b/src/Illuminate/Queue/Console/BatchesTableCommand.php
@@ -36,7 +36,7 @@ class BatchesTableCommand extends Command
     protected $composer;
 
     /**
-     * Create a new failed queue jobs table command instance.
+     * Create a new batched queue jobs table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  \Illuminate\Support\Composer  $composer
@@ -74,7 +74,7 @@ class BatchesTableCommand extends Command
      * @param  string  $table
      * @return string
      */
-    protected function createBaseMigration($table = 'failed_jobs')
+    protected function createBaseMigration($table = 'job_batches')
     {
         return $this->laravel['migration.creator']->create(
             'create_'.$table.'_table', $this->laravel->databasePath().'/migrations'
@@ -82,7 +82,7 @@ class BatchesTableCommand extends Command
     }
 
     /**
-     * Replace the generated migration with the failed job table stub.
+     * Replace the generated migration with the batches job table stub.
      *
      * @param  string  $path
      * @param  string  $table


### PR DESCRIPTION
Corrects the use of "failed_jobs" instead of "job_batches"
in BatchedTableCommand in comments and BatchedTableCommand::createBaseMigration()'s
default value for $table parameter.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
