### PR TITLE
[9.x] Fix callOnce seeder method to properly process arrays

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -105,7 +105,7 @@ abstract class Seeder
 
         foreach($classes as $class) {
             if (in_array($class, static::$called)) {
-                return;
+                continue;
             }
 
             $this->call($class, $silent, $parameters);

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -103,7 +103,7 @@ abstract class Seeder
     {
         $classes = Arr::wrap($class);
 
-        foreach($classes as $class) {
+        foreach ($classes as $class) {
             if (in_array($class, static::$called)) {
                 continue;
             }

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -101,11 +101,15 @@ abstract class Seeder
      */
     public function callOnce($class, $silent = false, array $parameters = [])
     {
-        if (in_array($class, static::$called)) {
-            return;
-        }
+        $classes = Arr::wrap($class);
 
-        $this->call($class, $silent, $parameters);
+        foreach($classes as $class) {
+            if (in_array($class, static::$called)) {
+                return;
+            }
+
+            $this->call($class, $silent, $parameters);
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Update the callOnce method in Seeder.php to correctly handle an array of seeder classes being supplied.

@sebastiandedeyne I'm assuming this was the intent of the original based on the doc block for the $class parameter (`string|array`) and your examples in your [post ](https://sebastiandedeyne.com/composable-laravel-seeders-with-callonce/)about callOnce being added.