### PR TITLE
* Fixed data_get default value bug

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -68,7 +68,7 @@ if (! function_exists('data_get')) {
                 $result = [];
 
                 foreach ($target as $item) {
-                    $result[] = data_get($item, $key);
+                    $result[] = data_get($item, $key, $default);
                 }
 
                 return in_array('*', $key) ? Arr::collapse($result) : $result;


### PR DESCRIPTION
Currently the function will only return default value for the parameter $default. This fix corrects the issue on * segments and will now return the value specified in $default.