### PR TITLE
[8.x] Prevent double throwing chained exception on sync queue

### DIFF
--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -49,6 +49,8 @@ class SyncQueue extends Queue implements QueueContract
             $this->raiseAfterJobEvent($queueJob);
         } catch (Throwable $e) {
             $this->handleException($queueJob, $e);
+        } finally {
+            $this->jobsCount--;
         }
 
         return 0;

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -12,7 +12,7 @@ use Orchestra\Testbench\TestCase;
 
 class JobChainingTest extends TestCase
 {
-    public static $catchCallbackRan = false;
+    public static $catchCallbackCount = 0;
 
     protected function getEnvironmentSetUp($app)
     {
@@ -30,7 +30,6 @@ class JobChainingTest extends TestCase
         JobChainingTestFirstJob::$ran = false;
         JobChainingTestSecondJob::$ran = false;
         JobChainingTestThirdJob::$ran = false;
-        static::$catchCallbackRan = false;
     }
 
     public function testJobsCanBeChainedOnSuccess()
@@ -148,17 +147,54 @@ class JobChainingTest extends TestCase
 
     public function testCatchCallbackIsCalledOnFailure()
     {
+        self::$catchCallbackCount = 0;
+
         Bus::chain([
             new JobChainingTestFirstJob,
             new JobChainingTestFailingJob,
             new JobChainingTestSecondJob,
         ])->catch(static function () {
-            self::$catchCallbackRan = true;
+            self::$catchCallbackCount++;
         })->dispatch();
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);
-        $this->assertTrue(static::$catchCallbackRan);
+        $this->assertSame(1, static::$catchCallbackCount);
         $this->assertFalse(JobChainingTestSecondJob::$ran);
+    }
+
+    public function testCatchCallbackIsCalledOnceOnSyncQueue()
+    {
+        self::$catchCallbackCount = 0;
+
+        try {
+            Bus::chain([
+                new JobChainingTestFirstJob(),
+                new JobChainingTestThrowJob(),
+                new JobChainingTestSecondJob(),
+            ])->catch(function () {
+                self::$catchCallbackCount++;
+            })->onConnection('sync')->dispatch();
+        } finally {
+            $this->assertTrue(JobChainingTestFirstJob::$ran);
+            $this->assertSame(1, static::$catchCallbackCount);
+            $this->assertFalse(JobChainingTestSecondJob::$ran);
+        }
+
+        self::$catchCallbackCount = 0;
+
+        try {
+            Bus::chain([
+                new JobChainingTestFirstJob(),
+                new JobChainingTestThrowJob(),
+                new JobChainingTestSecondJob(),
+            ])->catch(function () {
+                self::$catchCallbackCount++;
+            })->onConnection('sync')->dispatch();
+        } finally {
+            $this->assertTrue(JobChainingTestFirstJob::$ran);
+            $this->assertSame(1, static::$catchCallbackCount);
+            $this->assertFalse(JobChainingTestSecondJob::$ran);
+        }
     }
 
     public function testChainJobsUseSameConfig()
@@ -291,5 +327,15 @@ class JobChainingTestFailingJob implements ShouldQueue
     public function handle()
     {
         $this->fail();
+    }
+}
+
+class JobChainingTestThrowJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function handle()
+    {
+        throw new \Exception();
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #42883

As noted by issue #42883, when a chain of jobs is dispatched and a closure is provided to the chain's `catch` method, if an exception occur, the callback is called multiple times.

For example, consider this code:

~~~php
Bus::chain([
    new TestJob(1),
    new TestJob(2),
    new TestJob(3),
    new TestJob(4, exception: true),
    new TestJob(5),
    new TestJob(6),
    new TestJob(7),
])->catch(function (Throwable $e): void {
    dump('A job within the chain has failed...');
})->onConnection('sync')->dispatch();
~~~

When `new TestJob(4, exception: true)` throws an exception, the call back will be called 4 times, one for each of these job instances:

- `new TestJob(4, exception: true)`
- `new TestJob(3)`
- `new TestJob(2)`
- `new TestJob(1)`

If `new TestJob(4, exception: true)` was defined further down on the chain, the callback would be called more times, and vice-versa.

This happens as each job in the `sync` queue is executed in the same PHP process, so when the next job is dispatched it is actually "called" within the same execution call stack. 

Thus when an exception is thrown the exception triggers the `SyncQueue` exception handler multiple times, one for each job awaiting the execution call stack to complete.

This PR

- Adds an instance property to `SyncQueue` to track how many jobs were already pushed within its execution call stack
- Adds a guard to `SyncQueue@handleException` method, to ensure the handler is called only once for that execution call stack
- Adds a test case which fails without this PR's code 

