### PR TITLE
[8.x] Fix docblock for the Console Kernel commands method

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -172,7 +172,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Register the Closure based commands for the application.
+     * Register the commands for the application.
      *
      * @return void
      */


### PR DESCRIPTION
The `commands` method of Console Kernel class is to register any kind of commands for the application, not only Closure based commands. The description has to be consistent with https://github.com/laravel/laravel/blob/1f9eee06ddb38abf86e2f7df37a20281cd774e3d/app/Console/Kernel.php#L22