### PR TITLE
[8.x] Fixed bug on forceCreate on a MorphMay relationship  not including morph type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -46,4 +46,15 @@ class MorphMany extends MorphOneOrMany
     {
         return $this->matchMany($models, $results, $relation);
     }
+
+    /**
+     * Create a new instance of the related model. Allow mass-assignment.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function forceCreate(array $attributes = []) {
+        $attributes[$this->getMorphType()] = $this->morphClass;
+        parent::forceCreate($attributes);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -53,7 +53,8 @@ class MorphMany extends MorphOneOrMany
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate(array $attributes = []) {
+    public function forceCreate(array $attributes = []) 
+    {
         $attributes[$this->getMorphType()] = $this->morphClass;
         parent::forceCreate($attributes);
     }

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -94,6 +94,15 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $this->assertSame('active', $product->current_state->state);
     }
 
+    public function testForceCreateMorphType()
+    {
+        $product = MorphOneOfManyTestProduct::create();
+        $product->states()->forceCreate([
+            'state' => 'active',
+        ]);
+        $this->assertSame(MorphOneOfManyTestProduct::class, $product->current_state->stateful_type);
+    }
+
     public function testExists()
     {
         $product = MorphOneOfManyTestProduct::create();


### PR DESCRIPTION
Fixes #42796

`forceCreate` was not including the morph type on the attributes sent to create the related model. The  forceCreate method has been overrided to include the morph type on the attributes before passing the call to its parent.

This should solve the #42796 issue.
