### PR TITLE
[9.x] Add the `dot()` method to Collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -286,6 +286,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @param  string  $prepend
+     * @return static
+     */
+    public function dot($prepend = '')
+    {
+        return new static(Arr::dot($this->all(), $prepend));
+    }
+
+    /**
      * Retrieve duplicate items from the collection.
      *
      * @param  (callable(TValue): bool)|string|null  $callback

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -362,6 +362,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Flatten a multi-dimensional associative array with dots.
+     *
+     * @param  string  $prepend
+     * @return static
+     */
+    public function dot($prepend = '')
+    {
+        return $this->passthru('dot', [$prepend]);
+    }
+
+    /**
      * Retrieve duplicate items.
      *
      * @param  (callable(TValue): bool)|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5061,6 +5061,42 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testDot($collection)
+    {
+        $data = $collection::make([
+            'name' => 'Taylor',
+            'meta' => [
+                'foo' => 'bar',
+                'baz' => 'boom',
+                'bam' => [
+                    'boom' => 'bip',
+                ],
+            ],
+        ])->dot();
+        $this->assertSame([
+            'name' => 'Taylor',
+            'meta.foo' => 'bar',
+            'meta.baz' => 'boom',
+            'meta.bam.boom' => 'bip',
+        ], $data->all());
+
+        $data = $collection::make([
+            'foo' => [
+                'bar',
+                'baz',
+                'baz' => 'boom',
+            ],
+        ])->dot('prepend.');
+        $this->assertSame([
+            'prepend.foo.0' => 'bar',
+            'prepend.foo.1' => 'baz',
+            'prepend.foo.baz' => 'boom',
+        ], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testUndot($collection)
     {
         $data = $collection::make([


### PR DESCRIPTION
This PR adds the `dot()` method to `Collection` and `LazyCollection` classes.

We already have [`dot`](https://github.com/laravel/framework/blob/52cea7fb5f7f5e4704518b6a82b21a1e8ecb1cc9/src/Illuminate/Collections/Arr.php#L102-L122) and [`undot`](https://github.com/laravel/framework/blob/52cea7fb5f7f5e4704518b6a82b21a1e8ecb1cc9/src/Illuminate/Collections/Arr.php#L124-L139) methods implemented in the `Arr` class; however, our Collections had only the [`undot`](https://github.com/laravel/framework/blob/2bc180295ebf8c4848a6b9c4ae8fa0d00ec75217/src/Illuminate/Collections/Collection.php#L1522-L1530) method implemented.

This PR adds missing `dot` method to our Collections as well.

_PS: I've also prepared a companion [PR for the docs](https://github.com/laravel/docs/pull/7979)._