### PR TITLE
[9.x] Remove Unnecessary Commented Code

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -325,7 +325,6 @@ class Handler implements ExceptionHandlerContract
         try {
             return array_filter([
                 'userId' => Auth::id(),
-                // 'email' => optional(Auth::user())->email,
             ]);
         } catch (Throwable $e) {
             return [];


### PR DESCRIPTION
Upon doing some reading into the framework's Handler, I found the commented line of code and figured if anything, it would cause confusion by being there (as it did for me). Hence this PR removes the commented code that was last updated years ago.