### PR TITLE
[9.x] Add IgnoringCase variants for assertSee functions

### DIFF
--- a/src/Illuminate/Testing/Constraints/SeeInOrder.php
+++ b/src/Illuminate/Testing/Constraints/SeeInOrder.php
@@ -15,6 +15,13 @@ class SeeInOrder extends Constraint
     protected $content;
 
     /**
+     * Whether the comparison is case-sensitive
+     *
+     * @var bool
+     */
+    protected $caseSensitive;
+
+    /**
      * The last value that failed to pass validation.
      *
      * @var string
@@ -27,9 +34,10 @@ class SeeInOrder extends Constraint
      * @param  string  $content
      * @return void
      */
-    public function __construct($content)
+    public function __construct($content, $caseSensitive = true)
     {
         $this->content = $content;
+        $this->caseSensitive = $caseSensitive;
     }
 
     /**
@@ -47,7 +55,9 @@ class SeeInOrder extends Constraint
                 continue;
             }
 
-            $valuePosition = mb_strpos($this->content, $value, $position);
+            $valuePosition = $this->caseSensitive ?
+                mb_strpos($this->content, $value, $position) :
+                mb_stripos($this->content, $value, $position);
 
             if ($valuePosition === false || $valuePosition < $position) {
                 $this->failedValue = $value;

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -610,6 +610,23 @@ EOF;
     }
 
     /**
+     * Assert that the given string or array of strings are contained within the response, ignoring the case of the given strings.
+     *
+     * @param string|array $value
+     * @return $this
+     */
+    public function assertSeeIgnoringCase($value)
+    {
+        $values = Arr::wrap($value);
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringContainsStringIgnoringCase((string) $value, $this->getContent());
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the given strings are contained in order within the response.
      *
      * @param  array  $values
@@ -621,6 +638,20 @@ EOF;
         $values = $escape ? array_map('e', ($values)) : $values;
 
         PHPUnit::assertThat($values, new SeeInOrder($this->getContent()));
+
+        return $this;
+    }
+
+    /**
+     *  Assert that the given strings are contained in order within the response, ignoring the case
+     *
+     * @param array $values
+     * @return $this
+     */
+    public function assertSeeInOrderIgnoringCase(array $values)
+    {
+
+        PHPUnit::assertThat($values, new SeeInOrder($this->getContent(), caseSensitive: false));
 
         return $this;
     }
@@ -648,6 +679,27 @@ EOF;
     }
 
     /**
+     * Assert that the given string or array of strings are contained within the response text, ignoring the case.
+     *
+     * @param $value
+     * @return $this
+     */
+    public function assertSeeTextIgnoringCase($value)
+    {
+
+        $values = Arr::wrap($value);
+
+        tap(strip_tags($this->getContent()), function ($content) use ($values) {
+            foreach ($values as $value) {
+                PHPUnit::assertStringContainsStringIgnoringCase((string) $value, $content);
+            }
+        });
+
+        return $this;
+
+    }
+
+    /**
      * Assert that the given strings are contained in order within the response text.
      *
      * @param  array  $values
@@ -659,6 +711,20 @@ EOF;
         $values = $escape ? array_map('e', ($values)) : $values;
 
         PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->getContent())));
+
+        return $this;
+    }
+
+
+    /**
+     * Assert that the given strings are contained in order within the response text, ignoring the case.
+     *
+     * @param  array  $values
+     * @return $this
+     */
+    public function assertSeeTextInOrderIgnoringCase(array $values)
+    {
+        PHPUnit::assertThat($values, new SeeInOrder(strip_tags($this->getContent()), caseSensitive: false));
 
         return $this;
     }
