### PR TITLE
[9.x] Adds `Json` utility class

### DIFF
--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -24,7 +24,7 @@ class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggrega
     protected $data;
 
     /**
-     * Create a new JSON instance
+     * Create a new JSON instance.
      *
      * @param  mixed  $data
      */
@@ -101,7 +101,7 @@ class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggrega
      */
     public function missing($key)
     {
-        return !$this->has($key);
+        return ! $this->has($key);
     }
 
     /**
@@ -259,7 +259,7 @@ class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggrega
     }
 
     /**
-     * Retrieve an external iterator
+     * Retrieve an external iterator.
      *
      * @return \ArrayIterator
      */

--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -110,7 +110,7 @@ class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggrega
      * @param  string|int  $key
      * @return void
      */
-    public function unset($key)
+    public function forget($key)
     {
         $segment = $this->data;
 
@@ -190,7 +190,7 @@ class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggrega
      */
     public function __unset($name): void
     {
-        $this->unset($name);
+        $this->forget($name);
     }
 
     /**
@@ -235,7 +235,7 @@ class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggrega
      */
     public function offsetUnset($offset): void
     {
-        $this->unset($offset);
+        $this->forget($offset);
     }
 
     /**

--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -6,8 +6,6 @@ use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use function is_iterable;
-use function is_object;
 use IteratorAggregate;
 use JsonSerializable;
 use Stringable;

--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -6,8 +6,6 @@ use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Http\JsonResponse;
 use IteratorAggregate;
 use JsonSerializable;
 use Stringable;

--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -286,13 +286,15 @@ class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggrega
      */
     public function toArray()
     {
-        return array_map(function ($value) {
-            return $value instanceof Arrayable ? $value->toArray() : $value;
-        }, (array) match (true) {
+        $data = match (true) {
             $this->data instanceof Traversable, => iterator_to_array($this->data),
             is_object($this->data) => get_object_vars($this->data),
             default => $this->data,
-        });
+        };
+
+        return array_map(function ($value) {
+            return $value instanceof Arrayable ? $value->toArray() : $value;
+        }, Arr::wrap($data));
     }
 
     /**

--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -6,12 +6,12 @@ use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use function is_iterable;
+use function is_object;
 use IteratorAggregate;
 use JsonSerializable;
 use Stringable;
 use Traversable;
-use function is_iterable;
-use function is_object;
 
 class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggregate, Arrayable, Jsonable
 {

--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -138,6 +138,23 @@ class Json implements Stringable, ArrayAccess, JsonSerializable, IteratorAggrega
     }
 
     /**
+     * Retrieves a segment of the JSON into one Json instance.
+     *
+     * @param  array  $segment
+     * @return static
+     */
+    public function segment(array $segment)
+    {
+        $json = new static();
+
+        foreach ($segment as $key) {
+            $json->set($key, $this->get($key));
+        }
+
+        return $json;
+    }
+
+    /**
      * Returns a Json instance as a Collection.
      *
      * @param  string|null  $key

--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ArrayAccess;
+use ArrayIterator;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use IteratorAggregate;
+use JsonSerializable;
+use Stringable;
+
+class Json implements ArrayAccess, Stringable, JsonSerializable, IteratorAggregate, Arrayable, Jsonable
+{
+    use Traits\Conditionable;
+    use Traits\Tappable;
+
+    /**
+     * The JSON array.
+     *
+     * @var array
+     */
+    protected array $json = [];
+
+    /**
+     * Create a new Json instance.
+     *
+     * @param  array  $json
+     */
+    public function __construct(array $json = [])
+    {
+        $this->json = $json;
+    }
+
+    /**
+     * Returns the underlying JSON array.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->json;
+    }
+
+    /**
+     * Get an item from JSON using "dot" notation.
+     *
+     * @param  string|int  $key
+     * @param  mixed|null  $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        return Arr::get($this->json, $key, $default);
+    }
+
+    /**
+     * Check if an item or items exist in JSON using "dot" notation.
+     *
+     * @param  string|int  ...$keys
+     * @return bool
+     */
+    public function has(...$keys)
+    {
+        return Arr::has($this->json, $keys);
+    }
+
+    /**
+     * Determine if any of the keys exist in JSON using "dot" notation.
+     *
+     * @param  string|int  ...$keys
+     * @return bool
+     */
+    public function hasAny(...$keys)
+    {
+        return Arr::hasAny($this->json, $keys);
+    }
+
+    /**
+     * Check if the given key is missing using dot notation.
+     *
+     * @param  string|int  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        return ! $this->has($key);
+    }
+
+    /**
+     * Set a JSON item to a given value using "dot" notation.
+     *
+     * If no key is given to the method, the entire JSON will be replaced.
+     *
+     * @param  string|int|null  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function set($key, $value)
+    {
+        Arr::set($this->json, $key, $value);
+
+        return $this;
+    }
+
+    /**
+     * Remove one or many items from JSON using "dot" notation.
+     *
+     * @param  string|int  ...$keys
+     * @return $this
+     */
+    public function forget(...$keys)
+    {
+        Arr::forget($this->json, $keys);
+
+        return $this;
+    }
+
+    /**
+     * Returns a Json instance as a Collection.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect($key = null)
+    {
+        return new Collection($this->get($key));
+    }
+
+    /**
+     * Dynamically get JSON values.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        return $this->get($name);
+    }
+
+    /**
+     * Dynamically set JSON values.
+     *
+     * @param  string  $name
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set($name, $value)
+    {
+        $this->set($name, $value);
+    }
+
+    /**
+     * Dynamically check a JSON key presence.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        return $this->has($name);
+    }
+
+    /**
+     * Dynamically unset a JSON key.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function __unset($name)
+    {
+        $this->forget($name);
+    }
+
+    /**
+     * Whether an offset exists.
+     *
+     * @param  mixed
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        return $this->has($offset);
+    }
+
+    /**
+     * Offset to retrieve.
+     *
+     * @param  mixed  $offset
+     * @return mixed
+     */
+    public function offsetGet($offset): mixed
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * Offset to set.
+     *
+     * @param  mixed  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->set($offset, $value);
+    }
+
+    /**
+     * Offset to unset.
+     *
+     * @param  mixed  $offset
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        $this->forget($offset);
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->toJson();
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string.
+     */
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Retrieve an external iterator
+     *
+     * @return \ArrayIterator
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->toArray());
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array_map(fn ($item) => $item instanceof Arrayable ? $item->toArray() : $item, $this->json);
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return false|string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Create a new Json instance.
+     *
+     * @param  array  $json
+     * @return static
+     */
+    public static function make($json)
+    {
+        return new static($json);
+    }
+
+    /**
+     * Create a new Json instance from a JSON string.
+     *
+     * @param  string  $json
+     * @param  int  $depth
+     * @param  int  $options
+     * @return static
+     */
+    public static function fromJson($json, $depth = 512, $options = 0)
+    {
+        return new static(json_decode($json, true, $depth, $options));
+    }
+
+    /**
+     * Wraps an array into a Json instance.
+     *
+     * @param  self|array|null  $json
+     * @return static
+     */
+    public static function wrap($json)
+    {
+        return $json instanceof static ? $json : new static((array) $json);
+    }
+}
+

