### PR TITLE
HasAttributes::mutateAttributeForArray - Fix support enum cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -658,7 +658,9 @@ trait HasAttributes
      */
     protected function mutateAttributeForArray($key, $value)
     {
-        if ($this->isClassCastable($key)) {
+        if ($this->isEnumCastable($key)) {
+            $value = $this->getEnumCastableAttributeValue($key, $value);
+        } elseif ($this->isClassCastable($key)) {
             $value = $this->getClassCastableAttributeValue($key, $value);
         } elseif (isset(static::$getAttributeMutatorCache[get_class($this)][$key]) &&
                   static::$getAttributeMutatorCache[get_class($this)][$key] === true) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Actually: 
- Model::toArray() cannot be called if the current model is trying to cast a property of type Enum
```
Error: Cannot instantiate enum App\Enums\UserGender in file /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php on line 1585

#0 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(773): Illuminate\Database\Eloquent\Model->resolveCasterClass('gender')
#1 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(662): Illuminate\Database\Eloquent\Model->getClassCastableAttributeValue('gender', NULL)
#2 /var/www/app/Helpers/HasForeignAttributes.php(62): Illuminate\Database\Eloquent\Model->mutateAttributeForArray('gender', NULL)
#3 [internal function]: App\Models\User->__call('nickname', Array)
#4 /var/www/app/Helpers/HasForeignAttributes.php(56): call_user_func(Array)
#5 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(621): App\Models\User->__call('getNicknameAttr...', Array)
#6 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(671): Illuminate\Database\Eloquent\Model->mutateAttribute('nickname', NULL)
#7 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php(202): Illuminate\Database\Eloquent\Model->mutateAttributeForArray('nickname', NULL)
#8 /var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1517): Illuminate\Database\Eloquent\Model->attributesToArray()
#9 /var/www/routes/api.php(28): Illuminate\Database\Eloquent\Model->toArray()
```


Expected:
 - Can call Model::toArray(), get enum value and no error

Test:
 - [ ] I added 1 test case for this case

