### PR TITLE
[9.x] Dispatch jobs with the ShouldBeUnique interface only once after response

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -59,7 +59,7 @@ class UniqueLock
     /**
      * Determine the lock duration for the given job.
      *
-     * @param  mixed $job
+     * @param  mixed  $job
      * @return int
      */
     protected function getJobUniqueFor(mixed $job): int
@@ -85,7 +85,7 @@ class UniqueLock
     }
 
     /**
-     * @param  mixed $job
+     * @param  mixed  $job
      * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function getJobUniqueVia(mixed $job): Cache

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 use RuntimeException;
 
 class BusDispatcherTest extends TestCase
@@ -75,7 +75,7 @@ class BusDispatcherTest extends TestCase
 
     public function testUniqueJobIsDispatchedAfterResponseOnce()
     {
-        $container = new \Illuminate\Foundation\Application;
+        $container = $this->app;
         $mock = m::mock(Dispatcher::class.'[dispatchNow]', [$container]);
         $mock->shouldReceive('dispatchNow')->once();
 
@@ -193,4 +193,3 @@ class UniqueJob implements ShouldBeUnique
         //
     }
 }
-

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -7,12 +7,10 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Mockery as m;
-use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 class BusDispatcherTest extends TestCase
@@ -20,8 +18,6 @@ class BusDispatcherTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
-
-        parent::tearDown();
     }
 
     public function testCommandsThatShouldQueueIsQueued()
@@ -73,18 +69,6 @@ class BusDispatcherTest extends TestCase
         });
 
         $dispatcher->dispatch(new BusDispatcherBasicCommand);
-    }
-
-    public function testUniqueJobIsDispatchedAfterResponseOnce()
-    {
-        $container = $this->app;
-        $mock = m::mock(Dispatcher::class.'[dispatchNow]', [$container]);
-        $mock->shouldReceive('dispatchNow')->once();
-
-        $mock->dispatchAfterResponse(new UniqueJob);
-        $mock->dispatchAfterResponse(new UniqueJob);
-
-        $container->terminate();
     }
 
     public function testDispatcherCanDispatchStandAloneHandler()
@@ -183,15 +167,5 @@ class ShouldNotBeDispatched implements ShouldQueue
     public function handle()
     {
         throw new RuntimeException('This should not be run');
-    }
-}
-
-class UniqueJob implements ShouldBeUnique
-{
-    use Dispatchable;
-
-    public function handle()
-    {
-        //
     }
 }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -20,6 +20,8 @@ class BusDispatcherTest extends TestCase
     protected function tearDown(): void
     {
         m::close();
+
+        parent::tearDown();
     }
 
     public function testCommandsThatShouldQueueIsQueued()

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -178,7 +178,7 @@ class UniqueTestJob implements ShouldQueue, ShouldBeUnique
     public function handle()
     {
         static::$handled = true;
-        static::$handles ++;
+        static::$handles++;
     }
 }
 


### PR DESCRIPTION
When using the `dispatchAfterResponse` function on a job that implements the `ShouldBeUnique` interface, I would expect it to be dispatched only once after response. Instead, these jobs are dispatched as many times as you call the function.

Dispatching them only once is very useful when you have more than one reason to dispatch a job, but you need it to be actually running one time.

This PR offers a solution, just not sure if this would be considered a breaking change.