### PR TITLE
[9.x] Allow for Notifications to send Mailable class without `to()`

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -58,6 +58,10 @@ class MailChannel
         }
 
         if ($message instanceof Mailable) {
+            if (! $message->to) {
+                $message->to($notifiable);
+            }
+
             return $message->send($this->mailer);
         }
 

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -238,7 +238,7 @@ class SendingMailNotificationsTest extends TestCase
 
     public function testMailIsSentUsingMailableWithoutTo()
     {
-        $notification = new TestMailNotificationWithMailableThatHasNoTo;
+        $notification = new TestMailNotificationWithMailableThatHasNoRecipient;
 
         $user = NotifiableUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -428,12 +428,12 @@ class TestMailNotificationWithMailable extends Notification
     }
 }
 
-class TestMailNotificationWithMailableThatHasNoTo extends TestMailNotificationWithMailable
+class TestMailNotificationWithMailableThatHasNoRecipient extends TestMailNotificationWithMailable
 {
     public function toMail($notifiable)
     {
         $mailable = m::mock(Mailable::class);
-        $mailable->to = null;
+        $mailable->to = [];
 
         $mailable->shouldReceive('to')
             ->andReturn(m::self())

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -236,6 +236,17 @@ class SendingMailNotificationsTest extends TestCase
         $user->notify($notification);
     }
 
+    public function testMailIsSentUsingMailableWithoutTo()
+    {
+        $notification = new TestMailNotificationWithMailableThatHasNoTo;
+
+        $user = NotifiableUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $user->notify($notification);
+    }
+
     public function testMailIsSentUsingMailMessageWithHtmlAndPlain()
     {
         $notification = new TestMailNotificationWithHtmlAndPlain;
@@ -409,7 +420,26 @@ class TestMailNotificationWithMailable extends Notification
     {
         $mailable = m::mock(Mailable::class);
 
+        $mailable->to = 'taylor@laravel.com';
+
         $mailable->shouldReceive('send')->once();
+
+        return $mailable;
+    }
+}
+
+class TestMailNotificationWithMailableThatHasNoTo extends TestMailNotificationWithMailable
+{
+    public function toMail($notifiable)
+    {
+        $mailable = m::mock(Mailable::class);
+        $mailable->to = null;
+
+        $mailable->shouldReceive('to')
+            ->andReturn(m::self())
+            ->once()
+            ->shouldReceive('send')
+            ->once();
 
         return $mailable;
     }


### PR DESCRIPTION
This pull request aims to fix a perceived inconsistency present in sending Mailable classes via Notifications that has stung me a few times in the past.

As mentioned in the documentation, sending a `MailMessage` can be accomplished like so:

```php
/**
 * Get the mail representation of the notification.
 *
 * @param  mixed  $notifiable
 * @return \Illuminate\Notifications\Messages\MailMessage
 */
public function toMail($notifiable)
{
    return (new MailMessage)
                ->greeting('Hello!')
                ->attachData($this->pdf, 'name.pdf', [
                    'mime' => 'application/pdf',
                ]);
}
```

and, as we're sending this `MailMessage` (which doesn't have a `to()` method) the framework knows enough to build this `MailMessage` and route it directly to the `$notifiable` receiving the Notification.

However, when sending a Mailable, we're expected to explicitly pass the credentials of the `$notifiable` instance to the Mailable's `to()` method, like so:

```php
use App\Mail\InvoicePaid as InvoicePaidMailable;
 
/**
 * Get the mail representation of the notification.
 *
 * @param  mixed  $notifiable
 * @return Mailable
 */
public function toMail($notifiable)
{
    return (new InvoicePaidMailable($this->invoice))
                ->to($notifiable->email);
}
```

By adding a simple check for the contents of the `to` property on the Mailable, we can call the `to()` method for the developer, assuming the `$notifiable`, as the `MailChannel` already does for a `MailMessage`. If it's already been called (as in the example), then that address will be used instead (so this wouldn't be a breaking change).

Apologies if my test changes aren't up to scratch. If changes are needed, please advise how I can make them better.