### PR TITLE
[9.x] Don't ignore nested chained jobs while dispatching next job in chain

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -249,7 +249,7 @@ trait Queueable
     {
         if (! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
-                $next->chained = $this->chained;
+                $next->chained = array_merge($next->chained, $this->chained);
 
                 $next->onConnection($next->connection ?: $this->chainConnection);
                 $next->onQueue($next->queue ?: $this->chainQueue);

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -249,7 +249,7 @@ trait Queueable
     {
         if (! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
-                $next->chained = array_merge($next->chained, $this->chained);
+                array_push($next->chained, ...$this->chained);
 
                 $next->onConnection($next->connection ?: $this->chainConnection);
                 $next->onQueue($next->queue ?: $this->chainQueue);


### PR DESCRIPTION
It sounds kinda crazy, but...
`Queueable::dispatchNextJobInChain` replaces chained job `chained` property with the rest of current job's chained jobs.

But chained job also may have it's chained jobs... 

## Code example:

```php
$firstLevelJob = (new JobLevelFirst(1))->chain([
    (new JobLevelSecond(1))->chain([
        new JobLevelThird(1),
        new JobLevelThird(2),
        new JobLevelThird(3),
    ]),
    (new JobLevelSecond(2))->chain([
        new JobLevelThird(3),
        new JobLevelThird(4),
        new JobLevelThird(5),
    ]),
]);

$dispatcher->dispatch($firstLevelJob);
```

## Expected result: 
All the jobs were dispatched.
## Actual result: 
Only JobLevelFirst and JobLevelSecond jobs were dispatched.

## What is happening there?

There are three commits:
* First contains only test. 
* The second one fixes the test.
* The third one changes `array_merge` with `array_push` because it's faster
