### PR TITLE
[9.x]  Fix bug in setKeyForSaveQuery

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1139,10 +1139,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
+     *
+     * @throws \LogicException
      */
     protected function setKeysForSaveQuery($query)
     {
-        $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());
+        if (is_null($keyValue = $this->getKeyForSaveQuery())) {
+            throw new LogicException(sprintf(
+                'Select %s column because needed to execute this query',
+                $this->getKeyName()
+            ));
+        }
+
+        $query->where($this->getKeyName(), '=', $keyValue);
 
         return $query;
     }


### PR DESCRIPTION
This PR solves bug in [setKeysForSaveQuery()](https://github.com/laravel/framework/blob/93a1296bca43c1ca8dcb5df8f97107e819a71499/src/Illuminate/Database/Eloquent/Model.php#L1143), If we do not select primarykey so run `save()` or `update()` or `delete()`, Eloquent returns true in fact  Eloquent could not do it beacuse it does not have primary key to execute these query.


To solve it we have two solutions: we can throw an exception or returns false i think throw exception is good because we should inform the developers that query has problem

```
$user = User::select('name')->first();

$user->name = 'Mehdi';
$user->save(); // output is True but in fact is False 
```

```
$user = User::select('name')->first();
$user->delete()// output is True but in fact is False 
```
```
$user = User::select('name')->first();
$user->update(['name' => 'Mehdi']); // output is True but in fact is False 
```


**does not check value of primarkey in below:**
```    
protected function setKeysForSaveQuery($query)
{
     $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());

     return $query;
}
```

