### PR TITLE
[9.x] Allow instance of Enum pass Enum Rule  

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -38,7 +38,7 @@ class Enum implements Rule
             return false;
         }
 
-        if($value instanceof $this->type) {
+        if ($value instanceof $this->type) {
             return true;
         }
 

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -38,6 +38,10 @@ class Enum implements Rule
             return false;
         }
 
+        if($value instanceof $this->type) {
+            return true;
+        }
+
         try {
             return ! is_null($this->type::tryFrom($value));
         } catch (TypeError $e) {

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -38,6 +38,21 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertFalse($v->fails());
     }
 
+    public function testvalidationPassesWhenPassingInstanceOfEnum()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => StringStatus::done,
+            ],
+            [
+                'status' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
     public function testValidationFailsWhenProvidingNoExistingCases()
     {
         $v = new Validator(


### PR DESCRIPTION
Given this scenario, the validation for country currently fail as it expect the `value` of `CountryEnum`.
Laravel will automatically cast the enum instance when saving the model, therefore, it should be safe to validate by it's instance.

```php
$action = new CreateNewUser();

$action->create([
    'country' => CountryEnum::CH,
    'email'   => 'john.doe@example.org',
]);
```

```php
public function create(array $input)
{
    Validator::make($input, [
        'country' => ['required',  Enum(CountryEnum::class)],
        'email'   => [...],
    ])->validate();
}
```


