### PR TITLE
[9.x] Add new $eloquentBuilder model property to override Eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -35,6 +35,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         ForwardsCalls;
 
     /**
+     * The Eloquent builder to use for the model.
+     *
+     * @var string|null
+     */
+    protected $eloquentBuilder;
+
+    /**
      * The connection name for the model.
      *
      * @var string|null
@@ -1444,7 +1451,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newEloquentBuilder($query)
     {
-        return new Builder($query);
+        $builder = $this->eloquentBuilder ?: Builder::class;
+
+        return new $builder($query);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2396,6 +2396,19 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertNull($user->name);
     }
+
+    public function testSetCustomEloquentBuilder()
+    {
+        $model = new EloquentModelStub;
+        $this->addMockConnection($model);
+
+        $this->assertInstanceOf(Builder::class, $model->newModelQuery());
+
+        $model = new EloquentModelWithCustomEloquentBuilder();
+        $this->addMockConnection($model);
+
+        $this->assertInstanceOf(CustomBuilder::class, $model->newModelQuery());
+    }
 }
 
 class EloquentTestObserverStub
@@ -2869,4 +2882,14 @@ class Uppercase implements CastsInboundAttributes
     {
         return is_string($value) ? strtoupper($value) : $value;
     }
+}
+
+class EloquentModelWithCustomEloquentBuilder extends Model
+{
+    protected $eloquentBuilder = CustomBuilder::class;
+}
+
+class CustomBuilder extends Builder
+{
+    //
 }


### PR DESCRIPTION
This PR adds a new `$eloquentBuilder` property to the `Illuminate\Database\Eloquent\Model` class to easily override the Eloquent query Builder.
_For more context about these custom eloquent builders, Tim MacDonald wrote a [great article](https://timacdonald.me/dedicated-eloquent-model-query-builders/) about it._

**Why?**
In order to use a custom Eloquent Builder, you'll have to override the `newEloquentBuilder()` method from the abstract `Model` class.
In this method you'll need to add the `Builder $query` argument and then return your custom Builder class:
```php
use Illuminate\Database\Eloquent\Model;
use App\Builders\UserBuilder;

class User extends Model
{
    public function newEloquentBuilder($query)
    {
        return new UserBuilder($query);
    }
}
```

Since you only have to return your custom Builder class and nothing more, this can be simplified in my opinion.

I thought it would be nice if you can override this `newEloquentBuilder()` method by just setting a `$eloquentBuilder` property which accepts a custom Builder class:

```php
use Illuminate\Database\Eloquent\Model;
use App\Builders\UserBuilder;

class User extends Model
{
    protected $eloquentBuilder = UserBuilder::class;
}
```

```php
use Illuminate\Database\Eloquent\Builder;

class UserBuilder extends Builder
{
    //
}
```

To avoid conflicts or confusion about what the property does, i've called it `$eloquentBuilder` and not something like `$builder`, but suggestions are welcome.