### PR TITLE
[9.x] Add ability to resolve `Redirect::home()` via a callback

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Closure;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\Traits\Macroable;
@@ -25,6 +26,13 @@ class Redirector
     protected $session;
 
     /**
+     * The home resolver callback.
+     *
+     * @var \Closure
+     */
+    protected $homeResolver;
+
+    /**
      * Create a new Redirector instance.
      *
      * @param  \Illuminate\Routing\UrlGenerator  $generator
@@ -36,6 +44,19 @@ class Redirector
     }
 
     /**
+     * Set the home route resolver callback.
+     *
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function resolveHomeUsing(Closure $callback)
+    {
+        $this->homeResolver = $callback;
+
+        return $this;
+    }
+
+    /**
      * Create a new redirect response to the "home" route.
      *
      * @param  int  $status
@@ -43,7 +64,9 @@ class Redirector
      */
     public function home($status = 302)
     {
-        return $this->to($this->generator->route('home'), $status);
+        $homeResolver = $this->homeResolver ?: fn (UrlGenerator $generator) => $generator->route('home');
+
+        return $this->to($homeResolver($this->generator), $status);
     }
 
     /**

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -162,6 +162,20 @@ class RoutingRedirectorTest extends TestCase
         $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
 
+    public function testHomeRouteResolver()
+    {
+        $this->url->shouldReceive('route')->with('resolved')->andReturn('http://foo.com/resolved');
+        $this->url->shouldReceive('route')->with('resolved', [])->andReturn('http://foo.com/resolved');
+        $this->url->shouldReceive('to')->with('http://foo.com/resolved', [], null)->andReturn('http://foo.com/resolved');
+
+        $this->redirect->resolveHomeUsing(function (UrlGenerator $generator) {
+            return $generator->route('resolved');
+        });
+
+        $response = $this->redirect->home();
+        $this->assertSame('http://foo.com/resolved', $response->getTargetUrl());
+    }
+
     public function testSignedRoute()
     {
         $this->url->shouldReceive('signedRoute')->with('home', [], null)->andReturn('http://foo.com/bar?signature=secret');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Right now we have `return Redirect::home()` which returns a redirect to the route registered as 'home'.
It's useful but rather rigid.

This PR adds the ability to register a home resolver to allow end users to resolve where `home` is however they wish.
E.g.

**RouteServiceProvider.php**
```php
use Illuminate\Routing\UrlGenerator;
use Illuminate\Support\Facades\Auth;
use Illuminate\Support\Facades\Redirect;

//...
Redirect::resolveHomeUsing(fn (UrlGenerator $url) => match(Auth::user()?->role) {
    'admin' => $url->route('users.index'),
    'owner' => $url->route('organization.dashboard'),
    default => $url->route('user.dashboard')
});
```

The default resolver is set to the current resolution logic meaning there should be no BC breaks.