### PR TITLE
[10.x] Allow session data cookie to expire on close

### DIFF
--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -44,9 +44,10 @@ class CookieSessionHandler implements SessionHandlerInterface
      *
      * @param  \Illuminate\Contracts\Cookie\QueueingFactory  $cookie
      * @param  int  $minutes
+     * @param  bool  $expireOnClose
      * @return void
      */
-    public function __construct(CookieJar $cookie, $minutes, $expireOnClose)
+    public function __construct(CookieJar $cookie, $minutes, $expireOnClose = false)
     {
         $this->cookie = $cookie;
         $this->minutes = $minutes;

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -33,16 +33,24 @@ class CookieSessionHandler implements SessionHandlerInterface
     protected $minutes;
 
     /**
+     * Indicates whether the session should be expired when the browser closes.
+     *
+     * @var bool
+     */
+    protected $expireOnClose;
+
+    /**
      * Create a new cookie driven handler instance.
      *
      * @param  \Illuminate\Contracts\Cookie\QueueingFactory  $cookie
      * @param  int  $minutes
      * @return void
      */
-    public function __construct(CookieJar $cookie, $minutes)
+    public function __construct(CookieJar $cookie, $minutes, $expireOnClose)
     {
         $this->cookie = $cookie;
         $this->minutes = $minutes;
+        $this->expireOnClose = $expireOnClose;
     }
 
     /**
@@ -92,7 +100,7 @@ class CookieSessionHandler implements SessionHandlerInterface
         $this->cookie->queue($sessionId, json_encode([
             'data' => $data,
             'expires' => $this->availableAt($this->minutes * 60),
-        ]), $this->minutes);
+        ]), $this->expireOnClose ? 0 : $this->minutes);
 
         return true;
     }

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -47,7 +47,9 @@ class SessionManager extends Manager
     protected function createCookieDriver()
     {
         return $this->buildSession(new CookieSessionHandler(
-            $this->container->make('cookie'), $this->config->get('session.lifetime')
+            $this->container->make('cookie'),
+            $this->config->get('session.lifetime'),
+            $this->config->get('session.expire_on_close')
         ));
     }
 

--- a/tests/Integration/Session/CookieSessionHandlerTest.php
+++ b/tests/Integration/Session/CookieSessionHandlerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Session;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Orchestra\Testbench\TestCase;
+
+class CookieSessionHandlerTest extends TestCase
+{
+    public function testCookieSessionDriverCookiesCanExpireOnClose()
+    {
+        Route::get('/', fn () => '')->middleware('web');
+
+        $response = $this->get('/');
+        $sessionIdCookie = $response->getCookie('laravel_session');
+        $sessionValueCookie = $response->getCookie($sessionIdCookie->getValue());
+
+        $this->assertEquals(0, $sessionIdCookie->getExpiresTime());
+        $this->assertEquals(0, $sessionValueCookie->getExpiresTime());
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.key', Str::random(32));
+        $app['config']->set('session.driver', 'cookie');
+        $app['config']->set('session.expire_on_close', true);
+    }
+}
+

--- a/tests/Integration/Session/CookieSessionHandlerTest.php
+++ b/tests/Integration/Session/CookieSessionHandlerTest.php
@@ -27,4 +27,3 @@ class CookieSessionHandlerTest extends TestCase
         $app['config']->set('session.expire_on_close', true);
     }
 }
-

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -412,7 +412,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->handlerNeedsRequest());
         $session->getHandler()->shouldReceive('setRequest')->never();
 
-        $session = new Store('test', m::mock(new CookieSessionHandler(new CookieJar, 60)));
+        $session = new Store('test', m::mock(new CookieSessionHandler(new CookieJar, 60, false)));
         $this->assertTrue($session->handlerNeedsRequest());
         $session->getHandler()->shouldReceive('setRequest')->once();
         $request = new Request;


### PR DESCRIPTION
This seems like a bug but very low impact and with a small breaking fix so I'm targeting `master`.

When using the cookie session driver, the actual session data is stored in a cookie alongside the normal cookie with the session identifier. When configuring `'session.expire_on_close' => true`, it seems reasonable that both of these cookies are non-persistent but only the second one is at the moment (see image):

<img width="600" alt="image" src="https://user-images.githubusercontent.com/25909128/171797088-cbe9e5e4-7032-42e4-b766-8492bc6cee48.png">

One effect of this is lingering cookies after closing the browser. After closing and opening the browser a few times (with `expire_on_close` set to `true`), this is the result:

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/25909128/171797382-f26c7a0f-fb7f-45a8-95bb-7ccfd765a66c.png">

After too many, the browser or the server might reject the request due to excessive header size. As an example, I got Safari to display an error message with no apparent way how to resolve it for the end user.

This PR makes the second cookie non-persistent as well in case `expire_on_close` is enabled. Note that the session lifetime is still embedded within the cookie and respected in addition to expiring when closing the browser.

Any help with additional tests are welcome. I couldn't find any lower level tests for the different session drivers so I added a TestBench test, verifying that both cookies are non-persistent.
