### PR TITLE
now we can run migrations when we start server by passing m flag

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -69,6 +69,11 @@ class ServeCommand extends Command
      */
     public function handle()
     {
+        
+        if ($this->option('migration')) {
+            $this->runMigration();
+        }
+
         $this->line("<info>Starting Laravel development server:</info> http://{$this->host()}:{$this->port()}");
 
         $environmentFile = $this->option('env')
@@ -213,6 +218,16 @@ class ServeCommand extends Command
     }
 
     /**
+     * Run migrations.
+     *
+     * @return void
+     */
+    protected function runMigration()
+    {
+        $this->call('migrate');
+    }
+
+    /**
      * Get the console command options.
      *
      * @return array
@@ -224,6 +239,7 @@ class ServeCommand extends Command
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', Env::get('SERVER_PORT')],
             ['tries', null, InputOption::VALUE_OPTIONAL, 'The max number of ports to attempt to serve from', 10],
             ['no-reload', null, InputOption::VALUE_NONE, 'Do not reload the development server on .env file changes'],
+            ['migration', 'm', InputOption::VALUE_NONE, 'Run migrations'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -69,7 +69,6 @@ class ServeCommand extends Command
      */
     public function handle()
     {
-        
         if ($this->option('migration')) {
             $this->runMigration();
         }


### PR DESCRIPTION
With this we can run migrations at the time when we start our server by passing m flag with serve command.
Like:
**php artisan serve -m**
It would be helpful when more than one developers are working on a project, So they don't need to tell to run migrations in his branch.