### PR TITLE
[9.x] Allow assertions against pushed string based pushed jobs

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -253,7 +253,7 @@ class QueueFake extends QueueManager implements Queue
         $callback = $callback ?: fn () => true;
 
         return collect($this->jobs[$job])->filter(
-            fn ($data) => $callback($data['job'], $data['queue'])
+            fn ($data) => $callback($data['job'], $data['queue'], $data['data'])
         )->pluck('job');
     }
 
@@ -306,6 +306,7 @@ class QueueFake extends QueueManager implements Queue
             $this->jobs[is_object($job) ? get_class($job) : $job][] = [
                 'job' => $job,
                 'queue' => $queue,
+                'data' => $data,
             ];
         } else {
             is_object($job) && isset($job->connection)

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -52,6 +52,20 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class);
     }
 
+    public function testItCanAssertAgainstDataWithPush()
+    {
+        $data = null;
+        $this->fake->push(JobStub::class, ['foo' => 'bar'], 'redis');
+
+        $this->fake->assertPushed(JobStub::class, function ($job, $queue, $jobData) use (&$data) {
+            $data = $jobData;
+
+            return true;
+        });
+
+        $this->assertSame(['foo' => 'bar'], $data);
+    }
+
     public function testAssertPushedWithIgnore()
     {
         $job = new JobStub;


### PR DESCRIPTION
This PR allows developers to make assertions against pushed queued job data, when the job is queued in the following manner...

```php
Queue::push(MyJob::class, ['job' => 'data'], 'redis');
```

rather than pushing a job instance to the queue. The following test can now be created...

```php
// setup...
Queue::fake();

// implementation...
Queue::push(MyJob::class, ['job' => 'data'], 'redis');

// assertions...
Queue::assertPushed(MyJob::class, function ($class, $queue, $data) {
    return $data === ['job' => 'data'];
});
```