--- a/tests/Support/SupportJsonTest.php
+++ b/tests/Support/SupportJsonTest.php
@@ -78,21 +78,21 @@ class SupportJsonTest extends TestCase
         static::assertTrue($this->json->missing('quz.baz'));
     }
 
-    public function testUnset(): void
+    public function testForget(): void
     {
-        $this->json->unset('foo');
+        $this->json->forget('foo');
         static::assertTrue($this->json->missing('foo'));
 
-        $this->json->unset('bar.baz.quz');
+        $this->json->forget('bar.baz.quz');
         static::assertFalse($this->json->missing('bar'));
         static::assertFalse($this->json->missing('bar.baz'));
         static::asserttrue($this->json->missing('bar.baz.quz'));
 
-        $this->json->unset('bar.baz');
+        $this->json->forget('bar.baz');
         static::assertFalse($this->json->missing('bar'));
         static::assertTrue($this->json->missing('bar.baz'));
 
-        $this->json->unset('bar.baz');
+        $this->json->forget('bar.baz');
         static::assertFalse($this->json->missing('bar'));
         static::assertTrue($this->json->missing('bar.baz'));
     }

--- a/tests/Support/SupportJsonTest.php
+++ b/tests/Support/SupportJsonTest.php
@@ -4,9 +4,9 @@ namespace Illuminate\Tests\Support;
 
 use ArrayIterator;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Json;
 use IteratorAggregate;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Support\Json;
 use RecursiveArrayIterator;
 use Traversable;
 
