### PR TITLE
[9.x] Request retrieve date from JSON format

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -350,7 +350,7 @@ trait InteractsWithInput
      * @param  string  $key
      * @return \Illuminate\Support\Carbon|null
      */
-    public function jsDate($key)
+    public function jsonDate($key)
     {
         return $this->date($key, DateFactory::JSON_DATE)?->utc();
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -345,14 +345,17 @@ trait InteractsWithInput
     }
 
     /**
-     * Retrieve a ISO-8601/RFC-3339 date from the request as a Carbon instance in UTC.
+     * Retrieve a ISO-8601/RFC-3339 date from the request as a Carbon instance.
      *
      * @param  string  $key
+     * @param  bool  $asUtc
      * @return \Illuminate\Support\Carbon|null
      */
-    public function jsonDate($key)
+    public function jsonDate($key, $asUtc = false)
     {
-        return $this->date($key, DateFactory::JSON_DATE)?->utc();
+        $date = $this->date($key, DateFactory::JSON_DATE);
+
+        return $asUtc ? $date?->utc() : $date;
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\DateFactory;
 use Illuminate\Support\Facades\Date;
 use SplFileInfo;
 use stdClass;
@@ -341,6 +342,17 @@ trait InteractsWithInput
         }
 
         return Date::createFromFormat($format, $this->input($key), $tz);
+    }
+
+    /**
+     * Retrieve a ISO-8601/RFC-3339 date from the request as a Carbon instance in UTC.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Support\Carbon|null
+     */
+    public function jsDate($key)
+    {
+        return $this->date($key, DateFactory::JSON_DATE)?->utc();
     }
 
     /**

--- a/src/Illuminate/Support/DateFactory.php
+++ b/src/Illuminate/Support/DateFactory.php
@@ -91,6 +91,13 @@ class DateFactory
     const DEFAULT_CLASS_NAME = Carbon::class;
 
     /**
+     * The default format of JSON encoded Date Javascript objects with 1 to 6 subsecond precision.
+     *
+     * @var string
+     */
+    const JSON_DATE = "Y-m-d\TH:i:s.uP";
+
+    /**
      * The type (class) of dates that should be created.
      *
      * @var string

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -586,6 +586,40 @@ class HttpRequestTest extends TestCase
         $request->date('date', 'invalid_format');
     }
 
+    public function testJsDate()
+    {
+        $request = Request::create('/', 'GET', [
+            'as_null' => null,
+            'as_invalid' => 'invalid',
+
+            'as_js_date' => '2020-01-01T16:30:25.000Z',
+            'as_js_date_tz' => '2020-01-01T21:30:25.000+05:00',
+            'as_js_date_milli' => '2020-01-01T21:30:25.123+05:00',
+            'as_js_date_micro' => '2020-01-01T21:30:25.123456+05:00',
+        ]);
+
+        $date = Carbon::create(2020, 1, 1, 16, 30, 25);
+
+        $this->assertNull($request->jsDate('as_null'));
+        $this->assertNull($request->jsDate('doesnt_exists'));
+
+        $this->assertEquals($date, $request->jsDate('as_js_date'));
+        $this->assertEquals($date, $request->jsDate('as_js_date_tz'));
+        $this->assertEquals($date->milli(123), $request->jsDate('as_js_date_milli'));
+        $this->assertEquals($date->micro(123456), $request->jsDate('as_js_date_micro'));
+    }
+
+    public function testJsDateMethodExceptionWhenFormatInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $request = Request::create('/', 'GET', [
+            'date' => '2020-01-01T21:30:25@05:00',
+        ]);
+
+        $request->jsDate('date');
+    }
+
     public function testArrayAccess()
     {
         $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -607,6 +607,10 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($date, $request->jsonDate('as_js_date_tz'));
         $this->assertEquals($date->milli(123), $request->jsonDate('as_js_date_milli'));
         $this->assertEquals($date->micro(123456), $request->jsonDate('as_js_date_micro'));
+
+        $this->assertTrue($request->jsonDate('as_js_date')->isUtc());
+        $this->assertFalse($request->jsonDate('as_js_date_tz')->isUtc());
+        $this->assertTrue($request->jsonDate('as_js_date_tz', true)->isUtc());
     }
 
     public function testJsonDateMethodExceptionWhenFormatInvalid()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -586,7 +586,7 @@ class HttpRequestTest extends TestCase
         $request->date('date', 'invalid_format');
     }
 
-    public function testJsDate()
+    public function testJsonDate()
     {
         $request = Request::create('/', 'GET', [
             'as_null' => null,
@@ -600,16 +600,16 @@ class HttpRequestTest extends TestCase
 
         $date = Carbon::create(2020, 1, 1, 16, 30, 25);
 
-        $this->assertNull($request->jsDate('as_null'));
-        $this->assertNull($request->jsDate('doesnt_exists'));
+        $this->assertNull($request->jsonDate('as_null'));
+        $this->assertNull($request->jsonDate('doesnt_exists'));
 
-        $this->assertEquals($date, $request->jsDate('as_js_date'));
-        $this->assertEquals($date, $request->jsDate('as_js_date_tz'));
-        $this->assertEquals($date->milli(123), $request->jsDate('as_js_date_milli'));
-        $this->assertEquals($date->micro(123456), $request->jsDate('as_js_date_micro'));
+        $this->assertEquals($date, $request->jsonDate('as_js_date'));
+        $this->assertEquals($date, $request->jsonDate('as_js_date_tz'));
+        $this->assertEquals($date->milli(123), $request->jsonDate('as_js_date_milli'));
+        $this->assertEquals($date->micro(123456), $request->jsonDate('as_js_date_micro'));
     }
 
-    public function testJsDateMethodExceptionWhenFormatInvalid()
+    public function testJsonDateMethodExceptionWhenFormatInvalid()
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -617,7 +617,7 @@ class HttpRequestTest extends TestCase
             'date' => '2020-01-01T21:30:25@05:00',
         ]);
 
-        $request->jsDate('date');
+        $request->jsonDate('date');
     }
 
     public function testArrayAccess()


### PR DESCRIPTION
# What?

Retrieves a date from a JSON encoded `Date` Javascript object. Includes constant to easily validate the format.

```php
use Illuminate\Http\Request;
use Illuminate\Support\DateFactory;

// {
//     "kickoff": "2020-01-01T16:00:00.000+05:00"
// }
public function kickoff(Request $request)
{
    $request->validate([
        'kickoff' => 'date_format:' . DateFactory::JSON_DATE
    ]);
    
    $request->jsonDate('kickoff');
    // "2020-01-01 16:00:00.000 (+05:00)"
}
```

Current browsers encode the `Date` object in JSON with milliseconds, but Laravel encodes them with microseconds. This format accepts both sub-second precisions (3 or 6 digits), so the same data can be reused (like for inter-Laravel-apps-communication).

Also, this optionally shift the date to UTC using `jsonDate('kickoff', true)`. This is just convenience as the format already includes the timezone, making it ready to be persisted in the database.

```php
$request->jsonDate('kickoff', true);
// "2020-01-01 11:00:00.000 UTC (+00:00)"
```

The constant is added to the `DateFactory` mostly to avoid repeating `Y-m-d\TH:i:s.uP` every time the user want to validate a date. Also used by the helper.

> This separate PR #42475 allows `date_format:json` to avoid shoving the constant or using the full format string.

## BC?

None, only adding a method.