### PR TITLE
[9.x] Adds 'finished' method to jobs

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -77,6 +77,10 @@ class CallQueuedHandler
             $this->ensureSuccessfulBatchJobIsRecorded($command);
         }
 
+        if (method_exists($command, 'finished')) {
+            $command->finished();
+        }
+
         if (! $job->isDeletedOrReleased()) {
             $job->delete();
         }

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -216,7 +216,8 @@ class TestJobMiddleware
     }
 }
 
-class CallQueuedHandlerWithFinishedMethod {
+class CallQueuedHandlerWithFinishedMethod
+{
     use InteractsWithQueue;
 
     public static $finished = false;


### PR DESCRIPTION
This PR adds a `finished` method to jobs.

```php
class ImportContactsJob implements ShouldQueue
{
    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    public function __construct(protected int $userId)
    {
        //
    }

    public function handle()
    {
        //
    }

    // This method is called when the job has finished
    public function finished()
    {
        ImportContactsBatchUpdated::dispatch($this->userId, $this->batch()->jsonSerialize());
    }
}
```

I'm trying to broadcast the progress of a batch of jobs to my user.
When dispatching the event at the end of the `handle` method, the batch isn't updated yet.

The last job would say:

```
totalJobs : 10
pendingJobs: 1
processedJobs: 9
```

This is because the job was not marked as finished yet.

### Possible solutions
I tried to use this:

```php
Queue::after(function (JobProcessed $event) {
    // $event->connectionName
    // $event->job
    // $event->job->payload()
});
```
But `$event->job` is not an instance of `App\Jobs\ImportContactsJob` but of `Illuminate\Queue\Jobs\Job`.

What you could also do is sending the event in the `then` or `finally` method of `Bus::batch`.

```php
$batch = Bus::batch([
    new ImportContactsJob(auth()->id()),
])->then(function (Batch $batch) {
    ImportContactsBatchUpdated::dispatch(auth()->id(), $batch()->jsonSerialize());
})->name('Import Contacts')->dispatch()
```

I don't like this because you then have to dispatch the event in two places (the job for progress and the `then` method for 100% progress)