### PR TITLE
[9.x] Adds `Str::isJson`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -397,7 +397,7 @@ class Str
         if (! is_string($value)) {
             return false;
         }
-        
+
         try {
             json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -372,21 +372,6 @@ class Str
     }
 
     /**
-     * Determine if a given string is a valid UUID.
-     *
-     * @param  string  $value
-     * @return bool
-     */
-    public static function isUuid($value)
-    {
-        if (! is_string($value)) {
-            return false;
-        }
-
-        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
-    }
-
-    /**
      * Determine if a given string is valid JSON.
      *
      * @param  string  $value
@@ -405,6 +390,21 @@ class Str
         }
 
         return true;
+    }
+
+    /**
+     * Determine if a given string is a valid UUID.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isUuid($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Illuminate\Support\Traits\Macroable;
+use JsonException;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
@@ -383,6 +384,27 @@ class Str
         }
 
         return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
+    }
+
+    /**
+     * Determine if a given string is valid JSON.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isJson($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+        
+        try {
+            json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -308,6 +308,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given string is valid JSON.
+     *
+     * @return bool
+     */
+    public function isJson()
+    {
+        return Str::isJson($this->value);
+    }
+
+    /**
      * Determine if the given string is empty.
      *
      * @return bool

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -298,16 +298,6 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Determine if a given string is a valid UUID.
-     *
-     * @return bool
-     */
-    public function isUuid()
-    {
-        return Str::isUuid($this->value);
-    }
-
-    /**
      * Determine if a given string is valid JSON.
      *
      * @return bool
@@ -315,6 +305,16 @@ class Stringable implements JsonSerializable
     public function isJson()
     {
         return Str::isJson($this->value);
+    }
+
+    /**
+     * Determine if a given string is a valid UUID.
+     *
+     * @return bool
+     */
+    public function isUuid()
+    {
+        return Str::isUuid($this->value);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -413,7 +413,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isJson('[1,   2,   3]'));
         $this->assertTrue(Str::isJson('{"first": "John", "last": "Doe"}'));
         $this->assertTrue(Str::isJson('[{"first": "John", "last": "Doe"}, {"first": "Jane", "last": "Doe"}]'));
-   
+
         $this->assertFalse(Str::isJson('1,'));
         $this->assertFalse(Str::isJson('[1,2,3'));
         $this->assertFalse(Str::isJson('[1,   2   3]'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -406,6 +406,24 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isUuid($uuid));
     }
 
+    public function testIsJson()
+    {
+        $this->assertTrue(Str::isJson('1'));
+        $this->assertTrue(Str::isJson('[1,2,3]'));
+        $this->assertTrue(Str::isJson('[1,   2,   3]'));
+        $this->assertTrue(Str::isJson('{"first": "John", "last": "Doe"}'));
+        $this->assertTrue(Str::isJson('[{"first": "John", "last": "Doe"}, {"first": "Jane", "last": "Doe"}]'));
+   
+        $this->assertFalse(Str::isJson('1,'));
+        $this->assertFalse(Str::isJson('[1,2,3'));
+        $this->assertFalse(Str::isJson('[1,   2   3]'));
+        $this->assertFalse(Str::isJson('{first: "John"}'));
+        $this->assertFalse(Str::isJson('[{first: "John"}, {first: "Jane"}]'));
+        $this->assertFalse(Str::isJson(''));
+        $this->assertFalse(Str::isJson(null));
+        $this->assertFalse(Str::isJson([]));
+    }
+
     public function testKebab()
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -45,7 +45,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('[1,   2,   3]')->isJson());
         $this->assertTrue($this->stringable('{"first": "John", "last": "Doe"}')->isJson());
         $this->assertTrue($this->stringable('[{"first": "John", "last": "Doe"}, {"first": "Jane", "last": "Doe"}]')->isJson());
-   
+
         $this->assertFalse($this->stringable('1,')->isJson());
         $this->assertFalse($this->stringable('[1,2,3')->isJson());
         $this->assertFalse($this->stringable('[1,   2   3]')->isJson());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -53,7 +53,6 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('[{first: "John"}, {first: "Jane"}]')->isJson());
         $this->assertFalse($this->stringable('')->isJson());
         $this->assertFalse($this->stringable(null)->isJson());
-        $this->assertFalse($this->stringable([])->isJson());
     }
 
     public function testIsEmpty()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -38,6 +38,24 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98')->isUuid());
     }
 
+    public function testIsJson()
+    {
+        $this->assertTrue($this->stringable('1')->isJson());
+        $this->assertTrue($this->stringable('[1,2,3]')->isJson());
+        $this->assertTrue($this->stringable('[1,   2,   3]')->isJson());
+        $this->assertTrue($this->stringable('{"first": "John", "last": "Doe"}')->isJson());
+        $this->assertTrue($this->stringable('[{"first": "John", "last": "Doe"}, {"first": "Jane", "last": "Doe"}]')->isJson());
+   
+        $this->assertFalse($this->stringable('1,')->isJson());
+        $this->assertFalse($this->stringable('[1,2,3')->isJson());
+        $this->assertFalse($this->stringable('[1,   2   3]')->isJson());
+        $this->assertFalse($this->stringable('{first: "John"}')->isJson());
+        $this->assertFalse($this->stringable('[{first: "John"}, {first: "Jane"}]')->isJson());
+        $this->assertFalse($this->stringable('')->isJson());
+        $this->assertFalse($this->stringable(null)->isJson());
+        $this->assertFalse($this->stringable([])->isJson());
+    }
+
     public function testIsEmpty()
     {
         $this->assertTrue($this->stringable('')->isEmpty());


### PR DESCRIPTION
Adds `isJson()` to `Str` and `Stringable`.

```php
Str::isJson($data); 
//=> boolean

Str::of($data)->isJson()
//=> boolean

str($data)->isJson();
//=> boolean
```

Uses `JSON_THROW_ON_ERROR` flag introduced in PHP 7.3 under the hood.

