### PR TITLE
[9.x] Improve return value in Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -820,7 +820,7 @@ class Container implements ArrayAccess, ContainerContract
         // given abstract type. So, we will need to check if any aliases exist with this
         // type and then spin through them and check for contextual bindings on these.
         if (empty($this->abstractAliases[$abstract])) {
-            return;
+            return null;
         }
 
         foreach ($this->abstractAliases[$abstract] as $alias) {


### PR DESCRIPTION
The method says it should return `\Closure|string|array|null`, but it returns nothing instead of `null` after checking aliases.
This PR replaces nothing with `null` in `getContextualConcrete` method.