### PR TITLE
[9.x] Improve file attachment for mail and notifications

### DIFF
--- a/src/Illuminate/Contracts/Mail/Attachable.php
+++ b/src/Illuminate/Contracts/Mail/Attachable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Mail;
+
+interface Attachable
+{
+    /**
+     * Get an attachment instance for this entity.
+     *
+     * @return \Illuminate\Mail\Attachment
+     */
+    public function toMailAttachment();
+}

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -5,7 +5,6 @@ namespace Illuminate\Mail;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
 class Attachment

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Illuminate\Mail;
+
+use Closure;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
+
+class Attachment
+{
+    use Macroable;
+
+    /**
+     * The attached file's filename.
+     *
+     * @var string|null
+     */
+    public $as;
+
+    /**
+     * The attached file's mime type.
+     *
+     * @var string|null
+     */
+    public $mime;
+
+    /**
+     * A callback that attaches the attachment to the mail message.
+     *
+     * @var \Closure
+     */
+    protected $resolver;
+
+    /**
+     * Create a mail attachment.
+     *
+     * @param  \Closure  $resolver
+     * @return void
+     */
+    private function __construct(Closure $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * Create a mail attachment from a path.
+     *
+     * @param  string  $path
+     * @return static
+     */
+    public static function fromPath($path)
+    {
+        return new static(fn ($attachment, $pathStragegy) => $pathStragegy($path, $attachment));
+    }
+
+    /**
+     * Create a mail attachment from in-memory data.
+     *
+     * @param  \Closure  $data
+     * @param  string  $name
+     * @return static
+     */
+    public static function fromData(Closure $data, $name)
+    {
+        return (new static(
+            fn ($attachment, $pathStrategy, $dataStrategy) => $dataStrategy($data, $attachment)
+        ))->as($name);
+    }
+
+    /**
+     * Create a mail attachment from a file in the default storage disk.
+     *
+     * @param  string  $path
+     * @return static
+     */
+    public static function fromStorage($path)
+    {
+        return static::fromStorageDisk(null, $path);
+    }
+
+    /**
+     * Create a mail attachment from a file in the specified storage disk.
+     *
+     * @param  string|null  $disk
+     * @param  string  $path
+     * @return static
+     */
+    public static function fromStorageDisk($disk, $path)
+    {
+        return new static(function ($attachment, $pathStrategy, $dataStrategy) use ($disk, $path) {
+            $storage = Container::getInstance()->make(
+                FilesystemFactory::class
+            )->disk($disk);
+
+            $attachment
+                ->as($attachment->as ?? basename($path))
+                ->withMime($attachment->mime ?? $storage->mimeType($path));
+
+            $dataStrategy(fn () => $storage->get($path), $attachment);
+        });
+    }
+
+    /**
+     * Set the attached file's filename.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function as($name)
+    {
+        $this->as = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the attached file's mime type.
+     *
+     * @param  string  $mime
+     * @return $this
+     */
+    public function withMime($mime)
+    {
+        $this->mime = $mime;
+
+        return $this;
+    }
+
+    /**
+     * Attach the attachment with the given strategies.
+     *
+     * @param  \Closure  $pathStrategy
+     * @param  \Closure  $dataStrategy
+     * @return mixed
+     */
+    public function attachWith(Closure $pathStrategy, Closure $dataStrategy)
+    {
+        return ($this->resolver)($this, $pathStrategy, $dataStrategy);
+    }
+
+    /**
+     * Attach the attachment to a built-in mail type.
+     *
+     * @param  \Illuminate\Mail\Mailable|\Illuminate\Mail\Message|\Illuminate\Notifications\Messages\MailMessage  $mail
+     * @return mixed
+     */
+    public function attachTo($mail)
+    {
+        return $this->attachWith(
+            fn ($path) => $mail->attach($path, ['as' => $this->as, 'mime' => $this->mime]),
+            fn ($data) => $mail->attachData($data(), $this->as, ['mime' => $this->mime])
+        );
+    }
+}

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\Factory as Queue;
@@ -867,12 +868,20 @@ class Mailable implements MailableContract, Renderable
     /**
      * Attach a file to the message.
      *
-     * @param  string  $file
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
      * @param  array  $options
      * @return $this
      */
     public function attach($file, array $options = [])
     {
+        if ($file instanceof Attachable) {
+            $file = $file->toMailAttachment();
+        }
+
+        if ($file instanceof Attachment) {
+            return $file->attachTo($this);
+        }
+
         $this->attachments = collect($this->attachments)
                     ->push(compact('file', 'options'))
                     ->unique('file')

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Notifications\Messages;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Markdown;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 
 class MailMessage extends SimpleMessage implements Renderable
@@ -241,12 +244,20 @@ class MailMessage extends SimpleMessage implements Renderable
     /**
      * Attach a file to the message.
      *
-     * @param  string  $file
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Contracts\Mail\Attachable  $file
      * @param  array  $options
      * @return $this
      */
     public function attach($file, array $options = [])
     {
+        if ($file instanceof Attachable) {
+            $file = $file->toMailAttachment();
+        }
+
+        if ($file instanceof Attachment) {
+            return $file->attachTo($this);
+        }
+
         $this->attachments[] = compact('file', 'options');
 
         return $this;

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Markdown;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 
 class MailMessage extends SimpleMessage implements Renderable

--- a/tests/Integration/Mail/AttachingFromStorageTest.php
+++ b/tests/Integration/Mail/AttachingFromStorageTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Mail;
+
+use Illuminate\Mail\Attachment;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Storage;
+use Orchestra\Testbench\TestCase;
+
+class AttachingFromStorageTest extends TestCase
+{
+    public function testItCanAttachFromStorage()
+    {
+        Storage::disk('local')->put('/dir/foo.png', 'expected body contents');
+        $mail = new MailMessage();
+        $attachment = Attachment::fromStorageDisk('local', '/dir/foo.png')
+            ->as('bar')
+            ->withMime('text/css');
+
+        $attachment->attachTo($mail);
+
+        $this->assertSame([
+            'data' => 'expected body contents',
+            'name' => 'bar',
+            'options' => [
+                'mime' => 'text/css',
+            ],
+        ], $mail->rawAttachments[0]);
+
+        Storage::disk('local')->delete('/dir/foo.png');
+    }
+
+    public function testItCanAttachFromStorageAndFallbackToStorageNameAndMime()
+    {
+        Storage::disk()->put('/dir/foo.png', 'expected body contents');
+        $mail = new MailMessage();
+        $attachment = Attachment::fromStorageDisk('local', '/dir/foo.png');
+
+        $attachment->attachTo($mail);
+
+        $this->assertSame([
+            'data' => 'expected body contents',
+            'name' => 'foo.png',
+            'options' => [
+                // when using "prefer-lowest" the local filesystem driver will
+                // not detect the mime type based on the extension and will
+                // instead fallback to "text/plain".
+                'mime' => class_exists(\League\Flysystem\Local\FallbackMimeTypeDetector::class)
+                    ? 'image/png'
+                    : 'text/plain',
+            ],
+        ], $mail->rawAttachments[0]);
+
+        Storage::disk('local')->delete('/dir/foo.png');
+    }
+}

--- a/tests/Mail/AttachableTest.php
+++ b/tests/Mail/AttachableTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Contracts\Mail\Attachable;
+use Illuminate\Mail\Attachment;
+use Illuminate\Mail\Mailable;
+use PHPUnit\Framework\TestCase;
+
+class AttachableTest extends TestCase
+{
+    public function testItCanHaveMacroConstructors()
+    {
+        Attachment::macro('fromInvoice', function ($name) {
+            return Attachment::fromData(fn () => 'pdf content', $name);
+        });
+        $mailable = new Mailable;
+
+        $mailable->attach(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromInvoice('foo')
+                    ->as('bar')
+                    ->withMime('image/jpeg');
+            }
+        });
+
+        $this->assertSame([
+            'data' => 'pdf content',
+            'name' => 'bar',
+            'options' => [
+                'mime' => 'image/jpeg',
+            ],
+        ], $mailable->rawAttachments[0]);
+    }
+
+    public function testItCanUtiliseExistingApisOnNonMailBasedResourcesWithPath()
+    {
+        Attachment::macro('size', function () {
+            return 99;
+        });
+        $notification = new class()
+        {
+            public $pathArgs;
+
+            public function withPathAttachment()
+            {
+                $this->pathArgs = func_get_args();
+            }
+        };
+        $attachable = new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromPath('foo.jpg')
+                    ->as('bar')
+                    ->withMime('text/css');
+            }
+        };
+
+        $attachable->toMailAttachment()->attachWith(
+            fn ($path, $attachment) => $notification->withPathAttachment($path, $attachment->as, $attachment->mime, $attachment->size()),
+            fn () => null
+        );
+
+        $this->assertSame([
+            'foo.jpg',
+            'bar',
+            'text/css',
+            99,
+        ], $notification->pathArgs);
+    }
+
+    public function testItCanUtiliseExistingApisOnNonMailBasedResourcesWithArgs()
+    {
+        Attachment::macro('size', function () {
+            return 99;
+        });
+        $notification = new class()
+        {
+            public $pathArgs;
+
+            public function withDataAttachment()
+            {
+                $this->dataArgs = func_get_args();
+            }
+        };
+        $attachable = new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromData(fn () => 'expected attachment body', 'bar')
+                    ->withMime('text/css');
+            }
+        };
+
+        $attachable->toMailAttachment()->attachWith(
+            fn () => null,
+            fn ($data, $attachment) => $notification->withDataAttachment($data(), $attachment->as, $attachment->mime, $attachment->size()),
+        );
+
+        $this->assertSame([
+            'expected attachment body',
+            'bar',
+            'text/css',
+            99,
+        ], $notification->dataArgs);
+    }
+}

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -8,7 +8,6 @@ use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\Transport\ArrayTransport;
-use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\Transport\ArrayTransport;
+use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -493,6 +496,48 @@ class MailMailableTest extends TestCase
         $this->assertSame('hello@laravel.com', $sentMessage->getEnvelope()->getRecipients()[0]->getAddress());
         $this->assertStringContainsString('X-Tag: test', $sentMessage->toString());
         $this->assertStringContainsString('X-Tag: foo', $sentMessage->toString());
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromPath()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromPath('/foo.jpg')->as('bar')->withMime('image/png');
+            }
+        });
+
+        $this->assertSame([
+            'file' => '/foo.jpg',
+            'options' => [
+                'as' => 'bar',
+                'mime' => 'image/png',
+            ],
+        ], $mailable->attachments[0]);
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromData()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromData(fn () => 'bar', 'foo.jpg')->withMime('image/png');
+            }
+        });
+
+        $this->assertSame([
+            'data' => 'bar',
+            'name' => 'foo.jpg',
+            'options' => [
+                'mime' => 'image/png',
+            ],
+        ], $mailable->rawAttachments[0]);
     }
 }
 

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Illuminate\Contracts\Mail\Attachable;
+use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Message;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -86,15 +89,151 @@ class MailMessageTest extends TestCase
 
     public function testBasicAttachment()
     {
-        $message = new Message(new Email());
-        $message->attach('foo.jpg', ['as' => 'foo.jpg', 'mime' => 'image/jpeg']);
+        file_put_contents($path = __DIR__.'/foo.jpg', 'expected attachment body');
+
+        $this->message->attach($path, ['as' => 'bar.jpg', 'mime' => 'image/png']);
+
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('expected attachment body', $attachment->getBody());
+        $this->assertSame('Content-Type: image/png; name=bar.jpg', $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame('Content-Disposition: attachment; name=bar.jpg; filename=bar.jpg', $headers[2]);
+
+        unlink($path);
     }
 
     public function testDataAttachment()
     {
-        $message = new Message(new Email());
-        $message->attachData('foo', 'foo.jpg', ['mime' => 'image/jpeg']);
+        $this->message->attachData('expected attachment body', 'foo.jpg', ['mime' => 'image/png']);
 
-        $this->assertSame('foo', $message->getSymfonyMessage()->getAttachments()[0]->getBody());
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('expected attachment body', $attachment->getBody());
+        $this->assertSame('Content-Type: image/png; name=foo.jpg', $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame('Content-Disposition: attachment; name=foo.jpg; filename=foo.jpg', $headers[2]);
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromPath()
+    {
+        file_put_contents($path = __DIR__.'/foo.jpg', 'expected attachment body');
+
+        $this->message->attach(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromPath(__DIR__.'/foo.jpg')
+                    ->as('bar.jpg')
+                    ->withMime('image/png');
+            }
+        });
+
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('expected attachment body', $attachment->getBody());
+        $this->assertSame('Content-Type: image/png; name=bar.jpg', $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame('Content-Disposition: attachment; name=bar.jpg; filename=bar.jpg', $headers[2]);
+
+        unlink($path);
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromData()
+    {
+        $this->message->attach(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromData(fn () => 'expected attachment body', 'foo.jpg')
+                    ->withMime('image/png');
+            }
+        });
+
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('expected attachment body', $attachment->getBody());
+        $this->assertSame('Content-Type: image/png; name=foo.jpg', $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame('Content-Disposition: attachment; name=foo.jpg; filename=foo.jpg', $headers[2]);
+    }
+
+    public function testEmbedPath()
+    {
+        file_put_contents($path = __DIR__.'/foo.jpg', 'bar');
+
+        $cid = $this->message->embed($path);
+
+        $this->assertStringStartsWith('cid:', $cid);
+        $name = Str::after($cid, 'cid:');
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('bar', $attachment->getBody());
+        $this->assertSame("Content-Type: image/jpeg; name={$name}", $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame("Content-Disposition: inline; name={$name}; filename={$name}", $headers[2]);
+
+        unlink($path);
+    }
+
+    public function testDataEmbed()
+    {
+        $cid = $this->message->embedData('bar', 'foo.jpg', 'image/png');
+
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('cid:foo.jpg', $cid);
+        $this->assertSame('bar', $attachment->getBody());
+        $this->assertSame('Content-Type: image/png; name=foo.jpg', $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame('Content-Disposition: inline; name=foo.jpg; filename=foo.jpg', $headers[2]);
+    }
+
+    public function testItEmbedsFilesViaAttachableContractFromPath()
+    {
+        file_put_contents($path = __DIR__.'/foo.jpg', 'bar');
+
+        $cid = $this->message->embed(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromPath(__DIR__.'/foo.jpg')->as('baz')->withMime('image/png');
+            }
+        });
+
+        $this->assertSame('cid:baz', $cid);
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('bar', $attachment->getBody());
+        $this->assertSame('Content-Type: image/png; name=baz', $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame('Content-Disposition: inline; name=baz; filename=baz', $headers[2]);
+
+        unlink($path);
+    }
+
+    public function testItGeneratesARandomNameWhenAttachableHasNone()
+    {
+        file_put_contents($path = __DIR__.'/foo.jpg', 'bar');
+
+        $cid = $this->message->embed(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromPath(__DIR__.'/foo.jpg');
+            }
+        });
+
+        $this->assertStringStartsWith('cid:', $cid);
+        $name = Str::after($cid, 'cid:');
+        $this->assertSame(16, mb_strlen($name));
+        $attachment = $this->message->getSymfonyMessage()->getAttachments()[0];
+        $headers = $attachment->getPreparedHeaders()->toArray();
+        $this->assertSame('bar', $attachment->getBody());
+        $this->assertSame("Content-Type: image/jpeg; name={$name}", $headers[0]);
+        $this->assertSame('Content-Transfer-Encoding: base64', $headers[1]);
+        $this->assertSame("Content-Disposition: inline; name={$name};\r\n filename={$name}", $headers[2]);
+
+        unlink($path);
     }
 }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Notifications;
 use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Mail\Attachment;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
 class NotificationMailMessageTest extends TestCase

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Notifications;
 
