### PR TITLE
[9.x] Made Http::sequence()->push() consistent with Http::response()

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -119,7 +119,7 @@ class Factory
     /**
      * Create a new response instance for use during stubbing.
      *
-     * @param  array|string  $body
+     * @param  array|string|null  $body
      * @param  int  $status
      * @param  array  $headers
      * @return \GuzzleHttp\Promise\PromiseInterface

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -44,12 +44,12 @@ class ResponseSequence
     /**
      * Push a response to the sequence.
      *
-     * @param  string|array  $body
+     * @param  string|array|null  $body
      * @param  int  $status
      * @param  array  $headers
      * @return $this
      */
-    public function push($body = '', int $status = 200, array $headers = [])
+    public function push($body = null, int $status = 200, array $headers = [])
     {
         $body = is_array($body) ? json_encode($body) : $body;
 


### PR DESCRIPTION
This PR will make `Http::sequence()->push(null)` consistent with `Http::response(null)` by allowing `null` as the body. This should also fix PHPStan where it will throw an error that only `array` or `string` is allowed in `push()`.