### PR TITLE
[9.x] Add Fluent AssertableUri

### DIFF
--- a/src/Illuminate/Testing/Fluent/AssertableUri.php
+++ b/src/Illuminate/Testing/Fluent/AssertableUri.php
@@ -32,6 +32,7 @@ class AssertableUri
      * An URI string is composed of 8 components.
      *
      * @link https://www.php.net/manual/en/function.parse-url.php
+     *
      * @var array
      */
     protected $components = ['fragment', 'host', 'pass', 'path', 'port', 'query', 'scheme', 'user'];
@@ -184,6 +185,7 @@ class AssertableUri
      * @param  string  $method
      * @param  array  $arguments
      * @return $this
+     *
      * @throws \BadMethodCallException
      */
     public function __call($method, $arguments)

--- a/src/Illuminate/Testing/Fluent/AssertableUri.php
+++ b/src/Illuminate/Testing/Fluent/AssertableUri.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Illuminate\Testing\Fluent;
+
+use BadMethodCallException;
+use Closure;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+/**
+ * @method $this hasFragment()
+ * @method $this hasHost()
+ * @method $this hasPass()
+ * @method $this hasPath()
+ * @method $this hasPort()
+ * @method $this hasScheme()
+ * @method $this hasUser()
+ * @method $this whereFragment(string $value)
+ * @method $this whereHost(string $value)
+ * @method $this wherePass(string $value)
+ * @method $this wherePath(string $value)
+ * @method $this wherePort(string $value)
+ * @method $this whereScheme(string $value)
+ * @method $this whereUser(string $value)
+ */
+class AssertableUri
+{
+    use Concerns\Interaction;
+
+    /**
+     * An URI string is composed of 8 components.
+     *
+     * @link https://www.php.net/manual/en/function.parse-url.php
+     * @var array
+     */
+    protected $components = ['fragment', 'host', 'pass', 'path', 'port', 'query', 'scheme', 'user'];
+
+    /**
+     * Query string parameters of given URI.
+     *
+     * @var array
+     */
+    protected $query = [];
+
+    /**
+     * Containing any of the various components of the URI that are present.
+     *
+     * @var array
+     */
+    protected $uri;
+
+    /**
+     * Create a new fluent, assertable URI instance.
+     *
+     * @param  string  $uri
+     * @return void
+     */
+    public function __construct(string $uri)
+    {
+        $uri = parse_url($uri);
+
+        if (! empty($uri['query'])) {
+            parse_str($uri['query'], $this->query);
+        }
+
+        $this->uri = $uri;
+    }
+
+    /**
+     * Ensure that the given component exists.
+     *
+     * @param  string  $component
+     * @return $this
+     */
+    protected function has($component)
+    {
+        PHPUnit::assertTrue(
+            Arr::has($this->uri, $component),
+            sprintf('URI component [%s] does not exist.', Str::ucfirst($component))
+        );
+
+        return $this;
+    }
+
+    /**
+     * Ensure that the given query string exists.
+     *
+     * @param  string  $query
+     * @return $this
+     */
+    public function hasQuery($query)
+    {
+        $this->has('query');
+
+        $this->interactsWith($query);
+
+        PHPUnit::assertTrue(
+            Arr::has($this->query, $query),
+            sprintf('Query [%s] does not exist.', $query)
+        );
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the URI component matches the expected value.
+     *
+     * @param  string  $component
+     * @param  string  $value
+     * @return $this
+     */
+    protected function where($component, $value)
+    {
+        $this->has($component);
+
+        PHPUnit::assertSame(
+            Arr::get($this->uri, $component),
+            $value,
+            sprintf('URI component [%s] does not match the expected value.', Str::ucfirst($component))
+        );
+
+        return $this;
+    }
+
+    /**
+     * Asserts that certain/whole query matches the expected value.
+     *
+     * @param  string  $query
+     * @param  string|\Closure|null  $value
+     * @return $this
+     */
+    public function whereQuery(string $query, $value = null)
+    {
+        if (is_null($value)) {
+            return $this->where('query', $query);
+        }
+
+        $expected = $this->prop($query);
+
+        $this->hasQuery($query);
+
+        if ($value instanceof Closure) {
+            PHPUnit::assertTrue($value($expected));
+        } else {
+            PHPUnit::assertSame(
+                $expected,
+                $value,
+                "Query [$query] does not match the expected value."
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Asserts that all queries have been interacted with.
+     *
+     * @return void
+     */
+    public function interacted(): void
+    {
+        PHPUnit::assertSame(
+            [],
+            array_diff(array_keys($this->prop()), $this->interacted),
+            'Unexpected query were found on URI.'
+        );
+    }
+
+    /**
+     * Retrieve query string from URI using "dot" notation.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
+    protected function prop(string $key = null)
+    {
+        return Arr::get($this->query, $key);
+    }
+
+    /**
+     * Pass other method calls down.
+     *
+     * @param  string  $method
+     * @param  array  $arguments
+     * @return $this
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $arguments)
+    {
+        $component = Str::remove(['where', 'has'], Str::lower($method));
+
+        if (! in_array($component, $this->components)) {
+            throw new BadMethodCallException(sprintf(
+                'Call to undefined method %s::%s()', self::class, $method
+            ));
+        }
+
+        return Str::startsWith($method, 'where')
+            ? $this->where($component, ...$arguments)
+            : $this->has($component);
+    }
+}

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Testing\Fluent\AssertableUri;
 use Orchestra\Testbench\TestCase;
 
 class RouteRedirectTest extends TestCase
@@ -18,6 +19,23 @@ class RouteRedirectTest extends TestCase
         $response = $this->get($requestUri);
         $response->assertRedirect($redirectUri);
         $response->assertStatus(301);
+    }
+
+    public function testRouteRedirectUsingAssertableUri()
+    {
+        Route::redirect('from', 'https://foo.bar:8080/auth/token?scope=profile&include_granted_scopes=true', 301);
+
+        $response = $this->get('from');
+
+        $response->assertRedirect(function (AssertableUri $uri) {
+            $uri
+                ->whereScheme('https')
+                ->whereHost('foo.bar')
+                ->wherePort(8080)
+                ->wherePath('/auth/token')
+                ->whereQuery('scope', 'profile')
+                ->whereQuery('include_granted_scopes', 'true');
+        });
     }
 
     public function routeRedirectDataSets()

--- a/tests/Testing/Fluent/AssertableUriTest.php
+++ b/tests/Testing/Fluent/AssertableUriTest.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace Illuminate\Tests\Testing\Fluent;
+
+use BadMethodCallException;
+use Illuminate\Testing\Fluent\AssertableUri;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+
+class AssertableUriTest extends TestCase
+{
+    /** @var \Illuminate\Testing\Fluent\AssertableUri */
+    protected $assert;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->assert = new AssertableUri('https://username:password@hostname.com:8080/oauth2/v2.0?foo=bar#anchor');
+    }
+
+    public function testAssertHasFragment()
+    {
+        $this->assert->hasFragment();
+    }
+
+    public function testAssertHasFragmentFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('https://foo.bar');
+
+        $this->expectAssertionException('URI component [Fragment] does not exist.');
+
+        $assert->hasFragment();
+    }
+
+    public function testAssertHasHost()
+    {
+        $this->assert->hasHost();
+    }
+
+    public function testAssertHasHostFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('?foo=bar');
+
+        $this->expectAssertionException('URI component [Host] does not exist.');
+
+        $assert->hasHost();
+    }
+
+    public function testAssertHasPass()
+    {
+        $this->assert->hasPass();
+    }
+
+    public function testAssertHasPassFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('https://foo.bar');
+
+        $this->expectAssertionException('URI component [Pass] does not exist.');
+
+        $assert->hasPass();
+    }
+
+    public function testAssertHasPath()
+    {
+        $this->assert->hasPath();
+    }
+
+    public function testAssertHasPathFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('https://foo.bar');
+
+        $this->expectAssertionException('URI component [Path] does not exist.');
+
+        $assert->hasPath();
+    }
+
+    public function testAssertHasPort()
+    {
+        $this->assert->hasPort();
+    }
+
+    public function testAssertHasPortFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('https://foo.bar');
+
+        $this->expectAssertionException('URI component [Port] does not exist.');
+
+        $assert->hasPort();
+    }
+
+    public function testAssertHasSpecificQuery()
+    {
+        $this->assert->hasQuery('foo');
+    }
+
+    public function testAssertHasQueryFailsWhenKeyMissing()
+    {
+        $this->expectAssertionException('Query [baz] does not exist.');
+
+        $this->assert->hasQuery('baz');
+    }
+
+    public function testAssertHasNestedQuery()
+    {
+        $assert = new AssertableUri('https://foo.com?user[name]=Taylor&user[id]=1');
+
+        $assert->hasQuery('user');
+        $assert->hasQuery('user.name');
+        $assert->hasQuery('user.id');
+    }
+
+    public function testAssertHasQueryFailsWhenNestedKeyMissing()
+    {
+        $assert = new AssertableUri('https://foo.com?user[name]=Taylor&user[id]=1');
+
+        $this->expectAssertionException('Query [user.another] does not exist.');
+
+        $assert->hasQuery('user.another');
+    }
+
+    public function testAssertHasScheme()
+    {
+        $this->assert->hasScheme();
+    }
+
+    public function testAssertHasSchemeFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('foo.bar');
+
+        $this->expectAssertionException('URI component [Scheme] does not exist.');
+
+        $assert->hasScheme();
+    }
+
+    public function testAssertHasUser()
+    {
+        $this->assert->hasUser();
+    }
+
+    public function testAssertHasUserFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('https://foo.bar');
+
+        $this->expectAssertionException('URI component [User] does not exist.');
+
+        $assert->hasUser();
+    }
+
+    public function testAssertWhereHost()
+    {
+        $this->assert->whereHost('hostname.com');
+    }
+
+    public function testAssertWhereHostFailsWhenDoesNotMatchValue()
+    {
+        $this->expectAssertionException('URI component [Host] does not match the expected value.');
+
+        $this->assert->whereHost('incorrect');
+    }
+
+    public function testAssertWhereScheme()
+    {
+        $this->assert->whereScheme('https');
+    }
+
+    public function testAssertWhereSchemeFailsWhenDoesNotMatchValue()
+    {
+        $this->expectAssertionException('URI component [Scheme] does not match the expected value.');
+
+        $this->assert->whereScheme('http');
+    }
+
+    public function testAssertWherePort()
+    {
+        $this->assert->wherePort(8080);
+    }
+
+    public function testAssertWherePortFailsWhenDoesNotMatchValue()
+    {
+        $this->expectAssertionException('URI component [Port] does not match the expected value.');
+
+        $this->assert->wherePort(8000);
+    }
+
+    public function testAssertWhereUser()
+    {
+        $this->assert->whereUser('username');
+    }
+
+    public function testAssertWhereUserFailsWhenDoesNotMatchValue()
+    {
+        $this->expectAssertionException('URI component [User] does not match the expected value.');
+
+        $this->assert->whereUser('incorrect');
+    }
+
+    public function testAssertWherePass()
+    {
+        $this->assert->wherePass('password');
+    }
+
+    public function testAssertWherePassFailsWhenDoesNotMatchValue()
+    {
+        $this->expectAssertionException('URI component [Pass] does not match the expected value.');
+
+        $this->assert->wherePass('incorrect');
+    }
+
+    public function testAssertWherePath()
+    {
+        $this->assert->wherePath('/oauth2/v2.0');
+    }
+
+    public function testAssertWherePathFailsWhenDoesNotMatchValue()
+    {
+        $this->expectAssertionException('URI component [Path] does not match the expected value.');
+
+        $this->assert->wherePath('incorrect');
+    }
+
+    public function testAssertWhereQuery()
+    {
+        $this->assert->whereQuery('foo', 'bar');
+    }
+
+    public function testAssertWhereQueryFailsWhenDoesNotMatchValue()
+    {
+        $this->expectAssertionException('Query [foo] does not match the expected value.');
+
+        $this->assert->whereQuery('foo', 'baz');
+    }
+
+    public function testAssertWhereQueryFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('https://foo.bar');
+
+        $this->expectAssertionException('URI component [Query] does not exist.');
+
+        $assert->whereQuery('foo', 'bar');
+    }
+
+    public function testAssertRawWhereQuery()
+    {
+        $assert = new AssertableUri('https://foo.bar?name=Taylor&id=1');
+
+        $assert->whereQuery('name=Taylor&id=1');
+    }
+
+    public function testAssertWhereNestedQuery()
+    {
+        $assert = new AssertableUri('https://foo.com?user[name]=Taylor&user[id]=1');
+
+        $assert->whereQuery('user.name', 'Taylor');
+        $assert->whereQuery('user.id', '1');
+    }
+
+    public function testAssertWhereNestedQueryFailsWhenDoesNotMatchValue()
+    {
+        $assert = new AssertableUri('https://foo.com?user[name]=Taylor&user[id]=1');
+
+        $this->expectAssertionException('Query [user.name] does not match the expected value.');
+
+        $assert->whereQuery('user.name', 'baz');
+    }
+
+    public function testAssertWhereQueryUsingClosure()
+    {
+        $assert = new AssertableUri('https://foo.com?state='.str_repeat('a', 30));
+
+        $assert->whereQuery('state', function ($state) {
+            return strlen($state) === 30;
+        });
+    }
+
+    public function testAssertQueryIsUrlDecoded()
+    {
+        $assert = new AssertableUri('foo.bar?redirect_uri=https%3A%2F%2Flaravel.com%2Ftest');
+
+        $assert->whereQuery('redirect_uri', 'https://laravel.com/test');
+    }
+
+    public function testAssertWhereFragment()
+    {
+        $this->assert->whereFragment('anchor');
+    }
+
+    public function testAssertWhereFragmentFailsWhenDoesNotMatchValue()
+    {
+        $this->expectAssertionException('URI component [Fragment] does not match the expected value.');
+
+        $this->assert->whereFragment('incorrect');
+    }
+
+    public function testAssertWhereFailsWhenComponentMissing()
+    {
+        $assert = new AssertableUri('https://foo.bar');
+
+        $this->expectAssertionException('URI component [Path] does not exist.');
+
+        $assert->wherePath('missing');
+    }
+
+    public function testCanChainMultipleAssertion()
+    {
+        $this->assert->whereQuery('foo', 'bar')->whereFragment('anchor');
+    }
+
+    public function testMustAssertAllQueriesWhenInteractedFlagIsSet()
+    {
+        $assert = new AssertableUri('https://foo.bar?name=Taylor&id=1');
+
+        $assert->whereQuery('name', 'Taylor')
+            ->whereQuery('id', '1')
+            ->interacted();
+    }
+
+    public function testInteractedFailsWhenOneQueryIsNotAsserted()
+    {
+        $assert = new AssertableUri('https://foo.bar?name=Taylor&id=1');
+
+        $this->expectAssertionException('Unexpected query were found on URI');
+
+        $assert->whereQuery('name', 'Taylor')->interacted();
+    }
+
+    public function testCanDisableInteractionCheck()
+    {
+        $assert = new AssertableUri('https://foo.bar?name=Taylor&id=1');
+
+        $assert->whereQuery('name', 'Taylor')
+            ->etc()
+            ->interacted();
+    }
+
+    public function testThrowExceptionWhenMethodDoesNotExist()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $this->assert->hasInvalidMethod();
+    }
+
+    private function expectAssertionException($message)
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage($message);
+    }
+}


