### PR TITLE
[9.x] Add rememberUntil method to cache

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -505,6 +505,35 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Get an item from the cache, or execute the given Closure and store the result until dependency is false.
+     *
+     * @param $key
+     * @param $value
+     * @param $dependency
+     * @return mixed
+     */
+    public function rememberUntil($key, $value, $dependency)
+    {
+        $dependency = $dependency instanceof Closure ? $dependency() : $dependency;
+
+        if ($dependency == false) {
+            $this->store->forget($this->itemKey($key));
+        }
+
+        $cache = $this->store->get($key);
+
+        if (! is_null($cache)) {
+            return $cache;
+        }
+
+        $result = $value instanceof Closure ? $value() : $value;
+
+        $this->forever($key, $result);
+
+        return $result;
+    }
+
+    /**
      * Format the key for a cache item.
      *
      * @param  string  $key


### PR DESCRIPTION
cached data may also be invalidated according to some dependency changes. For example, if we are caching the content of some table or file and the table is changed, we should invalidate the cached copy and read the latest content from the table instead of the cache.

for example we want get users that have greater than two like and cache result it then when users update so cache will be expired and restore cache
```
$users = cache()->rememberUntil(
        'user_like',
        fn() => User::select('name', 'email')->where('like','>', '2')->get(),
        fn() => cache('user_like')->max('updated_at') == User::where('like', '>', 2 )->max('updated_at')
    );
```