### PR TITLE
Fix the way errors are added for compromised passwords:

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -329,15 +329,18 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
             }
         });
 
-        if ($validator->fails()) {
-            return $this->fail($validator->messages()->all());
+        if ($this->uncompromised && ! Container::getInstance()->make(UncompromisedVerifier::class)->verify([
+                'value' => $value,
+                'threshold' => $this->compromisedThreshold,
+            ])) {
+            $validator->errors()->add(
+                $attribute,
+                $this->getErrorMessage('validation.password.uncompromised')
+            );
         }
 
-        if ($this->uncompromised && ! Container::getInstance()->make(UncompromisedVerifier::class)->verify([
-            'value' => $value,
-            'threshold' => $this->compromisedThreshold,
-        ])) {
-            return $this->fail($this->getErrorMessage('validation.password.uncompromised'));
+        if ($validator->fails()) {
+            return $this->fail($validator->messages()->all());
         }
 
         return true;

--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -330,9 +330,9 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
         });
 
         if ($this->uncompromised && ! Container::getInstance()->make(UncompromisedVerifier::class)->verify([
-                'value' => $value,
-                'threshold' => $this->compromisedThreshold,
-            ])) {
+            'value' => $value,
+            'threshold' => $this->compromisedThreshold,
+        ])) {
             $validator->errors()->add(
                 $attribute,
                 $this->getErrorMessage('validation.password.uncompromised')


### PR DESCRIPTION
- Found an error where the error for a compromised password is not added to the validation error bag. This PR adds the error to the message bag for validation purposes