### PR TITLE
[8.x] Make BuildsQueries::tap consistent with other versions of tap

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -487,10 +487,12 @@ trait BuildsQueries
      * Pass the query to a given callback.
      *
      * @param  callable  $callback
-     * @return $this|mixed
+     * @return $this
      */
     public function tap($callback)
     {
-        return $this->when(true, $callback);
+        $callback($this);
+
+        return $this;
     }
 }


### PR DESCRIPTION
As previously mentioned on https://github.com/laravel/framework/issues/38343 and https://github.com/laravel/framework/pull/38353.

This PR makes `BuildsQueries::tap()` consistent with `EnumeratesValues::tap()` and `tap()`, meaning it will always return `$this` after executing the given callback. This change should not be breaking unless the developer was relying on undocumented behaviour (prior to https://github.com/laravel/framework/pull/38353).

This was merged in 9.x with https://github.com/laravel/framework/pull/38359 PR but still remains in 8.x.