### PR TITLE
[9.x] Use model route key when route parameter does not specifiy custom binding field but a different parameter does

### DIFF
--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -44,11 +44,15 @@ class RouteUri
         $bindingFields = [];
 
         foreach ($matches[0] as $match) {
-            if (! str_contains($match, ':')) {
+            $parameter = trim($match, '{}?');
+
+            if (! str_contains($parameter, ':')) {
+                $bindingFields[$parameter] = null;
+
                 continue;
             }
 
-            $segments = explode(':', trim($match, '{}?'));
+            $segments = explode(':', $parameter);
 
             $bindingFields[$segments[0]] = $segments[1];
 
@@ -56,6 +60,10 @@ class RouteUri
                     ? str_replace($match, '{'.$segments[0].'?}', $uri)
                     : str_replace($match, '{'.$segments[0].'}', $uri);
         }
+
+        $bindingFields = ! empty(array_filter($bindingFields))
+            ? $bindingFields
+            : [];
 
         return new static($uri, $bindingFields);
     }

--- a/tests/Routing/RouteUriTest.php
+++ b/tests/Routing/RouteUriTest.php
@@ -7,30 +7,72 @@ use PHPUnit\Framework\TestCase;
 
 class RouteUriTest extends TestCase
 {
-    public function testRouteUrisAreProperlyParsed()
+    /**
+     * @dataProvider uriProvider
+     */
+    public function testRouteUrisAreProperlyParsed($uri, $expectedParsedUri, $expectedBindingFields)
     {
-        $parsed = RouteUri::parse('/foo');
-        $this->assertSame('/foo', $parsed->uri);
-        $this->assertEquals([], $parsed->bindingFields);
+        $parsed = RouteUri::parse($uri);
+        $this->assertSame($expectedParsedUri, $parsed->uri);
+        $this->assertEquals($expectedBindingFields, $parsed->bindingFields);
+    }
 
-        $parsed = RouteUri::parse('/foo/{bar}');
-        $this->assertSame('/foo/{bar}', $parsed->uri);
-        $this->assertEquals([], $parsed->bindingFields);
-
-        $parsed = RouteUri::parse('/foo/{bar:slug}');
-        $this->assertSame('/foo/{bar}', $parsed->uri);
-        $this->assertEquals(['bar' => 'slug'], $parsed->bindingFields);
-
-        $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug}');
-        $this->assertSame('/foo/{bar}/baz/{qux}', $parsed->uri);
-        $this->assertEquals(['qux' => 'slug'], $parsed->bindingFields);
-
-        $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug?}');
-        $this->assertSame('/foo/{bar}/baz/{qux?}', $parsed->uri);
-        $this->assertEquals(['qux' => 'slug'], $parsed->bindingFields);
-
-        $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug?}/{test:id?}');
-        $this->assertSame('/foo/{bar}/baz/{qux?}/{test?}', $parsed->uri);
-        $this->assertEquals(['qux' => 'slug', 'test' => 'id'], $parsed->bindingFields);
+    /**
+     * @return array
+     */
+    public function uriProvider()
+    {
+        return [
+            [
+                '/foo',
+                '/foo',
+                [],
+            ],
+            [
+                '/foo/{bar}',
+                '/foo/{bar}',
+                [],
+            ],
+            [
+                '/foo/{bar}/baz/{qux}',
+                '/foo/{bar}/baz/{qux}',
+                [],
+            ],
+            [
+                '/foo/{bar}/baz/{qux?}',
+                '/foo/{bar}/baz/{qux?}',
+                [],
+            ],
+            [
+                '/foo/{bar:slug}',
+                '/foo/{bar}',
+                ['bar' => 'slug'],
+            ],
+            [
+                '/foo/{bar}/baz/{qux:slug}',
+                '/foo/{bar}/baz/{qux}',
+                ['bar' => null, 'qux' => 'slug'],
+            ],
+            [
+                '/foo/{bar}/baz/{qux:slug}',
+                '/foo/{bar}/baz/{qux}',
+                ['bar' => null, 'qux' => 'slug'],
+            ],
+            [
+                '/foo/{bar:slug}/baz/{qux}',
+                '/foo/{bar}/baz/{qux}',
+                ['bar' => 'slug', 'qux' => null],
+            ],
+            [
+                '/foo/{bar}/baz/{qux:slug?}',
+                '/foo/{bar}/baz/{qux?}',
+                ['bar' => null, 'qux' => 'slug'],
+            ],
+            [
+                '/foo/{bar}/baz/{qux:slug?}/{test:id?}',
+                '/foo/{bar}/baz/{qux?}/{test?}',
+                ['bar' => null, 'qux' => 'slug', 'test' => 'id'],
+            ],
+        ];
     }
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -373,6 +373,26 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/test-slug', $url->route('routable', [$model], false));
     }
 
