### PR TITLE
[9.x] Add nonconsecutive option to `Str::ucsplt`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1115,7 +1115,7 @@ class Str
      */
     public static function ucsplit($string, $consecutive = true)
     {
-        if($consecutive) {
+        if ($consecutive) {
             return preg_split('/(?=\p{Lu})/u', $string, -1, PREG_SPLIT_NO_EMPTY);
         } else {
             return preg_split('/(?=\p{Lu})(?<!\p{Lu})|(?=\p{Lu}\p{Ll})/u', $string, -1, PREG_SPLIT_NO_EMPTY);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1110,11 +1110,16 @@ class Str
      * Split a string into pieces by uppercase characters.
      *
      * @param  string  $string
+     * @param  bool  $consecutive
      * @return array
      */
-    public static function ucsplit($string)
+    public static function ucsplit($string, $consecutive = true)
     {
-        return preg_split('/(?=\p{Lu})/u', $string, -1, PREG_SPLIT_NO_EMPTY);
+        if($consecutive) {
+            return preg_split('/(?=\p{Lu})/u', $string, -1, PREG_SPLIT_NO_EMPTY);
+        } else {
+            return preg_split('/(?=\p{Lu})(?<!\p{Lu})|(?=\p{Lu}\p{Ll})/u', $string, -1, PREG_SPLIT_NO_EMPTY);
+        }
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -771,7 +771,7 @@ class SupportStrTest extends TestCase
 
         $this->assertSame(['Żółta', 'Łódka'], Str::ucsplit('ŻółtaŁódka', false));
         $this->assertSame(['sind', 'Öde', 'Und', 'So'], Str::ucsplit('sindÖdeUndSo', false));
-        $this->assertSame(['Öffentliche','ÖÖÖ', 'Überraschungen'], Str::ucsplit('ÖffentlicheÖÖÖÜberraschungen', false));
+        $this->assertSame(['Öffentliche', 'ÖÖÖ', 'Überraschungen'], Str::ucsplit('ÖffentlicheÖÖÖÜberraschungen', false));
     }
 
     public function testUuid()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -762,6 +762,18 @@ class SupportStrTest extends TestCase
         $this->assertSame(['Öffentliche', 'Überraschungen'], Str::ucsplit('ÖffentlicheÜberraschungen'));
     }
 
+    public function testUcsplitNonConsecutive()
+    {
+        $this->assertSame(['Laravel_p_h_p_framework'], Str::ucsplit('Laravel_p_h_p_framework', false));
+        $this->assertSame(['Laravel_', 'P_h_p_framework'], Str::ucsplit('Laravel_P_h_p_framework', false));
+        $this->assertSame(['laravel', 'PHP', 'Framework'], Str::ucsplit('laravelPHPFramework', false));
+        $this->assertSame(['Laravel-ph', 'P-framework'], Str::ucsplit('Laravel-phP-framework', false));
+
+        $this->assertSame(['Żółta', 'Łódka'], Str::ucsplit('ŻółtaŁódka', false));
+        $this->assertSame(['sind', 'Öde', 'Und', 'So'], Str::ucsplit('sindÖdeUndSo', false));
+        $this->assertSame(['Öffentliche','ÖÖÖ', 'Überraschungen'], Str::ucsplit('ÖffentlicheÖÖÖÜberraschungen', false));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());


### PR DESCRIPTION
This PR adds an option to `Str::ucsplt` to keep groups of uppercase characters together. 
Many times ucsplit is used to split text that contain acronyms such as 'PHP', which results in these acronyms being broken up, for example:
```php
Str::ucsplit('PHPIsCool'); // ['P', 'H', 'P', 'Is,', 'Cool']
``` 
Passing `$consecutive = false` results in
```php
Str::ucsplit('PHPIsCool'); // ['PHP', 'Is,', 'Cool']
``` 

Defaulting the `$consecutive` argument to true allows for full backwards compatibility with existing code.