### PR TITLE
[8.x] Test and annotate that Arr::pull() works with int keys

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -510,7 +510,7 @@ class Arr
      * Get a value from the array, and remove it.
      *
      * @param  array  $array
-     * @param  string  $key
+     * @param  string|int  $key
      * @param  mixed  $default
      * @return mixed
      */

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -620,19 +620,25 @@ class SupportArrTest extends TestCase
         $array = ['name' => 'Desk', 'price' => 100];
         $name = Arr::pull($array, 'name');
         $this->assertSame('Desk', $name);
-        $this->assertEquals(['price' => 100], $array);
+        $this->assertSame(['price' => 100], $array);
 
         // Only works on first level keys
         $array = ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane'];
         $name = Arr::pull($array, 'joe@example.com');
         $this->assertSame('Joe', $name);
-        $this->assertEquals(['jane@localhost' => 'Jane'], $array);
+        $this->assertSame(['jane@localhost' => 'Jane'], $array);
 
         // Does not work for nested keys
         $array = ['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']];
         $name = Arr::pull($array, 'emails.joe@example.com');
         $this->assertNull($name);
-        $this->assertEquals(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
+        $this->assertSame(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
+
+        // Works with int keys
+        $array = ['First', 'Second'];
+        $first = Arr::pull($array, 0);
+        $this->assertSame('First', $first);
+        $this->assertSame([1 => 'Second'], $array);
     }
 
     public function testQuery()


### PR DESCRIPTION
This pull request corrects the type hint of the argument
`$key` in `Illuminate\Support\Arr::pull()` to allow
int keys. This avoids false-positives from IDEs and
static analysis tools.

In order to ensure it actually works as intended,
I added a test case.