### PR TITLE
Overriding console command constructor is bad practice

### DIFF
--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -48,27 +48,15 @@ class CacheTableCommand extends Command
     protected $composer;
 
     /**
-     * Create a new cache table command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Support\Composer  $composer
-     * @return void
-     */
-    public function __construct(Filesystem $files, Composer $composer)
-    {
-        parent::__construct();
-
-        $this->files = $files;
-        $this->composer = $composer;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return void
      */
     public function handle()
     {
+        $this->files = $this->laravel->make(Filesystem::class);
+        $this->composer = $this->laravel->make(Composer::class);
+        
         $fullPath = $this->createBaseMigration();
 
         $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/cache.stub'));

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -52,27 +52,15 @@ class ClearCommand extends Command
     protected $files;
 
     /**
-     * Create a new cache clear command instance.
-     *
-     * @param  \Illuminate\Cache\CacheManager  $cache
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
-     */
-    public function __construct(CacheManager $cache, Filesystem $files)
-    {
-        parent::__construct();
-
-        $this->cache = $cache;
-        $this->files = $files;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return void
      */
     public function handle()
     {
+        $this->cache = $this->laravel->make(CacheManager::class);
+        $this->files = $this->laravel->make(Filesystem::class);
+        
         $this->laravel['events']->dispatch(
             'cache:clearing', [$this->argument('store'), $this->tags()]
         );

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -42,25 +42,14 @@ class ForgetCommand extends Command
     protected $cache;
 
     /**
-     * Create a new cache clear command instance.
-     *
-     * @param  \Illuminate\Cache\CacheManager  $cache
-     * @return void
-     */
-    public function __construct(CacheManager $cache)
-    {
-        parent::__construct();
-
-        $this->cache = $cache;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return void
      */
     public function handle()
     {
+        $this->cache = $this->laravel->make(CacheManager::class);
+        
         $this->cache->store($this->argument('store'))->forget(
             $this->argument('key')
         );

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -61,7 +61,7 @@ class Command extends SymfonyCommand
      *
      * @return void
      */
-    public function __construct()
+    final public function __construct()
     {
         // We will go ahead and set the name, description, and parameters on console
         // commands just to make things a little easier on the developer. This is

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -103,23 +103,6 @@ abstract class GeneratorCommand extends Command
     ];
 
     /**
-     * Create a new controller creator command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
-     */
-    public function __construct(Filesystem $files)
-    {
-        parent::__construct();
-
-        if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
-            $this->addTestOptions();
-        }
-
-        $this->files = $files;
-    }
-
-    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -135,6 +118,12 @@ abstract class GeneratorCommand extends Command
      */
     public function handle()
     {
+        if (in_array(CreatesMatchingTest::class, class_uses_recursive($this))) {
+            $this->addTestOptions();
+        }
+
+        $this->files = $this->laravel->make(Filesystem::class);
+        
         // First we need to ensure that the given name is not a reserved word within the PHP
         // language and that the class name will actually be valid. If it is not valid we
         // can error now and prevent from polluting the filesystem using invalid files.

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -77,18 +77,6 @@ class ScheduleRunCommand extends Command
     protected $handler;
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->startedAt = Date::now();
-
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
@@ -98,6 +86,8 @@ class ScheduleRunCommand extends Command
      */
     public function handle(Schedule $schedule, Dispatcher $dispatcher, ExceptionHandler $handler)
     {
+        $this->startedAt = Date::now();
+        
         $this->schedule = $schedule;
         $this->dispatcher = $dispatcher;
         $this->handler = $handler;

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -45,19 +45,6 @@ class ConfigCacheCommand extends Command
     protected $files;
 
     /**
-     * Create a new config cache command instance.
-     *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @return void
-     */
-    public function __construct(Filesystem $files)
-    {
-        parent::__construct();
-
-        $this->files = $files;
-    }
-
-    /**
      * Execute the console command.
      *
      * @return void
@@ -66,6 +53,8 @@ class ConfigCacheCommand extends Command
      */
     public function handle()
     {
+        $this->files = $this->laravel->make(Filesystem::class);
+        
         $this->call('config:clear');
 
         $config = $this->getFreshConfiguration();

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -166,11 +166,9 @@ class ConsoleCommandStub extends Command
     protected $description = 'This is a description about the command';
 
     protected $foo;
-
-    public function __construct(FooClassStub $foo)
+    
+    public function handle()
     {
-        parent::__construct();
-
-        $this->foo = $foo;
+        $this->foo = $this->laravel->make(FooClassStub::class);
     }
 }


### PR DESCRIPTION
To initialize the console command class, it would be more correct to initialize it in the "_handle_" method. Overriding a constructor can be a big hassle. This can be seen on large applications.

# Causes:
1) Not everyone who uses frameworks is a good programmer.
2) Code execution occurs that was not intended.
3) Throwing Implicit Errors
4) Execute code snippets only when needed.

# Examples:
* ## Example 1
```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;

class TestCommand extends Command
{
    protected $signature   = 'test_command';

    protected $description = 'Error example';

    // Is bad practic
    public function __construct()
    {
        parent::__construct();
        dd("This code is always executed");
    }

    public function handle(): void
    {
        // TODO logic
    }
}
```
#### If you run any command
```bash 
php artisan | php arisan cache:clear | php artisan queue:work | etc. 
```
##### In console output
```bash
"This code is always executed"
```
#### "Worker log" or "Horizon log" or "Supervisor log"
```bash 
"This code is always executed"
```
#### If you run cron, this task will run many times (/var/log/syslog)
```bash 
"This code is always executed"
```
In this example, we see that the code in the constructor is executed many times and everywhere. It would be nice if this was done upon request. When it is necessary. This example shows that it is very easy to get confused. On the one hand, the initialization of the class is described in the constructor. On the other hand, we get a time bomb.

* ## Example 2
TestCommand.php
```php
<?php

namespace App\Console\Commands;

use App\Models\User;
use Illuminate\Console\Command;
use Illuminate\Support\Collection;
use Illuminate\Support\Facades\Event;

/**
 * The task is to check who has not paid for a subscription for a long time
 * @package App\Console\Commands
 */
class TestCommand extends Command
{
    protected $signature   = 'test_command';

    protected $description = 'Error example';

    /**
     * @var Collection<User>
     *
     *     User |- <int>    id
     *          |- <string> name
     *          |- <bool>   paid
     *          |- <Carbon> paid_at
     *          |- <int>    tariff_id -> relation
     *          <etc...>
     *
     *     User relations
     *              hasOne Tariff
     */
    protected Collection $user;

    public function __construct()
    {
        parent::__construct();
        // class variable initialization : return collect 10000+ items.
        $this->user = User::with('tariff')
            ->where('id', '>', now()->addMonths(-5))
            ->get();


    }

    /**
     * This logic is just a demonstration.
     * The task is to compare and update the model.
     * According to the task, we have to iterate over the users
     */
    public function handle(): void
    {
        // Loop (model iteration) 10000+ items
        $this->user->each(
            function (User $user) {
                // Any comparison
                $user->paid = $user->tariff->value == 'VALUE';
                $user->save();
            }
        );
    }
}

```
EventServiceProvider.php
```php
<?php

namespace App\Providers;

use Illuminate\Auth\Events\Registered;
use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
use Illuminate\Support\Facades\Event;

class EventServiceProvider extends ServiceProvider
{
    /**
     * The event listener mappings for the application.
     *
     * @var array<class-string, array<int, class-string>>
     */
    protected $listen = [
        Registered::class => [
            SendEmailVerificationNotification::class,
        ],
    ];

    /**
     * Register any events for your application.
     *
     * @return void
     */
    public function boot()
    {
        // Register event ( ONLY FOR TEST )
        Event::listen("*", function(...$params) {
            dump($params[0]);
        });
    }
}
```

As you can see, we have created a console command and registered an event listener in the EventServiceProvider.
In the EventServiceProvider::boot method, we registered a listener just so we can monitor how the application is running. We are only interested in the name of the event.

#### If you run any command
```bash 
php artisan | php arisan cache:clear | php artisan queue:work | etc. 
```
##### In console output
```bash
"bootstrapped: Illuminate\Foundation\Bootstrap\BootProviders"
"Illuminate\Console\Events\ArtisanStarting"
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandFinished"
"Illuminate\Console\Events\CommandFinished"
```
#### "Worker log" or "Horizon log" or "Supervisor log"
```bash 
"bootstrapped: Illuminate\Foundation\Bootstrap\BootProviders"
"Illuminate\Console\Events\ArtisanStarting"
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandFinished"
"Illuminate\Console\Events\CommandFinished"
```
#### If you run cron, this task will run many times (/var/log/syslog)
```bash 
"bootstrapped: Illuminate\Foundation\Bootstrap\BootProviders"
"Illuminate\Console\Events\ArtisanStarting"
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandFinished"
"Illuminate\Console\Events\CommandFinished"
```

As you can see, we have created a load that we did not expect. In all practices, variables are initialized in the class constructor. But this place is so unique.
I understand why this is happening. The Illuminate\Foundation\Console\Kernel::load() function is called in the App\Console\Kernel::commands() method.
```php
    /**
     * Register the commands for the application.
     *
     * @return void
     */
    protected function commands(): void
    {
        $this->load(__DIR__.'/Commands'); // <= THIS

        require base_path('routes/console.php');
    }
```
After running the $this->laravel->make($command) function, the constructor will be called
```php
    protected function parseCommand($command, $parameters)
    {
        ...
        $command = $this->laravel->make($command)->getName(); // <= THIS
        ...
    }
    public function resolve($command)
    {
        return $this->add($this->laravel->make($command)); // <= OR THIS
    }
```
This is how all commands are initialized
I consider this a good reason to fix

* ## Example 3
TestCommand.php
```php
class TestCommand extends Command
{
    protected $signature   = 'test_command';

    protected $description = 'Error example';

    public function __construct()
    {
        parent::__construct();
        // I was in a hurry and forgot to remove
        // I needed this for testing or for development
        Auth::loginUsingId(1);
        // From now on, the whole application thinks that the user with id 1 is authorized
    }

    public function handle(): void
    {
        // The task requires it
        User::find(99)->update([ "paid_at" => now() ]);
    }
}
```
User.php
```php
<?php

namespace App\Models;

use Illuminate\Contracts\Auth\MustVerifyEmail;
use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Foundation\Auth\User as Authenticatable;
use Illuminate\Notifications\Notifiable;

class User extends Authenticatable
{
    use HasFactory;
    use Notifiable;

    public function __construct(array $attributes = [])
    {
        parent::__construct($attributes);
    }

    /**
     * The attributes that are mass assignable.
     *
     * @var array<int, string>
     */
    protected $fillable = [
        'name',
        'email',
        'password',
    ];

    /**
     * The attributes that should be hidden for serialization.
     *
     * @var array<int, string>
     */
    protected $hidden = [
        'password',
        'remember_token',
    ];

    /**
     * The attributes that should be cast.
     *
     * @var array<string, string>
     */
    protected $casts = [
        'email_verified_at' => 'datetime',
    ];

    protected static function boot()
    {
        parent::boot();

        // Or register Observer [ .env QUEUE_CONNECTION=sync ]
        static::updating(
            function (User $user) {

                // Let's pretend I'm using a helper "auth"
                if (auth()->check() /* TRUE */) {

                    // Log::class - changelog
                    Log::create(
                        [
                            "user_id"   => auth()->id(), // THIS ERROR
                            "entity"    => self::class,
                            ...
                        ]
                    );

                }
            }
        );
    }
}
```
In this task, we record that who made changes to a particular model.
As you can see, we have now received an implicit error. The search for which can take a very long time.

I agree that this behavior is normal for Laravel Framework. But this is very difficult to explain to an inexperienced developer. In my opinion, this could be a security and failover hole. I think this fix will help avoid a lot of bugs.