### PR TITLE
[9.x] PendingMailFake matching PendingMail

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -22,11 +22,11 @@ class PendingMailFake extends PendingMail
      * Send a new mailable message instance.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
-     * @return void
+     * @return \Illuminate\Mail\SentMessage|null
      */
     public function send(Mailable $mailable)
     {
-        $this->mailer->send($this->fill($mailable));
+        return $this->mailer->send($this->fill($mailable));
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `PendingMail` send function was altered to return the result of the mailer send call (see commit https://github.com/laravel/framework/commit/68971ff65d737a8caba125c72e4a4b8b25c1cec6).  However, this change was not reflected in the `PendingMailFake` class.  So, when testing the result of the send call will always return nothing when using `Mail::fake()`.  This makes it difficult to properly unit test functionality without these changes.   
