### PR TITLE
[9.x] Adds `Route::blockTooEarly()` for simple error response

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1154,6 +1154,19 @@ class Route
     }
 
     /**
+     * Alias for `block($lockSeconds, $waitSeconds, true)`
+     *
+     * @param  int|null  $lockSeconds
+     * @param  int|null  $waitSeconds
+     * @return $this
+     */
+    public function blockTooEarly($lockSeconds = 10, $waitSeconds = 10)
+    {
+
+        return $this->block($lockSeconds, $waitSeconds, true);
+    }
+
+    /**
      * Specify that the route should allow concurrent requests from the same session.
      *
      * @return $this

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1162,7 +1162,6 @@ class Route
      */
     public function blockTooEarly($lockSeconds = 10, $waitSeconds = 10)
     {
-
         return $this->block($lockSeconds, $waitSeconds, true);
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -115,6 +115,13 @@ class Route
     protected $waitSeconds;
 
     /**
+     * Indicates to throw HttpException(429, 'Too Early') instead of LockTimeoutException
+     *
+     * @var bool
+     */
+    protected $dontReport;
+
+    /**
      * The computed gathered middleware.
      *
      * @var array|null
@@ -1134,12 +1141,14 @@ class Route
      *
      * @param  int|null  $lockSeconds
      * @param  int|null  $waitSeconds
+     * @param  bool  $dontReport
      * @return $this
      */
-    public function block($lockSeconds = 10, $waitSeconds = 10)
+    public function block($lockSeconds = 10, $waitSeconds = 10, $dontReport = false)
     {
         $this->lockSeconds = $lockSeconds;
         $this->waitSeconds = $waitSeconds;
+        $this->dontReport = $dontReport;
 
         return $this;
     }
@@ -1172,6 +1181,16 @@ class Route
     public function waitsFor()
     {
         return $this->waitSeconds;
+    }
+
+    /**
+     * Get the exception that should be thrown when a lock is not acquired.
+     *
+     * @return bool
+     */
+    public function dontReport()
+    {
+        return $this->dontReport;
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -115,7 +115,7 @@ class Route
     protected $waitSeconds;
 
     /**
-     * Indicates to throw HttpException(429, 'Too Early') instead of LockTimeoutException
+     * Indicates to throw HttpException(429, 'Too Early') instead of LockTimeoutException.
      *
      * @var bool
      */
@@ -1154,7 +1154,7 @@ class Route
     }
 
     /**
-     * Alias for `block($lockSeconds, $waitSeconds, true)`
+     * Alias for `block($lockSeconds, $waitSeconds, true)`.
      *
      * @param  int|null  $lockSeconds
      * @param  int|null  $waitSeconds

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -96,9 +96,9 @@ class StartSession
             );
 
             return $this->handleStatefulRequest($request, $session, $next);
-        } catch(LockTimeoutException) {
+        } catch(LockTimeoutException $e) {
 
-            throw new HttpException(425, 'Too Early');
+            throw ($request->route()->dontReport() ? new HttpException(425, 'Too Early') : $e);
         } finally {
             $lock?->release();
         }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session\Middleware;
 
 use Closure;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
@@ -11,6 +12,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class StartSession
 {
@@ -94,6 +96,9 @@ class StartSession
             );
 
             return $this->handleStatefulRequest($request, $session, $next);
+        } catch(LockTimeoutException) {
+
+            throw new HttpException(425, 'Too Early');
         } finally {
             $lock?->release();
         }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -96,8 +96,7 @@ class StartSession
             );
 
             return $this->handleStatefulRequest($request, $session, $next);
-        } catch(LockTimeoutException $e) {
-
+        } catch (LockTimeoutException $e) {
             throw ($request->route()->dontReport() ? new HttpException(425, 'Too Early') : $e);
         } finally {
             $lock?->release();


### PR DESCRIPTION
This PR introduce an easy way to handle the exception in `Route::block()`.

We know that the `Route::block()` throws `\Illuminate\Contracts\Cache\LockTimeoutException` yet we cannot simple catch it.

```php
use Illuminate\Contracts\Cache\LockTimeoutException;
use Illuminate\Support\Facades\Route;

try {

    Route::post('/payment/send', SendPayment::class)->block();
} catch (LockTimeoutException){
    abort(425, 'Too Early');
}
```

Currently you need to extend the service provider for `\Illuminate\Session\Middleware\StartSession` to handle the `\Illuminate\Contracts\Cache\LockTimeoutException` exception.

**Route**
```php
use Illuminate\Support\Facades\Route;

Route::post('/payment/send', SendPayment::class)->block();
```

**Middleware**
```php
use Illuminate\Contracts\Cache\LockTimeoutException;
use Illuminate\Http\Request;
use Symfony\Component\HttpKernel\Exception\HttpException;

class StartSession extends \Illuminate\Session\Middleware\StartSession
{
    protected function handleRequestWhileBlocking(Request $request, $session, \Closure $next)
    {
        try {
            return parent::handleRequestWhileBlocking($request, $session, $next);
        } catch (LockTimeoutException) {

            throw new HttpException(425, 'Too Early');
        }
    }
}
```

**Service provider**
```php
use App\Http\Middleware\Laravel\StartSession as LaravelStartSession;
use Illuminate\Contracts\Cache\Factory;
use Illuminate\Session\Middleware\StartSession;
use Illuminate\Session\SessionManager;

class SessionServiceProvider extends \Illuminate\Session\SessionServiceProvider
{
    public function register()
    {
        $this->registerSessionManager();

        $this->registerSessionDriver();

        $this->app->singleton(StartSession::class, function ($app) {
            return new LaravelStartSession($app->make(SessionManager::class), function () use ($app) {
                return $app->make(Factory::class);
            });
        });
    }
}
```

This makes it hard as a new laravel developer.

To make things easier, we introduce this merge to simplify the process.

**Route**
```php
use Illuminate\Support\Facades\Route;

Route::post('/payment/send', SendPayment::class)->blockTooEarly();

// Alias for
Route::post('/payment/send', SendPayment::class)->block(doNotReport: true);
```