### PR TITLE
[9.x] Add iterable type hinting to Eloquent concerns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -28,7 +28,7 @@ trait GuardsAttributes
     /**
      * The actual columns that exist on the database and can be guarded.
      *
-     * @var array
+     * @var string[]
      */
     protected static $guardableColumns = [];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -7,14 +7,14 @@ trait GuardsAttributes
     /**
      * The attributes that are mass assignable.
      *
-     * @var string[]
+     * @var array<string>
      */
     protected $fillable = [];
 
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var string[]|bool
+     * @var array<string>|bool
      */
     protected $guarded = ['*'];
 
@@ -28,14 +28,14 @@ trait GuardsAttributes
     /**
      * The actual columns that exist on the database and can be guarded.
      *
-     * @var string[]
+     * @var array<string>
      */
     protected static $guardableColumns = [];
 
     /**
      * Get the fillable attributes for the model.
      *
-     * @return array
+     * @return array<string>
      */
     public function getFillable()
     {
@@ -45,7 +45,7 @@ trait GuardsAttributes
     /**
      * Set the fillable attributes for the model.
      *
-     * @param  array  $fillable
+     * @param  array<string>  $fillable
      * @return $this
      */
     public function fillable(array $fillable)
@@ -58,7 +58,7 @@ trait GuardsAttributes
     /**
      * Merge new fillable attributes with existing fillable attributes on the model.
      *
-     * @param  array  $fillable
+     * @param  array<string>  $fillable
      * @return $this
      */
     public function mergeFillable(array $fillable)
@@ -71,7 +71,7 @@ trait GuardsAttributes
     /**
      * Get the guarded attributes for the model.
      *
-     * @return array
+     * @return array<string>
      */
     public function getGuarded()
     {
@@ -83,7 +83,7 @@ trait GuardsAttributes
     /**
      * Set the guarded attributes for the model.
      *
-     * @param  array  $guarded
+     * @param  array<string>  $guarded
      * @return $this
      */
     public function guard(array $guarded)
@@ -96,7 +96,7 @@ trait GuardsAttributes
     /**
      * Merge new guarded attributes with existing guarded attributes on the model.
      *
-     * @param  array  $guarded
+     * @param  array<string>  $guarded
      * @return $this
      */
     public function mergeGuarded(array $guarded)

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -7,21 +7,21 @@ trait HidesAttributes
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var string[]
+     * @var array<string>
      */
     protected $hidden = [];
 
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var string[]
+     * @var array<string>
      */
     protected $visible = [];
 
     /**
      * Get the hidden attributes for the model.
      *
-     * @return array
+     * @return array<string>
      */
     public function getHidden()
     {
@@ -31,7 +31,7 @@ trait HidesAttributes
     /**
      * Set the hidden attributes for the model.
      *
-     * @param  array  $hidden
+     * @param  array<string>  $hidden
      * @return $this
      */
     public function setHidden(array $hidden)
@@ -44,7 +44,7 @@ trait HidesAttributes
     /**
      * Get the visible attributes for the model.
      *
-     * @return array
+     * @return array<string>
      */
     public function getVisible()
     {
@@ -54,7 +54,7 @@ trait HidesAttributes
     /**
      * Set the visible attributes for the model.
      *
-     * @param  array  $visible
+     * @param  array<string>  $visible
      * @return $this
      */
     public function setVisible(array $visible)
@@ -67,7 +67,7 @@ trait HidesAttributes
     /**
      * Make the given, typically hidden, attributes visible.
      *
-     * @param  array|string|null  $attributes
+     * @param  array<string>|string|null  $attributes
      * @return $this
      */
     public function makeVisible($attributes)
@@ -87,7 +87,7 @@ trait HidesAttributes
      * Make the given, typically hidden, attributes visible if the given truth test passes.
      *
      * @param  bool|\Closure  $condition
-     * @param  array|string|null  $attributes
+     * @param  array<string>|string|null  $attributes
      * @return $this
      */
     public function makeVisibleIf($condition, $attributes)
@@ -98,7 +98,7 @@ trait HidesAttributes
     /**
      * Make the given, typically visible, attributes hidden.
      *
-     * @param  array|string|null  $attributes
+     * @param  array<string>|string|null  $attributes
      * @return $this
      */
     public function makeHidden($attributes)
@@ -114,7 +114,7 @@ trait HidesAttributes
      * Make the given, typically visible, attributes hidden if the given truth test passes.
      *
      * @param  bool|\Closure  $condition
-     * @param  array|string|null  $attributes
+     * @param  array<string>|string|null  $attributes
      * @return $this
      */
     public function makeHiddenIf($condition, $attributes)

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -7,14 +7,14 @@ trait HidesAttributes
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var array
+     * @var string[]
      */
     protected $hidden = [];
 
     /**
      * The attributes that should be visible in serialization.
      *
-     * @var array
+     * @var string[]
      */
     protected $visible = [];
 


### PR DESCRIPTION
Changes the `array` type hinting to `string[]`.

This was already partially done in 9c047344505da509c2b893eed7aac369a73e07eb and this PR applies the same principle to the other properties in the traits.

I could add this extra typehinting to the different getters/setters in the trait if that is desirable. But the original PR didn't include them.