### PR TITLE
[9.x] Adds renameKeys to the Collection

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -817,4 +817,16 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Renames the given array keys.
+     *
+     * @param  array<string, mixed>  $array
+     * @param  array<string, string>  $replace
+     * @return array
+     */
+    public static function renameKeys(array $array, array $replace, $recursive = true)
+    {
+        return Collection::make($array)->renameKeys($replace, $recursive)->all();
+    }
 }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1635,6 +1635,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Renames the given array keys.
+     *
+     * @param  array<string, string>  $replace
+     * @return static
+     */
+    public function renameKeys(array $replace, $recursive = true)
+    {
+        return (new static($this->items))->mapWithKeys(
+            fn ($item, $key) => [($replace[$key] ?? $key) => $recursive && is_array($item) ? static::make($item)->renameKeys($replace)->all() : $item]
+        );
+    }
+
+    /**
      * Add an item to the collection.
      *
      * @param  TValue  $item


### PR DESCRIPTION
Adds the ability to rename some keys of an associative array collection without changing their order.

Following the previous PR #42657, this implementation is based on `mapWithKeys` with more tests covering edge cases.

```php
$array = [
  'key1' => 'val_1',
  'key2' => 'val_2',
  'nested' => [ 'key1' => 'val_1', 'key2' => 'val_2'],
];

// we want to rename "key2" to "new_key_2"
$replace = [
  'key2' => 'new_key_2',
];


$result = Collection::make($array)->renameKeys($replace, recursive: true)->all();


$result = [
  'key1' => 'val_1',
  'new_key_2' => 'val_2',
  'nested' => [ 'key1' => 'val_1', 'new_key_2' => 'val_4'],
];
```
- **Use cases**:
This is usually needed when we get some data from a source and want to expose it in a public API, but the keys are not very readable.
Another typical use case is when we receive a form request which represents data to be inserted in a table but the key names in the request does not exactly map to the name of the database columns.

```php
$data = request()->all();

$data = Arr::renameKeys($data, ....);

MyModel::create($data);

```