### PR TITLE
Overriding console command constructor is bad practice 

### DIFF
--- a/src/Illuminate/Console/ProtectedCommand.php
+++ b/src/Illuminate/Console/ProtectedCommand.php
@@ -4,14 +4,13 @@ namespace Illuminate\Console;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class ProtectedCommand
- * @package Illuminate\Console
- */
 class ProtectedCommand extends Command
 {
     /**
+     * Create a new console command instance.
      * Not used for protected command
+     *
+     * @return void
      */
     final public function __construct()
     {
@@ -19,11 +18,14 @@ class ProtectedCommand extends Command
     }
 
     /**
+     * Execute the console command.
      * Not used for protected command
+     *
+     * @return int
      */
     final public function handle()
     {
-        // Not implement handle() method.
+        return 0;
     }
 
     /**
@@ -36,6 +38,7 @@ class ProtectedCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (method_exists($this, '__invoke')) {
+            
             return (int) $this->laravel->call([$this, '__invoke']);
         }
 

--- a/src/Illuminate/Console/ProtectedCommand.php
+++ b/src/Illuminate/Console/ProtectedCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Console;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class ProtectedCommand
+ * @package Illuminate\Console
+ */
+class ProtectedCommand extends Command
+{
+    /**
+     * Not used for protected command
+     */
+    final public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Not used for protected command
+     */
+    final public function handle()
+    {
+        // Not implement handle() method.
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (method_exists($this, '__invoke')) {
+            return (int) $this->laravel->call([$this, '__invoke']);
+        }
+
+        return 1;
+    }
+}

--- a/src/Illuminate/Console/ProtectedCommand.php
+++ b/src/Illuminate/Console/ProtectedCommand.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Console;
+
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -8,7 +9,7 @@ class ProtectedCommand extends Command
 {
     /**
      * Create a new console command instance.
-     * Not used for protected command
+     * Not used for protected command.
      *
      * @return void
      */
@@ -19,7 +20,7 @@ class ProtectedCommand extends Command
 
     /**
      * Execute the console command.
-     * Not used for protected command
+     * Not used for protected command.
      *
      * @return int
      */
@@ -38,7 +39,6 @@ class ProtectedCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (method_exists($this, '__invoke')) {
-            
             return (int) $this->laravel->call([$this, '__invoke']);
         }
 

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -28,7 +28,7 @@ class ConsoleMakeCommand extends GeneratorCommand
      * @deprecated
      */
     protected static $defaultName = 'make:command';
-    
+
     /**
      * The console command description.
      *

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
+#[AsCommand(name: 'make:command')]
 class ConsoleMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -68,6 +68,10 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         $relativePath = '/stubs/console.stub';
 
+        if ($this->confirm('Do you want to create a protected command?')) {
+            $relativePath = '/stubs/console-protected.stub';
+        }
+        
         return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
             ? $customPath
             : __DIR__.$relativePath;

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -4,11 +4,9 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:command')]
 class ConsoleMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;
@@ -19,17 +17,6 @@ class ConsoleMakeCommand extends GeneratorCommand
      * @var string
      */
     protected $name = 'make:command';
-
-    /**
-     * The name of the console command.
-     *
-     * This name is used to identify the command during lazy loading.
-     *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected static $defaultName = 'make:command';
 
     /**
      * The console command description.
@@ -71,7 +58,7 @@ class ConsoleMakeCommand extends GeneratorCommand
         if ($this->confirm('Do you want to create a protected command?')) {
             $relativePath = '/stubs/console-protected.stub';
         }
-        
+
         return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
             ? $customPath
             : __DIR__.$relativePath;

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -19,6 +19,17 @@ class ConsoleMakeCommand extends GeneratorCommand
     protected $name = 'make:command';
 
     /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'make:command';
+    
+    /**
      * The console command description.
      *
      * @var string

--- a/src/Illuminate/Foundation/Console/stubs/console-protected.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console-protected.stub
@@ -6,7 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ProtectedCommand;
 
 /**
-* Use __invoke method
+* Use "__invoke()" method
+* Inject dependencies "__invoke(Application $application)"
 *
 * This console command is protected.
 * To make the current command unprotected change extend class to "Command"

--- a/src/Illuminate/Foundation/Console/stubs/console-protected.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console-protected.stub
@@ -1,0 +1,42 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ProtectedCommand;
+
+/**
+* Use __invoke method
+*
+* This console command is protected.
+* To make the current command unprotected change extend class to "Command"
+*
+* Example: class {{ class }} extends Command {}
+* @see Command
+*/
+class {{ class }} extends ProtectedCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = '{{ command }}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function __invoke()
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
My solution will protect developers from implicit code invocation!

To initialize the console command class, it would be more correct to initialize it in the "_handle_" method. Overriding a constructor can be a big hassle. This can be seen on large applications.

# Causes:
1) Not everyone who uses frameworks is a good programmer.
2) Code execution occurs that was not intended.
3) Throwing Implicit Errors
4) Execute code snippets only when needed.

