### PR TITLE
Type-hinted 'resolve' and 'app' helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -106,9 +106,11 @@ if (! function_exists('app')) {
     /**
      * Get the available container instance.
      *
-     * @param  string|null  $abstract
+     * @template T
+     *
+     * @param  class-string<T>|null  $abstract
      * @param  array  $parameters
-     * @return mixed|\Illuminate\Contracts\Foundation\Application
+     * @return T|\Illuminate\Contracts\Foundation\Application
      */
     function app($abstract = null, array $parameters = [])
     {
@@ -681,9 +683,11 @@ if (! function_exists('resolve')) {
     /**
      * Resolve a service from the container.
      *
-     * @param  string  $name
+     * @template T
+     *
+     * @param  class-string<T>  $name
      * @param  array  $parameters
-     * @return mixed
+     * @return T
      */
     function resolve($name, array $parameters = [])
     {


### PR DESCRIPTION
I have added [template annotations](https://psalm.dev/docs/annotating_code/templated_annotations/#param-class-stringt) supported by both [Psalm](https://psalm.dev/docs/annotating_code/templated_annotations/#param-class-stringt) and [PhpStorm](https://blog.jetbrains.com/phpstorm/2021/07/phpstorm-2021-2-release/#class_string_t) to the `resolve` and `app` helper functions.

This means
```php
$foo = resolve(Foo::class);
``` 
will be automatically recognised as having type `Foo` by Psalm and PhpStorm, without needing an extra manual `@var` annotation:


```php
/** @var $foo Foo */
$foo = resolve(Foo::class);
``` 