@@ -18,7 +18,8 @@ class SupportJsonTest extends TestCase
     {
         parent::setUp();
 
-        $this->json = new Json(new class {
+        $this->json = new Json(new class
+        {
             public function __construct($foo = ['foo' => 'bar'])
             {
                 $this->foo = $foo;
@@ -32,7 +33,7 @@ class SupportJsonTest extends TestCase
         static::assertSame(['foo' => 'bar'], $this->json->get('foo'));
         static::assertSame('qux', $this->json->get('bar.baz.quz'));
         static::assertSame('cougar', $this->json->get('baz', 'cougar'));
-        static::assertSame('cougar', $this->json->get('baz', fn() => 'cougar'));
+        static::assertSame('cougar', $this->json->get('baz', fn () => 'cougar'));
         static::assertNull($this->json->get('baz'));
     }
 
@@ -174,7 +175,8 @@ class SupportJsonTest extends TestCase
         static::assertInstanceOf(ArrayIterator::class, $json->getIterator());
         static::assertSame(['foo', 'bar', 'baz'], iterator_to_array($json));
 
-        $json = new Json(new class {
+        $json = new Json(new class
+        {
             public function __construct(public $foo = 'bar', public $baz = 'quz', public $qux = 'cougar')
             {
             }
@@ -183,7 +185,8 @@ class SupportJsonTest extends TestCase
         static::assertInstanceOf(ArrayIterator::class, $json->getIterator());
         static::assertSame(['foo' => 'bar', 'baz' => 'quz', 'qux' => 'cougar'], iterator_to_array($json));
 
-        $json = new Json(new class implements IteratorAggregate {
+        $json = new Json(new class implements IteratorAggregate
+        {
             public function getIterator(): Traversable
             {
                 return new RecursiveArrayIterator(['foo' => ['bar', 'quz']]);
@@ -199,7 +202,7 @@ class SupportJsonTest extends TestCase
         $json = Json::make(['foo' => 'bar']);
         static::assertSame(['foo' => 'bar'], $json->data());
 
-        $json = Json::make($object = (object)['foo' => 'bar']);
+        $json = Json::make($object = (object) ['foo' => 'bar']);
         static::assertSame($object, $json->data());
     }
 

--- a/tests/Support/SupportJsonTest.php
+++ b/tests/Support/SupportJsonTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Json;
+
+class SupportJsonTest extends TestCase
+{
+    /**
+     * @param  array  $array
+     * @return \Illuminate\Support\Json
+     */
+    protected function json($array = [])
+    {
+        return new Json($array);
+    }
+
+    public function testAll()
+    {
+        $this->assertSame(['foo' => 'bar'], $this->json(['foo' => 'bar'])->all());
+    }
+
+    public function testGet()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame('baz', $json->get('foo.bar'));
+
+        $this->assertNull($json->get('foo.baz'));
+
+        $this->assertSame('qux', $json->get('foo.baz', 'qux'));
+    }
+
+    public function testHas()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertTrue($json->has('foo.bar'));
+        $this->assertFalse($json->has('foo.baz'));
+
+        $this->assertTrue($json->has('foo', 'foo.bar'));
+        $this->assertFalse($json->has('foo', 'foo.baz'));
+    }
+
+    public function testHasAny()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertTrue($json->hasAny('foo.bar'));
+        $this->assertFalse($json->hasAny('foo.baz'));
+
+        $this->assertTrue($json->hasAny('foo', 'foo.bar'));
+        $this->assertTrue($json->hasAny('foo', 'foo.baz'));
+    }
+
+    public function testMissing()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertFalse($json->missing('foo.bar'));
+        $this->assertTrue($json->missing('foo.baz'));
+
+        $this->assertFalse($json->missing('foo.bar'));
+        $this->assertTrue($json->missing('foo.baz'));
+    }
+
+    public function testSet()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $json->set('foo.quz', 'qux');
+
+        $this->assertSame('qux', $json->get('foo.quz'));
+
+        $json->set(null, []);
+
+        $this->assertSame([], $json->all());
+    }
+
+    public function testForget()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz', 'quz' => 'qux']]);
+
+        $json->forget('foo.quz');
+
+        $this->assertSame(['foo' => ['bar' => 'baz']], $json->all());
+    }
+
+    public function testCollection()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz', 'quz' => 'qux']]);
+
+        $this->assertSame(['foo' => ['bar' => 'baz', 'quz' => 'qux']], $json->collect()->all());
+
+        $this->assertSame(['bar' => 'baz', 'quz' => 'qux'], $json->collect('foo')->all());
+    }
+
+    public function testDynamicAccess()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame(['bar' => 'baz'], $json->foo);
+
+        $json->foo = ['quz'];
+
+        $this->assertSame(['quz'], $json->foo);
+
+        $this->assertTrue(isset($json->foo));
+
+        unset($json->foo);
+
+        $this->assertNull($json->foo);
+    }
+
+    public function testArrayAccess()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame(['bar' => 'baz'], $json['foo']);
+
+        $json['foo'] = ['quz'];
+
+        $this->assertSame(['quz'], $json['foo']);
+
+        $this->assertTrue(isset($json['foo']));
+
+        unset($json['foo']);
+
+        $this->assertNull($json['foo']);
+    }
+
+    public function testToString()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame('{"foo":{"bar":"baz"}}', $json->__toString());
+        $this->assertSame('{"foo":{"bar":"baz"}}', (string) $json);
+    }
+
+    public function testIterator()
+    {
+        $json = $this->json($array = ['foo', 'bar', 'baz', 'quz']);
+
+        foreach ($json as $key => $value) {
+            $this->assertSame($array[$key], $value);
+        }
+    }
+
+    public function testToArray()
+    {
+        $json = $this->json(['foo', 'bar', 'baz', new Collection(['quz', 'qux'])]);
+
+        $this->assertSame(['foo', 'bar', 'baz', ['quz', 'qux']], $json->toArray());
+    }
+
+    public function testToJson()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame('{"foo":{"bar":"baz"}}', $json->toJson());
+    }
+
+    public function testMake()
+    {
+        $array = ['foo' => ['bar' => 'baz']];
+
+        $this->assertSame($array, Json::make($array)->all());
+    }
+
+    public function testFromJson()
+    {
+        $this->assertSame(['foo' => ['bar' => 'baz']], Json::fromJson('{"foo":{"bar":"baz"}}')->all());
+    }
+
+    public function testWrap()
+    {
+        $json = $this->json(['foo' => ['bar' => 'baz']]);
+
+        $this->assertSame($json, Json::wrap($json));
+
+        $this->assertSame(['foo' => ['bar' => 'baz']], Json::wrap(['foo' => ['bar' => 'baz']])->all());
+    }
+}

--- a/tests/Support/SupportJsonTest.php
+++ b/tests/Support/SupportJsonTest.php
@@ -48,13 +48,15 @@ class SupportJsonTest extends TestCase
         $this->assertSame('bar', $this->json->get('foo'));
     }
 
-    public function testSetOnNonArrayOrObject()
+    public function testSetOnSingleValues()
     {
-        $json = (new Json(null));
-
-        $json->set('quz', 'qux');
-
-        $this->assertSame('qux', $json->get('quz'));
+        $this->assertSame('qux', (new Json(null))->set('quz', 'qux')->get('quz'));
+        $this->assertSame('qux', (new Json('foo'))->set('quz', 'qux')->get('quz'));
+        $this->assertSame('qux', (new Json(true))->set('quz', 'qux')->get('quz'));
+        $this->assertSame('qux', (new Json(false))->set('quz', 'qux')->get('quz'));
+        $this->assertSame('qux', (new Json(10))->set('quz', 'qux')->get('quz'));
+        $this->assertSame('qux', (new Json(10.1))->set('quz', 'qux')->get('quz'));
+        $this->assertSame('qux', (new Json("\x66\x6f\x6f"))->set('quz', 'qux')->get('quz'));
     }
 
     public function testFill(): void
@@ -172,6 +174,17 @@ class SupportJsonTest extends TestCase
         );
     }
 