### PR DESCRIPTION
I was working on a project and in order to test oauth2 redirection, I ended up with something like this:

**Before**
```
$response = $this->get('integrations/calendars?provider=GOOGLE')
            ->assertStatus(302);

$location = $response->headers->get('location');
$query = parse_url($location, PHP_URL_QUERY);
parse_str($query, $params);

$this->assertEquals(secure_url('integrations/calendars/callback'), $params['redirect_uri']);
$this->assertStringContainsString('https://accounts.google.com/o/oauth2/auth', $location);
$this->assertEquals('https://www.googleapis.com/auth/calendar', $params['scope']);
$this->assertEquals(config('services.google.client_id'), $params['client_id']);
$this->assertEquals('true', $params['include_granted_scopes']);
$this->assertEquals('offline', $params['access_type']);
$this->assertEquals('code', $params['response_type']);
$this->assertTrue(strlen($params['state']) === 40);
$this->assertEquals('consent', $params['prompt']);
```
I think it would be cleaner and much more readable if have something similar to ``AssertableJson`` class.

**After**

```
$response = $this->get('integrations/calendars?provider=GOOGLE')
    ->assertRedirect(function (AssertableUri $uri) {
        $uri
            ->whereQuery('redirect_uri', secure_url('integrations/calendars/callback'))
            ->whereQuery('scope', 'https://www.googleapis.com/auth/calendar')
            ->whereQuery('client_id', config('services.google.client_id'))
            ->whereQuery('include_granted_scopes', 'true')
            ->whereQuery('access_type', 'offline')
            ->whereQuery('response_type', 'code')
            ->whereQuery('prompt', 'consent')
            ->whereQuery('state', function($state) {
                return strlen($state) === 40;
            });

    });
```

We can assert other parts of URI using these methods:

- whereFragment($value)
- whereHost($value)
- wherePass($value)
- wherePath($value)
- wherePort($value)
- whereScheme($value)
- whereUser($value)

IMO It's not practical but we can only check for existence of component using these methods:

- hasFragment()
- hasHost()
- hasPass()
- hasPath()
- hasPort()
- hasScheme()
- hasUser()

### ``etc()``

Like AssertableJson it uses ``Interaction`` trait, this will automatically fail your test when you haven't interacted with at least one of the props in a **URI query string**. Hence  the sequence is fixed in other parts of URI; they don't need to be affected by interacted method and can be asserted using ``assertRedirectContains`` method.



```
$assert = new AssertableUri('https://foo.bar?name=Taylor&id=1');
        $assert->whereQuery('name', 'Taylor')
            ->etc() // If remove this line, this will fail
            ->interacted();
```
