### PR TITLE
[9.x] Add new method `lockInProduction` in Route

### DIFF
--- a/src/Illuminate/Routing/Matching/IsLockInProductionValidator.php
+++ b/src/Illuminate/Routing/Matching/IsLockInProductionValidator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Routing\Matching;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+
+class IsLockInProductionValidator implements ValidatorInterface
+{
+    /**
+     * Validate a given rule against a route and request.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function matches(Route $route, Request $request)
+    {
+        return ! $route->getLockInProduction();
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
 use Illuminate\Routing\Matching\UriValidator;
+use Illuminate\Routing\Matching\IsLockInProductionValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -903,6 +904,29 @@ class Route
     }
 
     /**
+     * Get the lock route production of the route instance.
+     *
+     * @return bool
+     */
+    public function getLockInProduction()
+    {
+        return (bool) ($this->action['is_production'] ?? false);
+    }
+
+    /**
+     * Lock the route when the application is in production mode.
+     * 
+     * @param  mixed  $environments
+     * @return $this
+     */
+    public function lockInProduction()
+    {
+        $this->action['is_production'] = app()->isProduction();
+        
+        return $this;
+    }
+
+    /**
      * Set the handler for the route.
      *
      * @param  \Closure|array|string  $action
@@ -1213,6 +1237,7 @@ class Route
         return static::$validators = [
             new UriValidator, new MethodValidator,
             new SchemeValidator, new HostValidator,
+            new IsLockInProductionValidator,
         ];
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -8,10 +8,10 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Routing\Matching\HostValidator;
+use Illuminate\Routing\Matching\IsLockInProductionValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
 use Illuminate\Routing\Matching\UriValidator;
-use Illuminate\Routing\Matching\IsLockInProductionValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -915,14 +915,14 @@ class Route
 
     /**
      * Lock the route when the application is in production mode.
-     * 
+     *
      * @param  mixed  $environments
      * @return $this
      */
     public function lockInProduction()
     {
         $this->action['is_production'] = app()->isProduction();
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -23,6 +23,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [], int|array $status = 200, array $headers = [])
  * @method static \Illuminate\Routing\RouteRegistrar as(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar controller(string $controller)
+ * @method static \Illuminate\Routing\RouteRegistrar lockInProduction()
  * @method static \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  * @method static \Illuminate\Routing\RouteRegistrar name(string $value)

--- a/tests/Routing/RouteLockInProductionTest.php
+++ b/tests/Routing/RouteLockInProductionTest.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Tests\Routing;
 
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Events\Dispatcher;
-use Illuminate\Container\Container;
-use Illuminate\Foundation\Application;
-use Illuminate\Contracts\Routing\Registrar;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RouteLockInProductionTest extends TestCase

--- a/tests/Routing/RouteLockInProductionTest.php
+++ b/tests/Routing/RouteLockInProductionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Routing\Registrar;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class RouteLockInProductionTest extends TestCase
+{
+    public function testCanRegisterLockInLocal()
+    {
+        $this->setApplicationEnv('local');
+
+        $router = $this->getRouter();
+        $router->get('run-artisan', function () {
+            return 'done';
+        })->lockInProduction();
+
+        $this->assertStringContainsString('done', $router->dispatch(Request::create('run-artisan', 'GET'))->getContent());
+        $this->assertEquals(200, $router->dispatch(Request::create('run-artisan', 'GET'))->getStatusCode());
+    }
+
+    public function testCanRegisterLockInProduction()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->setApplicationEnv('production');
+
+        $router = $this->getRouter();
+        $router->get('run-artisan', function () {
+            return 'done';
+        })->lockInProduction();
+
+        $this->assertStringContainsString('Not Found', $router->dispatch(Request::create('run-artisan', 'GET'))->getContent());
+        $this->assertEquals(404, $router->dispatch(Request::create('run-artisan', 'GET'))->getStatusCode());
+    }
+
+    /**
+     * Set environment to Application.
+     *
+     * @param  string  $environment
+     * @return void
+     */
+    public function setApplicationEnv($environment)
+    {
+        $local = new Application;
+        $local['env'] = $environment;
+    }
+
+    protected function getRouter()
+    {
+        $container = new Container;
+
+        $router = new Router(new Dispatcher, $container);
+
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        return $router;
+    }
+}


### PR DESCRIPTION
This PR adds a new method in routes that makes sure that the application is in development mode or not and will help many developers because they are doing routes for experimentation and raising the project to the public without the be prohibited. and will also help developers not to make mistakes in any way.

Before
```php
Route::get('/run-artisan-command', function () {
    Artisan::call('migrate:fresh');
    return 'Done';
});

Route::get('/run-artisan-command', function () {
    if (app()->environment('local')) {
        Artisan::call('migrate:fresh');
        return 'Done';
    }
});
```

After
```php

Route::prefix('dev')->lockInProduction()->group(base_path('routes/dev.php'));

Route::get('/run-artisan-command', function () {
    Artisan::call('migrate:fresh');
    return 'Done';
})->lockInProduction();
```

Note:
The code needs a lot of development to be good, but it's only the beginning.