### PR TITLE
[9.x] Add "orWhere" to collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -32,6 +32,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     protected $items = [];
 
     /**
+     * The items contained in the collection before applied where clause.
+     *
+     * @var array<TKey, TValue>
+     */
+    protected $itemsBeforeWhere = [];
+
+    /**
      * Create a new collection.
      *
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $items
@@ -1645,6 +1652,35 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $this->items[] = $item;
 
         return $this;
+    }
+
+    /**
+     * Filter items by the given key value pair.
+     *
+     * @param  callable|string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return static
+     */
+    public function where($key, $operator = null, $value = null)
+    {
+        $collection = $this->filter($this->operatorForWhere(...func_get_args()));
+        $collection->itemsBeforeWhere = $this->all();
+
+        return $collection;
+    }
+
+    /**
+     * Filter items by the given key value pair.
+     *
+     * @param  callable|string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return static
+     */
+    public function orWhere($key, $operator = null, $value = null)
+    {
+        return $this->merge((new static($this->itemsBeforeWhere))->filter($this->operatorForWhere(...func_get_args())));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -925,6 +925,33 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(1, $c->filter->active());
     }
 
+    public function testOrWhere()
+    {
+        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => 4]]);
+
+        $results = $c
+            ->where('v', '<', 2)
+            ->orWhere('v', '>', 3)
+            ->values()->all();
+
+        $this->assertEquals([['v' => 1], ['v' => 4]], $results);
+
+        // It has no effect without a where clause.
+        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => 4]]);
+        $results = $c->orWhere('v', '>', 2)->values()->all();
+        $this->assertEquals([['v' => 1], ['v' => 2], ['v' => 3], ['v' => 4]], $results);
+
+        // It only pairs with the immediate previous where.
+        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => 4]]);
+        $results = $c
+            ->where('v', '>', 2)
+            ->where('v', '===', 3)
+            ->orWhere('v', '===', 1)
+            ->values()->all();
+
+        $this->assertEquals([['v' => 3]], $results);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This PR adds the missing `orWhere` method to collection and LazyCollection.
The `orWhere` method is designed to only be called immediately after a `where` method call to add to it.

```php
  $results = $c->where('v', '<', 2)->orWhere('v', '>', 5) ->values()->all();
```
- Tests are included.
- This is not included in the `LazyCollection` since it requires a more elaborate solution. Simply I was not able to workout a solution for the LazyCollections. Maybe @JosephSilber can.