### PR TITLE
[9.x] Add contains[Any|All|None] in Collection 

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -201,6 +201,43 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if all items exist in the collection their values.
+     *
+     * @param  array $values
+     * @return bool
+     */
+    public function containsAll($values)
+    {
+        $values = new static(array_unique($values));
+
+        return $this->intersect($values)->count() == $values->count();
+    }
+
+    /**
+     * Determine if any of the items exist in the collection their values.
+     *
+     * @param  array $values
+     * @return bool
+     */
+    public function containsAny($values)
+    {
+        $values = new static(array_unique($values));
+
+        return $this->intersect($values)->count() > 0;
+    }
+
+    /**
+     * Determine if none of the items exist in the collection their values.
+     *
+     * @param  array $values
+     * @return bool
+     */
+    public function containsNone($values)
+    {
+        return ! $this->containsAny($values);
+    }
+
+    /**
      * Cross join with the given lists, returning all possible permutations.
      *
      * @template TCrossJoinKey

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -203,7 +203,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if all items exist in the collection their values.
      *
-     * @param  array $values
+     * @param  array  $values
      * @return bool
      */
     public function containsAll($values)
@@ -216,7 +216,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if any of the items exist in the collection their values.
      *
-     * @param  array $values
+     * @param  array  $values
      * @return bool
      */
     public function containsAny($values)
@@ -229,7 +229,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Determine if none of the items exist in the collection their values.
      *
-     * @param  array $values
+     * @param  array  $values
      * @return bool
      */
     public function containsNone($values)

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -252,7 +252,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if all items exist in the collection their values.
      *
-     * @param  array $values
+     * @param  array  $values
      * @return bool
      */
     public function containsAll($values)
@@ -263,7 +263,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if any of the items exist in the collection their values.
      *
-     * @param  array $values
+     * @param  array  $values
      * @return bool
      */
     public function containsAny($values)
@@ -274,7 +274,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Determine if none of the items exist in the collection their values.
      *
-     * @param  array $values
+     * @param  array  $values
      * @return bool
      */
     public function containsNone($values)

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -250,6 +250,39 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if all items exist in the collection their values.
+     *
+     * @param  array $values
+     * @return bool
+     */
+    public function containsAll($values)
+    {
+        return $this->collect()->containsAll($values);
+    }
+
+    /**
+     * Determine if any of the items exist in the collection their values.
+     *
+     * @param  array $values
+     * @return bool
+     */
+    public function containsAny($values)
+    {
+        return $this->collect()->containsAny($values);
+    }
+
+    /**
+     * Determine if none of the items exist in the collection their values.
+     *
+     * @param  array $values
+     * @return bool
+     */
+    public function containsNone($values)
+    {
+        return ! $this->containsAny($values);
+    }
+
+    /**
      * Cross join the given iterables, returning all possible permutations.
      *
      * @template TCrossJoinKey

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3368,7 +3368,7 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testContainsAll($collection) 
+    public function testContainsAll($collection)
     {
         $c = new $collection([1, 3, 5]);
 
@@ -3386,7 +3386,7 @@ class SupportCollectionTest extends TestCase
         $c = new $collection([1, 3, 5]);
 
         $this->assertTrue($c->containsAny([1, 2]));
-        $this->assertFalse($c->containsAny([2,4]));
+        $this->assertFalse($c->containsAny([2, 4]));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3368,6 +3368,41 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testContainsAll($collection) 
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertTrue($c->containsAll([1, 3, 5]));
+        $this->assertTrue($c->containsAll(['1', '3', '5']));
+        $this->assertFalse($c->containsAll([2]));
+        $this->assertFalse($c->containsAll(['2']));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testContainsAny($collection)
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertTrue($c->containsAny([1, 2]));
+        $this->assertFalse($c->containsAny([2,4]));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testContainsNone($collection)
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertTrue($c->containsNone([2, 4]));
+        $this->assertFalse($c->containsNone([1, 2]));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSome($collection)
     {
         $c = new $collection([1, 3, 5]);


### PR DESCRIPTION
This PR to add `containsAll`,`containsAny` and `containsNone` in to Collection.
These functions allow checking the presence of any, none, or all values.

ِExamples for use:
```php

use Illuminate\Http\Request;

class UserController
{
    public function __invoke(Request $request)
    {
        $request->validate([
            'names' => ['required', 'array'],
        ]);

        $names = $request->collect('names');

        if ($names->containsAll(['Taylor', 'Michael'])) {
            # code...
        }

        if ($names->containsAny(['Taylor Otwell', 'Michael Nabil', 'Khaled Ahmed'])) {
            # code...
        }

        if ($names->containsNone(['Marian', 'Ahmed', 'Menna'])) {
            # code...
        }
    }
}
```

Another example:
```php 

use Illuminate\Http\Request;

class BookController
{
    public function __invoke(Request $request)
    {
        $books = ['book1', 'book2', 'book3'];
        
        if (collect($books)->containsAll(['book1', 'book2'])) {
            # code...
        }

        if (collect($books)->containsAny(['book1', 'book2', 'book5', 'book6'])) {
            # code...
        }

        if (collect($books)->containsNone(['book4', 'book5'])) {
            # code...
        }
    }
}


```