### PR TITLE
[9.x] Model::whereRelation add callback function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -365,7 +365,11 @@ trait QueriesRelationships
     public function whereRelation($relation, $column, $operator = null, $value = null)
     {
         return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
-            $query->where($column, $operator, $value);
+            if ($column instanceof Closure) {
+                $column($query);
+            } else {
+                $query->where($column, $operator, $value);
+            }
         });
     }
 
@@ -381,7 +385,11 @@ trait QueriesRelationships
     public function orWhereRelation($relation, $column, $operator = null, $value = null)
     {
         return $this->orWhereHas($relation, function ($query) use ($column, $operator, $value) {
-            $query->where($column, $operator, $value);
+            if ($column instanceof Closure) {
+                $column($query);
+            } else {
+                $query->where($column, $operator, $value);
+            }
         });
     }
 

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentWhereHasTest;
 
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Database\Query\Builder as QueryBuilder;
 
 class EloquentWhereHasTest extends DatabaseTestCase
 {
@@ -55,8 +55,8 @@ class EloquentWhereHasTest extends DatabaseTestCase
     public function testWhereRelationCallback($callbackEloquent, $callbackQuery)
     {
         $userWhereRelation = User::whereRelation("posts", $callbackEloquent);
-        $userWhereHas      = User::whereHas("posts", $callbackEloquent);
-        $query             = DB::table("users")->whereExists($callbackQuery);
+        $userWhereHas = User::whereHas("posts", $callbackEloquent);
+        $query = DB::table("users")->whereExists($callbackQuery);
 
         $this->assertEquals($userWhereRelation->getQuery()->toSql(), $query->toSql());
         $this->assertEquals($userWhereRelation->getQuery()->toSql(), $userWhereHas->toSql());
@@ -75,8 +75,8 @@ class EloquentWhereHasTest extends DatabaseTestCase
     public function testOrWhereRelationCallback($callbackEloquent, $callbackQuery)
     {
         $userOrWhereRelation = User::orWhereRelation("posts", $callbackEloquent);
-        $userOrWhereHas      = User::orWhereHas("posts", $callbackEloquent);
-        $query               = DB::table("users")->orWhereExists($callbackQuery);
+        $userOrWhereHas = User::orWhereHas("posts", $callbackEloquent);
+        $query = DB::table("users")->orWhereExists($callbackQuery);
 
         $this->assertEquals($userOrWhereRelation->getQuery()->toSql(), $query->toSql());
         $this->assertEquals($userOrWhereRelation->getQuery()->toSql(), $userOrWhereHas->toSql());
@@ -92,27 +92,27 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $callbackArray = function ($value) {
 
             $callbackEloquent = function (EloquentBuilder $builder) use ($value) {
-                $builder->selectRaw("id")->where("public", $value);
+                $builder->selectRaw('id')->where('public', $value);
             };
 
             $callbackQuery = function (QueryBuilder $builder) use ($value) {
                 $hasMany = app()->make(User::class)->posts();
 
-                $builder->from("posts")->addSelect(['*'])->whereColumn(
+                $builder->from('posts')->addSelect(['*'])->whereColumn(
                     $hasMany->getQualifiedParentKeyName(),
                     '=',
                     $hasMany->getQualifiedForeignKeyName()
                 );
 
-                $builder->selectRaw("id")->where("public", $value);
+                $builder->selectRaw('id')->where("public", $value);
             };
 
             return [$callbackEloquent, $callbackQuery];
         };
 
         return [
-            "Find user with post.public = true"  => $callbackArray(true),
-            "Find user with post.public = false" => $callbackArray(false),
+            'Find user with post.public = true'  => $callbackArray(true),
+            'Find user with post.public = false' => $callbackArray(false),
         ];
     }
 

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 class EloquentWhereHasTest extends DatabaseTestCase
 {
@@ -42,6 +45,75 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $post = tap((new Post(['public' => false]))->user()->associate($user))->save();
         (new Comment)->commentable()->associate($post)->save();
         (new Text(['content' => 'test2']))->post()->associate($post)->save();
+    }
+
+    /**
+     * Check that the 'whereRelation' callback function works.
+     *
+     * @dataProvider dataProviderWhereRelationCallback
+     */
+    public function testWhereRelationCallback($callbackEloquent, $callbackQuery)
+    {
+        $userWhereRelation = User::whereRelation("posts", $callbackEloquent);
+        $userWhereHas      = User::whereHas("posts", $callbackEloquent);
+        $query             = DB::table("users")->whereExists($callbackQuery);
+
+        $this->assertEquals($userWhereRelation->getQuery()->toSql(), $query->toSql());
+        $this->assertEquals($userWhereRelation->getQuery()->toSql(), $userWhereHas->toSql());
+        $this->assertEquals($userWhereHas->getQuery()->toSql(), $query->toSql());
+
+        $this->assertEquals($userWhereRelation->first()->id, $query->first()->id);
+        $this->assertEquals($userWhereRelation->first()->id, $userWhereHas->first()->id);
+        $this->assertEquals($userWhereHas->first()->id, $query->first()->id);
+    }
+
+    /**
+     * Check that the 'orWhereRelation' callback function works.
+     *
+     * @dataProvider dataProviderWhereRelationCallback
+     */
+    public function testOrWhereRelationCallback($callbackEloquent, $callbackQuery)
+    {
+        $userOrWhereRelation = User::orWhereRelation("posts", $callbackEloquent);
+        $userOrWhereHas      = User::orWhereHas("posts", $callbackEloquent);
+        $query               = DB::table("users")->orWhereExists($callbackQuery);
+
+        $this->assertEquals($userOrWhereRelation->getQuery()->toSql(), $query->toSql());
+        $this->assertEquals($userOrWhereRelation->getQuery()->toSql(), $userOrWhereHas->toSql());
+        $this->assertEquals($userOrWhereHas->getQuery()->toSql(), $query->toSql());
+
+        $this->assertEquals($userOrWhereRelation->first()->id, $query->first()->id);
+        $this->assertEquals($userOrWhereRelation->first()->id, $userOrWhereHas->first()->id);
+        $this->assertEquals($userOrWhereHas->first()->id, $query->first()->id);
+    }
+
+    public function dataProviderWhereRelationCallback()
+    {
+        $callbackArray = function ($value) {
+
+            $callbackEloquent = function (EloquentBuilder $builder) use ($value) {
+                $builder->selectRaw("id")->where("public", $value);
+            };
+
+            $callbackQuery = function (QueryBuilder $builder) use ($value) {
+                $hasMany = app()->make(User::class)->posts();
+
+                $builder->from("posts")->addSelect(['*'])->whereColumn(
+                    $hasMany->getQualifiedParentKeyName(),
+                    '=',
+                    $hasMany->getQualifiedForeignKeyName()
+                );
+
+                $builder->selectRaw("id")->where("public", $value);
+            };
+
+            return [$callbackEloquent, $callbackQuery];
+        };
+
+        return [
+            "Find user with post.public = true"  => $callbackArray(true),
+            "Find user with post.public = false" => $callbackArray(false),
+        ];
     }
 
     public function testWhereRelation()

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -90,7 +90,6 @@ class EloquentWhereHasTest extends DatabaseTestCase
     public function dataProviderWhereRelationCallback()
     {
         $callbackArray = function ($value) {
-
             $callbackEloquent = function (EloquentBuilder $builder) use ($value) {
                 $builder->selectRaw('id')->where('public', $value);
             };

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -54,9 +54,9 @@ class EloquentWhereHasTest extends DatabaseTestCase
      */
     public function testWhereRelationCallback($callbackEloquent, $callbackQuery)
     {
-        $userWhereRelation = User::whereRelation("posts", $callbackEloquent);
-        $userWhereHas = User::whereHas("posts", $callbackEloquent);
-        $query = DB::table("users")->whereExists($callbackQuery);
+        $userWhereRelation = User::whereRelation('posts', $callbackEloquent);
+        $userWhereHas = User::whereHas('posts', $callbackEloquent);
+        $query = DB::table('users')->whereExists($callbackQuery);
 
         $this->assertEquals($userWhereRelation->getQuery()->toSql(), $query->toSql());
         $this->assertEquals($userWhereRelation->getQuery()->toSql(), $userWhereHas->toSql());
@@ -74,9 +74,9 @@ class EloquentWhereHasTest extends DatabaseTestCase
      */
     public function testOrWhereRelationCallback($callbackEloquent, $callbackQuery)
     {
-        $userOrWhereRelation = User::orWhereRelation("posts", $callbackEloquent);
-        $userOrWhereHas = User::orWhereHas("posts", $callbackEloquent);
-        $query = DB::table("users")->orWhereExists($callbackQuery);
+        $userOrWhereRelation = User::orWhereRelation('posts', $callbackEloquent);
+        $userOrWhereHas = User::orWhereHas('posts', $callbackEloquent);
+        $query = DB::table('users')->orWhereExists($callbackQuery);
 
         $this->assertEquals($userOrWhereRelation->getQuery()->toSql(), $query->toSql());
         $this->assertEquals($userOrWhereRelation->getQuery()->toSql(), $userOrWhereHas->toSql());
@@ -104,7 +104,7 @@ class EloquentWhereHasTest extends DatabaseTestCase
                     $hasMany->getQualifiedForeignKeyName()
                 );
 
-                $builder->selectRaw('id')->where("public", $value);
+                $builder->selectRaw('id')->where('public', $value);
             };
 
             return [$callbackEloquent, $callbackQuery];


### PR DESCRIPTION
Example
```php
// I want to optimize the query. In callback function.
$userSQL = User::whereRelation(
    "posts",
    function($query) {
        $query->limit(1)->where("public", true);
    }
)->toSql();
```
Before this PR
```sql
select * 
from "users" 
where exists (
   select *
   from "posts" 
   where "users"."id" = "posts"."user_id" and ("public" = ?)
)
```

After this PR
```sql
select * 
from "users" 
where exists (
   select *
   from "posts" 
   where "users"."id" = "posts"."user_id" and "public" = ? limit 1
)
```

I added tests for checks.
This is not in the documentation, but it is logical.
It would be very convenient.

I think we're talking about a supplement. I'm not sure if this is a mistake. But many expect a different result using this method.