### PR TITLE
[8.x] Add flush handler to output buffer for streamed test response (bugfix)

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1491,8 +1491,9 @@ EOF;
             PHPUnit::fail('The response is not a streamed response.');
         }
 
-        ob_start(function(string $buffer): string {
+        ob_start(function (string $buffer): string {
             $this->streamedContent .= $buffer;
+
             return '';
         });
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1491,11 +1491,16 @@ EOF;
             PHPUnit::fail('The response is not a streamed response.');
         }
 
-        ob_start();
+        ob_start(function(string $buffer): string {
+            $this->streamedContent .= $buffer;
+            return '';
+        });
 
         $this->sendContent();
 
-        return $this->streamedContent = ob_get_clean();
+        ob_end_clean();
+
+        return $this->streamedContent;
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug which may lead to missed content for a streamed test response.

Typically, code which wants to ensure that its output is really streamed to browser contains code lines like these

```php
if (ob_get_level() > 0) {
  ob_flush();
}
flush();
```

This is the recommended best practice to ensure that all buffers are flushed and the content is sent to the browser:

 - [PHP Manual](https://www.php.net/manual/en/function.flush.php):
   > This means [`ob_flush()`](https://www.php.net/manual/en/function.ob-flush.php) should be called before `flush()` to flush the output buffers if they are in use.
 - [Symfony Manual](https://symfony.com/doc/current/components/http_foundation.html#streaming-a-response):
   > The `flush()` function does not flush buffering. If `ob_start()` has been called before or the `output_buffering` php.ini option is enabled, you must call `ob_flush()` before `flush()`.

The current implementation of the test response does not work if one follows this practice. In particular, `ob_flush` sends all content of the output buffer to stdout in test mode and clears the buffer. The method `ob_get_clean()` as used by the current implementation will always return the empty string. This means `TestResponse` misses all output.

The correct way is to register a handler with `ob_start` which is called whenever the buffer is flushed. [PHP Manual](https://www.php.net/manual/en/function.ob-start.php):

> An optional callback function may be specified. This function takes a string as a parameter and should return a string. The function will be called when the output buffer is flushed (sent) or cleaned (with [`ob_flush()`](https://www.php.net/manual/en/function.ob-flush.php), [...] or similar function) or when the output buffer is flushed to the browser at the end of the request. [...]. When callback is called, it will receive the contents of the output buffer as its parameter and is expected to return a new output buffer as a result, which will be sent to the browser.

Note, the bugfix always returns the empty string. During tests there is on browser and the output would be sent to stdout, if we were not returning the empty string.