### PR TITLE
[9.x] Allow underline in numeric validation values

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -407,7 +407,7 @@ trait ValidatesAttributes
 
         $size = $this->getSize($attribute, $value);
 
-        return $size >= $parameters[0] && $size <= $parameters[1];
+        return $size >= str_replace('_', '', (string) $parameters[0]) && $size <= str_replace('_', '', (string) $parameters[1]);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2395,6 +2395,30 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Between:50,100']);
         $this->assertFalse($v->passes());
 
+        // inclusive on min
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Between:123,200']);
+        $this->assertTrue($v->passes());
+
+        // inclusive on max
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'Numeric|Between:0,123']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '600000'], ['foo' => 'Numeric|Between:500_000,1_300_000']);
+        $this->assertTrue($v->passes());
+
+        // can work with float
+        $v = new Validator($trans, ['foo' => '0.02'], ['foo' => 'Numeric|Between:0.01,0.02']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0.02'], ['foo' => 'Numeric|Between:0.01,0.03']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '0.001'], ['foo' => 'Numeric|Between:0.01,0.03']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '14000'], ['foo' => 'Numeric|Between:500_000,1_300_000']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['foo' => '3'], ['foo' => 'Numeric|Between:1,5']);
         $this->assertTrue($v->passes());
 


### PR DESCRIPTION
PHP 7.4 allows putting the underline character in integers for more readability, like:
"1_500_000" instead of: "1500000"
This PR allows putting underline in numbers of validation rules: ```Numeric|Between:500_000,1_000_000```

- It also adds some important missing tests.