### PR TITLE
[9.x] Adds `addUnique()` to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1644,6 +1644,21 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Add an unique item to the collection.
+     *
+     * @param  TValue  $item
+     * @return $this
+     */
+    public function addUnique($item)
+    {
+        if (!$this->contains($item)) {
+            $this->items[] = $item;
+        }
+
+        return $this;
+    }
+
+    /**
      * Get a base Support collection instance from this collection.
      *
      * @return \Illuminate\Support\Collection<TKey, TValue>

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1651,7 +1651,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function addUnique($item)
     {
-        if (!$this->contains($item)) {
+        if (! $this->contains($item)) {
             $this->items[] = $item;
         }
 


### PR DESCRIPTION
### Usage

Adding item to specific collection.
```php
$numbers  = collect();
$numbers->add(1); // [1]
```
if you again add this number to collection it will add duplicate item.
```php
$numbers->add(1); // [1,1] 
```
but if you use `addUnique()` it will check if specific item not exists in collection and it will add item.
```php
$numbers->addUnique(1); // [1] 
$numbers->addUnique(1); // [1] 
```

