### PR TITLE
[9.x] Use `preferredLocale` when notification is queued

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -193,6 +193,8 @@ class NotificationSender
 
                 $notification->id = $notificationId;
 
+                $notification->locale = $this->preferredLocale($notifiable, $notification);
+
                 if (! is_null($this->locale)) {
                     $notification->locale = $this->locale;
                 }


### PR DESCRIPTION
Description
--

[Laravel's documentation](https://laravel.com/docs/8.x/mail#localizing-mailables) states
> [...] Laravel allows you to send mailables in a locale other than the request's current locale, and will even remember this locale if the mail is queued.

> [...] Once you have implemented the interface, Laravel will automatically use the preferred locale when sending mailables and notifications to the model.

however, this is only functioning for synced notifications, this PR fixes this by adding the functionality of sending a notification in the user's preferred locale when a notification is queued.

Example
--

```php
// config/app.php
    'locale' => 'en',
    'fallback_locale' => 'en',

// en/notifications/example.php
return [
    'message' => 'English message'
];

// pt-br/notifications/example.php
return [
    'message' => 'Mensagem em português'
];

```

```php
class User extends Authenticatable implements HasLocalePreference
{
     // ...

     public function preferredLocale(): string
     {
         return 'pt-br';
     }

     // ...
}
```

```php
class ExampleNotification extends BaseNotification implements ShouldQueue
{
    use Queueable;
 
    /**
     * Method called by base notification, running inside worker, that fetches/formats a message.
     */
    protected function getMessage()
    {
        return __('notifications/example/message');
    }
}
```

```php
$user->notify(new ExampleNotification());

// expected message: 'Mensagem em português'
// rendered message: 'English message'
```