### PR TITLE
[9.x] New validation rules `float` and `float_between`

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1031,6 +1031,54 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute has a given number of digits.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateFloat($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'float');
+
+        if (!is_numeric($value)) {
+            return false;
+        }
+
+        if (!is_string($value)) {
+            $value = strval($value);
+        }
+
+        return strlen($value) == $parameters[0] && ctype_digit($value);
+    }
+
+    /**
+     * Validate that an attribute is between a given number of digits.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateFloatBetween($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'float_between');
+
+        if (!is_numeric($value)) {
+            return false;
+        }
+
+        if (!is_string($value)) {
+            $value = strval($value);
+        }
+
+        $length = strlen($value);
+
+        return $length >= $parameters[0] && $length <= $parameters[1] && ctype_digit($value);
+    }
+
+    /**
      * Validate that an attribute is greater than another attribute.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1042,11 +1042,11 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'float');
 
-        if (!is_numeric($value)) {
+        if (! is_numeric($value)) {
             return false;
         }
 
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             $value = strval($value);
         }
 
@@ -1065,11 +1065,11 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'float_between');
 
-        if (!is_numeric($value)) {
+        if (! is_numeric($value)) {
             return false;
         }
 
-        if (!is_string($value)) {
+        if (! is_string($value)) {
             $value = strval($value);
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1006,6 +1006,92 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateFloat()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'float:5']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'float:200']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '+2.37'], ['foo' => 'float:5']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '2e7'], ['foo' => 'float:3']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'float:3']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '0.9876'], ['foo' => 'float:5']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'float:4']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '123.456.789'], ['foo' => 'float:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '...'], ['foo' => 'float:3']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.'], ['foo' => 'float:1']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.2'], ['foo' => 'float:2']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '2.'], ['foo' => 'float:2']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'float_between:1,6']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'float_between:1,10']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'float_between:4,5']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123456789'], ['foo' => 'float_between:4,8']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '12345678'], ['foo' => 'float_between:4,8']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1234'], ['foo' => 'float_between:4,4']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'float_between:1,6']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'float_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '0.9876'], ['foo' => 'float_between:1,5']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '1..2'], ['foo' => 'float_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '123.456.789'], ['foo' => 'float_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '...'], ['foo' => 'float_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.'], ['foo' => 'float_between:1,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '.2'], ['foo' => 'float_between:0,10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => '2.'], ['foo' => 'float_between:1,10']);
+        $this->assertTrue($v->fails());
+    }
+
     public function testValidationStopsAtFailedPresenceCheck()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Validation rules ```digits``` and ```digits_between``` validated, well, digits. They worked perfectly fine since [August 6, 2016](https://github.com/laravel/framework/pull/14650), for more than 5 years… On January 5, 2022, a **single** person suddenly woke up and [demanded](https://github.com/laravel/framework/issues/40264) that the rules should actually accept floats (to allow a dot between digits) and his wish was [fulfilled](https://github.com/laravel/framework/pull/40278) the next day.

Since nobody cares that [floats are not actually digits](https://github.com/laravel/framework/issues/42326) and [does not want to compromise](https://github.com/laravel/framework/pull/42339), here are 2 **"new"** validation rules that validate floats (digits, but nobody cares about the difference, right?).

Currently, [there are no other validation rules](https://github.com/laravel/framework/pull/42339#issuecomment-1122779620) (or rule combinations) that can guarantee that the input contains only digits and that the input contains only a specific number of digits.

For example, with the **"new"** validation rules ```float``` and ```float_between``` you can validate:
* PIN codes (```float:4``` passes ```0123``` and ```float_between:4,8``` passes ```01234567```)
* US Zip codes (```float:5``` passes ```02421```)
* Phone numbers
* Digits!