### PR TITLE
[8.x] fix `Request` offsetExists without routeResolver

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -669,10 +669,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
+        $route = $this->route();
+
         return Arr::has(
-            $this->all() + with($this->route(), function ($route) {
-                return $route ? $route->parameters() : [];
-            }),
+            $this->all() + ($route ? $route->parameters() : []),
             $offset
         );
     }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -670,7 +670,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function offsetExists($offset)
     {
         return Arr::has(
-            $this->all() + $this->route()->parameters(),
+            $this->all() + with($this->route(), function ($route) {
+                return $route ? $route->parameters() : [];
+            }),
             $offset
         );
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -613,6 +613,22 @@ class HttpRequestTest extends TestCase
         $this->assertSame('foo', $request['id']);
     }
 
+    public function testArrayAccessWithoutRouteResolver()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'foo' => ['bar' => null, 'baz' => '']]);
+
+        $this->assertFalse(isset($request['non-existent']));
+        $this->assertNull($request['non-existent']);
+
+        $this->assertTrue(isset($request['name']));
+        $this->assertSame('Taylor', $request['name']);
+
+        $this->assertTrue(isset($request['foo.bar']));
+        $this->assertNull($request['foo.bar']);
+        $this->assertTrue(isset($request['foo.baz']));
+        $this->assertSame('', $request['foo.baz']);
+    }
+
     public function testAllMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -615,18 +615,13 @@ class HttpRequestTest extends TestCase
 
     public function testArrayAccessWithoutRouteResolver()
     {
-        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'foo' => ['bar' => null, 'baz' => '']]);
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
 
         $this->assertFalse(isset($request['non-existent']));
         $this->assertNull($request['non-existent']);
 
         $this->assertTrue(isset($request['name']));
         $this->assertSame('Taylor', $request['name']);
-
-        $this->assertTrue(isset($request['foo.bar']));
-        $this->assertNull($request['foo.bar']);
-        $this->assertTrue(isset($request['foo.baz']));
-        $this->assertSame('', $request['foo.baz']);
     }
 
     public function testAllMethod()


### PR DESCRIPTION
When checking if a request parameter _isset_ without the routeResolver being set we get an error.

Example:

```php
isset((new \Illuminate\Http\Request())['foobar']);
// or
(new \Illuminate\Http\Request())['foobar'] ?? '';

// throws the following error
// PHP Error:  Call to a member function parameters() on null
```