### PR TITLE
Eloquent Expose morphType in MorphToMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -537,11 +537,12 @@ trait HasRelationships
      * @param  string|null  $parentKey
      * @param  string|null  $relatedKey
      * @param  bool  $inverse
+     * @param  string|null  $morphType
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function morphToMany($related, $name, $table = null, $foreignPivotKey = null,
                                 $relatedPivotKey = null, $parentKey = null,
-                                $relatedKey = null, $inverse = false)
+                                $relatedKey = null, $inverse = false, $morphType = null)
     {
         $caller = $this->guessBelongsToManyRelation();
 
@@ -568,7 +569,7 @@ trait HasRelationships
         return $this->newMorphToMany(
             $instance->newQuery(), $this, $name, $table,
             $foreignPivotKey, $relatedPivotKey, $parentKey ?: $this->getKeyName(),
-            $relatedKey ?: $instance->getKeyName(), $caller, $inverse
+            $relatedKey ?: $instance->getKeyName(), $caller, $inverse, $morphType
         );
     }
 
@@ -585,14 +586,15 @@ trait HasRelationships
      * @param  string  $relatedKey
      * @param  string|null  $relationName
      * @param  bool  $inverse
+     * @param  string|null  $morphType
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     protected function newMorphToMany(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
                                       $relatedPivotKey, $parentKey, $relatedKey,
-                                      $relationName = null, $inverse = false)
+                                      $relationName = null, $inverse = false, $morphType = null)
     {
         return new MorphToMany($query, $parent, $name, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey,
-            $relationName, $inverse);
+            $relationName, $inverse, $morphType);
     }
 
     /**
@@ -605,10 +607,11 @@ trait HasRelationships
      * @param  string|null  $relatedPivotKey
      * @param  string|null  $parentKey
      * @param  string|null  $relatedKey
+     * @param  string|null  $morphType
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function morphedByMany($related, $name, $table = null, $foreignPivotKey = null,
-                                  $relatedPivotKey = null, $parentKey = null, $relatedKey = null)
+                                  $relatedPivotKey = null, $parentKey = null, $relatedKey = null, $morphType = null)
     {
         $foreignPivotKey = $foreignPivotKey ?: $this->getForeignKey();
 
@@ -619,7 +622,7 @@ trait HasRelationships
 
         return $this->morphToMany(
             $related, $name, $table, $foreignPivotKey,
-            $relatedPivotKey, $parentKey, $relatedKey, true
+            $relatedPivotKey, $parentKey, $relatedKey, true, $morphType
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -44,13 +44,14 @@ class MorphToMany extends BelongsToMany
      * @param  string  $relatedKey
      * @param  string|null  $relationName
      * @param  bool  $inverse
+     * @param  string|null  $morphType
      * @return void
      */
     public function __construct(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
-                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false)
+                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false, $morphType = null)
     {
         $this->inverse = $inverse;
-        $this->morphType = $name.'_type';
+        $this->morphType = $morphType ?? $name.'_type';
         $this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();
 
         parent::__construct(


### PR DESCRIPTION
When working with legacy db, one sometimes need to adapt to existing column names, some are already changeable in eloquent, but morphType was not.
This PR propose to expose the type custom column name just like other fields (namely foreignPivotKey, relatedPivotKey, parentKey and relatedKey) when doing $this->morphedByMany()
Existing use isn't broken because the parameter is optional in each context and stands at the end of the function/class signature
It makes Eloquent more flexible when subject DB cannot be modified easily (think legacy db with production project running on it) and allows for more progressive integration of Laravel into older projects
