### PR TITLE
fix: Incorrect mask position

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -495,18 +495,15 @@ class Str
             return $string;
         }
 
-        $strlen = mb_strlen($string, $encoding);
-        $startIndex = $index;
-
-        if ($index < 0) {
-            $startIndex = $index < -$strlen ? 0 : $strlen + $index;
+        $posIndex = $index;
+        while ($posIndex < 0) {
+            $posIndex += mb_strlen($string);
         }
 
-        $start = mb_substr($string, 0, $startIndex, $encoding);
-        $segmentLen = mb_strlen($segment, $encoding);
-        $end = mb_substr($string, $startIndex + $segmentLen);
+        $start = mb_substr($string, 0, mb_strpos($string, $segment, $posIndex, $encoding), $encoding);
+        $end = mb_substr($string, mb_strpos($string, $segment, $posIndex, $encoding) + mb_strlen($segment, $encoding));
 
-        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen).$end;
+        return $start . str_repeat(mb_substr($character, 0, 1, $encoding), mb_strlen($segment, $encoding)) . $end;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -605,6 +605,8 @@ class SupportStrTest extends TestCase
         $this->assertSame('maria@email.co*', Str::mask('maria@email.com', '*', -1));
         $this->assertSame('***************', Str::mask('maria@email.com', '*', -15));
         $this->assertSame('***************', Str::mask('maria@email.com', '*', 0));
+
+        $this->assertSame('ssssssssss*s', Str::mask('ssssssssssss', '*', -26, 1));
     }
 
     public function testMatch()


### PR DESCRIPTION
- Fix mask error when $index<-strlen($string)，for example "Str::mask('ssss','*', -6, 1);" the current output is "*sss"
- Use the original code style and fix the "offset" value of mb_strpos()

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
