### PR TITLE
[9.x] Include model's table for route resolution query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1987,7 +1987,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
-        return $query->where($field ?? $this->getRouteKeyName(), $value);
+        return $query->where($field ?? $this->getTable() . '.' . $this->getRouteKeyName(), $value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1987,7 +1987,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
-        return $query->where($field ?? $this->getTable() . '.' . $this->getRouteKeyName(), $value);
+        return $query->where($field ?? $this->getTable().'.'.$this->getRouteKeyName(), $value);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Route resolution relies on `Model::find()` and therefore on `Model::resolveRouteBindingQuery()` which uses the models key name for resolution. This is usually good enough, but might break when scopes or similar are applied, which can lead to an SQL integrity contraint violation:

```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous
```

This behaviour can be solved by specifying the full table name instead of only the column name. A fully specified name should not break any correct existing queries.