### PR TITLE
[9.x] Implement robust handling of forwarding of exception codes

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -351,7 +351,7 @@ class Schedule
             } catch (BindingResolutionException $e) {
                 throw new RuntimeException(
                     'Unable to resolve the dispatcher from the service container. Please bind it or install the illuminate/bus package.',
-                    $e->getCode(), $e
+                    is_int($e->getCode()) ? $e->getCode() : 0, $e
                 );
             }
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -706,7 +706,7 @@ class Container implements ArrayAccess, ContainerContract
                 throw $e;
             }
 
-            throw new EntryNotFoundException($id, $e->getCode(), $e);
+            throw new EntryNotFoundException($id, is_int($e->getCode()) ? $e->getCode() : 0, $e);
         }
     }
 

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -88,7 +88,7 @@ trait ManagesTransactions
                 $this->getName(), $this->transactions
             );
 
-            throw new DeadlockException($e->getMessage(), (int) $e->getCode(), $e);
+            throw new DeadlockException($e->getMessage(), is_int($e->getCode()) ? $e->getCode() : 0, $e);
         }
 
         // If there was an exception we will rollback this transaction and then we

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -127,7 +127,7 @@ trait InteractsWithExceptionHandling
 
                 if ($e instanceof NotFoundHttpException) {
                     throw new NotFoundHttpException(
-                        "{$request->method()} {$request->url()}", $e, $e->getCode()
+                        "{$request->method()} {$request->url()}", $e, is_int($e->getCode()) ? $e->getCode() : 0
                     );
                 }
 

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -73,7 +73,7 @@ class SesTransport extends AbstractTransport
                 )
             );
         } catch (AwsException $e) {
-            throw new Exception('Request to AWS SES API failed.', $e->getCode(), $e);
+            throw new Exception('Request to AWS SES API failed.', is_int($e->getCode()) ? $e->getCode() : 0, $e);
         }
 
         $messageId = $result->get('MessageId');


### PR DESCRIPTION
`getCode(): string|int` but `__construct(..., int $code, ...)`. The most sensible thing to do is to attempt to only forward on integer exception codes, and just default back to zero, otherwise. String exception codes (at least ignoring janky 3rd party extensions), can only be found amongst the PHP database exceptions, and for those, we should consider the code to be zero for the purposes of forwarding - casting to `1` doesn't make any sense.