### PR TITLE
[9.x]  Add method to make instance of Illuminate\Http\Request for testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -666,4 +666,31 @@ trait MakesHttpRequests
             );
         });
     }
+
+    /**
+     * Create the request instance.
+     *
+     * @param  string  $uri  The URI
+     * @param  string  $method  The HTTP method
+     * @param  array  $parameters  The query (GET) or request (POST) parameters
+     * @param  array  $cookies  The request cookies ($_COOKIE)
+     * @param  array  $files  The request files ($_FILES)
+     * @param  array  $server  The server parameters ($_SERVER)
+     * @param  string|resource|null  $content  The raw body data
+     * @return Illuminate\Http\Request
+     */
+    protected function createRequest(string $uri, string $method = 'GET', array $parameters = [], array $cookies = [], array $files = [], array $server = [], $content = null): Request
+    {
+        $symfonyRequest = SymfonyRequest::create(
+            $uri,
+            $method,
+            $parameters,
+            $cookies,
+            $files,
+            $server,
+            $content
+        );
+
+        return Request::createFromBase($symfonyRequest);
+    }
 }


### PR DESCRIPTION
Sometimes maybe you should pass instance of request to test any class such as middleware. This PR adds a method for make instance of  `Illuminate\Http\Request` to inject any class.

**Before This PR** : 

```
$middleware = app(UserBannedMiddleware::class);

$request = Request::createFromBase(SymfonyRequest::create(
            '/panel',
            'GET',
        ));

$response = $middleware->handle(
            $request,
            fn () => new Response()
);
```

**After this PR**

```
$middleware = app(UserBannedMiddleware::class);

  $response = $middleware->handle(
            $this->createRequest('/panel', 'GET'),
            fn () => new Response()
);
```


**Method signature :**

```
createRequest(string $uri, string $method = 'GET', array $parameters = [], array $cookies = [], array $files = [], array $server = [], $content = null): Request
```