### PR TITLE
[9.x] Adds a new `ordinal` method to Str and Stringable classes

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -642,9 +642,10 @@ class Str
      * Generate an ordinal suffix for the given value.
      *
      * @param  int  $value
+     * @param  bool  $superscript
      * @return string
      */
-    public static function ordinal($value)
+    public static function ordinal($value, $superscript = false)
     {
         if (! is_numeric($value)) {
             return '';
@@ -654,10 +655,10 @@ class Str
 
         $indicators = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th'];
 
-        $suffix = $indicators[$value % 10];
+        $suffix = $superscript ? '<sup>' . $indicators[$value % 10] . '</sup>' : $indicators[$value % 10];
 
         if ($value % 100 >= 11 && $value % 100 <= 13) {
-            $suffix = 'th';
+            $suffix = $superscript ? '<sup>th</sup>' : 'th';
         }
 
         return number_format($value).$suffix;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -638,6 +638,32 @@ class Str
         return Pluralizer::plural($value, $count);
     }
 
+
+    /**
+     * Generate an ordinal suffix for the given value.
+     *
+     * @param  int  $value
+     * @return string
+     */
+    public static function ordinal($value)
+    {
+        if (! is_numeric($value)) {
+            return "";
+        }
+
+        $value = abs($value);
+
+        $indicators = ['th','st','nd','rd','th','th','th','th','th','th'];
+
+        $suffix = $indicators[$value % 10];
+
+        if ($value % 100 >= 11 && $value % 100 <= 13) {
+            $suffix = 'th';
+        }
+
+        return number_format($value) . $suffix;
+    }
+
     /**
      * Pluralize the last word of an English, studly caps case string.
      *

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -638,7 +638,6 @@ class Str
         return Pluralizer::plural($value, $count);
     }
 
-
     /**
      * Generate an ordinal suffix for the given value.
      *
@@ -648,12 +647,12 @@ class Str
     public static function ordinal($value)
     {
         if (! is_numeric($value)) {
-            return "";
+            return '';
         }
 
         $value = abs($value);
 
-        $indicators = ['th','st','nd','rd','th','th','th','th','th','th'];
+        $indicators = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th'];
 
         $suffix = $indicators[$value % 10];
 
@@ -661,7 +660,7 @@ class Str
             $suffix = 'th';
         }
 
-        return number_format($value) . $suffix;
+        return number_format($value).$suffix;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -655,7 +655,7 @@ class Str
 
         $indicators = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th'];
 
-        $suffix = $superscript ? '<sup>' . $indicators[$value % 10] . '</sup>' : $indicators[$value % 10];
+        $suffix = $superscript ? '<sup>'.$indicators[$value % 10].'</sup>' : $indicators[$value % 10];
 
         if ($value % 100 >= 11 && $value % 100 <= 13) {
             $suffix = $superscript ? '<sup>th</sup>' : 'th';

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -510,11 +510,12 @@ class Stringable implements JsonSerializable
     /**
      * Generate an ordinal suffix for the given value.
      *
-     * @return string
+     * @param  bool $superscript
+     * @return static
      */
-    public function ordinal()
+    public function ordinal($superscript = false)
     {
-        return new static(Str::ordinal($this->value));
+        return new static(Str::ordinal($this->value, $superscript));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -517,7 +517,6 @@ class Stringable implements JsonSerializable
         return new static(Str::ordinal($this->value));
     }
 
-
     /**
      * Pluralize the last word of an English, studly caps case string.
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -508,6 +508,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Generate an ordinal suffix for the given value.
+     *
+     * @return string
+     */
+    public function ordinal()
+    {
+        return new static(Str::ordinal($this->value));
+    }
+
+
+    /**
      * Pluralize the last word of an English, studly caps case string.
      *
      * @param  int  $count

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -510,7 +510,7 @@ class Stringable implements JsonSerializable
     /**
      * Generate an ordinal suffix for the given value.
      *
-     * @param  bool $superscript
+     * @param  bool  $superscript
      * @return static
      */
     public function ordinal($superscript = false)

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -70,6 +70,17 @@ class SupportStringableTest extends TestCase
         $this->assertSame('LaraCons', (string) $this->stringable('LaraCon')->pluralStudly(-2));
     }
 
+    public function testOrdinal()
+    {
+        $this->assertSame('1st', (string) $this->stringable(1)->ordinal());
+        $this->assertSame('2nd', (string) $this->stringable(2)->ordinal());
+        $this->assertSame('3rd', (string) $this->stringable(3)->ordinal());
+        $this->assertSame('4th', (string) $this->stringable(4)->ordinal());
+        $this->assertSame('5th', (string) $this->stringable(5)->ordinal());
+        $this->assertSame('101st', (string) $this->stringable(101)->ordinal());
+        $this->assertSame('512th', (string) $this->stringable(512)->ordinal());
+    }
+
     public function testMatch()
     {
         $stringable = $this->stringable('foo bar');

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -73,12 +73,19 @@ class SupportStringableTest extends TestCase
     public function testOrdinal()
     {
         $this->assertSame('1st', (string) $this->stringable(1)->ordinal());
+        $this->assertSame('1<sup>st</sup>', (string) $this->stringable(1)->ordinal(true));
         $this->assertSame('2nd', (string) $this->stringable(2)->ordinal());
+        $this->assertSame('2<sup>nd</sup>', (string) $this->stringable(2)->ordinal(true));
         $this->assertSame('3rd', (string) $this->stringable(3)->ordinal());
+        $this->assertSame('3<sup>rd</sup>', (string) $this->stringable(3)->ordinal(true));
         $this->assertSame('4th', (string) $this->stringable(4)->ordinal());
+        $this->assertSame('4<sup>th</sup>', (string) $this->stringable(4)->ordinal(true));
         $this->assertSame('5th', (string) $this->stringable(5)->ordinal());
+        $this->assertSame('5<sup>th</sup>', (string) $this->stringable(5)->ordinal(true));
         $this->assertSame('101st', (string) $this->stringable(101)->ordinal());
+        $this->assertSame('101<sup>st</sup>', (string) $this->stringable(101)->ordinal(true));
         $this->assertSame('512th', (string) $this->stringable(512)->ordinal());
+        $this->assertSame('512<sup>th</sup>', (string) $this->stringable(512)->ordinal(true));
     }
 
     public function testMatch()


### PR DESCRIPTION
This PR adds a new `ordinal` method to the Str and Stringable classes.

I'm building an application where I need to display a certain user's position in a ranking and I found that there is no built-in method to do this. I could easily create a function in my own app to do this, but I think it would be useful to have this available in the Str/Stringable classes.