### PR TITLE
[9.x] Add html debug comments around components.

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -272,6 +272,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
         if (! empty($this->echoHandlers)) {
             $result = $this->addBladeCompilerVariable($result);
         }
+        
+        // In debug only, this wraps every component with a comment so that when
+        // inspecting the source in the browser, it is easier to find back what
+        // file is being rendered.
+        if (config('app.debug')) {
+            $result = '<!--- START: ' . $this->path .' -->' . $result . '<!--- END: ' . $this->path .' -->';
+        }
 
         return str_replace(
             ['##BEGIN-COMPONENT-CLASS##', '##END-COMPONENT-CLASS##'],

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -272,11 +272,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
         if (! empty($this->echoHandlers)) {
             $result = $this->addBladeCompilerVariable($result);
         }
-        
+
         // In debug only, this wraps every component with a comment so that when
         // inspecting the source in the browser, it is easier to find back what
         // file is being rendered.
-        if (config('app.debug')) {
+        if (Container::getInstance()->make('config')->get('app.debug')) {
             $result = '<!--- START: ' . $this->path .' -->' . $result . '<!--- END: ' . $this->path .' -->';
         }
 


### PR DESCRIPTION
This proposed change adds a small comment around blade components.

The purpose is to allow for easier debugging while inspecting the code using a browser inspector so that you can navigate faster or have more information about the context of what you are looking at.

In this implementation, I added this using `app.debug` but we can also introduce a new config variable.

Example:

<img width="802" alt="Screenshot 2022-05-26 at 22 29 39" src="https://user-images.githubusercontent.com/866743/170574863-4fd4932e-59d9-4ab2-962d-05a23e3f6fcf.png">

