### PR TITLE
[8.x] Handle collection creation around a single enum

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -16,6 +16,7 @@ use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 use UnexpectedValueException;
+use UnitEnum;
 
 /**
  * @property-read HigherOrderCollectionProxy $average
@@ -991,7 +992,7 @@ trait EnumeratesValues
             return (array) $items->jsonSerialize();
         } elseif ($items instanceof Traversable) {
             return iterator_to_array($items);
-        } elseif ($items instanceof \UnitEnum) {
+        } elseif ($items instanceof UnitEnum) {
             return [$items];
         }
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -991,6 +991,8 @@ trait EnumeratesValues
             return (array) $items->jsonSerialize();
         } elseif ($items instanceof Traversable) {
             return iterator_to_array($items);
+        } elseif ($items instanceof \UnitEnum) {
+            return [$items];
         }
 
         return (array) $items;

--- a/tests/Support/Enums.php
+++ b/tests/Support/Enums.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+enum TestEnum
+{
+    case A;
+}
+
+enum TestBackedEnum: int
+{
+    case A = 1;
+}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -24,6 +24,10 @@ use stdClass;
 use Symfony\Component\VarDumper\VarDumper;
 use UnexpectedValueException;
 
+if (PHP_VERSION_ID >= 80100) {
+    include_once 'Enums.php';
+}
+
 class SupportCollectionTest extends TestCase
 {
     /**
@@ -4252,6 +4256,26 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(new ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
         $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     * @requires PHP >= 8.1
+     */
+    public function testCollectionFromEnum($collection)
+    {
+        $data = new $collection(TestEnum::A);
+        $this->assertEquals([TestEnum::A], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     * @requires PHP >= 8.1
+     */
+    public function testCollectionFromBackedEnum($collection)
+    {
+        $data = new $collection(TestBackedEnum::A);
+        $this->assertEquals([TestBackedEnum::A], $data->toArray());
     }
 
     /**


### PR DESCRIPTION
Current behaviour:

```php
$c = collect(SomeEnum::myCase);
$c->items; // ['name' => 'myCase']

$c = collect(BackedEnum::myCase);
$c->items; // ['name' => 'myCase', 'value' => BackedEnum::myCase->value]
```

In my opinion it is a bug, it is natural to expect `collect(SomeEnum::myCase)` to produce a single item collection containing the item itself like it does with `collect('mystring')` instead of unwrapping it and changing the item count based on whether it's a backed enum.

This PR changes the behaviour so that:

```php
$c = collect(SomeEnum::myCase);
$c->items; // [SomeEnum::myCase]
```