### PR TITLE
Eloquent Expose morphType in MorphToMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -538,11 +538,12 @@ trait HasRelationships
      * @param  string|null  $relatedKey
      * @param  string|null  $relation
      * @param  bool  $inverse
+     * @param  string|null  $morphType
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function morphToMany($related, $name, $table = null, $foreignPivotKey = null,
                                 $relatedPivotKey = null, $parentKey = null,
-                                $relatedKey = null, $relation = null, $inverse = false)
+                                $relatedKey = null, $relation = null, $inverse = false, $morphType = null)
     {
         $relation = $relation ?: $this->guessBelongsToManyRelation();
 
@@ -569,7 +570,7 @@ trait HasRelationships
         return $this->newMorphToMany(
             $instance->newQuery(), $this, $name, $table,
             $foreignPivotKey, $relatedPivotKey, $parentKey ?: $this->getKeyName(),
-            $relatedKey ?: $instance->getKeyName(), $relation, $inverse
+            $relatedKey ?: $instance->getKeyName(), $relation, $inverse, $morphType
         );
     }
 
@@ -586,14 +587,15 @@ trait HasRelationships
      * @param  string  $relatedKey
      * @param  string|null  $relationName
      * @param  bool  $inverse
+     * @param  string|null  $morphType
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     protected function newMorphToMany(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
                                       $relatedPivotKey, $parentKey, $relatedKey,
-                                      $relationName = null, $inverse = false)
+                                      $relationName = null, $inverse = false, $morphType = null)
     {
         return new MorphToMany($query, $parent, $name, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey,
-            $relationName, $inverse);
+            $relationName, $inverse, $morphType);
     }
 
     /**
@@ -607,10 +609,11 @@ trait HasRelationships
      * @param  string|null  $parentKey
      * @param  string|null  $relatedKey
      * @param  string|null  $relation
+     * @param  string|null  $morphType
      * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
     public function morphedByMany($related, $name, $table = null, $foreignPivotKey = null,
-                                  $relatedPivotKey = null, $parentKey = null, $relatedKey = null, $relation = null)
+                                  $relatedPivotKey = null, $parentKey = null, $relatedKey = null, $relation = null, $morphType = null)
     {
         $foreignPivotKey = $foreignPivotKey ?: $this->getForeignKey();
 
@@ -621,7 +624,7 @@ trait HasRelationships
 
         return $this->morphToMany(
             $related, $name, $table, $foreignPivotKey,
-            $relatedPivotKey, $parentKey, $relatedKey, $relation, true
+            $relatedPivotKey, $parentKey, $relatedKey, $relation, true, $morphType
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -44,13 +44,14 @@ class MorphToMany extends BelongsToMany
      * @param  string  $relatedKey
      * @param  string|null  $relationName
      * @param  bool  $inverse
+     * @param  string|null  $morphType
      * @return void
      */
     public function __construct(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
-                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false)
+                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false, $morphType = null)
     {
         $this->inverse = $inverse;
-        $this->morphType = $name.'_type';
+        $this->morphType = $morphType ?? $name.'_type';
         $this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();
 
         parent::__construct(

--- a/tests/Database/DatabaseEloquentRelationshipsTest.php
+++ b/tests/Database/DatabaseEloquentRelationshipsTest.php
@@ -180,10 +180,10 @@ class CustomPost extends Post
     }
 
     protected function newMorphToMany(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
-        $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false)
+        $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false, $morphType = null)
     {
         return new CustomMorphToMany($query, $parent, $name, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey,
-            $relationName, $inverse);
+            $relationName, $inverse, $morphType);
     }
 
     protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)


### PR DESCRIPTION
When working with legacy db, one sometimes need to adapt to existing column names, some are already changeable in eloquent, but morphType was not.
This PR propose to expose the type custom column name just like other fields (namely foreignPivotKey, relatedPivotKey, parentKey and relatedKey) when doing $this->morphedByMany()
Existing use isn't broken because the parameter is optional in each context and stands at the end of the function/class signature
It makes Eloquent more flexible when subject DB cannot be modified easily (think legacy db with production project running on it) and allows for more progressive integration of Laravel into older projects