### PR TITLE
[10.x] Remove deprecated Route::home method

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -36,17 +36,6 @@ class Redirector
     }
 
     /**
-     * Create a new redirect response to the "home" route.
-     *
-     * @param  int  $status
-     * @return \Illuminate\Http\RedirectResponse
-     */
-    public function home($status = 302)
-    {
-        return $this->to($this->generator->route('home'), $status);
-    }
-
-    /**
      * Create a new redirect response to the previous location.
      *
      * @param  int  $status

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -157,9 +157,6 @@ class RoutingRedirectorTest extends TestCase
 
         $response = $this->redirect->route('home');
         $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
-
-        $response = $this->redirect->home();
-        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
 
     public function testSignedRoute()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Removes the Route::home method we [deprecated in the 9.x branch](https://github.com/laravel/framework/pull/42600#issuecomment-1143149665).