### PR TITLE
[9.x] Pass thrown exception to $sleepMilliseconds closure in retry helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -249,7 +249,7 @@ if (! function_exists('retry')) {
             $sleepMilliseconds = $backoff[$attempts - 1] ?? $sleepMilliseconds;
 
             if ($sleepMilliseconds) {
-                usleep(value($sleepMilliseconds, $attempts) * 1000);
+                usleep(value($sleepMilliseconds, $attempts, $e) * 1000);
             }
 
             goto beginning;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -598,7 +598,8 @@ class SupportHelpersTest extends TestCase
             }
 
             throw new RuntimeException;
-        }, function ($attempt) {
+        }, function ($attempt, $exception) {
+            $this->assertInstanceOf(RuntimeException::class, $exception);
             return $attempt * 100;
         });
 


### PR DESCRIPTION
# What does this pull request implement?

This pull requests implement a backwards-compatible change to the `retry` helper. The `retry` helper accepts either an `int` or a `Closure`. When passing a `Closure` object, the `$attempts` parameter would be passed, allowed users to implement their own backoff algorithm.

In some cases, however, it would be desirable to implement a backoff strategy based on the exception that was thrown, for example in the case of an API client that returns a specific exception in the case of a `HTTP 429`. In such cases, the exception thrown could potentially hold information as to how long a user has to wait before a new attempt will be excepted.

This pull request allows you to access the thrown exception instance in the `$sleepMilliseconds` closure to implement a dynamic backoff strategy.

# Example use case

Imagine an API library that throws the following exception in the case of a HTTP 429:

```php
<?php

class TooManyRequestsException extends ApiException
{
    public int $retryAfterNumberOfSeconds;

    public int $currentRateLimit;

    public int $rateLimitResetsAfterTimestamp;
}
```

Using the above information, we would be able to implement a dynamic backoff strategy as follows:

```php
retry(3, function() {
    // Perform some kind of external API call
}, function($attempts, $exception) {
    // Use the information provided by the external API to provide `rescue` with a dynamic delay
    return $exception->retryAfterNumberOfSeconds / 1000;
});
```


