### PR TITLE
[9.x] Add `firstOrTap()` Eloquent methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -522,6 +522,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the first matching record or tap a new instance.
+     *
+     * @param Closure $callback
+     * @param array   $attributes
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function firstOrTap(Closure $callback, array $attributes = [])
+    {
+        $instance = $this->firstOrNew($attributes);
+
+        return $instance->exists ? $instance : tap($instance, $callback);
+    }
+
+    /**
      * Get the first record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
@@ -535,20 +549,6 @@ class Builder implements BuilderContract
         }
 
         return $this->newModelInstance(array_merge($attributes, $values));
-    }
-    
-    /**
-     * Get the first matching record or tap a new instance.
-     *
-     * @param Closure $callback
-     * @param array   $attributes
-     * @return \Illuminate\Database\Eloquent\Model|static
-     */
-    public function firstOrTap(Closure $callback, array $attributes = [])
-    {
-        $instance = $this->firstOrNew($attributes);
-
-        return $instance->exists ? $instance : tap($instance, $callback);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -536,6 +536,20 @@ class Builder implements BuilderContract
 
         return $this->newModelInstance(array_merge($attributes, $values));
     }
+    
+    /**
+     * Get the first matching record or tap a new instance.
+     *
+     * @param Closure $callback
+     * @param array   $attributes
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function firstOrTap(Closure $callback, array $attributes = [])
+    {
+        $instance = $this->firstOrNew($attributes);
+
+        return $instance->exists ? $instance : tap($instance, $callback);
+    }
 
     /**
      * Get the first record matching the attributes or create it.

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -524,8 +524,8 @@ class Builder implements BuilderContract
     /**
      * Get the first matching record or tap a new instance.
      *
-     * @param Closure $callback
-     * @param array   $attributes
+     * @param  Closure  $callback
+     * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function firstOrTap(Closure $callback, array $attributes = [])

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -592,6 +592,20 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Get the first matching related model record or tap a new instance.
+     *
+     * @param Closure $callback
+     * @param array   $attributes
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function firstOrTap(Closure $callback, array $attributes = [])
+    {
+        $instance = $this->firstOrNew($attributes);
+
+        return $instance->exists ? $instance : tap($instance, $callback);
+    }
+
+    /**
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -594,8 +594,8 @@ class BelongsToMany extends Relation
     /**
      * Get the first matching related model record or tap a new instance.
      *
-     * @param Closure $callback
-     * @param array   $attributes
+     * @param  Closure  $callback
+     * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function firstOrTap(Closure $callback, array $attributes = [])

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -230,8 +230,8 @@ class HasManyThrough extends Relation
     /**
      * Get the first matching related record or tap a new instance.
      *
-     * @param Closure $callback
-     * @param array   $attributes
+     * @param  Closure  $callback
+     * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function firstOrTap(Closure $callback, array $attributes = [])

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -228,6 +228,20 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Get the first matching related record or tap a new instance.
+     *
+     * @param Closure $callback
+     * @param array   $attributes
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function firstOrTap(Closure $callback, array $attributes = [])
+    {
+        $instance = $this->firstOrNew($attributes);
+
+        return $instance->exists ? $instance : tap($instance, $callback);
+    }
+
+    /**
      * Get the first related model record matching the attributes or instantiate it.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -202,6 +203,20 @@ abstract class HasOneOrMany extends Relation
         }
 
         return $instance;
+    }
+
+    /**
+     * Get the first matching related model record or tap a new instance.
+     *
+     * @param Closure $callback
+     * @param array   $attributes
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function firstOrTap(Closure $callback, array $attributes = [])
+    {
+        $instance = $this->firstOrNew($attributes);
+
+        return $instance->exists ? $instance : tap($instance, $callback);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -208,8 +208,8 @@ abstract class HasOneOrMany extends Relation
     /**
      * Get the first matching related model record or tap a new instance.
      *
-     * @param Closure $callback
-     * @param array   $attributes
+     * @param  Closure  $callback
+     * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function firstOrTap(Closure $callback, array $attributes = [])

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -83,6 +83,29 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
     }
 
+    public function testFirstOrTapMethodFindsFirstExistingModel()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('newInstance')->never();
+        $model->shouldReceive('setAttribute')->never();
+        $model->exists = true;
+
+        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {}, ['foo' => 'bar']));
+    }
+
+    public function testFirstOrTapMethodReturnsNewModelWithForeignKeySet()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('where')->once()->with(['foo' => 'bar'])->andReturn($relation->getQuery());
+        $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar'])->andReturn($model = m::mock(Model::class));
+        $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+
+        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {}, ['foo' => 'bar']));
+    }
+
     public function testFirstOrNewMethodFindsFirstModel()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -92,7 +92,8 @@ class DatabaseEloquentHasManyTest extends TestCase
         $model->shouldReceive('setAttribute')->never();
         $model->exists = true;
 
-        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {}, ['foo' => 'bar']));
+        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {
+        }, ['foo' => 'bar']));
     }
 
     public function testFirstOrTapMethodReturnsNewModelWithForeignKeySet()
@@ -103,7 +104,8 @@ class DatabaseEloquentHasManyTest extends TestCase
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo' => 'bar'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
-        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {}, ['foo' => 'bar']));
+        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {
+        }, ['foo' => 'bar']));
     }
 
     public function testFirstOrNewMethodFindsFirstModel()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -478,6 +478,38 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('Nuno Maduro', $user1->name);
     }
 
+    public function testFirstOrTap()
+    {
+        $user1 = EloquentTestUser::firstOrTap(
+            function (EloquentTestUser $user) {
+                $user->name = 'Taylor Otwell';
+            },
+            ['email' => 'taylorotwell@gmail.com']
+        );
+
+        $this->assertFalse($user1->exists);
+        $this->assertSame('Taylor Otwell', $user1->name);
+        $this->assertSame('taylorotwell@gmail.com', $user1->email);
+
+        $user2 = EloquentTestUser::firstOrTap(
+            function (EloquentTestUser $user) {
+                $user->save();
+            },
+            ['email' => 'taylorotwell@gmail.com']
+        );
+
+        $this->assertTrue($user2->exists);
+        $this->assertSame('taylorotwell@gmail.com', $user2->email);
+
+        $user3 = EloquentTestUser::firstOrTap(
+            function (EloquentTestUser $user) {
+                $user->email = 'nuno@laravel.com';
+            }
+        );
+        
+        $this->assertSame($user2->email, $user3->email);
+    }
+
     public function testFirstOrCreate()
     {
         $user1 = EloquentTestUser::firstOrCreate(['email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -506,7 +506,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $user->email = 'nuno@laravel.com';
             }
         );
-        
+
         $this->assertSame($user2->email, $user3->email);
     }
 

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -123,7 +123,8 @@ class DatabaseEloquentMorphTest extends TestCase
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
-        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {}));
+        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {
+        }));
     }
 
     public function testFirstOrTapMethodReturnsNewModelWithMorphKeysSet()
@@ -136,7 +137,8 @@ class DatabaseEloquentMorphTest extends TestCase
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
 
-        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {}, ['foo' => 'bar']));
+        $this->assertInstanceOf(Model::class, $relation->firstOrTap(function (Model $model) {
+        }, ['foo' => 'bar']));
     }
 
     public function testFirstOrNewMethodFindsFirstModel()

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -284,6 +284,28 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->assertEquals(2, $users->first()->id);
     }
 
+    public function testFirstOrTap()
+    {
+        $this->createUsers();
+
+        $result = SoftDeletesTestUser::firstOrTap(
+            function (SoftDeletesTestUser $user) {
+                $this->assertFalse($user->exists);
+            },
+            ['email' => 'taylorotwell@gmail.com']
+        );
+
+        $this->assertNull($result->id);
+
+        $result = SoftDeletesTestUser::withTrashed()->firstOrTap(
+            function (SoftDeletesTestUser $user) {
+                $this->fail('Should not be reached.');
+            },
+            ['email' => 'taylorotwell@gmail.com']
+        );
+        $this->assertEquals(1, $result->id);
+    }
+
     public function testFirstOrNew()
     {
         $this->createUsers();

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -484,6 +484,36 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertSame('callback result', $result);
     }
 
+    public function testFirstOrTapMethod()
+    {
+        $post = Post::create(['title' => Str::random()]);
+
+        $tag = Tag::create(['name' => Str::random()]);
+
+        $post->tags()->attach(Tag::all());
+
+        $this->assertEquals($tag->id, $post->tags()->firstOrTap(
+            function (Tag $model) {
+                $this->fail('Should not be reached.');
+            },
+            ['id' => $tag->id]
+        )->id);
+
+        $this->assertNull($post->tags()->firstOrTap(
+            function (Tag $model) {
+                $this->assertFalse($model->exists);
+            },
+            ['id' => 666]
+        )->id);
+
+        $this->assertInstanceOf(Tag::class, $post->tags()->firstOrTap(
+            function (Tag $model) {
+                $this->assertFalse($model->exists);
+            },
+            ['id' => 666]
+        ));
+    }
+
     public function testFirstOrNewMethod()
     {
         $post = Post::create(['title' => Str::random()]);


### PR DESCRIPTION
### Description

This PR adds a `firstOrTap($closure, $attributes = [])` method on the Eloquent `Builder`, `BelongsToMany` relation, `HasManyThrough` relation, and the `HasOneOrMany` relation.

When no existing model is found, a new instance is provided to the callback.

An optional array of attributes can be supplied in the second parameter as where clauses, which will pre-populate the new model instance's attributes if no model is found.

### Purpose

These methods provide convenient encapsulation of logic that may obscure some of the outer logic.

### Example

```php
$user = User::where('...')->firstOrTap(function (User $User) {
    $user->fill(['...'])->save();
});
```

```php
$meta = $book->metadata()->where('key', 'author')->firstOrTap(function (Metadata $meta) {
    $meta->fill(['key' => 'author', 'name' => 'John Doe'])->save();
});
```
