### PR TITLE
[9.x] Add `pipe` helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -305,6 +305,20 @@ if (! function_exists('tap')) {
     }
 }
 
+if (! function_exists('pipe')) {
+    /**
+     * Pass the value to the given callback and return the result.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @return mixed
+     */
+    function pipe($value, $callback)
+    {
+        return $callback($value);
+    }
+}
+
 if (! function_exists('throw_if')) {
     /**
      * Throw the given exception if the given condition is true.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -398,6 +398,18 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals($mock, tap($mock)->foo());
     }
 
+    public function testPipe()
+    {
+        $object = (object) ['id' => 1];
+        $this->assertEquals(2, pipe($object, function ($object) {
+            return 2;
+        }));
+
+        $mock = m::mock();
+        $mock->shouldReceive('foo')->once()->andReturn('bar');
+        $this->assertEquals($mock, tap($mock)->foo());
+    }
+
     public function testThrow()
     {
         $this->expectException(LogicException::class);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -402,7 +402,9 @@ class SupportHelpersTest extends TestCase
     {
         $object = (object) ['id' => 1];
         $this->assertEquals(2, pipe($object, function ($object) {
-            return 2;
+            $object->id = 2;
+
+            return $object->id;
         }));
 
         $mock = m::mock();


### PR DESCRIPTION
### Inspiration
This helper was inspired by the combination of `tap()` and `collect()->pipe()`. Sometimes it's handy if you can pipe something without creating a collection, the same manner we can go with `tap()`.

### Example
```php
return pipe(static::$tooLongObjectName, function ($shortened) {
    if ($shortened->someMethodIsTrue()) {
        return false;
    }

    if (! $shortened->anotherMethodIsFalse()) {
        return false;
    }

    return true;
});
```