+use Illuminate\Contracts\Mail\Attachable;
+use Illuminate\Mail\Attachment;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
 class NotificationMailMessageTest extends TestCase
@@ -269,5 +272,47 @@ class NotificationMailMessageTest extends TestCase
         $message = new MailMessage;
         $message->unless('truthy', $callback, $default);
         $this->assertSame([['truthy@example.com', null]], $message->cc);
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromPath()
+    {
+        $message = new MailMessage;
+
+        $message->attach(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromPath('/foo.jpg')->as('bar')->withMime('image/png');
+            }
+        });
+
+        $this->assertSame([
+            'file' => '/foo.jpg',
+            'options' => [
+                'as' => 'bar',
+                'mime' => 'image/png',
+            ],
+        ], $message->attachments[0]);
+    }
+
+    public function testItAttachesFilesViaAttachableContractFromData()
+    {
+        $mailMessage = new MailMessage();
+
+        $mailMessage->attach(new class() implements Attachable
+        {
+            public function toMailAttachment()
+            {
+                return Attachment::fromData(fn () => 'bar', 'foo.jpg')->withMime('image/png');
+            }
+        });
+
+        $this->assertSame([
+            'data' => 'bar',
+            'name' => 'foo.jpg',
+            'options' => [
+                'mime' => 'image/png',
+            ],
+        ], $mailMessage->rawAttachments[0]);
     }
 }


