### PR TITLE
[9.x] Adds attaches a concise error message to SES exceptions

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -73,7 +73,13 @@ class SesTransport extends AbstractTransport
                 )
             );
         } catch (AwsException $e) {
-            throw new Exception('Request to AWS SES API failed.', is_int($e->getCode()) ? $e->getCode() : 0, $e);
+            $reason = $e->getAwsErrorMessage() ?? $e->getMessage();
+
+            throw new Exception(
+                sprintf('Request to AWS SES API failed. Reason: %s.', $reason),
+                is_int($e->getCode()) ? $e->getCode() : 0,
+                $e
+            );
         }
 
         $messageId = $result->get('MessageId');


### PR DESCRIPTION
This pull request attaches a concise error message to SES exceptions coming from the SES transporter. Previously, a generic message as being presented, causing confusion, and making people investigate the real reason.

<img width="100%" alt="Screenshot 2022-05-18 at 16 11 01" src="https://user-images.githubusercontent.com/5457236/169075582-1aceb324-7041-45f3-8eab-00c120021590.png">
 