### PR TITLE
[9.x] Adds the Dispatchable trait

### DIFF
--- a/src/Illuminate/Events/Dispatchable.php
+++ b/src/Illuminate/Events/Dispatchable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Events;
+
+use Illuminate\Support\Facades\Event;
+
+trait Dispatchable
+{
+    /**
+     * Dispatches an event of the host class.
+     *
+     * @param ...$args
+     * @return array|null
+     */
+    public static function dispatch(...$args)
+    {
+        return Event::dispatch(new static(...$args));
+    }
+}


### PR DESCRIPTION
Laravel event classes can use the `Dispatchable` trait and be dispatched like this: 
### Usage:
```php
OrderShipped::dispatch($order);
```

OrderShipped:
```php
class OrderShipped
{
    use Dispatchable;

    public function __construct(public Order $order)
    {
          //
    }
}

```
