### PR TITLE
[10.x] Bring translatable error messages to closure based rules

### DIFF
--- a/src/Illuminate/Validation/ClosureValidationRule.php
+++ b/src/Illuminate/Validation/ClosureValidationRule.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Validation\Rule as RuleContract;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
-class ClosureValidationRule implements RuleContract
+class ClosureValidationRule implements RuleContract, ValidatorAwareRule
 {
     /**
      * The callback that validates the attribute.
@@ -21,11 +23,18 @@ class ClosureValidationRule implements RuleContract
     public $failed = false;
 
     /**
-     * The validation error message.
+     * The validation error messages.
      *
-     * @var string|null
+     * @var array
      */
-    public $message;
+    public $messages = [];
+
+    /**
+     * The current validator.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
 
     /**
      * Create a new Closure based validation rule.
@@ -52,19 +61,75 @@ class ClosureValidationRule implements RuleContract
         $this->callback->__invoke($attribute, $value, function ($message) {
             $this->failed = true;
 
-            $this->message = $message;
+            return $this->pendingPotentiallyTranslatedString($message);
         });
 
         return ! $this->failed;
     }
 
     /**
-     * Get the validation error message.
+     * Get the validation error messages.
      *
      * @return string
      */
     public function message()
     {
-        return $this->message;
+        return $this->messages;
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Create a pending potentially translated string.
+     *
+     * @param  string  $message
+     * @return \Illuminate\Translation\PotentiallyTranslatedString
+     */
+    protected function pendingPotentiallyTranslatedString($message)
+    {
+        return new class($message, $this->validator->getTranslator(), fn ($message) => $this->messages[] = $message) extends PotentiallyTranslatedString
+        {
+            /**
+             * The callback to call when the object destructs.
+             *
+             * @var \Closure
+             */
+            protected $destructor;
+
+            /**
+             * Create a new pending potentially translated string.
+             *
+             * @param  string  $string
+             * @param  \Illuminate\Contracts\Translation\Translator  $translator
+             * @param  \Closure  $destructor
+             */
+            public function __construct($message, $translator, $destructor)
+            {
+                parent::__construct($message, $translator);
+
+                $this->destructor = $destructor;
+            }
+
+            /**
+             * Handle the object's destruction.
+             *
+             * @return void
+             */
+            public function __destruct()
+            {
+                ($this->destructor)($this->toString());
+            }
+        };
     }
 }


### PR DESCRIPTION
This PR brings the translatable validation error messages [from the Invokable validation rule](https://github.com/laravel/framework/pull/42689) to Closure based rules for the next version of Laravel.

```php
public function rules()
{
    'foo' => [
        function ($attribute, $value, $fail) {
            $fail('validation.translation.key')->translate();
        },
    ],
}
```

Targeting master as I feel there are two (minor) breaking changes here...

1. Calling `$fail` more than once now appends to an array, so if you were calling it twice in a closure (which is probably a bug where you forgot to return), the behaviour would change.
2. $fail now returns an object , rather than void / null, so if you have typehinted your closure and are returning the result of the `$fail` call, it would break.