# Examples:
* ## Example 1
```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;

class TestCommand extends Command
{
    protected $signature   = 'test_command';

    protected $description = 'Error example';

    // Is bad practic
    public function __construct()
    {
        parent::__construct();
        dd("This code is always executed");
    }

    public function handle(): void
    {
        // TODO logic
    }
}
```
#### If you run any command
```bash 
php artisan | php arisan cache:clear | php artisan queue:work | etc. 
```
##### In console output
```bash
"This code is always executed"
```
#### "Worker log" or "Horizon log" or "Supervisor log"
```bash 
"This code is always executed"
```
#### If you run cron, this task will run many times (/var/log/syslog)
```bash 
"This code is always executed"
```
In this example, we see that the code in the constructor is executed many times and everywhere. It would be nice if this was done upon request. When it is necessary. This example shows that it is very easy to get confused. On the one hand, the initialization of the class is described in the constructor. On the other hand, we get a time bomb.

* ## Example 2
TestCommand.php
```php
<?php

namespace App\Console\Commands;

use App\Models\User;
use Illuminate\Console\Command;
use Illuminate\Support\Collection;
use Illuminate\Support\Facades\Event;

/**
 * The task is to check who has not paid for a subscription for a long time
 * @package App\Console\Commands
 */
class TestCommand extends Command
{
    protected $signature   = 'test_command';

    protected $description = 'Error example';

    /**
     * @var Collection<User>
     *
     *     User |- <int>    id
     *          |- <string> name
     *          |- <bool>   paid
     *          |- <Carbon> paid_at
     *          |- <int>    tariff_id -> relation
     *          <etc...>
     *
     *     User relations
     *              hasOne Tariff
     */
    protected Collection $user;

    public function __construct()
    {
        parent::__construct();
        // class variable initialization : return collect 10000+ items.
        $this->user = User::with('tariff')
            ->where('id', '>', now()->addMonths(-5))
            ->get();


    }

    /**
     * This logic is just a demonstration.
     * The task is to compare and update the model.
     * According to the task, we have to iterate over the users
     */
    public function handle(): void
    {
        // Loop (model iteration) 10000+ items
        $this->user->each(
            function (User $user) {
                // Any comparison
                $user->paid = $user->tariff->value == 'VALUE';
                $user->save();
            }
        );
    }
}

```
EventServiceProvider.php
```php
<?php

namespace App\Providers;

use Illuminate\Auth\Events\Registered;
use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
use Illuminate\Support\Facades\Event;

class EventServiceProvider extends ServiceProvider
{
    /**
     * The event listener mappings for the application.
     *
     * @var array<class-string, array<int, class-string>>
     */
    protected $listen = [
        Registered::class => [
            SendEmailVerificationNotification::class,
        ],
    ];

    /**
     * Register any events for your application.
     *
     * @return void
     */
    public function boot()
    {
        // Register event ( ONLY FOR TEST )
        Event::listen("*", function(...$params) {
            dump($params[0]);
        });
    }
}
```

As you can see, we have created a console command and registered an event listener in the EventServiceProvider.
In the EventServiceProvider::boot method, we registered a listener just so we can monitor how the application is running. We are only interested in the name of the event.

#### If you run any command
```bash 
php artisan | php arisan cache:clear | php artisan queue:work | etc. 
```
##### In console output
```bash
"bootstrapped: Illuminate\Foundation\Bootstrap\BootProviders"
"Illuminate\Console\Events\ArtisanStarting"
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandFinished"
"Illuminate\Console\Events\CommandFinished"
```
#### "Worker log" or "Horizon log" or "Supervisor log"
```bash 
"bootstrapped: Illuminate\Foundation\Bootstrap\BootProviders"
"Illuminate\Console\Events\ArtisanStarting"
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandFinished"
"Illuminate\Console\Events\CommandFinished"
```
#### If you run cron, this task will run many times (/var/log/syslog)
```bash 
"bootstrapped: Illuminate\Foundation\Bootstrap\BootProviders"
"Illuminate\Console\Events\ArtisanStarting"
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booting: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "eloquent.booted: App\Models\User" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\StatementPrepared" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
# "Illuminate\Database\Events\QueryExecuted" <= I don't think it's good.
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandStarting"
"Illuminate\Console\Events\CommandFinished"
"Illuminate\Console\Events\CommandFinished"
```

