### PR TITLE
[9.x] Remove meaningless parameter

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesEvents.php
+++ b/src/Illuminate/View/Concerns/ManagesEvents.php
@@ -55,7 +55,7 @@ trait ManagesEvents
         $composers = [];
 
         foreach ((array) $views as $view) {
-            $composers[] = $this->addViewEvent($view, $callback, 'composing: ');
+            $composers[] = $this->addViewEvent($view, $callback);
         }
 
         return $composers;


### PR DESCRIPTION
The default value of the `$prefix` parameter of the `addViewEvent()` method is `composing: `。
https://github.com/laravel/framework/blob/e4e40df0611db68f47b1995315350260aad8af93/src/Illuminate/View/Concerns/ManagesEvents.php#L72

So this parameter can not be passed when calling.

https://github.com/laravel/framework/blob/e4e40df0611db68f47b1995315350260aad8af93/src/Illuminate/View/Concerns/ManagesEvents.php#L58