+    public function testToArrayWithSingleValues(): void
+    {
+        $this->assertSame([], (new Json(null))->toArray());
+        $this->assertSame(['foo'], (new Json('foo'))->toArray());
+        $this->assertSame([true], (new Json(true))->toArray());
+        $this->assertSame([false], (new Json(false))->toArray());
+        $this->assertSame([10], (new Json(10))->toArray());
+        $this->assertSame([10.1], (new Json(10.1))->toArray());
+        $this->assertSame(["\x66\x6f\x6f"], (new Json("\x66\x6f\x6f"))->toArray());
+    }
+
     public function testIterator(): void
     {
         $this->assertEquals(
@@ -234,7 +247,7 @@ class SupportJsonTest extends TestCase
         $this->assertEmpty(Json::wrap(null)->data());
     }
 
-    public function testInstanceWithNonObjectsOrArray()
+    public function testInstanceWithSingleValues()
     {
         $this->assertSame('null', (new Json(null))->toJson());
         $this->assertSame('"foo"', (new Json('foo'))->toJson());
@@ -243,5 +256,6 @@ class SupportJsonTest extends TestCase
         $this->assertSame('10', (new Json(10))->toJson());
         $this->assertSame('10.1', (new Json(10.1))->toJson());
         $this->assertSame('"foo"', (new Json("\x66\x6f\x6f"))->toJson());
+        $this->assertSame('"{\"foo\":\"bar\"}"', (new Json('{"foo":"bar"}'))->toJson());
     }
 }

--- a/tests/Support/SupportJsonTest.php
+++ b/tests/Support/SupportJsonTest.php
@@ -48,6 +48,15 @@ class SupportJsonTest extends TestCase
         static::assertSame('bar', $this->json->get('foo'));
     }
 
+    public function testSetOnNonArrayOrObject()
+    {
+        $json = (new Json(null));
+
+        $json->set('quz', 'qux');
+
+        static::assertSame('qux', $json->get('quz'));
+    }
+
     public function testFill(): void
     {
         $this->json->fill('quz', 'qux');
@@ -223,5 +232,16 @@ class SupportJsonTest extends TestCase
         static::assertSame($object, Json::wrap($object)->data());
 
         static::assertEmpty(Json::wrap(null)->data());
+    }
+
+    public function testInstanceWithNonObjectsOrArray()
+    {
+        static::assertSame('null', (new Json(null))->toJson());
+        static::assertSame('"foo"', (new Json('foo'))->toJson());
+        static::assertSame('true', (new Json(true))->toJson());
+        static::assertSame('false', (new Json(false))->toJson());
+        static::assertSame('10', (new Json(10))->toJson());
+        static::assertSame('10.1', (new Json(10.1))->toJson());
+        static::assertSame('"foo"', (new Json("\x66\x6f\x6f"))->toJson());
     }
 }

