### PR TITLE
[9.x] Introduce Invokable validation classes

### DIFF
--- a/src/Illuminate/Contracts/Validation/InvokableRule.php
+++ b/src/Illuminate/Contracts/Validation/InvokableRule.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface InvokableRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function __invoke($attribute, $value, $fail);
+}

--- a/src/Illuminate/Translation/PotentiallyTranslatedString.php
+++ b/src/Illuminate/Translation/PotentiallyTranslatedString.php
@@ -32,7 +32,7 @@ class PotentiallyTranslatedString implements Stringable
      * Create a new potentially translated string.
      *
      * @param  string  $string
-     * @param \Illuminate\Contracts\Translation\Translator  $translator
+     * @param  \Illuminate\Contracts\Translation\Translator  $translator
      */
     public function __construct($string, $translator)
     {

--- a/src/Illuminate/Translation/PotentiallyTranslatedString.php
+++ b/src/Illuminate/Translation/PotentiallyTranslatedString.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Illuminate\Translation;
+
+use RuntimeException;
+use Stringable;
+
+class PotentiallyTranslatedString implements Stringable
+{
+    /**
+     * The string that may be translated.
+     *
+     * @var string
+     */
+    protected $string;
+
+    /**
+     * The translated string.
+     *
+     * @var string|null
+     */
+    protected $translation;
+
+    /**
+     * The validator that may perform the translation.
+     *
+     * @var \Illuminate\Contracts\Translation\Translator
+     */
+    protected $translator;
+
+    /**
+     * Create a new potentially translated string.
+     *
+     * @param  string  $string
+     * @param \Illuminate\Contracts\Translation\Translator  $translator
+     */
+    public function __construct($string, $translator)
+    {
+        $this->string = $string;
+
+        $this->translator = $translator;
+    }
+
+    /**
+     * Translate the string.
+     *
+     * @return $this
+     */
+    public function translate()
+    {
+        if (! $this->translator->has($this->string)) {
+            throw new RuntimeException("Unable to find translation [{$this->string}] for locale [{$this->translator->getLocale()}].");
+        }
+
+        $this->translation = $this->translator->get($this->string);
+
+        return $this;
+    }
+
+    /**
+     * Get the original string.
+     *
+     * @return string
+     */
+    public function original()
+    {
+        return $this->string;
+    }
+
+    /**
+     * Get the potentially translated string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->translation ?? $this->string;
+    }
+
+    /**
+     * Get the potentially translated string.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return (string) $this;
+    }
+}

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ImplicitRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class InvokableValidationRule implements Rule, ValidatorAwareRule
+{
+    /**
+     * The invokable that validates the attribute.
+     *
+     * @var \Illuminate\Contracts\Validation\InvokableRule
+     */
+    protected $invokable;
+
+    /**
+     * Indicates if the validation invokable failed.
+     *
+     * @var bool
+     */
+    protected $failed = false;
+
+    /**
+     * The validation error messages.
+     *
+     * @var array
+     */
+    protected $messages = [];
+
+    /**
+     * The current validator.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * Create a new implicit or explicit Invokable validation rule.
+     *
+     * @param  \Illuminate\Contracts\Validation\InvokableRule  $invokable
+     * @return \Illuminate\Contracts\Validation\ImplicitRule
+     */
+    public static function make($invokable)
+    {
+        if ($invokable->implicit ?? false) {
+            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {
+                //
+            };
+        }
+
+        return new InvokableValidationRule($invokable);
+    }
+
+    /**
+     * Create a new explicit Invokable validation rule.
+     *
+     * @param  \Illuminate\Contracts\Validation\InvokableRule  $invokable
+     * @return void
+     */
+    protected function __construct($invokable)
+    {
+        $this->invokable = $invokable;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->failed = false;
+
+        if ($this->invokable instanceof DataAwareRule) {
+            $this->invokable->setData($this->validator->getData());
+        }
+
+        if ($this->invokable instanceof ValidatorAwareRule) {
+            $this->invokable->setValidator($this->validator);
+        }
+
+        $this->invokable->__invoke($attribute, $value, function ($message) {
+            $this->failed = true;
+
+            return $this->pendingPotentiallyTranslatedString($message);
+        });
+
+        return ! $this->failed;
+    }
+
+    /**
+     * Get the validation error messages.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Create a pending potentially translated string.
+     *
+     * @param  string  $message
+     * @return \Illuminate\Translation\PotentiallyTranslatedString
+     */
+    protected function pendingPotentiallyTranslatedString($message)
+    {
+        return new class (
+            $message,
+            $this->validator->getTranslator(),
+            fn ($message) => $this->messages[] = $message
+        ) extends PotentiallyTranslatedString {
+            /**
+             * The callback to call when the object destructs.
+             *
+             * @var \Closure
+             */
+            protected $destructor;
+
+            /**
+             * Create a new pending potentially translated string.
+             *
+             * @param  string  $string
+             * @param  \Illuminate\Contracts\Translation\Translator  $translator
+             * @param  \Closure  $destructor
+             */
+            public function __construct($message, $translator, $destructor)
+            {
+                parent::__construct($message, $translator);
+
+                $this->destructor = $destructor;
+            }
+
+            /**
+             * Handle the object's destruction.
+             *
+             * @return void
+             */
+            public function __destruct()
+            {
+                ($this->destructor)($this->toString());
+            }
+        };
+    }
+}

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ImplicitRule;
+use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Translation\PotentiallyTranslatedString;
@@ -46,6 +47,17 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     protected $data = [];
 
     /**
+     * Create a new explicit Invokable validation rule.
+     *
+     * @param  \Illuminate\Contracts\Validation\InvokableRule  $invokable
+     * @return void
+     */
+    protected function __construct(InvokableRule $invokable)
+    {
+        $this->invokable = $invokable;
+    }
+
+    /**
      * Create a new implicit or explicit Invokable validation rule.
      *
      * @param  \Illuminate\Contracts\Validation\InvokableRule  $invokable
@@ -61,17 +73,6 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
         }
 
         return new InvokableValidationRule($invokable);
-    }
-
-    /**
-     * Create a new explicit Invokable validation rule.
-     *
-     * @param  \Illuminate\Contracts\Validation\InvokableRule  $invokable
-     * @return void
-     */
-    protected function __construct($invokable)
-    {
-        $this->invokable = $invokable;
     }
 
     /**

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -54,7 +54,8 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     public static function make($invokable)
     {
         if ($invokable->implicit ?? false) {
-            return new class($invokable) extends InvokableValidationRule implements ImplicitRule {
+            return new class($invokable) extends InvokableValidationRule implements ImplicitRule
+            {
                 //
             };
         }
@@ -145,11 +146,8 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
      */
     protected function pendingPotentiallyTranslatedString($message)
     {
-        return new class (
-            $message,
-            $this->validator->getTranslator(),
-            fn ($message) => $this->messages[] = $message
-        ) extends PotentiallyTranslatedString {
+        return new class($message, $this->validator->getTranslator(), fn ($message) => $this->messages[] = $message) extends PotentiallyTranslatedString
+        {
             /**
              * The callback to call when the object destructs.
              *

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Closure;
+use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -112,6 +113,10 @@ class ValidationRuleParser
     {
         if ($rule instanceof Closure) {
             $rule = new ClosureValidationRule($rule);
+        }
+
+        if ($rule instanceof InvokableRule) {
+            $rule = InvokableValidationRule::make($rule);
         }
 
         if (! is_object($rule) ||

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -16,7 +16,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanPass()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class () implements InvokableRule {
+        $rule = new class() implements InvokableRule
+        {
             public function __invoke($attribute, $value, $fail)
             {
                 //
@@ -32,7 +33,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanFail()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class () implements InvokableRule {
+        $rule = new class() implements InvokableRule
+        {
             public function __invoke($attribute, $value, $fail)
             {
                 $fail("The {$attribute} attribute is not 'foo'. Got '{$value}' instead.");
@@ -52,7 +54,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanReturnMultipleErrorMessages()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class () implements InvokableRule {
+        $rule = new class() implements InvokableRule
+        {
             public function __invoke($attribute, $value, $fail)
             {
                 $fail('Error message 1.');
@@ -65,8 +68,8 @@ class ValidationInvokableRuleTest extends TestCase
         $this->assertTrue($validator->fails());
         $this->assertSame([
             'foo' => [
-                "Error message 1.",
-                "Error message 2.",
+                'Error message 1.',
+                'Error message 2.',
             ],
         ], $validator->messages()->messages());
     }
@@ -75,7 +78,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.translated-error' => 'Translated error message.'], 'en');
-        $rule = new class () implements InvokableRule {
+        $rule = new class() implements InvokableRule
+        {
             public function __invoke($attribute, $value, $fail)
             {
                 $fail('validation.translated-error')->translate();
@@ -87,7 +91,7 @@ class ValidationInvokableRuleTest extends TestCase
         $this->assertTrue($validator->fails());
         $this->assertSame([
             'foo' => [
-                "Translated error message.",
+                'Translated error message.',
             ],
         ], $validator->messages()->messages());
     }
@@ -95,7 +99,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanAccessDataDuringValidation()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class () implements InvokableRule, DataAwareRule {
+        $rule = new class() implements InvokableRule, DataAwareRule
+        {
             public $data = [];
 
             public function setData($data)
@@ -124,7 +129,8 @@ class ValidationInvokableRuleTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $rule = new class () implements InvokableRule, ValidatorAwareRule {
+        $rule = new class() implements InvokableRule, ValidatorAwareRule
+        {
             public $validator = null;
 
             public function setValidator($validator)
@@ -149,7 +155,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanBeExplicit()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class () implements InvokableRule {
+        $rule = new class() implements InvokableRule
+        {
             public $implicit = false;
 
             public function __invoke($attribute, $value, $fail)
@@ -167,7 +174,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItCanBeImplicit()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class () implements InvokableRule {
+        $rule = new class() implements InvokableRule
+        {
             public $implicit = true;
 
             public function __invoke($attribute, $value, $fail)
@@ -189,7 +197,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItIsExplicitByDefault()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class () implements InvokableRule {
+        $rule = new class() implements InvokableRule
+        {
             public function __invoke($attribute, $value, $fail)
             {
                 $fail('xxxx');
@@ -205,7 +214,8 @@ class ValidationInvokableRuleTest extends TestCase
     public function testItThrowsIfTranslationIsNotFound()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $rule = new class () implements InvokableRule {
+        $rule = new class() implements InvokableRule
+        {
             public function __invoke($attribute, $value, $fail)
             {
                 $fail('validation.key')->translate();

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\InvokableRule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ValidationInvokableRuleTest extends TestCase
+{
+    public function testItCanPass()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class () implements InvokableRule {
+            public function __invoke($attribute, $value, $fail)
+            {
+                //
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->passes());
+        $this->assertSame([], $validator->messages()->messages());
+    }
+
+    public function testItCanFail()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class () implements InvokableRule {
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail("The {$attribute} attribute is not 'foo'. Got '{$value}' instead.");
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame([
+            'foo' => [
+                "The foo attribute is not 'foo'. Got 'bar' instead.",
+            ],
+        ], $validator->messages()->messages());
+    }
+
+    public function testItCanReturnMultipleErrorMessages()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class () implements InvokableRule {
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('Error message 1.');
+                $fail('Error message 2.');
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame([
+            'foo' => [
+                "Error message 1.",
+                "Error message 2.",
+            ],
+        ], $validator->messages()->messages());
+    }
+
+    public function testItCanTranslateMessages()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.translated-error' => 'Translated error message.'], 'en');
+        $rule = new class () implements InvokableRule {
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('validation.translated-error')->translate();
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame([
+            'foo' => [
+                "Translated error message.",
+            ],
+        ], $validator->messages()->messages());
+    }
+
+    public function testItCanAccessDataDuringValidation()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class () implements InvokableRule, DataAwareRule {
+            public $data = [];
+
+            public function setData($data)
+            {
+                $this->data = $data;
+            }
+
+            public function __invoke($attribute, $value, $fail)
+            {
+                if ($this->data === []) {
+                    $fail('xxxx');
+                }
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar', 'bar' => 'baz'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->passes());
+        $this->assertSame([
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ], $rule->data);
+    }
+
+    public function testItCanAccessValidatorDuringValidation()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $rule = new class () implements InvokableRule, ValidatorAwareRule {
+            public $validator = null;
+
+            public function setValidator($validator)
+            {
+                $this->validator = $validator;
+            }
+
+            public function __invoke($attribute, $value, $fail)
+            {
+                if ($this->validator === null) {
+                    $fail('xxxx');
+                }
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar', 'bar' => 'baz'], ['foo' => $rule]);
+
+        $this->assertTrue($validator->passes());
+        $this->assertSame($validator, $rule->validator);
+    }
+
+    public function testItCanBeExplicit()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class () implements InvokableRule {
+            public $implicit = false;
+
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('xxxx');
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => ''], ['foo' => $rule]);
+
+        $this->assertTrue($validator->passes());
+        $this->assertSame([], $validator->messages()->messages());
+    }
+
+    public function testItCanBeImplicit()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class () implements InvokableRule {
+            public $implicit = true;
+
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('xxxx');
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => ''], ['foo' => $rule]);
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame([
+            'foo' => [
+                'xxxx',
+            ],
+        ], $validator->messages()->messages());
+    }
+
+    public function testItIsExplicitByDefault()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class () implements InvokableRule {
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('xxxx');
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => ''], ['foo' => $rule]);
+
+        $this->assertTrue($validator->passes());
+        $this->assertSame([], $validator->messages()->messages());
+    }
+
+    public function testItThrowsIfTranslationIsNotFound()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class () implements InvokableRule {
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('validation.key')->translate();
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to find translation [validation.key] for locale [en].');
+
+        $validator->passes();
+    }
+
+    private function getIlluminateArrayTranslator()
+    {
+        return new Translator(
+            new ArrayLoader(),
+            'en'
+        );
+    }
+}


### PR DESCRIPTION
This PR aims to introduce a new class based validation implementation that mixes the brevity + simplicity of Closure based rules with the shareable, extendable, and chainable nature of class based rules by introducing an Invokable validation rule.

Some additional notes:

- Brings 1st party translation support to failure messages, without the need to reach for the translation helper.
- You no longer need to manage state around messages and failures when it comes to complex validation where multiple validation errors may occur.
- Within a complex validation rule, you can no longer add a messaged and return true. Adding a messages causes the rule to fail - so no more double handling.
- Having the error messages managed in another layer also creates consistency across validation rules.
- An exception is thrown when it is unable to find a validation key, if `$fail('key')->translate()` is called. I've see this a bit where validation messages are not added. This makes it strict about finding the validation message.

Below is a comparison of the two implementations with a rule that handles a rich object...

```php
class Quantity implements Rule
{
    protected $messages = [];

    public function passes($attribute, $value)
    {
        if (! is_array($value)) {
            $this->messages[] = trans('validation.quantity.must_be_an_object');

            return false;
        }

        if (! array_key_exists('magnitude', $value)) {
            $this->messages[] = trans('validation.quantity.missing_magnitude');
        }

        if (! array_key_exists('units', $value)) {
            $this->messages[] = trans('validation.quantity.missing_units');
        }

        return $this->messages === [];
    }

    public function message()
    {
        return $this->messages;
    }
}
```

```php
class InvokableQuantity implements InvokableRule
{
    public function __invoke($attribute, $value, $fail)
    {
        if (! is_array($value)) {
            return $fail('validation.quantity.must_be_an_object')->translate();
        }

        if (! array_key_exists('magnitude', $value)) {
            $fail('validation.quantity.missing_magnitude')->translate();
        }

        if (! array_key_exists('units', $value)) {
            $fail('validation.quantity.missing_units')->translate();
        }
    }
}
```