### PR TITLE
[9.x] Add array support to @error blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -16,9 +16,15 @@ trait CompilesErrors
 
         return '<?php $__errorArgs = ['.$expression.'];
 $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
-if ($__bag->has($__errorArgs[0])) :
+$__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
+if ($__bag->hasAny($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
-$message = $__bag->first($__errorArgs[0]); ?>';
+$message = "";
+$__i = 0;
+while ($message === "") {
+     $message = $__bag->first($__errorArgs[0][$__i++]);
+}
+?>';
     }
 
     /**
@@ -32,6 +38,6 @@ $message = $__bag->first($__errorArgs[0]); ?>';
         return '<?php unset($message);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
 endif;
-unset($__errorArgs, $__bag); ?>';
+unset($__errorArgs, $__bag, $__i); ?>';
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -23,8 +23,7 @@ $message = "";
 $__i = 0;
 while ($message === "") {
      $message = $__bag->first($__errorArgs[0][$__i++]);
-}
-?>';
+} ?>';
     }
 
     /**

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -16,9 +16,9 @@ $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
 $__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
 if ($__bag->hasAny($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
-$message = false;
+$message = "";
 $__i = 0;
-while (empty($message)) {
+while ($message === "") {
      $message = $__bag->first($__errorArgs[0][$__i++]);
 } ?>
     <span><?php echo e($message); ?></span>
@@ -42,9 +42,9 @@ $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
 $__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
 if ($__bag->hasAny($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
-$message = false;
+$message = "";
 $__i = 0;
-while (empty($message)) {
+while ($message === "") {
      $message = $__bag->first($__errorArgs[0][$__i++]);
 } ?>
     <span><?php echo e($message); ?></span>
@@ -67,9 +67,9 @@ $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
 $__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
 if ($__bag->hasAny($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
-$message = false;
+$message = "";
 $__i = 0;
-while (empty($message)) {
+while ($message === "") {
      $message = $__bag->first($__errorArgs[0][$__i++]);
 } ?>
     <span><?php echo e($message); ?></span>
@@ -93,9 +93,9 @@ $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
 $__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
 if ($__bag->hasAny($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
-$message = false;
+$message = "";
 $__i = 0;
-while (empty($message)) {
+while ($message === "") {
      $message = $__bag->first($__errorArgs[0][$__i++]);
 } ?>
     <span><?php echo e($message); ?></span>

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -51,7 +51,7 @@ while ($message === "") {
 <?php unset($message);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
 endif;
-unset($__errorArgs, $__bag); ?>';
+unset($__errorArgs, $__bag, $__i); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -13,14 +13,19 @@ class BladeErrorTest extends AbstractBladeTestCase
         $expected = '
 <?php $__errorArgs = [\'email\'];
 $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
-if ($__bag->has($__errorArgs[0])) :
+$__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
+if ($__bag->hasAny($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
-$message = $__bag->first($__errorArgs[0]); ?>
+$message = false;
+$__i = 0;
+while (empty($message)) {
+     $message = $__bag->first($__errorArgs[0][$__i++]);
+} ?>
     <span><?php echo e($message); ?></span>
 <?php unset($message);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
 endif;
-unset($__errorArgs, $__bag); ?>';
+unset($__errorArgs, $__bag, $__i); ?>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
@@ -34,14 +39,71 @@ unset($__errorArgs, $__bag); ?>';
         $expected = '
 <?php $__errorArgs = [\'email\', \'customBag\'];
 $__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
-if ($__bag->has($__errorArgs[0])) :
+$__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
+if ($__bag->hasAny($__errorArgs[0])) :
 if (isset($message)) { $__messageOriginal = $message; }
-$message = $__bag->first($__errorArgs[0]); ?>
+$message = false;
+$__i = 0;
+while (empty($message)) {
+     $message = $__bag->first($__errorArgs[0][$__i++]);
+} ?>
     <span><?php echo e($message); ?></span>
 <?php unset($message);
 if (isset($__messageOriginal)) { $message = $__messageOriginal; }
 endif;
 unset($__errorArgs, $__bag); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testErrorsWithMultipleKeysAreCompiled()
+    {
+        $string = '
+@error([\'email\', \'name\'])
+    <span>{{ $message }}</span>
+@enderror';
+        $expected = '
+<?php $__errorArgs = [[\'email\', \'name\']];
+$__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
+$__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
+if ($__bag->hasAny($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = false;
+$__i = 0;
+while (empty($message)) {
+     $message = $__bag->first($__errorArgs[0][$__i++]);
+} ?>
+    <span><?php echo e($message); ?></span>
+<?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__errorArgs, $__bag, $__i); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testErrorsWithMultipleKeysWithBagsAreCompiled()
+    {
+        $string = '
+@error([\'email\', \'name\'], \'customBag\')
+    <span>{{ $message }}</span>
+@enderror';
+        $expected = '
+<?php $__errorArgs = [[\'email\', \'name\'], \'customBag\'];
+$__bag = $errors->getBag($__errorArgs[1] ?? \'default\');
+$__errorArgs[0] = is_array($__errorArgs[0]) ? $__errorArgs[0] : [$__errorArgs[0]];
+if ($__bag->hasAny($__errorArgs[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = false;
+$__i = 0;
+while (empty($message)) {
+     $message = $__bag->first($__errorArgs[0][$__i++]);
+} ?>
+    <span><?php echo e($message); ?></span>
+<?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__errorArgs, $__bag, $__i); ?>';
+
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
This update allows for the @error blade directive to accept an array of keys to check for in the MessageBag.

When given an array, it will check if the error bag has an error in any of the keys, if so, the first error in the first key that has errors will be available in the `$message` variable.

Use case:
```php
<input id="accessCode" type="text" class="form-control @error(['code', 'throttled']) is-invalid @enderror"
placeholder="Code" name="code" value="{{ old('code') }}" aria-describedby="accessCodeFeedback">
<label>{{ trans('labels.access_code') }}</label>
@error(['code', 'throttled'])
<div id="accessCodeFeedback" class="invalid-feedback">{{ $message }}</div>
@enderror
```

I'm not sure on how to add testing coverage to this. Some help/guidance is welcome.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
