### PR TITLE
[9.x] Adds bootable traits to TestCase

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -143,6 +143,14 @@ abstract class TestCase extends BaseTestCase
             $this->setUpFaker();
         }
 
+        foreach ($uses as $trait) {
+            $method = 'boot'.class_basename($trait);
+
+            if (method_exists($this, $method)) {
+                $this->{$method}();
+            }
+        }
+
         return $uses;
     }
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -144,7 +144,7 @@ abstract class TestCase extends BaseTestCase
         }
 
         foreach ($uses as $trait) {
-            $method = 'boot'.class_basename($trait);
+            $method = 'setUp'.class_basename($trait);
 
             if (method_exists($this, $method)) {
                 $this->{$method}();

--- a/tests/Foundation/Testing/BootTraitsTest.php
+++ b/tests/Foundation/Testing/BootTraitsTest.php
@@ -10,7 +10,7 @@ trait TestTrait
 {
     public $booted = false;
 
-    public function bootTestTrait()
+    public function setUpTestTrait()
     {
         $this->booted = true;
     }

--- a/tests/Foundation/Testing/BootTraitsTest.php
+++ b/tests/Foundation/Testing/BootTraitsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use Illuminate\Foundation\Testing\TestCase as FoundationTestCase;
+use Orchestra\Testbench\Concerns\CreatesApplication;
+use PHPUnit\Framework\TestCase;
+
+trait TestTrait
+{
+    public $booted = false;
+
+    public function bootTestTrait()
+    {
+        $this->booted = true;
+    }
+}
+
+class TestCaseWithTrait extends FoundationTestCase
+{
+    use CreatesApplication;
+    use TestTrait;
+}
+
+class BootTraitsTest extends TestCase
+{
+    public function testSetUpTraitsWithBootMethod()
+    {
+        $testCase = new TestCaseWithTrait;
+
+        $method = new \ReflectionMethod(get_class($testCase), 'setUpTraits');
+        tap($method)->setAccessible(true)->invoke($testCase);
+
+        $this->assertTrue($testCase->booted);
+    }
+}


### PR DESCRIPTION
This PR brings the *bootable trait* feature from Eloquent over to the Foundation TestCase. 

Currently, the `setUpTraits` method checks several traits like `RefreshDatabase` and `DatabaseMigrations`, and then calls a method if the TestCase uses that trait. If you want to do this for custom traits, you must override the `setUp` or `setUpTraits` method. With this PR, it checks whether the trait has a *bootTraitName* method, and then calls that method.

```php
trait RefreshSomeService
{
    public function bootRefreshSomeService()
    {
        SomeService::refresh();
    }
}

class SomeServiceTest extends TestCase
{
    use RefreshDatabase;
    use RefreshSomeService;
}
``` 