--- a/tests/Support/SupportJsonTest.php
+++ b/tests/Support/SupportJsonTest.php
@@ -30,22 +30,22 @@ class SupportJsonTest extends TestCase
 
     public function testGet(): void
     {
-        static::assertSame(['foo' => 'bar'], $this->json->get('foo'));
-        static::assertSame('qux', $this->json->get('bar.baz.quz'));
-        static::assertSame('cougar', $this->json->get('baz', 'cougar'));
-        static::assertSame('cougar', $this->json->get('baz', fn () => 'cougar'));
-        static::assertNull($this->json->get('baz'));
+        $this->assertSame(['foo' => 'bar'], $this->json->get('foo'));
+        $this->assertSame('qux', $this->json->get('bar.baz.quz'));
+        $this->assertSame('cougar', $this->json->get('baz', 'cougar'));
+        $this->assertSame('cougar', $this->json->get('baz', fn () => 'cougar'));
+        $this->assertNull($this->json->get('baz'));
     }
 
     public function testSet(): void
     {
         $this->json->set('quz', 'qux');
 
-        static::assertSame('qux', $this->json->get('quz'));
+        $this->assertSame('qux', $this->json->get('quz'));
 
         $this->json->set('foo', 'bar');
 
-        static::assertSame('bar', $this->json->get('foo'));
+        $this->assertSame('bar', $this->json->get('foo'));
     }
 
     public function testSetOnNonArrayOrObject()
@@ -54,116 +54,116 @@ class SupportJsonTest extends TestCase
 
         $json->set('quz', 'qux');
 
