### PR TITLE
Attribute cast to array of enum

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -820,6 +820,7 @@ trait HasAttributes
                 'set' => explode(',', $value),
                 'json' => $this->fromJson($value),
             };
+
             return array_map(function ($item) use ($caster, $castType) {
                 return $caster($castType, $item);
             }, $values);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1132,7 +1132,7 @@ trait HasAttributes
             $this->attributes[$key] = null;
         } else {
             if ($type) {
-                $values = array_map(function($item) use ($caster, $enumClass) {
+                $values = array_map(function ($item) use ($caster, $enumClass) {
                     return $caster($enumClass, $item);
                 }, (array) $value);
                 $this->attributes[$key] = match ($type) {
@@ -1550,7 +1550,7 @@ trait HasAttributes
             return false;
         }
 
-        list($castType) = explode(':', $this->getCasts()[$key]);
+        [$castType] = explode(':', $this->getCasts()[$key]);
 
         if (in_array($castType, static::$primitiveCastTypes)) {
             return false;


### PR DESCRIPTION
Count this PR as just an idea.

As Laravel supports Enum casting, it seems reasonable to add support for arrays with Enums.

This PR brings support of array with enum (e.g. `set` database column type) to Eloquent.

This PR implements syntax for `set` database column type:

```php
protected $casts = [
    'roles' => \App\Enums\RoleEnum::class . ':set',
];
```

And for `text` or `json` database column type:

```php
protected $casts = [
    'roles' => \App\Enums\RoleEnum::class . ':json',
];
```