### PR TITLE
[9.x] Handle undefined array key error

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -536,7 +536,13 @@ class Route
     public function bindingFieldFor($parameter)
     {
         if (is_int($parameter)) {
-            $parameter = $this->parameterNames()[$parameter];
+            $parameters = $this->parameterNames();
+
+            if (!isset($parameters[$parameter])) {
+                return null;
+            }
+
+            $parameter = $parameters[$parameter];
         }
 
         return $this->bindingFields[$parameter] ?? null;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -538,7 +538,7 @@ class Route
         if (is_int($parameter)) {
             $parameters = $this->parameterNames();
 
-            if (!isset($parameters[$parameter])) {
+            if (! isset($parameters[$parameter])) {
                 return null;
             }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -373,6 +373,24 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/test-slug', $url->route('routable', [$model], false));
     }
 
+    public function testRoutableInterfaceRoutingAsQueryString()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo', ['as' => 'query-string']);
+        $routes->add($route);
+
+        $model = new RoutableInterfaceStub;
+        $model->key = 'routable';
+
+        $this->assertSame('/foo?routable', $url->route('query-string', $model, false));
+        $this->assertSame('/foo?routable', $url->route('query-string', [$model], false));
+        $this->assertSame('/foo?foo=routable', $url->route('query-string', ['foo' => $model], false));
+    }
+
     public function testRoutableInterfaceRoutingWithSeparateBindingFieldOnlyForSecondParameter()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Fixes #42605 

Oh boy, the gift that keeps on giving. Looks like there's yet another edge case.

## Summary

This PR fixes a regression when trying passing a model to the `route` helper for a route without route parameters.

```php
$model = new User(['id' => 1]);

Route::get('/foo')->name('foo');

route('foo', $model); // Used to return `/foo?1`, now throws an exception
```

While I think this behavior is pretty weird, I guess it shouldn't break between minor versions.