### PR TITLE
[8.x] Correct stack driver creator

### DIFF
--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -75,9 +75,12 @@ class LogManagerTest extends TestCase
             ["level" => Monolog::NOTICE, "bubble" => static::isFalse()],
             ["level" => Monolog::INFO, "bubble" => static::isTrue()],
         ];
+        $handler_ref = new \ReflectionProperty(GroupHandler::class, "handlers");
+        $handler_ref->setAccessible(true);
+
         foreach ($to_check as $index => $data) {
             $this->assertInstanceOf(GroupHandler::class, $handlers[$index]);
-            $group = $handlers[$index]->getHandlers();
+            $group = $handler_ref->getValue($handlers[$index]);
             $this->assertCount(1, $group);
             $this->assertInstanceOf(StreamHandler::class, $group[0]);
             $this->assertEquals($data["level"], $group[0]->getLevel());
@@ -433,7 +436,10 @@ class LogManagerTest extends TestCase
 
         $handler = $logger->getLogger()->getHandlers()[1];
         $this->assertInstanceOf(GroupHandler::class, $handler);
-        $processor = $handler->getProcessors()[0];
+
+        $processor_ref = new \ReflectionProperty(GroupHandler::class, "processors");
+        $processor_ref->setAccessible(true);
+        $processor = $processor_ref->getValue($handler)[0];
         $this->assertInstanceOf(UidProcessor::class, $processor);
 
         $url = new ReflectionProperty(get_class($handler), 'url');

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -75,7 +75,7 @@ class LogManagerTest extends TestCase
             ["level" => Monolog::NOTICE, "bubble" => static::isFalse()],
             ["level" => Monolog::INFO, "bubble" => static::isTrue()],
         ];
-        $handler_ref = new \ReflectionProperty(GroupHandler::class, "handlers");
+        $handler_ref = new ReflectionProperty(GroupHandler::class, "handlers");
         $handler_ref->setAccessible(true);
 
         foreach ($to_check as $index => $data) {
@@ -437,15 +437,20 @@ class LogManagerTest extends TestCase
         $handler = $logger->getLogger()->getHandlers()[1];
         $this->assertInstanceOf(GroupHandler::class, $handler);
 
-        $processor_ref = new \ReflectionProperty(GroupHandler::class, "processors");
+        $processor_ref = new ReflectionProperty(GroupHandler::class, "processors");
         $processor_ref->setAccessible(true);
         $processor = $processor_ref->getValue($handler)[0];
         $this->assertInstanceOf(UidProcessor::class, $processor);
 
-        $url = new ReflectionProperty(get_class($handler), 'url');
+        $handler_ref = new ReflectionProperty(GroupHandler::class, "handlers");
+        $handler_ref->setAccessible(true);
+        $group = $handler_ref->getValue($handler);
+        $this->assertInstanceOf(StreamHandler::class, $group[0]);
+
+        $url = new ReflectionProperty(get_class($group[0]), 'url');
         $url->setAccessible(true);
 
-        $this->assertSame(storage_path('logs/custom.log'), $url->getValue($handler));
+        $this->assertSame(storage_path('logs/custom.log'), $url->getValue($group[0]));
     }
 
     public function testWrappingHandlerInFingersCrossedWhenActionLevelIsUsed()


### PR DESCRIPTION
Hello.

### Description of problem
Logging processors must be used only on configured handlers.

**config/logging.php**
```php
<?php
return [
    'default' => env('LOG_CHANNEL', 'stack'),

    'channels' => [
        'stack' => [
            'driver' => 'stack',
            'channels' => ['channel_1', 'channel_2'],
            'ignore_exceptions' => false,
        ],
        'channel_1' => [
            'driver' => 'monolog',
            'handler' => SomeHandler1::class,
            'handler_with' => [...]
            'level' => 'info',
            'tap' => [
                Service1SpecialTagAdd::class,
                PublicInfoAdd::class,
            ],
        ],
        'channel_2' => [
            'driver' => 'monolog',
            'handler' => SomeHandler2::class,
            'handler_with' => [...]
            'level' => 'error',
            'tap' => [
                Service2SpecialTagAdd::class,
                PrivateInfoAdd::class,
            ],
        ],
    ],
];
```

#### Currently in laravel this is equivalent to:
```php
$stack = new Monolog(
    $name,
    [
        new SomeHandler1(...),
        new SomeHandler2(...),
    ],
    [
        new Service1SpecialTagAdd(...),
        new PublicInfoAdd(...),
        new Service2SpecialTagAdd(...),
        new PrivateInfoAdd(...),
    ]
);
```

Log channel `channel_1` must not receive private data.
But he gets.

#### With this merg this convert to:
```php
$stack = new Monolog(
    $name,
    [
        new \Monolog\Handler\GroupHandler(
            [
                new SomeHandler1(...),
            ],
            [
                new Service1SpecialTagAdd(...),
                new PublicInfoAdd(...),
            ]
        ),
        new \Monolog\Handler\GroupHandler(
            [
                new SomeHandler2(...),
            ],
            [
                new Service2SpecialTagAdd(...),
                new PrivateInfoAdd(...),
            ]
        ),
    ],
);
```

This eliminates the ingress of unnecessary information from one channel to another.

<hr/>
Respectfully yours,
<br>HiHub developer,
<br>Корочагин Денис Владимирович.