### PR TITLE
[10.x] Allow Carbon Period for HavingBetween QueryBuilder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2159,7 +2159,7 @@ class Builder implements BuilderContract
     public function havingBetween($column, iterable $values, $boolean = 'and', $not = false)
     {
         $type = 'between';
-        
+
         if ($values instanceof CarbonPeriod) {
             $values = $values->toArray();
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2151,14 +2151,18 @@ class Builder implements BuilderContract
      * Add a "having between " clause to the query.
      *
      * @param  string  $column
-     * @param  array  $values
+     * @param  iterable  $values
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function havingBetween($column, array $values, $boolean = 'and', $not = false)
+    public function havingBetween($column, iterable $values, $boolean = 'and', $not = false)
     {
         $type = 'between';
+        
+        if ($values instanceof CarbonPeriod) {
+            $values = $values->toArray();
+        }
 
         $this->havings[] = compact('type', 'column', 'values', 'boolean', 'not');
 


### PR DESCRIPTION
Allow a Carbon Period as the second parameter in the HavingBetween Query Builder method, implemented the same as for the WhereBetween method.

Preview of the [whereBetween](https://github.com/Joorren/framework/blob/48ef2a24eef2931798453d11d50541b0a489a525/src/Illuminate/Database/Query/Builder.php#L1184) method:

```php
    /**
     * Add a where between statement to the query.
     *
     * @param  string|\Illuminate\Database\Query\Expression  $column
     * @param  iterable  $values
     * @param  string  $boolean
     * @param  bool  $not
     * @return $this
     */
    public function whereBetween($column, iterable $values, $boolean = 'and', $not = false)
    {
        $type = 'between';

        if ($values instanceof CarbonPeriod) {
            $values = $values->toArray();
        }

        $this->wheres[] = compact('type', 'column', 'values', 'boolean', 'not');

        $this->addBinding(array_slice($this->cleanBindings(Arr::flatten($values)), 0, 2), 'where');

        return $this;
    }
``` 
