### PR TITLE
[9.x] Adds `Arr::filter`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -177,6 +177,18 @@ class Arr
     }
 
     /**
+     * Filter the array using the given callback.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function filter($array, callable $callback)
+    {
+        return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
      * Return the first element in an array passing a given truth test.
      *
      * @param  iterable  $array
@@ -787,7 +799,7 @@ class Arr
      */
     public static function where($array, callable $callback)
     {
-        return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+        return static::filter($array, $callback);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -369,7 +369,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function filter(callable $callback = null)
     {
         if ($callback) {
-            return new static(Arr::where($this->items, $callback));
+            return new static(Arr::filter($this->items, $callback));
         }
 
         return new static(array_filter($this->items));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -175,6 +175,28 @@ class SupportArrTest extends TestCase
         $this->assertEquals([0, false, '', []], $array);
     }
 
+    public function testFilter()
+    {
+        $array = [100, '200', 300, '400', 500];
+
+        $array = Arr::filter($array, function ($value, $key) {
+            return is_string($value);
+        });
+
+        $this->assertEquals([1 => '200', 3 => '400'], $array);
+    }
+
+    public function testFilterKey()
+    {
+        $array = ['10' => 1, 'foo' => 3, 20 => 2];
+
+        $array = Arr::filter($array, function ($value, $key) {
+            return is_numeric($key);
+        });
+
+        $this->assertEquals(['10' => 1, 20 => 2], $array);
+    }
+
     public function testFirst()
     {
         $array = [100, 200, 300];


### PR DESCRIPTION
I've been using `Arr` heavily and felt that it was missing a `filter` method.
Turns out it has been there all along, but is named `Arr::where`.

Almost every programming language as the concept of `map` and `filter`, 
so I think it would be more intuitive to call it `Arr::filter`.

To avoid a breaking change I've moved the logic to the new `filter` method, but kept `where` as a simple alias.