### PR TITLE
[9.x] Fix boolean values used as a date/datetime value when casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -279,7 +279,7 @@ trait HasAttributes
             // If the attribute cast was a date or a datetime, we will serialize the date as
             // a string. This allows the developers to customize how dates are serialized
             // into an array without affecting how they are persisted into the storage.
-            if ($attributes[$key] && in_array($value, ['date', 'datetime', 'immutable_date', 'immutable_datetime'])) {
+            if ($attributes[$key] && in_array($value, ['date', 'datetime', 'immutable_date', 'immutable_datetime'], true)) {
                 $attributes[$key] = $this->serializeDate($attributes[$key]);
             }
 


### PR DESCRIPTION
When a boolean value of `true` reaches the HasAttributes trait's addCastAttributesToArray function, it will be casted into a `date` as the `in_array` function isn't set to strict comparison mode. Please see the following screenshot:


![image](https://user-images.githubusercontent.com/2018660/173315429-f54e2d33-2d3a-4d3d-94c7-f074338e72f2.png)
