### PR TITLE
[9.x] Start session in `TestResponse` to allow marshalling of error bag from JSON

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1439,7 +1439,13 @@ EOF;
      */
     protected function session()
     {
-        return app('session.store');
+        $session = app('session.store');
+
+        if (! $session->isStarted()) {
+            $session->start();
+        }
+        
+        return $session;
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1444,7 +1444,7 @@ EOF;
         if (! $session->isStarted()) {
             $session->start();
         }
-        
+
         return $session;
     }
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1853,7 +1853,7 @@ class TestResponseTest extends TestCase
         ]));
 
         $store->save(); // Required to serialize error bag to JSON
- 
+
         $response = TestResponse::fromBaseResponse(new Response());
 
         $response->assertSessionHasErrors(['foo']);

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1840,6 +1840,25 @@ class TestResponseTest extends TestCase
         $response->assertSessionHasErrors(['foo']);
     }
 
+    public function testAssertJsonSerializedSessionHasErrors()
+    {
+        app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1), null, 'json'));
+
+        $store->put('errors', $errorBag = new ViewErrorBag);
+
+        $errorBag->put('default', new MessageBag([
+            'foo' => [
+                'foo is required',
+            ],
+        ]));
+
+        $store->save(); // Required to serialize error bag to JSON
+ 
+        $response = TestResponse::fromBaseResponse(new Response());
+
+        $response->assertSessionHasErrors(['foo']);
+    }
+
     public function testAssertSessionDoesntHaveErrors()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
When using `'session.serialization' => 'json'` the `ViewErrorBag` content is saved as an array and rebuilt when the session data is loaded. In `TestResponse` the `start()` method on the session `Store` was never called, causing the issue discovered by @tanthammar in https://github.com/laravel/framework/issues/42494

This PR adds a `$this->session()->start()` call in `TestResponse` unless the session is already started (i.e. once). The added test fails with `Error: Call to a member function getBag() on array` without the implementation change.

Related to https://github.com/laravel/framework/pull/42090 and https://github.com/laravel/framework/pull/40595