### PR TITLE
[9.x] Fix 0 division working with variable length pages

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -46,7 +46,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         }
 
         $this->total = $total;
-        $this->perPage = $perPage;
+        $this->perPage = (int) $perPage;
         $perPage = $perPage > 0 ? $perPage : 1;
         $this->lastPage = max((int) ceil($this->total / $perPage), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -46,8 +46,9 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         }
 
         $this->total = $total;
-        $this->perPage = $perPage > 0 ? (int) $perPage : 1;
-        $this->lastPage = max((int) ceil($this->total / $this->perPage), 1);
+        $this->perPage = $perPage;
+        $perPage = $perPage > 0 ? $perPage : 1;
+        $this->lastPage = max((int) ceil($this->total / $perPage), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : Collection::make($items);

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -46,8 +46,8 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         }
 
         $this->total = $total;
-        $this->perPage = (int) $perPage;
-        $this->lastPage = max((int) ceil($total / $perPage), 1);
+        $this->perPage = $perPage > 0 ? (int) $perPage : 1;
+        $this->lastPage = max((int) ceil($this->total / $this->perPage), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
         $this->items = $items instanceof Collection ? $items : Collection::make($items);

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -129,6 +129,6 @@ class LengthAwarePaginatorTest extends TestCase
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 0, 2, $this->options);
 
-        $this->assertSame(0, $p->toArray()['per_Page']);
+        $this->assertSame(0, $p->perPage());
     }
 }

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -124,4 +124,11 @@ class LengthAwarePaginatorTest extends TestCase
     {
         $this->assertSame($this->options, $this->p->getOptions());
     }
+
+    public function testLengthAwarePaginatorShouldAllowForZeroPerPage()
+    {
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 0, 2, $this->options);
+
+        $this->assertSame(0, $p->toArray()['per_Page']);
+    }
 }


### PR DESCRIPTION
Divide by zero fix for length aware paginator. Fixes a few issues with argument based pagination.