### PR TITLE
[9.x] Fix deprecation error in the `route:list` command

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -400,7 +400,7 @@ class RouteListCommand extends Command
                 $spaces,
                 preg_replace('#({[^}]+})#', '<fg=yellow>$1</>', $uri),
                 $dots,
-                str_replace('   ', ' › ', $action),
+                str_replace('   ', ' › ', $action ?? ''),
             ), $this->output->isVerbose() && ! empty($middleware) ? "<fg=#6C7280>$middleware</>" : null];
         })
             ->flatten()


### PR DESCRIPTION
Let's say you have a closure based route like this:

```php
use Illuminate\Support\Facades\Route;
 
Route::get('/', function () {
    return 'Hello World';
});
```

After you run the `route:list` command, you'll see a deprecation warning in Laravel Telescope (under PHP 8.1), because there is no `action` defined for this route:

```
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/[...]/RouteListCommand.php on line 403
```

- https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation