### PR TITLE
[9.x] Add ability to add table comments for MySQL and Postgres

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -335,17 +335,6 @@ class Blueprint
     }
 
     /**
-     * Adds a comment to the table.
-     *
-     * @param  string  $comment
-     * @return \Illuminate\Support\Fluent
-     */
-    public function comment($comment)
-    {
-        return $this->addCommand('tableComment', compact('comment'));
-    }
-
-    /**
      * Indicate that the given primary key should be dropped.
      *
      * @param  string|array|null  $index
@@ -1516,6 +1505,17 @@ class Blueprint
     public function rememberToken()
     {
         return $this->string('remember_token', 100)->nullable();
+    }
+
+    /**
+     * Add a comment to the table.
+     *
+     * @param  string  $comment
+     * @return \Illuminate\Support\Fluent
+     */
+    public function comment($comment)
+    {
+        return $this->addCommand('tableComment', compact('comment'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -335,6 +335,17 @@ class Blueprint
     }
 
     /**
+     * Adds a comment to the table.
+     *
+     * @param  string  $comment
+     * @return \Illuminate\Support\Fluent
+     */
+    public function comment($comment)
+    {
+        return $this->addCommand('tableComment', compact('comment'));
+    }
+
+    /**
      * Indicate that the given primary key should be dropped.
      *
      * @param  string|array|null  $index

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -493,6 +493,21 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a table comment command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileTableComment(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('alter table %s comment = %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->comment)
+        );
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -503,7 +503,7 @@ class MySqlGrammar extends Grammar
     {
         return sprintf('alter table %s comment = %s',
             $this->wrapTable($blueprint),
-            $this->wrap($command->comment)
+            "'".str_replace("'", "''", $command->comment)."'"
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -495,9 +495,9 @@ class PostgresGrammar extends Grammar
      */
     public function compileTableComment(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('comment on %s is %s',
+        return sprintf('comment on table %s is %s',
             $this->wrapTable($blueprint),
-            $this->wrap($command->comment)
+            "'".str_replace("'", "''", $command->comment)."'"
         );
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -487,6 +487,21 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a table comment command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileTableComment(Blueprint $blueprint, Fluent $command)
+    {
+        return sprintf('comment on %s is %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($command->comment)
+        );
+    }
+
+    /**
      * Quote-escape the given tables, views, or types.
      *
      * @param  array  $names

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -431,7 +431,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $blueprint = clone $base;
         $this->assertEquals([
-            'comment on "posts" is "Look at my comment, it is amazing"',
+            'comment on table "posts" is \'Look at my comment, it is amazing\'',
         ], $blueprint->toSql($connection, new PostgresGrammar));
     }
 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -426,7 +426,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $blueprint = clone $base;
         $this->assertEquals([
-            'alter table `posts` comment = `Look at my comment, it is amazing`',
+            'alter table `posts` comment = \'Look at my comment, it is amazing\'',
         ], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -415,4 +415,23 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "posts" add "note" nvarchar(255) null',
         ], $blueprint->toSql($connection, new SqlServerGrammar));
     }
+
+    public function testTableComment()
+    {
+        $base = new Blueprint('posts', function (Blueprint $table) {
+            $table->comment('Look at my comment, it is amazing');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'alter table `posts` comment = `Look at my comment, it is amazing`',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals([
+            'comment on "posts" is "Look at my comment, it is amazing"',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+    }
 }

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
@@ -22,7 +22,8 @@ class DatabaseMySqlSchemaBuilderTest extends MySqlTestCase
         $tableInfo = DB::table('information_schema.tables')
             ->where('table_schema', $this->app['config']->get('database.connections.mysql.database'))
             ->where('table_name', 'users')
-            ->select('table_comment')->first();
+            ->select('table_comment as table_comment')
+            ->first();
 
         $this->assertEquals('This is a comment', $tableInfo->table_comment);
 

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Integration\Database\MySql;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use stdClass;
 
 /**
  * @requires extension pdo_mysql

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\MySql;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use stdClass;
+
+/**
+ * @requires extension pdo_mysql
+ * @requires OS Linux|Darwin
+ */
+class DatabaseMySqlSchemaBuilderTest extends MySqlTestCase
+{
+    public function testAddCommentToTable()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->comment('This is a comment');
+        });
+
+        $tableInfo = DB::table('information_schema.tables')
+            ->where('table_schema', $this->app['config']->get('database.connections.mysql.database'))
+            ->where('table_name', 'users')
+            ->select('table_comment')->first();
+
+        $this->assertEquals('This is a comment', $tableInfo->table_comment);
+
+        Schema::drop('users');
+    }
+}

--- a/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
+++ b/tests/Integration/Database/Postgres/PostgresSchemaBuilderTest.php
@@ -107,6 +107,29 @@ class PostgresSchemaBuilderTest extends PostgresTestCase
         $this->assertFalse($this->hasView('private', 'foo'));
     }
 
+    public function testAddTableCommentOnNewTable()
+    {
+        Schema::create('public.posts', function (Blueprint $table) {
+            $table->comment('This is a comment');
+        });
+
+        $this->assertEquals('This is a comment', DB::selectOne("select obj_description('public.posts'::regclass, 'pg_class')")->obj_description);
+    }
+
+    public function testAddTableCommentOnExistingTable()
+    {
+        Schema::create('public.posts', function (Blueprint $table) {
+            $table->id();
+            $table->comment('This is a comment');
+        });
+
+        Schema::table('public.posts', function (Blueprint $table) {
+            $table->comment('This is a new comment');
+        });
+
+        $this->assertEquals('This is a new comment', DB::selectOne("select obj_description('public.posts'::regclass, 'pg_class')")->obj_description);
+    }
+
     protected function hasView($schema, $table)
     {
         return DB::table('information_schema.views')


### PR DESCRIPTION
This PR adds the ability to add a comment to a table in MySQL and Postgres

```php
Schema::table('posts', function (Blueprint $table) {
    $table->comment('This is a comment');
})
```

This feature is useful for us so that our Business Intelligence team can better understand our database schema. We can already add comments on columns, adding comments on the table itself will also be beneficial in helping describe it.