### PR TITLE
Added whereCreatedBefore/After, whereUpdatedBefore/After Eloquent methods

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1632,8 +1632,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated before statement to the query.
      *
-     * @param  mixed $value
-     * @param  string $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function andWhereUpdatedBefore($value, $column = 'updated_at')

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1536,8 +1536,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created before statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function whereCreatedBefore($value, $column = 'created_at')
@@ -1548,8 +1548,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created before statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function orWhereCreatedBefore($value, $column = 'created_at')
@@ -1560,8 +1560,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created before statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function andWhereCreatedBefore($value, $column = 'created_at')
@@ -1572,8 +1572,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created after statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function whereCreatedAfter($value, $column = 'created_at')
@@ -1584,8 +1584,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created after statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function orWhereCreatedAfter($value, $column = 'created_at')
@@ -1596,8 +1596,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created after statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function andWhereCreatedAfter($value, $column = 'created_at')
@@ -1608,8 +1608,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated before statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function whereUpdatedBefore($value, $column = 'updated_at')
@@ -1620,8 +1620,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated before statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function orWhereUpdatedBefore($value, $column = 'updated_at')
@@ -1632,8 +1632,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated before statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param  mixed $value
+     * @param  string $column
      * @return $this
      */
     public function andWhereUpdatedBefore($value, $column = 'updated_at')
@@ -1644,8 +1644,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated after statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function whereUpdatedAfter($value, $column = 'updated_at')
@@ -1656,8 +1656,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated after statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function orWhereUpdatedAfter($value, $column = 'updated_at')
@@ -1668,8 +1668,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated after statement to the query.
      *
