### PR TITLE
[9.x] Change type of default for Redirect:intended

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -98,7 +98,7 @@ class Redirector
     /**
      * Create a new redirect response to the previously intended location.
      *
-     * @param  string  $default
+     * @param  mixed  $default
      * @param  int  $status
      * @param  array  $headers
      * @param  bool|null  $secure


### PR DESCRIPTION
The value of `$default` passed to `Redirect::intended` can actually be anything `Arr::pull` accepts for it's default which is marked as `mixed` since it runs through the `value` helper.

This is useful as it allows a conditional fallback value e.g.
```php
return Redirect::intended(fn() => match($user->role) {
    'admin' => 'admin.dashboard',
    'owner' => 'owner.dashboard'
});
```

This PR simply changes the return type in the docblock so there are no backwards compatibility issues to consider.