### PR TITLE
Escape values before checking for their presence in HTML part of Mailables

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -976,10 +976,13 @@ class Mailable implements MailableContract, Renderable
      * Assert that the given text is present in the HTML email body.
      *
      * @param  string  $string
+     * @param  bool  $escape
      * @return $this
      */
-    public function assertSeeInHtml($string)
+    public function assertSeeInHtml($string, $escape = true)
     {
+        $string = $escape ? e($string) : $string;
+
         [$html, $text] = $this->renderForAssertions();
 
         PHPUnit::assertTrue(
@@ -994,10 +997,13 @@ class Mailable implements MailableContract, Renderable
      * Assert that the given text is not present in the HTML email body.
      *
      * @param  string  $string
+     * @param  bool  $escape
      * @return $this
      */
-    public function assertDontSeeInHtml($string)
+    public function assertDontSeeInHtml($string, $escape = true)
     {
+        $string = $escape ? e($string) : $string;
+
         [$html, $text] = $this->renderForAssertions();
 
         PHPUnit::assertFalse(
@@ -1012,10 +1018,13 @@ class Mailable implements MailableContract, Renderable
      * Assert that the given text strings are present in order in the HTML email body.
      *
      * @param  array  $strings
+     * @param  bool  $escape
      * @return $this
      */
-    public function assertSeeInOrderInHtml($strings)
+    public function assertSeeInOrderInHtml($strings, $escape = true)
     {
+        $strings = $escape ? array_map('e', ($strings)) : $strings;
+
         [$html, $text] = $this->renderForAssertions();
 
         PHPUnit::assertThat($strings, new SeeInOrder($html));

--- a/tests/Mail/MailMailableAssertionsTest.php
+++ b/tests/Mail/MailMailableAssertionsTest.php
@@ -44,7 +44,9 @@ class MailMailableAssertionsTest extends TestCase
     {
         $mailable = new MailableAssertionsStub;
 
-        $mailable->assertSeeInHtml('<li>First Item</li>');
+        $mailable->assertSeeInHtml('Fourth & Fifth Item');
+
+        $mailable->assertSeeInHtml('<li>First Item</li>', false);
     }
 
     public function testMailableAssertSeeInHtmlFailsWhenAbsent()
@@ -63,13 +65,22 @@ class MailMailableAssertionsTest extends TestCase
         $mailable->assertDontSeeInHtml('<li>Fourth Item</li>');
     }
 
-    public function testMailableAssertDontSeeInHtmlFailsWhenPresent()
+    public function testMailableAssertDontSeeInHtmlEscapedFailsWhenPresent()
     {
         $mailable = new MailableAssertionsStub;
 
         $this->expectException(AssertionFailedError::class);
 
-        $mailable->assertDontSeeInHtml('<li>First Item</li>');
+        $mailable->assertDontSeeInHtml('Fourth & Fifth Item');
+    }
+
+    public function testMailableAssertDontSeeInHtmlUnescapedFailsWhenPresent()
+    {
+        $mailable = new MailableAssertionsStub;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $mailable->assertDontSeeInHtml('<li>First Item</li>', false);
     }
 
     public function testMailableAssertSeeInOrderTextPassesWhenPresentInOrder()
@@ -101,10 +112,16 @@ class MailMailableAssertionsTest extends TestCase
         $mailable = new MailableAssertionsStub;
 
         $mailable->assertSeeInOrderInHtml([
+            'Third Item',
+            'Fourth & Fifth Item',
+            'Sixth Item',
+        ]);
+
+        $mailable->assertSeeInOrderInHtml([
             '<li>First Item</li>',
             '<li>Second Item</li>',
             '<li>Third Item</li>',
-        ]);
+        ], false);
     }
 
     public function testMailableAssertInOrderHtmlFailsWhenAbsentInOrder()
@@ -130,6 +147,8 @@ class MailableAssertionsStub extends Mailable
         - First Item
         - Second Item
         - Third Item
+        - Fourth & Fifth Item
+        - Sixth Item
         EOD;
 
         $html = <<<'EOD'
@@ -146,6 +165,8 @@ class MailableAssertionsStub extends Mailable
         <li>First Item</li>
         <li>Second Item</li>
         <li>Third Item</li>
+        <li>Fourth &amp; Fifth Item</li>
+        <li>Sixth Item</li>
         </ul>
         </body>
         </html>


### PR DESCRIPTION
Laravel offers the ability to assert presence of a value inside the HTML for both views and mailables. However, the implementation of these assertions differ in a way that may cause confusion and occasional failing tests:

`TestResponse::assertSee()` escapes the HTML by default,
`Mailable::assertSeeInHtml()` does not escape the HTML.

This means that, for the same HTML, `$response->assertSee("O'Connor");` will pass, while `$mail->assertSeeInHtml("O'Connor");` will fail.

The goal of this PR is to align the behaviour of Mailable assertion methods with the rest of the similar assertion methods.