-     * @param mixed  $value
-     * @param string  $column
+     * @param  mixed  $value
+     * @param  string  $column
      * @return $this
      */
     public function andWhereUpdatedAfter($value, $column = 'updated_at')

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1536,8 +1536,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created before statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function whereCreatedBefore($value, $column = 'created_at')
@@ -1548,8 +1548,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created before statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function orWhereCreatedBefore($value, $column = 'created_at')
@@ -1560,8 +1560,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created before statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function andWhereCreatedBefore($value, $column = 'created_at')
@@ -1572,8 +1572,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created after statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function whereCreatedAfter($value, $column = 'created_at')
@@ -1584,8 +1584,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created after statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function orWhereCreatedAfter($value, $column = 'created_at')
@@ -1596,8 +1596,8 @@ class Builder implements BuilderContract
     /**
      * Add a where created after statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function andWhereCreatedAfter($value, $column = 'created_at')
@@ -1608,8 +1608,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated before statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function whereUpdatedBefore($value, $column = 'updated_at')
@@ -1620,8 +1620,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated before statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function orWhereUpdatedBefore($value, $column = 'updated_at')
@@ -1644,8 +1644,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated after statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function whereUpdatedAfter($value, $column = 'updated_at')
@@ -1656,8 +1656,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated after statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function orWhereUpdatedAfter($value, $column = 'updated_at')
@@ -1668,8 +1668,8 @@ class Builder implements BuilderContract
     /**
      * Add a where updated after statement to the query.
      *
-     * @param mixed $value
-     * @param string $column
+     * @param mixed  $value
+     * @param string  $column
      * @return $this
      */
     public function andWhereUpdatedAfter($value, $column = 'updated_at')

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1534,6 +1534,150 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add a where created before statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function whereCreatedBefore($value, $column = 'created_at')
+    {
+        return $this->where($column, '<', $value);
+    }
+
+    /**
+     * Add a where created before statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function orWhereCreatedBefore($value, $column = 'created_at')
+    {
+        return $this->where($column, '<', $value, 'or');
+    }
+
+    /**
+     * Add a where created before statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function andWhereCreatedBefore($value, $column = 'created_at')
+    {
+        return $this->where($column, '<', $value, 'and');
+    }
+
+    /**
+     * Add a where created after statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function whereCreatedAfter($value, $column = 'created_at')
+    {
+        return $this->where($column, '>', $value);
+    }
+
+    /**
+     * Add a where created after statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function orWhereCreatedAfter($value, $column = 'created_at')
+    {
+        return $this->where($column, '>', $value, 'or');
+    }
+
+    /**
+     * Add a where created after statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function andWhereCreatedAfter($value, $column = 'created_at')
+    {
+        return $this->where($column, '>', $value, 'and');
+    }
+
+    /**
+     * Add a where updated before statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function whereUpdatedBefore($value, $column = 'updated_at')
+    {
+        return $this->where($column, '<', $value);
+    }
+
+    /**
+     * Add a where updated before statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function orWhereUpdatedBefore($value, $column = 'updated_at')
+    {
+        return $this->where($column, '<', $value, 'or');
+    }
+
+    /**
+     * Add a where updated before statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function andWhereUpdatedBefore($value, $column = 'updated_at')
+    {
+        return $this->where($column, '<', $value, 'and');
+    }
+
+    /**
+     * Add a where updated after statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function whereUpdatedAfter($value, $column = 'updated_at')
+    {
+        return $this->where($column, '>', $value);
+    }
+
+    /**
+     * Add a where updated after statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function orWhereUpdatedAfter($value, $column = 'updated_at')
+    {
+        return $this->where($column, '>', $value, 'or');
+    }
+
+    /**
+     * Add a where updated after statement to the query.
+     *
+     * @param mixed $value
+     * @param string $column
+     * @return $this
+     */
+    public function andWhereUpdatedAfter($value, $column = 'updated_at')
+    {
+        return $this->where($column, '>', $value, 'and');
+    }
+
+    /**
      * Add a nested where statement to the query.
      *
      * @param  \Closure  $callback

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -478,6 +478,134 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
+    public function testWhereCreatedBefore()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereCreatedBefore('2022-05-28 06:10:00');
+        $this->assertSame('select * from `users` where `created_at` < ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 06:10:00'], $builder->getBindings());
+    }
+
+    public function testOrWhereCreatedBefore()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereCreatedAfter('2022-05-28 06:10:00')->orWhereCreatedBefore('2022-05-28 03:10:00');
+        $this->assertSame('select * from `users` where `created_at` > ? or `created_at` < ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 06:10:00', 1 => '2022-05-28 03:10:00'], $builder->getBindings());
+    }
+
+    public function testAndWhereCreatedBefore()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereCreatedAfter('2022-05-28 06:10:00')->andWhereCreatedBefore('2022-05-28 03:10:00');
+        $this->assertSame('select * from `users` where `created_at` > ? and `created_at` < ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 06:10:00', 1 => '2022-05-28 03:10:00'], $builder->getBindings());
+    }
+
+    public function testWhereCreatedAfter()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereCreatedAfter('2022-05-28 06:10:00');
+        $this->assertSame('select * from `users` where `created_at` > ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 06:10:00'], $builder->getBindings());
+    }
+
+    public function testOrWhereCreatedAfter()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereCreatedBefore('2022-05-28 03:10:00')->orWhereCreatedAfter('2022-05-28 06:10:00');
+        $this->assertSame('select * from `users` where `created_at` < ? or `created_at` > ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 03:10:00', 1 => '2022-05-28 06:10:00'], $builder->getBindings());
+    }
+
+    public function testAndWhereCreatedAfter()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereCreatedBefore('2022-05-28 03:10:00')->andWhereCreatedAfter('2022-05-28 06:10:00');
+        $this->assertSame('select * from `users` where `created_at` < ? and `created_at` > ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 03:10:00', 1 => '2022-05-28 06:10:00'], $builder->getBindings());
+    }
+
+    public function testWhereUpdatedBefore()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereUpdatedBefore('2022-05-28 06:10:00');
+        $this->assertSame('select * from `users` where `updated_at` < ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 06:10:00'], $builder->getBindings());
+    }
+
+    public function testOrWhereUpdatedBefore()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereUpdatedAfter('2022-05-28 06:10:00')->orWhereUpdatedBefore('2022-05-28 03:10:00');
+        $this->assertSame('select * from `users` where `updated_at` > ? or `updated_at` < ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 06:10:00', 1 => '2022-05-28 03:10:00'], $builder->getBindings());
+    }
+
+    public function testAndWhereUpdatedBefore()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereUpdatedAfter('2022-05-28 06:10:00')->andWhereUpdatedBefore('2022-05-28 03:10:00');
+        $this->assertSame('select * from `users` where `updated_at` > ? and `updated_at` < ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 06:10:00', 1 => '2022-05-28 03:10:00'], $builder->getBindings());
+    }
+
+    public function testWhereUpdatedAfter()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereUpdatedAfter('22:00');
+        $this->assertSame('select * from `users` where `updated_at` > ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+    }
+
+    public function testOrWhereUpdatedAfter()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereUpdatedBefore('2022-05-28 03:10:00')->orWhereUpdatedAfter('2022-05-28 06:10:00');
+        $this->assertSame('select * from `users` where `updated_at` < ? or `updated_at` > ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 03:10:00', 1 => '2022-05-28 06:10:00'], $builder->getBindings());
+    }
+
+    public function testAndWhereUpdatedAfter()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereUpdatedBefore('2022-05-28 03:10:00')->andWhereUpdatedAfter('2022-05-28 06:10:00');
+        $this->assertSame('select * from `users` where `updated_at` < ? and `updated_at` > ?', $builder->toSql());
+        $this->assertEquals([0 => '2022-05-28 03:10:00', 1 => '2022-05-28 06:10:00'], $builder->getBindings());
+    }
+
+    public function testWhereCreatedBeforeMySqlAcceptsCustomColumn()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereCreatedBefore('22:00', 'created');
+        $this->assertSame('select * from `users` where `created` < ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+    }
+
+    public function testWhereUpdatedBeforeAcceptsCustomColumn()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereUpdatedBefore('22:00', 'updated');
+        $this->assertSame('select * from `users` where `updated` < ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+    }
+
+    public function testWhereUpdatedAfterAcceptsCustomColumn()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereUpdatedAfter('22:00', 'updated');
+        $this->assertSame('select * from `users` where `updated` > ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+    }
+
+    public function testWhereCreatedAfterAcceptsCustomColumn()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereCreatedAfter('22:00', 'created');
+        $this->assertSame('select * from `users` where `created` > ?', $builder->toSql());
+        $this->assertEquals([0 => '22:00'], $builder->getBindings());
+    }
+
     public function testWhereTimeOperatorOptionalPostgres()
     {
         $builder = $this->getPostgresBuilder();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR introduces four new Eloquent builder methods `whereCreatedBefore`, `whereCreatedAfter`, `whereUpdatedBefore`, and `whereUpdatedAfter`. Which provide nice syntax for querying database record creation/updates.

Example usage:
```php
$reports = Report::query()
    ->whereCreatedBefore('2022-01-01 16:00:00')
    ->orWhereUpdatedAfter('2022-02-05 10:00:00')
    ->get();
```
is equivalent to
```php
$reports = Report::query()
    ->where('created_at', '<', '2022-01-01 16:00:00')
    ->orWhere('updated_at', '>', '2022-02-05 10:00:00')
    ->get();
```

I image this will be particularly helpful for more complex reporting, or filtering records when working with large data sets. Especially when additional functions or methods are used to create the date-time portion.

```php
$reports = Report::query()
    ->whereCreatedBefore(Carbon::yesterday())
    ->get();
```

There is also the option to specify the column name as the second parameter:
```php
$reports = Report::query()
    ->whereCreatedBefore('2022-01-01 16:00:00', 'created')
    ->get();
```