### PR TITLE
[9.x] Add predefined_constants to reservedNames array

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -100,6 +100,14 @@ abstract class GeneratorCommand extends Command
         'while',
         'xor',
         'yield',
+        '__CLASS__',
+        '__DIR__',
+        '__FILE__',
+        '__FUNCTION__',
+        '__LINE__',
+        '__METHOD__',
+        '__NAMESPACE__',
+        '__TRAIT__'
     ];
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -107,7 +107,7 @@ abstract class GeneratorCommand extends Command
         '__LINE__',
         '__METHOD__',
         '__NAMESPACE__',
-        '__TRAIT__'
+        '__TRAIT__',
     ];
 
     /**


### PR DESCRIPTION
### What
_________________

This PR is for adding predefined_constants to reservedNames array in a generator command. for example: 

```
php artisan make:model __FILE__
```

### Why
_________________

Using PHP keywords & constants as the name when using generation commands is not only bad practice, but it simply does not even work.

For example, if there's a developer who wants to create a model called `__FILE__` 
![image](https://user-images.githubusercontent.com/29666390/174030288-cce3bb49-1f33-42f4-8534-01e716a60cba.png)

Some could say: 

> "Developers should just be cautious and not use keywords when scaffolding."

I partially agree, but when you use the following generation command for example:

```
php artisan make:model __FILE__ -a
```
![image](https://user-images.githubusercontent.com/29666390/174033421-f119abc8-0a07-424c-b6b1-ee35f9d2229e.png)

And now your project is polluted with a model class, factory, migration, and seeder, while the model isn't usable in the first place. It would be much better to disallow the scaffolding immediately and prevent this.

### Note
_________________

I asked myself why developers even name classes with underscores but when I checked the `reservedName` array I found the `__halt_compiler` keyword prevented before so that encourages me to add `predefined_constants` in PHP to prevent it also.

### Screenshot
_________________

![image](https://user-images.githubusercontent.com/29666390/174033522-603ba59c-6cca-4a22-aaec-c682efd38a0a.png)
