### PR TITLE
[9.x] Map integer parameter to parameter name when resolving binding field

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -46,7 +46,7 @@ class ImplicitRouteBinding
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 
-            if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || $route->bindingFieldFor($parameterName) !== null)) {
+            if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
                 $childRouteBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -535,9 +535,11 @@ class Route
      */
     public function bindingFieldFor($parameter)
     {
-        $fields = is_int($parameter) ? array_values($this->bindingFields) : $this->bindingFields;
+        if (is_int($parameter)) {
+            $parameter = $this->parameterNames()[$parameter];
+        }
 
-        return $fields[$parameter] ?? null;
+        return $this->bindingFields[$parameter] ?? null;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -44,26 +44,18 @@ class RouteUri
         $bindingFields = [];
 
         foreach ($matches[0] as $match) {
-            $parameter = trim($match, '{}?');
-
-            if (! str_contains($parameter, ':')) {
-                $bindingFields[$parameter] = null;
-
+            if (! str_contains($match, ':')) {
                 continue;
             }
 
-            $segments = explode(':', $parameter);
+            $segments = explode(':', trim($match, '{}?'));
 
             $bindingFields[$segments[0]] = $segments[1];
 
             $uri = str_contains($match, '?')
-                    ? str_replace($match, '{'.$segments[0].'?}', $uri)
-                    : str_replace($match, '{'.$segments[0].'}', $uri);
+                ? str_replace($match, '{'.$segments[0].'?}', $uri)
+                : str_replace($match, '{'.$segments[0].'}', $uri);
         }
-
-        $bindingFields = ! empty(array_filter($bindingFields))
-            ? $bindingFields
-            : [];
 
         return new static($uri, $bindingFields);
     }

--- a/tests/Routing/RouteUriTest.php
+++ b/tests/Routing/RouteUriTest.php
@@ -51,27 +51,22 @@ class RouteUriTest extends TestCase
             [
                 '/foo/{bar}/baz/{qux:slug}',
                 '/foo/{bar}/baz/{qux}',
-                ['bar' => null, 'qux' => 'slug'],
+                ['qux' => 'slug'],
             ],
             [
                 '/foo/{bar}/baz/{qux:slug}',
                 '/foo/{bar}/baz/{qux}',
-                ['bar' => null, 'qux' => 'slug'],
-            ],
-            [
-                '/foo/{bar:slug}/baz/{qux}',
-                '/foo/{bar}/baz/{qux}',
-                ['bar' => 'slug', 'qux' => null],
+                ['qux' => 'slug'],
             ],
             [
                 '/foo/{bar}/baz/{qux:slug?}',
                 '/foo/{bar}/baz/{qux?}',
-                ['bar' => null, 'qux' => 'slug'],
+                ['qux' => 'slug'],
             ],
             [
                 '/foo/{bar}/baz/{qux:slug?}/{test:id?}',
                 '/foo/{bar}/baz/{qux?}/{test?}',
-                ['bar' => null, 'qux' => 'slug', 'test' => 'id'],
+                ['qux' => 'slug', 'test' => 'id'],
             ],
         ];
     }


### PR DESCRIPTION
Fixes #42541

First of all, I'm really sorry about all the issues the initial PR has caused 😞

## Summary

This PR reverts most of the changes of the original PR (#42425) while still fixing the bug described in the PR. The only method that was changed was the `bindingFieldFor` method of the `Route` class. All changes to `ImplicitRouteBinding` and `RouteUri` were reverted.

To fix the bug described in the original PR, we now resolve the parameter index to the parameter name by looking it up in the route's `parameterNames` array. 

```php
public function bindingFieldFor($parameter)
{
    if (is_int($parameter))  {
        $parameter = $this->parameterNames()[$parameter];
    }

    return $this->bindingFields[$parameter] ?? null;
}
```

This means that we no longer have to change the structure of the `bindingFields` array itself like in the original PR. The bug described in the related issue (#42541) was due to the fact that the `ResourceRouteRegistrar` _also_ filled the route's binding fields with `null` values, just like my change in the original PR. The problem with that is that both of these implementations used `null` to signal the exact opposite of each other. My PR used `null` to mean "don't scope this parameter", whereas the `ResourceRouteRegistrar` used it to mean "scope this parameter but default to the model's route key name".

I left in all the additional tests I added since all the problems that got reported due to my original PR were not covered by any existing tests.