### PR TITLE
[9.x] Fix deprecated ${var} string interpolation patterns

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -118,7 +118,7 @@ class EncryptCookies
         $validated = [];
 
         foreach ($value as $index => $subValue) {
-            $validated[$index] = $this->validateValue("${key}[${index}]", $subValue);
+            $validated[$index] = $this->validateValue("{$key}[{$index}]", $subValue);
         }
 
         return $validated;


### PR DESCRIPTION
PHP 8.2 deprecates string interpolation patterns that place the dollar sign outside the curly braces. This fixes such patterns by replacing them with proper curly braced patterns.

Fixes `Illuminate\Cookie\Middleware\EncryptCookies::validateArray()`
This is so far the only such occurrence.

References:
 - [PHP.Watch: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated)
 - [wiki.php.net RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
