### PR TITLE
[9.x] Allow removing token during tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -103,6 +103,18 @@ trait MakesHttpRequests
     }
 
     /**
+     * Remove the authorization token from the request.
+     *
+     * @return $this
+     */
+    public function withoutToken()
+    {
+        unset($this->defaultHeaders['Authorization']);
+        
+        return $this;
+    }
+
+    /**
      * Flush all the configured headers.
      *
      * @return $this

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -26,6 +26,16 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('Basic foobar', $this->defaultHeaders['Authorization']);
     }
 
+
+    public function testWithoutTokenRemovesAuthorizationHeader()
+    {
+        $this->withToken('foobar');
+        $this->assertSame('Bearer foobar', $this->defaultHeaders['Authorization']);
+
+        $this->withoutToken();
+        $this->assertArrayNotHasKey('Authorization', $this->defaultHeaders);
+    }
+
     public function testWithoutAndWithMiddleware()
     {
         $this->assertFalse($this->app->has('middleware.disable'));


### PR DESCRIPTION
Once you use a token, you are stuck with an `Authorization` header for the remainder of the test:

```php
$this->getJson('a');

$this->withToken($token)->getJson('b');

$this->getJson('c'); // also uses the token
```

This PR adds a small helpers to turn off the token:


```php
$this->getJson('a');

$this->withToken($token)->getJson('b');
$this->getJson('c'); // also uses the token

$this->withoutToken()->getJson('d'); // does not use the token
$this->getJson('e'); // no token either
```