### PR TITLE
[9.x] Test for Validator Factory 🔍

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -27,7 +27,7 @@ class Factory implements FactoryContract
     /**
      * The IoC container instance.
      *
-     * @var \Illuminate\Contracts\Container\Container
+     * @var \Illuminate\Contracts\Container\Container|null
      */
     protected $container;
 
@@ -313,7 +313,7 @@ class Factory implements FactoryContract
     /**
      * Get the container instance used by the validation factory.
      *
-     * @return \Illuminate\Contracts\Container\Container
+     * @return \Illuminate\Contracts\Container\Container|null
      */
     public function getContainer()
     {


### PR DESCRIPTION
- The `excludeUnvalidatedArrayKeys` and `includeUnvalidatedArrayKeys` methods are not tested.
- Since it is absolutely possible for the `$container` property to be null, the doc-blocks are updated with `|null`.
- It checks the `setContainer` method can be chained.