### PR TITLE
[9.x] Add ability to set backoff in broadcast events

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -36,6 +36,13 @@ class BroadcastEvent implements ShouldQueue
     public $timeout;
 
     /**
+     * The number of seconds to wait before retrying a job that encountered an uncaught exception.
+     *
+     * @var int
+     */
+    public $backoff;
+
+    /**
      * Create a new job handler instance.
      *
      * @param  mixed  $event
@@ -46,6 +53,7 @@ class BroadcastEvent implements ShouldQueue
         $this->event = $event;
         $this->tries = property_exists($event, 'tries') ? $event->tries : null;
         $this->timeout = property_exists($event, 'timeout') ? $event->timeout : null;
+        $this->backoff = property_exists($event, 'backoff') ? $event->backoff : null;
         $this->afterCommit = property_exists($event, 'afterCommit') ? $event->afterCommit : null;
     }
 


### PR DESCRIPTION
This PR allows to set a backoff to broadcast events. This is useful when the websockets server is unstable and you want to give the server some time to recover.
