### PR TITLE
[9.x] Added getDirectorySize Method to Filesystem.php

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -752,4 +752,21 @@ class Filesystem
     {
         return $this->deleteDirectory($directory, true);
     }
+
+    /**
+     * Get the Size of the given Directory
+     *
+     * @param $directory
+     * @return int
+     */
+    public function getDirectorySize($directory)
+    {
+        $size = 0;
+
+        foreach($this->allFiles($directory) as $file) {
+            $size += $this->size($file->getPathname());
+        }
+
+        return $size;
+    }
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -763,7 +763,7 @@ class Filesystem
     {
         $size = 0;
 
-        foreach( $this->allFiles($directory) as $file) {
+        foreach ($this->allFiles($directory) as $file) {
             $size += $this->size($file->getPathname());
         }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -754,7 +754,7 @@ class Filesystem
     }
 
     /**
-     * Get the Size of the given Directory
+     * Get the Size of the given Directory.
      *
      * @param $directory
      * @return int
@@ -763,7 +763,7 @@ class Filesystem
     {
         $size = 0;
 
-        foreach($this->allFiles($directory) as $file) {
+        foreach( $this->allFiles($directory) as $file) {
             $size += $this->size($file->getPathname());
         }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -594,14 +594,16 @@ class FilesystemTest extends TestCase
         $this->assertSame('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash(self::$tempDir.'/foo.txt'));
     }
 
-    public function testGetDirectorySizeWithoutSubDirectories() {
+    public function testGetDirectorySizeWithoutSubDirectories()
+    {
         $filesystem = new Filesystem();
         file_put_contents(self::$tempDir.'/foo.txt', 'foo');
         file_put_contents(self::$tempDir.'/bar.txt', 'bar');
         $this->assertSame(6, $filesystem->getDirectorySize(self::$tempDir));
     }
 
-    public function testGetDirectorySizeWithSubDirectories() {
+    public function testGetDirectorySizeWithSubDirectories()
+    {
         $filesystem = new Filesystem();
         mkdir(self::$tempDir.'/sub', 0777, true);
         file_put_contents(self::$tempDir.'/root.txt', 'root');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -594,6 +594,21 @@ class FilesystemTest extends TestCase
         $this->assertSame('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash(self::$tempDir.'/foo.txt'));
     }
 
+    public function testGetDirectorySizeWithoutSubDirectories() {
+        $filesystem = new Filesystem();
+        file_put_contents(self::$tempDir.'/foo.txt', 'foo');
+        file_put_contents(self::$tempDir.'/bar.txt', 'bar');
+        $this->assertSame(6, $filesystem->getDirectorySize(self::$tempDir));
+    }
+
+    public function testGetDirectorySizeWithSubDirectories() {
+        $filesystem = new Filesystem();
+        mkdir(self::$tempDir.'/sub', 0777, true);
+        file_put_contents(self::$tempDir.'/root.txt', 'root');
+        file_put_contents(self::$tempDir.'/sub/sub.txt', 'sub');
+        $this->assertSame(7, $filesystem->getDirectorySize(self::$tempDir));
+    }
+
     /**
      * @param  string  $file
      * @return int


### PR DESCRIPTION
This Pullrequest adds the getDirectorySize Method to Filesystem.php Facade.

The Size of the given Directory will be returned in Bytes using the allFiles and size Methods.
