### PR TITLE
Add combine method to Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -75,6 +75,7 @@ class Arr
         if ($values === nul) {
             return array_combine($keys, $keys);
         }
+
         return array_combine($keys, $values);
     }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -62,6 +62,23 @@ class Arr
     }
 
     /**
+     * Create an array using one for key and another for values.
+     *
+     * If no values are provided then the keys will be used for both.
+     *
+     * @param  array  $keys
+     * @param  ?array $values
+     * @return array
+     */
+    public static combine($keys, $values = null)
+    {
+        if ($values === nul) {
+            return array_combine($keys, $keys);
+        }
+        return array_combine($keys, $values);
+    }
+
+    /**
      * Cross join the given arrays, returning all possible permutations.
      *
      * @param  iterable  ...$arrays

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -72,7 +72,7 @@ class Arr
      */
     public static function combine($keys, $values = null)
     {
-        if ($values === nul) {
+        if ($values === null) {
             return array_combine($keys, $keys);
         }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -70,7 +70,7 @@ class Arr
      * @param  ?array $values
      * @return array
      */
-    public static combine($keys, $values = null)
+    public static function combine($keys, $values = null)
     {
         if ($values === nul) {
             return array_combine($keys, $keys);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -67,7 +67,7 @@ class Arr
      * If no values are provided then the keys will be used for both.
      *
      * @param  array  $keys
-     * @param  ?array $values
+     * @param  array $values
      * @return array
      */
     public static function combine($keys, $values = null)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -67,7 +67,7 @@ class Arr
      * If no values are provided then the keys will be used for both.
      *
      * @param  array  $keys
-     * @param  array $values
+     * @param  array  $values
      * @return array
      */
     public static function combine($keys, $values = null)


### PR DESCRIPTION
I often need a method to create an array with the same keys as values. 
Say you wanted to generate options for a select input where the expected array shape was [value => label,...] where you just wanted a number range 1-5. 
You'd have to do something like:
```php
$range = range(1, 5);
$options = array_combine($range, $range);
```
With this you could do:
```php
$options = Arr::combine(range(1, 5));
```

Maybe the method shouldn't fall back to `array_combine` and should just set the keys and call it `keysFromValues` or something. Happy to discuss.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
