### PR TITLE
[8.x] apply where's from union query builder in cursor pagination

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -339,7 +339,7 @@ trait BuildsQueries
 
         if (! is_null($cursor)) {
             $addCursorConditions = function (self $builder, $previousColumn, $i) use (&$addCursorConditions, $cursor, $orders) {
-                $unionBuilders = collect($builder->unions)->pluck('query');
+                $unionBuilders = isset($builder->unions) ? collect($builder->unions)->pluck('query') : collect();
 
                 if (! is_null($previousColumn)) {
                     $builder->where(

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -348,7 +348,7 @@ trait BuildsQueries
                         $cursor->parameter($previousColumn)
                     );
 
-                    $unionBuilders->each(function($unionBuilder) use($previousColumn, $cursor) {
+                    $unionBuilders->each(function ($unionBuilder) use($previousColumn, $cursor) {
                         $unionBuilder->where(
                             $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
                             '=',
@@ -374,9 +374,8 @@ trait BuildsQueries
                         });
                     }
 
-                    $unionBuilders->each(function($unionBuilder) use($column, $direction, $cursor, $i, $orders, $addCursorConditions){
-
-                        $unionBuilder->where(function($unionBuilder) use($column, $direction, $cursor, $i, $orders, $addCursorConditions) {
+                    $unionBuilders->each(function ($unionBuilder) use ($column, $direction, $cursor, $i, $orders, $addCursorConditions){
+                        $unionBuilder->where(function ($unionBuilder) use ($column, $direction, $cursor, $i, $orders, $addCursorConditions) {
                             $unionBuilder->where(
                                 $this->getOriginalColumnNameForCursorPagination($this, $column),
                                 $direction === 'asc' ? '>' : '<',
@@ -391,7 +390,6 @@ trait BuildsQueries
 
                             $this->addBinding($unionBuilder->getRawBindings()['where'], 'union');
                         });
-
                     });
                 });
             };

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -339,15 +339,27 @@ trait BuildsQueries
 
         if (! is_null($cursor)) {
             $addCursorConditions = function (self $builder, $previousColumn, $i) use (&$addCursorConditions, $cursor, $orders) {
+                $unionBuilders = collect($builder->unions)->pluck('query');
+
                 if (! is_null($previousColumn)) {
                     $builder->where(
                         $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
                         '=',
                         $cursor->parameter($previousColumn)
                     );
+
+                    $unionBuilders->each(function($unionBuilder) use($previousColumn, $cursor) {
+                        $unionBuilder->where(
+                            $this->getOriginalColumnNameForCursorPagination($this, $previousColumn),
+                            '=',
+                            $cursor->parameter($previousColumn)
+                        );
+
+                        $this->addBinding($unionBuilder->getRawBindings()['where'], 'union');
+                    });
                 }
 
-                $builder->where(function (self $builder) use ($addCursorConditions, $cursor, $orders, $i) {
+                $builder->where(function (self $builder) use ($addCursorConditions, $cursor, $orders, $i, $unionBuilders) {
                     ['column' => $column, 'direction' => $direction] = $orders[$i];
 
                     $builder->where(
@@ -361,6 +373,26 @@ trait BuildsQueries
                             $addCursorConditions($builder, $column, $i + 1);
                         });
                     }
+
+                    $unionBuilders->each(function($unionBuilder) use($column, $direction, $cursor, $i, $orders, $addCursorConditions){
+
+                        $unionBuilder->where(function($unionBuilder) use($column, $direction, $cursor, $i, $orders, $addCursorConditions) {
+                            $unionBuilder->where(
+                                $this->getOriginalColumnNameForCursorPagination($this, $column),
+                                $direction === 'asc' ? '>' : '<',
+                                $cursor->parameter($column)
+                            );
+
+                            if ($i < $orders->count() - 1) {
+                                $unionBuilder->orWhere(function (self $builder) use ($addCursorConditions, $column, $i) {
+                                    $addCursorConditions($builder, $column, $i + 1);
+                                });
+                            }
+
+                            $this->addBinding($unionBuilder->getRawBindings()['where'], 'union');
+                        });
+
+                    });
                 });
             };
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2492,13 +2492,13 @@ class Builder
         })
             ->when(
             $shouldReverse,
-            function(Collection $orders) {
+            function (Collection $orders) {
                 return $orders->map(function ($order) {
                     $order['direction'] = $order['direction'] === 'asc' ? 'desc' : 'asc';
 
                     return $order;
                 });
-        })->values();
+            })->values();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2487,15 +2487,18 @@ class Builder
     {
         $this->enforceOrderBy();
 
-        if ($shouldReverse) {
-            $this->orders = collect($this->orders)->map(function ($order) {
-                $order['direction'] = $order['direction'] === 'asc' ? 'desc' : 'asc';
+        return collect($this->orders ?? $this->unionOrders ?? [])->filter(function ($order) {
+            return Arr::has($order, 'direction');
+        })
+            ->when(
+            $shouldReverse,
+            function(Collection $orders) {
+                return $orders->map(function ($order) {
+                    $order['direction'] = $order['direction'] === 'asc' ? 'desc' : 'asc';
 
-                return $order;
-            })->toArray();
-        }
-
-        return collect($this->orders);
+                    return $order;
+                });
+        })->values();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2489,16 +2489,13 @@ class Builder
 
         return collect($this->orders ?? $this->unionOrders ?? [])->filter(function ($order) {
             return Arr::has($order, 'direction');
-        })
-            ->when(
-            $shouldReverse,
-            function (Collection $orders) {
-                return $orders->map(function ($order) {
-                    $order['direction'] = $order['direction'] === 'asc' ? 'desc' : 'asc';
+        })->when($shouldReverse, function (Collection $orders) {
+            return $orders->map(function ($order) {
+                $order['direction'] = $order['direction'] === 'asc' ? 'desc' : 'asc';
 
-                    return $order;
-                });
-            })->values();
+                return $order;
+            });
+        })->values();
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4023,6 +4023,188 @@ SQL;
         ]), $result);
     }
 
