### PR TITLE
[8.x] Do not remove null query parameters

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -531,6 +531,12 @@ class Arr
      */
     public static function query($array)
     {
+        array_walk_recursive($array, function (&$value) {
+            if ($value === null) {
+                $value = '';
+            }
+        });
+
         return http_build_query($array, '', '&', PHP_QUERY_RFC3986);
     }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -323,9 +323,9 @@ EOF;
         );
 
         if (! is_null($name)) {
-            $expectedUri = rtrim($request->fullUrlWithQuery([
-                'signature' => null,
-                'expires' => null,
+            $expectedUri = rtrim($request->fullUrlWithoutQuery([
+                'signature',
+                'expires',
             ]), '?');
 
             PHPUnit::assertEquals(

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -49,6 +49,44 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('inline; filename=file.txt', $response->headers->get('content-disposition'));
     }
 
+    public function testMimeTypeIsNotCalledAlreadyProvidedToResponse()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $files = m::mock(FilesystemAdapter::class, [$this->filesystem])->makePartial();
+        $files->shouldReceive('mimeType')->never();
+
+        $files->response('file.txt', null, [
+            'Content-Type' => 'text/x-custom',
+        ]);
+    }
+
+    public function testSizeIsNotCalledAlreadyProvidedToResponse()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $files = m::mock(FilesystemAdapter::class, [$this->filesystem])->makePartial();
+        $files->shouldReceive('size')->never();
+
+        $files->response('file.txt', null, [
+            'Content-Length' => 11,
+        ]);
+    }
+
+    public function testFallbackNameCalledAlreadyProvidedToResponse()
+    {
+        $this->filesystem->write('file.txt', 'Hello World');
+
+        $files = m::mock(FilesystemAdapter::class, [$this->filesystem])
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $files->shouldReceive('fallbackName')->never();
+
+        $files->response('file.txt', null, [
+            'Content-Disposition' => 'attachment',
+        ]);
+    }
+
     public function testDownload()
     {
         $this->filesystem->write('file.txt', 'Hello World');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -261,7 +261,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional'));
-        $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => null]));
+        $this->assertSame('http://www.foo.com/foo/bar?baz=', $url->route('optional', ['baz' => null]));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => '']));
         $this->assertSame('http://www.foo.com/foo/bar/0', $url->route('optional', ['baz' => 0]));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', 'taylor'));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -641,7 +641,7 @@ class SupportArrTest extends TestCase
         $this->assertSame('foo=bar', Arr::query(['foo' => 'bar']));
         $this->assertSame('foo=bar&bar=baz', Arr::query(['foo' => 'bar', 'bar' => 'baz']));
         $this->assertSame('foo=bar&bar=1', Arr::query(['foo' => 'bar', 'bar' => true]));
-        $this->assertSame('foo=bar', Arr::query(['foo' => 'bar', 'bar' => null]));
+        $this->assertSame('foo=bar&bar=', Arr::query(['foo' => 'bar', 'bar' => null]));
         $this->assertSame('foo=bar&bar=', Arr::query(['foo' => 'bar', 'bar' => '']));
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As outlined in issue #42794 , `Arr:query()` removes parameters set to null as a side effect of using `http_build_query` internally.

For example:

~~~php
$query = ['foo' => 1, 'bar' => 'hello world', 'nullable' => null, 'empty' => ''];
~~~

Removes the `nullable => null` parameter, while keeping `empty => ''`, which might be confusing.

One particular scenario where this issue can occur is with GET routes which expect query parameters to get back to a filtered state.

With the current implementation, if this particular route expects a parameter just to be present, for example as a boolean parameter, the `UrlGenerator` would remove these null parameters when, for example generating redirects, or links in a mailable, among other scenarios.

This parameters could come from a view with a link "share report by email", as `ConvertEmptyStringsToNull` middleware convert all empty strings to null, the request would generate unexpected links in the sent mail.

This PR:

- Converts all empty string to `null` before calling `http_build_query` in `Arr@query()`
- Fixes test cases, and test helpers to account for nullable query parameters.




~~~

