### PR TITLE
[9.x] Adds `Arr::map` and `Arr::transform`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -531,6 +531,36 @@ class Arr
     }
 
     /**
+     * Run a map over each of the items in the array.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function map(array $array, callable $callback)
+    {
+        $keys = array_keys($array);
+
+        $items = array_map($callback, $array, $keys);
+
+        return array_combine($keys, $items);
+    }
+
+    /**
+     * Transform each item in the array using a callback.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function transform(&$array, callable $callback)
+    {
+        $array = Arr::map($array, $callback);
+
+        return $array;
+    }
+
+    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -547,20 +547,6 @@ class Arr
     }
 
     /**
-     * Transform each item in the array using a callback.
-     *
-     * @param  array  $array
-     * @param  callable  $callback
-     * @return array
-     */
-    public static function transform(&$array, callable $callback)
-    {
-        $array = Arr::map($array, $callback);
-
-        return $array;
-    }
-
-    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -720,11 +720,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function map(callable $callback)
     {
-        $keys = array_keys($this->items);
-
-        $items = array_map($callback, $this->items, $keys);
-
-        return new static(array_combine($keys, $items));
+        return new static(Arr::map($this->items, $callback));
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -622,6 +622,26 @@ class SupportArrTest extends TestCase
         $this->assertEquals([['taylorotwell@gmail.com'], [null, null]], Arr::pluck($array, 'users.*.email'));
     }
 
+    public function testMap()
+    {
+        $data = ['first' => 'taylor', 'last' => 'otwell'];
+        $mapped = Arr::map($data, function ($value, $key) {
+            return $key.'-'.strrev($value);
+        });
+        $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $mapped);
+        $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
+    }
+
+    public function testTransform()
+    {
+        $data = ['first' => 'taylor', 'last' => 'otwell'];
+        $mapped = Arr::transform($data, function ($value, $key) {
+            return $key.'-'.strrev($value);
+        });
+        $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $mapped);
+        $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data);
+    }
+
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -632,16 +632,6 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
     }
 
-    public function testTransform()
-    {
-        $data = ['first' => 'taylor', 'last' => 'otwell'];
-        $mapped = Arr::transform($data, function ($value, $key) {
-            return $key.'-'.strrev($value);
-        });
-        $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $mapped);
-        $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data);
-    }
-
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');


### PR DESCRIPTION
Adds `Arr::map` and `Arr::transform`.

I've finally created a PR for this after assuming it's there for a while.
Everytime I realize it's not, I'm wrapping my array in a collection to get that sweet syntactic sugar 🍬

- Significantly better syntax than `array_map`
- Iterates both values and keys out of the box
- Consistent API with Collection
- Refactored Collection to consume `Arr::map`

Added `Arr::transform` because they're basically the same, except `$array` is passed by reference.