### PR TITLE
Adds maskWords() for masking each words of the string separated by a separator

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -542,17 +542,17 @@ class Str
     /**
      * Masks each part of the string separated by a separator.
      *
-     * @param string $string
-     * @param string $separator
-     * @param string $character
-     * @param int $index
-     * @param int|null $length
-     * @param string $encoding
+     * @param  string  $string
+     * @param  string  $separator
+     * @param  string  $character
+     * @param  int  $index
+     * @param  int|null  $length
+     * @param  string  $encoding
      * @return string
      */
     public static function maskWords(string $string, string $separator = ' ', string $character = '*', int $index = 1, ?int $length = null, string $encoding = 'UTF-8'): string
     {
-        if (!self::length($separator)) {
+        if (! self::length($separator)) {
             return self::mask($string, $character, $index, $length, $encoding);
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -540,6 +540,31 @@ class Str
     }
 
     /**
+     * Masks each part of the string separated by a separator.
+     *
+     * @param string $string
+     * @param string $separator
+     * @param string $character
+     * @param int $index
+     * @param int|null $length
+     * @param string $encoding
+     * @return string
+     */
+    public static function maskEachPartition(string $string, string $separator = ' ', string $character = '*', int $index = 1, ?int $length = null, $encoding = 'UTF-8'): string
+    {
+        if (!self::length($separator)) {
+            return self::mask($string, $character, $index, $length, $encoding);
+        }
+
+        $items = explode($separator, $string);
+        $items = array_map(function ($value) use ($character, $index, $length, $encoding) {
+            return self::mask($value, $character, $index, $length, $encoding);
+        }, $items);
+
+        return implode($separator, $items);
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -550,13 +550,14 @@ class Str
      * @param string $encoding
      * @return string
      */
-    public static function maskEachPartition(string $string, string $separator = ' ', string $character = '*', int $index = 1, ?int $length = null, $encoding = 'UTF-8'): string
+    public static function maskWords(string $string, string $separator = ' ', string $character = '*', int $index = 1, ?int $length = null, string $encoding = 'UTF-8'): string
     {
         if (!self::length($separator)) {
             return self::mask($string, $character, $index, $length, $encoding);
         }
 
         $items = explode($separator, $string);
+
         $items = array_map(function ($value) use ($character, $index, $length, $encoding) {
             return self::mask($value, $character, $index, $length, $encoding);
         }, $items);

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -406,6 +406,21 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Masks each part of the string separated by a separator.
+     *
+     * @param string $separator
+     * @param string $character
+     * @param int $index
+     * @param int|null $length
+     * @param string $encoding
+     * @return string
+     */
+    public function maskEachPartition(string $separator = ' ', string $character = '*', int $index = 1, ?int $length = null, $encoding = 'UTF-8'): string
+    {
+        return new static(Str::maskEachPartition($this->value, $separator, $character, $index, $length, $encoding));
+    }
+
+    /**
      * Get the string matching the given pattern.
      *
      * @param  string  $pattern

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -408,11 +408,11 @@ class Stringable implements JsonSerializable
     /**
      * Masks each part of the string separated by a separator.
      *
-     * @param string $separator
-     * @param string $character
-     * @param int $index
-     * @param int|null $length
-     * @param string $encoding
+     * @param  string  $separator
+     * @param  string  $character
+     * @param  int  $index
+     * @param  int|null  $length
+     * @param  string  $encoding
      * @return string
      */
     public function maskWords(string $separator = ' ', string $character = '*', int $index = 1, ?int $length = null, string $encoding = 'UTF-8'): string

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -415,9 +415,9 @@ class Stringable implements JsonSerializable
      * @param string $encoding
      * @return string
      */
-    public function maskEachPartition(string $separator = ' ', string $character = '*', int $index = 1, ?int $length = null, $encoding = 'UTF-8'): string
+    public function maskWords(string $separator = ' ', string $character = '*', int $index = 1, ?int $length = null, string $encoding = 'UTF-8'): string
     {
-        return new static(Str::maskEachPartition($this->value, $separator, $character, $index, $length, $encoding));
+        return new static(Str::maskWords($this->value, $separator, $character, $index, $length, $encoding));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -672,6 +672,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('***************', Str::mask('maria@email.com', '*', 0));
     }
 
+    public function testMaskEachPartition()
+    {
+        $this->assertSame('Y**** O*** S***', Str::maskEachPartition('Yusuf Onur SARI'));
+        $this->assertSame('Y**************', Str::maskEachPartition('Yusuf Onur SARI', ''));
+        $this->assertSame('F**,B**,B**', Str::maskEachPartition('Foo,Bar,Baz', ','));
+        $this->assertSame('tay***@email.com', Str::maskEachPartition('taylor@email.com', '', '*', -13, 3));
+        $this->assertSame('Yus** On** SA**', Str::maskEachPartition('Yusuf Onur SARI', ' ', '*', -2, 2));
+    }
+
     public function testMatch()
     {
         $this->assertSame('bar', Str::match('/bar/', 'foo bar'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -672,13 +672,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('***************', Str::mask('maria@email.com', '*', 0));
     }
 
-    public function testMaskEachPartition()
+    public function testMaskWords()
     {
-        $this->assertSame('Y**** O*** S***', Str::maskEachPartition('Yusuf Onur SARI'));
-        $this->assertSame('Y**************', Str::maskEachPartition('Yusuf Onur SARI', ''));
-        $this->assertSame('F**,B**,B**', Str::maskEachPartition('Foo,Bar,Baz', ','));
-        $this->assertSame('tay***@email.com', Str::maskEachPartition('taylor@email.com', '', '*', -13, 3));
-        $this->assertSame('Yus** On** SA**', Str::maskEachPartition('Yusuf Onur SARI', ' ', '*', -2, 2));
+        $this->assertSame('Y**** O*** S***', Str::maskWords('Yusuf Onur SARI'));
+        $this->assertSame('Y**************', Str::maskWords('Yusuf Onur SARI', ''));
+        $this->assertSame('F**,B**,B**', Str::maskWords('Foo,Bar,Baz', ','));
+        $this->assertSame('tay***@email.com', Str::maskWords('taylor@email.com', '', '*', -13, 3));
+        $this->assertSame('Yus** On** SA**', Str::maskWords('Yusuf Onur SARI', ' ', '*', -2, 2));
     }
 
     public function testMatch()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -980,6 +980,15 @@ class SupportStringableTest extends TestCase
         $this->assertSame('**一段中文', (string) $this->stringable('这是一段中文')->mask('*', 0, 2));
     }
 
+    public function testMaskEachPartition()
+    {
+        $this->assertSame('Y**** O*** S***', $this->stringable('Yusuf Onur SARI')->maskEachPartition());
+        $this->assertSame('Y**************', $this->stringable('Yusuf Onur SARI')->maskEachPartition(''));
+        $this->assertSame('F**,B**,B**', $this->stringable('Foo,Bar,Baz')->maskEachPartition(','));
+        $this->assertSame('tay***@email.com', $this->stringable('taylor@email.com')->maskEachPartition('', '*', -13, 3));
+        $this->assertSame('Yus** On** SA**', $this->stringable('Yusuf Onur SARI')->maskEachPartition(' ', '*', -2, 2));
+    }
+
     public function testRepeat()
     {
         $this->assertSame('aaaaa', (string) $this->stringable('a')->repeat(5));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -980,13 +980,13 @@ class SupportStringableTest extends TestCase
         $this->assertSame('**一段中文', (string) $this->stringable('这是一段中文')->mask('*', 0, 2));
     }
 
-    public function testMaskEachPartition()
+    public function testMaskWords()
     {
-        $this->assertSame('Y**** O*** S***', $this->stringable('Yusuf Onur SARI')->maskEachPartition());
-        $this->assertSame('Y**************', $this->stringable('Yusuf Onur SARI')->maskEachPartition(''));
-        $this->assertSame('F**,B**,B**', $this->stringable('Foo,Bar,Baz')->maskEachPartition(','));
-        $this->assertSame('tay***@email.com', $this->stringable('taylor@email.com')->maskEachPartition('', '*', -13, 3));
-        $this->assertSame('Yus** On** SA**', $this->stringable('Yusuf Onur SARI')->maskEachPartition(' ', '*', -2, 2));
+        $this->assertSame('Y**** O*** S***', $this->stringable('Yusuf Onur SARI')->maskWords());
+        $this->assertSame('Y**************', $this->stringable('Yusuf Onur SARI')->maskWords(''));
+        $this->assertSame('F**,B**,B**', $this->stringable('Foo,Bar,Baz')->maskWords(','));
+        $this->assertSame('tay***@email.com', $this->stringable('taylor@email.com')->maskWords('', '*', -13, 3));
+        $this->assertSame('Yus** On** SA**', $this->stringable('Yusuf Onur SARI')->maskWords(' ', '*', -2, 2));
     }
 
     public function testRepeat()


### PR DESCRIPTION
Not every word can be masked in the text that is masked with mask. It takes extra effort to do this.

Each word can be masked according to the separator specified with maskWords.

Example:
```
use Illuminate\Support\Str;

$str = 'Yusuf Onur SARI';

return [
    Str::mask($str, "*", 1),
    Str::maskWords($str),
];

/*
[
    "Y**************",
    "Y**** O*** S***",
]
*/
```
