### PR TITLE
Except the given array of table from being migrated

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -44,6 +44,7 @@ class FreshCommand extends Command
             '--drop-views' => $this->option('drop-views'),
             '--drop-types' => $this->option('drop-types'),
             '--force' => true,
+            '--except' => $this->option('except'),
         ]));
 
         $this->call('migrate', array_filter([
@@ -53,6 +54,7 @@ class FreshCommand extends Command
             '--schema-path' => $this->input->getOption('schema-path'),
             '--force' => true,
             '--step' => $this->option('step'),
+            '--except' => $this->option('except'),
         ]));
 
         if ($this->laravel->bound(Dispatcher::class)) {
@@ -104,6 +106,7 @@ class FreshCommand extends Command
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
             ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
             ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],
+            ['except', null, InputOption::VALUE_OPTIONAL, 'Drop all tables except the given string of tables separated by comma (,)'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -19,6 +19,7 @@ class MigrateCommand extends BaseCommand
      */
     protected $signature = 'migrate {--database= : The database connection to use}
                 {--force : Force the operation to run when in production}
+                {--except= : The except(s) to except some table(s) while migration}
                 {--path=* : The path(s) to the migrations files to be executed}
                 {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
                 {--schema-path= : The path to a schema dump file}
@@ -81,9 +82,9 @@ class MigrateCommand extends BaseCommand
             // we will use the path relative to the root of this installation folder
             // so that migrations may be run for any path within the applications.
             $this->migrator->setOutput($this->output)
-                    ->run($this->getMigrationPaths(), [
+                    ->run($this->getMigrationPaths(), [], explode(",", $this->option('except')), [
                         'pretend' => $this->option('pretend'),
-                        'step' => $this->option('step'),
+                        'step' => $this->option('step')
                     ]);
 
             // Finally, if the "seed" option has been given, we will re-run the database

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -79,7 +79,7 @@ class WipeCommand extends Command
     {
         $this->laravel['db']->connection($database)
                     ->getSchemaBuilder()
-                    ->dropAllTables();
+                    ->dropAllTables($this->option('except'));
     }
 
     /**
@@ -120,6 +120,7 @@ class WipeCommand extends Command
             ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
             ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+            ['except', null, InputOption::VALUE_OPTIONAL, 'Drop all tables except the given string of tables separated by comma (,)'],
         ];
     }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -93,17 +93,21 @@ class Migrator
      *
      * @param  array|string  $paths
      * @param  array  $options
+     * @param  array  $except
      * @return array
      */
-    public function run($paths = [], array $options = [])
+    public function run($paths = [], array $options = [], array $except = [])
     {
         // Once we grab all of the migration files for the path, we will compare them
         // against the migrations that have already been run for this package then
         // run each of the outstanding migrations against a database connection.
         $files = $this->getMigrationFiles($paths);
 
+        $files = $this->guessMigrationFile($files, array_filter($except));
+
         $this->requireFiles($migrations = $this->pendingMigrations(
-            $files, $this->repository->getRan()
+            $files,
+            $this->repository->getRan()
         ));
 
         // Once we have all these migrations that are outstanding we are ready to run
@@ -533,6 +537,26 @@ class Migrator
         })->sortBy(function ($file, $key) {
             return $key;
         })->all();
+    }
+
+    /**
+     * Get all filtered of the migration files using the given except array.
+     *
+     * @param  array  $files
+     * @param  array  $except
+     * @return array
+     */
+    public function guessMigrationFile(array $files, array $except)
+    {
+        foreach ($files as $fileName => $filePath) {
+            foreach ($except as $index => $exc) {
+                if (str_contains($fileName, $exc)) {
+                    $except[$index] = $filePath;
+                }
+            }
+        }
+
+        return array_diff($files, $except);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2465,6 +2465,27 @@ class Builder implements BuilderContract
     {
         return $this->union($query, true);
     }
+    
+    /**
+     * Add a basic where clause to all the queries of union statement.
+     *
+     * @param  \Closure|string|array  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @param  bool  $all
+     * @return $this
+     */
+    public function whereAllUnion($query, $column, $operator = null, $value = null, $boolean = 'and', $all = false)
+    {
+        $query->where($column, $operator, $value, $boolean);
+
+        $this->where($column, $operator, $value, $boolean);
+
+        $this->union($query, $all);
+
+        return $this;
+    }
 
     /**
      * Lock the selected rows in the table.

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -300,11 +300,12 @@ class Builder
     /**
      * Drop all tables from the database.
      *
+     * @param  string  $except
      * @return void
      *
      * @throws \LogicException
      */
-    public function dropAllTables()
+    public function dropAllTables(string $except)
     {
         throw new LogicException('This database driver does not support dropping all tables.');
     }

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Schema;
 
+use Exception;
+
 class MySqlBuilder extends Builder
 {
     /**
@@ -63,19 +65,31 @@ class MySqlBuilder extends Builder
     }
 
     /**
-     * Drop all tables from the database.
+     * Drop all tables except the given table(s) string from the database.
      *
+     * @param  string  $except
      * @return void
+     *
+     * @throws \Exception
      */
-    public function dropAllTables()
+    public function dropAllTables($except)
     {
         $tables = [];
+        $exceptTables = array_filter(explode(',', $except));
+
+        foreach ($exceptTables as $table) {
+            if (!empty($table) && !$this->hasTable($table)) {
+                throw new Exception("The {$table} table does not exist.");
+            }
+        }
 
         foreach ($this->getAllTables() as $row) {
             $row = (array) $row;
 
             $tables[] = reset($row);
         }
+
+        $tables = array_diff($tables, $exceptTables);
 
         if (empty($tables)) {
             return;


### PR DESCRIPTION
It's important sometimes to except some tables from being fresh because maybe these tables contain important data

## Before this PR

```
php artisan migrate:fresh
```

this command will be translated into

```
Dropped all tables successfully.
Migration table created successfully.
Migrating: 2014_10_12_000000_create_users_table
Migrated:  2014_10_12_000000_create_users_table (570.18ms)
Migrating: 2014_10_12_100000_create_password_resets_table
Migrated:  2014_10_12_100000_create_password_resets_table (388.50ms)
Migrating: 2019_08_19_000000_create_failed_jobs_table
Migrated:  2019_08_19_000000_create_failed_jobs_table (492.07ms)
Migrating: 2019_12_14_000001_create_personal_access_tokens_table
Migrated:  2019_12_14_000001_create_personal_access_tokens_table (635.70ms)
```

but as I said what if the users' table has important data and I don't want to drop it So, say hello to the `--except` option

## After this PR

```
php artisan migrate:fresh --except=users
```

this command will be translated into

```
Dropped all tables successfully.
Migration table created successfully.
Migrating: 2014_10_12_100000_create_password_resets_table
Migrated:  2014_10_12_100000_create_password_resets_table (521.91ms)
Migrating: 2019_08_19_000000_create_failed_jobs_table
Migrated:  2019_08_19_000000_create_failed_jobs_table (411.83ms)
Migrating: 2019_12_14_000001_create_personal_access_tokens_table
Migrated:  2019_12_14_000001_create_personal_access_tokens_table (1,374.12ms)
```