-        static::assertSame('qux', $json->get('quz'));
+        $this->assertSame('qux', $json->get('quz'));
     }
 
     public function testFill(): void
     {
         $this->json->fill('quz', 'qux');
 
-        static::assertSame('qux', $this->json->get('quz'));
+        $this->assertSame('qux', $this->json->get('quz'));
 
         $this->json->fill('foo', 'bar');
 
-        static::assertSame(['foo' => 'bar'], $this->json->get('foo'));
+        $this->assertSame(['foo' => 'bar'], $this->json->get('foo'));
     }
 
     public function testHas(): void
     {
         $this->json->set('quz', ['bar' => null]);
 
-        static::assertTrue($this->json->has('foo'));
-        static::assertTrue($this->json->has('bar.baz.quz'));
-        static::assertFalse($this->json->has('quz.bar'));
-        static::assertFalse($this->json->has('quz.baz'));
+        $this->assertTrue($this->json->has('foo'));
+        $this->assertTrue($this->json->has('bar.baz.quz'));
+        $this->assertFalse($this->json->has('quz.bar'));
+        $this->assertFalse($this->json->has('quz.baz'));
     }
 
     public function testMissing(): void
     {
         $this->json->set('quz', ['bar' => null]);
 
-        static::assertFalse($this->json->missing('foo'));
-        static::assertFalse($this->json->missing('bar.baz.quz'));
-        static::assertTrue($this->json->missing('quz.bar'));
-        static::assertTrue($this->json->missing('quz.baz'));
+        $this->assertFalse($this->json->missing('foo'));
+        $this->assertFalse($this->json->missing('bar.baz.quz'));
+        $this->assertTrue($this->json->missing('quz.bar'));
+        $this->assertTrue($this->json->missing('quz.baz'));
     }
 
     public function testForget(): void
     {
         $this->json->forget('foo');
-        static::assertTrue($this->json->missing('foo'));
+        $this->assertTrue($this->json->missing('foo'));
 
         $this->json->forget('bar.baz.quz');
-        static::assertFalse($this->json->missing('bar'));
-        static::assertFalse($this->json->missing('bar.baz'));
-        static::asserttrue($this->json->missing('bar.baz.quz'));
+        $this->assertFalse($this->json->missing('bar'));
+        $this->assertFalse($this->json->missing('bar.baz'));
+        $this->asserttrue($this->json->missing('bar.baz.quz'));
 
         $this->json->forget('bar.baz');
-        static::assertFalse($this->json->missing('bar'));
-        static::assertTrue($this->json->missing('bar.baz'));
+        $this->assertFalse($this->json->missing('bar'));
+        $this->assertTrue($this->json->missing('bar.baz'));
 
         $this->json->forget('bar.baz');
-        static::assertFalse($this->json->missing('bar'));
-        static::assertTrue($this->json->missing('bar.baz'));
+        $this->assertFalse($this->json->missing('bar'));
+        $this->assertTrue($this->json->missing('bar.baz'));
     }
 
     public function testCollect(): void
     {
         $collection = $this->json->collect();
 
-        static::assertTrue($collection->has('foo'));
-        static::assertTrue($collection->has('bar'));
+        $this->assertTrue($collection->has('foo'));
+        $this->assertTrue($collection->has('bar'));
 
         $collection = $this->json->collect('bar');
 
-        static::assertTrue($collection->has('baz'));
+        $this->assertTrue($collection->has('baz'));
     }
 
     public function testDynamicAccess(): void
     {
-        static::assertSame(['foo' => 'bar'], $this->json->foo);
+        $this->assertSame(['foo' => 'bar'], $this->json->foo);
 
         $this->json->foo = 'bar';
-        static::assertSame('bar', $this->json->foo);
+        $this->assertSame('bar', $this->json->foo);
 
-        static::assertTrue(isset($this->json->bar));
-        static::assertFalse(isset($this->json->baz));
+        $this->assertTrue(isset($this->json->bar));
+        $this->assertFalse(isset($this->json->baz));
 
         unset($this->json->foo);
 
-        static::assertTrue($this->json->missing('foo'));
+        $this->assertTrue($this->json->missing('foo'));
     }
 
     public function testArrayAccess(): void
     {
-        static::assertSame(['foo' => 'bar'], $this->json['foo']);
+        $this->assertSame(['foo' => 'bar'], $this->json['foo']);
 
         $this->json['foo'] = 'bar';
-        static::assertSame('bar', $this->json['foo']);
+        $this->assertSame('bar', $this->json['foo']);
 
-        static::assertTrue(isset($this->json['bar']));
-        static::assertFalse(isset($this->json['baz']));
+        $this->assertTrue(isset($this->json['bar']));
+        $this->assertFalse(isset($this->json['baz']));
 
         unset($this->json['foo']);
 
-        static::assertTrue($this->json->missing('foo'));
+        $this->assertTrue($this->json->missing('foo'));
     }
 
     public function testToStringAsJson(): void
     {
-        static::assertSame('{"foo":{"foo":"bar"},"bar":{"baz":{"quz":"qux"}}}', (string) $this->json);
+        $this->assertSame('{"foo":{"foo":"bar"},"bar":{"baz":{"quz":"qux"}}}', (string) $this->json);
     }
 
     public function testToJson(): void
     {
-        static::assertSame('{"foo":{"foo":"bar"},"bar":{"baz":{"quz":"qux"}}}', $this->json->toJson());
+        $this->assertSame('{"foo":{"foo":"bar"},"bar":{"baz":{"quz":"qux"}}}', $this->json->toJson());
     }
 
     public function testToArray(): void
     {
         $this->json->set('baz', new Collection(['foo', 'bar', 'baz']));
 
-        static::assertEquals([
+        $this->assertEquals([
             'foo' => ['foo' => 'bar'],
             'bar' => (object) ['baz' => (object) ['quz' => 'qux']],
             'baz' => ['foo', 'bar', 'baz'],
@@ -174,15 +174,15 @@ class SupportJsonTest extends TestCase
 
     public function testIterator(): void
     {
-        static::assertEquals(
+        $this->assertEquals(
             ['foo' => ['foo' => 'bar'], 'bar' => (object) ['baz' => (object) ['quz' => 'qux']]],
             iterator_to_array($this->json)
         );
 
         $json = new Json(['foo', 'bar', 'baz']);
 
-        static::assertInstanceOf(ArrayIterator::class, $json->getIterator());
-        static::assertSame(['foo', 'bar', 'baz'], iterator_to_array($json));
+        $this->assertInstanceOf(ArrayIterator::class, $json->getIterator());
+        $this->assertSame(['foo', 'bar', 'baz'], iterator_to_array($json));
 
         $json = new Json(new class
         {
@@ -191,8 +191,8 @@ class SupportJsonTest extends TestCase
             }
         });
 
-        static::assertInstanceOf(ArrayIterator::class, $json->getIterator());
-        static::assertSame(['foo' => 'bar', 'baz' => 'quz', 'qux' => 'cougar'], iterator_to_array($json));
+        $this->assertInstanceOf(ArrayIterator::class, $json->getIterator());
+        $this->assertSame(['foo' => 'bar', 'baz' => 'quz', 'qux' => 'cougar'], iterator_to_array($json));
 
         $json = new Json(new class implements IteratorAggregate
         {
@@ -202,46 +202,46 @@ class SupportJsonTest extends TestCase
             }
         });
 
-        static::assertInstanceOf(RecursiveArrayIterator::class, $json->getIterator());
-        static::assertSame(['foo' => ['bar', 'quz']], iterator_to_array($json));
+        $this->assertInstanceOf(RecursiveArrayIterator::class, $json->getIterator());
+        $this->assertSame(['foo' => ['bar', 'quz']], iterator_to_array($json));
     }
 
     public function testMake(): void
     {
         $json = Json::make(['foo' => 'bar']);
-        static::assertSame(['foo' => 'bar'], $json->data());
+        $this->assertSame(['foo' => 'bar'], $json->data());
 
         $json = Json::make($object = (object) ['foo' => 'bar']);
-        static::assertSame($object, $json->data());
+        $this->assertSame($object, $json->data());
     }
 
     public function testFromString(): void
     {
         $json = Json::fromString('{"foo":{"foo":"bar"}}');
-        static::assertEquals((object) ['foo' => (object) ['foo' => 'bar']], $json->data());
+        $this->assertEquals((object) ['foo' => (object) ['foo' => 'bar']], $json->data());
     }
 
     public function testWrap(): void
     {
         $json = Json::fromString('{"foo":{"foo":"bar"}}');
 
-        static::assertSame($json, Json::wrap($json));
+        $this->assertSame($json, Json::wrap($json));
 
         $object = (object) ['foo' => (object) ['foo' => 'bar']];
 
-        static::assertSame($object, Json::wrap($object)->data());
+        $this->assertSame($object, Json::wrap($object)->data());
 
-        static::assertEmpty(Json::wrap(null)->data());
+        $this->assertEmpty(Json::wrap(null)->data());
     }
 
     public function testInstanceWithNonObjectsOrArray()
     {
-        static::assertSame('null', (new Json(null))->toJson());
-        static::assertSame('"foo"', (new Json('foo'))->toJson());
-        static::assertSame('true', (new Json(true))->toJson());
-        static::assertSame('false', (new Json(false))->toJson());
-        static::assertSame('10', (new Json(10))->toJson());
-        static::assertSame('10.1', (new Json(10.1))->toJson());
-        static::assertSame('"foo"', (new Json("\x66\x6f\x6f"))->toJson());
+        $this->assertSame('null', (new Json(null))->toJson());
+        $this->assertSame('"foo"', (new Json('foo'))->toJson());
+        $this->assertSame('true', (new Json(true))->toJson());
+        $this->assertSame('false', (new Json(false))->toJson());
+        $this->assertSame('10', (new Json(10))->toJson());
+        $this->assertSame('10.1', (new Json(10.1))->toJson());
+        $this->assertSame('"foo"', (new Json("\x66\x6f\x6f"))->toJson());
     }
 }

--- a/tests/Support/SupportJsonTest.php
+++ b/tests/Support/SupportJsonTest.php
@@ -28,7 +28,7 @@ class SupportJsonTest extends TestCase
         });
     }
 