+    public function testCursorPaginateWithUnionWheres() {
+        $ts = now()->toDateTimeString();
+
+        $perPage = 16;
+        $columns = ['test'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['created_at' => $ts]);
+        $builder = $this->getMockQueryBuilder();
+        $builder->select('id', 'start_time as created_at')->selectRaw("'video' as type")->from('videos');
+        $builder->union($this->getBuilder()->select('id', 'created_at')->selectRaw("'news' as type")->from('news'));
+        $builder->orderBy('created_at');
+
+        $builder->shouldReceive('newQuery')->andReturnUsing(function () use ($builder) {
+            return new Builder($builder->connection, $builder->grammar, $builder->processor);
+        });
+
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([
+            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => now(), 'type' => 'news']
+        ]);
+
+        $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
+            $this->assertEquals(
+                '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", \'news\' as type from "news" where ("start_time" > ?)) order by "created_at" asc limit 17',
+                $builder->toSql());
+            $this->assertEquals([$ts], $builder->bindings['where']);
+            $this->assertEquals([$ts], $builder->bindings['union']);
+            return $results;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['created_at'],
+        ]), $result);
+    }
+
+    public function testCursorPaginateWithUnionWheresWithRawOrderExpression() {
+        $ts = now()->toDateTimeString();
+
+        $perPage = 16;
+        $columns = ['test'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['created_at' => $ts]);
+        $builder = $this->getMockQueryBuilder();
+        $builder->select('id', 'is_published', 'start_time as created_at')->selectRaw("'video' as type")->where('is_published', true)->from('videos');
+        $builder->union($this->getBuilder()->select('id', 'is_published', 'created_at')->selectRaw("'news' as type")->where('is_published', true)->from('news'));
+        $builder->orderByRaw('case when (id = 3 and type="news" then 0 else 1 end)')->orderBy('created_at');
+
+        $builder->shouldReceive('newQuery')->andReturnUsing(function () use ($builder) {
+            return new Builder($builder->connection, $builder->grammar, $builder->processor);
+        });
+
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([
+            ['id' => 1, 'created_at' => now(), 'type' => 'video', 'is_published' => true],
+            ['id' => 2, 'created_at' => now(), 'type' => 'news', 'is_published' => true]
+        ]);
+
+        $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
+            $this->assertEquals(
+                '(select "id", "is_published", "start_time" as "created_at", \'video\' as type from "videos" where "is_published" = ? and ("start_time" > ?)) union (select "id", "is_published", "created_at", \'news\' as type from "news" where "is_published" = ? and ("start_time" > ?)) order by case when (id = 3 and type="news" then 0 else 1 end), "created_at" asc limit 17',
+                $builder->toSql());
+            $this->assertEquals([true, $ts], $builder->bindings['where']);
+            $this->assertEquals([true, $ts], $builder->bindings['union']);
+            return $results;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['created_at'],
+        ]), $result);
+    }
+
+    public function testCursorPaginateWithUnionWheresReverseOrder() {
+        $ts = now()->toDateTimeString();
+
+        $perPage = 16;
+        $columns = ['test'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['created_at' => $ts], false);
+        $builder = $this->getMockQueryBuilder();
+        $builder->select('id', 'start_time as created_at')->selectRaw("'video' as type")->from('videos');
+        $builder->union($this->getBuilder()->select('id', 'created_at')->selectRaw("'news' as type")->from('news'));
+        $builder->orderBy('created_at');
+
+        $builder->shouldReceive('newQuery')->andReturnUsing(function () use ($builder) {
+            return new Builder($builder->connection, $builder->grammar, $builder->processor);
+        });
+
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([
+            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => now(), 'type' => 'news']
+        ]);
+
+        $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
+            $this->assertEquals(
+                '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" < ?)) union (select "id", "created_at", \'news\' as type from "news" where ("start_time" < ?)) order by "created_at" asc limit 17',
+                $builder->toSql());
+            $this->assertEquals([$ts], $builder->bindings['where']);
+            $this->assertEquals([$ts], $builder->bindings['union']);
+            return $results;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['created_at'],
+        ]), $result);
+    }
+
+     public function testCursorPaginateWithUnionWheresMultipleOrders() {
+        $ts = now()->toDateTimeString();
+
+        $perPage = 16;
+        $columns = ['test'];
+        $cursorName = 'cursor-name';
+        $cursor = new Cursor(['created_at' => $ts, 'id' => 1]);
+        $builder = $this->getMockQueryBuilder();
+        $builder->select('id', 'start_time as created_at')->selectRaw("'video' as type")->from('videos');
+        $builder->union($this->getBuilder()->select('id', 'created_at')->selectRaw("'news' as type")->from('news'));
+        $builder->orderByDesc('created_at')->orderBy('id');
+
+        $builder->shouldReceive('newQuery')->andReturnUsing(function () use ($builder) {
+            return new Builder($builder->connection, $builder->grammar, $builder->processor);
+        });
+
+        $path = 'http://foo.bar?cursor='.$cursor->encode();
+
+        $results = collect([
+            ['id' => 1, 'created_at' => now(), 'type' => 'video'],
+            ['id' => 2, 'created_at' => now(), 'type' => 'news']
+        ]);
+
+        $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
+            $this->assertEquals(
+                '(select "id", "start_time" as "created_at", \'video\' as type from "videos" where ("start_time" < ? or ("start_time" = ? and ("id" > ?)))) union (select "id", "created_at", \'news\' as type from "news" where ("start_time" < ? or ("start_time" = ? and ("id" > ?)))) order by "created_at" desc, "id" asc limit 17',
+                $builder->toSql());
+            $this->assertEquals([$ts, $ts, 1], $builder->bindings['where']);
+            $this->assertEquals([$ts, $ts, 1], $builder->bindings['union']);
+            return $results;
+        });
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->cursorPaginate($perPage, $columns, $cursorName, $cursor);
+
+        $this->assertEquals(new CursorPaginator($results, $perPage, $cursor, [
+            'path' => $path,
+            'cursorName' => $cursorName,
+            'parameters' => ['created_at', 'id'],
+        ]), $result);
+    }
+
+
+
     public function testWhereRowValues()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -4023,7 +4023,8 @@ SQL;
         ]), $result);
     }
 
