### PR TITLE
[9.x] Improve type of `$container` property in pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -13,7 +13,7 @@ class Pipeline implements PipelineContract
     /**
      * The container implementation.
      *
-     * @var \Illuminate\Contracts\Container\Container
+     * @var \Illuminate\Contracts\Container\Container|null
      */
     protected $container;
 


### PR DESCRIPTION
Constructor can assign `null` to `$container` property in pipeline:
```php
public function __construct(Container $container = null)
{
    $this->container = $container;
}
```

This PR adds `null` to `$container` property PHPDoc.