### PR TITLE
[9.x] SesTransport: use correct `Tags` argument

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -51,7 +51,7 @@ class SesTransport extends AbstractTransport
         if ($message->getOriginalMessage() instanceof Message) {
             foreach ($message->getOriginalMessage()->getHeaders()->all() as $header) {
                 if ($header instanceof MetadataHeader) {
-                    $options['EmailTags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
+                    $options['Tags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
                 }
             }
         }


### PR DESCRIPTION
`Illuminate\Mail\Transport\SesTransport` uses SES v1's `ses:SendRawEmail` API but passes v2's `EmailTags` argument.
The call doesn't fail but the tags are not attached to the sent email.
(ConfigurationSet events don't include specified tags)

This PR fixes the parameter name to correct `Tags`.

Note: I didn't migrate to SesV2Client for backward compatibility.

Reference:
https://docs.aws.amazon.com/ja_jp/aws-sdk-php/v3/api/api-email-2010-12-01.html#sendrawemail
AWS SDK for PHP 3.x: `SesClient->sendRawEmail()`

I confirmed fired ConfigurationSet events include tags specified in `Mailable`'s `metadata()` method.

``` php
class TestMail extends Mailable
{
    public function build()
    {
        return $this->metadata('env', config('app.env'))->text('emails.test');
    }
}

Mail::to(...)->send(new TestMail());
```

Before:
``` json
{
    "eventType": "Delivery",
    "mail": {
        ...
        "tags": {
            "ses:operation": ["SendRawEmail"],
            ...
        }
    },
    "delivery": ...
}
```

After:
``` json
{
    "eventType": "Delivery",
    "mail": {
        ...
        "tags": {
            "ses:operation": ["SendRawEmail"],
            ...
            "env": ["local"] // <- HERE
        }
    },
    "delivery": ...
}
```
