### PR TITLE
Add php array_change_key_case() support to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1708,12 +1708,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
     /**
      * apply the same case to all the collection key
+     *
      * @param int $case
      *
      * @return $this
      */
     public function changeKeyCase(int $case = CASE_LOWER): self
     {
-        return new static(array_change_key_case($this->items,$case));
+        return new static(array_change_key_case($this->items, $case));
     }
 }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1707,10 +1707,9 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * apply the same case to all the collection key
+     * apply the same case to all the collection key.
      *
-     * @param int $case
-     *
+     * @param  int  $case
      * @return $this
      */
     public function changeKeyCase(int $case = CASE_LOWER): self

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1705,4 +1705,15 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * apply the same case to all the collection key
+     * @param int $case
+     *
+     * @return $this
+     */
+    public function changeKeyCase(int $case = CASE_LOWER): self
+    {
+        return new static(array_change_key_case($this->items,$case));
+    }
 }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1470,7 +1470,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         return $this->passthru('undot', []);
     }
-
+    /**
+     * apply the same case to all the collection key
+     * @param int $case
+     *
+     * @return $this
+     */
+    public function changeKeyCase(int $case = CASE_LOWER): self
+    {
+        return $this->passthru('changeKeyCase', [$case]);
+    }
     /**
      * Return only unique items from the collection array.
      *

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1470,16 +1470,18 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         return $this->passthru('undot', []);
     }
+
     /**
-     * apply the same case to all the collection key
-     * @param int $case
+     * apply the same case to all the collection key.
      *
+     * @param  int  $case
      * @return $this
      */
     public function changeKeyCase(int $case = CASE_LOWER): self
     {
         return $this->passthru('changeKeyCase', [$case]);
     }
+
     /**
      * Return only unique items from the collection array.
      *

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5093,6 +5093,14 @@ class SupportCollectionTest extends TestCase
             ],
         ], $data->all());
     }
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testChangeKeyCase($collection)
+    {
+        $c = new $collection(['FiRst' => 'Hello', 'Second' => 'hello']);
+        $this->assertEquals(['first' => 'Hello', 'second' => 'hello'], $c->changeKeyCase()->all());
+    }
 
     /**
      * Provides each collection class, respectively.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5093,6 +5093,7 @@ class SupportCollectionTest extends TestCase
             ],
         ], $data->all());
     }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This PR add provide the php `array_change_key_case()`  to Collection and LazyCollection.
**Benefit**:
When you retrieve data from onlines API's, sometimes they are not following any name convention. For the sake of code readability it's more convenient to work with standardize array keys. 
Also, when the api result have 100 array keys, it's hard to remember how they named/cased everything.
```
$apiData = collect([
     "ID"       => 1,
     "NAME"     => "some name",
     "Lastname" => "some lastname",
 ]);
 //before this PR
 $data = array_change_key_case($apiData->all());
 collect($data)->dd();
 //after this PR
 $apiData->changeKeyCase()->dd();
```