+    public function testRoutableInterfaceRoutingWithSeparateBindingFieldOnlyForSecondParameter()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{bar}/{baz:slug}', ['as' => 'routable']);
+        $routes->add($route);
+
+        $model1 = new RoutableInterfaceStub;
+        $model1->key = 'routable-1';
+
+        $model2 = new RoutableInterfaceStub;
+        $model2->key = 'routable-2';
+
+        $this->assertSame('/foo/routable-1/test-slug', $url->route('routable', ['bar' => $model1, 'baz' => $model2], false));
+        $this->assertSame('/foo/routable-1/test-slug', $url->route('routable', [$model1, $model2], false));
+    }
+
     public function testRoutableInterfaceRoutingWithSingleParameter()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
**Note:** I'm unsure to which branch I should send this bugfix since the implementation of `RouteUri` has changed between `8.x` and `9.x`. `9.x` uses `str_contains` instead of `strpos`. I might have to send two separate PRs to each respective branch? Help? 😅 

## Summary

This PR fixes a special circumstance where the wrong model route key would get used when substituting route parameters. For a tl;dr of what the bug is, check out the test I added to `RoutingUrlGeneratorTest.php` that reproduces the error. For the longer explanation, keep reading.

## Reproducing the bug

Let's say I have two models, `User` and `Post`. The `User` model overrides the `getRouteKeyName` method so the user's `username` field gets used during route generation instead of the `id`. The `Post` model is kept vanilla.

```php
class User extends Model
{
    public function getRouteKeyName()
    {
        return 'username';
    } 
}

class Post extends Model
{
}
```

Now, let's define a route like this.

```php
Route::get('/{user}/posts/{post:id}', UserPostsController::class)
    ->name('users.posts.show');
```

We specify an explicit binding field for the `post` so it gets scoped on the user. For the user, we don't specify an explicit binding key, so we expect it to use the `username` like we've configured. This works as expected if we generate the route url and pass the parameters as an _associative array_.

```php
$user = new User(['username' => 'kai']);
$post = new Post(['id' => 5]);

route('users.posts.show', ['user' => $user, 'post' => $post], false);
// => /kai/posts/5
```

However, if we pass the parameters without explicit keys it breaks.

```php
$user = new User(['username' => 'kai']);
$post = new Post(['id' => 5]);

route('users.posts.show', [$user, $post], false);
// => /1/posts/5
```

If we explicitly define the binding field for the `user` parameter as well, it works again as expected.

```php
Route::get('/{user:username}/posts/{post:id}', UserPostsController::class)
    ->name('users.posts.show');

route('users.posts.show', [$user, $post], false);
// => /kai/posts/5
```

I have added a test to the `RoutingUrlGeneratorTest` file that reproduces this error.

## Why the bug happens

When the `RouteUri` class parses the URI, it extracts all binding fields from the URI. This array then gets saved on the `Route` object's `$bindingFields` property. So our URI of

```
/{user}/posts/{post:id}
```

gets turned into 

```php
['post' => 'id']
```

So far so good, but note that the `user` parameter is missing since it doesn't define a an explicit binding field (no spoilers, but this is important).

When the `UrlGenerator` tries to resolve the route parameters, it loops of the parameters and calls the `bindingFieldFor` method of the `Route` object for each of them (https://github.com/laravel/framework/blob/9.x/src/Illuminate/Routing/UrlGenerator.php#L483).

This method is passed the **key** of the current parameter we're looping over. It then checks if that key is an integer, and if so, extracts the binding field from the route's `bindingFields` array by **index**.

```php
// Routing/Route.php#536

public function bindingFieldFor($parameter)
{
    $fields = is_int($parameter) ? array_values($this->bindingFields) : $this->bindingFields;

    return $fields[$parameter] ?? null;
}
```

Going back to our route above, the `bindingFields` array currently looks like this.

```php
['post' => 'id']
```

But since it's trying to look up the binding field by index, it ends doing this instead.

```php
array_values(['post' => 'id'])
// => [0 => 'id']
```

Since `user` is the first parameter we passed to the `route` call, it tries to look up the binding field with index `0` in this array. Which is why the `id` field gets mistakenly used for the `user` parameter.

Also, at this point "binding fields" has stopped sounding like a word.

## Changes

To fix this bug, I changed the `parse` method of the `RouteUri` class to keep track of all parameters, instead of only parameters with an explicit binding field. So when we first parse our URI, we get back this instead:

```php
"/{user}/posts/{post:id}"

// turns into
['user' => null, 'post' => 'id']
```

Before returning, I check if this array contains any values that are not `null`, meaning we have at least one explicit binDinG fIeLd. In that case, we keep the whole array—including `null` values—so the index positions line up as expected when calling `array_values` on it. In any other case, we simply return an empty array (like before).

## Other changes

I've refactored the tests for the `RouteUri` class to use a data provider instead of having all assertions in a single test. That made figuring out which test case actually broke quite a bit easier.