### PR TITLE
[9.x] Use route parameters in view

### DIFF
--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -32,13 +32,18 @@ class ViewController extends Controller
      */
     public function __invoke(...$args)
     {
-        $parameters = array_filter($args, function ($key) {
+        $routeParameters = array_filter($args, function ($key) {
             return ! in_array($key, ['view', 'data', 'status', 'headers']);
         }, ARRAY_FILTER_USE_KEY);
 
-        $args['data'] = array_merge($args['data'], $parameters);
+        $args['data'] = array_merge($args['data'], $routeParameters);
 
-        return $this->response->view($args['view'], $args['data'], $args['status'], $args['headers']);
+        return $this->response->view(
+            $args['view'],
+            $args['data'],
+            $args['status'],
+            $args['headers']
+        );
     }
 
     /**

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -41,7 +41,7 @@ class ViewController extends Controller
         return $this->response->view($args['view'], $args['data'], $args['status'], $args['headers']);
     }
 
-     /**
+    /**
      * Execute an action on the controller.
      *
      * @param  string  $method

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -32,8 +32,24 @@ class ViewController extends Controller
      */
     public function __invoke(...$args)
     {
-        [$view, $data, $status, $headers] = array_slice($args, -4);
+        $parameters = array_filter($args, function ($key) {
+            return ! in_array($key, ['view', 'data', 'status', 'headers']);
+        }, ARRAY_FILTER_USE_KEY);
 
-        return $this->response->view($view, $data, $status, $headers);
+        $args['data'] = array_merge($args['data'], $parameters);
+
+        return $this->response->view($args['view'], $args['data'], $args['status'], $args['headers']);
+    }
+
+     /**
+     * Execute an action on the controller.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function callAction($method, $parameters)
+    {
+        return $this->{$method}(...$parameters);
     }
 }

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -26,6 +26,9 @@ class RouteViewTest extends TestCase
 
         $this->assertStringContainsString('Test bar', $this->get('/route/value1/value2')->getContent());
         $this->assertStringContainsString('Test bar', $this->get('/route/value1')->getContent());
+
+        $this->assertEquals('value1', $this->get('/route/value1/value2')->viewData('param'));
+        $this->assertEquals('value2', $this->get('/route/value1/value2')->viewData('param2'));
     }
 
     public function testRouteViewWithStatus()


### PR DESCRIPTION
```php
Route::view('route/{parameter}', 'view');
```

I expected `$parameter` to be available in the view.
There is also [a test](https://github.com/laravel/framework/blob/c73253e51a3365a93eed0fb745f51771b89aa53c/tests/Integration/Routing/RouteViewTest.php#L21) which makes it seem like it is the expected behavior.

This will actually throw an exception:

```
Undefined variable $parameter
```

This PR fixes this.

It takes all function parameters, removes the [default values](https://github.com/laravel/framework/blob/c73253e51a3365a93eed0fb745f51771b89aa53c/src/Illuminate/Routing/Router.php#L277-L286) and adds them to the view's data.