### PR TITLE
[9.x] User authentication for Pusher

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastController.php
+++ b/src/Illuminate/Broadcasting/BroadcastController.php
@@ -22,4 +22,20 @@ class BroadcastController extends Controller
 
         return Broadcast::auth($request);
     }
+
+    /**
+     * Authenticate the request for user authorization.
+     * See: https://pusher.com/docs/channels/server_api/authenticating-users/#user-authentication
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function authenticateUser(Request $request)
+    {
+        if ($request->hasSession()) {
+            $request->session()->reflash();
+        }
+
+        return Broadcast::userAuthentication($request);
+    }
 }

--- a/src/Illuminate/Broadcasting/BroadcastController.php
+++ b/src/Illuminate/Broadcasting/BroadcastController.php
@@ -5,6 +5,7 @@ namespace Illuminate\Broadcasting;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Broadcast;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class BroadcastController extends Controller
 {
@@ -25,6 +26,7 @@ class BroadcastController extends Controller
 
     /**
      * Authenticate the request for user authorization.
+     *
      * See: https://pusher.com/docs/channels/server_api/authenticating-users/#user-authentication.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -36,6 +38,7 @@ class BroadcastController extends Controller
             $request->session()->reflash();
         }
 
-        return Broadcast::userAuthentication($request);
+        return Broadcast::resolveAuthenticatedUser($request)
+                    ?? throw new AccessDeniedHttpException;
     }
 }

--- a/src/Illuminate/Broadcasting/BroadcastController.php
+++ b/src/Illuminate/Broadcasting/BroadcastController.php
@@ -25,7 +25,7 @@ class BroadcastController extends Controller
 
     /**
      * Authenticate the request for user authorization.
-     * See: https://pusher.com/docs/channels/server_api/authenticating-users/#user-authentication
+     * See: https://pusher.com/docs/channels/server_api/authenticating-users/#user-authentication.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response

--- a/src/Illuminate/Broadcasting/BroadcastController.php
+++ b/src/Illuminate/Broadcasting/BroadcastController.php
@@ -25,7 +25,7 @@ class BroadcastController extends Controller
     }
 
     /**
-     * Authenticate the request for user authorization.
+     * Authenticate the current user.
      *
      * See: https://pusher.com/docs/channels/server_api/authenticating-users/#user-authentication.
      *

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -74,6 +74,11 @@ class BroadcastManager implements FactoryContract
                 ['get', 'post'], '/broadcasting/auth',
                 '\\'.BroadcastController::class.'@authenticate'
             )->withoutMiddleware([\Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class]);
+
+            $router->match(
+                ['get', 'post'], '/broadcasting/user-auth',
+                '\\'.BroadcastController::class.'@authenticateUser'
+            )->withoutMiddleware([\Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class]);
         });
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -72,7 +72,7 @@ abstract class Broadcaster implements BroadcasterContract
     /**
      * Register the user retrieval callback to authenticate connections.
      *
-     * @param \Closure $callback
+     * @param  \Closure  $callback
      * @return void
      */
     public function resolveUserAuthentication(Closure $callback)
