### PR TITLE
[9.x] Allow random string generation to be controlled

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -722,7 +722,6 @@ class Str
         });
     }
 
-
     /**
      * Indicate that random strings should be created normally and not using a custom factory.
      *

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -45,6 +45,13 @@ class Str
     protected static $uuidFactory;
 
     /**
+     * The callback that should be used to generate random strings.
+     *
+     * @var callable|null
+     */
+    protected static $randomStringFactory;
+
+    /**
      * Get a new stringable object from the given string.
      *
      * @param  string  $string
@@ -655,17 +662,75 @@ class Str
      */
     public static function random($length = 16)
     {
-        $string = '';
+        return (static::$randomStringFactory ?? function ($length) {
+            $string = '';
 
-        while (($len = strlen($string)) < $length) {
-            $size = $length - $len;
+            while (($len = strlen($string)) < $length) {
+                $size = $length - $len;
 
-            $bytes = random_bytes($size);
+                $bytes = random_bytes($size);
 
-            $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
-        }
+                $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
+            }
 
-        return $string;
+            return $string;
+        })($length);
+    }
+
+    /**
+     * Set the callable that will be used to generate random strings.
+     *
+     * @param  callable|null  $factory
+     * @return void
+     */
+    public static function createRandomStringsUsing(callable $factory = null)
+    {
+        static::$randomStringFactory = $factory;
+    }
+
+    /**
+     * Set the sequence that will be used to generate random strings.
+     *
+     * @param  array  $sequence
+     * @param  callable|null  $whenMissing
+     * @return void
+     */
+    public static function createRandomStringsUsingSequence(array $sequence, $whenMissing = null)
+    {
+        $next = 0;
+
+        $whenMissing ??= function ($length) use (&$next) {
+            $factoryCache = static::$randomStringFactory;
+
+            static::$randomStringFactory = null;
+
+            $randomString = static::random($length);
+
+            static::$randomStringFactory = $factoryCache;
+
+            $next++;
+
+            return $randomString;
+        };
+
+        static::createRandomStringsUsing(function ($length) use (&$next, $sequence, $whenMissing) {
+            if (array_key_exists($next, $sequence)) {
+                return $sequence[$next++];
+            }
+
+            return $whenMissing($length);
+        });
+    }
+
+
+    /**
+     * Indicate that random strings should be created normally and not using a custom factory.
+     *
+     * @return void
+     */
+    public static function createRandomStringsNormally()
+    {
+        static::$randomStringFactory = null;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -980,7 +980,7 @@ class SupportStrTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testItCanSpecifyASquenceOfUuidsToUtilise()
+    public function testItCanSpecifyASequenceOfUuidsToUtilise()
     {
         Str::createUuidsUsingSequence([
             0 => ($zeroth = Str::uuid()),

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -470,6 +470,53 @@ class SupportStrTest extends TestCase
         $this->assertIsString(Str::random());
     }
 
+    public function testRandomStringFactoryCanBeSet()
+    {
+        Str::createRandomStringsUsing(fn ($length) => 'length:'.$length);
+
+        $this->assertSame('length:7', Str::random(7));
+        $this->assertSame('length:7', Str::random(7));
+
+        Str::createRandomStringsNormally();
+
+        $this->assertNotSame('length:7', Str::random());
+    }
+
+    public function testItCanSpecifyASequenceOfRandomStringsToUtilise()
+    {
+        Str::createRandomStringsUsingSequence([
+            0 => 'x',
+            // 1 => just generate a random one here...
+            2 => 'y',
+            3 => 'z',
+            // ... => continue to generate random strings...
+        ]);
+
+        $this->assertSame('x', Str::random());
+        $this->assertSame(16, mb_strlen(Str::random()));
+        $this->assertSame('y', Str::random());
+        $this->assertSame('z', Str::random());
+        $this->assertSame(16, mb_strlen(Str::random()));
+        $this->assertSame(16, mb_strlen(Str::random()));
+
+        Str::createRandomStringsNormally();
+    }
+
+    public function testItCanSpecifyAFallbackForARandomStringSequence()
+    {
+        Str::createRandomStringsUsingSequence([Str::random(), Str::random()], fn () => throw new \Exception('Out of random strings.'));
+        Str::random();
+        Str::random();
+
+        try {
+            $this->expectExceptionMessage('Out of random strings.');
+            Str::random();
+            $this->fail();
+        } finally {
+            Str::createRandomStringsNormally();
+        }
+    }
+
     public function testReplace()
     {
         $this->assertSame('foo bar laravel', Str::replace('baz', 'laravel', 'foo bar baz'));


### PR DESCRIPTION
This PR is the counterpart https://github.com/laravel/framework/pull/42619, however this PR targets the `Str::random()` function.

This allows developers to intercept and control the random string generation. This is useful in testing where the `Str::random()` function has been used directly, rather than via a service, and the develop would like to make an assertion against the result of the `Str::random()` result.

Take a test for the following function...

```php
class Mailable
{
    public function embed($file)
    {
        $name = Str::random();

        $this->message->embed($file, $name);
  
        return "cid:{$name}";
    }
}

```

Here is a before an after for the potential tests. You will see that the first test doesn't give us as much confidence as the second.


```php
// before...

$cid = $mailable->attach('foo.jpg');

$this->assertStringStarts('cid:', $cid);
$name = Str::after($cid, 'cid:');
$this->assertSame(16, mb_strlen($name));

// after...

Str::createRandomStringsUsing(fn ($length) => "xyz|{$length}");

$cid = $mailable->attach('foo.jpg');

$this->assertSame('cid:xyz|16', $cid);

Str::createRandomStringsNormally();
```


It also allows developers to specify a sequence of random strings to return when the `Str::random()` function is called. This works in the same way seen in https://github.com/laravel/framework/pull/42619.

```php

Str::createRandomStringsUsingSequence(['abc', 'xyz']);
    
Str::random(); // "abc"
Str::random(); // "xyz"
Str::random(); // random
Str::random(); // random
```

You can also specify the array keys so you only control certain calls...

```php

Str::createRandomStringsUsingSequence([
    0 => 'abc',
 // 1 => generate normally
    2 => 'xyz',
 // 3... => generate normally
]);
    
Str::random(); // "abc"
Str::random(); // random
Str::random(); // "xyz"
Str::random(); // random
Str::random(); // random
```

Finally, you may pass a closure as the second parameter to control what happens when a random string is being generated, but you have not specified it in the sequence.

```php
Str::createRandomStringsUsingSequence([
    0 => 'abc',
    3 => 'xyz',
], fn () => throw new Exception('Sequence ended.'));

Str::random(); // "abc"
Str::uuid(); // THROWS
```

## Notes
- I didn't provide a Str::freeze() style function like the UUIDs, as I don't believe it adds any value for a raw string, when `Str::createRandomStringsUsing(fn () => 'xyz')` is easily used.