-    public function testGet(): void
+    public function testGet()
     {
         $this->assertSame(['foo' => 'bar'], $this->json->get('foo'));
         $this->assertSame('qux', $this->json->get('bar.baz.quz'));
@@ -37,7 +37,7 @@ class SupportJsonTest extends TestCase
         $this->assertNull($this->json->get('baz'));
     }
 
-    public function testSet(): void
+    public function testSet()
     {
         $this->json->set('quz', 'qux');
 
@@ -59,7 +59,7 @@ class SupportJsonTest extends TestCase
         $this->assertSame('qux', (new Json("\x66\x6f\x6f"))->set('quz', 'qux')->get('quz'));
     }
 
-    public function testFill(): void
+    public function testFill()
     {
         $this->json->fill('quz', 'qux');
 
@@ -70,7 +70,7 @@ class SupportJsonTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $this->json->get('foo'));
     }
 
-    public function testHas(): void
+    public function testHas()
     {
         $this->json->set('quz', ['bar' => null]);
 
@@ -80,7 +80,7 @@ class SupportJsonTest extends TestCase
         $this->assertFalse($this->json->has('quz.baz'));
     }
 
-    public function testMissing(): void
+    public function testMissing()
     {
         $this->json->set('quz', ['bar' => null]);
 
@@ -90,7 +90,7 @@ class SupportJsonTest extends TestCase
         $this->assertTrue($this->json->missing('quz.baz'));
     }
 
-    public function testForget(): void
+    public function testForget()
     {
         $this->json->forget('foo');
         $this->assertTrue($this->json->missing('foo'));
@@ -109,7 +109,27 @@ class SupportJsonTest extends TestCase
         $this->assertTrue($this->json->missing('bar.baz'));
     }
 
-    public function testCollect(): void
+    public function testSegment()
+    {
+        $json = new Json([
+            'foo' => 'bar',
+            'baz' => [
+                'quz' => [
+                    'qux',
+                    'quuz'
+                ],
+                'quux' => 'cougar',
+                'cougar' => 'foo',
+            ]
+        ]);
+
+        $this->assertSame(
+            '{"baz":{"quz":["qux","quuz"],"quux":"cougar"}}',
+            $json->segment(['baz.quz', 'baz.quux'])->toJson()
+        );
+    }
+
+    public function testCollect()
     {
         $collection = $this->json->collect();
 
@@ -121,7 +141,7 @@ class SupportJsonTest extends TestCase
         $this->assertTrue($collection->has('baz'));
     }
 
