### PR TITLE
[9.x] Define default Model Validation Rules directly in Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -12,6 +12,13 @@ trait GuardsAttributes
     protected $fillable = [];
 
     /**
+     * The attributes default Validation Rules
+     *
+     * @var array<string>
+     */
+    protected $rules = [];
+
+    /**
      * The attributes that aren't mass assignable.
      *
      * @var array<string>|bool
@@ -251,5 +258,10 @@ trait GuardsAttributes
         }
 
         return $attributes;
+    }
+
+    public function getRules()
+    {
+        return $this->rules;
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\ExcludeIf;
@@ -137,5 +138,24 @@ class Rule
     public static function unique($table, $column = 'NULL')
     {
         return new Unique($table, $column);
+    }
+
+    /**
+     * Get default Validation Rules defined for the Model
+     *
+     * @param  Model|string  $model
+     * @return mixed|void
+     */
+    public static function model(Model|string $model)
+    {
+        if($model instanceof Model) {
+            return $model->getRules();
+        }
+
+        if(class_exists($model) && in_array(Model::class, class_parents(new $model))) {
+            return (new $model)->getRules();
+        }
+
+        throw ValidationException::withMessages(["$model not found for Validation"]);
     }
 }

--- a/tests/Validation/ValidationModelTest.php
+++ b/tests/Validation/ValidationModelTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class ValidationModelTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Carbon::setTestNow(null);
+        m::close();
+    }
+
+    public function testModelRuleReturnsArrayCorrectly() {
+        $instance = new EloquentModelWithRulesSet();
+
+        $rules = $instance->getRules();
+
+        $this->assertArrayHasKey('name', $rules);
+
+        $this->assertArrayHasKey('email', $rules);
+
+        $this->assertSame(['required','string'], $rules['name']);
+
+        $this->assertSame(['required','email'], $rules['email']);
+    }
+
+    public function testModelRuleWithSetRulesArray() {
+        $validator = Validator::make([
+            'name' => 'My Name',
+            'email' => 'test@example.com'
+        ], Rule::model(EloquentModelWithRulesSet::class));
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function testModelRuleWithoutSetRulesArray() {
+        $validator = Validator::make([
+            'name' => 'My Name',
+            'email' => 'some-email'
+        ], Rule::model(EloquentModelWithRulesSet::class));
+
+        $this->assertTrue($validator->fails());
+
+        $this->assertArrayHasKey('email', $validator->errors()->getMessages());
+
+        $this->assertSame("The email must be a valid email address.", $validator->errors()->getMessages()['email'][0]);
+    }
+
+    public function testModelRuleWithNonExistingModel() {
+        $this->expectException(ValidationException::class);
+
+        $this->expectExceptionMessage("SomeNotExistingModel not found for Validation");
+
+        Validator::make([
+            'name' => 'My Name',
+            'email' => 'some-email'
+        ], [
+            Rule::model('SomeNotExistingModel')
+        ]);
+    }
+}
+
+class EloquentModelWithRulesSet extends Model
+{
+    protected $fillable = [
+        'name', 'email'
+    ];
+
+    protected $rules = [
+        'name' => ['required', 'string'],
+        'email' => ['required','email']
+    ];
+}


### PR DESCRIPTION
This PR adds a property to GuardsAttributes.php => rules. This can be retrieved using getRules() Method.

Additionally Rules.php got a Model Method expecting a string or instance of Illuminate\Database\Eloquent\Model.

Within the rules Property in Eloquent Model, default Validation Rules can be set which are retrieved by Rule::model Method.

For Example, instead of:


```
<?php 

class StoreRequest extends Request
{
public function rules() 
{
return [
'name' => ['required','string','max:255']
];
}
}

class UpdateRequest extends Request
{
public function rules() 
{
return [
'name' => ['required','string','max:255']
];
}
}

```


You can now easily do this:

```
<?php

/* namespace App\Models; */

use Illuminate\Database\Eloquent\Model;

class MyModel extends Model
{
protected $rules = [
'name' => ['required', 'string', 'max:255'
];
}


class StoreRequest extends Request
{
public function rules() 
{
return Rule::model(MyModel::class);
}
}

class UpdateRequest extends Request
{
public function rules() 
{
return Rule::model(MyModel::class);
}
}
```


This is covered by two Checks: 

- If a new Model Instance is used as Argument, it directly returns the result of getRules().
- If the class exists, which is submitted as string and it extends the Illuminate\Database\Eloquent\Models it instantiate the Model and returns the result of getRules().

If a Modelclass was not found, a ValidationException is thrown with declarative Message, containing the Model Name which cannot be resolved for Validation Rules.

