### PR TITLE
[9.x] Added Str::join(), Str::joinArray(), and str()->join()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -409,6 +409,37 @@ class Str
     }
 
     /**
+     * Join two strings while ensuring the cap is not repeated
+     *
+     * @param  string $start
+     * @param  string $glue
+     * @param  string $end
+     * @return string
+     */
+    public static function join(string $start, string $glue, string $end): string
+    {
+        return match (true) {
+            str_ends_with($start, $glue) && str_starts_with($end, $glue) => self::replaceLast($glue, '', $start).$end,
+            str_ends_with($start, $glue) || str_starts_with($end, $glue) => $start.$end,
+            default => $start.$glue.$end,
+        };
+    }
+
+    /**
+     * Implode array while ensuring the cap is not repeated
+     *
+     * @param  array<string> $items
+     * @param  string $glue
+     * @return string
+     */
+    public static function joinArray(array $items, string $glue): string
+    {
+        return collect($items)
+            ->values()
+            ->reduce(fn ($carry, $item, $key) => $key ? self::join($carry, $glue, $item) : $item, '');
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -409,11 +409,11 @@ class Str
     }
 
     /**
-     * Join two strings while ensuring the cap is not repeated
+     * Join two strings while ensuring the glue is not repeated
      *
-     * @param  string $start
-     * @param  string $glue
-     * @param  string $end
+     * @param  string  $start
+     * @param  string  $glue
+     * @param  string  $end
      * @return string
      */
     public static function join(string $start, string $glue, string $end): string
@@ -426,10 +426,10 @@ class Str
     }
 
     /**
-     * Implode array while ensuring the cap is not repeated
+     * Implode array while ensuring the glue is not repeated
      *
-     * @param  array<string> $items
-     * @param  string $glue
+     * @param  array<string>  $items
+     * @param  string  $glue
      * @return string
      */
     public static function joinArray(array $items, string $glue): string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -409,7 +409,7 @@ class Str
     }
 
     /**
-     * Join two strings while ensuring the glue is not repeated
+     * Join two strings while ensuring the glue is not repeated.
      *
      * @param  string  $start
      * @param  string  $glue
@@ -426,7 +426,7 @@ class Str
     }
 
     /**
-     * Implode array while ensuring the glue is not repeated
+     * Implode array while ensuring the glue is not repeated.
      *
      * @param  array<string>  $items
      * @param  string  $glue

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -338,7 +338,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Join multiple other strings with this string
+     * Join multiple other strings with this string.
      *
      * @param  array  $strings
      * @return static

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -338,6 +338,21 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Join multiple other strings with this string
+     *
+     * @param  array  $strings
+     * @return static
+     */
+    public function join(...$strings)
+    {
+        if (count($strings) === 1 && isset($strings[0]) && is_array($strings[0])) {
+            $strings = $strings[0];
+        }
+
+        return new static(Str::joinArray($strings, $this->value));
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -980,6 +980,33 @@ class SupportStrTest extends TestCase
             Str::createUuidsNormally();
         }
     }
+
+    public function testJoin()
+    {
+        $this->assertSame('foo/bar', Str::join('foo', '/', 'bar'));
+        $this->assertSame('foo/bar', Str::join('foo/', '/', 'bar'));
+        $this->assertSame('foo/bar', Str::join('foo', '/', '/bar'));
+        $this->assertSame('foo/bar', Str::join('foo/', '/', '/bar'));
+        $this->assertSame('foobazbar', Str::join('foo', 'baz', 'bar'));
+        $this->assertSame('foobazbar', Str::join('foobaz', 'baz', 'bar'));
+        $this->assertSame('foobazbar', Str::join('foo', 'baz', 'bazbar'));
+        $this->assertSame('foobazbar', Str::join('foobaz', 'baz', 'bazbar'));
+    }
+
+    public function testJoinArray()
+    {
+        $this->assertSame('foo/bar', Str::joinArray(['foo', 'bar'], '/'));
+        $this->assertSame('foo/bar', Str::joinArray(['foo/', 'bar'], '/'));
+        $this->assertSame('foo/bar', Str::joinArray(['foo', '/bar'], '/'));
+        $this->assertSame('foo/bar', Str::joinArray(['foo/', '/bar'], '/'));
+        $this->assertSame('foo/bar/baz', Str::joinArray(['foo', 'bar', 'baz'], '/'));
+        $this->assertSame('foo/bar/baz', Str::joinArray(['foo/', 'bar', 'baz'], '/'));
+        $this->assertSame('foo/bar/baz', Str::joinArray(['foo', '/bar', 'baz'], '/'));
+        $this->assertSame('foo/bar/baz', Str::joinArray(['foo/', '/bar', 'baz'], '/'));
+        $this->assertSame('foo/bar/baz', Str::joinArray(['foo/', '/bar/', '/baz'], '/'));
+        $this->assertSame('foo', Str::joinArray(['foo'], '/'));
+        $this->assertSame('', Str::joinArray([], '/'));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1037,4 +1037,15 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('[]')->exactly([]));
         $this->assertFalse($this->stringable('0')->exactly(0));
     }
