### PR TITLE
[9.x] Add new after registration callback for route groups

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -16,6 +16,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\Route patch(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route options(string $uri, \Closure|array|string|null $action = null)
  * @method \Illuminate\Routing\Route any(string $uri, \Closure|array|string|null $action = null)
+ * @method \Illuminate\Routing\RouteRegistrar afterRegisterCallback(\Closure $action)
  * @method \Illuminate\Routing\RouteRegistrar as(string $value)
  * @method \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method \Illuminate\Routing\RouteRegistrar domain(string $value)
@@ -58,6 +59,7 @@ class RouteRegistrar
      * @var string[]
      */
     protected $allowedAttributes = [
+        'afterRegisterCallback',
         'as',
         'controller',
         'domain',

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -489,6 +489,7 @@ class Router implements BindingRegistrar, RegistrarContract
         }
 
         $this->addWhereClausesToRoute($route);
+        $this->invokeAfterRegisterCallbackForRoute($route);
 
         return $route;
     }
@@ -614,6 +615,19 @@ class Router implements BindingRegistrar, RegistrarContract
         ));
 
         return $route;
+    }
+
+    /**
+     * Invoke the after registration callback of the route, if configured.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return void
+     */
+    protected function invokeAfterRegisterCallbackForRoute($route)
+    {
+        if (isset($route->action['afterRegisterCallback'])) {
+            $route->action['afterRegisterCallback']($route);
+        }
     }
 
     /**


### PR DESCRIPTION
Route groups are a nice and convenient way to apply settings to multiple routes at once. Currently, this only works for the more important features like `controller`, `namespace` and `prefix`. There are some route options which cannot be defined on a group level, such as `block()` (to prevent concurrent access to a route based on the user session).

This PR therefore suggests a new route group option called `afterRegisterCallback` (I'm not married to the name), which is being invoked for each route in the group individually, as last step in the route creation process. It allows for final touches of a route:

```php
// As method on the facade (through route registrar).
Route::afterRegisterCallback(fn (Route $route) => $route->block())
    ->group(function () {
        Route::get('foo', fn () => response()->make('bar'));
        Route::get('biz', fn () => response()->make('baz'));
    });

// As attribute for a route group.
Route::group(['afterRegisterCallback' => fn (Route $route) => $route->block()], function () {
    Route::get('foo', fn () => response()->make('bar'));
    Route::get('biz', fn () => response()->make('baz'));
});
```

---

Why introduce an `afterRegisterCallback` instead of a way to define `block()` on a group of routes directly?
My reasoning is that:
1. The `afterRegisterCallback` is more versatile and can be used for other options and route manipulations (on a group level) as well.
2. It would be not very clear, whether a `block()` set for a group of routes applies to the group as a whole or each group individually.

---

There also exists an alternative solution to change routes after their registration (e.g. at the bottom of `routes/web.php`), but filtering by group is quite difficult and only possible through the URI, name or similar:
```php
foreach (Route::getRoutes() as $route) {
    if (str_starts_with($route->uri(), 'foo') || str_starts_with($route->uri(), 'biz')) {
        $route->block();
    }
}
```