### PR TITLE
[9.x] Adds `not_starts_with` validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -627,4 +627,22 @@ trait ReplacesAttributes
 
         return str_replace(':values', implode(', ', $parameters), $message);
     }
+    
+    /**
+     * Replace all place-holders for the not_starts_with rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceNotStartsWith($message, $attribute, $rule, $parameters)
+    {
+        foreach ($parameters as &$parameter) {
+            $parameter = $this->getDisplayableValue($attribute, $parameter);
+        }
+
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1949,6 +1949,19 @@ trait ValidatesAttributes
     {
         return Str::startsWith($value, $parameters);
     }
+    
+    /**
+     * Validate the attribute not starts with a given substring.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateNotStartsWith($attribute, $value, $parameters)
+    {
+        return ! Str::startsWith($value, $parameters);
+    }
 
     /**
      * Validate the attribute ends with a given substring.


### PR DESCRIPTION
This PR adds the ability to check if the string does not start with the given values, and I think this validation is important and makes the validation easier and we will not resort to using something else such as Regex.

```PHP
$request->validate([
    'name' => ['required', 'not_starts_with:mahmoud'],
]);
```

@taylorotwell The PR sent to 9.x branch as you told :)