### PR TITLE
[9.x] Updates type hinting for `having()` and `orHaving()` QueryBuilder methods

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2003,8 +2003,8 @@ class Builder implements BuilderContract
      * Add a "having" clause to the query.
      *
      * @param  \Closure|string  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  string|int|float|null  $operator
+     * @param  string|int|float|null  $value
      * @param  string  $boolean
      * @return $this
      */
@@ -2047,8 +2047,8 @@ class Builder implements BuilderContract
      * Add an "or having" clause to the query.
      *
      * @param  \Closure|string  $column
-     * @param  mixed  $operator
-     * @param  mixed  $value
+     * @param  string|int|float|null  $operator
+     * @param  string|int|float|null  $value
      * @return $this
      */
     public function orHaving($column, $operator = null, $value = null)


### PR DESCRIPTION
This PR updates the changes made in [#42593](https://github.com/laravel/framework/pull/42593).
As describe in [my comment](https://github.com/nunomaduro/larastan/pull/1258#issuecomment-1144771521) on [nunomaduro/larastan](https://github.com/nunomaduro/larastan) , the `mixed` type hint was too generic.
As it only modifies a docblock, it should not break existing implementation.