### PR TITLE
[9.x] Add insert helper to add new item in array on any position

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -828,10 +828,8 @@ class Arr
      */
     public static function insert(array &$array, int $pos, $value)
     {
-        return array_merge(
-            array_slice($array, 0, $pos),
-            static::wrap($value),
-            array_slice($array, $pos, null, true)
-        );
+        array_splice($array, $pos, 0, static::wrap($value));
+
+        return $array;
     }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -817,4 +817,22 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Insert new item in array on any position
+     *
+     * @param array $array
+     * @param int $pos
+     * @param $value
+     * @return array
+     */
+    public static function insert(array &$array, int $pos, $value)
+    {
+        return array_merge(
+            array_slice($array, 0, $pos),
+            static::wrap($value),
+            array_slice($array, $pos, null, true)
+        );
+    }
+
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -819,10 +819,10 @@ class Arr
     }
 
     /**
-     * Insert new item in array on any position
+     * Insert new item in array on any position.
      *
-     * @param array $array
-     * @param int $pos
+     * @param  array  $array
+     * @param  int  $pos
      * @param $value
      * @return array
      */
@@ -834,5 +834,4 @@ class Arr
             array_slice($array, $pos, null, true)
         );
     }
-
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1097,4 +1097,15 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testInsert()
+    {
+        $alphabet = ['a', 'b', 'd'];
+
+        $alphabet = Arr::insert($alphabet, 2, 'c');
+        $this->assertEquals(['a', 'b', 'c', 'd'], $alphabet);
+
+        $alphabet = Arr::insert($alphabet, 4, 'e');
+        $this->assertEquals(['a', 'b', 'c', 'd', 'e'], $alphabet);
+    }
 }


### PR DESCRIPTION
Add insert helper to add new item in array on any position

```
$alphabet = ['a', 'b', 'd'];
$alphabet = Arr::insert($alphabet, 2, 'c');

//output => [a, b, c, d]

 $alphabet = Arr::insert($alphabet, 4, 'e');

//output => [a, b, c, d, e]

```