### PR TITLE
[9.x] Adds ability to have `paginate()` `$perPage` parameter as callable with access to `$total`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2634,7 +2634,7 @@ class Builder implements BuilderContract
     /**
      * Paginate the given query into a simple paginator.
      *
-     * @param  int  $perPage
+     * @param  int|callable  $perPage
      * @param  array  $columns
      * @param  string  $pageName
      * @param  int|null  $page
@@ -2645,6 +2645,8 @@ class Builder implements BuilderContract
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $total = $this->getCountForPagination();
+
+        $perPage = $perPage instanceof Closure ? $perPage($total) : $perPage;
 
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -269,6 +269,69 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('foo@gmail.com', $models[0]->email);
     }
 
+    public function testPaginatedModelCollectionRetrievalUsingCallablePerPage()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+        $models = EloquentTestUser::oldest('id')->paginate(function ($total) {
+            return $total <= 3 ? 3 : 2;
+        });
+
+        $this->assertCount(3, $models);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $models);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[1]);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[2]);
+        $this->assertSame('taylorotwell@gmail.com', $models[0]->email);
+        $this->assertSame('abigailotwell@gmail.com', $models[1]->email);
+        $this->assertSame('foo@gmail.com', $models[2]->email);
+
+        Paginator::currentPageResolver(function () {
+            return 2;
+        });
+        $models = EloquentTestUser::oldest('id')->paginate(function ($total) {
+            return $total <= 3 ? 3 : 2;
+        });
+
+        $this->assertCount(0, $models);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $models);
+
+        EloquentTestUser::create(['id' => 4, 'email' => 'bar@gmail.com']);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+        $models = EloquentTestUser::oldest('id')->paginate(function ($total) {
+            return $total <= 3 ? 3 : 2;
+        });
+
+        $this->assertCount(2, $models);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $models);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[1]);
+        $this->assertSame('taylorotwell@gmail.com', $models[0]->email);
+        $this->assertSame('abigailotwell@gmail.com', $models[1]->email);
+
+        Paginator::currentPageResolver(function () {
+            return 2;
+        });
+        $models = EloquentTestUser::oldest('id')->paginate(function ($total) {
+            return $total <= 3 ? 3 : 2;
+        });
+
+        $this->assertCount(2, $models);
+        $this->assertInstanceOf(LengthAwarePaginator::class, $models);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[1]);
+        $this->assertSame('foo@gmail.com', $models[0]->email);
+        $this->assertSame('bar@gmail.com', $models[1]->email);
+    }
+
     public function testPaginatedModelCollectionRetrievalWhenNoElements()
     {
         Paginator::currentPageResolver(function () {


### PR DESCRIPTION
Feature adds ability to have `$perPage` as a callback closure with access to `$total`.

```php
// Previously:
$total = DB::table('products')->count();
DB::table('products')->paginate( $total <= 110 ? 110 : 100 );

// Now (saves extra query and builder code):
DB::table('products')->paginate(function ($total) {
    return $total <= 110 ? 110 : 100;
});
```

There might be a scenario when you want to use different/dynamic per page depending on the total count of records.

Example, in a list of products, with above snippet, it will load all ~110 products if there is less then or equal to 110 products in total. Else, defaults to 100 as usual. So that, there won't be just a few items sitting around in second page.

Similarly, if we want to have exact 4 pages, we can provide dynamic per page value like such:

```php
Product::oldest()->paginate(function ($total) {
    return ceil($total / 4); // Will always have at most 4 pages in total
});
```

And, of course the normal `paginate(10)` will still work.