### PR TITLE
[9.x] Add "orWhere" to Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -62,6 +62,13 @@ trait EnumeratesValues
     protected $escapeWhenCastingToString = false;
 
     /**
+     * The items contained in the collection before applied where clause.
+     *
+     * @var array<TKey, TValue>
+     */
+    protected $itemsBeforeWhere = [];
+
+    /**
      * The methods that can be proxied.
      *
      * @var array<int, string>
@@ -572,7 +579,15 @@ trait EnumeratesValues
      */
     public function where($key, $operator = null, $value = null)
     {
-        return $this->filter($this->operatorForWhere(...func_get_args()));
+        $collection = $this->filter($this->operatorForWhere(...func_get_args()));
+        $collection->itemsBeforeWhere = $this->all();
+
+        return $collection;
+    }
+
+    public function orWhere($key, $operator = null, $value = null)
+    {
+        return $this->merge((new static($this->itemsBeforeWhere))->filter($this->operatorForWhere(...func_get_args())));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -928,6 +928,34 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testOrWhere($collection)
+    {
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => 4]]);
+
+        $results = $c->where('v', '<', 2)->orWhere('v', '>', 3)
+            ->values()->all();
+
+        $this->assertEquals([['v' => 1], ['v' => 4]], $results);
+
+        // it has no effect without a where clause.
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => 4]]);
+        $results = $c->orWhere('v', '>', 2)->values()->all();
+        $this->assertEquals([['v' => 1], ['v' => 2], ['v' => 3], ['v' => 4]], $results);
+
+        // it only pairs with the immediate previous where.
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => 4]]);
+        $results = $c
+            ->where('v', '>', 2)
+            ->where('v', '===', 3)
+            ->orWhere('v', '===', 1)
+            ->values()->all();
+
+        $this->assertEquals([['v' => 3]], $results);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhere($collection)
     {
         $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);


### PR DESCRIPTION
This PR adds the missing `orWhere` method to collection and LazyCollection.
The `orWhere` method is designed to only be called immediately after a `where` method call to add to it.

```php
  $results = $c->where('v', '<', 2)->orWhere('v', '>', 5) ->values()->all();
```
- Tests are included.