### PR TITLE
[9.x]Facade mock should not be created from a final class

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 use Mockery;
 use Mockery\LegacyMockInterface;
+use ReflectionClass;
 use RuntimeException;
 
 abstract class Facade
@@ -164,7 +165,12 @@ abstract class Facade
     protected static function getMockableClass()
     {
         if ($root = static::getFacadeRoot()) {
-            return get_class($root);
+            $class = get_class($root);
+            $reflection = new ReflectionClass($class);
+
+            if (! $reflection->isFinal()) {
+                return $class;
+            }
         }
     }
 

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -80,6 +80,15 @@ class SupportFacadeTest extends TestCase
         $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::expects('foo')->with('bar')->andReturn('baz')->getMock());
         $this->assertSame('baz', $app['foo']->foo('bar'));
     }
+
+    public function testFinalClassFacade()
+    {
+        $app = new ApplicationStub;
+        $app->setAttributes([FinalClass::class => new FinalClass()]);
+        FinalClassFacade::setFacadeApplication($app);
+        FinalClassFacade::shouldReceive('foo')->once()->andReturn('bar');
+        $this->assertSame('bar', FinalClassFacade::foo());
+    }
 }
 
 class FacadeStub extends Facade
@@ -87,6 +96,18 @@ class FacadeStub extends Facade
     protected static function getFacadeAccessor()
     {
         return 'foo';
+    }
+}
+
+final class FinalClass
+{
+}
+
+class FinalClassFacade extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return FinalClass::class;
     }
 }
 


### PR DESCRIPTION
It will show the following error message if try to create a Facade mock with final class before this PR

> Mockery\Exception: The class \Illuminate\Tests\Support\FinalClass is marked final and its methods cannot be replaced. Classes marked final can be passed in to \Mockery::mock() as instantiated objects to create a partial mock, but only if the mock is not subject to type hinting checks.