-    public function testDynamicAccess(): void
+    public function testDynamicAccess()
     {
         $this->assertSame(['foo' => 'bar'], $this->json->foo);
 
@@ -136,7 +156,7 @@ class SupportJsonTest extends TestCase
         $this->assertTrue($this->json->missing('foo'));
     }
 
-    public function testArrayAccess(): void
+    public function testArrayAccess()
     {
         $this->assertSame(['foo' => 'bar'], $this->json['foo']);
 
@@ -151,17 +171,17 @@ class SupportJsonTest extends TestCase
         $this->assertTrue($this->json->missing('foo'));
     }
 
-    public function testToStringAsJson(): void
+    public function testToStringAsJson()
     {
         $this->assertSame('{"foo":{"foo":"bar"},"bar":{"baz":{"quz":"qux"}}}', (string) $this->json);
     }
 
-    public function testToJson(): void
+    public function testToJson()
     {
         $this->assertSame('{"foo":{"foo":"bar"},"bar":{"baz":{"quz":"qux"}}}', $this->json->toJson());
     }
 
-    public function testToArray(): void
+    public function testToArray()
     {
         $this->json->set('baz', new Collection(['foo', 'bar', 'baz']));
 
@@ -174,7 +194,7 @@ class SupportJsonTest extends TestCase
         );
     }
 
-    public function testToArrayWithSingleValues(): void
+    public function testToArrayWithSingleValues()
     {
         $this->assertSame([], (new Json(null))->toArray());
         $this->assertSame(['foo'], (new Json('foo'))->toArray());
@@ -185,7 +205,7 @@ class SupportJsonTest extends TestCase
         $this->assertSame(["\x66\x6f\x6f"], (new Json("\x66\x6f\x6f"))->toArray());
     }
 
-    public function testIterator(): void
+    public function testIterator()
     {
         $this->assertEquals(
             ['foo' => ['foo' => 'bar'], 'bar' => (object) ['baz' => (object) ['quz' => 'qux']]],
@@ -219,7 +239,7 @@ class SupportJsonTest extends TestCase
         $this->assertSame(['foo' => ['bar', 'quz']], iterator_to_array($json));
     }
 
-    public function testMake(): void
+    public function testMake()
     {
         $json = Json::make(['foo' => 'bar']);
         $this->assertSame(['foo' => 'bar'], $json->data());
@@ -228,13 +248,13 @@ class SupportJsonTest extends TestCase
         $this->assertSame($object, $json->data());
     }
 
-    public function testFromString(): void
+    public function testFromString()
     {
         $json = Json::fromString('{"foo":{"foo":"bar"}}');
         $this->assertEquals((object) ['foo' => (object) ['foo' => 'bar']], $json->data());
     }
 
-    public function testWrap(): void
+    public function testWrap()
     {
         $json = Json::fromString('{"foo":{"foo":"bar"}}');
 


### PR DESCRIPTION
## What?

A utility class to manipulate JSON trees. 

```php
use Illuminate\Support\Json;

Json::make(['foo', 'bar']);
```

It's _memory friendly_. It uses `data_get()` and `data_set()` behind the scenes.

> Memory friendly as it never transforms to array objects until serialization. It also decodes JSON into objects instead of arrays.

## Why?

Because sometimes JSON is not a list of values, but rather a data tree (like the app config), that can be very cumbersome to parse and manipulate.

Usually, there are workarounds to manipulate JSON:

- If it's part of the request, you would use `json()` to retrieve all or part of the contents.
- If it's part of a response, you would use `data_get()` and `data_set()` on the `getContents()`.
- You would extend the Config `Repository` class.
- You would use Collections, and travel through a given key.
- Manipulate an array using `Arr`
- Use `data_get()` and `data_set()` indiscriminately.

Instead, the point of having a `Json` object is to centralize these operations into one object that can be shared across the application without the risk of memory duplication (much like Collections).

```php
use Illuminate\Support\Json;

$json = Json::make(['foo' => ['bar', 'baz']]);

$json->get('foo.bar'); // "baz"
```

It supports a lot of methods to make it convenient, all using dot notation like you would with the application config instance: get, set, forget, has, missing, dynamic access and array access. It also can be totally or partially transformed to a Collection using `collect()`, and is _iterable_.

```php
$collection = $json->collect()->map(fn ($item) => "$item is cool");

foreach ($json as $key => $item) {
    // ...
}
```

Of course, it also transforms to JSON when casting it to a string.

```php
use Illuminate\Support\Json;

$json = Json::make(['foo' => ['bar', 'baz']]);

(string) $json; // {"foo":{"bar":"baz"}}
```

It will also play nice with a Collections, as these enter as objects. Since objects are never transformed before JSON serialization, values can be edited without needing to use the `Json` instance itself.

```php
use Illuminate\Support\Json;

$collection = collect(['bar' => 'baz']);

$json = Json::make();

$json->set('foo', $collection);

$collection->put('bar', 'qux');

echo $json->get('foo.bar'); // "qux"
```