### PR TITLE
[8.x] Handle cursor paginator when no items are found

### DIFF
--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -155,6 +155,10 @@ abstract class AbstractCursorPaginator implements Htmlable
             return null;
         }
 
+        if ($this->items->isEmpty()) {
+            return null;
+        }
+
         return $this->getCursorForItem($this->items->first(), false);
     }
 
@@ -167,6 +171,10 @@ abstract class AbstractCursorPaginator implements Htmlable
     {
         if ((is_null($this->cursor) && ! $this->hasMore) ||
             (! is_null($this->cursor) && $this->cursor->pointsToNextItems() && ! $this->hasMore)) {
+            return null;
+        }
+
+        if ($this->items->isEmpty()) {
             return null;
         }
 

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Pagination;
 
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class CursorPaginatorTest extends TestCase
@@ -74,6 +75,26 @@ class CursorPaginatorTest extends TestCase
 
         $this->assertInstanceOf(CursorPaginator::class, $p);
         $this->assertSame([['id' => 6], ['id' => 7]], $p->items());
+    }
+
+    public function testReturnEmptyCursorWhenItemsAreEmpty()
+    {
+        $cursor = new Cursor(['id' => 25], true);
+
+        $p = new CursorPaginator(Collection::make(), 25, $cursor, [
+            'path' => 'http://website.com/test',
+            'cursorName' => 'cursor',
+            'parameters' => ['id']
+        ]);
+
+        $this->assertInstanceOf(CursorPaginator::class, $p);
+        $this->assertSame([
+            'data' => [],
+            'path' => 'http://website.com/test',
+            'per_page' => 25,
+            'next_page_url' => null,
+            'prev_page_url' => null,
+        ], $p->toArray());
     }
 
     protected function getCursor($params, $isNext = true)

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -84,7 +84,7 @@ class CursorPaginatorTest extends TestCase
         $p = new CursorPaginator(Collection::make(), 25, $cursor, [
             'path' => 'http://website.com/test',
             'cursorName' => 'cursor',
-            'parameters' => ['id']
+            'parameters' => ['id'],
         ]);
 
         $this->assertInstanceOf(CursorPaginator::class, $p);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #42962 

As noted by issue #42962, if the user has a link to a next, or previous page from a pagination using cursor pagination, accessing this URL throws an exception when no items are found.

This PR:

- Modifies `AbstractCursorPaginator@previousCursor` and `AbstractCursorPaginator@nextCursor` methods to check if the `$items` collection is empty, and if so early returning `null` before trying to build their respective `Cursor` instances
- Add a test case that would fail without the this PR's proposed changes

