### PR TITLE
[9.x] Fix afterCommit and DatabaseTransactions

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -20,6 +20,12 @@ trait DatabaseTransactions
             $connection->unsetEventDispatcher();
             $connection->beginTransaction();
             $connection->setEventDispatcher($dispatcher);
+            
+            if ($this->app->resolved('db.transactions')) {
+                $this->app->make('db.transactions')->callbacksShouldIgnore(
+                    $this->app->make('db.transactions')->getTransactions()->first()
+                );
+            }
         }
 
         $this->beforeApplicationDestroyed(function () use ($database) {


### PR DESCRIPTION
Fix so that DB::afterCommit() works in tests that use the DatabaseTransactions trait.

This is based off of #41782 where Taylor added it to RefreshDatabase but forgot to update DatabaseTransactions
