### PR TITLE
Added ucwords to String helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -739,6 +739,18 @@ class Str
     }
 
     /**
+     * Uppercase the first character of each word in a string.
+     *
+     * @param  string  $value
+     * @param  string  $separators
+     * @return string
+     */
+    public static function ucwords($value, $separators = " \t\r\n\f\v")
+    {
+        return ucwords($value, $separators);
+    }
+
+    /**
      * Convert the given string to title case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -622,6 +622,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Uppercase the first character of each word in a string.
+     *
+     * @param  string  $separators
+     * @return static
+     */
+    public function ucwords($separators = " \t\r\n\f\v")
+    {
+        return new static(Str::ucwords($this->value, $separators));
+    }
+
+    /**
      * Convert the given string to title case.
      *
      * @return static

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -646,6 +646,12 @@ class SupportStringableTest extends TestCase
         $this->assertSame('FOO BAR BAZ', (string) $this->stringable('foO bAr BaZ')->upper());
     }
 
+    public function testUcwords()
+    {
+        $this->assertSame('Foo Bar Baz', (string) $this->stringable('foo bar baz')->ucwords());
+        $this->assertSame('FoO BAr BaZ', (string) $this->stringable('foO bAr BaZ')->ucwords());
+    }
+
     public function testLimit()
     {
         $this->assertSame('Laravel is...',


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I needed to take an uppercase string, lower it then upper case the first letter of each word. 

Currently i have to do this: `ucwords((string)Str::of($value)->lower())`,

Now i can do this: `(string)Str::of($value)->lower()->ucwords()`,
