### PR TITLE
[10.x] Remove deprecated dates property

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -106,15 +106,6 @@ trait HasAttributes
     ];
 
     /**
-     * The attributes that should be mutated to dates.
-     *
-     * @deprecated Use the "casts" property
-     *
-     * @var array
-     */
-    protected $dates = [];
-
-    /**
      * The storage format of the model's date columns.
      *
      * @var string
@@ -1366,16 +1357,10 @@ trait HasAttributes
      */
     public function getDates()
     {
-        if (! $this->usesTimestamps()) {
-            return $this->dates;
-        }
-
-        $defaults = [
+        return $this->usesTimestamps() ? [
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
-        ];
-
-        return array_unique(array_merge($this->dates, $defaults));
+        ] : [];
     }
 
     /**


### PR DESCRIPTION
[It's been over two years since the dates property became deprecated](https://github.com/laravel/framework/commit/c0e0bb52a8e98169b4f5d2415890c7e80fdb04e5) and even longer since the introduction of casts. I feel it's time to remove this property so people can solely rely on the model casts for any datetime attributes. 