### PR TITLE
[9.x] Make HasTimestamps::updateTimestamps chainable

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -39,7 +39,7 @@ trait HasTimestamps
     /**
      * Update the creation and update timestamps.
      *
-     * @return void
+     * @return $this
      */
     public function updateTimestamps()
     {
@@ -56,6 +56,8 @@ trait HasTimestamps
         if (! $this->exists && ! is_null($createdAtColumn) && ! $this->isDirty($createdAtColumn)) {
             $this->setCreatedAt($time);
         }
+        
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -56,7 +56,7 @@ trait HasTimestamps
         if (! $this->exists && ! is_null($createdAtColumn) && ! $this->isDirty($createdAtColumn)) {
             $this->setCreatedAt($time);
         }
-        
+
         return $this;
     }
 


### PR DESCRIPTION
This PR makes the method `HasTimestamps::updateTimestamps` chainable, so we can do:

```php
$model->updateTimestamps()->save();
```