### PR TITLE
Add `whereAllUnion` function

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2465,6 +2465,27 @@ class Builder implements BuilderContract
     {
         return $this->union($query, true);
     }
+    
+    /**
+     * Add a basic where clause to all the queries of union statement.
+     *
+     * @param  \Closure|string|array  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @param  bool  $all
+     * @return $this
+     */
+    public function whereAllUnion($query, $column, $operator = null, $value = null, $boolean = 'and', $all = false)
+    {
+        $query->where($column, $operator, $value, $boolean);
+
+        $this->where($column, $operator, $value, $boolean);
+
+        $this->union($query, $all);
+
+        return $this;
+    }
 
     /**
      * Lock the selected rows in the table.


### PR DESCRIPTION
This function helps us to add the `where` clause for each query in the union statement in an easy manner instead of adding a separate `where` clause for each query for instance:

## Before This PR

```PHP
$market = DB::table('markets')
    ->select(['name', 'location', 'user_id'])
    ->where('user_id', 1);

$post = DB::table('posts')
    ->select(['title', 'body', 'user_id'])
    ->union($market)
    ->where('user_id', 1)
    ->get();
```

## After This PR

```PHP
$market = DB::table('markets')
    ->select(['name', 'location', 'user_id']);

$post = DB::table('posts')
    ->select(['title', 'body', 'user_id'])
    ->whereAllUnion($market, 'user_id', 1)
    ->get();
```