### PR TITLE
[9.x] Remove old monolog 1.x compat code

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -420,7 +420,7 @@ class LogManager implements LoggerInterface
             $handler = new FingersCrossedHandler($handler, $this->actionLevel($config));
         }
 
-        if (Monolog::API !== 1 && (Monolog::API !== 2 || ! $handler instanceof FormattableHandlerInterface)) {
+        if (! $handler instanceof FormattableHandlerInterface) {
             return $handler;
         }
 


### PR DESCRIPTION
Laravel has not supported Monolog 1.x for some time. Laravel 9 only supports Monolog 2.x.