### PR TITLE
[9.x] Add `toResourceCollection` and `toAnonymousResourceCollection` to Collections

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -925,6 +925,7 @@ trait EnumeratesValues
 
     /**
      * Get the collection of items as a resource collection.
+     *
      * @template TResourceCollectionClass of \Illuminate\Http\Resources\Json\ResourceCollection
      *
      * @param  class-string<TResourceCollectionClass>  $resourceCollectionClass
@@ -937,6 +938,7 @@ trait EnumeratesValues
 
     /**
      * Get the collection of items as an anonymous resource collection.
+     *
      * @template TResourceClass of \Illuminate\Http\Resources\Json\JsonResource
      *
      * @param  class-string<TResourceClass>  $resourceClass
@@ -945,7 +947,7 @@ trait EnumeratesValues
      */
     public function toAnonymousResourceCollection(string $resourceClass)
     {
-        if(is_subclass_of($resourceClass, JsonResource::class, true)){
+        if (is_subclass_of($resourceClass, JsonResource::class, true)) {
             return $resourceClass::collection($this);
         }
         throw new \Exception('`'.$resourceClass.'` is not a valid JsonResource.');

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -924,10 +924,10 @@ trait EnumeratesValues
     }
 
     /**
-     * Get the collection of items as a resource collection
+     * Get the collection of items as a resource collection.
      * @template TResourceCollectionClass of \Illuminate\Http\Resources\Json\ResourceCollection
      *
-     * @param class-string<TResourceCollectionClass> $resourceCollectionClass
+     * @param  class-string<TResourceCollectionClass>  $resourceCollectionClass
      * @return TResourceCollectionClass<TKey, TValue>
      */
     public function toResourceCollection(string $resourceCollectionClass)
@@ -936,14 +936,15 @@ trait EnumeratesValues
     }
 
     /**
-     * Get the collection of items as an anonymous resource collection
+     * Get the collection of items as an anonymous resource collection.
      * @template TResourceClass of \Illuminate\Http\Resources\Json\JsonResource
      *
-     * @param class-string<TResourceClass> $resourceClass
+     * @param  class-string<TResourceClass>  $resourceClass
      * @return AnonymousResourceCollection<TKey, TResourceClass<TValue>>
      * @throws Exception
      */
