### PR TITLE
[9.x] Prevent double sanitized key in `RateLimiter@tooManyAttempts`

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -89,10 +89,8 @@ class RateLimiter
      */
     public function tooManyAttempts($key, $maxAttempts)
     {
-        $key = $this->cleanRateLimiterKey($key);
-
         if ($this->attempts($key) >= $maxAttempts) {
-            if ($this->cache->has($key.':timer')) {
+            if ($this->cache->has($this->cleanRateLimiterKey($key).':timer')) {
                 return true;
             }
 

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -140,11 +140,15 @@ class CacheRateLimiterTest extends TestCase
     public function testKeyIsSanitizedOnlyOnce()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->once()->with('john&#039;doe', 0)->andReturn(1);
-        $cache->shouldReceive('has')->once()->with('john&#039;doe:timer')->andReturn(true);
-        $cache->shouldReceive('add')->never();
         $rateLimiter = new RateLimiter($cache);
 
-        $this->assertTrue($rateLimiter->tooManyAttempts("john'doe", 1));
+        $key = "john'doe";
+        $cleanedKey = $rateLimiter->cleanRateLimiterKey($key);
+
+        $cache->shouldReceive('get')->once()->with($cleanedKey, 0)->andReturn(1);
+        $cache->shouldReceive('has')->once()->with("$cleanedKey:timer")->andReturn(true);
+        $cache->shouldReceive('add')->never();
+
+        $this->assertTrue($rateLimiter->tooManyAttempts($key, 1));
     }
 }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -136,4 +136,15 @@ class CacheRateLimiterTest extends TestCase
 
         $this->assertTrue($rateLimiter->tooManyAttempts('jôhn', 1));
     }
+
+    public function testKeyIsSanitizedOnlyOnce()
+    {
+        $cache = m::mock(Cache::class);
+        $cache->shouldReceive('get')->once()->with('john&#039;doe', 0)->andReturn(1);
+        $cache->shouldReceive('has')->once()->with('john&#039;doe:timer')->andReturn(true);
+        $cache->shouldReceive('add')->never();
+        $rateLimiter = new RateLimiter($cache);
+
+        $this->assertTrue($rateLimiter->tooManyAttempts("john'doe", 1));
+    }
 }


### PR DESCRIPTION
Issue with RateLimiter with key containing `'`. 

```php
// Key with apostrophe
$key = "john'doe";

$rateLimiter->hit($key);

$rateLimiter->tooManyAttempts($key, 1); // false 
```

Calling `$rateLimiter->hit($key)` with key like `john'doe`. Will use `$this->cleanRateLimiterKey($key)` inside `RateLimiter`, which is `john&#039;doe`.

Then `$rateLimiter->tooManyAttempts($key, 1)` was calling `$key = $this->cleanRateLimiterKey($key)` and then passing cleaned key to the `$rateLimiter->attempts($key)` which cleaned the key again and returned `johna#039;doe`.

So it was changing the key from `john&#039;doe` to `johna#039;doe`. `&` to `a`