### PR TITLE
fix undefined constant error on dynamic slot names as key of object

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -460,7 +460,7 @@ class ComponentTagCompiler
         $value = preg_replace_callback($pattern, function ($matches) {
             $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name']);
 
-            if (Str::contains($name, '-') && !empty($matches['inlineName'])) {
+            if (Str::contains($name, '-') && ! empty($matches['inlineName'])) {
                 $name = Str::camel($name);
             }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -460,7 +460,7 @@ class ComponentTagCompiler
         $value = preg_replace_callback($pattern, function ($matches) {
             $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name']);
 
-            if (Str::contains($name, '-')) {
+            if (Str::contains($name, '-') && !empty($matches['inlineName'])) {
                 $name = Str::camel($name);
             }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It's solution for #42932

I've described problem in the issue. 

With 9.15 and after we cannot use `<x-slot :name="$model->name">` because it is rendering as  
`<?php $__env->slot($model>name, null, []); ?>` 
instead 
`<?php $__env->slot($model->name, null, []); ?>`
