### PR TITLE
[9.x] DOC BLOCK params fix on orderBy methods at Query Builder file

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2201,7 +2201,7 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @param  string  $direction
      * @return $this
      *
@@ -2234,7 +2234,7 @@ class Builder implements BuilderContract
     /**
      * Add a descending "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @return $this
      */
     public function orderByDesc($column)


### PR DESCRIPTION
As per the [documentation](https://laravel.com/docs/9.x/eloquent#subquery-ordering).

The first parameter can be an object of the eloquent builder. And also one more thing is the code of the `orderBy` and `orderByDesc` methods both are calling the `isQueryable` method. `isQueryable` method allows the user to pass the object of the eloquent builder.

PHPSTAN is throwing an error. That's why we need to add the eloquent builder to the parameters.