### PR TITLE
[9.x] Adds `silent` function to silence a callable thrown exception

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -257,6 +257,24 @@ if (! function_exists('retry')) {
     }
 }
 
+if (! function_exists('silent')) {
+    /**
+     * Returns a callback result, or false if it throws an exception.
+     *
+     * @param  callable  $callback
+     * @param  mixed  ...$arguments
+     * @return mixed|false
+     */
+    function silent(callable $callback, ...$arguments)
+    {
+        try {
+            return $callback(...$arguments);
+        } catch (Exception) {
+            return false;
+        }
+    }
+}
+
 if (! function_exists('str')) {
     /**
      * Get a new stringable object from the given string.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -269,7 +269,9 @@ if (! function_exists('silent')) {
     {
         try {
             return $callback(...$arguments);
-        } catch (Exception) {
+        } catch (Exception $e) {
+            report($e);
+
             return false;
         }
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -662,6 +662,18 @@ class SupportHelpersTest extends TestCase
         $this->assertEqualsWithDelta(0.05 + 0.1 + 0.2, microtime(true) - $startTime, 0.02);
     }
 
+    public function testSilent()
+    {
+        $callback = function ($foo, $fail) {
+            $this->assertSame('foo', $foo);
+
+            return $fail ? throw new LogicException() : $foo . 'bar';
+        };
+
+        $this->assertSame('foobar', silent($callback, 'foo', 0));
+        $this->assertFalse(silent($callback, 'foo', 1));
+    }
+
     public function testTransform()
     {
         $this->assertEquals(10, transform(5, function ($value) {

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -5,6 +5,8 @@ namespace Illuminate\Tests\Support;
 use ArrayAccess;
 use ArrayIterator;
 use Error;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
@@ -22,6 +24,7 @@ class SupportHelpersTest extends TestCase
 {
     protected function tearDown(): void
     {
+        Container::setInstance();
         m::close();
     }
 
@@ -665,6 +668,12 @@ class SupportHelpersTest extends TestCase
 
     public function testSilent()
     {
+        $m = m::mock(ExceptionHandler::class);
+        $m->expects('report')->with(m::type(LogicException::class));
+
+        $container = Container::setInstance(new Container());
+        $container->instance(ExceptionHandler::class, $m);
+
         $callback = function ($foo, $fail) {
             $this->assertSame('foo', $foo);
 
@@ -672,6 +681,7 @@ class SupportHelpersTest extends TestCase
         };
 
         $this->assertSame('foobar', silent($callback, 'foo', 0));
+
         $this->assertFalse(silent($callback, 'foo', 1));
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use ArrayAccess;
 use ArrayIterator;
+use Error;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
@@ -672,6 +673,15 @@ class SupportHelpersTest extends TestCase
 
         $this->assertSame('foobar', silent($callback, 'foo', 0));
         $this->assertFalse(silent($callback, 'foo', 1));
+    }
+
+    public function testSilentThrowsError()
+    {
+        $this->expectException(Error::class);
+
+        silent(function () {
+            throw new Error();
+        });
     }
 
     public function testTransform()


### PR DESCRIPTION
## What?

The `silent` function method will catch any `Exception` instance and return `false` instead of the callback result, while reporting the exception to the application. This removes the necessity of going for a try-catch-all block and reporting manually.

```php
$result = silent(Something::mayBreak(...));

if (! $result) {
   return 'Something broke!');
}
```

This can be very useful when using with `retry()`. A _silent retry_:

```php
$result = silent(retry(...), Something::mayBreak(...));
```

Of course, it won't silence `Errors` like invalid arguments or return types.