### PR TITLE
Added magic method to WhereRelation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1710,6 +1710,10 @@ class Builder implements BuilderContract
      */
     public function __call($method, $parameters)
     {
+        if (str_starts_with($method, 'whereRelation')) {
+            return $this->dynamicWhereRelation($method, $parameters);
+        }
+
         if ($method === 'macro') {
             $this->localMacros[$parameters[0]] = $parameters[1];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -834,5 +835,17 @@ trait QueriesRelationships
     protected function canUseExistsForExistenceCheck($operator, $count)
     {
         return ($operator === '>=' || $operator === '<') && $count === 1;
+    }
+
+    /**
+     * @param  string  $relation
+     * @param  array  $params
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    protected function dynamicWhereRelation($relation, $params)
+    {
+        $relation = substr($relation, 13);
+
+        return $this->whereRelation(...array_merge(Arr::wrap(lcfirst($relation)), $params));
     }
 }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -450,6 +450,16 @@ class SessionStoreTest extends TestCase
         $this->assertEquals(['PHP' => ['Laravel', 'Symfony']], $session->get('language'));
     }
 
+    public function testKeyPull()
+    {
+        $session = $this->getSession();
+        $session->put('name', 'Taylor');
+
+        $this->assertSame('Taylor', $session->pull('name'));
+        $this->assertSame('Taylor Otwell', $session->pull('name', 'Taylor Otwell'));
+        $this->assertNull($session->pull('name'));
+    }
+
     public function testKeyHas()
     {
         $session = $this->getSession();

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -441,6 +441,15 @@ class SessionStoreTest extends TestCase
         $this->assertSame('foo', $session->getName());
     }
 
+    public function testKeyPush()
+    {
+        $session = $this->getSession();
+        $session->put('language', ['PHP' => ['Laravel']]);
+        $session->push('language.PHP', 'Symfony');
+
+        $this->assertEquals(['PHP' => ['Laravel', 'Symfony']], $session->get('language'));
+    }
+
     public function testKeyHas()
     {
         $session = $this->getSession();


### PR DESCRIPTION
This PR allows you to where on relation  in that way out of convenience, if a name of method start with `whereRelation` and after it mentions relation name then will proxy to `whereRelation` mehtod.

`User::whereRelationPosts('viewed', '>', 9)->get()` 
`User::whereRelationPosts('publushed',  true)->get()` 
