### PR TITLE
[9.x] Add invokable option to make rule command

### DIFF
--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -51,17 +51,9 @@ class RuleMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $replace = 'Rule';
-
-        if ($this->option('invokable')) {
-            $replace = 'InvokableRule';
-        } elseif ($this->option('implicit')) {
-            $replace = 'ImplicitRule';
-        }
-
         return str_replace(
             '{{ ruleType }}',
-            $replace,
+            $this->option('implicit') ? 'ImplicitRule' : 'Rule',
             parent::buildClass($name)
         );
     }

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -68,7 +68,7 @@ class RuleMakeCommand extends GeneratorCommand
         $stub = '/stubs/rule.stub';
 
         if ($this->option('invokable')) {
-            $stub = "/stubs/rule.invokable.stub";
+            $stub = '/stubs/rule.invokable.stub';
         }
 
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -71,6 +71,10 @@ class RuleMakeCommand extends GeneratorCommand
             $stub = '/stubs/rule.invokable.stub';
         }
 
+        if ($this->option('implicit') && $this->option('invokable')) {
+            $stub = str_replace('.stub', '.implicit.stub', $stub);
+        }
+
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
             : __DIR__.$stub;

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -51,9 +51,17 @@ class RuleMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
+        $replace = 'Rule';
+
+        if ($this->option('invokable')) {
+            $replace = 'InvokableRule';
+        } elseif ($this->option('implicit')) {
+            $replace = 'ImplicitRule';
+        }
+
         return str_replace(
             '{{ ruleType }}',
-            $this->option('implicit') ? 'ImplicitRule' : 'Rule',
+            $replace,
             parent::buildClass($name)
         );
     }
@@ -65,11 +73,15 @@ class RuleMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        $relativePath = '/stubs/rule.stub';
+        $stub = '/stubs/rule.stub';
 
-        return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
+        if ($this->option('invokable')) {
+            $stub = "/stubs/rule.invokable.stub";
+        }
+
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__.$relativePath;
+            : __DIR__.$stub;
     }
 
     /**
@@ -92,6 +104,7 @@ class RuleMakeCommand extends GeneratorCommand
     {
         return [
             ['implicit', 'i', InputOption::VALUE_NONE, 'Generate an implicit rule.'],
+            ['invokable', null, InputOption::VALUE_NONE, 'Generate a single method, invokable rule class.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/rule.invokable.implicit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.invokable.implicit.stub
@@ -9,7 +9,7 @@ class {{ class }} implements InvokableRule
     /**
      * Indicates whether the rule should be implicit.
      *
-     * @var bool|null
+     * @var bool
      */
     public $implicit = true;
 

--- a/src/Illuminate/Foundation/Console/stubs/rule.invokable.implicit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.invokable.implicit.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Validation\InvokableRule;
+
+class {{ class }} implements InvokableRule
+{
+    /**
+     * Indicates whether the rule should be implicit.
+     *
+     * @var bool|null
+     */
+    public $implicit = true;
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function __invoke($attribute, $value, $fail)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/rule.invokable.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.invokable.stub
@@ -2,9 +2,9 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Contracts\Validation\{{ ruleType }};
+use Illuminate\Contracts\Validation\InvokableRule;
 
-class {{ class }} implements {{ ruleType }}
+class {{ class }} implements InvokableRule
 {
     /**
      * Run the validation rule.

--- a/src/Illuminate/Foundation/Console/stubs/rule.invokable.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.invokable.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Validation\{{ ruleType }};
+
+class {{ class }} implements {{ ruleType }}
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function __invoke($attribute, $value, $fail)
+    {
+        //
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Following the PR https://github.com/laravel/framework/pull/42689, this new PR adds an option to make an invokable rule to the existing make rule command.

This minor feature comes with no breaking change, the previous command will still work as usual.
For the end users, this additional option can be useful to generate an invokable rule.

