### PR TITLE
Add collect method to config

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -133,6 +133,17 @@ class Repository implements ArrayAccess, ConfigContract
     }
 
     /**
+     * Get the specified configuration value(s) as a collection.
+     *
+     * @param  array|string  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key)
+    {
+        return collect($this->get($key));
+    }
+
+    /**
      * Determine if the given configuration option exists.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -9,6 +9,7 @@ namespace Illuminate\Support\Facades;
  * @method static void prepend($key, $value)
  * @method static void push($key, $value)
  * @method static void set($key, $value = null)
+ * @method static Illuminate\Support\Collection collect($key)
  *
  * @see \Illuminate\Config\Repository
  */


### PR DESCRIPTION
I've added the collect method to the config repository. I see this being useful for quite a few users:

Users might have arrays within their configuration that they want to turn into a collection. What the user needs to do now to achieve this:

```php
collect(config('application.commands'));
```

The new approach will allow for the following:

```php
config()->collect('application.commands');
```

`\Illuminate\Http\Request` already has this method and is widely adopted. Therefore I reckon this might be useful for quite a lot of users.