### PR TITLE
[8.x] Free reserved memory before handling fatal errors

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -159,9 +159,9 @@ class HandleExceptions
      */
     public function handleException(Throwable $e)
     {
-        try {
-            self::$reservedMemory = null;
+        self::$reservedMemory = null;
 
+        try {
             $this->getExceptionHandler()->report($e);
         } catch (Exception $e) {
             //
@@ -217,6 +217,8 @@ class HandleExceptions
      */
     protected function fatalErrorFromPhpError(array $error, $traceOffset = null)
     {
+        self::$reservedMemory = null;
+
         return new FatalError($error['message'], 0, $error, $traceOffset);
     }
 


### PR DESCRIPTION
Free reserved memory before handling fatal errors

When the PHP process exceeds the configured memory limit,
a fatal error such as the following occurs:

```
Allowed memory size of 1073741824 bytes exhausted (tried to allocate 3358976 bytes)
```

Currently, the process abruptly exits in such cases without
and indication as to what has caused the error. This is
because the handler from `register_shutdown_function()`
attempts to instantiate a `FatalError` instance, thus trying
to use memory that is not available.

This clears the reserved memory before this instantiation,
thus ensuring that the process has enough memory to
properly handle the error. Reserved memory is also cleared
in `handleException` in the same way.