### PR TITLE
[9.x] Arr::map - Fix map-by-reference w/ built-ins

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use ArgumentCountError;
 use ArrayAccess;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
@@ -555,7 +556,13 @@ class Arr
     {
         $keys = array_keys($array);
 
-        $items = array_map($callback, $array, $keys);
+        try {
+            $items = array_map($callback, $array, $keys);
+        } catch (ArgumentCountError) {
+            // When the callback isn't accepting the key argument, we'll simply omit it.
+            // This allows to map-by-reference for fixed methods such as 'strrev'.
+            $items = array_map($callback, $array);
+        }
 
         return array_combine($keys, $items);
     }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -559,8 +559,6 @@ class Arr
         try {
             $items = array_map($callback, $array, $keys);
         } catch (ArgumentCountError) {
-            // When the callback isn't accepting the key argument, we'll simply omit it.
-            // This allows to map-by-reference for fixed methods such as 'strrev'.
             $items = array_map($callback, $array);
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -632,6 +632,15 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
     }
 
+    public function testMapByReference()
+    {
+        $data = ['first' => 'taylor', 'last' => 'otwell'];
+        $mapped = Arr::map($data, 'strrev');
+
+        $this->assertEquals(['first' => 'rolyat', 'last' => 'llewto'], $mapped);
+        $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
+    }
+
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');


### PR DESCRIPTION
This PR fixes fallback support for `map` by-reference with built-in's such as `strrev` that do not accept more than one argument, making it slightly more flexible, predictable and forgiving in behavior, as in the majority of situations the `$key` argument is omitted/ignored by the developer anyway.

While some situations _might_ remain unsolved for some built-ins (ones that have exactly 2 parameters), I think it's important to mention that in such situations the user would be better off with a different or lower-level method such as `array_map`  instead, [as Laravel's documentation clearly indicates that a `$key` arg is passed within the `map` method](https://laravel.com/docs/9.x/collections#method-map).

---

```
ArgumentCountError: strrev() expects exactly 1 argument, 2 given in [..]/Illuminate/Collections/Arr.php:558
Stack trace:
#0 [internal function]: strrev('usb', 0)
```

Closes #42789
