### PR TITLE
[9.x] allow dot symbol (.) in database connection when using Unique/Exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v9.18.0...9.x)
 
+### Fixed
+- allow dot symbol (.) in database connection when using Unique/Exists Rule (#xxxxx](---))
 
 ## [v9.18.0](https://github.com/laravel/framework/compare/v9.17.0...v9.18.0) - 2022-06-21
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -916,7 +916,9 @@ trait ValidatesAttributes
      */
     public function parseTable($table)
     {
-        [$connection, $table] = str_contains($table, '.') ? explode('.', $table, 2) : [null, $table];
+        [$connection, $table] = str_contains($table, '.')
+            ? [substr($table, 0, strrpos($table, '.')), substr($table, strrpos($table, '.') + 1)]
+            : [null, $table];
 
         if (str_contains($table, '\\') && class_exists($table) && is_a($table, Model::class, true)) {
             $model = new $table;


### PR DESCRIPTION
Scenario: a database connection with a dot (.) symbol like: `mysql_tunnel_to_192.168.10.10`.

Assuming the following rule: `'email' => 'required|email|unique:mysql_tunnel_to_192.168.10.10.users'`

Before this fix, Unique/Exists Validators will extract:

connection: `mysql_tunnel_to_192.`
table: `168.10.10`

which is wrong. With this fix, 

connection: `mysql_tunnel_to_192.168.10.10`
table: `168.10.10`

is being extracted which is correct.
If this is too hacky or you have an better idea, i suggest to throw an exception when a developer attempts to create a database connection with a dot in it. It can lead to unexpected behavior.

Thanks a lot !