### PR TITLE
Create resource file for a model when use make:model command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -84,6 +84,10 @@ class ModelMakeCommand extends GeneratorCommand
         if ($this->option('policy')) {
             $this->createPolicy();
         }
+
+        if ($this->option('resource')) {
+            $this->createResource();
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -246,10 +246,10 @@ class ModelMakeCommand extends GeneratorCommand
             ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller,create a new resource for the model'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
-            ['collection', null ,InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']
+            ['collection', null, InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']
 
         ];
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -249,7 +249,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
-            ['collection', null, InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']
+            ['collection', null, InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option'],
 
         ];
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -246,7 +246,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller,create a new resource for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
             ['collection', null ,InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -169,6 +169,21 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Create a resource file for the model.
+     *
+     * @return void
+     */
+    protected function createResource()
+    {
+        $resource = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:resource', [
+            'name'         => "{$resource}Resource",
+            '--collection' => $this->option('collection'),
+        ]);
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -230,6 +230,8 @@ class ModelMakeCommand extends GeneratorCommand
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
+            ['collection', null ,InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']
+
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -246,7 +246,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
             ['collection', null ,InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']


### PR DESCRIPTION
**What**
-----------------------

This PR is for creating `resource` file with `make:model` command when using `-a` or `--resource/-R` options also support creating resource collection by adding `--collection` to the command. for example:

```
php artisan make:model post -a
php artisan make:model post -R
```

The above command will create all old files + resource file with the name `PostResource`.

if you'd like to create a collection resource file you can add `--collection` option. for example

```
php artisan make:model post -a --collection /
php artisan make:model post -R --collection
```

**Why**
---------------------------
I always wondered why `resource` file didn't create with other files when using  `make:model` with `-a` or `--resource/-R` option, is that for a specific reason? maybe there's a reason I don't know it, also I think it'll save time because when we use `-a` option with `make:model` command we use it to create all other files to save time so I think it'll be good if create resource file to avoid writing another command to create it, and when use `--resource/-R` it'll be good to create a resource file also.

I tried to search why it doesn't create a `resource` file but I didn't find an answer, I found a question on Stackoverflow that asked the same question from 2 years ago for Larave 6,  you can check it from [here](https://stackoverflow.com/questions/57944093/why-make-model-a-command-doesnt-create-resource-file).

