### PR TITLE
[9.x] Deprecate Redirect::home()

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -40,6 +40,8 @@ class Redirector
      *
      * @param  int  $status
      * @return \Illuminate\Http\RedirectResponse
+     *
+     * @deprecated Will be removed in a future Laravel version.
      */
     public function home($status = 302)
     {


### PR DESCRIPTION
Deprecate `Redirect::home()` in response to Taylor's note on #42560
> Not sure we even document Redirect::home()... I would just redirect to a specific named route.

Deprecating, this undocumented feature will open up the name for use as a macro or similar by developers after it is removed in probably the 10.0 release.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