+
+    public function testJoin()
+    {
+        $this->assertSame('foo/bar', $this->stringable('/')->join('foo', 'bar')->value());
+        $this->assertSame('foo/bar', $this->stringable('/')->join(['foo', 'bar'])->value());
+        $this->assertSame('foo/bar/baz', $this->stringable('/')->join('foo', 'bar/', '/baz')->value());
+        $this->assertSame('foo/bar/baz', $this->stringable('/')->join(['foo', 'bar/', '/baz'])->value());
+        $this->assertSame('foo', $this->stringable('/')->join('foo')->value());
+        $this->assertSame('', $this->stringable('/')->join()->value());
+        $this->assertSame('', $this->stringable('/')->join([])->value());
+    }
 }


### PR DESCRIPTION
This PR adds two new helper string functions: `Str::join()`, and `Str::joinArray()`, and one fluent helper function `str()->join()`

These helper functions are similar to `Str::start()` and `Str::finish()`, where they ensure the `$glue` string only appears once when joining other strings.

## `Str::join()`

`Str::join()` allows you to join two strings with a third `$glue` string which may possibly _already_ exist on either (or both) of the two strings you wish to join. This is particularly helpful for joining parts of a path or URL:

```php
// Formatted for clarity
Str::join('https://example.com',  '/',  'api/endpoint'); // 'https://example.com/api/endpoint'
Str::join('https://example.com/', '/',  'api/endpoint'); // 'https://example.com/api/endpoint'
Str::join('https://example.com',  '/', '/api/endpoint'); // 'https://example.com/api/endpoint'
Str::join('https://example.com/', '/', '/api/endpoint'); // 'https://example.com/api/endpoint'
```

## `Str::joinArray()`
`Str::joinArray()` does the same thing, but "implodes" all of the elements of the array with the glue:

```php
// Formatted for clarity
Str::joinArray(['https://example.com',   'api',   'endpoint'], '/'); // 'https://example.com/api/endpoint'
Str::joinArray(['https://example.com/',  'api',   'endpoint'], '/'); // 'https://example.com/api/endpoint'
Str::joinArray(['https://example.com',  '/api',  '/endpoint'], '/'); // 'https://example.com/api/endpoint'
Str::joinArray(['https://example.com/', '/api/', '/endpoint'], '/'); // 'https://example.com/api/endpoint'
```

### How does this differ from `Arr:join()`?

`Arr::join()` doesn't ensure that the `$glue` string is not repeated, and can lead to unexpected joins:

```php
// Formatted for clarity
Arr::join(['https://example.com',   'api',   'endpoint'], '/'); // 'https://example.com/api/endpoint' 
Arr::join(['https://example.com/',  'api',   'endpoint'], '/'); // 'https://example.com//api/endpoint'
Arr::join(['https://example.com',  '/api',  '/endpoint'], '/'); // 'https://example.com//api//endpoint'
Arr::join(['https://example.com/', '/api/', '/endpoint'], '/'); // 'https://example.com///api///endpoint'
```

## `str()->join()`
`str()->join()` behaves like `Str::joinArray()`, and accepts either a single array, or multiple strings.

```php
str('/')->join('https://example.com', 'api', 'endpoint'); // 'https://example.com/api/endpoint' 
str('/')->join(['https://example.com', 'api', 'endpoint']); // 'https://example.com/api/endpoint' 
```

The decision to use the `Stringable` as the glue is similar to how javascript's `string.join(['array'])` works.

If this is accepted, I'll open a new PR for documentation.