### PR TITLE
[9.x] Adds `withoutEagerLoad` function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1575,12 +1575,12 @@ class Builder implements BuilderContract
     }
     
     /**
-     * Flush the given relationships being eagerly loaded.
+     * Indicate that the given relationships should not be eagerly loaded.
      *
      * @param  array  $relations
      * @return $this
      */
-    public function withoutEagerLoad($relations)
+    public function withoutEagerLoad(array $relations)
     {
         $relations = array_diff(array_keys($this->model->getRelations()), $relations);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1573,6 +1573,19 @@ class Builder implements BuilderContract
 
         return $this;
     }
+    
+    /**
+     * Flush the given relationships being eagerly loaded.
+     *
+     * @param  array  $relations
+     * @return $this
+     */
+    public function withoutEagerLoad($relations)
+    {
+        $relations = array_diff(array_keys($this->model->getRelations()), $relations);
+
+        return $this->with($relations);
+    }
 
     /**
      * Flush the relationships being eagerly loaded.


### PR DESCRIPTION
According to this [PR](https://github.com/laravel/framework/pull/41950) I have added a `withoutEagerLoad` to prevent the given relationships from being eagerly loaded.

```PHP
$user = \App\Models\User::with(['post', 'attachment'])->first();

// This line will return the first user with the post relationship
return $user->withoutEagerLoad(['attachment'])->first();
```