### PR TITLE
[9.x] Adds `compilePushIf` and `compileEndpushIf` functions

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -348,4 +348,27 @@ trait CompilesConditionals
     {
         return "<?php if{$condition}: echo 'readonly'; endif; ?>";
     }
+
+    /**
+     * Compile the push statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePushIf($expression)
+    {
+        $parts = explode(',', $this->stripParentheses($expression), 2);
+
+        return "<?php if({$parts[0]}): \$__env->startPush({$parts[1]}); ?>";
+    }
+
+    /**
+     * Compile the end-push statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndpushIf()
+    {
+        return '<?php $__env->stopPush(); endif; ?>';
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -367,7 +367,7 @@ trait CompilesConditionals
      *
      * @return string
      */
-    protected function compileEndpushIf()
+    protected function compileEndPushIf()
     {
         return '<?php $__env->stopPush(); endif; ?>';
     }


### PR DESCRIPTION
Sometimes we need to check about something to push the script, instead of using the `if` directive we can use this directive, for illuminate see the next example:

**Old version**

```BLADE
@if (true==false)
@push('scripts')
<script>
    console.log('Push');
</script>
@endpush
@endif
```

**New version**

```BLADE
@pushIf(true==false, 'scripts')
<script>
    console.log('Push If');
</script>
@endPushIf
```