### PR TITLE
[8.x] Replace resolved form request in container

### DIFF
--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -32,6 +32,7 @@ class FormRequestServiceProvider extends ServiceProvider
 
         $this->app->resolving(FormRequest::class, function ($request, $app) {
             $request = FormRequest::createFrom($app['request'], $request);
+            $app->instance('request', $request);
 
             $request->setContainer($app)->setRedirector($app->make(Redirector::class));
         });

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -32,6 +32,7 @@ class FormRequestServiceProvider extends ServiceProvider
 
         $this->app->resolving(FormRequest::class, function ($request, $app) {
             $request = FormRequest::createFrom($app['request'], $request);
+
             $app->instance('request', $request);
 
             $request->setContainer($app)->setRedirector($app->make(Redirector::class));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently when a Form Request is resolved from the container the container's current `Request` instance is not replaced, thus if a developer typehints a FormRequest in a controller action and then from a service class they use the `request()` helper to access the request instead, they will get different request instances.

This is problematic, when a developer wants to merge new values, for example in the `FormRequest@passedValidation` and later wants to access this value from the request helper.

For example consider this form request:

~~~php
<?php

namespace App\Http\Requests;

use Illuminate\Foundation\Http\FormRequest;

class SampleRequest extends FormRequest
{
    public function rules(): array
    {
        return [];
    }

    protected function passedValidation()
    {
        $this->merge(['foo' => 'bar']);
    }
}
~~~

And this route:

~~~php
Route::get('/', fn (SampleRequest $request) => request('foo'));
~~~

Currently this route would return `null` as the `request()` helper would be trying to get the field from the original request instance, not from the resolved form request.

This behavior was reported in issue #42765 

This PR:

- Replaces the `'request'` instance in the container after creating a new Form Request
- No tests were added as this is done inside the `FormRequestServiceProvider` and all `FormRequests` tests manually creates a new instance, so I could not figure out how to test it out in a simple manner.
- 
