### PR TITLE
[9.x] Ignore skipped tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         printerClass="Illuminate\Tests\IgnoreSkippedPrinter"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"

--- a/tests/IgnoreSkippedPrinter.php
+++ b/tests/IgnoreSkippedPrinter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests;
+
+use PHPUnit\Framework\TestResult;
+use PHPUnit\TextUI\DefaultResultPrinter;
+
+class IgnoreSkippedPrinter extends DefaultResultPrinter
+{
+    protected function printSkipped(TestResult $result): void
+    {
+        //
+    }
+}

--- a/tests/IgnoreSkippedPrinter.php
+++ b/tests/IgnoreSkippedPrinter.php
@@ -3,12 +3,24 @@
 namespace Illuminate\Tests;
 
 use PHPUnit\Framework\TestResult;
-use PHPUnit\TextUI\DefaultResultPrinter;
+use PHPUnit\Runner\Version;
+use PHPUnit\TextUI\DefaultResultPrinter as PHPUnit9ResultPrinter;
+use PHPUnit\TextUI\ResultPrinter as PHPUnit8ResultPrinter;
 
-class IgnoreSkippedPrinter extends DefaultResultPrinter
-{
-    protected function printSkipped(TestResult $result): void
+if (class_exists(Version::class) && (int) Version::series()[0] >= 9) {
+    class IgnoreSkippedPrinter extends PHPUnit9ResultPrinter
     {
-        //
+        protected function printSkipped(TestResult $result): void
+        {
+            //
+        }
+    }
+} else {
+    class IgnoreSkippedPrinter extends PHPUnit8ResultPrinter
+    {
+        protected function printSkipped(TestResult $result): void
+        {
+            //
+        }
     }
 }


### PR DESCRIPTION
Solves https://twitter.com/taylorotwell/status/1512497272281513984

This PR removes skipped tests from the PHPUnit output while still keeping verbose output. By implementing a different printer we can remove skipped tests output which isn't of use most of the time and keep the output clean for just failed tests.

Before:

<img width="914" alt="Screenshot 2022-05-31 at 14 06 32" src="https://user-images.githubusercontent.com/594614/171169295-92663e5b-2587-4fda-a288-23861739cdb6.png">

After:

<img width="757" alt="Screenshot 2022-05-31 at 14 03 01" src="https://user-images.githubusercontent.com/594614/171169310-53c61b51-f574-4ac8-b0aa-7ff072ca16a0.png">
