### PR TITLE
[9.x] Add ability to define "with" relations as a nested array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1430,22 +1430,13 @@ class Builder implements BuilderContract
      */
     protected function parseWithRelations(array $relations)
     {
+        if ($relations === []) {
+            return [];
+        }
+
         $results = [];
 
-        foreach ($relations as $name => $constraints) {
-            // If the "name" value is a numeric key, we can assume that no constraints
-            // have been specified. We will just put an empty Closure there so that
-            // we can treat these all the same while we are looping through them.
-            if (is_numeric($name)) {
-                $name = $constraints;
-
-                [$name, $constraints] = str_contains($name, ':')
-                            ? $this->createSelectWithConstraint($name)
-                            : [$name, static function () {
-                                //
-                            }];
-            }
-
+        foreach ($this->prepareNestedWithRelationships($relations) as $name => $constraints) {
             // We need to separate out any nested includes, which allows the developers
             // to load deep relationships using "dots" without stating each level of
             // the relationship with its own key in the array of eager-load names.
@@ -1455,6 +1446,91 @@ class Builder implements BuilderContract
         }
 
         return $results;
+    }
+
+    /**
+     * Prepare nested with relationships.
+     *
+     * @param  array  $relations
+     * @param  string  $prefix
+     * @return array
+     */
+    protected function prepareNestedWithRelationships($relations, $prefix = '')
+    {
+        $preparedRelationships = [];
+
+        if ($prefix !== '') {
+            $prefix .= '.';
+        }
+
+        // If any of the relationships are formatted with the [$attribute => array()]
+        // syntax, we shall loop over the nested relations and prepend each key of
+        // the array while flattening into the traditional dot notation format.
+        foreach ($relations as $key => $value) {
+            if (! is_string($key) || ! is_array($value)) {
+                continue;
+            }
+
+            [$attribute, $attributeSelectConstraint] = $this->parseNameAndAttributeSelectionConstraint($key);
+
+            $preparedRelationships = array_merge(
+                $preparedRelationships,
+                ["{$prefix}{$attribute}" => $attributeSelectConstraint],
+                $this->prepareNestedWithRelationships($value, "{$prefix}{$attribute}"),
+            );
+
+            unset($relations[$key]);
+        }
+
+        // We now know that the remaining relationships are in a dot notation format.
+        // The values maybe a string or a Closure. We'll loop over them and ensure
+        // existing Closures are merged and strings are made into a constraint.
+        foreach ($relations as $key => $value) {
+            if (is_numeric($key) && is_string($value)) {
+                [$key, $value] = $this->parseNameAndAttributeSelectionConstraint($value);
+            }
+
+            $preparedRelationships[$prefix.$key] = $this->combineContraints([
+                $value,
+                $preparedRelationships[$prefix.$key] ?? static function () {
+                    //
+                },
+            ]);
+        }
+
+        return $preparedRelationships;
+    }
+
+    /**
+     * Combine an array of constraints into a single constraint.
+     *
+     * @param  array  $constriants
+     * @return \Closure
+     */
+    protected function combineContraints(array $constraints)
+    {
+        return function ($builder) use ($constraints) {
+            foreach ($constraints as $constraint) {
+                $builder = $constraint($builder) ?? $builder;
+            }
+
+            return $builder;
+        };
+    }
+
+    /**
+     * Parse the attribute select constraints from the name.
+     *
+     * @param  string  $name
+     * @return array
+     */
+    protected function parseNameAndAttributeSelectionConstraint($name)
+    {
+        return str_contains($name, ':')
+            ? $this->createSelectWithConstraint($name)
+            : [$name, static function () {
+                //
+            }];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1465,7 +1465,7 @@ class Builder implements BuilderContract
 
         // If any of the relationships are formatted with the [$attribute => array()]
         // syntax, we shall loop over the nested relations and prepend each key of
-        // the array while flattening into the traditional dot notation format.
+        // this array while flattening into the traditional dot notation format.
         foreach ($relations as $key => $value) {
             if (! is_string($key) || ! is_array($value)) {
                 continue;
@@ -1482,9 +1482,9 @@ class Builder implements BuilderContract
             unset($relations[$key]);
         }
 
-        // We now know that the remaining relationships are in a dot notation format.
-        // The values maybe a string or a Closure. We'll loop over them and ensure
-        // existing Closures are merged and strings are made into a constraint.
+        // We now know that the remaining relationships are in a dot notation format
+        // and may be a string or Closure. We'll loop over them and ensure all of
+        // the present Closures are merged + strings are made into constraints.
         foreach ($relations as $key => $value) {
             if (is_numeric($key) && is_string($value)) {
                 [$key, $value] = $this->parseNameAndAttributeSelectionConstraint($value);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1490,7 +1490,7 @@ class Builder implements BuilderContract
                 [$key, $value] = $this->parseNameAndAttributeSelectionConstraint($value);
             }
 
-            $preparedRelationships[$prefix.$key] = $this->combineContraints([
+            $preparedRelationships[$prefix.$key] = $this->combineConstraints([
                 $value,
                 $preparedRelationships[$prefix.$key] ?? static function () {
                     //
@@ -1504,10 +1504,10 @@ class Builder implements BuilderContract
     /**
      * Combine an array of constraints into a single constraint.
      *
-     * @param  array  $constriants
+     * @param  array  $constraints
      * @return \Closure
      */
-    protected function combineContraints(array $constraints)
+    protected function combineConstraints(array $constraints)
     {
         return function ($builder) use ($constraints) {
             foreach ($constraints as $constraint) {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -842,7 +842,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         }]);
         $eagers = $builder->getEagerLoads();
 
-        $this->assertSame('foo', $eagers['orders']());
+        $this->assertSame('foo', $eagers['orders']($this->getBuilder()));
 
         $builder = $this->getBuilder();
         $builder->with(['orders.lines' => function () {
@@ -852,7 +852,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $this->assertInstanceOf(Closure::class, $eagers['orders']);
         $this->assertNull($eagers['orders']());
-        $this->assertSame('foo', $eagers['orders.lines']());
+        $this->assertSame('foo', $eagers['orders.lines']($this->getBuilder()));
 
         $builder = $this->getBuilder();
         $builder->with('orders.lines', function () {
@@ -862,7 +862,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $this->assertInstanceOf(Closure::class, $eagers['orders']);
         $this->assertNull($eagers['orders']());
-        $this->assertSame('foo', $eagers['orders.lines']());
+        $this->assertSame('foo', $eagers['orders.lines']($this->getBuilder()));
     }
 
     public function testQueryPassThru()

--- a/tests/Integration/Database/EloquentMultiDimensionalArrayEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMultiDimensionalArrayEagerLoadingTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMultiDimensionalArrayEagerLoadingTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentMultiDimensionalArrayEagerLoadingTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('avatars', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('content');
+            $table->unsignedInteger('user_id');
+        });
+
+        Schema::create('images', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('content');
+            $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('tags', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('comment_id');
+        });
+
+        $user = User::create();
+        $user->avatar()->create();
+        $posts = $user->posts()->createMany([
+            [
+                'title' => '1. post title',
+                'content' => '1. post content',
+            ],
+            [
+                'title' => '2. post title',
+                'content' => '2. post content',
+            ],
+        ]);
+        $posts->map->image()->each->create();
+        $comments = $posts->map->comments()->map->create([
+            'title' => 'comment title',
+            'content' => 'comment content',
+        ]);
+        $comments->map->tags()->each->create();
+        $comments->map->tags()->each->create();
+        $comments->map->tags()->each->create();
+    }
+
+    public function testItCanEagerLoad()
+    {
+        DB::enableQueryLog();
+
+        $users = User::query()
+            ->with([
+                'avatar',
+                'posts' => [
+                    'comments' => [
+                        'tags',
+                    ],
+                    'image',
+                ],
+            ])->get();
+
+        $this->assertCount(6, DB::getQueryLog());
+        $this->assertCount(1, $users);
+        $this->assertTrue($users[0]->relationLoaded('avatar'));
+        $this->assertNotNull($users[0]->avatar);
+        $this->assertTrue($users[0]->relationLoaded('posts'));
+        $this->assertCount(2, $users[0]->posts);
+        $this->assertTrue($users[0]->posts[0]->isNot($users[0]->posts[1]));
+        $this->assertTrue($users[0]->posts->every->relationLoaded('image'));
+        $this->assertCount(2, $users[0]->posts->map->image);
+        $this->assertTrue($users[0]->posts[0]->image->isNot($users[0]->posts[1]->image));
+        $this->assertTrue($users[0]->posts->every->relationLoaded('comments'));
+        $this->assertCount(2, $users[0]->posts->flatMap->comments);
+        $this->assertTrue($users[0]->posts[0]->comments[0]->isNot($users[0]->posts[1]->comments[0]));
+        $this->assertTrue($users[0]->posts->flatMap->comments->every->relationLoaded('tags'));
+        $this->assertCount(6, $users[0]->posts->flatMap->comments->flatMap->tags);
+    }
+
+    public function testItAppliesConstraintsViaClosuresAndCanContinueEagerLoading()
+    {
+        DB::enableQueryLog();
+
+        $users = User::query()
+            ->with([
+                'posts' => fn ($query) => $query->withCount('comments')->with([
+                    'comments' => [
+                        'tags',
+                    ],
+                ]),
+            ])
+            ->get();
+
+        $this->assertCount(4, DB::getQueryLog());
+        $this->assertCount(1, $users);
+        $this->assertTrue($users[0]->relationLoaded('posts'));
+        $this->assertCount(2, $users[0]->posts);
+        $users[0]->posts->every(fn ($post) => $this->assertEquals(1, $post->comments_count));
+        $this->assertTrue($users[0]->posts->every->relationLoaded('comments'));
+        $this->assertCount(2, $users[0]->posts->flatMap->comments);
+        $this->assertTrue($users[0]->posts->flatMap->comments->every->relationLoaded('tags'));
+    }
+
+    public function testItCanSpecifyAttributesToSelectInKeys()
+    {
+        DB::enableQueryLog();
+
+        $users = User::query()
+            ->with([
+                'posts:id,title,user_id' => [
+                    'comments:id,content,post_id' => [
+                        'tags',
+                    ],
+                ],
+            ])
+            ->get();
+
+        $this->assertCount(4, DB::getQueryLog());
+        $this->assertCount(1, $users);
+        $this->assertTrue($users[0]->relationLoaded('posts'));
+        $this->assertCount(2, $users[0]->posts);
+        $users[0]->posts->every(fn ($post) => $this->assertSame(['id', 'title', 'user_id'], array_keys($post->getAttributes())));
+        $this->assertTrue($users[0]->posts->every->relationLoaded('comments'));
+        $this->assertCount(2, $users[0]->posts->flatMap->comments);
+        $users[0]->posts->flatMap->comments->every(fn ($post) => $this->assertSame(['id', 'content', 'post_id'], array_keys($post->getAttributes())));
+        $this->assertTrue($users[0]->posts->flatMap->comments->every->relationLoaded('tags'));
+        $this->assertCount(6, $users[0]->posts->flatMap->comments->flatMap->tags);
+    }
+
+    public function testItMixesWithDotNotation()
+    {
+        DB::enableQueryLog();
+
+        $users = User::query()
+            ->with([
+                'posts' => [
+                    'comments',
+                ],
+                'posts.image',
+            ])
+            ->get();
+
+        $this->assertCount(4, DB::getQueryLog());
+        $this->assertCount(1, $users);
+        $this->assertTrue($users[0]->relationLoaded('posts'));
+        $this->assertCount(2, $users[0]->posts);
+        $this->assertTrue($users[0]->posts->every->relationLoaded('comments'));
+        $this->assertCount(2, $users[0]->posts->flatMap->comments);
+        $this->assertTrue($users[0]->posts->every->relationLoaded('image'));
+        $this->assertCount(2, $users[0]->posts->map->image);
+    }
+
+    public function testItMixesConstraintsFromDotNotation()
+    {
+        DB::enableQueryLog();
+
+        $users = User::query()
+            ->with([
+                'posts.comments' => fn ($query) => $query->with('tags'),
+                'posts:id,title,user_id' => [
+                    'comments' => fn ($query) => $query->withCount('tags'),
+                ],
+            ])
+            ->get();
+
+        $this->assertCount(4, DB::getQueryLog());
+        $this->assertCount(1, $users);
+        $this->assertTrue($users[0]->relationLoaded('posts'));
+        $this->assertCount(2, $users[0]->posts);
+        $users[0]->posts->every(fn ($post) => $this->assertNull($post->content));
+        $this->assertTrue($users[0]->posts->every->relationLoaded('comments'));
+        $this->assertCount(2, $users[0]->posts->flatMap->comments);
+        $users[0]->posts->flatMap->comments->every(fn ($comment) => $this->assertEquals(3, $comment->tags_count));
+        $this->assertTrue($users[0]->posts->flatMap->comments->every->relationLoaded('tags'));
+        $this->assertCount(6, $users[0]->posts->flatMap->comments->flatMap->tags);
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+
+    public function avatar()
+    {
+        return $this->hasOne(Avatar::class);
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function image()
+    {
+        return $this->hasOne(Image::class);
+    }
+}
+
+class Image extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function tags()
+    {
+        return $this->hasMany(Tag::class);
+    }
+}
+
+class Tag extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+}
+
+class Avatar extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}


### PR DESCRIPTION
## Purpose

This PR aims to add the ability to specify relationship "withs" as a PHP array, rather than dot notation.

## Usage

```php
// before...

User::with([
    'avatar',
    'posts.tags',
    'posts.author',
    'posts.featureImage',
    'posts.comments.tags' => fn ($q) => $q->latest(),
])->get();

// after...

User::with([
    'avatar',
    'posts' => [
        'tags',
        'author',
        'featureImage',
        'comments' => [
            'tags' => fn ($q) => $q->latest(),
        ],
    ],
])->get();

```

### Advanced

```php
// supports chaining...

User::with([
    'posts' => fn ($q) => $q->withCount('comments')->with([
        'comments' => [
            'tags',
        ],
    ]),
])->get();

// supports specifying attributes inline, although I think with this notation you
// should probably be specifying selects via a constraint.

User::with([
    'posts:id,title,user_id' => [
        'comments:id,content,post_id' => [
            'tags',
        ],
    ],
])->get();

// supports mixing notation. Not saying you should, just saying you can 🙈

User::with([
    'posts' => [
        'comments',
    ],
    'posts.image',
])->get();

// merges constraints from different notation - again, not saying you should. just saying you can.

User::with([
    'posts.comments' => fn ($q) => $q->with('tags'),
    'posts:id,title,user_id' => [
        'comments' => fn ($q) => $q->withCount('tags'),
    ],
])->get();


```

## What isn't supported

I should note that merging of selects from different notation is not supported. I don't see this as a problem, as the current dot notation suffers from the same constraint...

```php
// does not select "id" and "name"
User::query()
    ->with(['users:id,name'])
    ->with(['users:email'])
    ->get();

// nor does this...

User::query()
    ->with(['users' => fn ($q) => $q->select(['id', 'name'])])
    ->with(['users:email'])
    ->get();
```

and so the following is explicitly not supported...

```php
User::with([
    'posts.comments' => fn ($q) => $q->addSelect(['id']),
    'posts' => [
        'comments' => fn ($q) => $q->addSelect(['post_id'])
    ],
])->get();

User::with([
    'posts' => [
        'comments:post_id,title'
    ],
    'posts.comments:id',
])->get();
```

or any other mixture of notation with duplicate selects.

## Notes

I'd love to get some eyes on this from a range of people who are deep in Eloquent land.