### PR TITLE
[9.x] Add additional uuid testing helpers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -40,7 +40,7 @@ class Str
     /**
      * The callback that should be used to generate UUIDs.
      *
-     * @var callable
+     * @var callable|null
      */
     protected static $uuidFactory;
 
@@ -1113,7 +1113,14 @@ class Str
         static::$uuidFactory = $factory;
     }
 
-    public static function createUuidsUsingSequence(array $sequence, Closure $whenMissing = null)
+    /**
+     * Set the sequence that will be used to generate UUIDs.
+     *
+     * @param  array  $sequence
+     * @param  callable|null  $whenMissing
+     * @return void
+     */
+    public static function createUuidsUsingSequence(array $sequence, $whenMissing = null)
     {
         $next = 0;
 
@@ -1140,6 +1147,12 @@ class Str
         });
     }
 
+    /**
+     * Always return the same UUID when generating new UUIDs.
+     *
+     * @param  \Closure|null  $callback
+     * @return \Ramsey\Uuid\UuidInterface
+     */
     public static function freezeUuids(Closure $callback = null)
     {
         $uuid = Str::uuid();
@@ -1154,7 +1167,6 @@ class Str
 
         return $uuid;
     }
-
 
     /**
      * Indicate that UUIDs should be created normally and not using a custom factory.

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1113,15 +1113,11 @@ class Str
         static::$uuidFactory = $factory;
     }
 
-    public static function createUuidsUsingSequence(array $sequence)
+    public static function createUuidsUsingSequence(array $sequence, Closure $whenMissing = null)
     {
         $next = 0;
 
-        static::createUuidsUsing(function () use (&$next, $sequence) {
-            if (array_key_exists($next, $sequence)) {
-                return $sequence[$next++];
-            }
-
+        $whenMissing ??= function () use (&$next) {
             $factoryCache = static::$uuidFactory;
 
             static::$uuidFactory = null;
@@ -1133,6 +1129,14 @@ class Str
             $next++;
 
             return $uuid;
+        };
+
+        static::createUuidsUsing(function () use (&$next, $sequence, $whenMissing) {
+            if (array_key_exists($next, $sequence)) {
+                return $sequence[$next++];
+            }
+
+            return $whenMissing();
         });
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -891,6 +891,76 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame($expected, Str::transliterate($value, '?', true));
     }
+
+    public function testItCanFreezeUuids()
+    {
+        $this->assertNotSame((string) Str::uuid(), (string) Str::uuid());
+        $this->assertNotSame(Str::uuid(), Str::uuid());
+
+        $uuid = Str::freezeUuids();
+
+        $this->assertSame($uuid, Str::uuid());
+        $this->assertSame(Str::uuid(), Str::uuid());
+        $this->assertSame((string) $uuid, (string) Str::uuid());
+        $this->assertSame((string) Str::uuid(), (string) Str::uuid());
+
+        Str::createUuidsNormally();
+
+        $this->assertNotSame(Str::uuid(), Str::uuid());
+        $this->assertNotSame((string) Str::uuid(), (string) Str::uuid());
+    }
+
+    public function testItCanFreezeUuidsInAClosure()
+    {
+        $uuids = [];
+
+        $uuid = Str::freezeUuids(function ($uuid) use (&$uuids) {
+            $uuids[] = $uuid;
+            $uuids[] = Str::uuid();
+            $uuids[] = Str::uuid();
+        });
+
+        $this->assertSame($uuid, $uuids[0]);
+        $this->assertSame((string) $uuid, (string) $uuids[0]);
+        $this->assertSame((string) $uuids[0], (string) $uuids[1]);
+        $this->assertSame($uuids[0], $uuids[1]);
+        $this->assertSame((string) $uuids[0], (string) $uuids[1]);
+        $this->assertSame($uuids[1], $uuids[2]);
+        $this->assertSame((string) $uuids[1], (string) $uuids[2]);
+        $this->assertNotSame(Str::uuid(), Str::uuid());
+        $this->assertNotSame((string) Str::uuid(), (string) Str::uuid());
+    }
+
+    public function testItCanSpecifyASquenceOfUuidsToUtilise()
+    {
+        Str::createUuidsUsingSequence([
+            0 => ($zeroth = Str::uuid()),
+            1 => ($first = Str::uuid()),
+            // just generate a random one here...
+            3 => ($third = Str::uuid()),
+            // continue to generate random uuids...
+        ]);
+
+        $retrieved = Str::uuid();
+        $this->assertSame($zeroth, $retrieved);
+        $this->assertSame((string) $zeroth, (string) $retrieved);
+
+        $retrieved = Str::uuid();
+        $this->assertSame($first, $retrieved);
+        $this->assertSame((string) $first, (string) $retrieved);
+
+        $retrieved = Str::uuid();
+        $this->assertFalse(in_array($retrieved, [$zeroth, $first, $third], true));
+        $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
+
+        $retrieved = Str::uuid();
+        $this->assertSame($third, $retrieved);
+        $this->assertSame((string) $third, (string) $retrieved);
+
+        $retrieved = Str::uuid();
+        $this->assertFalse(in_array($retrieved, [$zeroth, $first, $third], true));
+        $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -961,6 +961,16 @@ class SupportStrTest extends TestCase
         $this->assertFalse(in_array($retrieved, [$zeroth, $first, $third], true));
         $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
     }
+
+    public function testItCanSpecifyAFallbackForASequence()
+    {
+        Str::createUuidsUsingSequence([Str::uuid(), Str::uuid()], fn () => throw new \Exception('Out of Uuids.'));
+        Str::uuid();
+        Str::uuid();
+
+        $this->expectExceptionMessage('Out of Uuids.');
+        Str::uuid();
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -929,6 +929,8 @@ class SupportStrTest extends TestCase
         $this->assertSame((string) $uuids[1], (string) $uuids[2]);
         $this->assertNotSame(Str::uuid(), Str::uuid());
         $this->assertNotSame((string) Str::uuid(), (string) Str::uuid());
+
+        Str::createUuidsNormally();
     }
 
     public function testItCanSpecifyASquenceOfUuidsToUtilise()
@@ -960,6 +962,8 @@ class SupportStrTest extends TestCase
         $retrieved = Str::uuid();
         $this->assertFalse(in_array($retrieved, [$zeroth, $first, $third], true));
         $this->assertFalse(in_array((string) $retrieved, [(string) $zeroth, (string) $first, (string) $third], true));
+
+        Str::createUuidsNormally();
     }
 
     public function testItCanSpecifyAFallbackForASequence()
@@ -968,8 +972,13 @@ class SupportStrTest extends TestCase
         Str::uuid();
         Str::uuid();
 
-        $this->expectExceptionMessage('Out of Uuids.');
-        Str::uuid();
+        try {
+            $this->expectExceptionMessage('Out of Uuids.');
+            Str::uuid();
+            $this->fail();
+        } finally {
+            Str::createUuidsNormally();
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds some testing helpers to the generation of UUIDs via the `Str` helper.

Currently in order to control UUID creation, you need to do the following...

```php
$uuid = Str::uuid();
Str::createUuidsUsing(fn () => $uuid);

// do stuff...

Str::uuid() === Str::uuid() === $uuid;

// cleanup...

Str::createUuidsNormally();
```

This locks the helper so that it only returns the one UUID throughout the whole process.

I find myself always having to re-learn how this works and that I have to capture a UUID first or needing to fake a specific UUID generation.


With this PR the following is now possible...

```php
Str::freezeUuids();

// do stuff...

Str::uuid() === Str::uuid() === $uuid;

// cleanup...

Str::createUuidsNormally();
```

You may also pass a closure to only freeze creation for the duration of the closure...

```php
Str::freezeUuids(function ($uuid) {
    // do stuff...
    Str::uuid() === Str::uuid() === $uuid;
});
```

Finally, it is also possible to provide a sequence of UUIDs to return. 
```php
Str::createUuidsUsingSequence([
    $zeroth = Str::uuid(),
    $first = Str::uuid(),
]);

Str::uuid() === $zeroth;
Str::uuid() === $first;
Str::uuid(); // back to random UUIDs
```

You may specify the keys if there are only certain instances you wish to sequence....

```php
Str::createUuidsUsingSequence([
    0 => ($zeroth = Str::uuid()),
    3 => ($third = Str::uuid()),
]);

Str::uuid() === $zeroth;
Str::uuid(); // random
Str::uuid(); // random
Str::uuid() === $third;
```

If you would like to throw an exception when there is no more UUIDs in the array, you pass a closure to control what happens when finding an index that has no specified UUID...


```php
Str::createUuidsUsingSequence([
    $zeroth = Str::uuid(),
    $first = Str::uuid(),
], fn () => throw new Exception('Sequence ended'));

Str::uuid() === $zeroth;
Str::uuid() === $first;
Str::uuid(); // THROWS
```

This closure is also called when there is a missing key if you specify specific keys in the sequence...

```php
Str::createUuidsUsingSequence([
    0 => Str::uuid(),
    3 => Str::uuid(),
], fn () => throw new Exception('Sequence ended'));

Str::uuid() === $zeroth;
Str::uuid(); // THROWS
```