### PR TITLE
[9.x] Allow handling cumulative query duration limit per DB connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -812,7 +812,7 @@ class Connection implements ConnectionInterface
 
         $this->listen(function ($event) use ($threshold, $handler, $key) {
             if ($this->queryDurationHandlers[$key]['not_yet_run'] && $this->totalQueryDuration() > $threshold) {
-                $handler($this);
+                $handler($this, $event);
 
                 $this->queryDurationHandlers[$key]['not_yet_run'] = false;
             }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -159,14 +159,14 @@ class Connection implements ConnectionInterface
     protected $loggingQueries = false;
 
     /**
-     * The duration of all run queries in milliseconds.
+     * The duration of all executed queries in milliseconds.
      *
      * @var float
      */
     protected $totalQueryDuration = 0.0;
 
     /**
-     * Query duration handlers.
+     * All of the registered query duration handlers.
      *
      * @var array
      */
@@ -804,30 +804,30 @@ class Connection implements ConnectionInterface
             : $threshold;
 
         $this->queryDurationHandlers[] = [
-            'not_yet_run' => true,
+            'has_run' => false,
             'handler' => $handler,
         ];
 
         $key = count($this->queryDurationHandlers) - 1;
 
         $this->listen(function ($event) use ($threshold, $handler, $key) {
-            if ($this->queryDurationHandlers[$key]['not_yet_run'] && $this->totalQueryDuration() > $threshold) {
+            if (! $this->queryDurationHandlers[$key]['has_run'] && $this->totalQueryDuration() > $threshold) {
                 $handler($this, $event);
 
-                $this->queryDurationHandlers[$key]['not_yet_run'] = false;
+                $this->queryDurationHandlers[$key]['has_run'] = true;
             }
         });
     }
 
     /**
-     * Restore all the query duration handlers that have already run.
+     * Allow all the query duration handlers to run again, even if they have already run.
      *
      * @return void
      */
-    public function restoreAlreadyRunQueryDurationHandlers()
+    public function allowQueryDurationHandlersToRunAgain()
     {
         foreach ($this->queryDurationHandlers as $key => $queryDurationHandler) {
-            $this->queryDurationHandlers[$key]['not_yet_run'] = true;
+            $this->queryDurationHandlers[$key]['has_run'] = false;
         }
     }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -797,7 +797,7 @@ class Connection implements ConnectionInterface
      * @param  callable  $handler
      * @return void
      */
-    public function handleExceedingQueryDuration($threshold, $handler)
+    public function handleExceedingCumulativeQueryDuration($threshold, $handler)
     {
         $threshold = $threshold instanceof CarbonInterval
             ? $threshold->totalMilliseconds

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -819,6 +819,11 @@ class Connection implements ConnectionInterface
         });
     }
 
+    /**
+     * Restore all the query duration handlers that have already run.
+     *
+     * @return void
+     */
     public function restoreAlreadyRunQueryDurationHandlers()
     {
         foreach ($this->queryDurationHandlers as $key => $queryDurationHandler) {

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -203,7 +203,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                 if (method_exists($app['db'], 'getConnections')) {
                     foreach ($app['db']->getConnections() as $connection) {
                         $connection->resetTotalQueryDuration();
-                        $connection->restoreAlreadyRunQueryDurationHandlers();
+                        $connection->allowQueryDurationHandlersToRunAgain();
                     }
                 }
 

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -200,6 +200,13 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                     $app['log']->withoutContext();
                 }
 
+                if (method_exists($app['db'], 'getConnections')) {
+                    foreach ($app['db']->getConnections() as $connection) {
+                        $connection->resetTotalQueryDuration();
+                        $connection->restoreAlreadyRunQueryDurationHandlers();
+                    }
+                }
+
                 return $app->forgetScopedInstances();
             };
 

--- a/tests/Database/QueryDurationThresholdTest.php
+++ b/tests/Database/QueryDurationThresholdTest.php
@@ -165,13 +165,13 @@ class QueryDurationThresholdTest extends TestCase
         $connection->logQuery('xxxx', [], 1);
         $this->assertSame(1, $called);
 
-        $connection->restoreAlreadyRunQueryDurationHandlers();
+        $connection->allowQueryDurationHandlersToRunAgain();
         $connection->logQuery('xxxx', [], 1);
         $connection->logQuery('xxxx', [], 1);
         $connection->logQuery('xxxx', [], 1);
         $this->assertSame(2, $called);
 
-        $connection->restoreAlreadyRunQueryDurationHandlers();
+        $connection->allowQueryDurationHandlersToRunAgain();
         $connection->logQuery('xxxx', [], 1);
         $connection->logQuery('xxxx', [], 1);
         $connection->logQuery('xxxx', [], 1);

