### PR TITLE
[10.x] Introduce int backed enum for implicit route binding

### DIFF
--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -28,7 +28,7 @@ class RouteSignatureParameters
 
         return match (true) {
             ! empty($conditions['subClass']) => array_filter($parameters, fn ($p) => Reflector::isParameterSubclassOf($p, $conditions['subClass'])),
-            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnumWithStringBackingType($p)),
+            ! empty($conditions['backedEnum']) => array_filter($parameters, fn ($p) => Reflector::isParameterBackedEnum($p)),
             default => $parameters,
         };
     }

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -141,20 +141,19 @@ class Reflector
     }
 
     /**
-     * Determine if the parameter's type is a Backed Enum with a string backing type.
+     * Determine if the parameter's type is a Backed Enum.
      *
      * @param  \ReflectionParameter  $parameter
      * @return bool
      */
-    public static function isParameterBackedEnumWithStringBackingType($parameter)
+    public static function isParameterBackedEnum($parameter)
     {
         $backedEnumClass = (string) $parameter->getType();
 
         if (function_exists('enum_exists') && enum_exists($backedEnumClass)) {
             $reflectionBackedEnum = new ReflectionEnum($backedEnumClass);
 
-            return $reflectionBackedEnum->isBacked()
-                && $reflectionBackedEnum->getBackingType()->getName() == 'string';
+            return $reflectionBackedEnum->isBacked();
         }
 
         return false;

--- a/tests/Integration/Routing/Enums.php
+++ b/tests/Integration/Routing/Enums.php
@@ -7,3 +7,9 @@ enum CategoryBackedEnum: string
     case People = 'people';
     case Fruits = 'fruits';
 }
+
+enum AnimalBackedEnum: int
+{
+    case Platypus = 0;
+    case Penguin = 1;
+}

--- a/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
@@ -14,10 +14,15 @@ class ImplicitBackedEnumRouteBindingTest extends TestCase
         $this->defineCacheRoutes(<<<PHP
 <?php
 
+use Illuminate\Tests\Integration\Routing\AnimalBackedEnum;
 use Illuminate\Tests\Integration\Routing\CategoryBackedEnum;
 
 Route::get('/categories/{category}', function (CategoryBackedEnum \$category) {
     return \$category->value;
+})->middleware('web');
+
+Route::get('/animals/{animal}', function (AnimalBackedEnum \$animal) {
+    return \$animal->value;
 })->middleware('web');
 PHP);
 
@@ -28,6 +33,15 @@ PHP);
         $response->assertSee('people');
 
         $response = $this->get('/categories/cars');
+        $response->assertNotFound(404);
+
+        $response = $this->get('/animals/0');
+        $response->assertSee(0);
+
+        $response = $this->get('/animals/1');
+        $response->assertSee(1);
+
+        $response = $this->get('/animals/2');
         $response->assertNotFound(404);
     }
 
@@ -46,6 +60,19 @@ PHP);
         $response->assertSee('people');
 
         $response = $this->post('/categories/cars');
+        $response->assertNotFound(404);
+
+        Route::post('/animals/{animal}', function (AnimalBackedEnum $animal) {
+            return $animal->value;
+        })->middleware(['web']);
+
+        $response = $this->post('/animals/0');
+        $response->assertSee(0);
+
+        $response = $this->post('/animals/1');
+        $response->assertSee(1);
+
+        $response = $this->post('/animals/2');
         $response->assertNotFound(404);
     }
 }

--- a/tests/Routing/Enums.php
+++ b/tests/Routing/Enums.php
@@ -13,3 +13,9 @@ enum CategoryBackedEnum: string
     case People = 'people';
     case Fruits = 'fruits';
 }
+
+enum AnimalBackedEnum: int
+{
+    case Platypus = 0;
+    case Penguin = 1;
+}

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -13,7 +13,7 @@ include 'Enums.php';
 
 class ImplicitRouteBindingTest extends TestCase
 {
-    public function test_it_can_resolve_the_implicit_backed_enum_route_bindings_for_the_given_route()
+    public function test_it_can_resolve_the_implicit_string_backed_enum_route_bindings_for_the_given_route()
     {
         $action = ['uses' => function (CategoryBackedEnum $category) {
             return $category->value;
@@ -50,7 +50,7 @@ class ImplicitRouteBindingTest extends TestCase
         $this->assertSame('fruits', $route->parameter('category'));
     }
 
-    public function test_implicit_backed_enum_internal_exception()
+    public function test_implicit_string_backed_enum_internal_exception()
     {
         $action = ['uses' => function (CategoryBackedEnum $category) {
             return $category->value;
@@ -68,6 +68,47 @@ class ImplicitRouteBindingTest extends TestCase
             'Case [%s] not found on Backed Enum [%s].',
             'cars',
             CategoryBackedEnum::class,
+        ));
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+    }
+
+    public function test_it_can_resolve_the_implicit_int_backed_enum_route_bindings_for_the_given_route()
+    {
+        $action = ['uses' => function (AnimalBackedEnum $animal) {
+            return $animal->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['animal' => 0];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertSame(0, $route->parameter('animal')->value);
+    }
+
+    public function test_implicit_backed_int_enum_internal_exception()
+    {
+        $action = ['uses' => function (AnimalBackedEnum $animal) {
+            return $animal->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['animal' => 2];
+
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        $this->expectException(BackedEnumCaseNotFoundException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Case [%s] not found on Backed Enum [%s].',
+            '2',
+            AnimalBackedEnum::class,
         ));
 
         ImplicitRouteBinding::resolveForRoute($container, $route);


### PR DESCRIPTION
This pull request introduces implicit int-backed Enum route binding.

The original pull request which added enum route binding (https://github.com/laravel/framework/pull/40281) rejected them as an option, however, it didn't include the reason behind it.

If this PR gets rejected, we should still consider specifying in the docs that only string-backed enums are a viable option for the routing