### PR TITLE
[9.x] Vite assets have deduplicated CSS <link>s

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -75,7 +75,7 @@ class Vite
 
         [$stylesheets, $scripts] = $tags->partition(fn ($tag) => str_starts_with($tag, '<link'));
 
-        return new HtmlString($stylesheets->join('').$scripts->join(''));
+        return new HtmlString($stylesheets->unique()->join('').$scripts->join(''));
     }
 
     /**

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -74,6 +74,19 @@ class FoundationViteTest extends TestCase
         );
     }
 
+    public function testViteWithDuplicateCssImport()
+    {
+        $this->makeViteManifest();
+
+        $result = (new Vite)(['resources/js/app-with-duplicate-css.js']);
+
+        $this->assertSame(
+            '<link rel="stylesheet" href="https://example.com/build/assets/common.versioned.css" />'
+            .'<script type="module" src="https://example.com/build/assets/app-with-duplicate-css.versioned.js"></script>',
+            $result->toHtml()
+        );
+    }
+
     public function testViteHotModuleReplacementWithJsOnly()
     {
         $this->makeViteHotFile();
@@ -125,12 +138,29 @@ class FoundationViteTest extends TestCase
                     '_someFile.js',
                 ],
             ],
+            'resources/js/app-with-duplicate-css.js' => [
+                'file' => 'assets/app-with-duplicate-css.versioned.js',
+                'imports' => [
+                    '_firstFile.js',
+                    '_secondFile.js',
+                ],
+            ],
             'resources/css/app.css' => [
                 'file' => 'assets/app.versioned.css',
             ],
             '_someFile.js' => [
                 'css' => [
                     'assets/shared-css.versioned.css',
+                ],
+            ],
+            '_firstFile.js' => [
+                'css' => [
+                    'assets/common.versioned.css',
+                ],
+            ],
+            '_secondFile.js' => [
+                'css' => [
+                    'assets/common.versioned.css',
                 ],
             ],
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

If two entrypoints are used that end up importing the same CSS chunk, multiple identical `<link>`s are output. This just makes the `$stylesheets` collection unique first. One caveat on this PR is a situation in which the `<link>`s are not consecutive.

```html
<!-- Current Output -->
<link rel="stylesheet" type="text/css" href="first.css">
<link rel="stylesheet" type="text/css" href="second.css">
<link rel="stylesheet" type="text/css" href="first.css">

<!-- Updated Output -->
<link rel="stylesheet" type="text/css" href="first.css">
<link rel="stylesheet" type="text/css" href="second.css">
```

Because CSS rules of equal specificity takes the later rule, the duplicated `first.css` stylesheet ends up overriding any overrides that came from the `second.css` stylesheet.

A trivial fix would be to chain more collection methods to ensure that the last duplicate of a file is the one that's retained. Something like `$stylesheets->reverse()->unique()->reverse()->join('')` would do it. This fix (or a more performant version) isn't included in this PR because I felt that the resulting order of the stylesheets shouldn't be a concern of this code. However, I know that my opinion comes from a place of bias. Nearly every project I work on has a singular stylesheet consisting of utility classes. If desired, I would be able to update this PR to account for it.