### PR TITLE
[9.x] Added Eloquent withWhereHas method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -153,6 +153,23 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a relationship count / exists condition to the query with where clauses.
+     * 
+     * Also load the relationship with same condition.
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function withWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    {
+        return $this->whereHas($relation, $callback, $operator, $count)
+            ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
+    }
+
+    /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @param  string  $relation

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -154,7 +154,7 @@ trait QueriesRelationships
 
     /**
      * Add a relationship count / exists condition to the query with where clauses.
-     * 
+     *
      * Also load the relationship with same condition.
      *
      * @param  string  $relation

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -121,6 +121,18 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertCount(1, $country);
     }
 
+    public function testWithWhereHasOnARelationWithCustomIntermediateAndLocalKey()
+    {
+        $this->seedData();
+        $country = HasManyThroughIntermediateTestCountry::withWhereHas('posts', function ($query) {
+            $query->where('title', 'A title');
+        })->get();
+
+        $this->assertCount(1, $country);
+        $this->assertTrue($country->first()->relationLoaded('posts'));
+        $this->assertEquals($country->first()->posts->pluck('title')->unique()->toArray(), ['A title']);
+    }
+
     public function testFindMethod()
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -277,7 +277,7 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
             $query->where('logins.id', $latestLogin->id);
         })->first();
 
-        $this->assertTrue((bool)$found);
+        $this->assertTrue((bool) $found);
         $this->assertTrue($found->relationLoaded('latest_login'));
         $this->assertEquals($found->latest_login->id, $latestLogin->id);
 

--- a/tests/Database/DatabaseEloquentHasOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentHasOneOfManyTest.php
@@ -267,6 +267,27 @@ class DatabaseEloquentHasOneOfManyTest extends TestCase
         $this->assertFalse($found);
     }
 
+    public function testWithHasNested()
+    {
+        $user = HasOneOfManyTestUser::create();
+        $previousLogin = $user->logins()->create();
+        $latestLogin = $user->logins()->create();
+
+        $found = HasOneOfManyTestUser::withWhereHas('latest_login', function ($query) use ($latestLogin) {
+            $query->where('logins.id', $latestLogin->id);
+        })->first();
+
+        $this->assertTrue((bool)$found);
+        $this->assertTrue($found->relationLoaded('latest_login'));
+        $this->assertEquals($found->latest_login->id, $latestLogin->id);
+
+        $found = HasOneOfManyTestUser::withWhereHas('latest_login', function ($query) use ($previousLogin) {
+            $query->where('logins.id', $previousLogin->id);
+        })->exists();
+
+        $this->assertFalse($found);
+    }
+
     public function testHasCount()
     {
         $user = HasOneOfManyTestUser::create();

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -116,6 +116,18 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->assertCount(1, $position);
     }
 
+    public function testWithWhereHasOnARelationWithCustomIntermediateAndLocalKey()
+    {
+        $this->seedData();
+        $position = HasOneThroughIntermediateTestPosition::withWhereHas('contract', function ($query) {
+            $query->where('title', 'A title');
+        })->get();
+
+        $this->assertCount(1, $position);
+        $this->assertTrue($position->first()->relationLoaded('contract'));
+        $this->assertEquals($position->first()->contract->pluck('title')->unique()->toArray(), ['A title']);
+    }
+
     public function testFirstOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -115,6 +115,30 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $this->assertTrue($exists);
     }
 
+    public function testWithWhereHas()
+    {
+        $product = MorphOneOfManyTestProduct::create();
+        $previousState = $product->states()->create([
+            'state' => 'draft',
+        ]);
+        $currentState = $product->states()->create([
+            'state' => 'active',
+        ]);
+
+        $exists = MorphOneOfManyTestProduct::withWhereHas('current_state', function ($q) use ($previousState) {
+            $q->whereKey($previousState->getKey());
+        })->exists();
+        $this->assertFalse($exists);
+
+        $exists = MorphOneOfManyTestProduct::withWhereHas('current_state', function ($q) use ($currentState) {
+            $q->whereKey($currentState->getKey());
+        })->get();
+
+        $this->assertCount(1, $exists);
+        $this->assertTrue($exists->first()->relationLoaded('current_state'));
+        $this->assertSame($exists->first()->current_state->state, $currentState->state);
+    }
+
     public function testWithExists()
     {
         $product = MorphOneOfManyTestProduct::create();


### PR DESCRIPTION
There are a lot of times that we need to load a relationship using `with` with the same conditions that we use for `whereHas`.

This method simplifies this selection by avoiding repeating the code used both to filter with `whereHas` and then to select that same record using `with`. There is less code, it is more readable and easier to maintain.

## Before

```php
CollectionModel::whereHas('products', function ($query) {
    $query->where('enabled', true)->where('sale', true);
})->with(['products' => function ($query) {
    $query->where('enabled', true)->where('sale', true);
});
```
## After

```php
CollectionModel::withWhereHas('products', fn ($query) => $query->where('enabled', true)->where('sale', true));
```

If it's ok for you, I will add tests :)