### PR TITLE
[9.x] '$backoff' can be an int or an array of int

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -278,7 +278,7 @@ abstract class Job
     /**
      * The number of seconds to wait before retrying a job that encountered an uncaught exception.
      *
-     * @return int|null
+     * @return int|int[]|null
      */
     public function backoff()
     {

--- a/src/Illuminate/Queue/ListenerOptions.php
+++ b/src/Illuminate/Queue/ListenerOptions.php
@@ -16,7 +16,7 @@ class ListenerOptions extends WorkerOptions
      *
      * @param  string  $name
      * @param  string|null  $environment
-     * @param  int  $backoff
+     * @param  int|int[]  $backoff
      * @param  int  $memory
      * @param  int  $timeout
      * @param  int  $sleep

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -14,7 +14,7 @@ class WorkerOptions
     /**
      * The number of seconds to wait before retrying a job that encountered an uncaught exception.
      *
-     * @var int
+     * @var int|int[]
      */
     public $backoff;
 
@@ -85,7 +85,7 @@ class WorkerOptions
      * Create a new worker options instance.
      *
      * @param  string  $name
-     * @param  int  $backoff
+     * @param  int|int[]  $backoff
      * @param  int  $memory
      * @param  int  $timeout
      * @param  int  $sleep


### PR DESCRIPTION
This PR corrects an error in the docblock: according to the documentation and the code, the `$backoff` property can be an `int` **or** an array of `int`(called "exponential backoff" in the Laravel documention).