### PR TITLE
[8.x] Replace duplicate AssertableJson test with new one

### DIFF
--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -362,17 +362,22 @@ class AssertTest extends TestCase
     public function testAssertWhereMatchesValueUsingArrayableWhenSortedDifferently()
     {
         $assert = AssertableJson::fromArray([
-            'bar' => [
-                'baz' => 'foo',
-                'example' => 'value',
+            'data' => [
+                'status' => 200,
+                'user' => [
+                    'id' => 1,
+                    'name' => 'Taylor',
+                ],
             ],
         ]);
 
-        $assert->where('bar', function ($value) {
-            $this->assertInstanceOf(Collection::class, $value);
-
-            return $value->count() === 2;
-        });
+        $assert->where('data', [
+            'user' => [
+                'name' => 'Taylor',
+                'id' => 1,
+            ],
+            'status' => 200,
+        ]);
     }
 
     public function testAssertWhereFailsWhenDoesNotMatchValueUsingArrayable()


### PR DESCRIPTION
Currently ``testAssertWhereMatchesValueUsingArrayableWhenSortedDifferently`` is same as this one:

https://github.com/laravel/framework/blob/c73253e51a3365a93eed0fb745f51771b89aa53c/tests/Testing/Fluent/AssertTest.php#L335-L349

As test name indicates, ``where`` should compare equality of array even if keys are sorted differently. 