### PR TITLE
[8.x] Loose comparison causes the value not to be saved

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1956,8 +1956,8 @@ trait HasAttributes
             return $this->fromDateTime($attribute) ===
                 $this->fromDateTime($original);
         } elseif ($this->hasCast($key, ['object', 'collection'])) {
-            return $this->castAttribute($key, $attribute) ==
-                $this->castAttribute($key, $original);
+            return $this->fromJson($attribute) ===
+                $this->fromJson($original);
         } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
             if (($attribute === null && $original !== null) || ($attribute !== null && $original === null)) {
                 return false;


### PR DESCRIPTION
**The PR back-ports  https://github.com/laravel/framework/issues/41337 to 8.x branch.**

The description below is copied from the original PR.
---
Given an attribute with the cast object or collection, the $model->isDirty() method returns the wrong value due to the use of loose comparison.

Example from issue https://github.com/laravel/framework/issues/37961:

```php
use Illuminate\Database\Eloquent\Model;

class Test extends Model
{
    protected $casts = [
        'collection' => 'collection',
    ];
    protected $fillable = [
        'collection',
    ];
}

$model = new Test(['collection' => ['key' => true]]);
$model->syncOriginal();
$model->fill(['collection' => ['key' => 'value']]);

$model->isDirty(); // false but should be true

// or
$model = new Test(['collection' => ['key' => null]]);
$model->syncOriginal();
$model->fill(['collection' => ['key' => false]]);

$model->isDirty(); // false but should be true
```