### PR TITLE
[9.x] Implement index checking methods in schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1578,6 +1578,18 @@ class Blueprint
     }
 
     /**
+     * Create a default index name for the table.
+     *
+     * @param  string  $type
+     * @param  array  $columns
+     * @return string
+     */
+    public function createDefaultIndexName(string $type, array $columns): string
+    {
+        return $this->createIndexName($type, $columns);
+    }
+
+    /**
      * Add a new column to the blueprint.
      *
      * @param  string  $type

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -328,7 +328,7 @@ class Builder
      * @param  \Closure      $callback
      * @return void
      */
-    public function whenTableDoesntHaveindex(string $table, string|array $index, string $type, Closure $callback): void
+    public function whenTableDoesntHaveIndex(string $table, string|array $index, string $type, Closure $callback): void
     {
         if (! $this->hasIndex($table, $index, $type)) {
             $this->table($table, fn (Blueprint $table) => $callback($table));

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -239,7 +239,7 @@ class Builder
     {
         $schemaManager = $this->connection->getDoctrineSchemaManager();
 
-        $indexes = $schemaManager->listTableIndexes($this->connection->getTablePrefix() . $table);
+        $indexes = $schemaManager->listTableIndexes($this->connection->getTablePrefix().$table);
 
         return array_keys($indexes);
     }
@@ -248,12 +248,13 @@ class Builder
      * Determine if the given table has a given index.
      * The type param must be given in case the index param is array,
      * to create the default index name. Which must be one of these values:
-     * 'primary', 'unique', 'index', 'fulltext', 'fullText', 'spatialIndex'
+     * 'primary', 'unique', 'index', 'fulltext', 'fullText', 'spatialIndex'.
      *
-     * @param  string        $table
+     * @param  string  $table
      * @param  string|array  $index
-     * @param  string        $type
+     * @param  string  $type
      * @return bool
+     *
      * @throws \LogicException
      */
     public function hasIndex(string $table, string|array $index, string $type = ''): bool
@@ -274,12 +275,13 @@ class Builder
      * Determine if the given table has given indexes.
      * The type param must be given in case the index param's item is array,
      * to create the default index name. Which must be one of these values:
-     * 'primary', 'unique', 'index', 'fulltext', 'fullText', 'spatialIndex'
+     * 'primary', 'unique', 'index', 'fulltext', 'fullText', 'spatialIndex'.
      *
      * @param  string  $table
-     * @param  array   $indexes
+     * @param  array  $indexes
      * @param  string  $type
      * @return bool
+     *
      * @throws \LogicException
      */
     public function hasIndexes(string $table, array $indexes, string $type = ''): bool
@@ -293,7 +295,7 @@ class Builder
                 $index = $this->createBlueprint($table)->createDefaultIndexName($type, $index);
             }
 
-            if (!in_array(strtolower($index), $tableIndexes)) {
+            if (! in_array(strtolower($index), $tableIndexes)) {
                 return false;
             }
         }
@@ -305,10 +307,10 @@ class Builder
      * Execute a table builder callback if the given table has a given index.
      * Index type param can be empty string in case the index param is string.
      *
-     * @param  string        $table
+     * @param  string  $table
      * @param  string|array  $index
-     * @param  string        $type
-     * @param  \Closure      $callback
+     * @param  string  $type
+     * @param  \Closure  $callback
      * @return void
      */
     public function whenTableHasIndex(string $table, string|array $index, string $type, Closure $callback): void
@@ -322,10 +324,10 @@ class Builder
      * Execute a table builder callback if the given table doesn't have a given index.
      * Index type param can be empty string in case the index param is string.
      *
-     * @param  string        $table
+     * @param  string  $table
      * @param  string|array  $index
-     * @param  string        $type
-     * @param  \Closure      $callback
+     * @param  string  $type
+     * @param  \Closure  $callback
      * @return void
      */
     public function whenTableDoesntHaveIndex(string $table, string|array $index, string $type, Closure $callback): void

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -24,6 +24,11 @@ namespace Illuminate\Support\Facades;
  * @method static void morphUsingUuids()
  * @method static \Illuminate\Database\Connection getConnection()
  * @method static \Illuminate\Database\Schema\Builder setConnection(\Illuminate\Database\Connection $connection)
+ * @method static array getIndexListing(string $table)
+ * @method static bool hasIndex(string $table, string|array $index, string $type = '')
+ * @method static bool hasIndexes(string $table, array $indexes, string $type = '')
+ * @method static void whenTableHasIndex(string $table, string|array $index, string $type, Closure $callback)
+ * @method static void whenTableDoesntHaveIndex(string $table, string|array $index, string $type, Closure $callback)
  *
  * @see \Illuminate\Database\Schema\Builder
  */

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -92,11 +92,11 @@ class DatabaseSchemaBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')
             ->andReturn('');
 
-        $blueprint = m::mock(Blueprint::class . '[createDefaultIndexName]', ['users']);
+        $blueprint = m::mock(Blueprint::class.'[createDefaultIndexName]', ['users']);
         $blueprint->shouldReceive('createDefaultIndexName')
             ->with(['users', ['country_id']])->andReturn('users_country_id_foreign');
 
-        $builder = m::mock(Builder::class . '[getIndexListing]', [$connection])
+        $builder = m::mock(Builder::class.'[getIndexListing]', [$connection])
             ->shouldAllowMockingProtectedMethods();
 
         $builder->shouldReceive('getIndexListing')->with('users')->times(3)
@@ -119,11 +119,11 @@ class DatabaseSchemaBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')
             ->andReturn('');
 
-        $blueprint = m::mock(Blueprint::class . '[createDefaultIndexName]', ['users']);
+        $blueprint = m::mock(Blueprint::class.'[createDefaultIndexName]', ['users']);
         $blueprint->shouldReceive('createDefaultIndexName')
             ->with(['users', ['country_id']])->andReturn('users_country_id_foreign');
 
-        $builder = m::mock(Builder::class . '[getIndexListing]', [$connection])
+        $builder = m::mock(Builder::class.'[getIndexListing]', [$connection])
             ->shouldAllowMockingProtectedMethods();
 
         $builder->shouldReceive('getIndexListing')->with('users')->times(3)


### PR DESCRIPTION
Implemented some methods in Illuminate\Database\Schema\Builder class to work with indexes:

- getIndexListing(string $table) which returns an array containing all of the given table's indexes.
- hasIndex(string $table, string|array $index, string $type = '') checks whether an index exists in the given table.
- hasIndexes(string $table, array $indexes, string $type = '') checks whether a list of indexes exist in the given table.
- whenTableHasIndex(string $table, string|array $index, string $type, Closure $callback) Execute a table builder callback if the given table has a given index.
- whenTableDoesntHaveIndex(string $table, string|array $index, string $type, Closure $callback) Execute a table builder callback if the given table doesn't have a given index.

Also added a publicly accessible method in Illuminate\Database\Schema\Blueprint class, to make Builder methods able to build a default name for given array index params:
- createDefaultIndexName(string $type, array $columns)

It helps developers to work with indexes/foreign keys in a safer way in migrations.