### PR TITLE
[9.x] Add `CREATE LIKE` grammar for MySQL and Postgres

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -280,6 +280,16 @@ class Blueprint
     }
 
     /**
+     * Indicate that the table needs to be created from an existing table.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function createLike($fromTable)
+    {
+        return $this->addCommand('createLike', compact('fromTable'));
+    }
+
+    /**
      * Indicate that the table needs to be temporary.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -258,6 +258,21 @@ class Builder
     }
 
     /**
+     * Create a new table on the schema after an existing table.
+     *
+     * @param  string  $table
+     * @param  string  $fromTable
+     * @return void
+     */
+    public function createLike($table, $fromTable)
+    {
+        $this->build(tap(
+            $this->createBlueprint($table),
+            fn ($blueprint) => $blueprint->createLike($fromTable))
+        );
+    }
+
+    /**
      * Drop a table from the schema.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -124,6 +124,23 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile a create table like command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string
+     */
+    public function compileCreateLike(Blueprint $blueprint, Fluent $command, Connection $connection)
+    {
+        return trim(sprintf('%s table %s LIKE %s',
+            $blueprint->temporary ? 'create temporary' : 'create',
+            $this->wrapTable($blueprint),
+            $this->wrapTable($command->fromTable)
+        ));
+    }
+
+    /**
      * Append the character set specifications to a command.
      *
      * @param  string  $sql

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 
@@ -99,6 +100,22 @@ class PostgresGrammar extends Grammar
             $this->wrapTable($blueprint),
             implode(', ', $this->getColumns($blueprint))
         )], $this->compileAutoIncrementStartingValues($blueprint))));
+    }
+
+    /**
+     * Compile a create table like command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileCreateLike(Blueprint $blueprint, Fluent $command)
+    {
+        return trim(sprintf('%s table %s LIKE %s',
+            $blueprint->temporary ? 'create temporary' : 'create',
+            $this->wrapTable($blueprint),
+            $this->wrapTable($command->fromTable)
+        ));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
-use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -47,6 +47,20 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
     }
 
+    public function testBasicCreateTableLike()
+    {
+        $blueprint = new Blueprint('users2');
+        $blueprint->createLike('users');
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table `users2` LIKE `users`', $statements[0]);
+    }
+
     public function testAutoIncrementStartingValue()
     {
         $blueprint = new Blueprint('users');
@@ -165,6 +179,21 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+    }
+
+    public function testCreateTemporaryTableLike()
+    {
+        $blueprint = new Blueprint('temp_users');
+        $blueprint->createLike('users');
+        $blueprint->temporary();
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->andReturn(null);
+
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create temporary table `temp_users` LIKE `users`', $statements[0]);
     }
 
     public function testDropTable()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -38,6 +38,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "id" serial primary key not null, add column "email" varchar(255) not null', $statements[0]);
     }
 
+    public function testBasicCreateTableLike()
+    {
+        $blueprint = new Blueprint('users2');
+        $blueprint->createLike('users');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table "users2" LIKE "users"', $statements[0]);
+    }
+
     public function testCreateTableWithAutoIncrementStartingValue()
     {
         $blueprint = new Blueprint('users');
@@ -76,6 +87,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('create temporary table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+    }
+
+    public function testCreateTemporaryTableLike()
+    {
+        $blueprint = new Blueprint('temp_users');
+        $blueprint->createLike('users');
+        $blueprint->temporary();
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create temporary table "temp_users" LIKE "users"', $statements[0]);
     }
 
     public function testDropTable()


### PR DESCRIPTION
This PR adds support for the `CREATE LIKE` syntax for both MySQL and PostgreSQL.

The CREATE LIKE syntax in MySQL and PostgreSQL creates a copy of an existing table schema.
This PR allows to create a copy of the users table into users2 by executing:

```php
Schema::createLike(table: 'users2', fromTable: 'users')
```

Currently, raw statements have to be issued to achieve the same, e.g.
```php
DB::statement('CREATE TABLE `users2` LIKE `users`')
```

### Partial PostgreSQL Support

PostgreSQL supports options allowing for the inclusion or exclusion of copied features like comments, constraints etc. By default, none of the features will be copied to the new table. I decided to keep the implementation minimal for now, but it looks like it would be a good idea to include these options for PostgreSQL because I suppose it is desirable to keep some of the features on schema copies.

I'm open for opinions. @tpetry ?

### SQL Server Support

While it seems to be possible to achieve a similar effect with `SELECT top 0 * INTO users2 FROM users` in SQL Server, I decided not to implement this because it does not have native support and I could not test the implementation.

### SQLite Support

SQLite does not have native support for copying table schemas either. `CREATE TABLE users2 AS SELECT * FROM users WHERE 0` can be used to create a copy, but only basic type information is retained.