### PR TITLE
[10.x] Add `can` middleware helper to resource routes and route registrar, improve consistency

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -149,15 +149,33 @@ class PendingResourceRegistration
      */
     public function middleware($middleware)
     {
-        $middleware = Arr::wrap($middleware);
+        if (! is_array($middleware)) {
+            $middleware = func_get_args();
+        }
 
         foreach ($middleware as $key => $value) {
             $middleware[$key] = (string) $value;
         }
 
-        $this->options['middleware'] = $middleware;
+        $this->options['middleware'] = array_merge(
+            (array) ($this->options['middleware'] ?? []), $middleware
+        );
 
         return $this;
+    }
+
+    /**
+     * Specify that the "Authorize" / "can" middleware should be applied to the route with the given options.
+     *
+     * @param  string  $ability
+     * @param  array|string  $models
+     * @return $this
+     */
+    public function can($ability, $models = [])
+    {
+        return empty($models)
+                    ? $this->middleware(['can:'.$ability])
+                    : $this->middleware(['can:'.$ability.','.implode(',', Arr::wrap($models))]);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -17,6 +17,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\Route options(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route any(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\RouteRegistrar as(string $value)
+ * @method \Illuminate\Routing\RouteRegistrar can(string $ability, array|null $models = [])
  * @method \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
@@ -115,7 +116,7 @@ class RouteRegistrar
 
         $attributeKey = Arr::get($this->aliases, $key, $key);
 
-        if ($key === 'withoutMiddleware') {
+        if (in_array($key, ['middleware', 'withoutMiddleware'])) {
             $value = array_merge(
                 (array) ($this->attributes[$attributeKey] ?? []), Arr::wrap($value)
             );
@@ -237,6 +238,12 @@ class RouteRegistrar
     {
         if (in_array($method, $this->passthru)) {
             return $this->registerRoute($method, ...$parameters);
+        }
+
+        if ($method === 'can') {
+            return $parameters[1] ?? false
+                ? $this->attribute('middleware', ['can:'.$parameters[0].','.implode(',', Arr::wrap($parameters[1]))])
+                : $this->attribute('middleware', ['can:'.$parameters[0]]);
         }
 
         if (in_array($method, $this->allowedAttributes)) {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1363,10 +1363,16 @@ class Router implements BindingRegistrar, RegistrarContract
             return $this->macroCall($method, $parameters);
         }
 
-        if ($method === 'middleware') {
-            return (new RouteRegistrar($this))->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
+        $registrar = new RouteRegistrar($this);
+
+        if ($method === 'can') {
+            return $registrar->can(...$parameters);
         }
 
-        return (new RouteRegistrar($this))->attribute($method, array_key_exists(0, $parameters) ? $parameters[0] : true);
+        if ($method === 'middleware') {
+            return $registrar->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
+        }
+
+        return $registrar->attribute($method, array_key_exists(0, $parameters) ? $parameters[0] : true);
     }
 }

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -22,6 +22,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route substituteBindings(\Illuminate\Support\Facades\Route $route)
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [], int|array $status = 200, array $headers = [])
  * @method static \Illuminate\Routing\RouteRegistrar as(string $value)
+ * @method static \Illuminate\Routing\RouteRegistrar can(string $ability, array|null $models = [])
  * @method static \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method static \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -764,6 +764,30 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware(RouteRegistrarMiddlewareStub::class);
     }
 
+    public function testCanSetCanMiddlewareOnRegisteredResource()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->can('create', Router::class);
+
+        $this->seeMiddleware('can:create,Illuminate\Routing\Router');
+    }
+
+    public function testMiddlewareAndCanDoesNotOverrideEachOtherOnRegisteredResource()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->middleware('can:1')
+                     ->can('2')
+                     ->middleware('3')
+                     ->can('4');
+
+        $this->assertEquals([
+            'can:1',
+            'can:2',
+            '3',
+            'can:4',
+        ], $this->getRoute()->middleware());
+    }
+
     public function testResourceWithoutMiddlewareRegistration()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -64,7 +64,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanMiddlewareFluentRegistration()
     {
-        $this->router->can('see', 'a_class')->get('users', fn() => 'all-users');
+        $this->router->can('see', 'a_class')->get('users', fn () => 'all-users');
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->assertEquals(['can:see,a_class'], $this->getRoute()->middleware());
@@ -76,7 +76,7 @@ class RouteRegistrarTest extends TestCase
                      ->can('2', 'a')
                      ->middleware('3', '4')
                      ->can('5')
-                     ->get('users', fn() => 'all-users');
+                     ->get('users', fn () => 'all-users');
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->assertEquals([

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -62,6 +62,31 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['seven'], $this->getRoute()->middleware());
     }
 
+    public function testCanMiddlewareFluentRegistration()
+    {
+        $this->router->can('see', 'a_class')->get('users', fn() => 'all-users');
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals(['can:see,a_class'], $this->getRoute()->middleware());
+    }
+
+    public function testMiddlewareAndCanDoesNotOverrideEachOtherOnFluentRegistration()
+    {
+        $this->router->middleware('can:1')
+                     ->can('2')
+                     ->middleware('3')
+                     ->can('4')
+                     ->get('users', fn() => 'all-users');
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+        $this->assertEquals([
+            'can:1',
+            'can:2',
+            '3',
+            'can:4',
+        ], $this->getRoute()->middleware());
+    }
+
     public function testNullNamespaceIsRespected()
     {
         $this->router->middleware(['one'])->namespace(null)->get('users', function () {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -73,17 +73,18 @@ class RouteRegistrarTest extends TestCase
     public function testMiddlewareAndCanDoesNotOverrideEachOtherOnFluentRegistration()
     {
         $this->router->middleware('can:1')
-                     ->can('2')
-                     ->middleware('3')
-                     ->can('4')
+                     ->can('2', 'a')
+                     ->middleware('3', '4')
+                     ->can('5')
                      ->get('users', fn() => 'all-users');
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->assertEquals([
             'can:1',
-            'can:2',
+            'can:2,a',
             '3',
-            'can:4',
+            '4',
+            'can:5',
         ], $this->getRoute()->middleware());
     }
 
@@ -797,19 +798,31 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware('can:create,Illuminate\Routing\Router');
     }
 
+    public function testCanSetMultipleMiddlewareOnRegisteredResource()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->middleware('3', '4');
+
+        $this->assertEquals([
+            '3',
+            '4',
+        ], $this->getRoute()->middleware());
+    }
+
     public function testMiddlewareAndCanDoesNotOverrideEachOtherOnRegisteredResource()
     {
         $this->router->resource('users', RouteRegistrarControllerStub::class)
                      ->middleware('can:1')
                      ->can('2')
-                     ->middleware('3')
-                     ->can('4');
+                     ->middleware('3', '4')
+                     ->can('5');
 
         $this->assertEquals([
             'can:1',
             'can:2',
             '3',
-            'can:4',
+            '4',
+            'can:5',
         ], $this->getRoute()->middleware());
     }
 


### PR DESCRIPTION
I really enjoy the `can` method added in #39464. So much that I often run into situations where I try to use it but it's not available there (yet).

This PR adds the ability to use of `can` in these two constructions:

```php
Route::resource('users', UserController::class)->can('manage-users');

Route::can('view-enums')->group(function () {
    Route::get('statuses', fn() => 'Ok');
});
```

To prevent `can('action')->middleware('mw')` or `middleware('mw')->can('action')` from overriding each other I changed the behaviour of `->middleware()` to merge the middleware stack instead of overriding it:

```php
Route::middleware('a')
    ->middleware('b')
    ->get('users', fn() => 'Ok');

Route::resource('users', UserController::class)
    ->middleware('a')
    ->middleware('b');
```

These previously lead to middleware stack `['b']`, but now lead to middleware stack `['a', 'b']` and that is why this PR is a breaking change. This new behaviour is consistent with how `->middleware('x')` behaves on a route (e.g. when chaining after `Route::get()`).

And one more consistency improvement is that comma-separated arg list can now be used to set multiple middlewares on resources, just like it was already available on `Route::middleware()` and `Route::get()->middleware()`:

```php
// Previously 'b' and 'c' would be discarded
Route::resource('users', UserController::class)->middleware('a', 'b', 'c');
```