### PR TITLE
[9.x] Add dynamic `trashed` factory state

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
@@ -842,7 +843,7 @@ abstract class Factory
 
         if ($method === 'trashed' && in_array(SoftDeletes::class, class_uses_recursive($this->modelName()))) {
             return $this->state([
-                $this->newModel()->getDeletedAtColumn() => $parameters[0] ?? now()->subDay(),
+                $this->newModel()->getDeletedAtColumn() => $parameters[0] ?? Carbon::now()->subDay(),
             ]);
         }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
@@ -837,6 +838,12 @@ abstract class Factory
     {
         if (static::hasMacro($method)) {
             return $this->macroCall($method, $parameters);
+        }
+
+        if ($method === 'trashed' && in_array(SoftDeletes::class, class_uses_recursive($this->modelName()))) {
+            return $this->state([
+                $this->newModel()->getDeletedAtColumn() => $parameters[0] ?? now()->subDay(),
+            ]);
         }
 
         if (! Str::startsWith($method, ['for', 'has'])) {

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -605,6 +605,8 @@ class DatabaseEloquentFactoryTest extends TestCase
         $post = FactoryTestPostFactory::new()->trashed($deleted_at)->create();
 
         $this->assertTrue($deleted_at->equalTo($post->deleted_at));
+
+        Carbon::setTestNow();
     }
 
     public function test_dynamic_trashed_state_respects_existing_state()
@@ -614,6 +616,8 @@ class DatabaseEloquentFactoryTest extends TestCase
         $comment = FactoryTestCommentFactory::new()->trashed()->create();
 
         $this->assertTrue($comment->deleted_at->equalTo($now->subWeek()));
+
+        Carbon::setTestNow();
     }
 
     public function test_dynamic_trashed_state_throws_exception_when_not_a_softdeletes_model()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Carbon\Carbon;
 use Faker\Generator;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
@@ -12,6 +13,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -58,6 +60,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             $table->increments('id');
             $table->foreignId('user_id');
             $table->string('title');
+            $table->softDeletes();
             $table->timestamps();
         });
 
@@ -66,6 +69,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             $table->foreignId('commentable_id');
             $table->string('commentable_type');
             $table->string('body');
+            $table->softDeletes();
             $table->timestamps();
         });
 
@@ -589,6 +593,35 @@ class DatabaseEloquentFactoryTest extends TestCase
             });
     }
 
+    public function test_dynamic_trashed_state_for_softdeletes_models()
+    {
+        $now = Carbon::create(2020, 6, 7, 8, 9);
+        Carbon::setTestNow($now);
+        $post = FactoryTestPostFactory::new()->trashed()->create();
+
+        $this->assertTrue($post->deleted_at->equalTo($now->subDay()));
+
+        $deleted_at = Carbon::create(2020, 1, 2, 3, 4, 5);
+        $post = FactoryTestPostFactory::new()->trashed($deleted_at)->create();
+
+        $this->assertTrue($deleted_at->equalTo($post->deleted_at));
+    }
+
+    public function test_dynamic_trashed_state_respects_existing_state()
+    {
+        $now = Carbon::create(2020, 6, 7, 8, 9);
+        Carbon::setTestNow($now);
+        $comment = FactoryTestCommentFactory::new()->trashed()->create();
+
+        $this->assertTrue($comment->deleted_at->equalTo($now->subWeek()));
+    }
+
+    public function test_dynamic_trashed_state_throws_exception_when_not_a_softdeletes_model()
+    {
+        $this->expectException(\BadMethodCallException::class);
+        FactoryTestUserFactory::new()->trashed()->create();
+    }
+
     /**
      * Get a database connection instance.
      *
@@ -660,6 +693,8 @@ class FactoryTestPostFactory extends Factory
 
 class FactoryTestPost extends Eloquent
 {
+    use SoftDeletes;
+
     protected $table = 'posts';
 
     public function user()
@@ -695,10 +730,19 @@ class FactoryTestCommentFactory extends Factory
             'body' => $this->faker->name,
         ];
     }
+
+    public function trashed()
+    {
+        return $this->state([
+            'deleted_at' => Carbon::now()->subWeek(),
+        ]);
+    }
 }
 
 class FactoryTestComment extends Eloquent
 {
+    use SoftDeletes;
+
     protected $table = 'comments';
 
     public function commentable()


### PR DESCRIPTION
This adds dynamic support of a `trashed` factory state for models using the `SoftDeletes` trait. It has an optional argument of the date value. If not passed, the default is yesterday.

**Before**
```php
// in Factory class
public function trashed()
{
    return $this->state([
        'deleted_at' => now()->subDay(),
    ]);
}
```

If this is merged, you would no longer need to define such a state in factories for `SoftDeletes` models.

This was implemented within `__call`. As such, this should be fully backward compatible if a `trashed` method already exists. A test case also demonstrates this.

