### PR TITLE
[9.x] Added `quarterlyOn` cron schedule frequency command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -470,6 +470,8 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run quarterly on a given day and time.
      *
+     * @param  int  $dayOfQuarter
+     * @param  int  $time
      * @return $this
      */
     public function quarterlyOn($dayOfQuarter = 1, $time = '0:0')

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -468,6 +468,19 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run quarterly on a given day and time.
+     *
+     * @return $this
+     */
+    public function quarterlyOn($dayOfQuarter = 1, $time = '0:0')
+    {
+        $this->dailyAt($time);
+
+        return $this->spliceIntoPosition(3, $dayOfQuarter)
+                    ->spliceIntoPosition(4, '1-12/3');
+    }
+
+    /**
      * Schedule the event to run yearly.
      *
      * @return $this


### PR DESCRIPTION
quarterlyOn cron scheduling frequency was missing before.
I beleive it could be a great asset to have it for use. 
I understand that the dayOfQuarter will be affecting the first month of the quarter,  but I beleive it could be still pretty useful to be able to set up cron commands quarterly with the possibility to set the day.