### PR TITLE
[9.x] Add unique identifier of persistent row to Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1627,10 +1627,22 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function is($model)
     {
-        return ! is_null($model) &&
-               $this->getKey() === $model->getKey() &&
-               $this->getTable() === $model->getTable() &&
-               $this->getConnectionName() === $model->getConnectionName();
+        return ! is_null($model)
+            && $this->getIdentifierOfPersistentRow() === $model->getIdentifierOfPersistentRow();
+    }
+
+    /**
+     * Get a string that uniquely identifies the database row represented by the model.
+     *
+     * @return string
+     */
+    public function getIdentifierOfPersistentRow()
+    {
+        return implode('__', [
+            $this->getKey(),
+            $this->getTable(),
+            $this->getConnectionName(),
+        ]);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2167,6 +2167,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testGetIdentifierOfPersistentRow()
+    {
+        $model = new EloquentModelStub(['id' => 1]);
+        $model->setTable('foo');
+        $model->setConnection('bar');
+
+        $this->assertEquals('1__foo__bar', $model->getIdentifierOfPersistentRow());
+    }
+
     public function testWithoutTouchingCallback()
     {
         new EloquentModelStub(['id' => 1]);


### PR DESCRIPTION
Sometimes I needed to do things like removing duplicates from a collection of Eloquent models that come from different tables.

```php
$mixedCollection->unique(fn ($model) => $model->getIdentifierOfPersistentRow());
```

I thought that the same technique that is used in `Model::is` can be reused to uniquely identify the DB row represented by the model.