### PR TITLE
[9.x] Adds `plain_text` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1463,7 +1463,6 @@ trait ValidatesAttributes
      */
     public function validatePlainText($attribute, $value)
     {
-        dump(trim(strip_tags($value)), $value);
         return trim(strip_tags($value)) === $value;
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1455,6 +1455,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is plain text.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validatePlainText($attribute, $value)
+    {
+        dump(trim(strip_tags($value)), $value);
+        return trim(strip_tags($value)) === $value;
+    }
+
+    /**
      * Validate that an attribute exists even if not filled.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1463,7 +1463,6 @@ trait ValidatesAttributes
      */
     public function validatePlainText($attribute, $value)
     {
-        dump(str_replace(["\n","\r","\t","\v","\0","\x00"], '', strip_tags($value)), $value);
         return str_replace(["\n","\r","\t","\v","\0","\x00"], '', strip_tags($value)) === $value;
     }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1463,7 +1463,8 @@ trait ValidatesAttributes
      */
     public function validatePlainText($attribute, $value)
     {
-        return trim(strip_tags($value)) === $value;
+        dump(str_replace(["\n","\r","\t","\v","\0","\x00"], '', strip_tags($value)), $value);
+        return str_replace(["\n","\r","\t","\v","\0","\x00"], '', strip_tags($value)) === $value;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1463,7 +1463,7 @@ trait ValidatesAttributes
      */
     public function validatePlainText($attribute, $value)
     {
-        return str_replace(["\n","\r","\t","\v","\0","\x00"], '', strip_tags($value)) === $value;
+        return str_replace(["\n", "\r", "\t", "\v", "\0", "\x00"], '', strip_tags($value)) === $value;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1060,13 +1060,13 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => "\tJoe\nDoe"], ['x' => 'plain_text']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => "Joe Doe "], ['x' => 'plain_text']);
+        $v = new Validator($trans, ['x' => 'Joe Doe '], ['x' => 'plain_text']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => "Joe\nDoe"], ['x' => 'plain_text']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => " Joe Doe "], ['x' => 'plain_text']);
+        $v = new Validator($trans, ['x' => ' Joe Doe '], ['x' => 'plain_text']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => " Joe\tDoe\v"], ['x' => 'plain_text']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1059,6 +1059,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => "Joe\x00Doe"], ['x' => 'plain_text']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '<?php echo "hello"; ?>'], ['x' => 'plain_text']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidatePresent()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1027,6 +1027,40 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['validation.present'], $v->errors()->get('name'));
     }
 
+    public function testValidatePlainText()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls1-_3dlks O\'Brian'], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '🔥'], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '<h1>Hello</h1>'], ['x' => 'plain_text']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'Hello<br>Yo'], ['x' => 'plain_text']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "\tJoe\n Doe"], ['x' => 'plain_text']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => " Joe\tDoe\v"], ['x' => 'plain_text']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "Joe\x00Doe"], ['x' => 'plain_text']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidatePresent()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1033,10 +1033,16 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => 'asls1-_3dlks O\'Brian'], ['x' => 'plain_text']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['x' => 'John Doe'], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '!"#$%&/()=_-@*^¨1234567890'], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => 'http://-g232oogle.com'], ['x' => 'plain_text']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['x' => 'नमस्कार-_'], ['x' => 'plain_text']);
+        $v = new Validator($trans, ['x' => 'नमस्  कार-_'], ['x' => 'plain_text']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'plain_text']);
@@ -1051,8 +1057,17 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => 'Hello<br>Yo'], ['x' => 'plain_text']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['x' => "\tJoe\n Doe"], ['x' => 'plain_text']);
+        $v = new Validator($trans, ['x' => "\tJoe\nDoe"], ['x' => 'plain_text']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => "Joe Doe "], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => "Joe\nDoe"], ['x' => 'plain_text']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => " Joe Doe "], ['x' => 'plain_text']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => " Joe\tDoe\v"], ['x' => 'plain_text']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
### Why?
When validating user input (especially non-English) rules like `alpha`, `alpha_dash` and `alpha_num` doesn't work well, while `string` is too inclusive.

We want to allow as much as possible _(characters, quotes, dashes and emojis)_ -- while making sure there are no code injection / executable code.

| Test | `plain_text` | `alpha` | `alpha_dash` | `alpha_num` | `string` |
|-|-|-|-|-|-|
| Joe O'Brian | ✅ | ❌ | ❌ | ❌ | ✅ |
| Mary-Kate | ✅ | ❌ | ✅ | ❌ | ✅ |
| X Æ A-Xii | ✅ | ❌ | ❌ | ❌ | ✅ |
| Mrs. Jackson | ✅ | ❌ | ❌ | ❌ | ✅ |
| Can contain "double quotes" | ✅ | ❌ | ❌ | ❌ | ✅ |
| Blåbærsyltetøy | ✅ | ✅ | ✅ | ✅ | ✅ |
| ラーメン | ✅ | ✅ | ✅ | ✅ | ✅ |
| 🍑 | ✅ | ❌ | ❌ | ❌ | ✅ |
| https://url.com | ✅ | ❌ | ❌ | ❌ | ✅ |
| !"#$%&/()=_-@*^¨1234567890 | ✅ | ❌ | ❌ | ❌ | ✅ |
|     John Doe | ✅ | ❌ | ❌ | ❌ | ✅ |
| John\nDoe | ❌ | ❌ | ❌ | ❌ | ✅ |
| `<p>HTML tags is not OK</p>` | ❌ | ❌ | ❌ | ❌ | ✅ |
| \t\n\r\0\v is not OK | ❌ | ❌ | ❌ | ❌ | ✅ |
| <script>console.log('hello');</script> | ❌ | ❌ | ❌ | ❌ | ✅ |