--- a/tests/Database/QueryDurationThresholdTest.php
+++ b/tests/Database/QueryDurationThresholdTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Carbon\CarbonInterval;
+use Illuminate\Database\Connection;
+use Illuminate\Events\Dispatcher;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class QueryDurationThresholdTest extends TestCase
+{
+    public function testItCanHandleReachingADurationThresholdInTheDb()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $connection->setEventDispatcher(new Dispatcher());
+        $called = 0;
+        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1.1), function () use (&$called) {
+            $called++;
+        });
+
+        $connection->logQuery('xxxx', [], 1.0);
+        $connection->logQuery('xxxx', [], 0.1);
+        $this->assertSame(0, $called);
+
+        $connection->logQuery('xxxx', [], 0.1);
+        $this->assertSame(1, $called);
+    }
+
+    public function testItIsOnlyCalledOnce()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $connection->setEventDispatcher(new Dispatcher());
+        $called = 0;
+        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+            $called++;
+        });
+
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+
+        $this->assertSame(1, $called);
+    }
+
+    public function testItCanSpecifyMultipleHandlersWithTheSameIntervals()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $connection->setEventDispatcher(new Dispatcher());
+        $called = [];
+        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+            $called['a'] = true;
+        });
+        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+            $called['b'] = true;
+        });
+
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+
+        $this->assertSame([
+            'a' => true,
+            'b' => true,
+        ], $called);
+    }
+
+    public function testItCanSpecifyMultipleHandlersWithDifferentIntervals()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $connection->setEventDispatcher(new Dispatcher());
+        $called = [];
+        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+            $called['a'] = true;
+        });
+        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(2), function () use (&$called) {
+            $called['b'] = true;
+        });
+
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+        $this->assertSame([
+            'a' => true,
+        ], $called);
+
+        $connection->logQuery('xxxx', [], 1);
+        $this->assertSame([
+            'a' => true,
+            'b' => true,
+        ], $called);
+    }
+
+    public function testItHasAccessToConnectionInHandler()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'), '', '', ['name' => 'expected-name']);
+        $connection->setEventDispatcher(new Dispatcher());
+        $name = null;
+        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function ($connection) use (&$name) {
+            $name = $connection->getName();
+        });
+
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+
+        $this->assertSame('expected-name', $name);
+    }
+
+    public function testItHasSpecifyThresholdWithFloat()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $connection->setEventDispatcher(new Dispatcher());
+        $called = false;
+        $connection->handleExceedingQueryDuration(1.1, function () use (&$called) {
+            $called = true;
+        });
+
+        $connection->logQuery('xxxx', [], 1.1);
+        $this->assertFalse($called);
+
+        $connection->logQuery('xxxx', [], 0.1);
+        $this->assertTrue($called);
+    }
+
+    public function testItHasSpecifyThresholdWithInt()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $connection->setEventDispatcher(new Dispatcher());
+        $called = false;
+        $connection->handleExceedingQueryDuration(2, function () use (&$called) {
+            $called = true;
+        });
+
+        $connection->logQuery('xxxx', [], 1.1);
+        $this->assertFalse($called);
+
+        $connection->logQuery('xxxx', [], 1.0);
+        $this->assertTrue($called);
+    }
+
+    public function testItCanResetTotalQueryDuration()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $connection->setEventDispatcher(new Dispatcher());
+
+        $connection->logQuery('xxxx', [], 1.1);
+        $this->assertSame(1.1, $connection->totalQueryDuration());
+        $connection->logQuery('xxxx', [], 1.1);
+        $this->assertSame(2.2, $connection->totalQueryDuration());
+
+        $connection->resetTotalQueryDuration();
+        $this->assertSame(0.0, $connection->totalQueryDuration());
+    }
+
+    public function testItCanRestoreAlreadyRunHandlers()
+    {
+        $connection = new Connection(new PDO('sqlite::memory:'));
+        $connection->setEventDispatcher(new Dispatcher());
+        $called = 0;
+        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+            $called++;
+        });
+
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+        $this->assertSame(1, $called);
+
+        $connection->restoreAlreadyRunQueryDurationHandlers();
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+        $this->assertSame(2, $called);
+
+        $connection->restoreAlreadyRunQueryDurationHandlers();
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+        $connection->logQuery('xxxx', [], 1);
+        $this->assertSame(3, $called);
+    }
+}

--- a/tests/Database/QueryDurationThresholdTest.php
+++ b/tests/Database/QueryDurationThresholdTest.php
@@ -15,7 +15,7 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = 0;
-        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1.1), function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(CarbonInterval::milliseconds(1.1), function () use (&$called) {
             $called++;
         });
 
@@ -32,7 +32,7 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = 0;
-        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called++;
         });
 
@@ -48,10 +48,10 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = [];
-        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called['a'] = true;
         });
-        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called['b'] = true;
         });
 
