### PR TITLE
[9.x] Add flattening multidimensional array keys and flattening multidimensional array keys with their values

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -252,6 +252,7 @@ class Arr
         return $result;
     }
 
+
     /**
      * Remove one or many array items from a given array using "dot" notation.
      *
@@ -816,5 +817,63 @@ class Arr
         }
 
         return is_array($value) ? $value : [$value];
+    }
+
+
+    /**
+     * Flatten a multi-dimensional array keys into a single level.
+     *
+     * @param  iterable  $array
+     * @return array
+     */
+    public static function flattenKeys($array)
+    {
+        $keys = [];
+
+        foreach ($array as $key => $value) {
+            $keys[] = $key;
+
+            if (is_array($value)) {
+                $keys = array_merge($keys, static::flattenKeys($value));
+            }
+        }
+
+        return $keys;
+    }
+    /**
+     * Flatten a multi-dimensional array keys into a single level.
+     *
+     * @param  iterable  $array
+     * @return array
+     */
+    public static function flattenKeysWithValues($array)
+    {
+        $keys = [];
+
+        foreach ($array as $key => $value) {
+            $keys[$key] = $value;
+
+            if (is_array($value)) {
+                $keys = array_merge($keys, static::flattenKeysWithValues($value));
+            }
+        }
+
+
+        $arr_filter = array_filter($keys, function ($value) {
+            if (is_array($value)) {
+                $filtered = array_filter(array_keys($value), 'is_string');
+                if (empty($filtered)) {
+
+                    return $value;
+                }
+            }
+            return !is_array($value);
+        });
+
+        return array_filter(
+            $arr_filter,
+            fn($key) => !is_numeric($key),
+            ARRAY_FILTER_USE_KEY
+        );
     }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -841,7 +841,7 @@ class Arr
         return $keys;
     }
     /**
-     * Flatten a multi-dimensional array keys into a single level.
+     * Flatten a multi-dimensional array keys with values into a single level.
      *
      * @param  iterable  $array
      * @return array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1705,4 +1705,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+
+
+
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1097,4 +1097,66 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testFlattenKeys()
+    {
+        $array = [
+            'name' => 'taylor',
+            'languages' => [
+                'web' => [
+                    'backend' => 'php',
+                    'frontend' => 'vue'
+                ],
+                'mobile' => [
+                    'android' => 'java',
+                    'ios' => 'swift'
+                ]
+            ],
+           'favorite' => 'laravel'
+
+        ];
+
+        $this->assertEquals([
+            0 => "name",
+            1 => "languages",
+            2 => "web",
+            3 => "backend",
+            4 => "frontend",
+            5 => "mobile",
+            6 => "android",
+            7 => "ios",
+            8 => "favorite"
+        ], Arr::flattenKeys($array));
+    }
+
+    public function testFlattenKeysWithValues()
+    {
+        $array = [
+            'name' => 'taylor',
+            'languages' => [
+                'web' => [
+                    'backend' => 'php',
+                    'frontend' => 'vue'
+                ],
+                'mobile' => [
+                    'android' => 'java',
+                    'ios' => 'swift'
+                ]
+            ],
+            'favorites' => ['laravel', 'lambo']
+
+        ];
+
+        $this->assertEquals([
+            "name" => "taylor",
+            "backend" => "php",
+            "frontend" => "vue",
+            "android" => "java",
+            "ios" => "swift",
+            "favorites" => [
+                0 => "laravel",
+                1 => "lambo"
+            ],
+        ], Arr::flattenKeysWithValues($array));
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5022,6 +5022,8 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($originalData, $data->whereNotNull()->all());
     }
 
+
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
Currently, Laravel has flattening features for multidimensional arrays but only for values. This PR aims to add feature of flattening multidimensional array keys. It also aims to add flattening multidimensional array keys with their values.

#To explain with an example. There is an example array;

``` 
$array = [
            'name' => 'taylor',
            'languages' => [
                'web' => [
                    'backend' => 'php',
                    'frontend' => 'vue'
                ],
                'mobile' => [
                    'android' => 'java',
                    'ios' => 'swift'
                ]
            ],
           'favorite' => 'laravel'
        ];
```

#FlattenKeys feature aims to this output;

``` 
$flattenKeys = Arr::flattenKeys($array);

expected return => 

[ 
0 => "name",  
1 => "languages",  
2 => "web",  
3 => "backend",  
4 => "frontend",  
5 => "mobile",  
6 => "android",  
7 => "ios",  
8 => "favorite" 
]
```
#FlattenKeysWithValues aims to this output

```
$flattenKeysWithValues = Arr::flattenKeysWithValues($array);

expected return => 

[
"name" => "taylor",
"backend" => "php",
"frontend" => "vue",
"android" => "java",
"ios" => "swift",
"favorite" =>"laravel"
]
```