### PR DESCRIPTION
## Purpose

This PR aims to bring the concept of an "Attachable" for re-use of attaching files to a mail or other notification-like resources. It also standardises the attachable features across:

- `Illuminate/Mail/Mailable`
- `Illuminate/Mail/Message`
- `Illuminate/Notifications/Messages/MailMessage`

which is currently inconsistent, with `Mailable` supporting attaching from storage, while the others do not.

## Why this feature is useful

Often in applications you have a model or POPO that represents a "file" that you attach to a notification. The best of example of this is the ever classic example of an `Invoice`. You may have in invoice model in your system that has an associated PDF that you attach to notifications.

There may be several emails that you want the invoice attached to, and what's more is you might have some extra logic involved in retrieving the invoice before attaching to an email.

Currently we can attach files to an email in the following ways...

```php
class InvoiceCreated extends Mailable
{
    public function __construct(private Invoice $invoice)
    {
        //
    }

    public function build()
    {
        // From a file on the local filesystem...

        $this->attach($this->invoice->path);

        // As above, but with a nice filename and specifying the mime type...

        $this->attach($this->invoice->path, [
            'as' => "Acme Invoice {$this->invoice->number}.pdf",
            'mime' => 'application/pdf',
        ]);

        // From in-memory data...

        $this->attachData(
            $this->invoice->content,
            "Acme Invoice {$this->invoice->number}.pdf",
            ['mime' => 'application/pdf']
        );

        // Getting the contents on the fly...

        $data = Http::withHeaders(['Accept' => 'application/pdf'])
            ->get("https://api.xero.com/api.xro/2.0/Invoices/{$this->invoice->xero_id}")
            ->throw()
            ->body();

        $this->attachData(
            $data,
            "Acme Invoice {$this->invoice->number}.pdf",
            ['mime' => 'application/pdf']
        );


        /*
         * The following are only available on the `Mailable` class, making the API inconsistent...
         */

        // From the default storage disk...

        $this->attachFromStorage(
            $this->invoice->path,
            "Acme Invoice {$this->invoice->number}.pdf",
            ['mime' => 'application/pdf']
        );

        // From a specific storage disk...

        $this->attachFromStorageDisk(
            'backblaze',
            $this->invoice->file_path,
            "Acme Invoice {$this->invoice->number}.pdf",
            ['mime' => 'application/pdf']
        );
    }
}

```

