### PR TITLE
[9.x] Add onFailure method to Pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -25,6 +25,13 @@ class Pipeline implements PipelineContract
     protected $passable;
 
     /**
+     * The callback to be executed on failure pipeline.
+     *
+     * @var Closure
+     */
+    protected $onFailure;
+
+    /**
      * The array of class pipes.
      *
      * @var array
@@ -182,6 +189,10 @@ class Pipeline implements PipelineContract
 
                     return $this->handleCarry($carry);
                 } catch (Throwable $e) {
+                    if ($this->onFailure) {
+                        return call_user_func($this->onFailure, $pipe);
+                    }
+
                     return $this->handleException($passable, $e);
                 }
             };
@@ -240,6 +251,19 @@ class Pipeline implements PipelineContract
     public function setContainer(Container $container)
     {
         $this->container = $container;
+
+        return $this;
+    }
+
+    /**
+     * Set callback to be executed on failure pipeline.
+     *
+     * @param  Closure  $catch
+     * @return $this
+     */
+    public function onFailure(Closure $callback)
+    {
+        $this->onFailure = $callback;
 
         return $this;
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -231,6 +231,20 @@ class PipelineTest extends TestCase
             });
     }
 
+    public function testExceptionIsHandledByOnFailureMethodInPipeline()
+    {
+        $result = (new Pipeline(new Container))
+            ->send('data')
+            ->through(PipelineWithException::class)
+            ->onFailure(function () {
+                return 'error';
+            })->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertEquals('error', $result);
+    }
+
     public function testPipelineThenReturnMethodRunsPipelineThenReturnsPassable()
     {
         $result = (new Pipeline(new Container))
@@ -277,5 +291,13 @@ class PipelineTestParameterPipe
         $_SERVER['__test.pipe.parameters'] = [$parameter1, $parameter2];
 
         return $next($piped);
+    }
+}
+
+class PipelineWithException
+{
+    public function handle($piped, $next)
+    {
+        throw new \Exception('Foo');
     }
 }


### PR DESCRIPTION
Now, we are not able to do some stuff with the pipeline if there is a failed pipe.

With this new method, we will be able to throw a custom exception or our custom functionality (like logging, ...)