### PR TITLE
[9.x] Fix database session driver keeps resetting CSRF token

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
-            $table->text('payload');
+            $table->longText('payload');
             $table->integer('last_activity')->index();
         });
     }


### PR DESCRIPTION
We have a multi-tenant app that runs on multiple servers using a load balancer, and as the app is load balanced across multiple servers, we are using a centralized store that all servers can access which is `Redis`.

Everything is working just fine on Redis driver, but when we changed the session driver to `database` we start having an issue with `CSRF token` and the token keep changing on every request and that caused `CSRF Token Mismatch` exception.

After a lot of debugging, I found that the issue was not with session config or the front-end request, it was from the `payload` column in the `sessions` table in the database, the session payload was too long and that caused an issue on decrypting the payload which is causing the mismatch and missing token.

We fixed is issue by changing the `payload` column from `text` to `longText`, and it worked!

This issue was reported in #13570