@@ -684,6 +750,23 @@ EOF;
     }
 
     /**
+     * Assert that the given string or array of strings are not contained within the response, ignoring the case.
+     *
+     * @param  string|array  $value
+     * @return $this
+     */
+    public function assertDontSeeIgnoringCase($value)
+    {
+        $values = Arr::wrap($value);
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringNotContainsStringIgnoringCase((string) $value, $this->getContent());
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the given string or array of strings are not contained within the response text.
      *
      * @param  string|array  $value
@@ -699,6 +782,25 @@ EOF;
         tap(strip_tags($this->getContent()), function ($content) use ($values) {
             foreach ($values as $value) {
                 PHPUnit::assertStringNotContainsString((string) $value, $content);
+            }
+        });
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given string or array of strings are not contained within the response text, ignoring the case.
+     *
+     * @param  string|array  $value
+     * @return $this
+     */
+    public function assertDontSeeTextIgnoringCase($value)
+    {
+        $values = Arr::wrap($value);
+
+        tap(strip_tags($this->getContent()), function ($content) use ($values) {
+            foreach ($values as $value) {
+                PHPUnit::assertStringNotContainsStringIgnoringCase((string) $value, $content);
             }
         });
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -255,6 +255,29 @@ class TestResponseTest extends TestCase
         $response->assertSee(['bar & baz', 'baz & qux']);
     }
 
+    public function testAssertSeeIgnoringCase()
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>Foo</li><li>bar</li><li>Baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeIgnoringCase('foo');
+        $response->assertSeeIgnoringCase(['baz', 'bar']);
+    }
+
+    public function testAssertSeeIgnoringCaseCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeIgnoringCase('Item');
+        $response->assertSeeIgnoringCase(['Not', 'found']);
+    }
+
+
     public function testAssertSeeInOrder()
     {
         $response = $this->makeMockResponse([
@@ -286,6 +309,38 @@ class TestResponseTest extends TestCase
         ]);
 
         $response->assertSeeInOrder(['foo', 'qux', 'bar', 'baz']);
+    }
+
+    public function testAssertSeeInOrderIgnoringCase()
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>Bar</li><li>Baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeInOrderIgnoringCase(['foo', 'bar', 'baz']);
+        $response->assertSeeInOrderIgnoringCase(['foo', 'bar', 'Baz', 'Foo']);
+    }
+
+    public function testAssertSeeInOrderIgnoringCaseCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeInOrderIgnoringCase(['baz', 'bar', 'foo']);
+    }
+
+    public function testAssertSeeInOrderIgnoringCaseCanFail2()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertSeeInOrderIgnoringCase(['foo', 'qux', 'bar', 'baz']);
     }
 
     public function testAssertSeeText()
@@ -332,6 +387,28 @@ class TestResponseTest extends TestCase
         $response->assertSeeText(['foo & bar', 'bar & baz']);
     }
 
+    public function testAssertSeeTextIgnoringCase()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>baz<strong>qUx</strong>',
+        ]);
+
+        $response->assertSeeTextIgnoringCase('fooBar');
+        $response->assertSeeTextIgnoringCase(['bazQux', 'foobar']);
+    }
+
+    public function testAssertSeeTextIgnoringCaseCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>',
+        ]);
+
+        $response->assertSeeTextIgnoringCase('baZfoo');
+        $response->assertSeeTextIgnoringCase(['bazfoo', 'barqux']);
+    }
+
     public function testAssertSeeTextInOrder()
     {
         $response = $this->makeMockResponse([
@@ -372,6 +449,39 @@ class TestResponseTest extends TestCase
         ]);
 
         $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
+    }
+
+    public function testAssertSeeTextInOrderIgnoringCase()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong> baz <strong>foO</strong>',
+        ]);
+
+        $response->assertSeeTextInOrderIgnoringCase(['Foobar', 'baZ']);
+
+        $response->assertSeeTextInOrderIgnoringCase(['foObar', 'baZ', 'foo']);
+    }
+
+    public function testAssertSeeTextInOrderIgnoringCaseCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong> baz <strong>foo</strong>',
+        ]);
+
+        $response->assertSeeTextInOrderIgnoringCase(['baz', 'foobar']);
+    }
+
+    public function testAssertSeeTextInOrderIgnoringCaseCanFail2()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>baR</strong> baz <strong>foo</strong>',
+        ]);
+
+        $response->assertSeeTextInOrderIgnoringCase(['foobar', 'qux', 'baz']);
     }
 
     public function testAssertDontSee()
