### PR TITLE
[9.x] Fix undefined constant error when use slot name as key of object

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -460,7 +460,7 @@ class ComponentTagCompiler
         $value = preg_replace_callback($pattern, function ($matches) {
             $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name']);
 
-            if (Str::contains($name, '-') && !empty($matches['inlineName'])) {
+            if (Str::contains($name, '-') && ! empty($matches['inlineName'])) {
                 $name = Str::camel($name);
             }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -460,7 +460,7 @@ class ComponentTagCompiler
         $value = preg_replace_callback($pattern, function ($matches) {
             $name = $this->stripQuotes($matches['inlineName'] ?: $matches['name']);
 
-            if (Str::contains($name, '-')) {
+            if (Str::contains($name, '-') && !empty($matches['inlineName'])) {
                 $name = Str::camel($name);
             }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -44,6 +44,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("@slot(\$foo, null, []) \n".' @endslot', trim($result));
     }
 
+    public function testDynamicSlotsCanBeCompiledWithKeyOfObjects()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot :name="$foo->name">
+</x-slot>');
+
+        $this->assertSame("@slot(\$foo->name, null, []) \n".' @endslot', trim($result));
+    }
+
     public function testSlotsWithAttributesCanBeCompiled()
     {
         $result = $this->compiler()->compileSlots('<x-slot name="foo" class="font-bold">


### PR DESCRIPTION

It's solution for #42932

I've described problem in the issue. 

With 9.15 and after we cannot use `<x-slot :name="$model->name">` because it is rendering as  

`<?php $__env->slot($model>name, null, []); ?>` 

instead 

`<?php $__env->slot($model->name, null, []); ?>`
