### PR TITLE
[9.x] Unless validation rule

### DIFF
--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -40,7 +40,7 @@ class ConditionalRules
      * @param  callable|bool  $condition
      * @param  array|string|\Closure  $rules
      * @param  array|string|\Closure  $defaultRules
-     * @param  bool $isInverted
+     * @param  bool  $isInverted
      * @return void
      */
     public function __construct($condition, $rules, $defaultRules = [], $isInverted = false)

--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -62,6 +62,7 @@ class ConditionalRules
         $result = is_callable($this->condition)
                     ? call_user_func($this->condition, new Fluent($data))
                     : $this->condition;
+
         return $this->isInverted ? ! $result : $result;
     }
 

--- a/src/Illuminate/Validation/ConditionalRules.php
+++ b/src/Illuminate/Validation/ConditionalRules.php
@@ -28,18 +28,27 @@ class ConditionalRules
     protected $defaultRules;
 
     /**
+     * Whether the condition should pass for a falsey value.
+     *
+     * @var bool
+     */
+    protected $isInverted;
+
+    /**
      * Create a new conditional rules instance.
      *
      * @param  callable|bool  $condition
      * @param  array|string|\Closure  $rules
      * @param  array|string|\Closure  $defaultRules
+     * @param  bool $isInverted
      * @return void
      */
-    public function __construct($condition, $rules, $defaultRules = [])
+    public function __construct($condition, $rules, $defaultRules = [], $isInverted = false)
     {
         $this->condition = $condition;
         $this->rules = $rules;
         $this->defaultRules = $defaultRules;
+        $this->isInverted = $isInverted;
     }
 
     /**
@@ -50,9 +59,10 @@ class ConditionalRules
      */
     public function passes(array $data = [])
     {
-        return is_callable($this->condition)
+        $result = is_callable($this->condition)
                     ? call_user_func($this->condition, new Fluent($data))
                     : $this->condition;
+        return $this->isInverted ? ! $result : $result;
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -31,6 +31,19 @@ class Rule
     }
 
     /**
+     * Create a new inverted conditional rule set.
+     *
+     * @param  callable|bool  $condition
+     * @param  array|string|\Closure  $rules
+     * @param  array|string|\Closure  $defaultRules
+     * @return \Illuminate\Validation\ConditionalRules
+     */
+    public static function unless($condition, $rules, $defaultRules = [])
+    {
+        return new ConditionalRules(! $condition, $rules, $defaultRules);
+    }
+
+    /**
      * Get a dimensions constraint builder instance.
      *
      * @param  array  $constraints

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -40,7 +40,7 @@ class Rule
      */
     public static function unless($condition, $rules, $defaultRules = [])
     {
-        return new ConditionalRules(! $condition, $rules, $defaultRules, true);
+        return new ConditionalRules($condition, $rules, $defaultRules, true);
     }
 
     /**

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -40,7 +40,7 @@ class Rule
      */
     public static function unless($condition, $rules, $defaultRules = [])
     {
-        return new ConditionalRules(! $condition, $rules, $defaultRules);
+        return new ConditionalRules(! $condition, $rules, $defaultRules, true);
     }
 
     /**

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -134,6 +134,21 @@ class ValidationRuleParserTest extends TestCase
     public function testEmptyConditionalRulesArePreserved()
     {
         $rules = ValidationRuleParser::filterConditionalRules([
+            'name' => Rule::when(true, '', ['string', 'max:10']),
+            'email' => Rule::when(false, ['required', 'min:2'], []),
+            'password' => Rule::when(false, 'required|min:2', 'string|max:10'),
+        ]);
+
+        $this->assertEquals([
+            'name' => [],
+            'email' => [],
+            'password' => ['string', 'max:10'],
+        ], $rules);
+    }
+
+    public function testEmptyInvertedConditionalRulesArePreserved()
+    {
+        $rules = ValidationRuleParser::filterConditionalRules([
             'name' => Rule::unless(false, '', ['string', 'max:10']),
             'email' => Rule::unless(true, ['required', 'min:2'], []),
             'password' => Rule::unless(true, 'required|min:2', 'string|max:10'),


### PR DESCRIPTION
https://github.com/laravel/framework/discussions/42684

The `Conditionable` trait includes a `when()` method for applying a callback if the given value is (or resolves to) truthy. It also provides an `unless()` method that acts in an opposite fashion. This change applies that same paradigm to the Rule class for use in request validation.

## Context

Existing "When" method:

```php
request()->validate([
    'credential' => [
        'min:5',
        Rule::when($isNotAdmin, ['required'])
    ],
]);
```


Proposed "Unless" method:
```php
request()->validate([
    'credential' => [
        'min:5',
        Rule::unless($isAdmin, ['required'])
    ],
]);
```

I think this rule's existence is intuitive (as it was for me).