-    public function toAnonymousResourceCollection(string $resourceClass){
+    public function toAnonymousResourceCollection(string $resourceClass)
+    {
         if(is_subclass_of($resourceClass, JsonResource::class, true)){
             return $resourceClass::collection($this);
         }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -943,6 +943,7 @@ trait EnumeratesValues
      *
      * @param  class-string<TResourceClass>  $resourceClass
      * @return AnonymousResourceCollection<TKey, TResourceClass<TValue>>
+     *
      * @throws Exception
      */
     public function toAnonymousResourceCollection(string $resourceClass)

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -7,6 +7,8 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
@@ -919,6 +921,33 @@ trait EnumeratesValues
     public function toJson($options = 0)
     {
         return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Get the collection of items as a resource collection
+     * @template TResourceCollectionClass of \Illuminate\Http\Resources\Json\ResourceCollection
+     *
+     * @param class-string<TResourceCollectionClass> $resourceCollectionClass
+     * @return TResourceCollectionClass<TKey, TValue>
+     */
+    public function toResourceCollection(string $resourceCollectionClass)
+    {
+        return new $resourceCollectionClass($this);
+    }
+
+    /**
+     * Get the collection of items as an anonymous resource collection
+     * @template TResourceClass of \Illuminate\Http\Resources\Json\JsonResource
+     *
+     * @param class-string<TResourceClass> $resourceClass
+     * @return AnonymousResourceCollection<TKey, TResourceClass<TValue>>
+     * @throws Exception
+     */
+    public function toAnonymousResourceCollection(string $resourceClass){
+        if(is_subclass_of($resourceClass, JsonResource::class, true)){
+            return $resourceClass::collection($this);
+        }
+        throw new \Exception('`'.$resourceClass.'` is not a valid JsonResource.');
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3945,7 +3945,7 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(AnonymousResourceCollection::class, $mappedIntoAnonymous);
         $this->assertEquals(2, $mappedIntoAnonymous->count());
         $values = [];
-        foreach($mappedIntoAnonymous as $resource) {
+        foreach ($mappedIntoAnonymous as $resource) {
             $this->assertInstanceOf(TestCollectionResource::class, $resource);
             $values[] = $resource['field'];
         }
@@ -3956,7 +3956,7 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(TestCollectionResourceCollection::class, $mappedIntoNamedCollection);
         $this->assertEquals(2, $mappedIntoNamedCollection->count());
         $namedValues = [];
-        foreach($mappedIntoNamedCollection as $resource) {
+        foreach ($mappedIntoNamedCollection as $resource) {
             $this->assertInstanceOf(TestCollectionResource::class, $resource);
             $namedValues[] = $resource['field'];
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3938,14 +3938,14 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([
             ['field' => 'foo'],
-            ['field' => 'bar']
+            ['field' => 'bar'],
         ]);
 
         $mappedIntoAnonymous = $c->toAnonymousResourceCollection(TestCollectionResource::class);
         $this->assertInstanceOf(AnonymousResourceCollection::class, $mappedIntoAnonymous);
         $this->assertEquals(2, $mappedIntoAnonymous->count());
         $values = [];
-        foreach($mappedIntoAnonymous as $resource){
+        foreach($mappedIntoAnonymous as $resource) {
             $this->assertInstanceOf(TestCollectionResource::class, $resource);
             $values[] = $resource['field'];
         }
@@ -3956,7 +3956,7 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(TestCollectionResourceCollection::class, $mappedIntoNamedCollection);
         $this->assertEquals(2, $mappedIntoNamedCollection->count());
         $namedValues = [];
-        foreach($mappedIntoNamedCollection as $resource){
+        foreach($mappedIntoNamedCollection as $resource) {
             $this->assertInstanceOf(TestCollectionResource::class, $resource);
             $namedValues[] = $resource['field'];
         }
@@ -5279,8 +5279,11 @@ class TestCollectionMapIntoObject
     }
 }
 
-class TestCollectionResource extends JsonResource {}
-class TestCollectionResourceCollection extends ResourceCollection {
+class TestCollectionResource extends JsonResource
+{
+}
+class TestCollectionResourceCollection extends ResourceCollection
+{
     public $collects = TestCollectionResource::class;
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3951,7 +3951,6 @@ class SupportCollectionTest extends TestCase
         }
         $this->assertSame($values, $c->pluck('field')->toArray());
 
-
         $mappedIntoNamedCollection = $c->toResourceCollection(TestCollectionResourceCollection::class);
         $this->assertInstanceOf(TestCollectionResourceCollection::class, $mappedIntoNamedCollection);
         $this->assertEquals(2, $mappedIntoNamedCollection->count());

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1018,14 +1018,16 @@ foreach ($collection as $int => $user) {
 /**
  * @template TResource
  */
-class CustomResourceClass extends \Illuminate\Http\Resources\Json\JsonResource {
+class CustomResourceClass extends \Illuminate\Http\Resources\Json\JsonResource
+{
     /** @var TResource */
     public $resource;
 }
 /**
  * @template TResourceClass
  */
-class CustomResourceCollectionClass extends \Illuminate\Http\Resources\Json\ResourceCollection {
+class CustomResourceCollectionClass extends \Illuminate\Http\Resources\Json\ResourceCollection
+{
     /** @var class-string<TResourceClass> */
     public $collects = CustomResourceClass::class;
 }

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -1014,3 +1014,24 @@ foreach ($collection as $int => $user) {
     assertType('int', $int);
     assertType('User', $user);
 }
+
+/**
+ * @template TResource
+ */
+class CustomResourceClass extends \Illuminate\Http\Resources\Json\JsonResource {
+    /** @var TResource */
+    public $resource;
+}
+/**
+ * @template TResourceClass
+ */
+class CustomResourceCollectionClass extends \Illuminate\Http\Resources\Json\ResourceCollection {
+    /** @var class-string<TResourceClass> */
+    public $collects = CustomResourceClass::class;
+}
+assertType('Illuminate\Http\Resources\Json\AnonymousResourceCollection&iterable<int, Illuminate\Http\Resources\Json\JsonResource<User>>',
+    $collection->toAnonymousResourceCollection(CustomResourceClass::class)
+);
+assertType('CustomResourceCollectionClass&iterable<int, User>',
+    $collection->toResourceCollection(CustomResourceCollectionClass::class)
+);


### PR DESCRIPTION
This PR aims to add two new collection methods: `toResourceCollection` and `toAnonymousResourceCollection`.

`toResourceCollection` allows a user to specify a `ResourceCollection` that the current collection can be cast into instead of having to wrap the collection in a `ResourceCollection::make()`.

Same with `toAnonymousResourceCollection` -- this allows a user to specify a `JsonResource` that the current collection would be put into with the existing `JsonResource::collection()` method.

```php
class UserResource extends JsonResource {
}

class UserResourceCollection extends ResourceCollection {
    public $collects = UserResource::class;
}

// UserController.php
// using toResourceCollection
class UserController extends Controller {
    public function oldIndex(Request $request){
        return UserResourceCollection::make(
            User::whereIn('name', ['Bennett', 'Taylor', 'et all'])->get()
        );
    }

    public function newIndex(Request $request){
        return User::whereIn('name', ['Bennett', 'Taylor', 'et all'])
            ->get()
            ->toResourceCollection(UserResourceCollection::class);
    }
}

// UserController.php
// using toAnonymousResourceCollection()
class UserController extends Controller {
    public function oldIndex(Request $request){
        return UserResource::collection(
            User::whereIn('name', ['Bennett', 'Taylor', 'et all'])->get()
        );
    }

    public function newIndex(Request $request){
        return User::whereIn('name', ['Bennett', 'Taylor', 'et all'])
            ->get()
            ->toAnonymousResourceCollection(UserResource::class);
    }
}
```

The benefit here is that this method is just end of the chain of the collection pipeline and doesn't need to be wrapped in the resource methods to achieve the same effect.
This is definitely just a DX improvement, and does not introduce any new functionality so it would not break any existing features related to collections and resources.


**Note:** I am not 100% on the PHPStan type assertions -- I have them passing now but I don't think they're as specific as they can get, but I've tried all the combinations I could think of to get the classes to pass around correctly, but no dice. 
Also, not hard-stuck on the names `toResourceCollection`, `toAnonymousResourceCollection`.

**EDIT:** I am now aware there is a `pipe` method that would potentially allow userland to implement this exact function -- however, since resources are a first-class Laravel object, I think it would be fitting to have a collection method to reflect that. I understand this is just syntactic sugar in that case, but would be curious to see if that puts this at a tipping point for acceptance.