### PR TITLE
[9.x] Fix Factory::createQuietly() parameter type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -280,7 +280,7 @@ abstract class Factory
     /**
      * Create a collection of models and persist them to the database without dispatching any model events.
      *
-     * @param  array<string, mixed>  $attributes
+     * @param  (callable(array<string, mixed>): array<string, mixed>)|array<string, mixed>  $attributes
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent
      * @return \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model|TModel>|\Illuminate\Database\Eloquent\Model|TModel
      */

--- a/types/Database/Eloquent/Factories/Factory.php
+++ b/types/Database/Eloquent/Factories/Factory.php
@@ -102,6 +102,11 @@ assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Elo
 assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->createQuietly([
     'string' => 'string',
 ]));
+assertType('Illuminate\Database\Eloquent\Collection<int, Illuminate\Database\Eloquent\Model>|Illuminate\Database\Eloquent\Model', $factory->createQuietly(function ($attributes) {
+    assertType('array<string, mixed>', $attributes);
+
+    return ['string' => 'string'];
+}));
 
 // assertType('Closure(): Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->lazy());
 // assertType('Closure(): Illuminate\Database\Eloquent\Collection<int, User>|User', $factory->lazy([


### PR DESCRIPTION
This calls `Factory::create()` which accepts a callable as well