### PR TITLE
[9.x] Adds expected behavior to `where` function in query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -712,7 +712,7 @@ class Builder implements BuilderContract
         // If operator is an array and has multiple values, we will assume the developer
         // wants a “where in” clause instead. We also assume the developer wants a
         // "where not in" if they use the "whereNot" function.
-        if(is_array($operator) && count($operator) > 1) {
+        if(is_array($operator) || $operator instanceof Arrayable) {
             return $this->whereIn($column, $operator, str_ireplace(' not', '', $boolean), str_contains($boolean, 'not'));
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -708,6 +708,13 @@ class Builder implements BuilderContract
         if (is_array($column)) {
             return $this->addArrayOfWheres($column, $boolean);
         }
+        
+        // If operator is an array and has multiple values, we will assume the developer
+        // wants a “where in” clause instead. We also assume the developer wants a
+        // "where not in" if they use the "whereNot" function.
+        if(is_array($operator) && count($operator) > 1) {
+            return $this->whereIn($column, $operator, str_ireplace(' not', '', $boolean), str_contains($boolean, 'not'));
+        }
 
         // Here we will make some assumptions about the operator. If only 2 values are
         // passed to the method, we will assume that the operator is an equals sign

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -708,11 +708,11 @@ class Builder implements BuilderContract
         if (is_array($column)) {
             return $this->addArrayOfWheres($column, $boolean);
         }
-        
+
         // If operator is an array and has multiple values, we will assume the developer
         // wants a “where in” clause instead. We also assume the developer wants a
         // "where not in" if they use the "whereNot" function.
-        if(is_array($operator) || $operator instanceof Arrayable) {
+        if (is_array($operator) || $operator instanceof Arrayable) {
             return $this->whereIn($column, $operator, str_ireplace(' not', '', $boolean), str_contains($boolean, 'not'));
         }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1716,7 +1716,6 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereNot()
     {
-
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNot('id', [12, 30]);
         $this->assertSame('select * from "users" where "id" not in (?, ?)', $builder->toSql());

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -314,7 +314,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', [12]);
-        $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" in (?)', $builder->toSql());
         $this->assertEquals([0 => 12], $builder->getBindings());
         
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -316,12 +316,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', [12]);
         $this->assertSame('select * from "users" where "id" in (?)', $builder->toSql());
         $this->assertEquals([0 => 12], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', [12, 30]);
         $this->assertSame('select * from "users" where "id" in (?, ?)', $builder->toSql());
         $this->assertEquals([0 => 12, 1 => 30], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', [12, 30]);
         $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
@@ -1716,12 +1716,12 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereNot()
     {
-    
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNot('id', [12, 30]);
         $this->assertSame('select * from "users" where "id" not in (?, ?)', $builder->toSql());
         $this->assertEquals([0 => 12, 1 => 30], $builder->getBindings());
-        
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNot(function ($q) {
             $q->where('email', '=', 'foo');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -316,7 +316,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', [12]);
         $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
         $this->assertEquals([0 => 12], $builder->getBindings());
-
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', [12, 30]);
+        $this->assertSame('select * from "users" where "id" in (?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 12, 1 => 30], $builder->getBindings());
+        
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', [12, 30]);
         $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
@@ -1711,6 +1716,12 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testWhereNot()
     {
+    
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot('id', [12, 30]);
+        $this->assertSame('select * from "users" where "id" not in (?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 12, 1 => 30], $builder->getBindings());
+        
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNot(function ($q) {
             $q->where('email', '=', 'foo');


### PR DESCRIPTION
_Coming at this with a different angle -- original: https://github.com/laravel/framework/pull/42432_

If you pass an array of values as the operator, I expect it to return rows that include those values. 

For example:

```
DB::table('users')->where('name', ['foo', 'bar']);
```

Would return users that have the name `foo` and `bar`. 

However, it only returns users that have the name `foo`. 