### PR TITLE
[9.x] Added --only-vendor option to route:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -266,7 +266,8 @@ class RouteListCommand extends Command
             ($this->option('path') && ! Str::contains($route['uri'], $this->option('path'))) ||
             ($this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) ||
             ($this->option('domain') && ! Str::contains((string) $route['domain'], $this->option('domain'))) ||
-            ($this->option('except-vendor') && $route['vendor'])) {
+            ($this->option('except-vendor') && $route['vendor']) ||
+            ($this->option('only-vendor') && !$route['vendor'])) {
             return;
         }
 
@@ -476,6 +477,7 @@ class RouteListCommand extends Command
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes'],
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware) to sort by', 'uri'],
             ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
+            ['only-vendor', null, InputOption::VALUE_NONE, 'Only display routes defined by vendor packages'],
         ];
     }
 }


### PR DESCRIPTION
Hey! This PR is only a small one but I think it could be useful. It adds a new `--only-vendor` option that you can use when calling the `route:list` command. If you use this option, only the vendor routes will be output in the terminal (your own application's routes will be ignored).

This is example of what it would look like:

<img width="1005" alt="Screenshot 2022-05-28 at 00 46 46" src="https://user-images.githubusercontent.com/39652331/170800892-e5c554ba-a5a7-4a16-ac68-55bebf60e4fd.png">

I think this is something that could be pretty handy because it gives you a quick insight into any routes that you aren't aware of that might have been registered by packages.

I know in the past that I've installed packages in my projects and only realised further down the line that they're registering routes (usually for a feature that I'm not needing). So, by having this, it'd make it easier to "audit" (for lack of a better term) my project and make sure I've not got any open routes that are expecting authorisation or authentication to be added to them (via a service provider, config, etc).

By the way, I did consider adding some validation to check that the `--only-vendor` and `--except-vendor` flags weren't passed at the same time. But, it looks like if you do that anyway, you'll get the following error message: `Your application doesn't have any routes matching the given criteria.` which sort of covers the base already. If you think a specific error message would be better for this situation, I'd be happy to add it.

If this is something that you might consider merging, please let me know if any changes need making 😄
