### PR TITLE
[9.x] form requests: populate input to public properties

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Validation;
 
+use ReflectionClass;
+use ReflectionProperty;
+
 /**
  * Provides default implementation of ValidatesWhenResolved contract.
  */
@@ -25,6 +28,8 @@ trait ValidatesWhenResolvedTrait
         if ($instance->fails()) {
             $this->failedValidation($instance);
         }
+
+        $this->refresh();
 
         $this->passedValidation();
     }
@@ -96,5 +101,21 @@ trait ValidatesWhenResolvedTrait
     protected function failedAuthorization()
     {
         throw new UnauthorizedException;
+    }
+
+    /**
+     * Populate the request data to properties.
+     *
+     * @return $this
+     */
+    public function refresh()
+    {
+        foreach ((new ReflectionClass($this))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($this->has(($property->name)) && $property->getDeclaringClass()->getName() === $this::class) {
+                $this->{$property->name} = $this->input($property->name);
+            }
+        }
+
+        return $this;
     }
 }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -149,6 +149,24 @@ class FoundationFormRequestTest extends TestCase
         $this->assertSame('bar', $request->validated('nested.foo'));
     }
 
+    public function testPopulateToProperties()
+    {
+        $request = $this->createRequest(['name' => 'Adam'], FoundationTestFormRequestWithProperties::class);
+
+        $request->refresh();
+
+        $this->assertSame('Adam', $request->name);
+    }
+
+    public function testPopulateToPropertiesWontTouchParentProperties()
+    {
+        $request = $this->createRequest(['request' => 'fake'], FoundationTestFormRequestWithProperties::class);
+
+        $request->refresh();
+
+        $this->assertIsNotScalar($request->request);
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -377,3 +395,14 @@ class FoundationTestFormRequestPassesWithResponseStub extends FormRequest
         return Response::allow('baz');
     }
 }
+
+class FoundationTestFormRequestWithProperties extends FormRequest
+{
+    public string $name;
+
+    public function rules()
+    {
+        return [];
+    }
+}
+


### PR DESCRIPTION
This PR introduces a suggested feature to form requests: populate input to the typed public properties.

If a `FormRequest` instance had a `$name` public property and the request had `name` input, the input value will be populated to the property.

``` php
use Illuminate\Foundation\Http\FormRequest;

class CreateUserRequest extends FormRequest
{
    public string $name;

    public function rules()
    {
        return [
            'name' => ['required', 'string',]
        ];
    }
}
```
``` php
        $this->post('user', [
            'name' => 'abc',
        ]);
```
``` php
    public function store(CreateUserRequest $request)
    {
        $request->name; // 'abc'
    }
```

> In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

Mainly, IDE support and better development experience.