When you then implement another email that sends this same file, you may then find yourself duplicating this code or reaching for the docs to remember how the APIs work, etc.

This PR aims to improve experience of attaching files to an email or other notification system.

## Usage

There is now an new contract called `Illumiante\Contracts\Mail\Attachable` that is meant for your model and a new `Illuminate\Mail\Attachment` class that you return from the contract method.

You can specify how you want the attachment to be attached to you mail / notification...

```php
class Invoice extends Model implements Attachable
{
    public function toMailAttachment()
    {
        // From a file on the local filesystem...

        return Attachment::fromPath($this->path);

        // As above, but with a nice filename and specifying the mime type...

        return Attachment::fromPath($this->path)
            ->as("Acme Invoice {$this->number}.pdf")
            ->withMime('application/pdf');

        // From in-memory data...

        return Attachment::fromData(fn () => $this->content)
            ->as("Acme Invoice {$this->number}.pdf")
            ->withMime('application/pdf');

        // Getting the contents on the fly...

        return Attachment::fromData(fn () => Http::withHeaders(['Accept' => 'application/pdf'])
            ->get("https://api.xero.com/api.xro/2.0/Invoices/{$this->xero_id}")
            ->throw()
            ->body()
        )->as("Acme Invoice {$this->invoice->number}.pdf")->withMime('application/pdf');
 

        /*
         * The following are now available on the `Mailable` and mail messages, both mail and notifications,
         * making the API consistent 🎉
         */


        // From the default storage disk...

        return Attachment::fromStorage($this->path)
            ->as("Acme Invoice {$this->number}.pdf")
            ->withMime('application/pdf');

        // From a specific storage disk...

        return Attachment::fromStorageDisk('backblaze', $this->path)
            ->as("Acme Invoice {$this->number}.pdf")
            ->withMime('application/pdf');
    }
}
```

