### PR TITLE
Fix README incorrect use statement 

### DIFF
--- a/src/Illuminate/Database/README.md
+++ b/src/Illuminate/Database/README.md
@@ -23,7 +23,7 @@ $capsule->addConnection([
 ]);
 
 // Set the event dispatcher used by Eloquent models... (optional)
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Container\Container;
 $capsule->setEventDispatcher(new Dispatcher(new Container));
 


### PR DESCRIPTION
Fix incorrect using in bootstrap documentation: Illuminate\Events\Dispatcher > Illuminate\Contracts\Events\Dispatcher

![error](https://user-images.githubusercontent.com/1455401/172068844-edbae123-9b91-4ce1-8a32-0f02e0349200.png)

