### PR TITLE
[9.x] Clear cast cache when setting attributes using arrow

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1061,6 +1061,10 @@ trait HasAttributes
             ? $this->castAttributeAsEncryptedString($key, $value)
             : $value;
 
+        if ($this->isClassCastable($key)) {
+            unset($this->classCastCache[$key]);
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
Hi,

It's sometime convenient to use the arrow notation to set the value of a class casted attribute.

Here is an example in a Nova resource:
```php
Boolean::make('New order notification', 'settings->newOrderNotification')
```
This PR fixes a bug that prevented the model to detect the change because of the cache.

The commit can be cherry-picked in the 8.x branch.

Thanks