### PR TITLE
[10.x] Remove deprecated dispatchNow functionality

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -58,18 +58,6 @@ trait Dispatchable
     }
 
     /**
-     * Dispatch a command to its appropriate handler in the current process.
-     *
-     * @return mixed
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     */
-    public static function dispatchNow(...$arguments)
-    {
-        return app(Dispatcher::class)->dispatchNow(new static(...$arguments));
-    }
-
-    /**
      * Dispatch a command to its appropriate handler after the current process.
      *
      * @return mixed

--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -20,19 +20,6 @@ trait DispatchesJobs
     /**
      * Dispatch a job to its appropriate handler in the current process.
      *
-     * @param  mixed  $job
-     * @return mixed
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     */
-    public function dispatchNow($job)
-    {
-        return app(Dispatcher::class)->dispatchNow($job);
-    }
-
-    /**
-     * Dispatch a job to its appropriate handler in the current process.
-     *
      * Queueable jobs will be dispatched to the "sync" queue.
      *
      * @param  mixed  $job

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -406,22 +406,6 @@ if (! function_exists('dispatch_sync')) {
     }
 }
 
-if (! function_exists('dispatch_now')) {
-    /**
-     * Dispatch a command to its appropriate handler in the current process.
-     *
-     * @param  mixed  $job
-     * @param  mixed  $handler
-     * @return mixed
-     *
-     * @deprecated Will be removed in a future Laravel version.
-     */
-    function dispatch_now($job, $handler = null)
-    {
-        return app(Dispatcher::class)->dispatchNow($job, $handler);
-    }
-}
-
 if (! function_exists('encrypt')) {
     /**
      * Encrypt the given value.


### PR DESCRIPTION
This will remove the deprecated functions and methods around dispatchNow. The internals will remain to not make the upgrade path too hard but in general we want to push people more to use `dispatchSync` which is the only supported way to dispatching immediately.