### PR TITLE
[10.x] Restrict `__()` helper to return `string|null`

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -880,7 +880,7 @@ if (! function_exists('__')) {
      * @param  string|null  $key
      * @param  array  $replace
      * @param  string|null  $locale
-     * @return string|array|null
+     * @return string|null
      */
     function __($key = null, $replace = [], $locale = null)
     {
@@ -888,7 +888,9 @@ if (! function_exists('__')) {
             return $key;
         }
 
-        return trans($key, $replace, $locale);
+        return transform(trans($key, $replace, $locale), function ($translation) use ($key) {
+            return is_string($translation) ? $translation : $key;
+        });
     }
 }
 

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Foundation;
 
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
@@ -132,6 +133,25 @@ class FoundationHelpersTest extends TestCase
         file_put_contents($path, $content);
 
         return $path;
+    }
+
+    public function testUnderscoreUnderscoreCanTranslate()
+    {
+        $this->assertSame('Auth', __('Auth'));
+        $this->assertSame('auth', __('auth'));
+        $this->assertSame('Pagination', __('Pagination'));
+        $this->assertSame('pagination', __('pagination'));
+        $this->assertSame('Passwords', __('Passwords'));
+        $this->assertSame('passwords', __('passwords'));
+        $this->assertSame('Validation', __('Validation'));
+        $this->assertSame('validation', __('validation'));
+
+        $this->assertSame('Laravel Framework', __('Laravel Framework'));
+
+        $this->assertSame('Laravel Framework '.Application::VERSION, __('Laravel Framework :version', ['version' => Application::VERSION]));
+
+        $this->assertSame('validation.size', __('validation.size'));
+        $this->assertSame('The Name field is required.', __('validation.required', ['attribute' => 'Name']));
     }
 }
 


### PR DESCRIPTION
Target branch: 10.x due to breaking change 
Related issues:
- https://github.com/laravel/nova-issues/issues/4467

-------

`__()` is commonly used to translate JSON or short key translation value,
however, since it replicates the functionality of `trans()` method it is
also possible to return the whole `array` if the given key matches
a translation file which causes the following limitation:

![image](https://user-images.githubusercontent.com/172966/175189667-bab8964a-6cd7-46e0-937b-69865d810b1c.png)


The changes would restrict those use-case and instead would return translated
`$key`. Developer who wishes to still return `array` should use
`trans()` method instead.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>