### PR TITLE
Avoid creating data when make (#41313)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -90,6 +90,13 @@ abstract class Factory
     protected $faker;
 
     /**
+     * The "is creating" is true when a factory is created.
+     *
+     * @var bool
+     */
+    protected $isCreating = false;
+
+    /**
      * The default namespace where factories reside.
      *
      * @var string
@@ -256,6 +263,8 @@ abstract class Factory
      */
     public function create($attributes = [], ?Model $parent = null)
     {
+        $this->isCreating = true;
+
         if (! empty($attributes)) {
             return $this->state($attributes)->create([], $parent);
         }
@@ -452,7 +461,7 @@ abstract class Factory
         return collect($definition)
             ->map($evaluateRelations = function ($attribute) {
                 if ($attribute instanceof self) {
-                    $attribute = $attribute->create()->getKey();
+                    $attribute = ($this->isCreating) ? $attribute->create()->getKey() : null;
                 } elseif ($attribute instanceof Model) {
                     $attribute = $attribute->getKey();
                 }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -182,6 +182,17 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $post = FactoryTestPostFactory::new()->raw(['title' => 'Test Title']);
         $this->assertIsArray($post);
+        $this->assertNull($post['user_id']);
+        $this->assertSame('Test Title', $post['title']);
+    }
+
+    public function test_expanded_model_attributes_can_be_created_and_set()
+    {
+        $post = FactoryTestPostFactory::new()->raw();
+        $this->assertIsArray($post);
+
+        $post = FactoryTestPostFactory::new()->raw(['title' => 'Test Title', 'user_id' => 1]);
+        $this->assertIsArray($post);
         $this->assertIsInt($post['user_id']);
         $this->assertSame('Test Title', $post['title']);
     }


### PR DESCRIPTION
This update prevents a [model factory with a defined relationship field](https://laravel.com/docs/9.x/database-testing#defining-relationships-within-factories) from creating data in the database when using `make`.

For that we create the status field `isCreating`, which is set to true only when a model factory is being created, and then we check this new field to see if it can create the related model factory or not.

This update may require user adjustments to existing tests.
Example:
```php
class AddressFactory extends Factory
{
    public function definition(): array
    {
        return [
            'user_id' => User::factory(),
        ];
    }
}
```

Before:
```php
Address::factory()->make()->user_id;
```

After:
```php
Address::factory()->make(['user_id' => 1])->user_id;
```