Then to attach the invoice to a built in mailable resource the following API is used...

```php
class InvoiceCreated extends Mailable
{
    public function __construct(private Invoice $invoice)
    {
        //
    }

    public function build()
    {
        $this->attach($this->invoice);
    }
}
```

It is also possible to set the filename or mine from within the mailable itself, if that is wanted...

```php
class InvoiceCreated extends Mailable
{
    public function __construct(private Invoice $invoice)
    {
        //
    }

    public function build()
    {
        $this->attach(
            $this->invoice->toMailAttachment()->as('Pay Me.pdf')
        );
    }
}
```

## Mutiple attachments

Sometimes your model may several attachments. No troubles...

```php
class Invoice extends Model implements Attachable
{
    public function overdueAttachment()
    {
        return Attachment::fromData(/* ... */);
    }

    public function renewalAttachment()
    {
        return Attachment::fromData(/* ... */);
    }

    public function toMailAttachment()
    {
        return Attachment::fromData(/* ... */);
    }
}


// in the build function of your mailable....


$this->attach($this->invoice);

$this->attach($this->invoice->renewalAttachment());

$this->attach($this->invoice->overdueAttachment());

```

it is also possible to just use the attachment class right inline while attaching to a `Mail\Mailable`, `Mail\Message`, and `Notification\Messages\MailMessage`, with the latter two now being able to utilise the storage machanism.