@@ -418,6 +528,28 @@ class TestResponseTest extends TestCase
         $response->assertDontSee(['php & friends', 'laravel & php']);
     }
 
+    public function testAssertDontSeeIgnoringCase()
+    {
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertDontSeeIgnoringCase('laravel');
+        $response->assertDontSeeIgnoringCase(['php', 'friends']);
+    }
+
+    public function testAssertDontSeeCanFailIgnoringCase()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => '<ul><li>foo</li><li>bar</li><li>baz</li><li>foo</li></ul>',
+        ]);
+
+        $response->assertDontSeeIgnoringCase('Foo');
+        $response->assertDontSeeIgnoringCase(['baz', 'Bar']);
+    }
+
     public function testAssertDontSeeText()
     {
         $response = $this->makeMockResponse([
@@ -460,6 +592,28 @@ class TestResponseTest extends TestCase
 
         $response->assertDontSeeText('laravel & php');
         $response->assertDontSeeText(['php & friends', 'laravel & php']);
+    }
+
+    public function testAssertDontSeeTextIgnoringCase()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>baz<strong>qux</strong>',
+        ]);
+
+        $response->assertDontSeeTextIgnoringCase('laravelphp');
+        $response->assertDontSeeTextIgnoringCase(['phpfriends', 'laravelphp']);
+    }
+
+    public function testAssertDontSeeTextIgnoringCaseCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>baz<strong>qux</strong>',
+        ]);
+
+        $response->assertDontSeeTextIgnoringCase('foobaR');
+        $response->assertDontSeeTextIgnoringCase(['bazQux', 'Foobar']);
     }
 
     public function testAssertOk()


### PR DESCRIPTION
The following variants are added to `TestResponse` class.

* `assertSee` -> `assertSeeIgnoringCase`
* `assertSeeInOrder` -> `assertSeeInOrderIgnoringCase`
* `assertSeeText` -> `assertSeeTextIgnoringCase`
* `assertSeeTextInOrder` -> `assertSeeTextInOrderIgnoringCase`
* `assertDontSee` -> `assertDontSeeIgnoringCase`
* `assertDontSeeText` -> `assertDontSeeTextIgnoringCase`

Under the hood, PHPUnit's [assertStringContainsStringIgnoringCase](https://phpunit.readthedocs.io/en/9.5/assertions.html#assertstringcontainsstringignoringcase) function and [mb_stripos](https://www.php.net/manual/en/function.mb-stripos.php) are used.

### Why?

I first noticed this is a handy feature to have while testing error messages in HTTP responses. For example, if the error message is "Subdomain is already taken", I have to write one of these:

```php
$response->assertSee('Subdomain is already taken');
$response->assertSee(['Subdomain', 'taken']);
```

While I prefer the second one, it is still a hassle to write it in the same case as the response. If I ever had to change the error message to "The subdomain is already taken", I would have to change the test too because of the case sensitivity. So, the following way would be better.

```php
$response->assertSeeIgnoringCase(['subdomain', 'taken']);
```

## Decisions Made

* **Dropped the $escape param** - I have not used the `$escape` param in the new functions. The reason is that HTML escaped entities are case-sensitive. There is no point in doing a case-insensitive if you want to match escaped HTML entities. Therefore, the newly added functions do not escape the given strings.
* The `IgnoringCase` suffix was inspired by PHPUnit.

### Other discussions

* A feature request in Dusk: https://github.com/laravel/dusk/issues/217
* A discussion on forums: https://laracasts.com/discuss/channels/testing/assertsee-assertseein-case-sensitive

Finally, if this idea is to be accepted, I can add similar variants to other classes that have `->assertSee` functions (Mailable, View, etc).