### PR TITLE
[9.x] Predis v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^9.5.8",
-        "predis/predis": "^1.1.9",
+        "predis/predis": "^1.1.9|^2.0",
         "symfony/cache": "^6.0"
     },
     "provide": {
@@ -154,7 +154,7 @@
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
         "phpunit/phpunit": "Required to use assertions and run tests (^9.5.8).",
-        "predis/predis": "Required to use the predis connector (^1.1.9).",
+        "predis/predis": "Required to use the predis connector (^1.1.9|^2.0).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^6.0).",

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^9.5.8",
-        "predis/predis": "^1.1.9|^2.0",
+        "predis/predis": "^2.0",
         "symfony/cache": "^6.0"
     },
     "provide": {

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^9.5.8",
-        "predis/predis": "^2.0",
+        "predis/predis": "^1.1.9|^2.0",
         "symfony/cache": "^6.0"
     },
     "provide": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -27,7 +27,7 @@
     },
     "suggest": {
         "ext-redis": "Required to use the phpredis connector (^4.0|^5.0).",
-        "predis/predis": "Required to use the predis connector (^1.1.9)."
+        "predis/predis": "Required to use the predis connector (^1.1.9|^2.0)."
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Predis v2 is released now: https://github.com/predis/predis/releases/tag/v2.0.0

It's only a maintenance release so nothing should break.