### PR TITLE
Add method to make instance of Illuminate\Http\Request for testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -666,4 +666,21 @@ trait MakesHttpRequests
             );
         });
     }
+
+    /**
+     * Create the request instance.
+     *
+     * @param $method
+     * @param $uri
+     * @return Illuminate\Http\Request
+     */
+    protected function createRequest($method, $uri): Request
+    {
+        $symfonyRequest = SymfonyRequest::create(
+            $uri,
+            $method,
+        );
+
+        return Request::createFromBase($symfonyRequest);
+    }
 }


### PR DESCRIPTION
Sometimes maybe you should pass instance of request to test any class such as middleware. This PR adds a method for make instance of  `Illuminate\Http\Request` to inject any class.

**Before This PR** : 

```
$middleware = app(UserBannedMiddleware::class);

$request = Request::createFromBase(SymfonyRequest::create(
            '/panel',
            'GET',
        ));

$response = $middleware->handle(
            $request,
            fn () => new Response()
);
```

**After this PR**

```
$middleware = app(UserBannedMiddleware::class);

  $response = $middleware->handle(
            $this->createRequest('get', '/'),
            fn () => new Response()
);
```
