### PR TITLE
[9.x] Introduce a fake() helper to resolve faker singletons, per locale

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -451,6 +451,26 @@ if (! function_exists('event')) {
     }
 }
 
+if (! function_exists('fake') && class_exists(\Faker\Factory::class)) {
+    /**
+     * Get a faker instance.
+     *
+     * @param  ?string  $locale
+     * @return \Faker\Generator
+     */
+    function fake($locale = null) {
+        $locale ??= app('config')->get('app.faker_locale') ?? 'en_US';
+
+        $abstract = \Faker\Generator::class.':'.$locale;
+
+        if (! app()->bound($abstract)) {
+            app()->singleton($abstract, fn () => \Faker\Factory::create($locale));
+        }
+
+        return app()->make($abstract);
+    }
+}
+
 if (! function_exists('info')) {
     /**
      * Write some information to the log.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -458,7 +458,8 @@ if (! function_exists('fake') && class_exists(\Faker\Factory::class)) {
      * @param  ?string  $locale
      * @return \Faker\Generator
      */
-    function fake($locale = null) {
+    function fake($locale = null)
+    {
         $locale ??= app('config')->get('app.faker_locale') ?? 'en_US';
 
         $abstract = \Faker\Generator::class.':'.$locale;

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
+use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Mix;
@@ -243,5 +244,34 @@ class FoundationHelpersTest extends TestCase
         });
 
         $this->assertSame('expected', mix('asset.png'));
+    }
+
+    public function testFakeReturnsSameInstance()
+    {
+        app()->instance('config', new ConfigRepository([]));
+
+        $this->assertSame(fake(), fake());
+        $this->assertSame(fake(), fake('en_US'));
+        $this->assertSame(fake('en_AU'), fake('en_AU'));
+        $this->assertNotSame(fake('en_US'), fake('en_AU'));
+
+        app()->flush();
+    }
+
+    public function testFakeUsesLocale()
+    {
+        mt_srand(12345, MT_RAND_PHP);
+        app()->instance('config', new ConfigRepository([]));
+
+        // Should fallback to en_US
+        $this->assertSame('Arkansas', fake()->state());
+        $this->assertSame('Australian Capital Territory', fake('en_AU')->state());
+        $this->assertSame('Guadeloupe', fake('fr_FR')->region());
+
+        app()->instance('config', new ConfigRepository(['app' => ['faker_locale' => 'en_AU']]));
+        mt_srand(4, MT_RAND_PHP);
+
+        // Should fallback to en_US
+        $this->assertSame('Australian Capital Territory', fake()->state());
     }
 }


### PR DESCRIPTION
This PR introduces a global `fake()` helper to allow you to easily access a shared (singleton) faker instance across your application.

The helper is only created if the function doesn't already exist AND if Faker is installed, which it is only in "dev-dependencies" out of the box.

This is super useful in different scenarios.

1. Prototyping
2. Testing
3. Factories / Seeding

Now some of these are already covered with their own implementations, but this improves the scenario across all.

First, this IMO is much nicer to look at...a little more "high end" some might say 🧐

```php
return [
    'name' => fake()->name(),
];
```

When it comes to a Rapid Application Development framework like Laravel, speed of prototyping a feature is through the roof. But often you will want to prototype a view without having the even create any backing models or anything. You just wanna throw some tailwind and some blade at the problem and get some eyes on it.

```blade
@for($i = 0; $i < 10; $i++)
    <dl>
        <dt>Name</dt>
        <dd>{{ fake()->name() }}</dd>

        <dt>Phone</dt>
        <dd>{{ fake()->phoneNumber() }}</dd>

    </dl>
@endfor
```

You can also swap between languages, and you'll be guaranteed to always have a singleton for each locale...

```php
fake()->name() // config('app.faker_locale') ?? 'en_US'
fake('en_AU')->name() // en_AU
```

This makes it nice when you want to ensure unique values across all the different things. You might want to use faker in your factories and in your seeder and be sure that you are getting unique values when you run them in the same thread.


```php
// UserFactory...
function definition()
{
    return [
        'name' => fake()->unique()->name(),
    ];
}


// DB Seeder...

function run()
{
    DB::table('users')->insert(['name' => fake()->unique()->name()]);
}
```

As with all the helpers, don't use them if you don't like them 👍

PRs suggesting a faker helper have been proposed previously, but hoping with a few more examples of its utility, this might be reconsidered.

This won't conflict with any of the existing framework faker bindings (see DatabaseServiceProvider) as the key is the container is suffixed with a colon and then the locale, .e.g `\Faker\Factory:en_US` and it is only bound at runtime, not during boot, so if you do not call this function nothing changes.

Previous PRs:
- https://github.com/laravel/framework/pull/23451
- https://github.com/laravel/framework/pull/41130