### PR TITLE
[9.x] Adds ability to have simplePaginate() $perPage parameter as callable with access to $total

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2661,7 +2661,7 @@ class Builder implements BuilderContract
      *
      * This is more efficient on larger data-sets, etc.
      *
-     * @param  int  $perPage
+     * @param  int|callable  $perPage
      * @param  array|string  $columns
      * @param  string  $pageName
      * @param  int|null  $page
@@ -2671,9 +2671,13 @@ class Builder implements BuilderContract
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $this->offset(($page - 1) * $perPage)->limit($perPage + 1);
+        $total = $this->getCountForPagination();
 
-        return $this->simplePaginator($this->get($columns), $perPage, $page, [
+        $perPage = $perPage instanceof Closure ? $perPage($total) : $perPage;
+
+        $results = $total ? $this->offset(($page - 1) * $perPage)->limit($perPage + 1)->get($columns) : collect();
+
+        return $this->simplePaginator($results, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -332,6 +332,68 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('bar@gmail.com', $models[1]->email);
     }
 
+    public function testSimplePaginatedModelCollectionRetrievalUsingCallablePerPage()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+        $models = EloquentTestUser::oldest('id')->simplePaginate(function ($total) {
+            return $total <= 3 ? 3 : 2;
+        });
+
+        $this->assertCount(3, $models);
+        $this->assertInstanceOf(Paginator::class, $models);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[1]);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[2]);
+        $this->assertSame('taylorotwell@gmail.com', $models[0]->email);
+        $this->assertSame('abigailotwell@gmail.com', $models[1]->email);
+        $this->assertSame('foo@gmail.com', $models[2]->email);
+
+        Paginator::currentPageResolver(function () {
+            return 2;
+        });
+        $models = EloquentTestUser::oldest('id')->simplePaginate(function ($total) {
+            return $total <= 3 ? 3 : 2;
+        });
+
+        $this->assertCount(0, $models);
+        $this->assertInstanceOf(Paginator::class, $models);
+
+        EloquentTestUser::create(['id' => 4, 'email' => 'bar@gmail.com']);
+
+        Paginator::currentPageResolver(function () {
+            return 1;
+        });
+        $models = EloquentTestUser::oldest('id')->simplePaginate(function ($total) {
+            return $total <= 3 ? 3 : 2;
+        });
+        $this->assertCount(2, $models);
+        $this->assertInstanceOf(Paginator::class, $models);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[1]);
+        $this->assertSame('taylorotwell@gmail.com', $models[0]->email);
+        $this->assertSame('abigailotwell@gmail.com', $models[1]->email);
+
+        Paginator::currentPageResolver(function () {
+            return 2;
+        });
+        $models = EloquentTestUser::oldest('id')->simplePaginate(function ($total) {
+            return $total <= 3 ? 3 : 2;
+        });
+
+        $this->assertCount(2, $models);
+        $this->assertInstanceOf(Paginator::class, $models);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
+        $this->assertInstanceOf(EloquentTestUser::class, $models[1]);
+        $this->assertSame('foo@gmail.com', $models[0]->email);
+        $this->assertSame('bar@gmail.com', $models[1]->email);
+    }
+
     public function testPaginatedModelCollectionRetrievalWhenNoElements()
     {
         Paginator::currentPageResolver(function () {


### PR DESCRIPTION
The feature adds the ability to have `$perPage` as a callback closure with access to $total.

```php
// Previously:
$total = DB::table('products')->count();
DB::table('products')->simplePaginate($total <= 110 ? 110 : 100);

// Now (saves extra query and builder code):
DB::table('products')->simplePaginate(function ($total) {
    return $total <= 110 ? 110 : 100;
});
```

There might be a scenario when you want to use different/dynamic per page depending on the total count of records.

For example, in a list of products, with the above snippet, it will load all ~110 products if there are less than or equal to 110 products in total. Else, defaults to 100 as usual. So that, there won't be just a few items sitting around on the second page.

Similarly, if we want to have exact 4 pages, we can provide a dynamic per page value like such:

```php
Product::oldest()->simplePaginate(function ($total) {
    return ceil($total / 4); // Will always have at most 4 pages in total
});
```
And, of course, the normal simplePaginate(10) will still work.

This PR is a same this PR https://github.com/laravel/framework/pull/42429 put in `simplePaginate`