### PR TITLE
[8.x] Do not resolve already set headers

### DIFF
--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -49,6 +49,44 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('inline; filename=file.txt', $response->headers->get('content-disposition'));
     }
 
+    public function testMimeTypeIsNotCalledAlreadyProvidedToResponse()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $files = m::mock(FilesystemAdapter::class, [$this->filesystem])->makePartial();
+        $files->shouldReceive('mimeType')->never();
+
+        $files->response('file.txt', null, [
+            'Content-Type' => 'text/x-custom',
+        ]);
+    }
+
+    public function testSizeIsNotCalledAlreadyProvidedToResponse()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $files = m::mock(FilesystemAdapter::class, [$this->filesystem])->makePartial();
+        $files->shouldReceive('size')->never();
+
+        $files->response('file.txt', null, [
+            'Content-Length' => 11,
+        ]);
+    }
+
+    public function testFallbackNameCalledAlreadyProvidedToResponse()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $files = m::mock(FilesystemAdapter::class, [$this->filesystem])
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $files->shouldReceive('fallbackName')->never();
+
+        $files->response('file.txt', null, [
+            'Content-Disposition' => 'attachment',
+        ]);
+    }
+
     public function testDownload()
     {
         $this->filesystem->write('file.txt', 'Hello World');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently `Illuminate\Filesystem\FilesystemAdapter@response`, will implicitly calculate the `Content-Type`, `Content-Length`, and `Content-Disposition` default headers values, even when the user already provided those headers.

Also, the calculated default values end up not being used, as the default headers are merged to the user provided headers using the `+` operator, which preserve keys already present.

~~~php
$response->headers->replace($headers + [
    'Content-Type' => $this->mimeType($path),
    'Content-Length' => $this->size($path),
    'Content-Disposition' => $disposition,
]);
~~~

As outlined in issue #42758 , this can create an issue, for example, when a developer is trying to send a custom file extension, even when they provide a custom `Content-Type` header, as the `FilesystemAdapter@mimeType` method would be called anyways.

This PR:

- Checks if each of the  `Content-Type`, `Content-Length`, and `Content-Disposition` headers are not present before calculating their corresponding default
- Adds test cases to ensure the methods are not called when those headers are provided

Note: Per support policy this PR was sent to the 8.x branch, as the issue's reporter reports the issue as a bug.

If accepted, when merging this PR to the 9.x branch, the partial mock creation on the added test cases will need to be changed, as  the `FilesystemAdapter` constructor expects an extra adapter argument on the 9.x branch.

Short, when merging to 9.x, mock definitions like this...

~~~php
$files = m::mock(FilesystemAdapter::class, [$this->filesystem])->makePartial();
~~~

... will need to be changed to this:

~~~php
$files = m::mock(FilesystemAdapter::class, [$this->filesystem, $this->adapter])->makePartial();
~~~

No further changes will be needed on the test cases.
