### PR TITLE
[9.x] Adds new methods in `Eloquent Builder` and `Query Builder`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -346,6 +346,7 @@ class Builder implements BuilderContract
     {
         return $this->whereNot($column, $operator, $value, 'or');
     }
+
     /**
      * Add an "where when" clause to the query.
      *

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -24,6 +24,8 @@ use ReflectionMethod;
  * @property-read HigherOrderBuilderProxy $orWhere
  * @property-read HigherOrderBuilderProxy $whereNot
  * @property-read HigherOrderBuilderProxy $orWhereNot
+ * @property-read HigherOrderBuilderProxy $whereWhen
+ * @property-read HigherOrderBuilderProxy $whereUnless
  *
  * @mixin \Illuminate\Database\Query\Builder
  */
@@ -343,6 +345,45 @@ class Builder implements BuilderContract
     public function orWhereNot($column, $operator = null, $value = null)
     {
         return $this->whereNot($column, $operator, $value, 'or');
+    }
+    /**
+     * Add an "where when" clause to the query.
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter  $condition
+     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereWhen($condition, $column, $operator = null, $value = null)
+    {
+        [$value, $operator] = $this->query->prepareValueAndOperator(
+            $value,
+            $operator,
+            func_num_args() === 2
+        );
+
+        return $this->when($condition, fn ($query, $whenValue) => $query->where($column, $operator, $value ?? $whenValue));
+    }
+
+    /**
+     * Add an "where unless" clause to the query.
+     *
+     * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter  $condition
+     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereUnless($condition, $column, $operator = null, $value = null)
+    {
+        [$value, $operator] = $this->query->prepareValueAndOperator(
+            $value,
+            $operator,
+            func_num_args() === 2
+        );
+
+        return $this->unless($condition, fn ($query, $unlessValue) => $query->where($column, $operator, $value ?? $unlessValue));
     }
 
     /**
@@ -1784,7 +1825,7 @@ class Builder implements BuilderContract
      */
     public function __get($key)
     {
-        if (in_array($key, ['orWhere', 'whereNot', 'orWhereNot'])) {
+        if (in_array($key, ['orWhere', 'whereNot', 'orWhereNot', 'whereWhen', 'whereUnless'])) {
             return new HigherOrderBuilderProxy($this, $key);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -911,6 +911,46 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add an "where when" clause to the query.
+     *
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter  $condition
+     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereWhen($condition, $column, $operator = null, $value = null)
+    {
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value,
+            $operator,
+            func_num_args() === 2
+        );
+
+        return $this->when($condition, fn ($query, $whenValue) => $query->where($column, $operator, $value ?? $whenValue));
+    }
+
+    /**
+     * Add an "where unless" clause to the query.
+     *
+     * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter  $condition
+     * @param  \Closure|array|string|\Illuminate\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function whereUnless($condition, $column, $operator = null, $value = null)
+    {
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value,
+            $operator,
+            func_num_args() === 2
+        );
+
+        return $this->unless($condition, fn ($query, $unlessValue) => $query->where($column, $operator, $value ?? $unlessValue));
+    }
+
+    /**
      * Add a "where" clause comparing two columns to the query.
      *
      * @param  string|array  $first

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -955,6 +955,54 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals($builder, $result);
     }
 
+    public function testWhereWhen()
+    {
+        $model = new EloquentBuilderTestNestedStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereWhen(true, 'foo', '=', 'bar');
+        $this->assertSame('select * from "table" where "foo" = ? and "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals(['bar'], $query->getBindings());
+
+        $query = $model->newQuery()->whereWhen(false, 'foo', '=', 'bar');
+        $this->assertSame('select * from "table" where "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+
+        $foo = 'bar';
+        $query = $model->newQuery()->whereWhen($foo, 'foo');
+        $this->assertSame('select * from "table" where "foo" = ? and "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals(['bar'], $query->getBindings());
+
+        $foo = '';
+        $query = $model->newQuery()->whereWhen($foo, 'foo');
+        $this->assertSame('select * from "table" where "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+    }
+
+    public function testWhereUnless()
+    {
+        $model = new EloquentBuilderTestNestedStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $query = $model->newQuery()->whereUnless(true, 'foo', '=', 'bar');
+        $this->assertSame('select * from "table" where "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+
+        $query = $model->newQuery()->whereUnless(false, 'foo', '=', 'bar');
+        $this->assertSame('select * from "table" where "foo" = ? and "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals(['bar'], $query->getBindings());
+
+        $foo = 'bar';
+        $query = $model->newQuery()->whereUnless($foo, 'foo');
+        $this->assertSame('select * from "table" where "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+
+        $foo = '';
+        $query = $model->newQuery()->whereUnless($foo, 'foo');
+        $this->assertSame('select * from "table" where "foo" = ? and "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals([''], $query->getBindings());
+    }
+
     public function testRealNestedWhereWithScopes()
     {
         $model = new EloquentBuilderTestNestedStub;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -182,6 +182,27 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
     }
 
+    public function testWhereWhenCallback()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereWhen(true, 'id', '=', 1)->where('email', 'foo');
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereWhen(false, 'id', '=', 1)->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+
+        $id = 1;
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereWhen($id, 'id')->where('email', 'foo');
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $id = '';
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereWhen($id, 'id')->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
     public function testWhenCallbackWithReturn()
     {
         $callback = function ($query, $condition) {
@@ -239,6 +260,27 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->unless(true, $callback)->where('email', 'foo');
         $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
+    public function testWhereUnlessCallback()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereUnless(false, 'id', '=', 1)->where('email', 'foo');
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereUnless(true, 'id', '=', 1)->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+
+        $id = 1;
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereUnless($id, 'id')->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+
+        $id = '';
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereUnless($id, 'id')->where('email', 'foo');
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
     }
 
     public function testUnlessCallbackWithReturn()


### PR DESCRIPTION
A lot of developers need to work when with the use of where. This PR helps them to shorten the matter nicely, and we hope to add it in the next release

### Before in `Eloquent Builder`
```php
$carts = Cart::query()
            ->when($request->id, function ($query, $id) {
                return $query->where('id', '!=', $id);
            })
            ->get();

$carts = Cart::query()
            ->unless($request->id, function ($query, $id) {
                return $query->where('id', $id);
            })
            ->get();
```

### After in `Eloquent Builder`
```php
$carts = Cart::whereWhen($request->id, 'id', '!=', '#'.$request->id)->get();

$carts = Cart::whereUnless($request->id, 'id', '!=', '#'.$request->id)->get();

$carts = Cart::whereWhen($request->search, 'id')->get();

$carts = Cart::whereUnless($request->id, 'id')->get();
```

### Before in `Query Builder`
```php
$carts = DB::table('carts')
            ->when($request->id, function ($query, $id) {
                return $query->where('id', '!=', $id);
            })
            ->get();

$carts = DB::table('carts')
            ->unless($request->id, function ($query, $id) {
                return $query->where('id', $id);
            })
            ->get();
```

### After in `Query Builder`
```php
$carts = DB::table('carts')->whereWhen($request->id, 'id', '!=', '#'.$request->id)->get();

$carts = DB::table('carts')->whereUnless($request->id, 'id', '!=', '#'.$request->id)->get();

$carts = DB::table('carts')->whereWhen($request->search, 'id')->get();

$carts = DB::table('carts')->whereUnless($request->id, 'id')->get();
```