### PR TITLE
Enforce complete Deferrable ServiceProviders

### DIFF
--- a/src/Illuminate/Support/AggregateServiceProvider.php
+++ b/src/Illuminate/Support/AggregateServiceProvider.php
@@ -43,8 +43,9 @@ class AggregateServiceProvider extends ServiceProvider
 
         foreach ($this->providers as $provider) {
             $instance = $this->app->resolveProvider($provider);
-
-            $provides = array_merge($provides, $instance->provides());
+            if ($instance->isDeferred()) {
+                $provides = array_merge($provides, $instance->provides());
+            }
         }
 
         return $provides;

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -388,16 +388,6 @@ abstract class ServiceProvider
     }
 
     /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return [];
-    }
-
-    /**
      * Get the events that trigger this service provider to register.
      *
      * @return array

--- a/src/Illuminate/Testing/ParallelTestingServiceProvider.php
+++ b/src/Illuminate/Testing/ParallelTestingServiceProvider.php
@@ -35,4 +35,14 @@ class ParallelTestingServiceProvider extends ServiceProvider implements Deferrab
             });
         }
     }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [];
+    }
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -591,7 +591,7 @@ class InterfaceToImplementationDeferredServiceProvider extends ServiceProvider i
     public function provides()
     {
         return [
-            SampleInterface::class
+            SampleInterface::class,
         ];
     }
 }
@@ -648,7 +648,7 @@ class ApplicationMultiProviderStub extends ServiceProvider implements Deferrable
     {
         return [
             'foo',
-            'bar'
+            'bar',
         ];
     }
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -520,7 +520,7 @@ class ApplicationDeferredSharedServiceProviderStub extends ServiceProvider imple
     public function provides()
     {
         return [
-            'foo'
+            'foo',
         ];
     }
 }
@@ -538,7 +538,7 @@ class ApplicationDeferredServiceProviderCountStub extends ServiceProvider implem
     public function provides()
     {
         return [
-            'foo'
+            'foo',
         ];
     }
 }
@@ -556,7 +556,7 @@ class ApplicationDeferredServiceProviderStub extends ServiceProvider implements 
     public function provides()
     {
         return [
-            'foo'
+            'foo',
         ];
     }
 }
@@ -608,7 +608,7 @@ class SampleImplementationDeferredServiceProvider extends ServiceProvider implem
     public function provides()
     {
         return [
-            '$primitive'
+            '$primitive',
         ];
     }
 }
@@ -627,7 +627,7 @@ class ApplicationFactoryProviderStub extends ServiceProvider implements Deferrab
     public function provides()
     {
         return [
-            'foo'
+            'foo',
         ];
     }
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -516,6 +516,13 @@ class ApplicationDeferredSharedServiceProviderStub extends ServiceProvider imple
             return new stdClass;
         });
     }
+
+    public function provides()
+    {
+        return [
+            'foo'
+        ];
+    }
 }
 
 class ApplicationDeferredServiceProviderCountStub extends ServiceProvider implements DeferrableProvider
@@ -527,6 +534,13 @@ class ApplicationDeferredServiceProviderCountStub extends ServiceProvider implem
         static::$count++;
         $this->app['foo'] = new stdClass;
     }
+
+    public function provides()
+    {
+        return [
+            'foo'
+        ];
+    }
 }
 
 class ApplicationDeferredServiceProviderStub extends ServiceProvider implements DeferrableProvider
@@ -537,6 +551,13 @@ class ApplicationDeferredServiceProviderStub extends ServiceProvider implements 
     {
         static::$initialized = true;
         $this->app['foo'] = 'foo';
+    }
+
+    public function provides()
+    {
+        return [
+            'foo'
+        ];
     }
 }
 
@@ -566,6 +587,13 @@ class InterfaceToImplementationDeferredServiceProvider extends ServiceProvider i
     {
         $this->app->bind(SampleInterface::class, SampleImplementation::class);
     }
+
+    public function provides()
+    {
+        return [
+            SampleInterface::class
+        ];
+    }
 }
 
 class SampleImplementationDeferredServiceProvider extends ServiceProvider implements DeferrableProvider
@@ -575,6 +603,13 @@ class SampleImplementationDeferredServiceProvider extends ServiceProvider implem
         $this->app->when(SampleImplementation::class)->needs('$primitive')->give(function () {
             return 'foo';
         });
+    }
+
+    public function provides()
+    {
+        return [
+            '$primitive'
+        ];
     }
 }
 
@@ -588,6 +623,13 @@ class ApplicationFactoryProviderStub extends ServiceProvider implements Deferrab
             return ++$count;
         });
     }
+
+    public function provides()
+    {
+        return [
+            'foo'
+        ];
+    }
 }
 
 class ApplicationMultiProviderStub extends ServiceProvider implements DeferrableProvider
@@ -600,6 +642,14 @@ class ApplicationMultiProviderStub extends ServiceProvider implements Deferrable
         $this->app->singleton('bar', function ($app) {
             return $app['foo'].'bar';
         });
+    }
+
+    public function provides()
+    {
+        return [
+            'foo',
+            'bar'
+        ];
     }
 }
 


### PR DESCRIPTION
In the DeferrableProvider interface, the 'provides' method is present. When implementing this interface, [the 'provides' method should be implemented](https://laravel.com/docs/9.x/providers#deferred-providers), otherwise the services in this provider are never available and are technically broken. 

The 'provides' method is also always defined on the abstract ServiceProvider, returning an empty array there. So when a serviceprovider implements the deferabbleProvider interface the presence of a 'provides' method is no longer enforced as it is already present in the parent class.

This PR moves the 'provides' method out of the abstract serviceprovider so Deferrable providers that don't implement the 'provides' method themselves are not silently broken anymore. 

As any existing serviceProvider that is deferrable without a 'provides' method now breaks (And is currently also broken but silently), this is a breaking change, hence the PR to master instead of 9.x.