### PR TITLE
[9.x] Add authorize function to Authorizable trait

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -7,6 +7,20 @@ use Illuminate\Contracts\Auth\Access\Gate;
 trait Authorizable
 {
     /**
+     * Determine if the entity should be granted the given ability.
+     *
+     * @param  string  $ability
+     * @param  array|mixed  $arguments
+     * @return \Illuminate\Auth\Access\Response
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorize($ability, $arguments = [])
+    {
+        return app(Gate::class)->forUser($this)->authorize($ability, $arguments);
+    }
+
+    /**
      * Determine if the entity has the given abilities.
      *
      * @param  iterable|string  $abilities

--- a/tests/Auth/AuthorizableTest.php
+++ b/tests/Auth/AuthorizableTest.php
@@ -10,50 +10,50 @@ use Illuminate\Foundation\Testing\TestCase;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 use Throwable;
 
-//class AuthorizableTest extends TestCase
-//{
-//    use CreatesApplication;
-//
-//    public function testAuthorizeMethodThrowsAuthorizationExceptionWithPolicyDenial()
-//    {
-//        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
-//
-//        $user = new User();
-//
-//        try {
-//            $user->authorize('willDeny', AuthorizableTestDummy::class);
-//        } catch (Throwable $e) {
-//            $this->assertInstanceOf(AuthorizationException::class, $e);
-//            $this->assertTrue($e->response()->denied());
-//        }
-//    }
-//
-//    public function testAuthorizeMethodReturnsAllowedResponseWithPolicySuccess()
-//    {
-//        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
-//
-//        $user = new User();
-//
-//        $response = $user->authorize('willSucceed', AuthorizableTestDummy::class);
-//
-//        $this->assertTrue($response->allowed());
-//    }
-//}
-//
-//class AuthorizableTestDummy
-//{
-//
-//}
-//
-//class AuthorizableTestPolicy
-//{
-//    public function willDeny($user)
-//    {
-//        return false;
-//    }
-//
-//    public function willSucceed($user)
-//    {
-//        return true;
-//    }
-//}
+class AuthorizableTest extends TestCase
+{
+    use CreatesApplication;
+
+    public function testAuthorizeMethodThrowsAuthorizationExceptionWithPolicyDenial()
+    {
+        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
+
+        $user = new User();
+
+        try {
+            $user->authorize('willDeny', AuthorizableTestDummy::class);
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(AuthorizationException::class, $e);
+            $this->assertTrue($e->response()->denied());
+        }
+    }
+
+    public function testAuthorizeMethodReturnsAllowedResponseWithPolicySuccess()
+    {
+        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
+
+        $user = new User();
+
+        $response = $user->authorize('willSucceed', AuthorizableTestDummy::class);
+
+        $this->assertTrue($response->allowed());
+    }
+}
+
+class AuthorizableTestDummy
+{
+
+}
+
+class AuthorizableTestPolicy
+{
+    public function willDeny($user)
+    {
+        return false;
+    }
+
+    public function willSucceed($user)
+    {
+        return true;
+    }
+}

--- a/tests/Auth/AuthorizableTest.php
+++ b/tests/Auth/AuthorizableTest.php
@@ -16,10 +16,10 @@ class AuthorizableTest extends TestCase
     {
         $container = Container::setInstance(new Container());
 
-        $gate = new Gate($container, fn() => null);
+        $gate = new Gate($container, fn () => null);
         $gate->policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
-        
-        $container->singleton(GateContract::class, fn() => $gate);
+
+        $container->singleton(GateContract::class, fn () => $gate);
     }
 
     public function testAuthorizeMethodThrowsAuthorizationExceptionWithPolicyDenial()

--- a/tests/Auth/AuthorizableTest.php
+++ b/tests/Auth/AuthorizableTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\Gate;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Testing\TestCase;
+use Orchestra\Testbench\Concerns\CreatesApplication;
+use Throwable;
+
+class AuthorizableTest extends TestCase
+{
+    use CreatesApplication;
+
+    public function testAuthorizeMethodThrowsAuthorizationExceptionWithPolicyDenial()
+    {
+        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
+
+        $user = new User();
+
+        try {
+            $user->authorize('willDeny', AuthorizableTestDummy::class);
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(AuthorizationException::class, $e);
+            $this->assertTrue($e->response()->denied());
+        }
+    }
+
+    public function testAuthorizeMethodReturnsAllowedResponseWithPolicySuccess()
+    {
+        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
+
+        $user = new User();
+
+        $response = $user->authorize('willSucceed', AuthorizableTestDummy::class);
+
+        $this->assertTrue($response->allowed());
+    }
+
+    protected function getBasicGate($isAdmin = false)
+    {
+        return new Gate(new Container, function () use ($isAdmin) {
+            return (object)['id' => 1, 'isAdmin' => $isAdmin];
+        });
+
+    }
+
+}
+
+class AuthorizableTestDummy
+{
+
+}
+
+class AuthorizableTestPolicy
+{
+    public function willDeny($user)
+    {
+        return false;
+    }
+
+    public function willSucceed($user)
+    {
+        return true;
+    }
+}

--- a/tests/Auth/AuthorizableTest.php
+++ b/tests/Auth/AuthorizableTest.php
@@ -38,15 +38,6 @@ class AuthorizableTest extends TestCase
 
         $this->assertTrue($response->allowed());
     }
-
-    protected function getBasicGate($isAdmin = false)
-    {
-        return new Gate(new Container, function () use ($isAdmin) {
-            return (object)['id' => 1, 'isAdmin' => $isAdmin];
-        });
-
-    }
-
 }
 
 class AuthorizableTestDummy

--- a/tests/Auth/AuthorizableTest.php
+++ b/tests/Auth/AuthorizableTest.php
@@ -10,50 +10,50 @@ use Illuminate\Foundation\Testing\TestCase;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 use Throwable;
 
-class AuthorizableTest extends TestCase
-{
-    use CreatesApplication;
-
-    public function testAuthorizeMethodThrowsAuthorizationExceptionWithPolicyDenial()
-    {
-        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
-
-        $user = new User();
-
-        try {
-            $user->authorize('willDeny', AuthorizableTestDummy::class);
-        } catch (Throwable $e) {
-            $this->assertInstanceOf(AuthorizationException::class, $e);
-            $this->assertTrue($e->response()->denied());
-        }
-    }
-
-    public function testAuthorizeMethodReturnsAllowedResponseWithPolicySuccess()
-    {
-        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
-
-        $user = new User();
-
-        $response = $user->authorize('willSucceed', AuthorizableTestDummy::class);
-
-        $this->assertTrue($response->allowed());
-    }
-}
-
-class AuthorizableTestDummy
-{
-
-}
-
-class AuthorizableTestPolicy
-{
-    public function willDeny($user)
-    {
-        return false;
-    }
-
-    public function willSucceed($user)
-    {
-        return true;
-    }
-}
+//class AuthorizableTest extends TestCase
+//{
+//    use CreatesApplication;
+//
+//    public function testAuthorizeMethodThrowsAuthorizationExceptionWithPolicyDenial()
+//    {
+//        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
+//
+//        $user = new User();
+//
+//        try {
+//            $user->authorize('willDeny', AuthorizableTestDummy::class);
+//        } catch (Throwable $e) {
+//            $this->assertInstanceOf(AuthorizationException::class, $e);
+//            $this->assertTrue($e->response()->denied());
+//        }
+//    }
+//
+//    public function testAuthorizeMethodReturnsAllowedResponseWithPolicySuccess()
+//    {
+//        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
+//
+//        $user = new User();
+//
+//        $response = $user->authorize('willSucceed', AuthorizableTestDummy::class);
+//
+//        $this->assertTrue($response->allowed());
+//    }
+//}
+//
+//class AuthorizableTestDummy
+//{
+//
+//}
+//
+//class AuthorizableTestPolicy
+//{
+//    public function willDeny($user)
+//    {
+//        return false;
+//    }
+//
+//    public function willSucceed($user)
+//    {
+//        return true;
+//    }
+//}

--- a/tests/Auth/AuthorizableTest.php
+++ b/tests/Auth/AuthorizableTest.php
@@ -5,19 +5,25 @@ namespace Illuminate\Tests\Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Foundation\Auth\User;
-use Illuminate\Foundation\Testing\TestCase;
-use Orchestra\Testbench\Concerns\CreatesApplication;
+use PHPUnit\Framework\TestCase;
 use Throwable;
 
 class AuthorizableTest extends TestCase
 {
-    use CreatesApplication;
+    public function setUp(): void
+    {
+        $container = Container::setInstance(new Container());
+
+        $gate = new Gate($container, fn() => null);
+        $gate->policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
+        
+        $container->singleton(GateContract::class, fn() => $gate);
+    }
 
     public function testAuthorizeMethodThrowsAuthorizationExceptionWithPolicyDenial()
     {
-        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
-
         $user = new User();
 
         try {
@@ -30,8 +36,6 @@ class AuthorizableTest extends TestCase
 
     public function testAuthorizeMethodReturnsAllowedResponseWithPolicySuccess()
     {
-        \Illuminate\Support\Facades\Gate::policy(AuthorizableTestDummy::class, AuthorizableTestPolicy::class);
-
         $user = new User();
 
         $response = $user->authorize('willSucceed', AuthorizableTestDummy::class);
@@ -42,7 +46,6 @@ class AuthorizableTest extends TestCase
 
 class AuthorizableTestDummy
 {
-
 }
 
 class AuthorizableTestPolicy


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds an `authorize` function to the `Authorizable` trait that mirrors the `authorize` function found on the `Gate` class. This provides the convenience of being able to throw an authorization exception from an authorizable entity without using the Gate facade.

Before:
```
Gate::forUser($user)->authorize('update-post', $post);
```
After:
```
$user->authorize('update-post', $post);
```

This update doesn't change or remove any existing functionality just adds another convenient way to perform an authorization check. 