### PR TITLE
Add `--except-vendor` and `--only-vendor` to `artisan list`

### DIFF
--- a/src/Illuminate/Console/ListCommand.php
+++ b/src/Illuminate/Console/ListCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Console;
+
+use Illuminate\Foundation\Console\ClosureCommand;
+use Illuminate\Console\Application;
+use ReflectionClass;
+use ReflectionFunction;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\ListCommand as SymfonyListCommand;
+use Symfony\Component\Console\Command\Command;
+
+class ListCommand extends SymfonyListCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+        
+        $definition = $this->getDefinition();
+        $definition->addOption(
+            new InputOption('except-vendor', null, InputOption::VALUE_NONE, 'Do not include commands defined by vendor packages (except ClosureCommands)'),
+        );
+
+        $this->setDefinition($definition);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $exceptVendor = $input->getOption('except-vendor');
+
+        if ($exceptVendor) {
+            $this->getApplication()->setShouldExcludeVendor(true);
+        }
+
+        $returnCode = parent::execute($input, $output);
+
+        if ($exceptVendor) {
+            $this->getApplication()->setShouldExcludeVendor(true);
+        }
+
+        return $returnCode;
+    }
+}

--- a/src/Illuminate/Console/ListCommand.php
+++ b/src/Illuminate/Console/ListCommand.php
@@ -20,7 +20,10 @@ class ListCommand extends SymfonyListCommand
         
         $definition = $this->getDefinition();
         $definition->addOption(
-            new InputOption('except-vendor', null, InputOption::VALUE_NONE, 'Do not include commands defined by vendor packages (except ClosureCommands)'),
+            new InputOption('except-vendor', null, InputOption::VALUE_NONE, 'Do not include commands defined by vendor packages')
+        );
+        $definition->addOption(
+            new InputOption('only-vendor', null, InputOption::VALUE_NONE, 'Only include commands defined by vendor packages')
         );
 
         $this->setDefinition($definition);
@@ -29,17 +32,20 @@ class ListCommand extends SymfonyListCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $exceptVendor = $input->getOption('except-vendor');
+        $onlyVendor = $input->getOption('only-vendor');
 
         if ($exceptVendor) {
-            $this->getApplication()->setShouldExcludeVendor(true);
+            $this->getApplication()
+                ->setShouldExcludeVendor(true)
+                ->setShouldExcludeNonVendor(false);
         }
 
-        $returnCode = parent::execute($input, $output);
-
-        if ($exceptVendor) {
-            $this->getApplication()->setShouldExcludeVendor(true);
+        if ($onlyVendor) {
+            $this->getApplication()
+                ->setShouldExcludeVendor(false)
+                ->setShouldExcludeNonVendor(true);
         }
 
-        return $returnCode;
+        return parent::execute($input, $output);
     }
 }

--- a/tests/Console/ListCommandTest.php
+++ b/tests/Console/ListCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use App\ExampleCommand;
+use Illuminate\Console\Application;
+use Illuminate\Console\Command;
+use Illuminate\Console\ListCommand;
+use Illuminate\Foundation\Console\ClosureCommand;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ListCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testShowsAllCommandsByDefault()
+    {
+        $app = new Application(
+            $app = m::mock(ApplicationContract::class, ['version' => '6.0']),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+
+        $output = new BufferedOutput();
+        $app->call('list', [], $output);
+
+        // Should see default Symfony "completion" command
+        $this->assertMatchesRegularExpression("/Available commands:\n\s+completion/s", $output->fetch());
+    }
+
+    public function testDoesNotShowDefaultCommandsWithExceptVendor()
+    {
+        $console = new Application(
+            $app = m::mock(ApplicationContract::class, ['version' => '6.0']),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+        $console->add(new ExampleCommand);
+        $console->add(new ClosureCommand('example-closure', function () {}));
+
+        $app->shouldReceive('getNamespace')->andReturn('App\\');
+        $app->shouldReceive('basePath')->with('vendor')->andReturn('/xyz');
+        $app->shouldReceive('make')->with(Dispatcher::class)->andReturn($events);
+
+        $output = new BufferedOutput();
+        $console->call('list', ['--except-vendor' => true], $output);
+
+        $outputStr = $output->fetch();
+
+        // Should not see default Symfony "completion" command
+        $this->assertDoesNotMatchRegularExpression("/Available commands:\n\s+completion/s", $outputStr);
+
+        // Should see App namespace and ClosureCommands
+        $this->assertMatchesRegularExpression("/Available commands:\n\s+example.*?\n\s+example-closure/s", $outputStr);
+    }
+
+    public function testDoesNotShowClosureCommandsInsideVendorWithExceptVendor()
+    {
+        $console = new Application(
+            $app = m::mock(ApplicationContract::class, ['version' => '6.0']),
+            $events = m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+        $console->add(new ExampleCommand);
+        $console->add(new ClosureCommand('example-closure', function () {}));
+
+        $app->shouldReceive('getNamespace')->andReturn('App\\');
+        $app->shouldReceive('basePath')->with('vendor')->andReturn(__DIR__);
+        $app->shouldReceive('make')->with(Dispatcher::class)->andReturn($events);
+
+        $output = new BufferedOutput();
+        $console->call('list', ['--except-vendor' => true], $output);
+
+        $outputStr = $output->fetch();
+
+        // Should not see example-closure command
+        $this->assertDoesNotMatchRegularExpression("/Available commands:\n\s+example-closure/s", $outputStr);
+    }
+}
+
+namespace App;
+
+use Illuminate\Console\Command;
+
+class ExampleCommand extends Command
+{
+    protected $signature = 'example';
+}


### PR DESCRIPTION
This PR replaces the default Symfony ListCommand with an extended ListCommand that supports newly introduced `--except-vendor` and `--only vendor` flags. This is similar to the functionality available in the `artisan route:list` command.

* Running `artisan list` normally will include all commands.
* Running `artisan list --except-vendor` will include all commands except those defined by vendors (including Laravel)
* Running `artisan list --only-vendor` will only include commands that have been defined by vendors (including Laravel)

The inclusion of the `--except-vendor` flag in particular will make it easy for developers coming into a new Laravel project to see what commands are available that are specific to that project.