### PR TITLE
[8.x] Increase reserved memory for error handling

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -208,6 +208,8 @@ class HandleExceptions
      */
     public function handleShutdown()
     {
+        self::$reservedMemory = null;
+
         if (! is_null($error = error_get_last()) && $this->isFatal($error['type'])) {
             $this->handleException($this->fatalErrorFromPhpError($error, 0));
         }
@@ -222,8 +224,6 @@ class HandleExceptions
      */
     protected function fatalErrorFromPhpError(array $error, $traceOffset = null)
     {
-        self::$reservedMemory = null;
-
         return new FatalError($error['message'], 0, $error, $traceOffset);
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -36,11 +36,6 @@ class HandleExceptions
      */
     public function bootstrap(Application $app)
     {
-        // The amount of times to repeat needs to be determined experimentally:
-        // - save the result of memory_get_peak_usage()
-        // - trigger error handling through trigger_error()
-        // - subtract the previous from the current memory_get_peak_usage()
-        // - divide the result by 1.2 and add some leeway
         self::$reservedMemory = str_repeat('x', 32768);
 
         $this->app = $app;

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -36,7 +36,12 @@ class HandleExceptions
      */
     public function bootstrap(Application $app)
     {
-        self::$reservedMemory = str_repeat('x', 10240);
+        // The amount of times to repeat needs to be determined experimentally:
+        // - save the result of memory_get_peak_usage()
+        // - trigger error handling through trigger_error()
+        // - subtract the previous from the current memory_get_peak_usage()
+        // - divide the result by 1.2 and add some leeway
+        self::$reservedMemory = str_repeat('x', 32768);
 
         $this->app = $app;
 


### PR DESCRIPTION
Follow up to #42630

The error handler should be able to report exceptions
arising from exceeding the PHP memory limit. Because
of changes made to error handling, the previously
configured value is no longer sufficiently large.

A similar change was also done in Symfony a while ago,
see symfony/symfony#44327.

I used the following artisan command to determine the amount
of memory required for error handling, using a reporter that
simply writes to a file:

```php
<?php declare(strict_types=1);

namespace App\Console\Commands;

use Illuminate\Console\Command;

final class MeasureHandlerMemory extends Command
{
    protected $signature = 'measure-handler-memory';

    private int $peak;

    public function handle(): void
    {
        $this->peak = memory_get_peak_usage();

        trigger_error('', E_USER_ERROR);
    }

    public function __destruct()
    {
        $used = memory_get_peak_usage() - $this->peak;
        echo "error handling used: " . $used . "\n";

        $before = memory_get_usage();
        $times = 10240;
        $reserve = str_repeat('x', $times);
        $after = memory_get_usage() - $before;
        echo 'repeat times ' . $times . ' reserves: ' . $after . "\n";

        $ratio = $after / $times;
        echo 'ratio between bytes and repeat: ' . $ratio . "\n";

        echo 'minimum times to repeat: ' . $used / $ratio . "\n";
    }
}
```

It produced the following output for me:

```
error handling used: 24920
repeat times 10240 reserves: 12288
ratio between bytes and repeat: 1.2
minimum times to repeat: 20766.666666667
```