### PR TITLE
[9.x] Add counts to route:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -405,7 +405,7 @@ class RouteListCommand extends Command
         })
             ->flatten()
             ->filter()
-            ->prepend('')->prepend($routeCount)->prepend('')
+            ->prepend('')
             ->push('')->push($routeCount)->push('')
             ->toArray();
     }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -360,6 +360,8 @@ class RouteListCommand extends Command
 
         $terminalWidth = $this->getTerminalWidth();
 
+        $routeCount = $this->determineRouteCountOutput($routes, $terminalWidth);
+
         return $routes->map(function ($route) use ($maxMethod, $terminalWidth) {
             [
                 'action' => $action,
@@ -399,7 +401,29 @@ class RouteListCommand extends Command
                 $dots,
                 str_replace('   ', ' › ', $action),
             ), $this->output->isVerbose() && ! empty($middleware) ? "<fg=#6C7280>$middleware</>" : null];
-        })->flatten()->filter()->prepend('')->push('')->toArray();
+        })
+            ->flatten()
+            ->filter()
+            ->prepend('')->prepend($routeCount)->prepend('')
+            ->push('')->push($routeCount)->push('')
+            ->toArray();
+    }
+
+    /**
+     * Determine and return the output for displaying the number of routes in the CLI output.
+     *
+     * @param  \Illuminate\Support\Collection  $routes
+     * @param  int  $terminalWidth
+     * @return string
+     */
+    protected function determineRouteCountOutput($routes, $terminalWidth)
+    {
+        $routeCountText = 'Showing ['.$routes->count().'] routes';
+
+        $offset = $terminalWidth - mb_strlen($routeCountText) - 2;
+        $spaces = str_repeat(' ', $offset);
+
+        return $spaces.'<fg=blue;options=bold>Showing ['.$routes->count().'] routes</>';
     }
 
     /**

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -60,14 +60,13 @@ class RouteListCommandTest extends TestCase
 
         $this->artisan(RouteListCommand::class)
             ->assertSuccessful()
-            ->expectsOutput('')
+            ->expectsOutputToContain('Showing [6] routes')
             ->expectsOutput('  GET|HEAD   / ..................................................... ')
             ->expectsOutput('  GET|HEAD   {account}.example.com/ ................................ ')
             ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\Tests\Testing\Console\…')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\Tests\Testing\Cons…')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
-            ->expectsOutput('');
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show');
     }
 
     public function testDisplayRoutesForCliInVerboseMode()
@@ -86,13 +85,12 @@ class RouteListCommandTest extends TestCase
 
         $this->artisan(RouteListCommand::class, ['-v' => true])
             ->assertSuccessful()
-            ->expectsOutput('')
+            ->expectsOutputToContain('Showing [4] routes')
             ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\Console\\FooController')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Testing\\Console\\FooController@show')
             ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
-            ->expectsOutput('             ⇂ web')
-            ->expectsOutput('');
+            ->expectsOutput('             ⇂ web');
     }
 
     public function testRouteCanBeFilteredByName()
@@ -108,9 +106,8 @@ class RouteListCommandTest extends TestCase
 
         $this->artisan(RouteListCommand::class, ['--name' => 'foo'])
             ->assertSuccessful()
-            ->expectsOutput('')
-            ->expectsOutput('  GET|HEAD       foo ...................................... foo.show')
-            ->expectsOutput('');
+            ->expectsOutputToContain('Showing [1] route')
+            ->expectsOutput('  GET|HEAD       foo ...................................... foo.show');
     }
 
     public function testDisplayRoutesExceptVendor()
@@ -121,11 +118,10 @@ class RouteListCommandTest extends TestCase
 
         $this->artisan(RouteListCommand::class, ['-v' => true, '--except-vendor' => true])
             ->assertSuccessful()
-            ->expectsOutput('')
+            ->expectsOutputToContain('Showing [3] routes')
             ->expectsOutput('  GET|HEAD       foo/{user} Illuminate\Tests\Testing\Console\FooController@show')
             ->expectsOutput('  ANY            redirect .... Illuminate\Routing\RedirectController')
-            ->expectsOutput('  GET|HEAD       view .............................................. ')
-            ->expectsOutput('');
+            ->expectsOutput('  GET|HEAD       view .............................................. ');
     }
 
     protected function tearDown(): void

--- a/tests/Testing/Console/RouteListCommandTest.php
+++ b/tests/Testing/Console/RouteListCommandTest.php
@@ -60,13 +60,16 @@ class RouteListCommandTest extends TestCase
 
         $this->artisan(RouteListCommand::class)
             ->assertSuccessful()
-            ->expectsOutputToContain('Showing [6] routes')
+            ->expectsOutput('')
             ->expectsOutput('  GET|HEAD   / ..................................................... ')
             ->expectsOutput('  GET|HEAD   {account}.example.com/ ................................ ')
             ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\Tests\Testing\Console\…')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\Tests\Testing\Cons…')
-            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show');
+            ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
+            ->expectsOutput('')
+            ->expectsOutput('                                                  Showing [6] routes')
+            ->expectsOutput('');
     }
 
     public function testDisplayRoutesForCliInVerboseMode()
@@ -85,12 +88,15 @@ class RouteListCommandTest extends TestCase
 
         $this->artisan(RouteListCommand::class, ['-v' => true])
             ->assertSuccessful()
-            ->expectsOutputToContain('Showing [4] routes')
+            ->expectsOutput('')
             ->expectsOutput('  GET|HEAD   closure ............................................... ')
             ->expectsOutput('  POST       controller-invokable Illuminate\\Tests\\Testing\\Console\\FooController')
             ->expectsOutput('  GET|HEAD   controller-method/{user} Illuminate\\Tests\\Testing\\Console\\FooController@show')
             ->expectsOutput('  GET|HEAD   {account}.example.com/user/{id} ............. user.show')
-            ->expectsOutput('             ⇂ web');
+            ->expectsOutput('             ⇂ web')
+            ->expectsOutput('')
+            ->expectsOutput('                                                  Showing [4] routes')
+            ->expectsOutput('');
     }
 
     public function testRouteCanBeFilteredByName()
@@ -106,8 +112,11 @@ class RouteListCommandTest extends TestCase
 
         $this->artisan(RouteListCommand::class, ['--name' => 'foo'])
             ->assertSuccessful()
-            ->expectsOutputToContain('Showing [1] route')
-            ->expectsOutput('  GET|HEAD       foo ...................................... foo.show');
+            ->expectsOutput('')
+            ->expectsOutput('  GET|HEAD       foo ...................................... foo.show')
+            ->expectsOutput('')
+            ->expectsOutput('                                                  Showing [1] routes')
+            ->expectsOutput('');
     }
 
     public function testDisplayRoutesExceptVendor()
@@ -118,10 +127,13 @@ class RouteListCommandTest extends TestCase
 
         $this->artisan(RouteListCommand::class, ['-v' => true, '--except-vendor' => true])
             ->assertSuccessful()
-            ->expectsOutputToContain('Showing [3] routes')
+            ->expectsOutput('')
             ->expectsOutput('  GET|HEAD       foo/{user} Illuminate\Tests\Testing\Console\FooController@show')
             ->expectsOutput('  ANY            redirect .... Illuminate\Routing\RedirectController')
-            ->expectsOutput('  GET|HEAD       view .............................................. ');
+            ->expectsOutput('  GET|HEAD       view .............................................. ')
+            ->expectsOutput('')
+            ->expectsOutput('                                                  Showing [3] routes')
+            ->expectsOutput('');
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
Hi again! This is just another small PR to the `route:list` command that I think could come in handy. It adds 2 counts to the CLI output showing the amount of routes that are being displayed. One count is placed at the bottom and one is placed at the top.

Here's an example of how it could look if you don't have a lot of routes and can see both counts:

<img width="1005" alt="Screenshot 2022-05-28 at 02 01 30" src="https://user-images.githubusercontent.com/39652331/170803625-7971fe85-2181-4411-9aef-1736292add05.png">


Here's an example of how it could look if you have a lot of routes and can only see the bottom count:

<img width="1003" alt="Screenshot 2022-05-28 at 02 01 15" src="https://user-images.githubusercontent.com/39652331/170803624-57c585c3-4ff6-45d3-8fd9-144001e72e37.png">

I think could just be another small UI nicety to make the route list even easier (and quicker) to read and understand.

I couldn't seem to get the tests fully working for this. I have a feeling that it might be something to do with me outputting the same line twice, but that's just a guess. But I have updated the tests to pass with what I've done so far.

If you think this is something that might be worth merging, please let me know if you'd like any changes making 😄