### PR TITLE
[9.x] Adds JSON format helper to validate ISO-8601/RFC-3339 dates

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -13,6 +13,7 @@ use Egulias\EmailValidator\Validation\RFCValidation;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\DateFactory;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
@@ -501,6 +502,10 @@ trait ValidatesAttributes
         }
 
         foreach ($parameters as $format) {
+            if ($format === 'json') {
+                $format = DateFactory::JSON_DATE;
+            }
+
             $date = DateTime::createFromFormat('!'.$format, $value);
 
             if ($date && $date->format($format) == $value) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4078,6 +4078,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => '17:43'], ['x' => 'date_format:H:i']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '2000-01-01T00:00:00.000000+00:30'], ['x' => 'date_format:json']);
+        $this->assertTrue($v->passes());
     }
 
     public function testDateEquals()


### PR DESCRIPTION
## What?

Aliases ISO-8601/RFC-3339 date format to `json` when using the `date_format` rule:

```php
validator([
    'kickoff' => '2020-01-01T21:30:25.123456+05:00',
], [
    // Before
    'kickoff' => 'date_format:Y-m-d\TH:i:s.uP',
    // After
    'kickoff' => 'date_format:json',
]);
```

This is a separate PR for #42474, where the validation rule must use a const or use that format.