### PR TITLE
[9.x] Extract ServeCommand env list to static property

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -45,11 +45,11 @@ class ServeCommand extends Command
     protected $portOffset = 0;
 
     /**
-     * The env variables that should be passed from host machine to the php server process.
+     * The environment variables that should be passed from host machine to the PHP server process.
      *
      * @var string[]
      */
-    public static $passthruEnv = [
+    public static $passthroughVariables = [
         'APP_ENV',
         'LARAVEL_SAIL',
         'PHP_CLI_SERVER_WORKERS',
@@ -127,7 +127,7 @@ class ServeCommand extends Command
                 return [$key => $value];
             }
 
-            return in_array($key, static::$passthruEnv) ? [$key => $value] : [$key => false];
+            return in_array($key, static::$passthroughVariables) ? [$key => $value] : [$key => false];
         })->all());
 
         $process->start(function ($type, $buffer) {

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -45,6 +45,22 @@ class ServeCommand extends Command
     protected $portOffset = 0;
 
     /**
+     * The env variables that should be passed from host machine to the php server process.
+     *
+     * @var string[]
+     */
+    public static $passthruEnv = [
+        'APP_ENV',
+        'LARAVEL_SAIL',
+        'PHP_CLI_SERVER_WORKERS',
+        'PHP_IDE_CONFIG',
+        'SYSTEMROOT',
+        'XDEBUG_CONFIG',
+        'XDEBUG_MODE',
+        'XDEBUG_SESSION',
+    ];
+
+    /**
      * Execute the console command.
      *
      * @return int
@@ -111,16 +127,7 @@ class ServeCommand extends Command
                 return [$key => $value];
             }
 
-            return in_array($key, [
-                'APP_ENV',
-                'LARAVEL_SAIL',
-                'PHP_CLI_SERVER_WORKERS',
-                'PHP_IDE_CONFIG',
-                'SYSTEMROOT',
-                'XDEBUG_CONFIG',
-                'XDEBUG_MODE',
-                'XDEBUG_SESSION',
-            ]) ? [$key => $value] : [$key => false];
+            return in_array($key, static::$passthruEnv) ? [$key => $value] : [$key => false];
         })->all());
 
         $process->start(function ($type, $buffer) {


### PR DESCRIPTION
This PR extracts the hardcoded list of allowed ENV variables from the ServeCommand to a public static property. 

**Background**

Currently the Artisan serve command filters out any host ENV variables that is not explicitly listed in a hardcoded array.

```
return in_array($key, [
    'APP_ENV',
    'LARAVEL_SAIL',
    'PHP_CLI_SERVER_WORKERS',
    'PHP_IDE_CONFIG',
    'SYSTEMROOT',
    'XDEBUG_CONFIG',
    'XDEBUG_MODE',
    'XDEBUG_SESSION',
]) ? [$key => $value] : [$key => false];
```

This makes it hard as a developer to add pass additional ENV to the server process - for instance from docker-compose.yml using Sail. The additional ENV can be accessed just fine from CLI but will never be accessible from the browser because it is filtered out from the serve command.

**Proposal**

Make it easier to allow extra ENV to be passed through to the php built-in server by extracting the above list to a public static property so it can be changed from a ServiceProvider@register/boot function without having to extend and customise the serve command.

Additionally it could be handy to automatically pass through any ENV variable starting with a prefix such as `PUBLIC_` or `LARAVEL_`. 
This is similar to what VUE CLI does by making any ENV variables accessible from client javascript if they start with `VUE_APP_`. This would give the best developer experience as no customisations are needed by the developer.
If there is support for this I'm happy to implement it too. 