### PR TITLE
[9.x] Avoid throwing on invalid mime-type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "fruitcake/php-cors": "^1.2",
         "laravel/serializable-closure": "^1.0",
         "league/commonmark": "^2.2",
-        "league/flysystem": "^3.0",
+        "league/flysystem": "^3.0.16",
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.53.1",
         "psr/container": "^1.1.1|^2.0.1",

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -24,6 +24,7 @@ use League\Flysystem\UnableToDeleteDirectory;
 use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToReadFile;
+use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\Visibility;
@@ -548,7 +549,13 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function mimeType($path)
     {
-        return $this->driver->mimeType($path);
+        try {
+            return $this->driver->mimeType($path);
+        } catch (UnableToRetrieveMetadata $e) {
+            throw_if($this->throwsExceptions(), $e);
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`league/flysystem` version 3, changed to throw exceptions in places it previously returned `null` or `false` when a called method failed to execute.

As noted by issue #42758 , calling `Illuminate\Filesystem\FilesystemAdapter@mimeType` throws an exception when a file has a custom extension.

This becomes a problem when this method is called within other methods such in:

- https://github.com/laravel/framework/blob/2bc180295ebf8c4848a6b9c4ae8fa0d00ec75217/src/Illuminate/Filesystem/FilesystemAdapter.php#L278
- https://github.com/laravel/framework/blob/2bc180295ebf8c4848a6b9c4ae8fa0d00ec75217/src/Illuminate/Mail/Attachment.php#L98
- https://github.com/laravel/framework/blob/2bc180295ebf8c4848a6b9c4ae8fa0d00ec75217/src/Illuminate/Mail/Mailable.php#L463

Disclaimer: usage on `Illuminate\Filesystem\FilesystemAdapter@response` is changed to be lazily evaluated in PR #42760 

This PR

- Changes `Illuminate\Filesystem\FilesystemAdapter@mimeType` to return `false`, as per its docblock, when the mime type cannot be detected
- Honors the `throw` configuration, when a developer sets it to `true` an exception will be thrown instead
- Adds two test cases covering both cases

**EDIT**

As `league/flysystem` changed the mime type detection behavior on tag 3.0.16, I updated the `composer.json` file to require at least this version.

Otherwise tests with prefer-lowest were failing

