### PR TITLE
[9.x] Restore lost logic

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -446,6 +446,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public static function createFromBase(SymfonyRequest $request)
     {
+        if ($request instanceof static) {
+ 		    return $request;
+ 	    }
+        
         $newRequest = (new static)->duplicate(
             $request->query->all(), $request->request->all(), $request->attributes->all(),
             $request->cookies->all(), $request->files->all(), $request->server->all()


### PR DESCRIPTION
See: [7bd8edd](https://github.com/illuminate/http/commit/7bd8edddd41c4df3c0b953afbdf4472b1183954f)

This was removed for no obvious reason.

This has generated a problem whereby a request that is provided will lose its JSON content when returned.

Was working before:

```
$request = Request::create('...','..');
$request->setJson(new ParameterBag(['....]));
app()->handle($request);
```

In target controller you could use $request->input() to read the JSON contents.
Without these lines of code, the input is empty and JSON is not present.

The workaround we use currently is:

```
$request = Request::create('...','..');
$request->setJson(new ParameterBag(['....]));
app(\App\Http\Kernel::class)->handle($request);
```

Reference: https://github.com/illuminate/http/pull/27

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
