### PR TITLE
[9.x] Added ShouldDispatch

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -107,6 +107,10 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchNow($command, $handler = null)
     {
+        if (method_exists($command, 'shouldDispatch') && ! $command->shouldDispatch()) {
+            return;
+        }
+
         $uses = class_uses_recursive($command);
 
         if (in_array(InteractsWithQueue::class, $uses) &&
@@ -214,6 +218,10 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchToQueue($command)
     {
+        if (method_exists($command, 'shouldDispatch') && ! $command->shouldDispatch()) {
+            return;
+        }
+
         $connection = $command->connection ?? null;
 
         $queue = call_user_func($this->queueResolver, $connection);


### PR DESCRIPTION
This change adds an optional `shouldDispatch` function to jobs. The function gives the ability to keep the condition for dispatching or not a job inside of the job itself. With this, you can dispatch a job and if the shouldDispatch is false, the job will not be dispatched to queue and reduce processing.