### PR TITLE
[9.x] Prevent `$mailer` being reset when testing mailables that implement `ShouldQueue`

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -351,11 +351,11 @@ class MailFake implements Factory, Mailer, MailQueue
 
         $view->mailer($this->currentMailer);
 
-        $this->currentMailer = null;
-
         if ($view instanceof ShouldQueue) {
             return $this->queue($view, $data);
         }
+        
+        $this->currentMailer = null;
 
         $this->mailables[] = $view;
     }


### PR DESCRIPTION
```php
class Signup extends Mailable implements ShouldQueue
{
    // snip
}
```

```php
Mail::mailer('mail-connection')
    ->to('some@address.com')
    ->send(new Signup());
```

```php
public function send_signup_using_correct_mailer()
{
    Mail::fake();

    // snip

    Mail::assertQueued(Signup::class, function ($mail) {
        return $mail->mailer == 'mail-connection'; // FAILS: It is actually NULL
    });
}
```

When calling `send()`, the `$mailer` is set on the `Mailable` instance, then immediately reset to `null` on the `MailFake` (which it should do).

The problem occurs when the `Mailable` implements `ShouldQueue`. After the `$mailer` property has been reset, the `queue()` method then sets the `$mailer` again on the `Mailable`, but this time it is now `NULL`.

This change fixes that.