### PR TITLE
[9.x] Fix getting '0' from route parameter in Authorize middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -75,7 +75,7 @@ class Authorize
         if ($this->isClassName($model)) {
             return trim($model);
         } else {
-            return $request->route($model, null) ?:
+            return $request->route($model, null) ??
                 ((preg_match("/^['\"](.*)['\"]$/", trim($model), $matches)) ? $matches[1] : null);
         }
     }

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -178,6 +178,24 @@ class AuthorizeMiddlewareTest extends TestCase
         $this->assertSame('success', $response->content());
     }
 
+    public function testSimpleAbilityWithStringParameter0FromRouteParameter()
+    {
+        $this->gate()->define('view-dashboard', function ($user, $param) {
+            return $param === '0';
+        });
+
+        $this->router->get('dashboard/{route_parameter}', [
+            'middleware' => Authorize::class.':view-dashboard,route_parameter',
+            'uses' => function () {
+                return 'success';
+            },
+        ]);
+
+        $response = $this->router->dispatch(Request::create('dashboard/0', 'GET'));
+
+        $this->assertSame('success', $response->content());
+    }
+
     public function testModelTypeUnauthorized()
     {
         $this->expectException(AuthorizationException::class);


### PR DESCRIPTION
Given the following :

```php
// api.php
Route::get('sin/{angle}', [SinusController::class, 'compute'])
    ->whereNumber('angle')
    ->can('compute', [Sinus::class, 'angle']); 

// SinusPolicy
public function compute(User $user, int $angle)
{
    return 0<= $angle && $angle <= 360;
}
```

Calling `GET api/sin/90` will correctly pass but calling `GET api/sin/0` will fail in the policy because `$angle` is `null` instead of expected `0`.

Problem comes from the fact that `$request->route($model, null) ` is `'0'` and `'0' ?: 'bar'` is `'bar'`.  

Changing the Elvis `?:` to null coalesce `??` solves the issue.
