### PR TITLE
[9.x] Fix EventFake::assertListening doc-block

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -53,7 +53,7 @@ class EventFake implements Dispatcher
      * Assert if an event has a listener attached to it.
      *
      * @param  string  $expectedEvent
-     * @param  string  $expectedListener
+     * @param  string|array  $expectedListener
      * @return void
      */
     public function assertListening($expectedEvent, $expectedListener)


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
The method accepts arrays as well as strings, but the doc-block only allows strings.

Trying to assert cases like `Event::assertListening('event', [SubscriberClass::class, 'method'])` will raise a warning in IDE and static analysis tools. However, according to tests this should be a valid assertion.
