### PR TITLE
[9.x] Add Conditionable Trait to Illuminate\Support\Carbon

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -4,9 +4,12 @@ namespace Illuminate\Support;
 
 use Carbon\Carbon as BaseCarbon;
 use Carbon\CarbonImmutable as BaseCarbonImmutable;
+use Illuminate\Support\Traits\Conditionable;
 
 class Carbon extends BaseCarbon
 {
+    use Conditionable;
+
     /**
      * {@inheritdoc}
      */

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -117,4 +117,10 @@ class SupportCarbonTest extends TestCase
         $this->assertSame('2017-06-27 13:14:15', BaseCarbon::now()->toDateTimeString());
         $this->assertSame('2017-06-27 13:14:15', BaseCarbonImmutable::now()->toDateTimeString());
     }
+
+    public function testCarbonIsConditionable()
+    {
+        $this->assertTrue(Carbon::now()->when(null, fn(Carbon $carbon) => $carbon->addDays(1))->isToday());
+        $this->assertTrue(Carbon::now()->when(true, fn(Carbon $carbon) => $carbon->addDays(1))->isTomorrow());
+    }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -120,7 +120,7 @@ class SupportCarbonTest extends TestCase
 
     public function testCarbonIsConditionable()
     {
-        $this->assertTrue(Carbon::now()->when(null, fn(Carbon $carbon) => $carbon->addDays(1))->isToday());
-        $this->assertTrue(Carbon::now()->when(true, fn(Carbon $carbon) => $carbon->addDays(1))->isTomorrow());
+        $this->assertTrue(Carbon::now()->when(null, fn (Carbon $carbon) => $carbon->addDays(1))->isToday());
+        $this->assertTrue(Carbon::now()->when(true, fn (Carbon $carbon) => $carbon->addDays(1))->isTomorrow());
     }
 }


### PR DESCRIPTION
Today I had a situation where I needed to set the week-number of a Carbon date, but only when a user selected a filter. Otherwise the Carbon instance should default to the current time. 

I think that many developers as well have had the situation where they wanted to conditionably apply a method to a Carbon object. At least, I've had this feeling multiple times previously.

I could've done this with an `if`-condition, but I really missed the elegance of using the `->when()` method from the Conditionable, so this looked like the perfect situation for adding the Conditionable trait. 

### Simple example

```php
// Could be `null` or `[$year, $week]`
$filter = /** */

// Old:
$carbon = $filter ? Carbon::now()->setIsoDate(...$filter) : Carbon::now();

// New:
$carbon = Carbon::now()->when($filter, fn(Carbon $carbon) => $carbon->setIsoDate(...$filter));
```

I hope this will be useful to many developers!