### PR TITLE
[9.x] Added withoutCount method in Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -185,6 +185,19 @@ class Builder implements BuilderContract
 
         return $this;
     }
+    
+    /**
+     * Prevent the specified relations count from being eager loaded.
+     *
+     * @param  mixed  $relationNames
+     * @return $this
+     */
+    public function withoutCount($relationNames)
+    {
+        $this->withCount = array_diff($this->withCount, is_string($relationNames) ? func_get_args() : $relationNames);
+
+        return $this;
+    }
 
     /**
      * Remove all or passed registered global scopes.

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -185,7 +185,7 @@ class Builder implements BuilderContract
 
         return $this;
     }
-    
+
     /**
      * Prevent the specified relations count from being eager loaded.
      *


### PR DESCRIPTION
Added `withoutCount` method in Eloquent Builder

Sometime we have to ignore the withCount property in runtime that's why I've added a method in eloquent builder which is `withoutCount`

### Usage

```php

$categories = Category::latest()->withoutCount('articles')->get();
// or 
$categories = Category::latest()->withoutCount('articles', 'votes')->get();
// or
$categories = Category::latest()->withoutCount(['articles', 'votes'])->get();

```