### PR TITLE
[10.x] Pass the full custom pivot model to the `deleting` & `deleted` events.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -475,7 +475,7 @@ trait InteractsWithPivotTable
 
         $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
 
-        foreach($pivots as $pivot) {
+        foreach ($pivots as $pivot) {
             $results += $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)->delete();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -473,7 +473,10 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
+        $pivots = $this->using::withoutGlobalScopes()
+            ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
+            ->whereIn($this->relatedPivotKey, $this->parseIds($ids))
+            ->get();
 
         foreach ($pivots as $pivot) {
             $results += $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)->delete();

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -473,11 +473,10 @@ trait InteractsWithPivotTable
     {
         $results = 0;
 
-        foreach ($this->parseIds($ids) as $id) {
-            $results += $this->newPivot([
-                $this->foreignPivotKey => $this->parent->{$this->parentKey},
-                $this->relatedPivotKey => $id,
-            ], true)->delete();
+        $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
+
+        foreach($pivots as $pivot) {
+            $results += $pivot->delete();
         }
 
         return $results;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -476,7 +476,7 @@ trait InteractsWithPivotTable
         $pivots = $this->using::where($this->foreignPivotKey, $this->parent->{$this->parentKey})->whereIn($this->relatedPivotKey, $this->parseIds($ids))->get();
 
         foreach($pivots as $pivot) {
-            $results += $pivot->delete();
+            $results += $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)->delete();
         }
 
         return $results;


### PR DESCRIPTION
The changes made in this PR will provide the actual pivot model to be passed into the `deleting` & `deleted` events, instead of solely the foreign pivot key & related pivot key.

🔴 Full description & conversation in #42668. (Closed for 8.x)