### PR TITLE
[9.x] Removed unused parameter

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -77,10 +77,9 @@ trait AuthorizesRequests
      * @param  string|array  $model
      * @param  string|array|null  $parameter
      * @param  array  $options
-     * @param  \Illuminate\Http\Request|null  $request
      * @return void
      */
-    public function authorizeResource($model, $parameter = null, array $options = [], $request = null)
+    public function authorizeResource($model, $parameter = null, array $options = [])
     {
         $model = is_array($model) ? implode(',', $model) : $model;
 


### PR DESCRIPTION
This small PR removes the unused `$request` parameter from the `AuthorizesRequests` trait's `authorizeResource` method.