### PR TITLE
[9.x] Fix default parameter bug

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -94,6 +94,13 @@ class Route
     protected $originalParameters;
 
     /**
+     * The named parameter defaults.
+     *
+     * @var array
+     */
+    public $defaultParameters = [];
+
+    /**
      * Indicates "trashed" models can be retrieved when resolving implicit model bindings for this route.
      *
      * @var bool
@@ -507,9 +514,11 @@ class Route
     {
         preg_match_all('/\{(.*?)\}/', $this->getDomain().$this->uri, $matches);
 
-        return array_map(function ($m) {
+        return array_values(array_filter(array_map(function ($m) {
             return trim($m, '?');
-        }, $matches[1]);
+        }, $matches[1]), function ($parameterName) {
+            return ! array_key_exists($parameterName, $this->defaultParameters);
+        }));
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -94,11 +94,11 @@ class Route
     protected $originalParameters;
 
     /**
-     * The named parameter defaults.
+     * The parameters to exlude when determining the route's parameter names.
      *
      * @var array
      */
-    public $defaultParameters = [];
+    public $excludedParameters = [];
 
     /**
      * Indicates "trashed" models can be retrieved when resolving implicit model bindings for this route.
@@ -517,7 +517,7 @@ class Route
         return array_values(array_filter(array_map(function ($m) {
             return trim($m, '?');
         }, $matches[1]), function ($parameterName) {
-            return ! array_key_exists($parameterName, $this->defaultParameters);
+            return ! array_key_exists($parameterName, $this->excludedParameters);
         }));
     }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -478,7 +478,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function toRoute($route, $parameters, $absolute)
     {
-        $route->defaultParameters = $this->getDefaultParameters();
+        $route->excludedParameters = $this->getDefaultParameters();
 
         $parameters = collect(Arr::wrap($parameters))->map(function ($value, $key) use ($route) {
             return $value instanceof UrlRoutable && $route->bindingFieldFor($key)

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -478,6 +478,8 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function toRoute($route, $parameters, $absolute)
     {
+        $route->defaultParameters = $this->getDefaultParameters();
+
         $parameters = collect(Arr::wrap($parameters))->map(function ($value, $key) use ($route) {
             return $value instanceof UrlRoutable && $route->bindingFieldFor($key)
                     ? $value->{$route->bindingFieldFor($key)}

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -356,7 +356,6 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/routable', $url->route('routable', [$model], false));
     }
 
-    /** @group Foo */
     public function testRoutableInterfaceRoutingWithCustomBindingField()
     {
         $url = new UrlGenerator(
@@ -375,7 +374,6 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/test-slug', $url->route('routable', ['bar' => $model], false));
     }
 
-    /** @group Foo */
     public function testRoutableInterfaceRoutingWithUrlDefaults()
     {
         $url = new UrlGenerator(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -356,6 +356,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/routable', $url->route('routable', [$model], false));
     }
 
+    /** @group Foo */
     public function testRoutableInterfaceRoutingWithCustomBindingField()
     {
         $url = new UrlGenerator(
@@ -369,8 +370,29 @@ class RoutingUrlGeneratorTest extends TestCase
         $model = new RoutableInterfaceStub;
         $model->key = 'routable';
 
-        $this->assertSame('/foo/test-slug', $url->route('routable', ['bar' => $model], false));
+        $this->assertSame('/foo/test-slug', $url->route('routable', $model, false));
         $this->assertSame('/foo/test-slug', $url->route('routable', [$model], false));
+        $this->assertSame('/foo/test-slug', $url->route('routable', ['bar' => $model], false));
+    }
+
+    /** @group Foo */
+    public function testRoutableInterfaceRoutingWithUrlDefaults()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $url->defaults(['locale' => 'baz']);
+        $route = new Route(['GET'], '{locale}/foo/{bar:slug}', ['as' => 'routable']);
+        $routes->add($route);
+
+        $model = new RoutableInterfaceStub;
+        $model->key = 'routable';
+
+        $this->assertSame('/baz/foo/test-slug', $url->route('routable', $model, false));
+        $this->assertSame('/baz/foo/test-slug', $url->route('routable', [$model], false));
+        $this->assertSame('/baz/foo/test-slug', $url->route('routable', ['bar' => $model], false));
     }
 
     public function testRoutableInterfaceRoutingAsQueryString()


### PR DESCRIPTION
This took me the better part of the day to figure out but I finally found a solution that resolves https://github.com/laravel/framework/issues/42707. After the introduction of https://github.com/laravel/framework/pull/42425 several bugs got introduced as well. This is the last remaining one (we know of so far).

Let me try to explain the reasoning here. In the `compileParameterNames` of the `Route` object we return all parameter names of a route. These are mapped in an index array from 0 to up. Because this method has no knowledge of what a default parameter is it incorrectly matches a default param instead of the correct regular param. What we need to do is filter out the default params here before we try to map the regular passed params that we feed to the `route` method. The `Route` object does not have any knowledge about these so we need to pass in to the route so it can filter the params out. Afterwards we can match our own params properly with the non-default ones.

This fix is a bit of a crutch and I'm not 100% sure it's the correct one but without more examples I cannot make sure it's going to cover all use cases. At least all tests pass now.

Fixes https://github.com/laravel/framework/issues/42707