### PR TITLE
[9.x] Allows BelongsToMany sync method to bulk insert the new relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -157,7 +157,7 @@ trait InteractsWithPivotTable
     }
 
     /**
-     * Attach all of the records that aren't in the given current records.
+     * Attach all the records that aren't in the given current records.
      *
      * @param  array  $records
      * @param  array  $current
@@ -167,15 +167,15 @@ trait InteractsWithPivotTable
     protected function attachNew(array $records, array $current, $touch = true)
     {
         $changes = ['attached' => [], 'updated' => []];
+        $toAttach = [];
 
         foreach ($records as $id => $attributes) {
             // If the ID is not in the list of existing pivot IDs, we will insert a new pivot
             // record, otherwise, we will just update this existing record on this joining
             // table, so that the developers will easily update these records pain free.
             if (! in_array($id, $current)) {
-                $this->attach($id, $attributes, $touch);
-
                 $changes['attached'][] = $this->castKey($id);
+                $toAttach[$id] = $attributes;
             }
 
             // Now we'll try to update an existing pivot record with the attributes that were
@@ -185,6 +185,10 @@ trait InteractsWithPivotTable
                 $this->updateExistingPivot($id, $attributes, $touch)) {
                 $changes['updated'][] = $this->castKey($id);
             }
+        }
+
+        if (count($toAttach) > 0) {
+            $this->attach($toAttach, [], $touch);
         }
 
         return $changes;

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -54,7 +54,7 @@ class EloquentPivotEventsTest extends DatabaseTestCase
 
         PivotEventsTestCollaborator::$eventsCalled = [];
         $project->collaborators()->sync([$user->id => ['role' => 'owner'], $user2->id => ['role' => 'contributor']]);
-        $this->assertEquals(['saving', 'creating', 'created', 'saved', 'saving', 'updating', 'updated', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
+        $this->assertEquals(['saving', 'updating', 'updated', 'saved', 'saving', 'creating', 'created', 'saved'], PivotEventsTestCollaborator::$eventsCalled);
 
         PivotEventsTestCollaborator::$eventsCalled = [];
         $project->collaborators()->detach($user);


### PR DESCRIPTION
A simple refactor that allows the `$entity->relation()->sync()` method used by the `InteractsWithPivotTable` trait method to bulk insert any new relations sent to the method, instead of inserting them one by one.

**Before:**
```
$user->roles()->sync([1, 2, 3, 4, 5]);

// Results in:
// INSERT INTO user_role (user_id, role_id) VALUES (1, 1)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 2)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 3)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 4)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 5)

$user->roles()->sync([4, 5, 6, 7, 8, 9, 10]);

// Results in:
// DELETE FROM user_role WHERE user_id = 1 AND role_id in (1, 2, 3)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 6)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 7)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 8)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 9)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 10)
```

**After:**
```
$user->roles()->sync([1, 2, 3, 4, 5]);

// Results in:
// INSERT INTO user_role (user_id, role_id) VALUES (1, 1), (1, 2), (1, 3), (1, 4), (1, 5)

$user->roles()->sync([4, 5, 6, 7, 8, 9, 10]);

// Results in:
// DELETE FROM user_role WHERE user_id = 1 AND role_id in (1, 2, 3)
// INSERT INTO user_role (user_id, role_id) VALUES (1, 6), (1, 7), (1, 8), (1, 9), (1, 10)
```

The `attach()` method used by this method to insert new relations already accepts an array with attributes, so this refactor is possible without breaking the framework code in any way.