### PR TITLE
[9.x] Create resource file when writes make:model with `-a` and `--api` options

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -84,6 +84,10 @@ class ModelMakeCommand extends GeneratorCommand
         if ($this->option('policy')) {
             $this->createPolicy();
         }
+
+        if ($this->option('resource')) {
+            $this->createResource();
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -246,10 +246,10 @@ class ModelMakeCommand extends GeneratorCommand
             ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller,create a new resource for the model'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
-            ['collection', null ,InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']
+            ['collection', null, InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']
 
         ];
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -246,7 +246,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
             ['collection', null, InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option'],

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -237,7 +237,7 @@ class ModelMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['all', 'a', InputOption::VALUE_NONE, 'Generate a migration, seeder, factory, policy, and resource controller for the model, generate a resource file with --api option'],
+            ['all', 'a', InputOption::VALUE_NONE, 'Generate a migration, seeder, factory, policy, and resource controller for the model'],
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model'],
             ['factory', 'f', InputOption::VALUE_NONE, 'Create a new factory for the model'],
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -85,7 +85,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->createPolicy();
         }
 
-        if ($this->option('all') && $this->option("api")) {
+        if ($this->option('all') && $this->option('api')) {
             $this->createResource();
         }
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -237,7 +237,7 @@ class ModelMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['all', 'a', InputOption::VALUE_NONE, 'Generate a migration, seeder, factory, policy, and resource controller for the model'],
+            ['all', 'a', InputOption::VALUE_NONE, 'Generate a migration, seeder, factory, policy, and resource controller for the model, generate a resource file with --api option'],
             ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model'],
             ['factory', 'f', InputOption::VALUE_NONE, 'Create a new factory for the model'],
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
@@ -247,7 +247,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
-            ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
+            ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller, generate a resource file with -a/--all option'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
             ['collection', null, InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option'],
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -249,7 +249,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
-            ['collection', null, InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']
+            ['collection', null, InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option'],
 
         ];
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -246,7 +246,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller,create a new resource for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
             ['collection', null ,InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -169,6 +169,21 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Create a resource file for the model.
+     *
+     * @return void
+     */
+    protected function createResource()
+    {
+        $resource = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:resource', [
+            'name'         => "{$resource}Resource",
+            '--collection' => $this->option('collection'),
+        ]);
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -85,7 +85,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->createPolicy();
         }
 
-        if ($this->option('resource')) {
+        if ($this->option('all') && $this->option("api")) {
             $this->createResource();
         }
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -230,6 +230,8 @@ class ModelMakeCommand extends GeneratorCommand
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
+            ['collection', null ,InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']
+
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -246,7 +246,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
-            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller, create a new resource for the model'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
             ['collection', null ,InputOption::VALUE_NONE, 'Create a resource collection, must be with resource option']


### PR DESCRIPTION
**What**
-----------------------

This PR is for creating `resource` file with `make:model` command when using `-a/--all` with `--api` options also supports creating resource collection by adding `--collection` to the command. for example:

```
php artisan make:model post -a --api
```

The above command will create all old files + resource file with the name `PostResource`.

if you'd like to create a collection resource file you can add `--collection` option. for example

```
php artisan make:model post -a --api --collection
```

**Why**
---------------------------
I made my first pull request here about this https://github.com/laravel/framework/pull/42862, after seeing @taylorotwell response he show me some unclear points to me so that's why I create this pull request, let me explain what's the changes that I made 

I think we can create a resource file when the user adds `-a/--all` option with `--api` option because like @taylorotwell said 

> many Laravel applications don't have external APIs, which are what resources are for.

So the whole command will be like this: `php artisan make:model post -a --api`

currently when the user writes `-a` with `--api` it creates a different controller with all API functions, if the user writes `-a` without `--api` option it'll create a controller with all resource functions so I think it'll be more useful when creating a resource file when a user writes `--api` option with `-a` option.