@@ -83,7 +83,7 @@ abstract class Broadcaster implements BroadcasterContract
     /**
      * Authenticate the incoming connection request for a given user.
      * Expecting an array with the user details or false.
-     * See: https://pusher.com/docs/channels/library_auth_reference/auth-signatures/#user-authentication
+     * See: https://pusher.com/docs/channels/library_auth_reference/auth-signatures/#user-authentication.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return mixed

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -76,7 +76,7 @@ class PusherBroadcaster extends Broadcaster
         $encodedUser = json_encode($user);
         $decodedString = "{$request->socket_id}::user::{$encodedUser}";
 
-        $auth = $settings['auth_key'] . ':' . hash_hmac(
+        $auth = $settings['auth_key'].':'.hash_hmac(
             'sha256', $decodedString, $settings['secret']
         );
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -55,38 +55,6 @@ class PusherBroadcaster extends Broadcaster
     }
 
     /**
-     * Respond to the Pusher's authentication of the incoming connection request.
-     * This should return a response according to the Pusher protocol.
-     *
-     * See: https://pusher.com/docs/channels/library_auth_reference/auth-signatures/#user-authentication
-     * See: https://pusher.com/docs/channels/server_api/authenticating-users/#response
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return mixed
-     *
-     * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
-     */
-    public function userAuthentication($request)
-    {
-        if (! $user = parent::userAuthentication($request)) {
-            throw new AccessDeniedHttpException;
-        }
-
-        $settings = $this->pusher->getSettings();
-        $encodedUser = json_encode($user);
-        $decodedString = "{$request->socket_id}::user::{$encodedUser}";
-
-        $auth = $settings['auth_key'].':'.hash_hmac(
-            'sha256', $decodedString, $settings['secret']
-        );
-
-        return [
-            'auth' => $auth,
-            'user_data' => $encodedUser,
-        ];
-    }
-
-    /**
      * Return the valid authentication response.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -133,6 +101,35 @@ class PusherBroadcaster extends Broadcaster
 
         return response()->json(json_decode($response, true))
                     ->withCallback($request->callback);
+    }
+
+    /**
+     * Resolve the authenticated user payload for an incoming connection request.
+     *
+     * See: https://pusher.com/docs/channels/library_auth_reference/auth-signatures/#user-authentication
+     * See: https://pusher.com/docs/channels/server_api/authenticating-users/#response
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|null
+     */
+    public function resolveAuthenticatedUser($request)
+    {
+        if (! $user = parent::resolveAuthenticatedUser($request)) {
+            return;
+        }
+
+        $settings = $this->pusher->getSettings();
+        $encodedUser = json_encode($user);
+        $decodedString = "{$request->socket_id}::user::{$encodedUser}";
+
+        $auth = $settings['auth_key'].':'.hash_hmac(
+            'sha256', $decodedString, $settings['secret']
+        );
+
+        return [
+            'auth' => $auth,
+            'user_data' => $encodedUser,
+        ];
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -32,6 +32,35 @@ class PusherBroadcaster extends Broadcaster
     }
 
     /**
+     * Resolve the authenticated user payload for an incoming connection request.
+     *
+     * See: https://pusher.com/docs/channels/library_auth_reference/auth-signatures/#user-authentication
+     * See: https://pusher.com/docs/channels/server_api/authenticating-users/#response
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|null
+     */
+    public function resolveAuthenticatedUser($request)
+    {
+        if (! $user = parent::resolveAuthenticatedUser($request)) {
+            return;
+        }
+
+        $settings = $this->pusher->getSettings();
+        $encodedUser = json_encode($user);
+        $decodedString = "{$request->socket_id}::user::{$encodedUser}";
+
+        $auth = $settings['auth_key'].':'.hash_hmac(
+            'sha256', $decodedString, $settings['secret']
+        );
+
+        return [
+            'auth' => $auth,
+            'user_data' => $encodedUser,
+        ];
+    }
+
+    /**
      * Authenticate the incoming request for a given channel.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -101,35 +130,6 @@ class PusherBroadcaster extends Broadcaster
 
         return response()->json(json_decode($response, true))
                     ->withCallback($request->callback);
-    }
-
-    /**
-     * Resolve the authenticated user payload for an incoming connection request.
-     *
-     * See: https://pusher.com/docs/channels/library_auth_reference/auth-signatures/#user-authentication
-     * See: https://pusher.com/docs/channels/server_api/authenticating-users/#response
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return array|null
-     */
-    public function resolveAuthenticatedUser($request)
-    {
-        if (! $user = parent::resolveAuthenticatedUser($request)) {
-            return;
-        }
-
-        $settings = $this->pusher->getSettings();
-        $encodedUser = json_encode($user);
-        $decodedString = "{$request->socket_id}::user::{$encodedUser}";
-
-        $auth = $settings['auth_key'].':'.hash_hmac(
-            'sha256', $decodedString, $settings['secret']
-        );
-
-        return [
-            'auth' => $auth,
-            'user_data' => $encodedUser,
-        ];
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -6,11 +6,11 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
 
 /**
  * @method static \Illuminate\Broadcasting\Broadcasters\Broadcaster channel(string $channel, callable|string  $callback, array $options = [])
- * @method static mixed auth(\Illuminate\Http\Request $request)
- * @method static \Illuminate\Contracts\Broadcasting\Broadcaster connection($name = null);
- * @method static void routes(array $attributes = null)
  * @method static \Illuminate\Broadcasting\BroadcastManager socket($request = null)
- * @method static void resolveUserAuthentication(Closure $callback)
+ * @method static \Illuminate\Contracts\Broadcasting\Broadcaster connection($name = null);
+ * @method static mixed auth(\Illuminate\Http\Request $request)
+ * @method static void resolveAuthenticatedUserUsing(Closure $callback)
+ * @method static void routes(array $attributes = null)
  *
  * @see \Illuminate\Contracts\Broadcasting\Factory
  */

--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
  * @method static \Illuminate\Contracts\Broadcasting\Broadcaster connection($name = null);
  * @method static void routes(array $attributes = null)
  * @method static \Illuminate\Broadcasting\BroadcastManager socket($request = null)
+ * @method static void resolveUserAuthentication(Closure $callback)
  *
  * @see \Illuminate\Contracts\Broadcasting\Factory
  */

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -287,11 +287,11 @@ class BroadcasterTest extends TestCase
 
     public function testUserAuthenticationWithValidUser()
     {
-        $this->broadcaster->resolveUserAuthentication(function ($request) {
+        $this->broadcaster->resolveAuthenticatedUserUsing(function ($request) {
             return ['id' => '12345', 'socket' => $request->socket_id];
         });
 
-        $user = $this->broadcaster->userAuthentication(new Request(['socket_id' => '1234.1234']));
+        $user = $this->broadcaster->resolveAuthenticatedUser(new Request(['socket_id' => '1234.1234']));
 
         $this->assertSame([
             'id' => '12345',
@@ -301,19 +301,18 @@ class BroadcasterTest extends TestCase
 
     public function testUserAuthenticationWithInvalidUser()
     {
-        $this->broadcaster->resolveUserAuthentication(function ($request) {
+        $this->broadcaster->resolveAuthenticatedUserUsing(function ($request) {
             return null;
         });
 
-        $user = $this->broadcaster->userAuthentication(new Request(['socket_id' => '1234.1234']));
+        $user = $this->broadcaster->resolveAuthenticatedUser(new Request(['socket_id' => '1234.1234']));
 
         $this->assertNull($user);
     }
 
     public function testUserAuthenticationWithoutResolve()
     {
-        $this->expectException(AccessDeniedHttpException::class);
-        $this->broadcaster->userAuthentication(new Request(['socket_id' => '1234.1234']));
+        $this->assertNull($this->broadcaster->resolveAuthenticatedUser(new Request(['socket_id' => '1234.1234'])));
     }
 
     /**

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class BroadcasterTest extends TestCase
@@ -282,6 +283,37 @@ class BroadcasterTest extends TestCase
                 ->withNoArgs();
 
         $this->broadcaster->retrieveUser($request, 'somechannel');
+    }
+
+    public function testUserAuthenticationWithValidUser()
+    {
+        $this->broadcaster->resolveUserAuthentication(function ($request) {
+            return ['id' => '12345', 'socket' => $request->socket_id];
+        });
+
+        $user = $this->broadcaster->userAuthentication(new Request(['socket_id' => '1234.1234']));
+
+        $this->assertSame([
+            'id' => '12345',
+            'socket' => '1234.1234',
+        ], $user);
+    }
+
+    public function testUserAuthenticationWithInvalidUser()
+    {
+        $this->broadcaster->resolveUserAuthentication(function ($request) {
+            return null;
+        });
+
+        $user = $this->broadcaster->userAuthentication(new Request(['socket_id' => '1234.1234']));
+
+        $this->assertNull($user);
+    }
+
+    public function testUserAuthenticationWithoutResolve()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->broadcaster->userAuthentication(new Request(['socket_id' => '1234.1234']));
     }
 
     /**

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -146,6 +146,31 @@ class PusherBroadcasterTest extends TestCase
         );
     }
 
+    public function testUserAuthenticationForPusher()
+    {
+        $this->pusher
+            ->shouldReceive('getSettings')
+            ->andReturn([
+                'auth_key' => '278d425bdf160c739803',
+                'secret' => '7ad3773142a6692b25b8',
+            ]);
+
+        $this->broadcaster = new PusherBroadcaster($this->pusher);
+
+        $this->broadcaster->resolveUserAuthentication(function () {
+            return ['id' => '12345'];
+        });
+
+        $response = $this->broadcaster->userAuthentication(new Request(['socket_id' => '1234.1234']));
+
+        // The result is hard-coded from the Pusher docs
+        // See: https://pusher.com/docs/channels/library_auth_reference/auth-signatures/#user-authentication
+        $this->assertSame([
+            'auth' => '278d425bdf160c739803:4708d583dada6a56435fb8bc611c77c359a31eebde13337c16ab43aa6de336ba',
+            'user_data' => json_encode(['id' => '12345']),
+        ], $response);
+    }
+
     /**
      * @param  string  $channel
      * @return \Illuminate\Http\Request

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -157,11 +157,11 @@ class PusherBroadcasterTest extends TestCase
 
         $this->broadcaster = new PusherBroadcaster($this->pusher);
 
-        $this->broadcaster->resolveUserAuthentication(function () {
+        $this->broadcaster->resolveAuthenticatedUserUsing(function () {
             return ['id' => '12345'];
         });
 
-        $response = $this->broadcaster->userAuthentication(new Request(['socket_id' => '1234.1234']));
+        $response = $this->broadcaster->resolveAuthenticatedUser(new Request(['socket_id' => '1234.1234']));
 
         // The result is hard-coded from the Pusher docs
         // See: https://pusher.com/docs/channels/library_auth_reference/auth-signatures/#user-authentication


### PR DESCRIPTION
### Purpose

Pusher recently launched a feature that allows their users to enable authentication for connections, alongside the channel authorizations: https://pusher.com/docs/channels/using_channels/user-authentication/

Shortly, it's a feature that will make sure that anyone connecting to the websockets should be an authenticated user within the app. This will increase the trust of your connected users and you can broadcast events to user's connections by their database ID, instead of the usual Socket ID.

This is also a gateway step to implement Authorized Connections for the clients, to prevent developers from having attackers abuse the connection quota by creating fake websocket connections without subscribing to any channel: https://pusher.com/docs/channels/using_channels/authorized-connections/

### Approach

In Laravel, this requires a new endpoint that Pusher can call. This was implemented as `/broadcasting/user-auth` (Pusher default is `/pusher/user-auth`) which receives a `socket_id` as request parameter. The issue here is that we cannot find a correlation between socket ID and user, so the requests from the frontend need to be authenticated via the already-injected session by Echo, or with Sanctum with a custom authorizer that will automatically bind the session to the request, in order to be able to retrieve the user.

In `BroadcastServiceProvider`, developers can provide a callback for the user data to send back to Pusher, in the same manner it's done for presence channels:

```php
Broadcast::resolveUserAuthentication(function (Request $request) {
    if (! $request->user()) {
        return;
    }

    return [
        'id' => $request->user()->id,
        'name' => $request->user()->name,
    ];
});
```

Currently, this feature is enabled only for Pusher.

### Breaking Changes

There are no breaking changes to be considered. The `/user-auth` endpoint is going to return 404 for Laravel versions prior to this PR and 401 in case the users don't implement the `resolveUserAuthentication` method.

### Additional steps

Extra, this implies:

- Docs about feature
- Additional changes to docs to include the endpoint for user auth (same as channel auth)
- Laravel Echo changes (optional)

Read more about the feature:

- https://blog.pusher.com/user-centric-applications-with-pusher/
- https://pusher.com/docs/channels/using_channels/user-authentication/
- https://pusher.com/docs/channels/server_api/authenticating-users/
- https://pusher.com/docs/channels/library_auth_reference/auth-signatures/