### PR TITLE
Removal of a unused function in redirectResponse

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -183,16 +183,6 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
-     * Get the original response content.
-     *
-     * @return null
-     */
-    public function getOriginalContent()
-    {
-        //
-    }
-
-    /**
      * Get the request instance.
      *
      * @return \Illuminate\Http\Request|null


### PR DESCRIPTION
Removal unused function `getOriginalContent` in redirectResponse.