### PR TITLE
Add hasQuery() method to Illuminate\Http\Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -566,4 +566,15 @@ trait InteractsWithInput
 
         return $this;
     }
+
+    /**
+     * Determine if a query key is set on the request.
+     *
+     * @param $key
+     * @return bool
+     */
+    public function hasQuery($key): bool
+    {
+        return ! is_null($this->query($key));
+    }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1351,4 +1351,13 @@ class HttpRequestTest extends TestCase
         $request->setLaravelSession($session);
         $request->flashExcept(['email']);
     }
+
+    public function testHasQueryMethod()
+    {
+        $request = Request::create('/', 'GET', [], [], []);
+        $this->assertFalse($request->hasQuery('foo'));
+
+        $request = Request::create('/', 'GET', ['foo' => 'bar'], [], []);
+        $this->assertTrue($request->hasQuery('foo'));
+    }
 }


### PR DESCRIPTION
This PR adds a `hasQuery()` method to Illuminate\Http\Request.

```php
public function index(Request $request)
{
     if($request->hasQuery('foo')){

        //do something ...

     }
}
```