```php
// in the build function…

$this->attach(Attachment::fromStorageDisk('s3', 'logo.png'));
```

## General API for 3rd parties

This new class has two ways of attaching data. By referencing a path or by supplying a Cloure that resolves a string of data. All APIs are just wrappers around these two features.

Third party packages that want to integrate with this class may specify how they want to handle an attachment. They must specify both a handler for a path based resource and a data based resource.

```php
class NotificationFrom3rdParty
{
    public function attach(Attachment $attachment): void
    {
        $attachment->attachWith(
            fn (string $path) => $this->attachPath($path, $attachment->as, $attachment->mime),
            fn (Closure $data) => $this->attachData($data, $attachment->as, $attachment->mime),
        );
    }

    public function attachData(Closure $data, string $filename, string $mimeType): void
    {
        //
    }

    public function attachPath(string $path, string $filename, string $mimeType): void
    {
        //
    }
}

$notificationFrom3rdPartyInstance->attach($invoiceModel);

```

You can see that the `$data` is not eagerly resolved, allowing the integration to decide _when_ they want to resolve the data - which is useful for delaying the resolution from storage etc, which is how the current mail system works.

### Extending the dev facing API

The attachment class is also Macroable, so it is possible to create nice named constructors from 3rd party libraries...


```php
// Service provider...

Attachment::macro('fromXeroInvoice', function ($id) {
    return Attachment::fromData(fn () => Http::withHeaders(['Accept' => 'application/pdf'])
        ->get("https://api.xero.com/api.xro/2.0/Invoices/{$id}")
        ->throw()
        ->body());
});

// Attachable...

public function toMailAttachment()
{
    return Attachment::fromXeroInvoice($this->xero_id)
        ->as("Acme Invoice {$this->number}.pdf")
        ->withMime('application/pdf');;
}
```

Or even just a more generic way of retrieving from a public API...

```php
Attachment::macro('fromUrl', function ($url) {
    return Attachment::fromData(fn () => Http::get($url)->throw()->body();
});
```

## Notes

- I've put the new contract and the new Attachment class in the `Mail` namespace, but as shown above it is kinda just generic "Notification". I'm happy to move it to the `Notifications` namespace if we feel that is a better fit.
- This new implementation does not dedupe "fromStorage" attachments in the same way that the current Mailable implementation does, as it has to resolve the Data the know how to dedupe.
- The current mail implementation does eagerly load the data during the "build" function call.
- It would be possible to consolidate both the `fromPath` and `fromData` APIs so that everything at the end of the day results in a `fromData`. This would simplify the integration as well, as you no longer have to handle both the "Path" and "Data" based attachments. The reason I didn't opt for a simple `file_get_contents` is that the Symfony mailer is doing a heap under the hood that I didn't want to have to replicate, so we continue to have two APIs - just like we currently do.
- This PR does not support inline attachments, as I wanted to make sure it was wanted before doing the work. Will do a follow up PR to ensure they work with inline attachments if this is merged / wanted. I'll also bring the embed feature to `Mailable` and `Notifications/Messages/MailMessage` which do not currently support inline embeds as a first class feature.