### PR TITLE
[9.x] Allow invokable rules to push messages to nested (or other) attributes

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -816,9 +816,11 @@ class Validator implements ValidatorContract
 
             $messages = $messages ? (array) $messages : [get_class($rule)];
 
-            foreach ($messages as $message) {
-                $this->messages->add($attribute, $this->makeReplacements(
-                    $message, $attribute, get_class($rule), []
+            foreach ($messages as $key => $message) {
+                $key = is_string($key) ? $key : $attribute;
+
+                $this->messages->add($key, $this->makeReplacements(
+                    $message, $key, get_class($rule), []
                 ));
             }
         }

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -230,6 +230,31 @@ class ValidationInvokableRuleTest extends TestCase
         $validator->passes();
     }
 
+    public function testItCanSpecifyTheValidationErrorKeyForTheErrorMessage()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class() implements InvokableRule
+        {
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('bar.baz', 'Another attribute error.');
+                $fail('This attribute error.');
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'xxxx'], ['foo' => $rule]);
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame([
+            'bar.baz' => [
+                'Another attribute error.',
+            ],
+            'foo' => [
+                'This attribute error.',
+            ],
+        ], $validator->messages()->messages());
+    }
+
     private function getIlluminateArrayTranslator()
     {
         return new Translator(


### PR DESCRIPTION
This allows invokable validation rule classes to push errors to nested or other attributes. This allows greater integration with the validator and allows userland rules to validate rich object structures, but apply errors to the correct keys.

```php
class UserRule implements InvokableRule
{
    public function __invoke($attribute, $value, $fail)
    {
        if (! is_array($attribute) || array_is_list($attribute)) {
            return $fail('Must be an object.'); // apply to $attribute
        }

        if (! array_key_exists('name', $attribute)) {
            return $fail("{$attribute}.name", 'Is required.'); // apply to nested attribute
        }

        /* ... */
    }
}
```

Potential error messages...

```php
Validator::make(
    [
        'user_1' => ['xxxx'],
        'user_2' => ['age' => 23],
    ],
    [
        'user_1' => [new UserRule()],
        'user_2' => [new UserRule()],
    ]
);

// errors...

[
    'user_1' => ['Must be an object.'],
    'user_2.name' => ['Is required.'],
]

```

This feature allows developers to create validation rules that can handle rich objects and validate not only the top level value, but also nested values.

In combination with the `DataAware` interface, a developer may also push validation errors to other keys. For example a developer could re-create the prohibits validation rule, but put the error message on the attribute that should not exist, rather than the attribute that specified the validation rule.