### PR TITLE
[9.x] Allow the "order by field()" use, in MySQL

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2243,33 +2243,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Add an "order by field()" clause to the query.
-     *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
-     * @param  array  $field
-     * @return $this
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function orderByField($column, $field)
-    {
-        if ($this->isQueryable($column)) {
-            [$query, $bindings] = $this->createSub($column);
-
-            $column = new Expression('('.$query.')');
-
-            $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
-        }
-
-        $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
-            'column' => $column,
-            'field' => $field,
-        ];
-
-        return $this;
-    }
-
-    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
@@ -2314,6 +2287,24 @@ class Builder implements BuilderContract
         $type = 'Raw';
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = compact('type', 'sql');
+
+        $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
+
+        return $this;
+    }
+
+    /**
+     * Add an "order by field()" clause to the query.
+     *
+     * @param  string  $sql
+     * @param  array  $bindings
+     * @return $this
+     */
+    public function orderByField($sql, $bindings = [])
+    {
+        $type = 'Field';
+
+        $this->{$this->unions ? 'unionOrders' : 'orders'}[] = compact('type', 'sql', 'bindings');
 
         $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2243,6 +2243,33 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add an "order by field()" clause to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  array  $field
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function orderByField($column, $field)
+    {
+        if ($this->isQueryable($column)) {
+            [$query, $bindings] = $this->createSub($column);
+
+            $column = new Expression('('.$query.')');
+
+            $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
+        }
+
+        $this->{$this->unions ? 'unionOrders' : 'orders'}[] = [
+            'column' => $column,
+            'field' => $field,
+        ];
+
+        return $this;
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -858,10 +858,10 @@ class Grammar extends BaseGrammar
      */
     protected function compileOrdersToArray(Builder $query, $orders)
     {
-        return array_map(function ($order) use($query) {
-            if(isset($order['type']) && $order['type'] === 'Field') {
+        return array_map(function ($order) use ($query) {
+            if (isset($order['type']) && $order['type'] === 'Field') {
                 return $this->compileOrderByField($query, $order);
-            } elseif(isset($order['sql'])) {
+            } elseif (isset($order['sql'])) {
                 return $order['sql'];
             } else {
                 return $this->wrap($order['column']).' '.$order['direction'];
@@ -880,8 +880,8 @@ class Grammar extends BaseGrammar
     {
         $column = $order['sql'];
 
-        return 'case '.implode(' ', array_map(function($field, $value) use($column) {
-            return 'when '. $this->wrap($column).'='.$this->parameter($field).' then '.($value + 1);
+        return 'case '.implode(' ', array_map(function ($field, $value) use ($column) {
+            return 'when '.$this->wrap($column).'='.$this->parameter($field).' then '.($value + 1);
         }, $order['bindings'], array_keys($order['bindings']))).' else 0';
     }
 

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -278,7 +278,7 @@ class MySqlGrammar extends Grammar
      */
     protected function compileOrderByField(Builder $query, $order)
     {
-        return 'field('.$this->wrap($order['sql']).', '.implode(', ', array_map(function($field) {
+        return 'field('.$this->wrap($order['sql']).', '.implode(', ', array_map(function ($field) {
             return $this->parameter($field);
         }, $order['bindings'])).')';
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -270,6 +270,19 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the "order by field()" portion of the query.
+     *
+     * @param array $order
+     * @return string
+     */
+    protected function compileOrderByField($order)
+    {
+        return 'field('.$this->wrap($order['column']).', '.implode(', ', array_map(function($field) {
+            return '"'.$field.'"';
+        }, $order['field'])).')';
+    }
+
+    /**
      * Prepare the bindings for an update statement.
      *
      * Booleans, integers, and doubles are inserted into JSON updates as raw values.

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -272,14 +272,15 @@ class MySqlGrammar extends Grammar
     /**
      * Compile the "order by field()" portion of the query.
      *
-     * @param array $order
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $order
      * @return string
      */
-    protected function compileOrderByField($order)
+    protected function compileOrderByField(Builder $query, $order)
     {
-        return 'field('.$this->wrap($order['column']).', '.implode(', ', array_map(function($field) {
-            return '"'.$field.'"';
-        }, $order['field'])).')';
+        return 'field('.$this->wrap($order['sql']).', '.implode(', ', array_map(function($field) {
+            return $this->parameter($field);
+        }, $order['bindings'])).')';
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1288,11 +1288,18 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderByField('age', [5, 7, 9]);
-        $this->assertSame('select * from "users" order by "email" asc, case when "age"="5" then 1 when "age"="7" then 2 when "age"="9" then 3 else 4', $builder->toSql());
+        $this->assertSame('select * from "users" order by "email" asc, case when "age"=? then 1 when "age"=? then 2 when "age"=? then 3 else 0', $builder->toSql());
+        $this->assertEquals([5, 7, 9], $builder->getBindings());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users')->orderBy('email')->orderByField('age', [5, 7, 9]);
+        $this->assertSame('select * from [users] order by [email] asc, case when [age]=? then 1 when [age]=? then 2 when [age]=? then 3 else 0', $builder->toSql());
+        $this->assertEquals([5, 7, 9], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderByField('age', [5, 7, 9]);
-        $this->assertSame('select * from `users` order by `email` asc, field(`age`, "5", "7", "9")', $builder->toSql());
+        $this->assertSame('select * from `users` order by `email` asc, field(`age`, ?, ?, ?)', $builder->toSql());
+        $this->assertEquals([5, 7, 9], $builder->getBindings());
     }
 
     public function testOrderBysSqlServer()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1284,6 +1284,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
 
+    public function testOrderByFields()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('email')->orderByField('age', [5, 7, 9]);
+        $this->assertSame('select * from "users" order by "email" asc, case when "age"="5" then 1 when "age"="7" then 2 when "age"="9" then 3 else 4', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->orderBy('email')->orderByField('age', [5, 7, 9]);
+        $this->assertSame('select * from `users` order by `email` asc, field(`age`, "5", "7", "9")', $builder->toSql());
+    }
+
     public function testOrderBysSqlServer()
     {
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
This PR adds the "order by FIELD()"  sorting, in MySQL.

Currently, if we want to order a query with the `FIELD()` method, we have to create a raw query, but it's not portable (if we decide to migrate from MySQL to another database).
With this PR, we have a new method `orderByField()`, which works with MySQL.
Use with MySQL:
```php
$builder->select('*')->from('users')->orderByField('age', [5, 7, 9]);
// select * from `users` order by field(`age`, "5", "7", "9")
```

Of course, if we use another database than MySQL, this method works too!
The same query, but with another database:
```php
$builder->select('*')->from('users')->orderByField('age', [5, 7, 9]);
// select * from "users" order by case when "age"="5" then 1 when "age"="7" then 2 when "age"="9" then 3 else 0'
```