### PR TITLE
[9.x] Custom session values on "Remember Me" option for session rebuild 

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -141,6 +141,10 @@ class AuthManager implements FactoryContract
             $guard->setRememberDuration($config['remember']);
         }
 
+        if (isset($config['remember_segments'])) {
+            $guard->setRememberSegments($config['remember_segments']);
+        }
+
         return $guard;
     }
 


### PR DESCRIPTION
**Example:** 
Company is a manyToMany relation with User, on login user pick wich company use for signin, on "remember me" laravel rebuild the user session **but not the picked  company**,  would be great if session guard can handle that extra id/ids and rebuild the session, also **user can be logged on two or more companies at the same time**(using different devices, browser, others)

**Usage:**
On `auth.php`
```php
'guards' => [
    'web' => [
        'driver' => 'session',
        'provider' => 'users',
        'remember_segments' => ['company_id'], // ['company_id', 'year'] more keys
    ],
    // ...
],
```
So on login user picks the `company_id`
```php
// request()->all(); request sent to login
[
    'email' => 'email@email.com',
    'password' => 'PASSWORD',
    'company_id' => 1,
    // 'year' => '2021',
    'remember' => 'on',
]
```
After authentication, `company_id` will be in `session()`, and on session rebuild  via "Remember Me", `company_id` returns to `session()`
Also it's posible use `$request->merge()` for adding values to request before login

Complement of: #42316
Use case: **Teams on**  https://github.com/spatie/laravel-permission/discussions/2075


### **Open to discussion, could be better**
Maybe methods and properties naming needs changes