### PR TITLE
[9.x] Prevent triggering belongs to query if there are no relations to load

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -15,6 +15,8 @@ class BelongsTo extends Relation
         InteractsWithDictionary,
         SupportsDefaultModels;
 
+    protected bool $hasValidConstrains = true;
+
     /**
      * The child model instance of the relation.
      *
@@ -113,7 +115,15 @@ class BelongsTo extends Relation
 
         $whereIn = $this->whereInMethod($this->related, $this->ownerKey);
 
-        $this->query->{$whereIn}($key, $this->getEagerModelKeys($models));
+        // Do trigger query if there is nothing to load
+        $eagerModelKeys = $this->getEagerModelKeys($models);
+
+        if ($eagerModelKeys === []) {
+            $this->hasValidConstrains = false;
+            return;
+        }
+
+        $this->query->{$whereIn}($key, $eagerModelKeys);
     }
 
     /**
@@ -138,6 +148,15 @@ class BelongsTo extends Relation
         sort($keys);
 
         return array_values(array_unique($keys));
+    }
+
+    public function getEager()
+    {
+        if ($this->hasValidConstrains) {
+            return parent::getEager();
+        }
+
+        return new Collection();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -120,6 +120,7 @@ class BelongsTo extends Relation
 
         if ($eagerModelKeys === []) {
             $this->hasValidConstrains = false;
+
             return;
         }
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -86,6 +86,16 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation->addEagerConstraints($models);
     }
 
+    public function testIdsInEagerConstraintsWithMixedRelationExistOrNonExists()
+    {
+        $relation = $this->getRelation();
+        $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
+        $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
+        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('relation.id', [0, 'foreign.value']);
+        $models = [new EloquentBelongsToModelStub, new EloquentBelongsToModelStubWithZeroId, new MissingEloquentBelongsToModelStub];
+        $relation->addEagerConstraints($models);
+    }
+
     public function testRelationIsProperlyInitialized()
     {
         $relation = $this->getRelation();
@@ -175,7 +185,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('relation.id', m::mustBe([]));
+        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->never();
+        $relation->getQuery()->shouldReceive('whereIn')->never();
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }
@@ -183,7 +194,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testDefaultEagerConstraintsWhenIncrementingAndNonIntKeyType()
     {
         $relation = $this->getRelation(null, 'string');
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([]));
+        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->never();
+        $relation->getQuery()->shouldReceive('whereIn')->never();
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }
@@ -193,7 +205,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $relation = $this->getRelation();
         $relation->getRelated()->shouldReceive('getKeyName')->andReturn('id');
         $relation->getRelated()->shouldReceive('getKeyType')->andReturn('int');
-        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->once()->with('relation.id', m::mustBe([]));
+        $relation->getQuery()->shouldReceive('whereIntegerInRaw')->never();
+        $relation->getQuery()->shouldReceive('whereIn')->never();
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }


### PR DESCRIPTION
References issue #42493

- At this moment add the protection only for BelongsTo relation (can be added to `Relation` if more use cases are found)
- Prevents a query with empty whereIn value which reduces queries to DB.