### PR TITLE
[9.x] Improve tap() documented return type

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -289,9 +289,11 @@ if (! function_exists('tap')) {
     /**
      * Call the given Closure with the given value then return the value.
      *
-     * @param  mixed  $value
-     * @param  callable|null  $callback
-     * @return mixed
+     * @template TValue
+     *
+     * @param  TValue  $value
+     * @param  (callable(TValue): mixed)|null  $callback
+     * @return TValue|\Illuminate\Support\HigherOrderTapProxy
      */
     function tap($value, $callback = null)
     {

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -2,6 +2,12 @@
 
 use function PHPStan\Testing\assertType;
 
+assertType('Illuminate\Support\HigherOrderTapProxy|User', tap(new User()));
+
+assertType('Illuminate\Support\HigherOrderTapProxy|User', tap(new User(), function ($user) {
+    assertType('User', $user);
+}));
+
 assertType('User', with(new User()));
 assertType('bool', with(new User())->save());
 assertType('User', with(new User(), function (User $user) {


### PR DESCRIPTION
This PR aims to improve the documented return type of `tap()`. It still is not 100% accurate, but it's a fair bit better than `mixed` in my opinion.

(This also makes the global tap helper return type consistent with `Tappable::tap()`)