### PR TITLE
Add make:trait command to generate Trait under Models directory

### DIFF
--- a/src/Illuminate/Foundation/Console/TraitMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TraitMakeCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+
+#[AsCommand(name: 'make:trait')]
+class TraitMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:trait';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'make:trait';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Trait';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Trait';
+
+    /**
+    * Get the stub file for the generator.
+    *
+    * @return string
+    */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/trait.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return is_dir(app_path('Models')) ? $rootNamespace.'\\Models\\Traits' : $rootNamespace;
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the trait'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the trait even if the name already exists'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/trait.stub
+++ b/src/Illuminate/Foundation/Console/stubs/trait.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+trait {{ class }}
+{
+
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -58,6 +58,7 @@ use Illuminate\Foundation\Console\ServeCommand;
 use Illuminate\Foundation\Console\StorageLinkCommand;
 use Illuminate\Foundation\Console\StubPublishCommand;
 use Illuminate\Foundation\Console\TestMakeCommand;
+use Illuminate\Foundation\Console\TraitMakeCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Foundation\Console\ViewCacheCommand;
@@ -176,6 +177,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Serve' => ServeCommand::class,
         'StubPublish' => StubPublishCommand::class,
         'TestMake' => TestMakeCommand::class,
+        'TraitMake' => TraitMakeCommand::class,
         'VendorPublish' => VendorPublishCommand::class,
     ];
 
@@ -1031,6 +1033,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(TestMakeCommand::class, function ($app) {
             return new TestMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerTraitMakeCommand()
+    {
+        $this->app->singleton(TraitMakeCommand::class, function ($app) {
+            return new TraitMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
Running the following command:
```ssh
php artisan make:trait HasTrait
```

Will generate this trait file:
```php
<?php

namespace App\Models\Traits;

trait HasTrait
{
    
}
```