-    public function testCursorPaginateWithUnionWheres() {
+    public function testCursorPaginateWithUnionWheres()
+    {
         $ts = now()->toDateTimeString();
 
         $perPage = 16;
@@ -4043,7 +4044,7 @@ SQL;
 
         $results = collect([
             ['id' => 1, 'created_at' => now(), 'type' => 'video'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news']
+            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -4068,7 +4069,8 @@ SQL;
         ]), $result);
     }
 
-    public function testCursorPaginateWithUnionWheresWithRawOrderExpression() {
+    public function testCursorPaginateWithUnionWheresWithRawOrderExpression()
+    {
         $ts = now()->toDateTimeString();
 
         $perPage = 16;
@@ -4088,7 +4090,7 @@ SQL;
 
         $results = collect([
             ['id' => 1, 'created_at' => now(), 'type' => 'video', 'is_published' => true],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news', 'is_published' => true]
+            ['id' => 2, 'created_at' => now(), 'type' => 'news', 'is_published' => true],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -4113,7 +4115,8 @@ SQL;
         ]), $result);
     }
 
-    public function testCursorPaginateWithUnionWheresReverseOrder() {
+    public function testCursorPaginateWithUnionWheresReverseOrder()
+    {
         $ts = now()->toDateTimeString();
 
         $perPage = 16;
@@ -4133,7 +4136,7 @@ SQL;
 
         $results = collect([
             ['id' => 1, 'created_at' => now(), 'type' => 'video'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news']
+            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -4158,7 +4161,8 @@ SQL;
         ]), $result);
     }
 
-     public function testCursorPaginateWithUnionWheresMultipleOrders() {
+     public function testCursorPaginateWithUnionWheresMultipleOrders()
+     {
         $ts = now()->toDateTimeString();
 
         $perPage = 16;
@@ -4178,7 +4182,7 @@ SQL;
 
         $results = collect([
             ['id' => 1, 'created_at' => now(), 'type' => 'video'],
-            ['id' => 2, 'created_at' => now(), 'type' => 'news']
+            ['id' => 2, 'created_at' => now(), 'type' => 'news'],
         ]);
 
         $builder->shouldReceive('get')->once()->andReturnUsing(function () use ($builder, $results, $ts) {
@@ -4202,8 +4206,6 @@ SQL;
             'parameters' => ['created_at', 'id'],
         ]), $result);
     }
-
-
 
     public function testWhereRowValues()
     {


### PR DESCRIPTION
adds the ability to use cursor pagination with union queries.

here's an example:
```php
$builder->select('id', 'start_time as created_at')->selectRaw("'video' as type")->from('videos');
$builder->union($this->getBuilder()->select('id', 'created_at')->selectRaw("'news' as type")->from('news'));
$builder->orderBy('created_at');
```

The specified order for this builder instance is now on `unionOrders` property rather than `orders`. But further down the road in `src/Illuminate/Database/Query/Builder.php` method `ensureOrderForCursorPagination`, the order is retrieved from `orders` property, which is null. Within that function, the specified order needs to be retrieved either from `orders` or `unionOrders` property, it also needs a filter for orders without direction (type "Raw").

Next issue to address is in method `paginateUsingCursor` from `src/Illuminate/Database/Concerns/BuildsQueries.php`. It only adds the conditions from the cursor to the main query, not the union query.

So instead of 
```sql
(select "id", "start_time" as "created_at", 'video' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", 'news' as type from "news" where ("start_time" > ?)) order by "created_at" asc limit 17
```

it produces 
```sql
(select "id", "start_time" as "created_at", 'video' as type from "videos" where ("start_time" > ?)) union (select "id", "created_at", 'news' as type from "news") order by "created_at" asc limit 17
```

