### PR TITLE
[9.x] Possibility to force safe retrieval in Form Request

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -292,6 +292,6 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         return ! $this->safeInputElements
             ? parent::__get($key)
-            : Arr::get($this->safe(), $key, fn () => $this->route($key));
+            : Arr::get($this->validated(), $key, fn () => $this->route($key));
     }
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationException;
 
@@ -65,6 +66,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @var bool
      */
     protected $stopOnFirstFailure = false;
+
+    /**
+     * Indicates whether form request should return safe input elements from validator by default.
+     *
+     * @var bool
+     */
+    protected $safeInputElements = false;
 
     /**
      * The validator instance.

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -281,4 +281,17 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         return $this;
     }
+
+    /**
+     * Get a safe input element from the form request.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return ! $this->safeInputElements
+            ? parent::__get($key)
+            : Arr::get($this->safe(), $key, fn () => $this->route($key));
+    }
 }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -38,6 +38,18 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['name' => 'specified'], $request->validated());
     }
 
+    public function testFormRequestReturnsSafeDataFromMagicMethods()
+    {
+        $payload = ['name' => 'specified', 'with' => 'extras'];
+
+        $request = $this->createRequest($payload, FoundationTestSafeFormRequestStub::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals('specified', $request->name);
+        $this->assertNull($request->with);
+    }
+
     public function testValidatedMethodReturnsTheValidatedDataNestedRules()
     {
         $payload = ['nested' => ['foo' => 'bar', 'baz' => ''], 'array' => [1, 2]];
@@ -262,6 +274,16 @@ class FoundationTestFormRequestStub extends FormRequest
     public function authorize()
     {
         return true;
+    }
+}
+
+class FoundationTestSafeFormRequestStub extends FormRequest
+{
+    protected $safeInputElements = true;
+
+    public function rules()
+    {
+        return ['name' => 'required'];
     }
 }
 


### PR DESCRIPTION
### The case
FormRequest values are usually accessed by using `$request->value`, i.e. by a magic method. If `$request->value` is accessed, it means that all defined values have been validated, however, it does not mean that the value itself has been validated and wanted by the application. It could be resolved by using safe or validated methods, but I cannot find an option to set this behavior by default when requesting values from a form request.

This PR adds the possibility to force a safe retrieval from the `validated` method when accessing values in Form Requests.
You can turn it on by overriding class property:
```php
protected $safeInputElements = true;
```

This saves us from extracting validated input each time:
```php
public function controllerMethod(FormRequest $request): mixed
{
    $request = $request->safe();
}
```

### Breaking?
It's fully backward-compatible since this feature is optional and turned off by default. When disabled, the new `__get` just forwards the call to the parent.

### Any thoughts?
What do you think about this? The PR will stay as a draft until I see the green light from the community, or close it if people don't want this feature. 🔨