### PR TITLE
[9.x] Avoid Storing Turbo Frame Visits as Previous URL

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -202,7 +202,8 @@ class StartSession
         if ($request->isMethod('GET') &&
             $request->route() instanceof Route &&
             ! $request->ajax() &&
-            ! $request->prefetch()) {
+            ! $request->prefetch() &&
+            ! $request->headers->has('Turbo-Frame')) {
             $session->setPreviousUrl($request->fullUrl());
         }
     }
@@ -218,9 +219,15 @@ class StartSession
     {
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
-                $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
-                $config['path'], $config['domain'], $config['secure'] ?? false,
-                $config['http_only'] ?? true, false, $config['same_site'] ?? null
+                $session->getName(),
+                $session->getId(),
+                $this->getCookieExpirationDate(),
+                $config['path'],
+                $config['domain'],
+                $config['secure'] ?? false,
+                $config['http_only'] ?? true,
+                false,
+                $config['same_site'] ?? null
             ));
         }
     }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -219,15 +219,9 @@ class StartSession
     {
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
-                $session->getName(),
-                $session->getId(),
-                $this->getCookieExpirationDate(),
-                $config['path'],
-                $config['domain'],
-                $config['secure'] ?? false,
-                $config['http_only'] ?? true,
-                false,
-                $config['same_site'] ?? null
+                $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
+                $config['path'], $config['domain'], $config['secure'] ?? false,
+                $config['http_only'] ?? true, false, $config['same_site'] ?? null
             ));
         }
     }

--- a/tests/Integration/Session/SessionPreviousUrlPersistenceTest.php
+++ b/tests/Integration/Session/SessionPreviousUrlPersistenceTest.php
@@ -2,14 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Session;
 
-use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Http\Response;
-use Illuminate\Session\NullSessionHandler;
-use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
-use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
 class SessionPreviousUrlPersistenceTest extends TestCase
@@ -53,13 +47,6 @@ class SessionPreviousUrlPersistenceTest extends TestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        $app->instance(
-            ExceptionHandler::class,
-            $handler = m::mock(ExceptionHandler::class)->shouldIgnoreMissing()
-        );
-
-        $handler->shouldReceive('render')->andReturn(new Response);
-
         $app['config']->set('app.key', Str::random(32));
         $app['config']->set('session.driver', 'array');
         $app['config']->set('session.expire_on_close', true);

--- a/tests/Integration/Session/SessionPreviousUrlPersistenceTest.php
+++ b/tests/Integration/Session/SessionPreviousUrlPersistenceTest.php
@@ -14,8 +14,10 @@ use Orchestra\Testbench\TestCase;
 
 class SessionPreviouslUrlPersistenceTest extends TestCase
 {
-    public function testRemembersPreviouslyVisitedUrl()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         Route::middleware('web')->get('_test/session-url/home', function () {
             return url()->previous();
         });
@@ -23,7 +25,10 @@ class SessionPreviouslUrlPersistenceTest extends TestCase
         Route::middleware('web')->get('_test/session-url/my-page', function () {
             return 'my-page-content';
         });
+    }
 
+    public function testRemembersPreviouslyVisitedUrl()
+    {
         $this->get('_test/session-url/my-page')
             ->assertOk()
             ->assertSee('my-page-content');
@@ -35,14 +40,6 @@ class SessionPreviouslUrlPersistenceTest extends TestCase
 
     public function testIgnoresTurboFrameVisitsFromPreviousUrl()
     {
-        Route::middleware('web')->get('_test/session-url/home', function () {
-            return url()->previous();
-        });
-
-        Route::middleware('web')->get('_test/session-url/my-page', function () {
-            return 'my-page-content';
-        });
-
         $this->withHeaders(['Turbo-Frame' => 'testing-frame'])
             ->get('_test/session-url/my-page')
             ->assertOk()

--- a/tests/Integration/Session/SessionPreviousUrlPersistenceTest.php
+++ b/tests/Integration/Session/SessionPreviousUrlPersistenceTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Str;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-class SessionPreviouslUrlPersistenceTest extends TestCase
+class SessionPreviousUrlPersistenceTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Integration/Session/SessionPreviousUrlPersistenceTest.php
+++ b/tests/Integration/Session/SessionPreviousUrlPersistenceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Session;
+
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\Response;
+use Illuminate\Session\NullSessionHandler;
+use Illuminate\Session\TokenMismatchException;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class SessionPreviouslUrlPersistenceTest extends TestCase
+{
+    public function testRemembersPreviouslyVisitedUrl()
+    {
+        Route::middleware('web')->get('_test/session-url/home', function () {
+            return url()->previous();
+        });
+
+        Route::middleware('web')->get('_test/session-url/my-page', function () {
+            return 'my-page-content';
+        });
+
+        $this->get('_test/session-url/my-page')
+            ->assertOk()
+            ->assertSee('my-page-content');
+
+        $this->get('_test/session-url/home')
+            ->assertOk()
+            ->assertSee(url('_test/session-url/my-page'));
+    }
+
+    public function testIgnoresTurboFrameVisitsFromPreviousUrl()
+    {
+        Route::middleware('web')->get('_test/session-url/home', function () {
+            return url()->previous();
+        });
+
+        Route::middleware('web')->get('_test/session-url/my-page', function () {
+            return 'my-page-content';
+        });
+
+        $this->withHeaders(['Turbo-Frame' => 'testing-frame'])
+            ->get('_test/session-url/my-page')
+            ->assertOk()
+            ->assertSee('my-page-content');
+
+        $this->get('_test/session-url/home')
+            ->assertOk()
+            ->assertSee(url(''))
+            ->assertDontSee(url('_test/session-url/my-page'));
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app->instance(
+            ExceptionHandler::class,
+            $handler = m::mock(ExceptionHandler::class)->shouldIgnoreMissing()
+        );
+
+        $handler->shouldReceive('render')->andReturn(new Response);
+
+        $app['config']->set('app.key', Str::random(32));
+        $app['config']->set('session.driver', 'array');
+        $app['config']->set('session.expire_on_close', true);
+    }
+}


### PR DESCRIPTION
There was [an issue](https://github.com/tonysm/turbo-laravel/issues/60#issuecomment-1123142591) in the Turbo Laravel package where someone noticed the `url()->previous()` was behaving weirdly. I traced it down to how Laravel stores the previously visited URL in the session.

I think it's safe to ignore visits from Turbo Frames to get stored as previously visited URL, since that's generally not a URL you would want to redirect users to (since it's mostly for UI fragments, not always entire pages). The only way to override this behavior was by creating a new middleware that extends the StartSession and override that method.

I think it wouldn't hurt to add this to the core or at least provide a way where I could customize this behavior in the package.

Couldn't find tests for this behavior, so I also added a test case just for that behavior.