### PR TITLE
[9.x] Standardise invokable rule translation functionality

### DIFF
--- a/src/Illuminate/Translation/PotentiallyTranslatedString.php
+++ b/src/Illuminate/Translation/PotentiallyTranslatedString.php
@@ -44,15 +44,19 @@ class PotentiallyTranslatedString implements Stringable
     /**
      * Translate the string.
      *
+     * @param  array  $replacements
+     * @param  ?string  $locale
      * @return $this
      */
-    public function translate()
+    public function translate($replacements = [], $locale = null)
     {
-        if (! $this->translator->has($this->string)) {
-            throw new RuntimeException("Unable to find translation [{$this->string}] for locale [{$this->translator->getLocale()}].");
+        $locale ??= $this->translator->getLocale();
+
+        if (! $this->translator->has($this->string, $locale)) {
+            throw new RuntimeException("Unable to find translation [{$this->string}] for locale [{$locale}].");
         }
 
-        $this->translation = $this->translator->get($this->string);
+        $this->translation = $this->translator->get($this->string, $replacements, $locale);
 
         return $this;
     }

--- a/src/Illuminate/Translation/PotentiallyTranslatedString.php
+++ b/src/Illuminate/Translation/PotentiallyTranslatedString.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Translation;
 
-use RuntimeException;
 use Stringable;
 
 class PotentiallyTranslatedString implements Stringable
@@ -44,19 +43,28 @@ class PotentiallyTranslatedString implements Stringable
     /**
      * Translate the string.
      *
-     * @param  array  $replacements
-     * @param  ?string  $locale
+     * @param  array  $replace
+     * @param  string|null  $locale
      * @return $this
      */
-    public function translate($replacements = [], $locale = null)
+    public function translate($replace = [], $locale = null)
     {
-        $locale ??= $this->translator->getLocale();
+        $this->translation = $this->translator->get($this->string, $replace, $locale);
 
-        if (! $this->translator->has($this->string, $locale)) {
-            throw new RuntimeException("Unable to find translation [{$this->string}] for locale [{$locale}].");
-        }
+        return $this;
+    }
 
-        $this->translation = $this->translator->get($this->string, $replacements, $locale);
+    /**
+     * Translates the string based on a count.
+     *
+     * @param  \Countable|int|array  $number
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @return $this
+     */
+    public function translateChoice($number, array $replace = [], $locale = null)
+    {
+        $this->translation = $this->translator->choice($this->string, $number, $replace, $locale);
 
         return $this;
     }


### PR DESCRIPTION
This PR aligns the translation capabilities of invokable validation rules with the rest of the translation system. The initial PR had some opinions baked in that on reflection I don't believe should have been present and should instead be left to the developer to handle.

This PR:
- removes the strict nature of the invokable / callable translation. On reflection the initial PR introduced a quirk to the translation stuff that made it act differently to the rest of the system. Although I personally liked the strict nature of throwing when the key doesn't exist - it is a departure from what already exists and I think consistency is best. If this functionality is wanted, it should be implemented at the translator level.
- Adds the ability to specify replacements for messages. The standard `:attribute`, `:index`, and `:position` replacements are already in place, so this just adds custom replacement key capabilities:

```php
// validation.php

return [
    'is' => 'The :attribute is not :value.',
];

// Rule class...

class IsRule implements InvokableRule
{
    public function __construct(private mixed $value)
    {
        //
    }

    public function __invoke($attribute, $value, $fail)
    {
        if ($this->value !== $value) {
            $fail('validation.translated-error')->translate([
                'value' => $this->value,
            ]);
        }
    }
}

// Form request rules...

return [
    'email' => new IsRule('tim@example.com'),
];

// error...

"The email is not tim@example.com."
```

- enables developers to specify on-the-fly locales for error messages...

```php
$fail('validation.translated-error')->translate([
    'value' => $this->value,
], 'fr'); // Specifying french translation.
```

- and also enables translation with choices for pluralisation support.

With these features in place, this should cover all the require translation support for the new invokable / closure based rule stuff.