### PR TITLE
[8.x] Fix docblock for WithoutOverlapping class

### DIFF
--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -80,7 +80,7 @@ class WithoutOverlapping
     /**
      * Set the delay (in seconds) to release the job back to the queue.
      *
-     * @param  int  $releaseAfter
+     * @param  \DateTimeInterface|int  $releaseAfter
      * @return $this
      */
     public function releaseAfter($releaseAfter)


### PR DESCRIPTION
In `WithoutOverlapping` class, `$releaseAfter` property accepts **\DateTimeInterface**, int or null. If developers want to skip overlapping jobs, they have to use `dontRelease` method. Otherwise, they can call `releaseAfter` method with **\DateTimeInterface** or **int** as an argument. Thus, I just fix docblock for `releaseAfter` method.