### PR TITLE
[8.x] Use duplicate instead of createFromBase to clone request when routes are cached

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -152,7 +152,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     protected function requestWithoutTrailingSlash(Request $request)
     {
-        $trimmedRequest = Request::createFromBase($request);
+        $trimmedRequest = $request->duplicate();
 
         $parts = explode('?', $request->server->get('REQUEST_URI'), 2);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #42403 

When routes are compiled, the `CompiledRouteCollection@requestWithoutTrailingSlash` method uses the static method `Request@createFromBase` to clone a `Illuminate\Http\Request`.

When the request is a JSON request, this call causes the request's JSON payload to be parsed twice:

- first when the request is captured
- and then when `CompiledRouteCollection@requestWithoutTrailingSlash` is called, which, as noticed on issue #42403 , can cause a noticeable increase on memory usage when processing large JSON payloads.

Actually, issue #42403 describes a memory exhaust scenario with default PHP configuration.

The doc block on `CompiledRouteCollection@requestWithoutTrailingSlash` states  this method `Get a cloned instance of the given request without any trailing slash on the URI`, so as the original `$request` is already a `Illuminate\Http\Request`, e.g. it is already bootstrapped, we can safely change this call to use the `Request@duplicate` method, which internally actually clones the request object, avoiding the double `json_encode` parsing.

This PR:

- Changes the method `CompiledRouteCollection@requestWithoutTrailingSlash` to call `Request@duplicate` instead of `Request@captureFromBase`, to clone the current request.

Notes:

This behavior only happens when routes are cached.

I didn't add any tests, as I would need to mock the `Illuminate\Http\Request` and assert its static method `createFromBase` was not called twice.

I don't know how to properly mock static methods. If someone can guide me on how to do it, I will appreciate.