### PR TITLE
[9.x] Support kebab case for slot name shortcut 

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -460,7 +460,7 @@ class ComponentTagCompiler
         $value = preg_replace_callback($pattern, function ($matches) {
             $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name']);
 
-            if(Str::contains($name, '-')) {
+            if (Str::contains($name, '-')) {
                 $name = Str::camel($name);
             }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -458,7 +458,11 @@ class ComponentTagCompiler
         /x";
 
         $value = preg_replace_callback($pattern, function ($matches) {
-            $name = str_replace('-', '_', $this->stripQuotes($matches['inlineName'] ?: $matches['name']));
+            $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name']);
+
+            if(Str::contains($name, '-')) {
+                $name = Str::camel($name);
+            }
 
             if ($matches[2] !== ':') {
                 $name = "'{$name}'";

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -426,7 +426,7 @@ class ComponentTagCompiler
             <
                 \s*
                 x[\-\:]slot
-                (?:\:(?<inlineName>\w+))?
+                (?:\:(?<inlineName>\w+(-\w+)*))?
                 (?:\s+(:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
                 (?<attributes>
                     (?:
@@ -458,7 +458,7 @@ class ComponentTagCompiler
         /x";
 
         $value = preg_replace_callback($pattern, function ($matches) {
-            $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name']);
+            $name = str_replace('-', '_', $this->stripQuotes($matches['inlineName'] ?: $matches['name']));
 
             if ($matches[2] !== ':') {
                 $name = "'{$name}'";

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -460,7 +460,7 @@ class ComponentTagCompiler
         $value = preg_replace_callback($pattern, function ($matches) {
             $name = str_replace('-', '_', $this->stripQuotes($matches['inlineName'] ?: $matches['name']));
 
-            if ($matches[2] !== ':') {
+            if ($matches[3] !== ':') {
                 $name = "'{$name}'";
             }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -426,7 +426,7 @@ class ComponentTagCompiler
             <
                 \s*
                 x[\-\:]slot
-                (?:\:(?<inlineName>\w+(-\w+)*))?
+                (?:\:(?<inlineName>\w+(?:-\w+)*))?
                 (?:\s+(:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
                 (?<attributes>
                     (?:
@@ -460,7 +460,7 @@ class ComponentTagCompiler
         $value = preg_replace_callback($pattern, function ($matches) {
             $name = str_replace('-', '_', $this->stripQuotes($matches['inlineName'] ?: $matches['name']));
 
-            if ($matches[3] !== ':') {
+            if ($matches[2] !== ':') {
                 $name = "'{$name}'";
             }
 


### PR DESCRIPTION
This is a revision of #42536 as per @taylorotwell's [request](https://github.com/laravel/framework/pull/42536#issuecomment-1141168765)

The inline slot name shortcut was added in laravel 9 but it does not comply with the blade component kebab case naming convention.
This PR will make the feature fit intuitively with the blade component naming conventions. 
Any kebab-cased slot names will be converted to camelCase so they can be used like so:
```xml
<!-- /resources/views/components/my-layout.blade.php -->
<html lang="en">
    <body>
        {{ $mySlot }}
    </body>
</html>

<!-- /resources/views/components/child.blade.php -->
<x-my-layout>
    <x-slot:my-slot>
        <div>My super cool content</div>
    </x-slot:my-slot>
</x-my-layout>
```
Previously this would have to be done like this:  
```xml
<!-- /resources/views/components/child.blade.php -->
<x-my-layout>
    <x-slot:mySlot>
        <div>My super cool content</div>
    </x-slot:mySlot>
</x-my-layout>
```
Not bad, but it doesnt fit conventions and a multiword slot-name example isn't provided in the documentation.

### **Breaking Changes?** 
There are no breaking changes, slot names provided in camelCase or in snake_case will continue work the same.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
