### PR TITLE
[9.x] add enum support to collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Traits;
 use CachingIterator;
 use Closure;
 use Exception;
+use UnitEnum;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
@@ -1071,7 +1072,12 @@ trait EnumeratesValues
         }
 
         return function ($item) use ($value) {
-            return data_get($item, $value);
+            $outputValue = data_get($item, $value);
+            if ($outputValue instanceof UnitEnum) {
+                return $outputValue->value;
+            }
+
+            return $outputValue;
         };
     }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support\Traits;
 use CachingIterator;
 use Closure;
 use Exception;
-use UnitEnum;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
@@ -16,6 +15,7 @@ use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 use UnexpectedValueException;
+use UnitEnum;
 
 /**
  * @template TKey of array-key

--- a/tests/Support/Fixtures/TestEnum.php
+++ b/tests/Support/Fixtures/TestEnum.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Illuminate\Tests\Support\Fixtures;
 
 enum TestEnum : string

--- a/tests/Support/Fixtures/TestEnum.php
+++ b/tests/Support/Fixtures/TestEnum.php
@@ -1,0 +1,8 @@
+<?php
+namespace Illuminate\Tests\Support\Fixtures;
+
+enum TestEnum : string
+{
+    case Value1 = 'value_1';
+    case Value2 = 'value_2';
+}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2,28 +2,28 @@
 
 namespace Illuminate\Tests\Support;
 
-use stdClass;
-use Exception;
 use ArrayAccess;
-use ArrayObject;
-use Mockery as m;
 use ArrayIterator;
+use ArrayObject;
 use CachingIterator;
-use ReflectionClass;
-use JsonSerializable;
-use Illuminate\Support\Str;
-use InvalidArgumentException;
-use UnexpectedValueException;
-use PHPUnit\Framework\TestCase;
+use Exception;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\LazyCollection;
-use Illuminate\Contracts\Support\Jsonable;
-use Symfony\Component\VarDumper\VarDumper;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\ItemNotFoundException;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\MultipleItemsFoundException;
+use Illuminate\Support\Str;
 use Illuminate\Tests\Support\Fixtures\TestEnum;
+use InvalidArgumentException;
+use JsonSerializable;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use stdClass;
+use Symfony\Component\VarDumper\VarDumper;
+use UnexpectedValueException;
 
 class SupportCollectionTest extends TestCase
 {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3087,8 +3087,8 @@ class SupportCollectionTest extends TestCase
         $result = $data->groupBy('type');
 
         $this->assertEquals([
-            "value_1" => [['rating' => 1, 'type' => TestEnum::Value1]],
-            "value_2" => [['rating' => 1, 'type' => TestEnum::Value2]],
+            'value_1' => [['rating' => 1, 'type' => TestEnum::Value1]],
+            'value_2' => [['rating' => 1, 'type' => TestEnum::Value2]],
         ], $result->toArray());
     }
 
@@ -5211,7 +5211,8 @@ class TestCollectionSubclass extends Collection
     //
 }
 
-enum TestEnum: string {
+enum TestEnum: string
+{
     case Value1 = 'value_1';
     case Value2 = 'value_2';
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3076,6 +3076,25 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+
+    public function testGroupByWithEnumValue($collection)
+    {
+        $data = new $collection([
+            ['rating' => 1, 'type' => TestEnum::Value1],
+            ['rating' => 1, 'type' => TestEnum::Value2],
+        ]);
+
+        $result = $data->groupBy('type');
+
+        $this->assertEquals([
+            "value_1" => [['rating' => 1, 'type' => TestEnum::Value1]],
+            "value_2" => [['rating' => 1, 'type' => TestEnum::Value2]],
+        ], $result->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testGroupByAttributePreservingKeys($collection)
     {
         $data = new $collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
@@ -5190,4 +5209,9 @@ class TestCollectionMapIntoObject
 class TestCollectionSubclass extends Collection
 {
     //
+}
+
+enum TestEnum: string {
+    case Value1 = 'value_1';
+    case Value2 = 'value_2';
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3076,7 +3076,6 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-
     public function testGroupByWithEnumValue($collection)
     {
         $data = new $collection([
@@ -5211,7 +5210,7 @@ class TestCollectionSubclass extends Collection
     //
 }
 
-enum TestEnum: string
+enum TestEnum : string
 {
     case Value1 = 'value_1';
     case Value2 = 'value_2';

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2,27 +2,28 @@
 
 namespace Illuminate\Tests\Support;
 
-use ArrayAccess;
-use ArrayIterator;
-use ArrayObject;
-use CachingIterator;
+use stdClass;
 use Exception;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Support\Collection;
-use Illuminate\Support\HtmlString;
-use Illuminate\Support\ItemNotFoundException;
-use Illuminate\Support\LazyCollection;
-use Illuminate\Support\MultipleItemsFoundException;
+use ArrayAccess;
+use ArrayObject;
+use Mockery as m;
+use ArrayIterator;
+use CachingIterator;
+use ReflectionClass;
+use JsonSerializable;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use JsonSerializable;
-use Mockery as m;
-use PHPUnit\Framework\TestCase;
-use ReflectionClass;
-use stdClass;
-use Symfony\Component\VarDumper\VarDumper;
 use UnexpectedValueException;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Collection;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Contracts\Support\Jsonable;
+use Symfony\Component\VarDumper\VarDumper;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\ItemNotFoundException;
+use Illuminate\Support\MultipleItemsFoundException;
+use Illuminate\Tests\Support\Fixtures\TestEnum;
 
 class SupportCollectionTest extends TestCase
 {
@@ -3078,6 +3079,10 @@ class SupportCollectionTest extends TestCase
      */
     public function testGroupByWithEnumValue($collection)
     {
+        if (version_compare(PHP_VERSION, '8.1') < 0) {
+            $this->markTestSkipped('PHP 8.1 is required.');
+        }
+
         $data = new $collection([
             ['rating' => 1, 'type' => TestEnum::Value1],
             ['rating' => 1, 'type' => TestEnum::Value2],
@@ -5208,10 +5213,4 @@ class TestCollectionMapIntoObject
 class TestCollectionSubclass extends Collection
 {
     //
-}
-
-enum TestEnum : string
-{
-    case Value1 = 'value_1';
-    case Value2 = 'value_2';
 }


### PR DESCRIPTION
REF #42043 #42031

when doing `groupBy` or `keyBy` with enum field that casted from a model sometimes it returns an enum instance. it will cause an error `array_key_exists(): Argument #1 ($key) must be a valid array offset type`.
for example like below

```php
enum CustomerStatus: string
{
    case Bussines = 'bussines';
    case Private = 'private';
}
```

```php
class Customer  extends Model {
    protected $casts = [
        'status' => CustomerStatus::class,
    ];
}
```

then when we do 
```php
Customer::all()->groupBy('status')
``` 

it will cause an error 
```
array_key_exists(): Argument #1 ($key) must be a valid array offset type
```

we need to workaround with enum for example `Customer::all()->groupBy('status.value')`
this PR will make accessing value of an enum directly like `Customer::all()->groupBy('status')`