### PR TITLE
[9.x] Add convenience method to set foreignIdFor to be constrained and inde…

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -79,6 +79,13 @@ class Blueprint
     public $after;
 
     /**
+     * Whether to index and constrain foreignIdFor by default.
+     *
+     * @var bool
+     */
+    private static bool $constrainForeignFor = false;
+
+    /**
      * Create a new schema blueprint.
      *
      * @param  string  $table
@@ -94,6 +101,17 @@ class Blueprint
         if (! is_null($callback)) {
             $callback($this);
         }
+    }
+
+    /**
+     * Constrain and Index ForeignIds by when true.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function constrainForeignFor($value = true)
+    {
+        static::$constrainForeignFor = $value;
     }
 
     /**
@@ -931,9 +949,15 @@ class Blueprint
             $model = new $model;
         }
 
-        return $model->getKeyType() === 'int' && $model->getIncrementing()
+        $definition = $model->getKeyType() === 'int' && $model->getIncrementing()
                     ? $this->foreignId($column ?: $model->getForeignKey())
                     : $this->foreignUuid($column ?: $model->getForeignKey());
+
+        if (self::$constrainForeignFor === true) {
+            return $definition->index()->constrained();
+        }
+
+        return $definition;
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -415,4 +415,87 @@ class DatabaseSchemaBlueprintTest extends TestCase
             'alter table "posts" add "note" nvarchar(255) null',
         ], $blueprint->toSql($connection, new SqlServerGrammar));
     }
+
+    public function testMySqlGrammarCanAutomaticallyConstrainAndIndexForeignIdFor()
+    {
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
+
+        Blueprint::constrainForeignFor();
+
+        $base = new Blueprint('posts', function ($table) {
+            $table->foreignIdFor('EloquentModelUuidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
+            'alter table `posts` add constraint `posts_eloquent_model_uuid_stub_id_foreign` foreign key (`eloquent_model_uuid_stub_id`) references `eloquent_model_uuid_stubs` (`id`)',
+            'alter table `posts` add index `posts_eloquent_model_uuid_stub_id_index`(`eloquent_model_uuid_stub_id`)',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
+    public function testPostgresGrammarCanAutomaticallyConstrainAndIndexForeignIdFor()
+    {
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
+
+        Blueprint::constrainForeignFor();
+
+        $base = new Blueprint('posts', function ($table) {
+            $table->foreignIdFor('EloquentModelUuidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table "posts" add column "eloquent_model_uuid_stub_id" uuid not null',
+            'alter table "posts" add constraint "posts_eloquent_model_uuid_stub_id_foreign" foreign key ("eloquent_model_uuid_stub_id") references "eloquent_model_uuid_stubs" ("id")',
+            'create index "posts_eloquent_model_uuid_stub_id_index" on "posts" ("eloquent_model_uuid_stub_id")',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+    }
+
+    public function testSqlServerGrammarCanAutomaticallyConstrainAndIndexForeignIdFor()
+    {
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
+
+        Blueprint::constrainForeignFor();
+
+        $base = new Blueprint('posts', function ($table) {
+            $table->foreignIdFor('EloquentModelUuidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table "posts" add "eloquent_model_uuid_stub_id" uniqueidentifier not null',
+            'alter table "posts" add constraint "posts_eloquent_model_uuid_stub_id_foreign" foreign key ("eloquent_model_uuid_stub_id") references "eloquent_model_uuid_stubs" ("id")',
+            'create index "posts_eloquent_model_uuid_stub_id_index" on "posts" ("eloquent_model_uuid_stub_id")',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
+
+    public function testConstrainForeignForHasNoAffectOnSQLiteGrammar()
+    {
+        require_once __DIR__.'/stubs/EloquentModelUuidStub.php';
+
+        Blueprint::constrainForeignFor();
+
+        $base = new Blueprint('posts', function ($table) {
+            $table->foreignIdFor('EloquentModelUuidStub');
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $blueprint = clone $base;
+
+        $this->assertEquals([
+            'alter table "posts" add column "eloquent_model_uuid_stub_id" varchar not null',
+            'create index "posts_eloquent_model_uuid_stub_id_index" on "posts" ("eloquent_model_uuid_stub_id")',
+        ], $blueprint->toSql($connection, new SQLiteGrammar));
+    }
 }


### PR DESCRIPTION
This PR adds the ability to index and constrain by default when using the `foreignIdFor` method on `Illuminate\Database\Schema\Blueprint`.

```php
/** AppServiceProvider::boot() **/

Blueprint::constrainForeignFor();
```

This is a convenience method only and is opt-in by design, removing the necessity for a developer to chain `index()` and `constrained()` methods within migrations when using `foreignIdFor()`