### PR TITLE
[9.x] Test path added

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -62,6 +62,14 @@ interface Application extends Container
     public function storagePath($path = '');
 
     /**
+     * Get the path to the tests directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function testPath($path = '');
+
+    /**
      * Get or check the current application environment.
      *
      * @param  string|array  $environments

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -319,6 +319,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->instance('path.database', $this->databasePath());
         $this->instance('path.resources', $this->resourcePath());
         $this->instance('path.bootstrap', $this->bootstrapPath());
+        $this->instance('path.test', $this->testPath());
 
         $this->useLangPath(value(function () {
             if (is_dir($directory = $this->resourcePath('lang'))) {
@@ -503,6 +504,17 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $basePath = $this['config']->get('view.paths')[0];
 
         return rtrim($basePath, DIRECTORY_SEPARATOR).($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+    }
+
+    /**
+     * Get the path to the tests directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function testPath($path = '')
+    {
+        return $this->basePath.DIRECTORY_SEPARATOR.'tests'.($path != '' ? DIRECTORY_SEPARATOR.$path : '');
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -948,3 +948,16 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('test_path')) {
+    /**
+     * Get the path to the test folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function test_path($path = '')
+    {
+        return app()->testPath($path);
+    }
+}


### PR DESCRIPTION
If I write tests and I need some test related files I paste them to the tests/files folder. In this cases I would like to use the test_path helper like: `test_path('files/import.csv')`.