### PR TITLE
[9.x] Fix exception message in reduceSpread

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -796,7 +796,7 @@ trait EnumeratesValues
 
             if (! is_array($result)) {
                 throw new UnexpectedValueException(sprintf(
-                    "%s::reduceMany expects reducer to return an array, but got a '%s' instead.",
+                    "%s::reduceSpread expects reducer to return an array, but got a '%s' instead.",
                     class_basename(static::class), gettype($result)
                 ));
             }


### PR DESCRIPTION
Updating an incorrect exception message when `EnumeratesValues::reduceSpread()` does not produce an array. `reduceMany` has been deprecated.