### PR TITLE
[9.x] Add modulepreload links for Vite assets

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -64,6 +64,8 @@ class Vite
 
             if (isset($manifest[$entrypoint]['imports'])) {
                 foreach ($manifest[$entrypoint]['imports'] as $import) {
+                    $tags->push($this->makeModulePreloadTag(asset("{$buildDirectory}/{$manifest[$import]['file']}")));
+
                     if (isset($manifest[$import]['css'])) {
                         foreach ($manifest[$import]['css'] as $css) {
                             $tags->push($this->makeStylesheetTag(asset("{$buildDirectory}/{$css}")));
@@ -131,6 +133,17 @@ class Vite
     protected function makeScriptTag($url)
     {
         return sprintf('<script type="module" src="%s"></script>', $url);
+    }
+
+    /**
+     * Generate a modulepreload tag for the given URL.
+     *
+     * @param  string  $url
+     * @return string
+     */
+    protected function makeModulePreloadTag($url)
+    {
+        return sprintf('<link rel="modulepreload" href="%s" />', $url);
     }
 
     /**

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -35,6 +35,19 @@ class FoundationViteTest extends TestCase
         $this->assertSame('<script type="module" src="https://example.com/build/assets/app.versioned.js"></script>', $result->toHtml());
     }
 
+    public function testViteWithNestedJs()
+    {
+        $this->makeViteManifest();
+
+        $result = (new Vite)('resources/js/parent.js');
+
+        $this->assertSame(
+            '<link rel="modulepreload" href="https://example.com/build/assets/child.versioned.js" />'
+            .'<script type="module" src="https://example.com/build/assets/parent.versioned.js"></script>',
+            $result->toHtml()
+        );
+    }
+
     public function testViteWithCssAndJs()
     {
         $this->makeViteManifest();
@@ -68,7 +81,8 @@ class FoundationViteTest extends TestCase
         $result = (new Vite)(['resources/js/app-with-shared-css.js']);
 
         $this->assertSame(
-            '<link rel="stylesheet" href="https://example.com/build/assets/shared-css.versioned.css" />'
+            '<link rel="modulepreload" href="https://example.com/build/assets/someFile.versioned.js" />'
+            .'<link rel="stylesheet" href="https://example.com/build/assets/shared-css.versioned.css" />'
             .'<script type="module" src="https://example.com/build/assets/app-with-shared-css.versioned.js"></script>',
             $result->toHtml()
         );
@@ -113,6 +127,12 @@ class FoundationViteTest extends TestCase
             'resources/js/app.js' => [
                 'file' => 'assets/app.versioned.js',
             ],
+            'resources/js/parent.js' => [
+                'file' => 'assets/parent.versioned.js',
+                'imports' => [
+                    '_child.js',
+                ],
+            ],
             'resources/js/app-with-css-import.js' => [
                 'file' => 'assets/app-with-css-import.versioned.js',
                 'css' => [
@@ -128,7 +148,11 @@ class FoundationViteTest extends TestCase
             'resources/css/app.css' => [
                 'file' => 'assets/app.versioned.css',
             ],
+            '_child.js' => [
+                'file' => 'assets/child.versioned.js',
+            ],
             '_someFile.js' => [
+                'file' => 'assets/someFile.versioned.js',
                 'css' => [
                     'assets/shared-css.versioned.css',
                 ],


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

It is currently possible to end up with a waterfall problem where the entrypoints end up importing a chunk that was externalized to be shared between various entrypoints. Depending on the how the dependencies are determined, it could turn into a rather large waterfall of requests. This PR adds a step of converting the entrypoint's imports into `<link rel="modulepreload">`s.

`modulepreload` isn't terribly [well supported](https://caniuse.com/link-rel-modulepreload) right now. However, the [Vite documentation](https://vitejs.dev/config/#build-polyfillmodulepreload) says to import a polyfill to account for it. I think that how Laravel handles the inclusion of that polyfill as beyond the scope of this PR. As far as I'm aware, browsers that don't understand `modulepreload` will just ignore them. I believe this PR could be merged without any negative impact and then followed up with another one to resolve the handling of the polyfill once a decision is made.