### PR TITLE
[9.x] Add `$withoutScopes` parameter to Model `refresh` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1567,16 +1567,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Reload the current model instance with fresh attributes from the database.
      *
+     * @param  bool  $withoutScopes
      * @return $this
      */
-    public function refresh()
+    public function refresh(bool $withoutScopes = true)
     {
         if (! $this->exists) {
             return $this;
         }
 
         $this->setRawAttributes(
-            $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
+            $this->setKeysForSelectQuery($withoutScopes ? $this->newQueryWithoutScopes() : $this->newQuery())
                 ->useWritePdo()
                 ->firstOrFail()
                 ->attributes

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -7,7 +7,9 @@ use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class EloquentModelRefreshTest extends DatabaseTestCase
 {
@@ -71,6 +73,15 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
         $post->children->first()->refresh();
     }
+
+    public function testItRefreshesModelWithGlobalScopes()
+    {
+        $post = Post::create(['title' => 'Taylor']);
+        
+        $post->refresh(false);
+
+        $this->assertEquals('taylor', $post->slug);
+    }
 }
 
 class Post extends Model
@@ -87,6 +98,10 @@ class Post extends Model
 
         static::addGlobalScope('age', function ($query) {
             $query->where('title', '!=', 'mohamed');
+        });
+        static::addGlobalScope('slug', function ($query) {
+            $query->select('*');
+            $query->addSelect(DB::raw('lower(title) as slug'));
         });
     }
 }


### PR DESCRIPTION
This PR will add a `$withoutScopes` to Model `refresh` method which defines whether the refresh should be executed with or without scopes. The default behaviour right now is that the refresh is read without scopes in order to allow refreshes to not fail when there are global where conditions that would exclude the entity. However, that also means that if there are global scopes that select additional fields those would be excluded as well, e.g.:

```php
class Post extends Model
{
  protected static function boot()
  {
    static::addGlobalScope('slug', function ($query) {
         $query->select('*');
         $query->addSelect(DB::raw('lower(title) as slug'));
     });
  }
}
```

Now, if we read the model:
```php
$model = Model::find(1);
dump($model->slug); // filled
        
$model->refresh();
        
dump($model->slug); // null
```

As a developer I would expect that the `slug` attribute would still be defined but it is in fact now. The proposed change adds a parameter to `refresh` method to control the behaviour:
```php
$model = Model::find(1);
dump($model->slug); // filled
        
$model->refresh();
        
dump($model->slug); // null
        
$model->refresh(false);

dump($model->slug); // filled
```

The parameter is `true` by defined to be backward compatible.