### PR TITLE
[9.x] contains stringable doesn't contain the ignoreCase parameter

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -167,22 +167,24 @@ class Stringable implements JsonSerializable
      * Determine if a given string contains a given substring.
      *
      * @param  string|string[]  $needles
+     * @param  bool  $ignoreCase
      * @return bool
      */
-    public function contains($needles)
+    public function contains($needles, $ignoreCase = false)
     {
-        return Str::contains($this->value, $needles);
+        return Str::contains($this->value, $needles, $ignoreCase);
     }
 
     /**
      * Determine if a given string contains all array values.
      *
      * @param  array  $needles
+     * @param  bool  $ignoreCase
      * @return bool
      */
-    public function containsAll(array $needles)
+    public function containsAll(array $needles, $ignoreCase = false)
     {
-        return Str::containsAll($this->value, $needles);
+        return Str::containsAll($this->value, $needles, $ignoreCase );
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -184,7 +184,7 @@ class Stringable implements JsonSerializable
      */
     public function containsAll(array $needles, $ignoreCase = false)
     {
-        return Str::containsAll($this->value, $needles, $ignoreCase );
+        return Str::containsAll($this->value, $needles, $ignoreCase);
     }
 
     /**


### PR DESCRIPTION
Looks like the `Stringable` class doesn't contain the `$ignoreCase` parameter.

```
use Illuminate\Support\Str;
 
$contains = Str::of('This is My name')->contains(['my', 'foo'], true);
 
// true
```