### PR TITLE
[9.x] Add `charAt` convenience method to Str and Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -202,6 +202,17 @@ class Str
     }
 
     /**
+     * Retrieve character at specified position in string.
+     *
+     * @param string  $value
+     * @param int  $index
+     * @return string
+     */
+    public static function charAt($value, $index) {
+        return static::substr($value, $index, 1);
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -164,6 +164,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Retrieve character at specified position in string.
+     *
+     * @param int  $index
+     * @return static
+     */
+    public function charAt($index)
+    {
+        return new static(Str::charAt($this->value, $index));
+    }
+
+    /**
      * Determine if a given string contains a given substring.
      *
      * @param  string|string[]  $needles

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -633,6 +633,16 @@ class SupportStrTest extends TestCase
         $this->assertSame('fooBarBaz', Str::camel('foo-bar_baz'));
     }
 
+    public function testCharAt()
+    {
+        $this->assertSame('L', Str::charAt('Laravel_p_h_p_framework', 0));
+        $this->assertSame('_', Str::charAt('Laravel_p_h_p_framework', 7));
+        $this->assertSame('k', Str::charAt('Laravel_p_h_p_framework', -1));
+        $this->assertSame('r', Str::charAt('Laravel_p_h_p_framework', -2));
+        $this->assertSame('T', Str::charAt('Tay', -3));
+        $this->assertEmpty(Str::charAt('Tay', 3));
+    }
+
     public function testSubstr()
     {
         $this->assertSame('Ё', Str::substr('БГДЖИЛЁ', -1));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -831,6 +831,16 @@ class SupportStringableTest extends TestCase
         $this->assertSame('fooBarBaz', (string) $this->stringable('foo-bar_baz')->camel());
     }
 
+    public function testCharAt()
+    {
+        $this->assertSame('L', (string) $this->stringable('Laravel_p_h_p_framework')->charAt(0));
+        $this->assertSame('_', (string) $this->stringable('Laravel_p_h_p_framework')->charAt(7));
+        $this->assertSame('k', (string) $this->stringable('Laravel_p_h_p_framework')->charAt(-1));
+        $this->assertSame('r', (string) $this->stringable('Laravel_p_h_p_framework')->charAt(-2));
+        $this->assertSame('T', (string) $this->stringable('Tay')->charAt(-3));
+        $this->assertEmpty((string) $this->stringable('Tay')->charAt(3));
+    }
+
     public function testSubstr()
     {
         $this->assertSame('Ё', (string) $this->stringable('БГДЖИЛЁ')->substr(-1));


### PR DESCRIPTION
Sometimes it is necessary to access a specific character in a string - i.e. for parsing data. This PR adds a convenient way of retrieving a single character from a string, which arguably is cleaner than just using `substr`, when the string length is predetermined.

It uses `Str::substr` under the hood.

Usage:
```php
Str::charAt('Tay', 1)
Str::of('Tay')->charAt(1)
str('Tay')->charAt(1)
```