@@ -69,10 +69,10 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = [];
-        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called['a'] = true;
         });
-        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(2), function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(CarbonInterval::milliseconds(2), function () use (&$called) {
             $called['b'] = true;
         });
 
@@ -94,7 +94,7 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'), '', '', ['name' => 'expected-name']);
         $connection->setEventDispatcher(new Dispatcher());
         $name = null;
-        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function ($connection) use (&$name) {
+        $connection->handleExceedingCumulativeQueryDuration(CarbonInterval::milliseconds(1), function ($connection) use (&$name) {
             $name = $connection->getName();
         });
 
@@ -109,7 +109,7 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = false;
-        $connection->handleExceedingQueryDuration(1.1, function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(1.1, function () use (&$called) {
             $called = true;
         });
 
@@ -125,7 +125,7 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = false;
-        $connection->handleExceedingQueryDuration(2, function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(2, function () use (&$called) {
             $called = true;
         });
 
@@ -155,7 +155,7 @@ class QueryDurationThresholdTest extends TestCase
         $connection = new Connection(new PDO('sqlite::memory:'));
         $connection->setEventDispatcher(new Dispatcher());
         $called = 0;
-        $connection->handleExceedingQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
+        $connection->handleExceedingCumulativeQueryDuration(CarbonInterval::milliseconds(1), function () use (&$called) {
             $called++;
         });
 


### PR DESCRIPTION
This PR aims to being a nice way to detect and handle when your application has spent a specified cumulative duration querying the database throughout a request / job.

We already have the ability to "handle" what happens when an n+1 is triggered via Eloquent. This PR is in a similar spirit.

The query count isn't always reflective of a "performant" operation, so instead I wanted to be able to track the cumulative duration spent querying the DB for a specific connection.

```php
DB::handleExceedingCumulativeQueryDuration(Interval::seconds(5), function (Connection $connection) {
    Log::warning("Database queries exceeded 5 seconds on {$connection->getName()}");
});
```

This does differ from the n+1 query handling that already exists in Laravel. The n+1 handler is called on _every_ query, where as these handlers are only ever called a maximum of once per request / job.

```php
DB::handleExceedingCumulativeQueryDuration(Interval::seconds(2), fn ($c) => echo 'handled');

DB::table('users')->get(); // 1 second query; total query time: 1 second;
DB::table('users')->get(); // 1 second query; total query time: 2 seconds;
DB::table('users')->get(); // 1 second query; total query time: 3 seconds;
// echo "handled"
DB::table('users')->get(); // 1 second query; total query time: 4 seconds;
DB::table('users')->get(); // 1 second query; total query time: 5 seconds;
DB::table('users')->get(); // 1 second query; total query time: 6 seconds;
DB::table('users')->get(); // 1 second query; total query time: 7 seconds;
```

It is important to note that this is all done on a per connection basis.

```php
// default connection...
DB::handleExceedingCumulativeQueryDuration(/* */);

// specific connection...
DB::connection('postgres')->handleExceedingCumulativeQueryDuration(/* */);
```

## Performance

Of course when introducing something around performance, I wanted to be extremely careful about impacting existing performance.

So if you do not utilise this feature, this is the only extra code that is executed for a standard request...

```php
$this->totalQueryDuration += $time ?? 0.0;
```

this does however mean that even if you don't use this feature directly, you now have a nice way to get the total duration off of a connection...

```php
DB::connection()->totalQueryDuration();
```

When it comes to the queue worker / octane, they do need to also reset the duration between jobs / requests.

## To use the event system or not?!

There is one consideration here. I'm currently hooking into the event dispatcher. If another event that is listening to `QueryExecuted` returns `false`, it will mean that our handler will no longer trigger.

So with that in mind, we might want to consider not using the event listener. If this is preferred, I'll refactor this so it doesn't lean on the event dispatcher at all.

## Architecture

So this might look a bit strange, but the reason we are holding onto the handlers on the connection instance and doing the whole `"not_yet_run"` song and dance is that we only want them to run once, but we also need to be able to "restore" the handlers in Octane and on a Queue worker.

Octane PR: https://github.com/laravel/octane/pull/541

## Notes

This is an easy starting point for handling slow endpoints / jobs with problematic (slow / many) queries and not a full blown replacement for the slow query log or other metric system, but gives developers some quick insight into their system with little to no extra knowledge / setup.

This is targeting a cumulative total duration, as I feel this where the most value initially   lay, what's more is you can already easily handle individual query duration..

```php
DB::enableQueryLog();

DB::listen(function ($event) {
    if ($event->time > 1000) {
        Log::warning("Individual database query exceeded 1 second.");
    }
});
```

That being said, I can see value in introducing nicely named helper for that as well, but I will introduce a different PR for that, if we are keen on it.