### PR TITLE
[9.x] Adds `Arr::mapWithKeys`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -475,9 +475,9 @@ class Arr
      */
     public static function prependKeysWith($array, $prependWith)
     {
-        return Collection::make($array)->mapWithKeys(function ($item, $key) use ($prependWith) {
+        return Arr::mapWithKeys($array, function ($item, $key) use ($prependWith) {
             return [$prependWith.$key => $item];
-        })->all();
+        });
     }
 
     /**
@@ -558,6 +558,30 @@ class Arr
         $items = array_map($callback, $array, $keys);
 
         return array_combine($keys, $items);
+    }
+
+    /**
+     * Run an associative map over each of the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function mapWithKeys(array $array, callable $callback)
+    {
+        $result = [];
+
+        foreach ($array as $key => $value) {
+            $assoc = $callback($value, $key);
+
+            foreach ($assoc as $mapKey => $mapValue) {
+                $result[$mapKey] = $mapValue;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -768,17 +768,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function mapWithKeys(callable $callback)
     {
-        $result = [];
-
-        foreach ($this->items as $key => $value) {
-            $assoc = $callback($value, $key);
-
-            foreach ($assoc as $mapKey => $mapValue) {
-                $result[$mapKey] = $mapValue;
-            }
-        }
-
-        return new static($result);
+        return new static(Arr::mapWithKeys($this->items, $callback));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Relations\Concerns;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 
 trait InteractsWithPivotTable
@@ -134,7 +135,7 @@ trait InteractsWithPivotTable
      */
     public function syncWithPivotValues($ids, array $values, bool $detaching = true)
     {
-        return $this->sync(collect($this->parseIds($ids))->mapWithKeys(function ($id) use ($values) {
+        return $this->sync(Arr::mapWithKeys($this->parseIds($ids), function ($id) use ($values) {
             return [$id => $values];
         }), $detaching);
     }
@@ -147,13 +148,13 @@ trait InteractsWithPivotTable
      */
     protected function formatRecordsList(array $records)
     {
-        return collect($records)->mapWithKeys(function ($attributes, $id) {
+        return Arr::mapWithKeys($records, function ($attributes, $id) {
             if (! is_array($attributes)) {
                 [$id, $attributes] = [$attributes, []];
             }
 
             return [$id => $attributes];
-        })->all();
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -2,13 +2,14 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
-use Illuminate\Contracts\Http\Kernel as HttpKernel;
-use Illuminate\Cookie\CookieValuePrefix;
-use Illuminate\Http\Request;
-use Illuminate\Testing\LoggedExceptionCollection;
-use Illuminate\Testing\TestResponse;
-use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
+use Illuminate\Testing\TestResponse;
+use Illuminate\Testing\LoggedExceptionCollection;
+use Illuminate\Support\Arr;
+use Illuminate\Http\Request;
+use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 
 trait MakesHttpRequests
 {
@@ -558,11 +559,11 @@ trait MakesHttpRequests
      */
     protected function transformHeadersToServerVars(array $headers)
     {
-        return collect(array_merge($this->defaultHeaders, $headers))->mapWithKeys(function ($value, $name) {
+        return Arr::mapWithKeys(array_merge($this->defaultHeaders, $headers), function ($value, $name) {
             $name = strtr(strtoupper($name), '-', '_');
 
             return [$this->formatServerHeaderKey($name) => $value];
-        })->all();
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -3,13 +3,13 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
-use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
-use Illuminate\Testing\TestResponse;
-use Illuminate\Testing\LoggedExceptionCollection;
-use Illuminate\Support\Arr;
-use Illuminate\Http\Request;
 use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Http\Request;
+use Illuminate\Testing\LoggedExceptionCollection;
+use Illuminate\Testing\TestResponse;
+use Illuminate\Support\Arr;
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 trait MakesHttpRequests
 {

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Illuminate\Testing\TestResponse;
@@ -9,7 +10,6 @@ use Illuminate\Testing\LoggedExceptionCollection;
 use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Cookie\CookieValuePrefix;
-use Illuminate\Contracts\Http\Kernel as HttpKernel;
 
 trait MakesHttpRequests
 {

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -5,9 +5,9 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Testing\LoggedExceptionCollection;
 use Illuminate\Testing\TestResponse;
-use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 
 class SetCacheHeaders
 {

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -2,8 +2,9 @@
 
 namespace Illuminate\Http\Middleware;
 
-use Closure;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Arr;
+use Closure;
 
 class SetCacheHeaders
 {
@@ -55,10 +56,10 @@ class SetCacheHeaders
      */
     protected function parseOptions($options)
     {
-        return collect(explode(';', rtrim($options, ';')))->mapWithKeys(function ($option) {
+        return Arr::mapWithKeys(explode(';', rtrim($options, ';')), function ($option) {
             $data = explode('=', $option, 2);
 
             return [$data[0] => $data[1] ?? true];
-        })->all();
+        });
     }
 }

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Http\Middleware;
 
+use Closure;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Arr;
-use Closure;
 
 class SetCacheHeaders
 {

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -223,11 +223,11 @@ class MailChannel
             $recipients = [$recipients];
         }
 
-        return collect($recipients)->mapWithKeys(function ($recipient, $email) {
+        return Arr::mapWithKeys($recipients, function ($recipient, $email) {
             return is_numeric($email)
                     ? [$email => (is_string($recipient) ? $recipient : $recipient->email)]
                     : [$email => $recipient];
-        })->all();
+        });
     }
 
     /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -154,9 +154,9 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function getUrlRange($start, $end)
     {
-        return collect(range($start, $end))->mapWithKeys(function ($page) {
+        return Arr::mapWithKeys(range($start, $end), function ($page) {
             return [$page => $this->url($page)];
-        })->all();
+        });
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1095,9 +1095,9 @@ class Validator implements ValidatorContract
      */
     public function setRules(array $rules)
     {
-        $rules = collect($rules)->mapWithKeys(function ($value, $key) {
+        $rules = Arr::mapWithKeys($rules, function ($value, $key) {
             return [str_replace('\.', $this->dotPlaceholder, $key) => $value];
-        })->toArray();
+        });
 
         $this->initialRules = $rules;
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -2,16 +2,17 @@
 
 namespace Illuminate\View\Compilers;
 
-use Illuminate\Container\Container;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\View\Factory;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
-use Illuminate\View\AnonymousComponent;
-use Illuminate\View\DynamicComponent;
-use Illuminate\View\ViewFinderInterface;
-use InvalidArgumentException;
 use ReflectionClass;
+use InvalidArgumentException;
+use Illuminate\View\ViewFinderInterface;
+use Illuminate\View\DynamicComponent;
+use Illuminate\View\AnonymousComponent;
+use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Container\Container;
 
 /**
  * @author Spatie bvba <info@spatie.be>
@@ -235,225 +236,226 @@ class ComponentTagCompiler
 <?php $attributes = $attributes->except(collect($constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
 <?php $component->withAttributes(['.$this->attributesToString($attributes->all(), $escapeAttributes = $class !== DynamicComponent::class).']); ?>';
+}
+
+/**
+* Get the component class for a given component alias.
+*
+* @param string $component
+* @return string
+*
+* @throws \InvalidArgumentException
+*/
+public function componentClass(string $component)
+{
+$viewFactory = Container::getInstance()->make(Factory::class);
+
+if (isset($this->aliases[$component])) {
+if (class_exists($alias = $this->aliases[$component])) {
+return $alias;
+}
+
+if ($viewFactory->exists($alias)) {
+return $alias;
+}
+
+throw new InvalidArgumentException(
+"Unable to locate class or view [{$alias}] for component [{$component}]."
+);
+}
+
+if ($class = $this->findClassByComponent($component)) {
+return $class;
+}
+
+if (class_exists($class = $this->guessClassName($component))) {
+return $class;
+}
+
+$guess = collect($this->blade->getAnonymousComponentNamespaces())
+->filter(function ($directory, $prefix) use ($component) {
+return Str::startsWith($component, $prefix.'::');
+})
+->prepend('components', $component)
+->reduce(function ($carry, $directory, $prefix) use ($component, $viewFactory) {
+if (! is_null($carry)) {
+return $carry;
+}
+
+$componentName = Str::after($component, $prefix.'::');
+
+if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory))) {
+return $view;
+}
+
+if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory).'.index')) {
+return $view;
+}
+});
+
+if (! is_null($guess)) {
+return $guess;
+}
+
+throw new InvalidArgumentException(
+"Unable to locate a class or view for component [{$component}]."
+);
+}
+
+/**
+* Find the class for the given component using the registered namespaces.
+*
+* @param string $component
+* @return string|null
+*/
+public function findClassByComponent(string $component)
+{
+$segments = explode('::', $component);
+
+$prefix = $segments[0];
+
+if (! isset($this->namespaces[$prefix], $segments[1])) {
+return;
+}
+
+if (class_exists($class = $this->namespaces[$prefix].'\\'.$this->formatClassName($segments[1]))) {
+return $class;
+}
+}
+
+/**
+* Guess the class name for the given component.
+*
+* @param string $component
+* @return string
+*/
+public function guessClassName(string $component)
+{
+$namespace = Container::getInstance()
+->make(Application::class)
+->getNamespace();
+
+$class = $this->formatClassName($component);
+
+return $namespace.'View\\Components\\'.$class;
+}
+
+/**
+* Format the class name for the given component.
+*
+* @param string $component
+* @return string
+*/
+public function formatClassName(string $component)
+{
+$componentPieces = array_map(function ($componentPiece) {
+return ucfirst(Str::camel($componentPiece));
+}, explode('.', $component));
+
+return implode('\\', $componentPieces);
+}
+
+/**
+* Guess the view name for the given component.
+*
+* @param string $name
+* @param string $prefix
+* @return string
+*/
+public function guessViewName($name, $prefix = 'components.')
+{
+if (! Str::endsWith($prefix, '.')) {
+$prefix .= '.';
+}
+
+$delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
+
+if (str_contains($name, $delimiter)) {
+return Str::replaceFirst($delimiter, $delimiter.$prefix, $name);
+}
+
+return $prefix.$name;
+}
+
+/**
+* Partition the data and extra attributes from the given array of attributes.
+*
+* @param string $class
+* @param array $attributes
+* @return array
+*/
+public function partitionDataAndAttributes($class, array $attributes)
+{
+// If the class doesn't exist, we'll assume it is a class-less component and
+// return all of the attributes as both data and attributes since we have
+// now way to partition them. The user can exclude attributes manually.
+if (! class_exists($class)) {
+return [collect($attributes), collect($attributes)];
+}
+
+$constructor = (new ReflectionClass($class))->getConstructor();
+
+$parameterNames = $constructor
+? collect($constructor->getParameters())->map->getName()->all()
+: [];
+
+return collect($attributes)->partition(function ($value, $key) use ($parameterNames) {
+return in_array(Str::camel($key), $parameterNames);
+})->all();
+}
+
+/**
+* Compile the closing tags within the given string.
+*
+* @param string $value
+* @return string
+*/
+protected function compileClosingTags(string $value)
+{
+return preg_replace("/<\ /\s*x[-\:][\w\-\:\.]*\s*>/", ' @endComponentClass##END-COMPONENT-CLASS##',
+    $value);
     }
 
     /**
-     * Get the component class for a given component alias.
-     *
-     * @param  string  $component
-     * @return string
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function componentClass(string $component)
-    {
-        $viewFactory = Container::getInstance()->make(Factory::class);
-
-        if (isset($this->aliases[$component])) {
-            if (class_exists($alias = $this->aliases[$component])) {
-                return $alias;
-            }
-
-            if ($viewFactory->exists($alias)) {
-                return $alias;
-            }
-
-            throw new InvalidArgumentException(
-                "Unable to locate class or view [{$alias}] for component [{$component}]."
-            );
-        }
-
-        if ($class = $this->findClassByComponent($component)) {
-            return $class;
-        }
-
-        if (class_exists($class = $this->guessClassName($component))) {
-            return $class;
-        }
-
-        $guess = collect($this->blade->getAnonymousComponentNamespaces())
-            ->filter(function ($directory, $prefix) use ($component) {
-                return Str::startsWith($component, $prefix.'::');
-            })
-            ->prepend('components', $component)
-            ->reduce(function ($carry, $directory, $prefix) use ($component, $viewFactory) {
-                if (! is_null($carry)) {
-                    return $carry;
-                }
-
-                $componentName = Str::after($component, $prefix.'::');
-
-                if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory))) {
-                    return $view;
-                }
-
-                if ($viewFactory->exists($view = $this->guessViewName($componentName, $directory).'.index')) {
-                    return $view;
-                }
-            });
-
-        if (! is_null($guess)) {
-            return $guess;
-        }
-
-        throw new InvalidArgumentException(
-            "Unable to locate a class or view for component [{$component}]."
-        );
-    }
-
-    /**
-     * Find the class for the given component using the registered namespaces.
-     *
-     * @param  string  $component
-     * @return string|null
-     */
-    public function findClassByComponent(string $component)
-    {
-        $segments = explode('::', $component);
-
-        $prefix = $segments[0];
-
-        if (! isset($this->namespaces[$prefix], $segments[1])) {
-            return;
-        }
-
-        if (class_exists($class = $this->namespaces[$prefix].'\\'.$this->formatClassName($segments[1]))) {
-            return $class;
-        }
-    }
-
-    /**
-     * Guess the class name for the given component.
-     *
-     * @param  string  $component
-     * @return string
-     */
-    public function guessClassName(string $component)
-    {
-        $namespace = Container::getInstance()
-                    ->make(Application::class)
-                    ->getNamespace();
-
-        $class = $this->formatClassName($component);
-
-        return $namespace.'View\\Components\\'.$class;
-    }
-
-    /**
-     * Format the class name for the given component.
-     *
-     * @param  string  $component
-     * @return string
-     */
-    public function formatClassName(string $component)
-    {
-        $componentPieces = array_map(function ($componentPiece) {
-            return ucfirst(Str::camel($componentPiece));
-        }, explode('.', $component));
-
-        return implode('\\', $componentPieces);
-    }
-
-    /**
-     * Guess the view name for the given component.
-     *
-     * @param  string  $name
-     * @param  string  $prefix
-     * @return string
-     */
-    public function guessViewName($name, $prefix = 'components.')
-    {
-        if (! Str::endsWith($prefix, '.')) {
-            $prefix .= '.';
-        }
-
-        $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
-
-        if (str_contains($name, $delimiter)) {
-            return Str::replaceFirst($delimiter, $delimiter.$prefix, $name);
-        }
-
-        return $prefix.$name;
-    }
-
-    /**
-     * Partition the data and extra attributes from the given array of attributes.
-     *
-     * @param  string  $class
-     * @param  array  $attributes
-     * @return array
-     */
-    public function partitionDataAndAttributes($class, array $attributes)
-    {
-        // If the class doesn't exist, we'll assume it is a class-less component and
-        // return all of the attributes as both data and attributes since we have
-        // now way to partition them. The user can exclude attributes manually.
-        if (! class_exists($class)) {
-            return [collect($attributes), collect($attributes)];
-        }
-
-        $constructor = (new ReflectionClass($class))->getConstructor();
-
-        $parameterNames = $constructor
-                    ? collect($constructor->getParameters())->map->getName()->all()
-                    : [];
-
-        return collect($attributes)->partition(function ($value, $key) use ($parameterNames) {
-            return in_array(Str::camel($key), $parameterNames);
-        })->all();
-    }
-
-    /**
-     * Compile the closing tags within the given string.
-     *
-     * @param  string  $value
-     * @return string
-     */
-    protected function compileClosingTags(string $value)
-    {
-        return preg_replace("/<\/\s*x[-\:][\w\-\:\.]*\s*>/", ' @endComponentClass##END-COMPONENT-CLASS##', $value);
-    }
-
-    /**
-     * Compile the slot tags within the given string.
-     *
-     * @param  string  $value
-     * @return string
-     */
+    * Compile the slot tags within the given string.
+    *
+    * @param string $value
+    * @return string
+    */
     public function compileSlots(string $value)
     {
-        $pattern = "/
-            <
-                \s*
-                x[\-\:]slot
-                (?:\:(?<inlineName>\w+(?:-\w+)*))?
-                (?:\s+(:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
-                (?<attributes>
-                    (?:
-                        \s+
-                        (?:
-                            (?:
-                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
-                            )
-                            |
-                            (?:
-                                [\w\-:.@]+
-                                (
-                                    =
-                                    (?:
-                                        \\\"[^\\\"]*\\\"
-                                        |
-                                        \'[^\']*\'
-                                        |
-                                        [^\'\\\"=<>]+
-                                    )
-                                )?
-                            )
-                        )
+    $pattern = "/
+    < \s*
+        x[\-\:]slot
+        (?:\:(?<inlineName>\w+(?:-\w+)*))?
+        (?:\s+(:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
+            (?<attributes>
+                (?:
+                \s+
+                (?:
+                (?:
+                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
+                )
+                |
+                (?:
+                [\w\-:.@]+
+                (
+                =
+                (?:
+                \\\"[^\\\"]*\\\"
+                |
+                \'[^\']*\'
+                |
+                [^\'\\\"=<>]+
+                    )
+                    )?
+                    )
+                    )
                     )*
                     \s*
-                )
-                (?<![\/=\-])
+                    )
+                    (?
+                    <![\/=\-])
             >
         /x";
 
@@ -510,7 +512,7 @@ class ComponentTagCompiler
             return [];
         }
 
-        return collect($matches)->mapWithKeys(function ($match) {
+        return Arr::mapWithKeys($matches, function ($match) {
             $attribute = $match['attribute'];
             $value = $match['value'] ?? null;
 
@@ -535,7 +537,7 @@ class ComponentTagCompiler
             }
 
             return [$attribute => $value];
-        })->toArray();
+        });
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -2,17 +2,17 @@
 
 namespace Illuminate\View\Compilers;
 
-use ReflectionClass;
-use InvalidArgumentException;
-use Illuminate\View\ViewFinderInterface;
-use Illuminate\View\DynamicComponent;
-use Illuminate\View\AnonymousComponent;
-use Illuminate\Support\Str;
-use Illuminate\Support\Arr;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Contracts\View\Factory;
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\View\AnonymousComponent;
+use Illuminate\View\DynamicComponent;
+use Illuminate\View\ViewFinderInterface;
+use InvalidArgumentException;
+use ReflectionClass;
 
 /**
  * @author Spatie bvba <info@spatie.be>

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -649,7 +649,7 @@ class SupportArrTest extends TestCase
             $mapped,
         );
     }
-        
+
     public function testMapWithKeysIntegerKeys()
     {
         $data = [

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -632,6 +632,79 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
     }
 
+    public function testMapWithKeys()
+    {
+        $data = [
+            ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
+            ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
+            ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
+        ];
+
+        $mapped = Arr::mapWithKeys($data, function ($pokemon) {
+            return [$pokemon['name'] => $pokemon['type']];
+        });
+
+        $this->assertEquals(
+            ['Blastoise' => 'Water', 'Charmander' => 'Fire', 'Dragonair' => 'Dragon'],
+            $mapped,
+        );
+    }
+        
+    public function testMapWithKeysIntegerKeys()
+    {
+        $data = [
+            ['id' => 1, 'name' => 'A'],
+            ['id' => 3, 'name' => 'B'],
+            ['id' => 2, 'name' => 'C'],
+        ];
+
+        $mapped = Arr::mapWithKeys($data, function ($item) {
+            return [$item['id'] => $item];
+        });
+
+        $this->assertSame([1, 3, 2], array_keys($mapped));
+    }
+
+    public function testMapWithKeysMultipleRows()
+    {
+        $data = [
+            ['id' => 1, 'name' => 'A'],
+            ['id' => 2, 'name' => 'B'],
+            ['id' => 3, 'name' => 'C'],
+        ];
+
+        $mapped = Arr::mapWithKeys($data, function ($item) {
+            return [$item['id'] => $item['name'], $item['name'] => $item['id']];
+        });
+
+        $this->assertSame(
+            [
+                1 => 'A',
+                'A' => 1,
+                2 => 'B',
+                'B' => 2,
+                3 => 'C',
+                'C' => 3,
+            ],
+            $mapped,
+        );
+    }
+
+    public function testMapWithKeysCallbackKey()
+    {
+        $data = [
+            3 => ['id' => 1, 'name' => 'A'],
+            5 => ['id' => 3, 'name' => 'B'],
+            4 => ['id' => 2, 'name' => 'C'],
+        ];
+
+        $mapped = Arr::mapWithKeys($data, function ($item, $key) {
+            return [$key => $item['id']];
+        });
+
+        $this->assertSame([3, 5, 4], array_keys($mapped));
+    }
+
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');


### PR DESCRIPTION
Adds `Arr::mapWithKeys` as it's super handy but currently only available in `Collection`.

1. Adds `Arr::mapWithKeys`
2. Utilize `Arr::mapWithKeys` in `collect()->mapWithKeys`
3. Refactor `Arr::prependKeysWith` to use `Arr` instead of `Collection`
4. Refactor from `Collection` to `Arr` in
    - `src/Illuminate/Validation/Validator.php`
    - `src/Illuminate/Http/Middleware/SetCacheHeaders.php`
    - `src/Illuminate/Notifications/Channels/MailChannel.php`
    - `src/Illuminate/Pagination/AbstractPaginator.php`
    - `src/Illuminate/View/Compilers/ComponentTagCompiler.php`
    - `src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php`
    - `src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php`
