### PR TITLE
[9.x] Added the "for" method to the Eloquent Builder and Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1434,8 +1434,8 @@ class Builder implements BuilderContract
     /**
      * Set the foreign key for a relationship to another model.
      *
-     * @param  Model  $model
-     * @param  string  $relationship
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string|null  $relationship
      * @return $this
      */
     public function for($model, $relationship = null)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -681,7 +681,7 @@ class Builder implements BuilderContract
      */
     public function get($columns = ['*'])
     {
-        $builder = $this->applyScopes();
+        $builder = $this->where($this->mergeForeignKeys([]))->applyScopes();
 
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded, which will solve the

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -537,7 +537,7 @@ class Builder implements BuilderContract
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (! is_null($instance = $this->where($this->mergeForeignKeys($attributes))->first())) {
             return $instance;
         }
 
@@ -553,7 +553,7 @@ class Builder implements BuilderContract
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (! is_null($instance = $this->where($this->mergeForeignKeys($attributes))->first())) {
             return $instance;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -681,7 +681,7 @@ class Builder implements BuilderContract
      */
     public function get($columns = ['*'])
     {
-        $builder = $this->where($this->mergeForeignKeys([]))->applyScopes();
+        $builder = $this->applyScopes();
 
         // If we actually found models we will also eager load any relationships that
         // have been specified as needing to be eager loaded, which will solve the

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1155,10 +1155,8 @@ class Builder implements BuilderContract
      */
     protected function mergeForeignKeys($attributes)
     {
-        if (count($this->for)) {
-            foreach ($this->for as $model) {
-                $attributes[$model['foreignKey']] = $model['model']->getKey();
-            }
+        foreach ($this->for as $model) {
+            $attributes[$model['foreignKey']] = $model['model']->getKey();
         }
 
         return $attributes;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1150,7 +1150,7 @@ class Builder implements BuilderContract
     /**
      * Merge the attributes that will be used in the query with the specific foreign keys.
      *
-     * @param array $attributes
+     * @param  array  $attributes
      * @return array
      */
     protected function mergeForeignKeys($attributes)
@@ -1436,8 +1436,8 @@ class Builder implements BuilderContract
     /**
      * Set the foreign key for a relationship to another model.
      *
-     * @param Model $model
-     * @param string $relationship
+     * @param  Model  $model
+     * @param  string  $relationship
      * @return $this
      */
     public function for($model, $relationship = null)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -456,7 +456,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Set the foreign key for a relationship to another model.
      *
-     * @param  Model  $model
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string|null  $relationship
      * @return $this
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -456,8 +456,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Set the foreign key for a relationship to another model.
      *
-     * @param Model $model
-     * @param string|null $relationship
+     * @param  Model  $model
+     * @param  string|null  $relationship
      * @return $this
      */
     public function forModel($model, $relationship = null)

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -236,7 +236,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (is_null($instance = $this->where($this->mergeForeignKeys($attributes))->first())) {
             $instance = $this->related->newInstance($this->mergeForeignKeys(array_merge($attributes, $values)));
 
             $this->setForeignAttributesForCreate($instance);
@@ -254,7 +254,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrCreate(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (is_null($instance = $this->where($this->mergeForeignKeys($attributes))->first())) {
             $instance = $this->create(array_merge($attributes, $values));
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -202,10 +202,8 @@ abstract class HasOneOrMany extends Relation
      */
     protected function mergeForeignKeys($attributes)
     {
-        if (count($this->for)) {
-            foreach ($this->for as $model) {
-                $attributes[$model['foreignKey']] = $model['model']->getKey();
-            }
+        foreach ($this->for as $model) {
+            $attributes[$model['foreignKey']] = $model['model']->getKey();
         }
 
         return $attributes;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -321,8 +321,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Set the foreign key for a relationship to another model.
      *
-     * @param  Model  $model
-     * @param  string  $relationship
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string|null  $relationship
      * @return $this
      */
     public function for($model, $relationship = null)

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -210,6 +210,17 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Execute the query as a "select" statement.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function get($columns = ['*'])
+    {
+        return $this->query->where($this->mergeForeignKeys([]))->get($columns);
+    }
+
+    /**
      * Find a model by its primary key or return a new instance of the related model.
      *
      * @param  mixed  $id

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -210,17 +210,6 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Execute the query as a "select" statement.
-     *
-     * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    public function get($columns = ['*'])
-    {
-        return $this->query->where($this->mergeForeignKeys([]))->get($columns);
-    }
-
-    /**
      * Find a model by its primary key or return a new instance of the related model.
      *
      * @param  mixed  $id

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -197,7 +197,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Merge the attributes that will be used in the query with the specific foreign keys.
      *
-     * @param array $attributes
+     * @param  array  $attributes
      * @return array
      */
     protected function mergeForeignKeys($attributes)
@@ -323,8 +323,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Set the foreign key for a relationship to another model.
      *
-     * @param Model $model
-     * @param string $relationship
+     * @param  Model  $model
+     * @param  string  $relationship
      * @return $this
      */
     public function for($model, $relationship = null)

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -523,7 +523,13 @@ class EloquentForTest extends DatabaseTestCase
 class User extends Model
 {
     public $table = 'users';
+
     protected $guarded = [];
+
+    protected $casts = [
+        'post_id' => 'integer',
+        'comment_id' => 'integer',
+    ];
 
     public function posts()
     {
@@ -539,6 +545,7 @@ class User extends Model
 class Post extends Model
 {
     public $table = 'posts';
+
     protected $guarded = [];
 
     public function comments()
@@ -552,6 +559,11 @@ class Comment extends Model
     use HasFactory;
 
     protected $guarded = [];
+
+    protected $casts = [
+        'post_id' => 'integer',
+        'user_id' => 'integer',
+    ];
 
     public function blogPost(): BelongsTo
     {

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -264,40 +264,6 @@ class EloquentForTest extends DatabaseTestCase
         $this->assertInstanceOf(Post::class, $comment->blogPost);
     }
 
-    public function testForCanBeUsedOnBuilderGet()
-    {
-        $user = User::create(['name' => 'My name']);
-        $anotherUser = User::create(['name' => 'Another user']);
-        $post = Post::create(['title' => 'My title']);
-
-        $existingCommentOne = Comment::create([
-            'user_id' => $user->id,
-            'post_id' => $post->id,
-            'content' => 'Hello',
-        ]);
-
-        $existingCommentTwo = Comment::create([
-            'user_id' => $user->id,
-            'post_id' => $post->id,
-            'content' => 'Hello',
-        ]);
-
-        // This belongs to a different user and shouldn't be included.
-        $anotherComment = Comment::create([
-            'user_id' => $anotherUser->id,
-            'post_id' => $post->id,
-            'content' => 'Hello',
-        ]);
-
-        $comments = Comment::for($user)
-            ->for($post, 'blogPost')
-            ->get();
-
-        $this->assertCount(2, $comments);
-        $this->assertSame($existingCommentOne->id, $comments[0]->id);
-        $this->assertSame($existingCommentTwo->id, $comments[1]->id);
-    }
-
     public function testForCanBeUsedOnModelUpdate()
     {
         $user = User::create(['name' => 'My name']);
@@ -553,40 +519,6 @@ class EloquentForTest extends DatabaseTestCase
 
         $this->assertSame($post->id, $comments[1]->post_id);
         $this->assertInstanceOf(Post::class, $comments[1]->blogPost);
-    }
-
-    public function testForCanBeUsedOnRelationshipGet()
-    {
-        $user = User::create(['name' => 'My name']);
-        $anotherUser = User::create(['name' => 'Another user']);
-        $post = Post::create(['title' => 'My title']);
-
-        $existingCommentOne = Comment::create([
-            'user_id' => $user->id,
-            'post_id' => $post->id,
-            'content' => 'Hello',
-        ]);
-
-        $existingCommentTwo = Comment::create([
-            'user_id' => $user->id,
-            'post_id' => $post->id,
-            'content' => 'Hello',
-        ]);
-
-        // This belongs to a different user and shouldn't be included.
-        $anotherComment = Comment::create([
-            'user_id' => $anotherUser->id,
-            'post_id' => $post->id,
-            'content' => 'Hello',
-        ]);
-
-        $comments = $post->comments()
-            ->for($user)
-            ->get();
-
-        $this->assertCount(2, $comments);
-        $this->assertSame($existingCommentOne->id, $comments[0]->id);
-        $this->assertSame($existingCommentTwo->id, $comments[1]->id);
     }
 }
 

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -264,6 +264,40 @@ class EloquentForTest extends DatabaseTestCase
         $this->assertInstanceOf(Post::class, $comment->blogPost);
     }
 
+    public function testForCanBeUsedOnBuilderGet()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another user']);
+        $post = Post::create(['title' => 'My title']);
+
+        $existingCommentOne = Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $existingCommentTwo = Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        // This belongs to a different user and shouldn't be included.
+        $anotherComment = Comment::create([
+            'user_id' => $anotherUser->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comments = Comment::for($user)
+            ->for($post, 'blogPost')
+            ->get();
+
+        $this->assertCount(2, $comments);
+        $this->assertSame($existingCommentOne->id, $comments[0]->id);
+        $this->assertSame($existingCommentTwo->id, $comments[1]->id);
+    }
+
     public function testForCanBeUsedOnModelUpdate()
     {
         $user = User::create(['name' => 'My name']);
@@ -519,6 +553,40 @@ class EloquentForTest extends DatabaseTestCase
 
         $this->assertSame($post->id, $comments[1]->post_id);
         $this->assertInstanceOf(Post::class, $comments[1]->blogPost);
+    }
+
+    public function testForCanBeUsedOnRelationshipGet()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another user']);
+        $post = Post::create(['title' => 'My title']);
+
+        $existingCommentOne = Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $existingCommentTwo = Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        // This belongs to a different user and shouldn't be included.
+        $anotherComment = Comment::create([
+            'user_id' => $anotherUser->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comments = $post->comments()
+            ->for($user)
+            ->get();
+
+        $this->assertCount(2, $comments);
+        $this->assertSame($existingCommentOne->id, $comments[0]->id);
+        $this->assertSame($existingCommentTwo->id, $comments[1]->id);
     }
 }
 

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -141,7 +141,7 @@ class EloquentForTest extends DatabaseTestCase
             ->for($user)
             ->for($post, 'blogPost')
             ->firstOrCreate([
-                'user_id' => $anotherUser->id, // This will be overridden by the $anotherUser in the for()
+                'user_id' => $anotherUser->id, // This will be overridden by the $user in the for()
             ], [
                 'content' => 'Goodbye',
             ]);
@@ -262,11 +262,6 @@ class EloquentForTest extends DatabaseTestCase
 
         $this->assertSame($post->id, $comment->post_id);
         $this->assertInstanceOf(Post::class, $comment->blogPost);
-    }
-
-    public function testForCanBeUsedWithBuilderGet()
-    {
-
     }
 
     public function testForCanBeUsedOnModelUpdate()
@@ -398,12 +393,12 @@ class EloquentForTest extends DatabaseTestCase
         $comment = $post->comments()
             ->for($anotherUser)
             ->firstOrNew([
-                'user_id' => $user->id,
+                'user_id' => $user->id, // This will be overridden by the $anotherUser in the for()
             ], [
                 'content' => 'hello',
             ]);
 
-        $this->assertSame($user->id, $comment->user_id);
+        $this->assertSame($anotherUser->id, $comment->user_id);
     }
 
     public function testForCanBeUsedOnRelationshipsFirstOrNewIfTheModelDoesNotExist()
@@ -442,9 +437,9 @@ class EloquentForTest extends DatabaseTestCase
         ]);
 
         $comment = $post->comments()
-            ->for($anotherUser)
+            ->for($user)
             ->firstOrCreate([
-                'user_id' => $user->id,
+                'user_id' => $anotherUser->id, // This will be overridden by the $user in the for()
             ], [
                 'content' => 'hello',
             ]);
@@ -467,7 +462,7 @@ class EloquentForTest extends DatabaseTestCase
         $comment = $post->comments()
             ->for($anotherUser)
             ->firstOrCreate([
-                'user_id' => 123,
+                'user_id' => $user->id, // This will be overridden by the $anotherUser in the for()
             ], [
                 'content' => 'hello',
             ]);

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Integration\Database\EloquentForTest;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentForTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -82,7 +82,7 @@ class EloquentForTest extends DatabaseTestCase
         $anotherUser = User::create(['name' => 'Another name']);
         $post = Post::create(['title' => 'My title']);
 
-        Comment::create([
+        $existingComment = Comment::create([
             'user_id' => $user->id,
             'post_id' => $post->id,
             'content' => 'Hello',
@@ -96,6 +96,7 @@ class EloquentForTest extends DatabaseTestCase
                 'value' => 'Goodbye',
             ]);
 
+        $this->assertSame($comment->id, $existingComment->id);
         $this->assertSame($user->id, $comment->user_id);
     }
 
@@ -105,7 +106,7 @@ class EloquentForTest extends DatabaseTestCase
         $anotherUser = User::create(['name' => 'Another name']);
         $post = Post::create(['title' => 'My title']);
 
-        Comment::create([
+        $existingComment = Comment::create([
             'user_id' => $user->id,
             'post_id' => $post->id,
             'content' => 'Hello',
@@ -119,6 +120,7 @@ class EloquentForTest extends DatabaseTestCase
                 'value' => 'Goodbye',
             ]);
 
+        $this->assertNotSame($comment->id, $existingComment->id);
         $this->assertSame($anotherUser->id, $comment->user_id);
     }
 

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -89,14 +89,14 @@ class EloquentForTest extends DatabaseTestCase
         ]);
 
         $comment = Comment::query()
-            ->for($anotherUser)
+            ->for($user)
             ->firstOrNew([
-                'user_id' => $user->id,
+                'user_id' => $anotherUser->id, // This will be overridden by the $user in for()
             ], [
                 'value' => 'Goodbye',
             ]);
 
-        $this->assertSame($comment->id, $existingComment->id);
+        $this->assertSame($existingComment->id, $comment->id);
         $this->assertSame($user->id, $comment->user_id);
     }
 
@@ -120,7 +120,7 @@ class EloquentForTest extends DatabaseTestCase
                 'value' => 'Goodbye',
             ]);
 
-        $this->assertNotSame($comment->id, $existingComment->id);
+        $this->assertNull($comment->id);
         $this->assertSame($anotherUser->id, $comment->user_id);
     }
 
@@ -138,10 +138,10 @@ class EloquentForTest extends DatabaseTestCase
         ]);
 
         $comment = Comment::query()
-            ->for($anotherUser)
-            ->for($anotherPost, 'blogPost')
+            ->for($user)
+            ->for($post, 'blogPost')
             ->firstOrCreate([
-                'user_id' => $user->id,
+                'user_id' => $anotherUser->id, // This will be overridden by the $anotherUser in the for()
             ], [
                 'content' => 'Goodbye',
             ]);
@@ -167,7 +167,7 @@ class EloquentForTest extends DatabaseTestCase
             ->for($anotherUser)
             ->for($anotherPost, 'blogPost')
             ->firstOrCreate([
-                'user_id' => 123,
+                'user_id' => 123, // This will be overridden by the $anotherUser in the for()
             ], [
                 'content' => 'Goodbye',
             ]);
@@ -262,6 +262,11 @@ class EloquentForTest extends DatabaseTestCase
 
         $this->assertSame($post->id, $comment->post_id);
         $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedWithBuilderGet()
+    {
+
     }
 
     public function testForCanBeUsedOnModelUpdate()

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentForTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('post_id');
+            $table->string('content');
+            $table->timestamps();
+        });
+    }
+
+    public function testForCanBeUsedOnBuilderCreate()
+    {
+        $user = User::create(['name' => 'My name']);
+        $post = Post::create(['title' => 'My title']);
+
+        $comment = Comment::for($user)
+            ->for($post, 'blogPost')
+            ->create([
+                'content' => 'hello',
+            ])
+            ->fresh();
+
+        $this->assertSame('hello', $comment->content);
+
+        $this->assertSame($user->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($post->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedOnBuilderMake()
+    {
+        $user = User::query()->create(['name' => 'My name']);
+        $post = Post::create(['title' => 'My title']);
+
+        $comment = Comment::query()
+            ->for($user)
+            ->for($post, 'blogPost')
+            ->make([
+                'content' => 'hello',
+            ]);
+
+        $this->assertSame('hello', $comment->content);
+
+        $this->assertSame($user->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($post->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedOnFirstOrNewAndIsNotAppliedIfTheModelAlreadyExists()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = Comment::query()
+            ->for($anotherUser)
+            ->firstOrNew([
+                'user_id' => $user->id,
+            ], [
+                'value' => 'Goodbye',
+            ]);
+
+        $this->assertSame($user->id, $comment->user_id);
+    }
+
+    public function testForCanBeUsedOnFirstOrNewAndIsAppliedIfTheModelDoesNotAlreadyExist()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = Comment::query()
+            ->for($anotherUser)
+            ->firstOrNew([
+                'user_id' => 123,
+            ], [
+                'value' => 'Goodbye',
+            ]);
+
+        $this->assertSame($anotherUser->id, $comment->user_id);
+    }
+
+    public function testForCanBeUsedOnFirstOrCreateIfTheModelAlreadyExists()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+        $anotherPost = Post::create(['title' => 'Another title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = Comment::query()
+            ->for($anotherUser)
+            ->for($anotherPost, 'blogPost')
+            ->firstOrCreate([
+                'user_id' => $user->id,
+            ], [
+                'content' => 'Goodbye',
+            ]);
+
+        $this->assertSame($user->id, $comment->user_id);
+        $this->assertSame($post->id, $comment->post_id);
+    }
+
+    public function testForCanBeUsedOnFirstOrCreateIfTheModelDoesNotAlreadyExist()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+        $anotherPost = Post::create(['title' => 'Another title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = Comment::query()
+            ->for($anotherUser)
+            ->for($anotherPost, 'blogPost')
+            ->firstOrCreate([
+                'user_id' => 123,
+            ], [
+                'content' => 'Goodbye',
+            ]);
+
+        $this->assertSame($anotherUser->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($anotherPost->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedOnBuilderUpdate()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+        $anotherPost = Post::create(['title' => 'Another title']);
+
+        $commentOne = Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello1',
+        ]);
+
+        $commentTwo = Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $anotherPost->id,
+            'content' => 'Hello2',
+        ]);
+
+        Comment::query()
+            ->for($anotherUser)
+            ->update([
+                'content' => 'Hello3',
+            ]);
+
+        $commentOne->refresh();
+        $commentTwo->refresh();
+
+        $this->assertSame($anotherUser->id, $commentOne->user_id);
+        $this->assertSame('Hello3', $commentOne->content);
+
+        $this->assertSame($anotherUser->id, $commentTwo->user_id);
+        $this->assertSame('Hello3', $commentTwo->content);
+    }
+
+    public function testForCanBeUsedOnUpdateOrCreate()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+        $anotherPost = Post::create(['title' => 'Another title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = Comment::query()
+            ->for($anotherUser)
+            ->for($anotherPost, 'blogPost')
+            ->updateOrCreate([
+                'user_id' => 123,
+            ], [
+                'content' => 'Goodbye',
+            ]);
+
+        $this->assertSame($anotherUser->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($anotherPost->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedOnForceCreate()
+    {
+        $user = User::create(['name' => 'My name']);
+        $post = Post::create(['title' => 'My title']);
+
+        $comment = Comment::for($user)
+            ->for($post, 'blogPost')
+            ->forceCreate([
+                'content' => 'hello',
+            ])
+            ->fresh();
+
+        $this->assertSame('hello', $comment->content);
+
+        $this->assertSame($user->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($post->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedOnModelUpdate()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+        $anotherPost = Post::create(['title' => 'Another title']);
+
+        $comment = Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        // Make sure this comment isn't updated accidentally.
+        $anotherComment = Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello123',
+        ]);
+
+        $comment->for($anotherUser)
+            ->for($anotherPost, 'blogPost')
+            ->update([
+                'content' => 'goodbye',
+            ]);
+
+        $comment->refresh();
+        $anotherComment->refresh();
+
+        $this->assertSame('goodbye', $comment->content);
+
+        $this->assertSame($anotherUser->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($anotherPost->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+
+        $this->assertSame('Hello123', $anotherComment->content);
+        $this->assertSame($user->id, $anotherComment->user_id);
+        $this->assertSame($post->id, $anotherComment->post_id);
+    }
+}
+
+class User extends Model
+{
+    public $table = 'users';
+    protected $guarded = [];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+}
+
+class Post extends Model
+{
+    public $table = 'posts';
+    protected $guarded = [];
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+}
+
+class Comment extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function blogPost(): BelongsTo
+    {
+        return $this->belongsTo(Post::class, 'post_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/tests/Integration/Database/EloquentForTest.php
+++ b/tests/Integration/Database/EloquentForTest.php
@@ -303,6 +303,221 @@ class EloquentForTest extends DatabaseTestCase
         $this->assertSame($user->id, $anotherComment->user_id);
         $this->assertSame($post->id, $anotherComment->post_id);
     }
+
+    public function testForCanBeUsedOnRelationshipCreate()
+    {
+        /** @var User $user */
+        $user = User::create(['name' => 'My name']);
+        $post = Post::create(['title' => 'My title']);
+
+        $comment = $user->comments()
+            ->for($post, 'blogPost')
+            ->create([
+                'content' => 'hello',
+            ]);
+
+        $this->assertSame('hello', $comment->content);
+
+        $this->assertSame($user->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($post->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedOnRelationshipMake()
+    {
+        /** @var User $user */
+        $user = User::create(['name' => 'My name']);
+        $post = Post::create(['title' => 'My title']);
+
+        $comment = $user->comments()
+            ->for($post, 'blogPost')
+            ->make([
+                'content' => 'hello',
+            ]);
+
+        $this->assertSame('hello', $comment->content);
+
+        $this->assertSame($user->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($post->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedOnRelationshipMakeMany()
+    {
+        /** @var User $user */
+        $user = User::create(['name' => 'My name']);
+        $post = Post::create(['title' => 'My title']);
+
+        $comments = $user->comments()
+            ->for($post, 'blogPost')
+            ->makeMany([
+                ['content' => 'hello'],
+                ['content' => 'second'],
+            ]);
+
+        $this->assertSame('hello', $comments[0]->content);
+
+        $this->assertSame($user->id, $comments[0]->user_id);
+        $this->assertInstanceOf(User::class, $comments[0]->user);
+
+        $this->assertSame($post->id, $comments[0]->post_id);
+        $this->assertInstanceOf(Post::class, $comments[0]->blogPost);
+
+        $this->assertSame('second', $comments[1]->content);
+
+        $this->assertSame($user->id, $comments[1]->user_id);
+        $this->assertInstanceOf(User::class, $comments[1]->user);
+
+        $this->assertSame($post->id, $comments[1]->post_id);
+        $this->assertInstanceOf(Post::class, $comments[1]->blogPost);
+    }
+
+    public function testForCanBeUsedOnRelationshipFirstOrNewIfTheModelExists()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = $post->comments()
+            ->for($anotherUser)
+            ->firstOrNew([
+                'user_id' => $user->id,
+            ], [
+                'content' => 'hello',
+            ]);
+
+        $this->assertSame($user->id, $comment->user_id);
+    }
+
+    public function testForCanBeUsedOnRelationshipsFirstOrNewIfTheModelDoesNotExist()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = $post->comments()
+            ->for($anotherUser)
+            ->firstOrNew([
+                'user_id' => 123,
+            ], [
+                'content' => 'hello',
+            ]);
+
+        $this->assertSame($anotherUser->id, $comment->user_id);
+    }
+
+    public function testForCanBeUsedOnRelationshipFirstOrCreateIfTheModelExists()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = $post->comments()
+            ->for($anotherUser)
+            ->firstOrCreate([
+                'user_id' => $user->id,
+            ], [
+                'content' => 'hello',
+            ]);
+
+        $this->assertSame($user->id, $comment->user_id);
+    }
+
+    public function testForCanBeUsedOnRelationshipFirstOrCreateIfTheModelDoesNotExist()
+    {
+        $user = User::create(['name' => 'My name']);
+        $anotherUser = User::create(['name' => 'Another name']);
+        $post = Post::create(['title' => 'My title']);
+
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'content' => 'Hello',
+        ]);
+
+        $comment = $post->comments()
+            ->for($anotherUser)
+            ->firstOrCreate([
+                'user_id' => 123,
+            ], [
+                'content' => 'hello',
+            ]);
+
+        $this->assertSame($anotherUser->id, $comment->user_id);
+    }
+
+    public function testForCanBeUsedOnRelationshipForceCreate()
+    {
+        /** @var User $user */
+        $user = User::create(['name' => 'My name']);
+        $post = Post::create(['title' => 'My title']);
+
+        $comment = $user->comments()
+            ->for($post, 'blogPost')
+            ->forceCreate([
+                'content' => 'hello',
+            ]);
+
+        $this->assertSame('hello', $comment->content);
+
+        $this->assertSame($user->id, $comment->user_id);
+        $this->assertInstanceOf(User::class, $comment->user);
+
+        $this->assertSame($post->id, $comment->post_id);
+        $this->assertInstanceOf(Post::class, $comment->blogPost);
+    }
+
+    public function testForCanBeUsedOnRelationshipCreateMany()
+    {
+        /** @var User $user */
+        $user = User::create(['name' => 'My name']);
+        $post = Post::create(['title' => 'My title']);
+
+        $comments = $user->comments()
+            ->for($post, 'blogPost')
+            ->createMany([
+                ['content' => 'hello'],
+                ['content' => 'second'],
+            ]);
+
+        $this->assertSame('hello', $comments[0]->content);
+
+        $this->assertSame($user->id, $comments[0]->user_id);
+        $this->assertInstanceOf(User::class, $comments[0]->user);
+
+        $this->assertSame($post->id, $comments[0]->post_id);
+        $this->assertInstanceOf(Post::class, $comments[0]->blogPost);
+
+        $this->assertSame('second', $comments[1]->content);
+
+        $this->assertSame($user->id, $comments[1]->user_id);
+        $this->assertInstanceOf(User::class, $comments[1]->user);
+
+        $this->assertSame($post->id, $comments[1]->post_id);
+        $this->assertInstanceOf(Post::class, $comments[1]->blogPost);
+    }
 }
 
 class User extends Model
@@ -313,6 +528,11 @@ class User extends Model
     public function posts()
     {
         return $this->hasMany(Post::class);
+    }
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
     }
 }
 


### PR DESCRIPTION
Hey! This PR proposes a new "for" method that can be used on models and in Eloquent queries.

I've marked this as a draft PR for the time being because I'm about half way through doing it. I still need to add the "for" method to the relationships (explained in more detail below). So, I didn't want to spend too much time working on it if you didn't think it would be worth merging in.

## Context

This PR is inspired by the `whereBelongsTo` method that you can use in queries like:

```php
Post::whereBelongsTo($user)->get();
```

I like how it makes the code a lot more human-readable and avoids writing column names (e.g. - `user_id`). So, I thought I'd give it a go and see if we could add something similar for creating/updating models.

I chose the "for" name based on the fact that the functionality is similar to the "for" model factories.

## Before

Excuse the super basic examples, but they should hopefully demonstrate my general point. Before my proposed method, you could have either of these example statements:

```php
Comment::create([
    'user_id' => $user->id,
    'post_id' => $post->id,
    'content' => 'abc',
]);
```

Or...

```php
$post->comments()->create([
    'user_id' => $user->id,
    'content' => 'abc',
]);
```

Or...

```php
$comment->update([
    'user_id' => $anotherUser->id,
    'content' => 'abc',
]);
```

## After

But the problem is that there's always still another ID field in the `create` method if you're trying to make a relationship to more than one model. So, we could rewrite the queries as:

```php
Comment::for($user)
    ->for(post)
    ->create([
        'content' => 'abc',
    ];
```

Or...

```php
$post->comments()
    ->for($user)
    ->create([
        'content' => 'abc',
    ]);
```

```php
$comment->for($anotherUser)->update([
    'content' => 'abc',
]);
```

At the moment, I've only got the `Model::for()` and `$model->for()` approaches working for all the different query methods (as far as I can see, but I might have missed something). I haven't made a start on the relationships (e.g. - `$model->relationship()->for()->create()`) yet just in case this PR wasn't something that would get merged. If you think that this is something that would be valuable to other devs though, I'll carry on and get the relationships working too.

Personally, I could see this being particularly useful feature and think it'd be a nice way of making our Laravel project codebases even cleaner! 😄

Apologies, by the way, if this sort of logic already exists and I've just completely missed it.

Hopefully, it's heading in a good direction, but it's no problem if you'd rather close the PR 😄
