### PR TITLE
[9.x] Add contains rule for validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1951,6 +1951,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the attribute contains a given substring.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateContains($attribute, $value, $parameters)
+    {
+        return Str::contains($value, $parameters);
+    }
+
+    /**
      * Validate the attribute does not start with a given substring.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2158,6 +2158,21 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('The url must start with one of the following values http, https', $v->messages()->first('url'));
     }
 
+    public function testValidateContains()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['key' => 'Foo Bar'], ['key' => 'contains:Foo']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['key' => 'Foo Bar'], ['key' => 'contains:Biz']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['key' => 'Foo Bar Biz'], ['key' => 'contains:Foo,Biz']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateDoesntStartWith()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
With these new changes, we will be able to use the `contains` rule for validations.
For example:
```PHP
return [
    'foo' => 'required|contains:Foo,Bar'
];
```
If the value of `foo` contains `Foo` or `Bar` it will be passed.