### PR TITLE
[9.x] Deprecated message fix

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -438,6 +438,10 @@ class Str
         if ($encoding) {
             return mb_strlen($value, $encoding);
         }
+        
+        if (is_null($value)) {
+            return 0;
+        }
 
         return mb_strlen($value);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -433,14 +433,10 @@ class Str
      * @param  string|null  $encoding
      * @return int
      */
-    public static function length($value, $encoding = null)
+    public static function length(string $value, $encoding = null)
     {
         if ($encoding) {
             return mb_strlen($value, $encoding);
-        }
-        
-        if (is_null($value)) {
-            return 0;
         }
 
         return mb_strlen($value);


### PR DESCRIPTION
Deprecated message on Str::length. Check is null than return 0;

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
