### PR TITLE
[9.x] Fix clone issue on updateOrCreate and firstOrCreate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -618,7 +618,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrCreate(array $attributes = [], array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->clone()->where($attributes)->first())) {
+        if (is_null($instance = (clone $this)->where($attributes)->first())) {
             if (is_null($instance = $this->related->where($attributes)->first())) {
                 $instance = $this->create(array_merge($attributes, $values), $joining, $touch);
             } else {
@@ -640,7 +640,7 @@ class BelongsToMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->clone()->where($attributes)->first())) {
+        if (is_null($instance = (clone $this)->where($attributes)->first())) {
             if (is_null($instance = $this->related->where($attributes)->first())) {
                 return $this->create(array_merge($attributes, $values), $joining, $touch);
             } else {

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1154,6 +1154,42 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             })->id
         );
     }
+
+    public function testUpdateOrCreateQueryBuilderIsolation()
+    {
+        $user = User::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        $user->postsWithCustomPivot()->attach($post);
+
+        $instance = $user->postsWithCustomPivot()->updateOrCreate(
+            ['uuid' => $post->uuid],
+            ['title' => Str::random()],
+        );
+
+        $this->assertArrayNotHasKey(
+            'user_uuid',
+            $instance->toArray(),
+        );
+    }
+
+    public function testFirstOrCreateQueryBuilderIsolation()
+    {
+        $user = User::create(['name' => Str::random()]);
+        $post = Post::create(['title' => Str::random()]);
+
+        $user->postsWithCustomPivot()->attach($post);
+
+        $instance = $user->postsWithCustomPivot()->firstOrCreate(
+            ['uuid' => $post->uuid],
+            ['title' => Str::random()],
+        );
+
+        $this->assertArrayNotHasKey(
+            'user_uuid',
+            $instance->toArray(),
+        );
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
#42087 breaks functionality on `BelongsToMany` with a custom pivot table/model for `updateOrCreate()` and `firstOrCreate()`.

The current behavior, 

    $instance = $this->clone()->where($attributes)->first()

is creating an issue in which all columns from the pivot table are applied to `$instance`. This isn't expected behavior in general, but is a breaking change introduced in #42087 when the pivot table has a primary key matching the source model - `$instance->id` will end up being the `id` from the pivot table, not the target table the `firstOrCreate()` or `updateOrCreate()` is pointing to.

The chain of magic `__call` and `__clone` methods between `Relation`, `Eloquent\Builder` and `Query\Builder` is a bit hard to follow. This is compounded by the fact that `$this->clone()` uses the `ForwardsCalls` trait to delegate the call into `Eloquent\Builder`, returning an instance of that builder instead of a copy of `Relation.

`(clone $this)` - directly cloning the `Relation` to do the `$instance` query keeps the pivot table data out of `$instance`.

/cc @trideout