### PR TITLE
[9.x] Added full callable support to `schedule:list`

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Closure;
 use Cron\CronExpression;
 use DateTimeZone;
 use Illuminate\Console\Application;
@@ -173,15 +174,24 @@ class ScheduleListCommand extends Command
      */
     private function getClosureLocation(CallbackEvent $event)
     {
-        $function = new ReflectionFunction(tap((new ReflectionClass($event))->getProperty('callback'))
+        $callback = tap((new ReflectionClass($event))->getProperty('callback'))
                         ->setAccessible(true)
-                        ->getValue($event));
+                        ->getValue($event);
 
-        return sprintf(
-            '%s:%s',
-            str_replace($this->laravel->basePath().DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
-            $function->getStartLine()
-        );
+        if ($callback instanceof Closure) {
+            $function = new ReflectionFunction($callback);
+            return sprintf(
+                '%s:%s',
+                str_replace($this->laravel->basePath() . DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
+                $function->getStartLine()
+            );
+        }
+
+        if (is_array($callback)) {
+            return sprintf('%s::%s', $callback[0]::class, $callback[1]);
+        }
+
+        return sprintf('%s::__invoke', $callback::class);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -182,7 +182,7 @@ class ScheduleListCommand extends Command
             $function = new ReflectionFunction($callback);
             return sprintf(
                 '%s:%s',
-                str_replace($this->laravel->basePath() . DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
+                str_replace($this->laravel->basePath().DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),
                 $function->getStartLine()
             );
         }

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -180,6 +180,7 @@ class ScheduleListCommand extends Command
 
         if ($callback instanceof Closure) {
             $function = new ReflectionFunction($callback);
+
             return sprintf(
                 '%s:%s',
                 str_replace($this->laravel->basePath().DIRECTORY_SEPARATOR, '', $function->getFileName() ?: ''),


### PR DESCRIPTION
For more details, see [#42380 ](https://github.com/laravel/framework/discussions/42380)

Supported keys: 

1. ` $schedule->call(new SomeScheduleTask())->everyMinute();`
2. `$schedule->call([new SomeScheduleTask(), 'callback'])->everyMinute();`

Output example: 

```
  * * * * *  Closure at: App\Console\SomeScheduleTask::__invoke ........................ Next Due: 24 seconds from now
  * * * * *  Closure at: App\Console\SomeScheduleTask::callback ........................ Next Due: 24 seconds from now
```