### PR TITLE
[9.x] Allow bootable test traits to teardown

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -144,10 +144,12 @@ abstract class TestCase extends BaseTestCase
         }
 
         foreach ($uses as $trait) {
-            $method = 'setUp'.class_basename($trait);
-
-            if (method_exists($this, $method)) {
+            if (method_exists($this, $method = 'setUp'.class_basename($trait))) {
                 $this->{$method}();
+            }
+
+            if (method_exists($this, $method = 'tearDown'.class_basename($trait))) {
+                $this->beforeApplicationDestroyed(fn () => $this->{$method}());
             }
         }
 

--- a/tests/Foundation/Testing/BootTraitsTest.php
+++ b/tests/Foundation/Testing/BootTraitsTest.php
@@ -8,11 +8,17 @@ use PHPUnit\Framework\TestCase;
 
 trait TestTrait
 {
-    public $booted = false;
+    public $setUp = false;
+    public $tearDown = false;
 
     public function setUpTestTrait()
     {
-        $this->booted = true;
+        $this->setUp = true;
+    }
+
+    public function tearDownTestTrait()
+    {
+        $this->tearDown = true;
     }
 }
 
@@ -24,13 +30,18 @@ class TestCaseWithTrait extends FoundationTestCase
 
 class BootTraitsTest extends TestCase
 {
-    public function testSetUpTraitsWithBootMethod()
+    public function testSetUpAndTearDownTraits()
     {
         $testCase = new TestCaseWithTrait;
 
-        $method = new \ReflectionMethod(get_class($testCase), 'setUpTraits');
+        $method = new \ReflectionMethod($testCase, 'setUpTraits');
         tap($method)->setAccessible(true)->invoke($testCase);
 
-        $this->assertTrue($testCase->booted);
+        $this->assertTrue($testCase->setUp);
+
+        $method = new \ReflectionMethod($testCase, 'callBeforeApplicationDestroyedCallbacks');
+        tap($method)->setAccessible(true)->invoke($testCase);
+
+        $this->assertTrue($testCase->tearDown);
     }
 }


### PR DESCRIPTION
This allows the [recently added bootable traits](https://github.com/laravel/framework/pull/42394) to teardown when the test is done. In my case I've got a trait that creates a database and populates it with a large amount of data for a testcase. When the test is done it would be nice to be able to clean things up.

I based how this works on the PR here: https://github.com/laravel/framework/pull/39883

