### PR TITLE
[9.x] Conditionable should return HigherOrderWhenProxy only when the args number is exactly 1

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -22,7 +22,7 @@ trait Conditionable
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
-        if (! $callback) {
+        if (func_num_args() === 1) {
             return new HigherOrderWhenProxy($this, $value);
         }
 
@@ -50,7 +50,7 @@ trait Conditionable
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
-        if (! $callback) {
+        if (func_num_args() === 1) {
             return new HigherOrderWhenProxy($this, ! $value);
         }
 

--- a/tests/Conditionable/ConditionableTest.php
+++ b/tests/Conditionable/ConditionableTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Tests\Conditionable;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class ConditionableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    public function testWhen(): void
+    {
+        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, TestConditionableModel::query()->when(true));
+        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, TestConditionableModel::query()->when(false));
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, TestConditionableModel::query()->when(false, null));
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, TestConditionableModel::query()->when(true, function () {
+        }));
+    }
+
+    public function testUnless(): void
+    {
+        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(true));
+        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(false));
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, TestConditionableModel::query()->unless(true, null));
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, TestConditionableModel::query()->unless(false, function () {
+        }));
+    }
+}
+
+class TestConditionableModel extends Model
+{
+}


### PR DESCRIPTION
```
$extraFilter = $condition ? null : function ($query) { $query->where('field', 'value'); };
$query = User::query()->when($extraFilter !== null, $extraFilter);

// When $condition is false, which means $extraFilter is null
// Before: Illuminate\Support\HigherOrderWhenProxy
// After: Illuminate\Database\Eloquent\Builder
dump(get_class($query));
```