### PR TITLE
[8.x] Pass the full custom pivot model to the `deleting` & `deleted` events.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -475,7 +475,7 @@ trait InteractsWithPivotTable
 
         $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
 
-        foreach($pivots as $pivot) {
+        foreach ($pivots as $pivot) {
             $results += $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)->delete();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -473,7 +473,10 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
+        $pivots = $this->using::withoutGlobalScopes()
+            ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
+            ->whereIn($this->relatedPivotKey, $this->parseIds($ids))
+            ->get();
 
         foreach ($pivots as $pivot) {
             $results += $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)->delete();

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -473,11 +473,10 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        foreach ($this->parseIds($ids) as $id) {
-            $results += $this->newPivot([
-                $this->foreignPivotKey => $this->parent->{$this->parentKey},
-                $this->relatedPivotKey => $id,
-            ], true)->delete();
+        $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
+
+        foreach($pivots as $pivot) {
+            $results += $pivot->delete();
         }
 
         return $results;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -476,7 +476,7 @@ trait InteractsWithPivotTable
         $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
 
         foreach($pivots as $pivot) {
-            $results += $pivot->delete();
+            $results += $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)->delete();
         }
 
         return $results;


### PR DESCRIPTION
The changes made in this PR will provide the actual pivot model to be passed into the `deleting` & `deleted` events, instead of solely the foreign pivot key & related pivot key.

### Real life example:
I have a `Company::class` model and a `PaymentMethod::class` model along with a `CompanyPaymentMethod::class` pivot model . The pivot table has an additional boolean column called `is_primary`. In this event I would like to apply some business logic and do certain things when a primary payment method relationship is being destroyed, but I do not have access to the "full" `CompanyPaymentMethod::class` pivot model's attributes as it only comes in with the foreign & primary keys.

The workaround I currently provided in in project was to change my event from `deleted` to `deleting` in order to be able to query the table myself, it is not a good solution as it will cause a `n + 1`, in case a `sync()` or multiple `detach()` is being made.
```
public function deleting(CompanyPaymentMethod $pivot)
{
    $pivot = CompanyPaymentMethod::where([
        'company_id' => $pivot->company_id,
        'payment_method_id' => $pivot->payment_method_id
    ])->first();

    if ($pivot->is_primary) {
        // do something
    }
}
```

🔴  A disadvantage I would see vs the current solution is the fact that this will be making an additional query to retrieve the pivot models that will be deleted. But it could prevent hundreds of queries if there are people applying a workaround like the one I mention above and could also save countless hours in debugging this as all other pivot model events pass in the full pivot model as it is expected.