### PR TITLE
[9.x] Fix ProhibitedIf docblock and constructor

### DIFF
--- a/src/Illuminate/Validation/Rules/ExcludeIf.php
+++ b/src/Illuminate/Validation/Rules/ExcludeIf.php
@@ -10,7 +10,7 @@ class ExcludeIf
     /**
      * The condition that validates the attribute.
      *
-     * @var callable|bool
+     * @var \Closure|bool
      */
     public $condition;
 

--- a/src/Illuminate/Validation/Rules/ProhibitedIf.php
+++ b/src/Illuminate/Validation/Rules/ProhibitedIf.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation\Rules;
 
+use Closure;
 use InvalidArgumentException;
 
 class ProhibitedIf
@@ -9,19 +10,21 @@ class ProhibitedIf
     /**
      * The condition that validates the attribute.
      *
-     * @var callable|bool
+     * @var \Closure|bool
      */
     public $condition;
 
     /**
      * Create a new prohibited validation rule based on a condition.
      *
-     * @param  callable|bool  $condition
+     * @param  \Closure|bool  $condition
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($condition)
     {
-        if (! is_string($condition)) {
+        if ($condition instanceof Closure || is_bool($condition)) {
             $this->condition = $condition;
         } else {
             throw new InvalidArgumentException('The provided condition must be a callable or boolean.');

--- a/tests/Validation/ValidationProhibitedIfTest.php
+++ b/tests/Validation/ValidationProhibitedIfTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class ValidationProhibitedIfTest extends TestCase
 {
@@ -38,9 +39,14 @@ class ValidationProhibitedIfTest extends TestCase
 
         $rule = new ProhibitedIf(true);
 
-        $this->expectException(InvalidArgumentException::class);
-
-        $rule = new ProhibitedIf('phpinfo');
+        foreach ([1, 1.1, 'phpinfo', new stdClass] as $condition) {
+            try {
+                $rule = new ProhibitedIf($condition);
+                $this->fail('The ProhibitedIf constructor must not accept '.gettype($condition));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertEquals('The provided condition must be a callable or boolean.', $exception->getMessage());
+            }
+        }
     }
 
     public function testItReturnedRuleIsNotSerializable()


### PR DESCRIPTION
This applies the same fixes to ProhibitedIf as ExcludeIf.
- Add missing `@throws` declaration in docblock: https://github.com/laravel/framework/pull/41729
- Enforces a `boolean` in the constructor: https://github.com/laravel/framework/pull/41931 https://github.com/laravel/framework/pull/41969

Also, fixes the ExcludeIf `@var` docblock to match its constructor as a `\Closure`. This will make both classes uniformed.
