### PR TITLE
[8.x] Retain the original attribute value during validation of an array key with a dot for correct failure message

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -20,6 +20,10 @@ trait FormatsMessages
      */
     protected function getMessage($attribute, $rule)
     {
+        $attributeWithPlaceholders = $attribute;
+
+        $attribute = $this->replacePlaceholderInString($attribute);
+
         $inlineMessage = $this->getInlineMessage($attribute, $rule);
 
         // First we will retrieve the custom message for the validation rule if one
@@ -46,7 +50,7 @@ trait FormatsMessages
         // specific error message for the type of attribute being validated such
         // as a number, file or string which all have different message types.
         elseif (in_array($rule, $this->sizeRules)) {
-            return $this->getSizeMessage($attribute, $rule);
+            return $this->getSizeMessage($attributeWithPlaceholders, $rule);
         }
 
         // Finally, if no developer specified messages have been set, and no other

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -867,6 +867,8 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
+        $original = $attribute;
+
         $attribute = str_replace(
             [$this->dotPlaceholder, '__asterisk__'],
             ['.', '*'],
@@ -878,7 +880,7 @@ class Validator implements ValidatorContract
         }
 
         $this->messages->add($attribute, $this->makeReplacements(
-            $this->getMessage($attribute, $rule), $attribute, $rule, $parameters
+            $this->getMessage($original, $rule), $attribute, $rule, $parameters
         ));
 
         $this->failedRules[$attribute][$rule] = $parameters;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -867,7 +867,7 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
-        $original = $attribute;
+        $attributeWithPlaceholders = $attribute;
 
         $attribute = str_replace(
             [$this->dotPlaceholder, '__asterisk__'],
@@ -880,7 +880,7 @@ class Validator implements ValidatorContract
         }
 
         $this->messages->add($attribute, $this->makeReplacements(
-            $this->getMessage($original, $rule), $attribute, $rule, $parameters
+            $this->getMessage($attributeWithPlaceholders, $rule), $attribute, $rule, $parameters
         ));
 
         $this->failedRules[$attribute][$rule] = $parameters;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7158,6 +7158,28 @@ class ValidationValidatorTest extends TestCase
         );
     }
 
+    public function testArrayKeysWithDotIntegerMin()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $data = [
+            'foo.bar' => -1,
+        ];
+
+        $rules = [
+            'foo\.bar' => 'integer|min:1',
+        ];
+
+        $expectedResult = [
+            'foo.bar' => [
+                'validation.min.numeric',
+            ],
+        ];
+
+        $validator = new Validator($trans, $data, $rules, [], []);
+        $this->assertEquals($expectedResult, $validator->getMessageBag()->getMessages());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);


### PR DESCRIPTION
During validation of an array key with a dot, using a `integer|min:1` rule - the package will incorrectly return `validation.min.string` instead of the expected `validation.min.numeric`.

Illuminate\Validation\Validator replaces the placeholder in the attribute a bit prematurely in the [addFailure](https://github.com/laravel/framework/blob/f3940f8cd42bae1fe38e21400c19126ba8ff030d/src/Illuminate/Validation/Validator.php#L870) function. 

Code will continue to [makeReplacements](https://github.com/laravel/framework/blob/f3940f8cd42bae1fe38e21400c19126ba8ff030d/src/Illuminate/Validation/Validator.php#L881), [getMessage](https://github.com/laravel/framework/blob/f3940f8cd42bae1fe38e21400c19126ba8ff030d/src/Illuminate/Validation/Concerns/FormatsMessages.php#L49), [getSizeMessage](https://github.com/laravel/framework/blob/f3940f8cd42bae1fe38e21400c19126ba8ff030d/src/Illuminate/Validation/Concerns/FormatsMessages.php#L175), [getAttributeType](https://github.com/laravel/framework/blob/f3940f8cd42bae1fe38e21400c19126ba8ff030d/src/Illuminate/Validation/Concerns/FormatsMessages.php#L193), [hasRule](https://github.com/laravel/framework/blob/f3940f8cd42bae1fe38e21400c19126ba8ff030d/src/Illuminate/Validation/Validator.php#L1007), [getRule](https://github.com/laravel/framework/blob/f3940f8cd42bae1fe38e21400c19126ba8ff030d/src/Illuminate/Validation/Validator.php#L1019)

You can see down the line you are searching a with-placeholder rules array for a without-placeholder key. When the numeric search fails, it will default to string.

My fix retains that original attribute value including the placeholder to return the expected failure message