As you can see, we have created a load that we did not expect. In all practices, variables are initialized in the class constructor. But this place is so unique.
I understand why this is happening. The Illuminate\Foundation\Console\Kernel::load() function is called in the App\Console\Kernel::commands() method.
```php
    /**
     * Register the commands for the application.
     *
     * @return void
     */
    protected function commands(): void
    {
        $this->load(__DIR__.'/Commands'); // <= THIS

        require base_path('routes/console.php');
    }
```
After running the $this->laravel->make($command) function, the constructor will be called
```php
    protected function parseCommand($command, $parameters)
    {
        ...
        $command = $this->laravel->make($command)->getName(); // <= THIS
        ...
    }
    public function resolve($command)
    {
        return $this->add($this->laravel->make($command)); // <= OR THIS
    }
```
This is how all commands are initialized
I consider this a good reason to fix

* ## Example 3
TestCommand.php
```php
class TestCommand extends Command
{
    protected $signature   = 'test_command';

    protected $description = 'Error example';

    public function __construct()
    {
        parent::__construct();
        // I was in a hurry and forgot to remove
        // I needed this for testing or for development
        Auth::loginUsingId(1);
        // From now on, the whole application thinks that the user with id 1 is authorized
    }

    public function handle(): void
    {
        // The task requires it
        User::find(99)->update([ "paid_at" => now() ]);
    }
}
```
User.php
```php
<?php

namespace App\Models;

use Illuminate\Contracts\Auth\MustVerifyEmail;
use Illuminate\Database\Eloquent\Factories\HasFactory;
use Illuminate\Foundation\Auth\User as Authenticatable;
use Illuminate\Notifications\Notifiable;

class User extends Authenticatable
{
    use HasFactory;
    use Notifiable;

    public function __construct(array $attributes = [])
    {
        parent::__construct($attributes);
    }

    /**
     * The attributes that are mass assignable.
     *
     * @var array<int, string>
     */
    protected $fillable = [
        'name',
        'email',
        'password',
    ];

    /**
     * The attributes that should be hidden for serialization.
     *
     * @var array<int, string>
     */
    protected $hidden = [
        'password',
        'remember_token',
    ];

    /**
     * The attributes that should be cast.
     *
     * @var array<string, string>
     */
    protected $casts = [
        'email_verified_at' => 'datetime',
    ];

    protected static function boot()
    {
        parent::boot();

        // Or register Observer [ .env QUEUE_CONNECTION=sync ]
        static::updating(
            function (User $user) {

                // Let's pretend I'm using a helper "auth"
                if (auth()->check() /* TRUE */) {

                    // Log::class - changelog
                    Log::create(
                        [
                            "user_id"   => auth()->id(), // THIS ERROR
                            "entity"    => self::class,
                            ...
                        ]
                    );

                }
            }
        );
    }
}
```
In this task, we record that who made changes to a particular model.
As you can see, we have now received an implicit error. The search for which can take a very long time.

I agree that this behavior is normal for Laravel Framework. But this is very difficult to explain to an inexperienced developer. In my opinion, this could be a security and failover hole. I think this fix will help avoid a lot of bugs.

-------------
How to use?
1) Run in console
```bash
php artisan make:command NameYouCommand
```
2) Read confirm
```bash
Do you want to create a protected command? (yes/no) [no]:
```
3) Write yes for create Protected command
4) Use new protected console command

New protected console command
```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Illuminate\Console\ProtectedCommand;

/**
* Use "__invoke()" method
* Inject dependencies "__invoke(Application $application)"
*
* This console command is protected.
* To make the current command unprotected change extend class to "Command"
*
* Example: class TestCommand  extends Command {}
* @see Command
*/
class TestCommand extends ProtectedCommand
{
    /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'test_comand';

    /**
     * The console command description.
     *
     * @var string
     */
    protected $description = 'Command without __construct()';

    /**
     * Execute the console command.
     *
     * @return int
     */
    public function __invoke()
    {
        return 0;
    }
}
```