### PR TITLE
[9.x] Add class support for console routing

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,17 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.83.16...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.83.17...8.x)
+
+
+## [v8.83.17 (2022-06-21)](https://github.com/laravel/framework/compare/v8.83.16...v8.83.17)
+
+### Added
+- Apply where's from union query builder in cursor pagination ([#42651](https://github.com/laravel/framework/pull/42651))
+- Handle collection creation around a single enum ([#42839](https://github.com/laravel/framework/pull/42839))
+
+### Fixed
+- Fixed Request offsetExists without routeResolver ([#42754](https://github.com/laravel/framework/pull/42754))
+- Fixed: Loose comparison causes the value not to be saved ([#42793](https://github.com/laravel/framework/pull/42793))
 
 
 ## [v8.83.16 (2022-06-07)](https://github.com/laravel/framework/compare/v8.83.15...v8.83.16)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,14 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.83.17...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.83.18...8.x)
+
+
+## [v8.83.18 (2022-06-28)](https://github.com/laravel/framework/compare/v8.83.17...v8.83.18)
+
+### Fixed
+- Fixed bug on forceCreate on a MorphMay relationship not including morph type ([#42929](https://github.com/laravel/framework/pull/42929))
+- Handle cursor paginator when no items are found ([#42963](https://github.com/laravel/framework/pull/42963))
+- Fixed Str::Mask() for repeating chars ([#42956](https://github.com/laravel/framework/pull/42956))
 
 
 ## [v8.83.17 (2022-06-21)](https://github.com/laravel/framework/compare/v8.83.16...v8.83.17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Release Notes for 9.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.18.0...9.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.19.0...9.x)
+
+
+## [v9.19.0](https://github.com/laravel/framework/compare/v9.18.0...v9.19.0) - 2022-06-28
+
+### Added
+- Add new allowMaxRedirects method to PendingRequest ([#42902](https://github.com/laravel/framework/pull/42902))
+- Add support to detect dirty encrypted model attributes ([#42888](https://github.com/laravel/framework/pull/42888))
+- Added Vite ([#42785](https://github.com/laravel/framework/pull/42785))
+
+### Fixed
+- Fixed bug on forceCreate on a MorphMay relationship not including morph type ([#42929](https://github.com/laravel/framework/pull/42929))
+- Fix default parameter bug in routes ([#42942](https://github.com/laravel/framework/pull/42942))
+- Handle cursor paginator when no items are found ([#42963](https://github.com/laravel/framework/pull/42963))
+- Fixed Str::Mask() for repeating chars ([#42956](https://github.com/laravel/framework/pull/42956))
+- Fix undefined constant error when use slot name as key of object ([#42943](https://github.com/laravel/framework/pull/42943))
+- Fix BC break for Log feature tests ([#42987](https://github.com/laravel/framework/pull/42987))
+
+### Changed
+- Allow instance of Enum pass Enum Rule ([#42906](https://github.com/laravel/framework/pull/42906))
 
 
 ## [v9.18.0](https://github.com/laravel/framework/compare/v9.17.0...v9.18.0) - 2022-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - Fixed bug on forceCreate on a MorphMay relationship not including morph type ([#42929](https://github.com/laravel/framework/pull/42929))
 - Fix default parameter bug in routes ([#42942](https://github.com/laravel/framework/pull/42942))
 - Handle cursor paginator when no items are found ([#42963](https://github.com/laravel/framework/pull/42963))
-- Fixed Str::Mask() for repeating chars ([#42956](https://github.com/laravel/framework/pull/42956))
 - Fix undefined constant error when use slot name as key of object ([#42943](https://github.com/laravel/framework/pull/42943))
 - Fix BC break for Log feature tests ([#42987](https://github.com/laravel/framework/pull/42987))
 

--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -15,6 +15,13 @@ class AuthorizationException extends Exception
     protected $response;
 
     /**
+     * The HTTP response status code.
+     *
+     * @var int|null
+     */
+    protected $status;
+
+    /**
      * Create a new authorization exception instance.
      *
      * @param  string|null  $message
@@ -53,12 +60,55 @@ class AuthorizationException extends Exception
     }
 
     /**
+     * Set the HTTP response status code.
+     *
+     * @param  int|null  $status
+     * @return $this
+     */
+    public function withStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Set the HTTP response status code to 404.
+     *
+     * @return $this
+     */
+    public function asNotFound()
+    {
+        return $this->withStatus(404);
+    }
+
+    /**
+     * Determine if the HTTP status code has been set.
+     *
+     * @return bool
+     */
+    public function hasStatus()
+    {
+        return $this->status !== null;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return int|null
+     */
+    public function status()
+    {
+        return $this->status;
+    }
+
+    /**
      * Create a deny response object from this exception.
      *
      * @return \Illuminate\Auth\Access\Response
      */
     public function toResponse()
     {
-        return Response::deny($this->message, $this->code);
+        return Response::deny($this->message, $this->code)->withStatus($this->status);
     }
 }

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -4,6 +4,7 @@ namespace Illuminate\Auth\Access;
 
 use Closure;
 use Exception;
+use Illuminate\Auth\Access\Events\GateEvaluated;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -592,7 +593,7 @@ class Gate implements GateContract
     {
         if ($this->container->bound(Dispatcher::class)) {
             $this->container->make(Dispatcher::class)->dispatch(
-                new Events\GateEvaluated($user, $ability, $result, $arguments)
+                new GateEvaluated($user, $ability, $result, $arguments)
             );
         }
     }

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -27,4 +27,29 @@ trait HandlesAuthorization
     {
         return Response::deny($message, $code);
     }
+
+    /**
+     * Deny with a HTTP status code.
+     *
+     * @param  int  $status
+     * @param  ?string  $message
+     * @param  ?int  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function denyWithStatus($status, $message = null, $code = null)
+    {
+        return Response::denyWithStatus($status, $message, $code);
+    }
+
+    /**
+     * Deny with a 404 HTTP status code.
+     *
+     * @param  ?string  $message
+     * @param  ?int  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function denyAsNotFound($message = null, $code = null)
+    {
+        return Response::denyWithStatus(404, $message, $code);
+    }
 }

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -28,6 +28,13 @@ class Response implements Arrayable
     protected $code;
 
     /**
+     * The HTTP response status code.
+     *
+     * @var int|null
+     */
+    protected $status;
+
+    /**
      * Create a new response.
      *
      * @param  bool  $allowed
@@ -64,6 +71,31 @@ class Response implements Arrayable
     public static function deny($message = null, $code = null)
     {
         return new static(false, $message, $code);
+    }
+
+    /**
+     * Create a new "deny" Response with a HTTP status code.
+     *
+     * @param  int  $status
+     * @param  string|null  $message
+     * @param  mixed  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public static function denyWithStatus($status, $message = null, $code = null)
+    {
+        return static::deny($message, $code)->withStatus($status);
+    }
+
+    /**
+     * Create a new "deny" Response with a 404 HTTP status code.
+     *
+     * @param  string|null  $message
+     * @param  mixed  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public static function denyAsNotFound($message = null, $code = null)
+    {
+        return static::denyWithStatus(404, $message, $code);
     }
 
     /**
@@ -117,10 +149,44 @@ class Response implements Arrayable
     {
         if ($this->denied()) {
             throw (new AuthorizationException($this->message(), $this->code()))
-                        ->setResponse($this);
+                ->setResponse($this)
+                ->withStatus($this->status);
         }
 
         return $this;
+    }
+
+    /**
+     * Set the HTTP response status code.
+     *
+     * @param  null|int  $status
+     * @return $this
+     */
+    public function withStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Set the HTTP response status code to 404.
+     *
+     * @return $this
+     */
+    public function asNotFound()
+    {
+        return $this->withStatus(404);
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return int|null
+     */
+    public function status()
+    {
+        return $this->status;
     }
 
     /**

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -510,7 +510,7 @@ class Arr
      * Get a value from the array, and remove it.
      *
      * @param  array  $array
-     * @param  string  $key
+     * @param  string|int  $key
      * @param  mixed  $default
      * @return mixed
      */

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -978,7 +978,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get one or a specified number of items randomly from the collection.
      *
-     * @param  int|null  $number
+     * @param  (callable(TValue): int)|int|null  $number
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException
@@ -987,6 +987,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         if (is_null($number)) {
             return Arr::random($this->items);
+        }
+
+        if (is_callable($number)) {
+            return new static(Arr::random($this->items, $number($this)));
         }
 
         return new static(Arr::random($this->items, $number));

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -351,7 +351,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function sortImports($stub)
     {
-        if (preg_match('/(?P<imports>(?:use [^;]+;$\n?)+)/m', $stub, $match)) {
+        if (preg_match('/(?P<imports>(?:use [^;{]+;$\n?)+)/m', $stub, $match)) {
             $imports = explode("\n", trim($match['imports']));
 
             sort($imports);

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -295,7 +295,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Determine if a key exists in the collection.
      *
-     * @param  (callable(TModel, TKey): bool)|TModel|string  $key
+     * @param  (callable(TModel, TKey): bool)|TModel|string|int  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1858,7 +1858,7 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the model or any of the given attribute(s) have been modified.
+     * Determine if the model or any of the given attribute(s) were changed when the model was last saved.
      *
      * @param  array|string|null  $attributes
      * @return bool
@@ -1871,7 +1871,7 @@ trait HasAttributes
     }
 
     /**
-     * Determine if any of the given attributes were changed.
+     * Determine if any of the given attributes were changed when the model was last saved.
      *
      * @param  array  $changes
      * @param  array|string|null  $attributes
@@ -1917,7 +1917,7 @@ trait HasAttributes
     }
 
     /**
-     * Get the attributes that were changed.
+     * Get the attributes that were changed when the model was last saved.
      *
      * @return array
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1620,6 +1620,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Clone the model into a new, non-existing instance without raising any events.
+     *
+     * @param  array|null  $except
+     * @return static
+     */
+    public function replicateQuietly(array $except = null)
+    {
+        return static::withoutEvents(function () use ($except) {
+            return $this->replicate($except);
+        });
+    }
+
+    /**
      * Determine if two models have the same ID and belong to the same table.
      *
      * @param  \Illuminate\Database\Eloquent\Model|null  $model

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -57,6 +57,6 @@ class MorphMany extends MorphOneOrMany
     {
         $attributes[$this->getMorphType()] = $this->morphClass;
 
-        parent::forceCreate($attributes);
+        return parent::forceCreate($attributes);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -46,4 +46,15 @@ class MorphMany extends MorphOneOrMany
     {
         return $this->matchMany($models, $results, $relation);
     }
+
+    /**
+     * Create a new instance of the related model. Allow mass-assignment.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function forceCreate(array $attributes = []) {
+        $attributes[$this->getMorphType()] = $this->morphClass;
+        parent::forceCreate($attributes);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -53,7 +53,7 @@ class MorphMany extends MorphOneOrMany
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate(array $attributes = []) 
+    public function forceCreate(array $attributes = [])
     {
         $attributes[$this->getMorphType()] = $this->morphClass;
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -56,6 +56,7 @@ class MorphMany extends MorphOneOrMany
     public function forceCreate(array $attributes = []) 
     {
         $attributes[$this->getMorphType()] = $this->morphClass;
+
         parent::forceCreate($attributes);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -53,7 +53,8 @@ class MorphMany extends MorphOneOrMany
      * @param  array  $attributes
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function forceCreate(array $attributes = []) {
+    public function forceCreate(array $attributes = []) 
+    {
         $attributes[$this->getMorphType()] = $this->morphClass;
         parent::forceCreate($attributes);
     }

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -85,10 +85,10 @@ class MySqlSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
+        $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
 
         if (! $this->connection->isMaria()) {
-            $command .= ' --column-statistics=0 --set-gtid-purged=OFF';
+            $command .= ' --set-gtid-purged=OFF';
         }
 
         return $command.' "${:LARAVEL_LOAD_DATABASE}"';

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.83.18';
+    const VERSION = '8.83.19';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.83.17';
+    const VERSION = '8.83.18';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Console/CallableCommand.php
+++ b/src/Illuminate/Foundation/Console/CallableCommand.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Closure;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\SerializableClosure\SerializableClosure;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CallableCommand extends Command
+{
+    /**
+     * The command callback.
+     *
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * The callable object.
+     */
+    protected $callableInstance;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  string  $signature
+     * @param  callable  $callback
+     * @return void
+     */
+    public function __construct($signature, $callable)
+    {
+        $this->callback = is_array($callable)
+            ? [$callable[0] ?? null, $callable[1] ?? '__invoke']
+            : Str::parseCallback($callable, '__invoke');
+
+        $this->signature = $signature;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $inputs = array_merge($input->getArguments(), $input->getOptions());
+
+        $parameters = [];
+
+        [$object, $method] = $this->callback;
+
+        foreach ((new ReflectionMethod($object, $method))->getParameters() as $parameter) {
+            if (isset($inputs[$parameter->getName()])) {
+                $parameters[$parameter->getName()] = $inputs[$parameter->getName()];
+            }
+        }
+
+        $this->callableInstance = is_string($object)
+            ? $this->laravel->make($object)
+            : $object;
+
+        $closure = unserialize(serialize(new SerializableClosure(
+            Closure::fromCallable([$this->callableInstance, $method])
+        )))->getClosure();
+
+        return $this->laravel->call(
+            $closure->bindTo($this, $this->callableInstance), $parameters
+        );
+    }
+
+    /**
+     * Set the description for the command.
+     *
+     * @param  string  $description
+     * @return $this
+     */
+    public function purpose($description)
+    {
+        return $this->describe($description);
+    }
+
+    /**
+     * Set the description for the command.
+     *
+     * @param  string  $description
+     * @return $this
+     */
+    public function describe($description)
+    {
+        $this->setDescription($description);
+
+        return $this;
+    }
+
+    /**
+     * Forward property access to underlying callable.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->callableInstance->$key;
+    }
+
+    /**
+     * Dynamically set properties on the underlying callable.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        $this->callableInstance->$key = $value;
+    }
+
+    /**
+     * Handle dynamic method calls into the underlying callable.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->callableInstance->$method(...$parameters);
+    }
+
+    /**
+     * Handle dynamic static method calls into the underlying callable.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        $className = get_class($this->callableInstance);
+
+        return $className::$method(...$parameters);
+    }
+}

--- a/src/Illuminate/Foundation/Console/CallableCommand.php
+++ b/src/Illuminate/Foundation/Console/CallableCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Closure;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Laravel\SerializableClosure\SerializableClosure;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CallableCommand extends Command
+{
+    /**
+     * The command callback.
+     *
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * The callable object.
+     */
+    protected $callableInstance;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  string  $signature
+     * @param  callable  $callback
+     * @return void
+     */
+    public function __construct($signature, $callable)
+    {
+        $this->callback = is_array($callable)
+            ? [$callable[0] ?? null, $callable[1] ?? '__invoke']
+            : Str::parseCallback($callable, '__invoke');
+
+        $this->signature = $signature;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $inputs = array_merge($input->getArguments(), $input->getOptions());
+
+        $parameters = [];
+
+        [$object, $method] = $this->callback;
+
+        foreach ((new ReflectionMethod($object, $method))->getParameters() as $parameter) {
+            if (isset($inputs[$parameter->getName()])) {
+                $parameters[$parameter->getName()] = $inputs[$parameter->getName()];
+            }
+        }
+
+        $this->callableInstance = is_string($object)
+            ? $this->laravel->make($object)
+            : $object;
+
+        $closure = unserialize(serialize(new SerializableClosure(
+            Closure::fromCallable([$this->callableInstance, $method])
+        )))->getClosure();
+
+        return $this->laravel->call(
+            $closure->bindTo($this, $this->callableInstance), $parameters
+        );
+    }
+
+    /**
+     * Set the description for the command.
+     *
+     * @param  string  $description
+     * @return $this
+     */
+    public function purpose($description)
+    {
+        return $this->describe($description);
+    }
+
+    /**
+     * Set the description for the command.
+     *
+     * @param  string  $description
+     * @return $this
+     */
+    public function describe($description)
+    {
+        $this->setDescription($description);
+
+        return $this;
+    }
+
+    /**
+     * Forward property access to underlying callable.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->callableInstance->$key;
+    }
+
+    /**
+     * Dynamically set properties on the underlying callable.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        $this->callableInstance->$key = $value;
+    }
+
+    /**
+     * Handle dynamic method calls into the underlying callable.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->callableInstance->$method(...$parameters);
+    }
+}

--- a/src/Illuminate/Foundation/Console/CallableCommand.php
+++ b/src/Illuminate/Foundation/Console/CallableCommand.php
@@ -134,18 +134,4 @@ class CallableCommand extends Command
     {
         return $this->callableInstance->$method(...$parameters);
     }
-
-    /**
-     * Handle dynamic static method calls into the underlying callable.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public static function __callStatic($method, $parameters)
-    {
-        $className = get_class($this->callableInstance);
-
-        return $className::$method(...$parameters);
-    }
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -185,12 +185,14 @@ class Kernel implements KernelContract
      * Register a Closure based command with the application.
      *
      * @param  string  $signature
-     * @param  \Closure  $callback
+     * @param  \Closure|callable  $callback
      * @return \Illuminate\Foundation\Console\ClosureCommand
      */
-    public function command($signature, Closure $callback)
+    public function command($signature, $callback)
     {
-        $command = new ClosureCommand($signature, $callback);
+        $command = $callback instanceof Closure
+            ? new ClosureCommand($signature, $callback)
+            : new CallableCommand($signature, $callback);
 
         Artisan::starting(function ($artisan) use ($command) {
             $artisan->add($command);

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -265,15 +265,15 @@ class Handler implements ExceptionHandlerContract
             $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
         );
 
-        $logger->log(
-            $level,
-            $e->getMessage(),
-            array_merge(
-                $this->exceptionContext($e),
-                $this->context(),
-                ['exception' => $e]
-            )
+        $context = array_merge(
+            $this->exceptionContext($e),
+            $this->context(),
+            ['exception' => $e]
         );
+
+        method_exists($logger, $level)
+            ? $logger->{$level}($e->getMessage(), $context)
+            : $logger->log($level, $e->getMessage(), $context);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -375,7 +375,8 @@ class Handler implements ExceptionHandlerContract
         return match (true) {
             $e instanceof BackedEnumCaseNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
             $e instanceof ModelNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
-            $e instanceof AuthorizationException => new AccessDeniedHttpException($e->getMessage(), $e),
+            $e instanceof AuthorizationException && $e->hasStatus() => new HttpException($e->status(), $e->getMessage(), $e),
+            $e instanceof AuthorizationException && ! $e->hasStatus() => new AccessDeniedHttpException($e->getMessage(), $e),
             $e instanceof TokenMismatchException => new HttpException(419, $e->getMessage(), $e),
             $e instanceof SuspiciousOperationException => new NotFoundHttpException('Bad hostname provided.', $e),
             $e instanceof RecordsNotFoundException => new NotFoundHttpException('Not found.', $e),

--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -92,6 +92,7 @@ class Inspiring
             'Life is available only in the present moment. - Thich Nhat Hanh',
             'The best way to take care of the future is to take care of the present moment. - Thich Nhat Hanh',
             'Nothing in life is to be feared, it is only to be understood. Now is the time to understand more, so that we may fear less. - Marie Curie',
+            'The biggest battle is the war against ignorance. - Mustafa Kemal Atatürk',
         ])->random();
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -109,8 +109,17 @@ trait InteractsWithContainer
             $this->originalVite = app(Vite::class);
         }
 
-        $this->swap(Vite::class, function () {
-            return '';
+        $this->swap(Vite::class, new class
+        {
+            public function __invoke()
+            {
+                return '';
+            }
+
+            public function __call($name, $arguments)
+            {
+                return '';
+            }
         });
 
         return $this;

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -51,8 +51,6 @@ class ResponseSequence
      */
     public function push($body = null, int $status = 200, array $headers = [])
     {
-        $body = is_array($body) ? json_encode($body) : $body;
-
         return $this->pushResponse(
             Factory::response($body, $status, $headers)
         );

--- a/src/Illuminate/Mail/Attachment.php
+++ b/src/Illuminate/Mail/Attachment.php
@@ -97,7 +97,7 @@ class Attachment
                 ->as($attachment->as ?? basename($path))
                 ->withMime($attachment->mime ?? $storage->mimeType($path));
 
-            $dataStrategy(fn () => $storage->get($path), $attachment);
+            return $dataStrategy(fn () => $storage->get($path), $attachment);
         });
     }
 

--- a/src/Illuminate/Pagination/AbstractCursorPaginator.php
+++ b/src/Illuminate/Pagination/AbstractCursorPaginator.php
@@ -155,6 +155,10 @@ abstract class AbstractCursorPaginator implements Htmlable
             return null;
         }
 
+        if ($this->items->isEmpty()) {
+            return null;
+        }
+
         return $this->getCursorForItem($this->items->first(), false);
     }
 
@@ -167,6 +171,10 @@ abstract class AbstractCursorPaginator implements Htmlable
     {
         if ((is_null($this->cursor) && ! $this->hasMore) ||
             (! is_null($this->cursor) && $this->cursor->pointsToNextItems() && ! $this->hasMore)) {
+            return null;
+        }
+
+        if ($this->items->isEmpty()) {
             return null;
         }
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -113,7 +113,7 @@ class CallQueuedHandler
     protected function dispatchThroughMiddleware(Job $job, $command)
     {
         if ($command instanceof \__PHP_Incomplete_Class) {
-            throw new \Exception('Job is incomplete class: '.json_encode($command));
+            throw new Exception('Job is incomplete class: '.json_encode($command));
         }
 
         return (new Pipeline($this->container))->send($command)

--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -8,6 +8,15 @@ use Illuminate\Routing\Exceptions\InvalidSignatureException;
 class ValidateSignature
 {
     /**
+     * The names of the parameters that should be ignored.
+     *
+     * @var array<int, string>
+     */
+    protected $ignore = [
+        //
+    ];
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -19,7 +28,7 @@ class ValidateSignature
      */
     public function handle($request, Closure $next, $relative = null)
     {
-        if ($request->hasValidSignature($relative !== 'relative')) {
+        if ($request->hasValidSignatureWhileIgnoring($this->ignore, $relative !== 'relative')) {
             return $next($request);
         }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -423,7 +423,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $url = $absolute ? $request->url() : '/'.$request->path();
 
-        $queryString = collect(explode('&', $request->server->get('QUERY_STRING')))
+        $queryString = collect(explode('&', (string) $request->server->get('QUERY_STRING')))
             ->reject(fn ($parameter) => in_array(Str::before($parameter, '='), $ignoreQuery))
             ->join('&');
 

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -26,6 +26,7 @@ namespace Illuminate\Support\Facades;
  * @method static string environmentFile()
  * @method static string environmentFilePath()
  * @method static string environmentPath()
+ * @method static void forgetInstance(string $abstract)
  * @method static string getCachedConfigPath()
  * @method static string getCachedPackagesPath()
  * @method static string getCachedRoutesPath()

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -6,6 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Doctrine\DBAL\Driver\PDOConnection getPdo()
  * @method static \Illuminate\Database\ConnectionInterface connection(string $name = null)
  * @method static \Illuminate\Database\Query\Builder table(string $table, string $as = null)
+ * @method static \Illuminate\Database\Query\Builder query()
  * @method static \Illuminate\Database\Query\Expression raw($value)
  * @method static array getQueryLog()
  * @method static array prepareBindings(array $bindings)

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -260,6 +260,10 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      */
     protected function transform($messages, $format, $messageKey)
     {
+        if ($format == ':message') {
+            return (array) $messages;
+        }
+
         return collect((array) $messages)
             ->map(function ($message) use ($format, $messageKey) {
                 // We will simply spin through the given messages and transform each one

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -437,10 +437,18 @@ class Str
             return $string;
         }
 
-        $start = mb_substr($string, 0, mb_strpos($string, $segment, 0, $encoding), $encoding);
-        $end = mb_substr($string, mb_strpos($string, $segment, 0, $encoding) + mb_strlen($segment, $encoding));
+        $strlen = mb_strlen($string, $encoding);
+        $startIndex = $index;
 
-        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), mb_strlen($segment, $encoding)).$end;
+        if ($index < 0) {
+            $startIndex = $index < -$strlen ? 0 : $strlen + $index;
+        }
+
+        $start = mb_substr($string, 0, $startIndex, $encoding);
+        $segmentLen = mb_strlen($segment, $encoding);
+        $end = mb_substr($string, $startIndex + $segmentLen);
+
+        return $start.str_repeat(mb_substr($character, 0, 1, $encoding), $segmentLen).$end;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -5,7 +5,11 @@ namespace Illuminate\Support;
 use Closure;
 use Illuminate\Support\Traits\Macroable;
 use JsonException;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
+use League\CommonMark\MarkdownConverter;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
@@ -499,6 +503,25 @@ class Str
     public static function markdown($string, array $options = [])
     {
         $converter = new GithubFlavoredMarkdownConverter($options);
+
+        return (string) $converter->convert($string);
+    }
+
+    /**
+     * Converts inline Markdown into HTML.
+     *
+     * @param  string  $string
+     * @param  array  $options
+     * @return string
+     */
+    public static function inlineMarkdown($string, array $options = [])
+    {
+        $environment = new Environment($options);
+
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+        $environment->addExtension(new InlinesOnlyExtension());
+
+        $converter = new MarkdownConverter($environment);
 
         return (string) $converter->convert($string);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -224,6 +224,10 @@ class Str
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
+        if (is_null($haystack) || is_null($needles)) {
+            return false;
+        }
+
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', (array) $needles);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -224,10 +224,6 @@ class Str
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
-        if (is_null($haystack) || is_null($needles)) {
-            return false;
-        }
-
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', (array) $needles);

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -392,6 +392,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Convert inline Markdown into HTML.
+     *
+     * @param  array  $options
+     * @return static
+     */
+    public function inlineMarkdown(array $options = [])
+    {
+        return new static(Str::inlineMarkdown($this->value, $options));
+    }
+
+    /**
      * Masks a portion of a string with a repeated character.
      *
      * @param  string  $character

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -339,6 +339,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile a required block into valid PHP.
+     *
+     * @param  string  $condition
+     * @return string
+     */
+    protected function compileRequired($condition)
+    {
+        return "<?php if{$condition}: echo 'required'; endif; ?>";
+    }
+
+    /**
      * Compile a readonly block into valid PHP.
      *
      * @param  string  $condition

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -35,6 +35,82 @@ class AuthAccessResponseTest extends TestCase
         $this->assertNull($response->message());
     }
 
+    public function testItSetsEmptyStatusOnExceptionWhenAuthorizing()
+    {
+        try {
+            Response::deny('foo', 3)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertNull($e->status());
+            $this->assertFalse($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+    }
+
+    public function testItSetsStatusOnExceptionWhenAuthorizing()
+    {
+        try {
+            Response::deny('foo', 3)->withStatus(418)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(418, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+
+        try {
+            Response::deny('foo', 3)->asNotFound()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+
+        try {
+            Response::denyWithStatus(444)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(444, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        try {
+            Response::denyWithStatus(444, 'foo', 3)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(444, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+
+        try {
+            Response::denyAsNotFound()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        try {
+            Response::denyAsNotFound('foo', 3)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+    }
+
     public function testAuthorizeMethodThrowsAuthorizationExceptionWhenResponseDenied()
     {
         $response = Response::deny('Some message.', 'some_code');

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Auth;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use PHPUnit\Framework\TestCase;
 
@@ -27,5 +28,112 @@ class AuthHandlesAuthorizationTest extends TestCase
         $this->assertFalse($response->allowed());
         $this->assertSame('some message', $response->message());
         $this->assertSame('some_code', $response->code());
+    }
+
+    public function testDenyHasNullStatus()
+    {
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->deny('xxxx', 321);
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertFalse($e->hasStatus());
+            $this->assertNull($e->status());
+        }
+    }
+
+    public function testItCanDenyWithStatus()
+    {
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyWithStatus(418);
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(418, $e->status());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyWithStatus(418, 'foo', 3);
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(418, $e->status());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+    }
+
+    public function testItCanDenyAsNotFound()
+    {
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyAsNotFound();
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(404, $e->status());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyAsNotFound('foo', 3);
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(404, $e->status());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
     }
 }

--- a/tests/Conditionable/ConditionableTest.php
+++ b/tests/Conditionable/ConditionableTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Conditionable;
 
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HigherOrderWhenProxy;
 use PHPUnit\Framework\TestCase;
 
 class ConditionableTest extends TestCase
@@ -23,19 +25,19 @@ class ConditionableTest extends TestCase
 
     public function testWhen(): void
     {
-        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, TestConditionableModel::query()->when(true));
-        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, TestConditionableModel::query()->when(false));
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, TestConditionableModel::query()->when(false, null));
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, TestConditionableModel::query()->when(true, function () {
+        $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->when(true));
+        $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->when(false));
+        $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(false, null));
+        $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(true, function () {
         }));
     }
 
     public function testUnless(): void
     {
-        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(true));
-        $this->assertInstanceOf(\Illuminate\Support\HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(false));
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, TestConditionableModel::query()->unless(true, null));
-        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Builder::class, TestConditionableModel::query()->unless(false, function () {
+        $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(true));
+        $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(false));
+        $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(true, null));
+        $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(false, function () {
         }));
     }
 }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use Faker\Generator;
 use Illuminate\Container\Container;
@@ -17,6 +18,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Tests\Database\Fixtures\Models\Money\Price;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class DatabaseEloquentFactoryTest extends TestCase
 {
@@ -443,7 +445,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             ['name' => 'Dayle Rees']
         );
 
-        $class = new \ReflectionClass($factory);
+        $class = new ReflectionClass($factory);
         $prop = $class->getProperty('count');
         $prop->setAccessible(true);
         $value = $prop->getValue($factory);
@@ -622,7 +624,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_dynamic_trashed_state_throws_exception_when_not_a_softdeletes_model()
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         FactoryTestUserFactory::new()->trashed()->create();
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1834,6 +1834,24 @@ class DatabaseEloquentModelTest extends TestCase
         $model->replicate();
     }
 
+    public function testReplicateQuietlyCreatesANewModelInstanceWithSameAttributeValuesAndIsQuiet()
+    {
+        $model = new EloquentModelStub;
+        $model->id = 'id';
+        $model->foo = 'bar';
+        $model->created_at = new DateTime;
+        $model->updated_at = new DateTime;
+        $replicated = $model->replicateQuietly();
+
+        $model->setEventDispatcher($events = m::mock(Dispatcher::class));
+        $events->shouldReceive('dispatch')->never()->with('eloquent.replicating: '.get_class($model), $model)->andReturn(true);
+
+        $this->assertNull($replicated->id);
+        $this->assertSame('bar', $replicated->foo);
+        $this->assertNull($replicated->created_at);
+        $this->assertNull($replicated->updated_at);
+    }
+
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
         $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -94,6 +94,15 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
         $this->assertSame('active', $product->current_state->state);
     }
 
+    public function testForceCreateMorphType()
+    {
+        $product = MorphOneOfManyTestProduct::create();
+        $product->states()->forceCreate([
+            'state' => 'active',
+        ]);
+        $this->assertSame(MorphOneOfManyTestProduct::class, $product->current_state->stateful_type);
+    }
+
     public function testExists()
     {
         $product = MorphOneOfManyTestProduct::create();

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -97,9 +97,11 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
     public function testForceCreateMorphType()
     {
         $product = MorphOneOfManyTestProduct::create();
-        $product->states()->forceCreate([
+        $state = $product->states()->forceCreate([
             'state' => 'active',
         ]);
+
+        $this->assertNotNull($state);
         $this->assertSame(MorphOneOfManyTestProduct::class, $product->current_state->stateful_type);
     }
 

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Database;
 
+use Generator;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\Schema\MySqlSchemaState;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 class DatabaseMySqlSchemaStateTest extends TestCase
 {
@@ -19,19 +21,19 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         $schemaState = new MySqlSchemaState($connection);
 
         // test connectionString
-        $method = new \ReflectionMethod(get_class($schemaState), 'connectionString');
+        $method = new ReflectionMethod(get_class($schemaState), 'connectionString');
         $connString = tap($method)->setAccessible(true)->invoke($schemaState);
 
         self::assertEquals($expectedConnectionString, $connString);
 
         // test baseVariables
-        $method = new \ReflectionMethod(get_class($schemaState), 'baseVariables');
+        $method = new ReflectionMethod(get_class($schemaState), 'baseVariables');
         $variables = tap($method)->setAccessible(true)->invoke($schemaState, $dbConfig);
 
         self::assertEquals($expectedVariables, $variables);
     }
 
-    public function provider(): \Generator
+    public function provider(): Generator
     {
         yield 'default' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"', [

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -74,7 +74,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Exception message', m::hasKey('exception')])->once();
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')])->once();
 
         $this->handler->report(new RuntimeException('Exception message'));
     }
@@ -83,7 +83,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Exception message', m::subset(['foo' => 'bar'])])->once();
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::subset(['foo' => 'bar'])])->once();
 
         $this->handler->report(new ContextProvidingException('Exception message'));
     }
@@ -92,7 +92,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Exception message', m::hasKey('exception')])->once();
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')])->once();
 
         $this->handler->report(new UnReportableException('Exception message'));
     }
@@ -101,16 +101,17 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldReceive('log')->withArgs([LogLevel::CRITICAL, 'Critical message', m::hasKey('exception')])->once();
-        $logger->shouldReceive('log')->withArgs([LogLevel::ERROR, 'Error message', m::hasKey('exception')])->once();
-        $logger->shouldReceive('log')->withArgs([LogLevel::WARNING, 'Warning message', m::hasKey('exception')])->once();
+
+        $logger->shouldReceive('critical')->withArgs(['Critical message', m::hasKey('exception')])->once();
+        $logger->shouldReceive('error')->withArgs(['Error message', m::hasKey('exception')])->once();
+        $logger->shouldReceive('log')->withArgs(['custom', 'Custom message', m::hasKey('exception')])->once();
 
         $this->handler->level(InvalidArgumentException::class, LogLevel::CRITICAL);
-        $this->handler->level(OutOfRangeException::class, LogLevel::WARNING);
+        $this->handler->level(OutOfRangeException::class, 'custom');
 
         $this->handler->report(new InvalidArgumentException('Critical message'));
         $this->handler->report(new RuntimeException('Error message'));
-        $this->handler->report(new OutOfRangeException('Warning message'));
+        $this->handler->report(new OutOfRangeException('Custom message'));
     }
 
     public function testHandlerIgnoresNotReportableExceptions()

--- a/tests/Foundation/Testing/BootTraitsTest.php
+++ b/tests/Foundation/Testing/BootTraitsTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Foundation\Testing;
 use Illuminate\Foundation\Testing\TestCase as FoundationTestCase;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 trait TestTrait
 {
@@ -34,12 +35,12 @@ class BootTraitsTest extends TestCase
     {
         $testCase = new TestCaseWithTrait;
 
-        $method = new \ReflectionMethod($testCase, 'setUpTraits');
+        $method = new ReflectionMethod($testCase, 'setUpTraits');
         tap($method)->setAccessible(true)->invoke($testCase);
 
         $this->assertTrue($testCase->setUp);
 
-        $method = new \ReflectionMethod($testCase, 'callBeforeApplicationDestroyedCallbacks');
+        $method = new ReflectionMethod($testCase, 'callBeforeApplicationDestroyedCallbacks');
         tap($method)->setAccessible(true)->invoke($testCase);
 
         $this->assertTrue($testCase->tearDown);

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -17,6 +17,14 @@ class InteractsWithContainerTest extends TestCase
         $this->assertSame($this, $instance);
     }
 
+    public function testWithoutViteHandlesReactRefresh()
+    {
+        $instance = $this->withoutVite();
+
+        $this->assertSame('', app(Vite::class)->reactRefresh());
+        $this->assertSame($this, $instance);
+    }
+
     public function testWithViteRestoresOriginalHandlerAndReturnsInstance()
     {
         $handler = new stdClass;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -478,6 +478,7 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory->get('https://example.com');
         $this->assertSame(['fact' => 'Cats are great!'], $response->json());
+        $this->assertSame('application/json', $response->header('Content-Type'));
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Exception;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
@@ -392,7 +393,7 @@ class JsonSettingsCaster implements CastsAttributes
         }
 
         if (! $value instanceof Settings) {
-            throw new \Exception("Attribute `{$key}` with JsonSettingsCaster should be a Settings object");
+            throw new Exception("Attribute `{$key}` with JsonSettingsCaster should be a Settings object");
         }
 
         return $value->toJson();

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Illuminate\Auth\Access\Response;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class ExceptionHandlerTest extends TestCase
+{
+    public function testItRendersAuthorizationExceptions()
+    {
+        Route::get('test-route', fn () => Response::deny('expected message', 321)->authorize());
+
+        // HTTP request...
+        $this->get('test-route')
+            ->assertStatus(403)
+            ->assertSeeText('expected message');
+
+        // JSON request...
+        $this->getJson('test-route')
+            ->assertStatus(403)
+            ->assertExactJson([
+                'message' => 'expected message',
+            ]);
+    }
+
+    public function testItRendersAuthorizationExceptionsWithCustomStatusCode()
+    {
+        Route::get('test-route', fn () => Response::deny('expected message', 321)->withStatus(404)->authorize());
+
+        // HTTP request...
+        $this->get('test-route')
+            ->assertStatus(404)
+            ->assertSeeText('Not Found');
+
+        // JSON request...
+        $this->getJson('test-route')
+            ->assertStatus(404)
+            ->assertExactJson([
+                'message' => 'expected message',
+            ]);
+    }
+}

--- a/tests/Integration/Mail/AttachingFromStorageTest.php
+++ b/tests/Integration/Mail/AttachingFromStorageTest.php
@@ -53,4 +53,16 @@ class AttachingFromStorageTest extends TestCase
 
         Storage::disk('local')->delete('/dir/foo.png');
     }
+
+    public function testItCanChainAttachWithMailMessage()
+    {
+        Storage::disk('local')->put('/dir/foo.png', 'expected body contents');
+        $message = new MailMessage();
+
+        $result = $message->attach(
+            Attachment::fromStorageDisk('local', '/dir/foo.png')
+        );
+
+        $this->assertSame($message, $result);
+    }
 }

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -12,7 +12,7 @@ use Orchestra\Testbench\TestCase;
 
 class JobChainingTest extends TestCase
 {
-    public static $catchCallbackRan = false;
+    public static $catchCallbackCount = 0;
 
     protected function getEnvironmentSetUp($app)
     {
@@ -30,7 +30,6 @@ class JobChainingTest extends TestCase
         JobChainingTestFirstJob::$ran = false;
         JobChainingTestSecondJob::$ran = false;
         JobChainingTestThirdJob::$ran = false;
-        static::$catchCallbackRan = false;
     }
 
     public function testJobsCanBeChainedOnSuccess()
@@ -148,17 +147,54 @@ class JobChainingTest extends TestCase
 
     public function testCatchCallbackIsCalledOnFailure()
     {
+        self::$catchCallbackCount = 0;
+
         Bus::chain([
             new JobChainingTestFirstJob,
             new JobChainingTestFailingJob,
             new JobChainingTestSecondJob,
         ])->catch(static function () {
-            self::$catchCallbackRan = true;
+            self::$catchCallbackCount++;
         })->dispatch();
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);
-        $this->assertTrue(static::$catchCallbackRan);
+        $this->assertSame(1, static::$catchCallbackCount);
         $this->assertFalse(JobChainingTestSecondJob::$ran);
+    }
+
+    public function testCatchCallbackIsCalledOnceOnSyncQueue()
+    {
+        self::$catchCallbackCount = 0;
+
+        try {
+            Bus::chain([
+                new JobChainingTestFirstJob(),
+                new JobChainingTestThrowJob(),
+                new JobChainingTestSecondJob(),
+            ])->catch(function () {
+                self::$catchCallbackCount++;
+            })->onConnection('sync')->dispatch();
+        } finally {
+            $this->assertTrue(JobChainingTestFirstJob::$ran);
+            $this->assertSame(1, static::$catchCallbackCount);
+            $this->assertFalse(JobChainingTestSecondJob::$ran);
+        }
+
+        self::$catchCallbackCount = 0;
+
+        try {
+            Bus::chain([
+                new JobChainingTestFirstJob(),
+                new JobChainingTestThrowJob(),
+                new JobChainingTestSecondJob(),
+            ])->catch(function () {
+                self::$catchCallbackCount++;
+            })->onConnection('sync')->dispatch();
+        } finally {
+            $this->assertTrue(JobChainingTestFirstJob::$ran);
+            $this->assertSame(1, static::$catchCallbackCount);
+            $this->assertFalse(JobChainingTestSecondJob::$ran);
+        }
     }
 
     public function testChainJobsUseSameConfig()
@@ -291,5 +327,15 @@ class JobChainingTestFailingJob implements ShouldQueue
     public function handle()
     {
         $this->fail();
+    }
+}
+
+class JobChainingTestThrowJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function handle()
+    {
+        throw new \Exception();
     }
 }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -273,7 +273,8 @@ class UrlSigningTest extends TestCase
 
     protected function createValidateSignatureMiddleware(array $ignore)
     {
-        return new class ($ignore) extends ValidateSignature {
+        return new class($ignore) extends ValidateSignature
+        {
             public function __construct(array $ignore)
             {
                 $this->ignore = $ignore;

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Exceptions\InvalidSignatureException;
 use Illuminate\Routing\Middleware\ValidateSignature;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
@@ -250,6 +251,34 @@ class UrlSigningTest extends TestCase
 
         $response = $this->get('/foo/relative');
         $response->assertStatus(403);
+    }
+
+    public function testSignedMiddlewareIgnoringParameter()
+    {
+        Route::get('/foo/{id}}', function (Request $request, $id) {
+        })->name('foo')->middleware('signed:relative');
+
+        $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1]).'&ignore=me');
+        $request = Request::create($url);
+        $middleware = $this->createValidateSignatureMiddleware(['ignore']);
+
+        try {
+            $middleware->handle($request, function ($request) {
+                $this->assertTrue($request->hasValidSignatureWhileIgnoring(['ignore']));
+            });
+        } catch (InvalidSignatureException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+    protected function createValidateSignatureMiddleware(array $ignore)
+    {
+        return new class ($ignore) extends ValidateSignature {
+            public function __construct(array $ignore)
+            {
+                $this->ignore = $ignore;
+            }
+        };
     }
 }
 

--- a/tests/Integration/Support/PluralizerPortugueseTest.php
+++ b/tests/Integration/Support/PluralizerPortugueseTest.php
@@ -8,14 +8,14 @@ use Orchestra\Testbench\TestCase;
 
 class PluralizerPortugueseTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
         Pluralizer::useLanguage('portuguese');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -143,6 +143,39 @@ class ArtisanCommandTest extends TestCase
         });
     }
 
+    public function test_callable_command_is_callable()
+    {
+        Artisan::command('callable-string', [CallableCommand::class, '__invoke']);
+        Artisan::command('callable-default-method', CallableCommand::class);
+        Artisan::command('callable-handle-method', [CallableMethod::class, 'handle']);
+        Artisan::command('callable-at-style', CallableMethod::class.'@handle');
+
+        $this->artisan('callable-string')->assertExitCode(0);
+        $this->artisan('callable-default-method')->assertExitCode(0);
+        $this->artisan('callable-handle-method')->assertExitCode(1);
+        $this->artisan('callable-at-style')->assertExitCode(1);
+    }
+
+    public function test_callable_command_is_constructed_once()
+    {
+        $this->assertEquals(0, CallableConstruct::$count);
+
+        Artisan::command('callable-construct', [new CallableConstruct]);
+
+        $this->artisan('callable-construct')->assertExitCode(3);
+
+        $this->assertEquals(1, CallableConstruct::$count);
+    }
+
+    public function test_callable_object_can_be_accessed()
+    {
+        Artisan::command('callable-object', CallableObject::class);
+
+        $this->artisan('callable-object')
+            ->expectsOutputToContain('Taylor Otwell')
+            ->assertExitCode(5);
+    }
+
     /**
      * Don't allow Mockery's InvalidCountException to be reported. Mocks setup
      * in PendingCommand cause PHPUnit tearDown() to later throw the exception.
@@ -161,5 +194,55 @@ class ArtisanCommandTest extends TestCase
                 // Ignore mock exception from PendingCommand::expectsOutput().
             }
         }
+    }
+}
+
+class CallableCommand
+{
+    public function __invoke()
+    {
+        return 0;
+    }
+}
+
+class CallableMethod
+{
+    public function handle()
+    {
+        return 1;
+    }
+}
+
+class CallableConstruct
+{
+    public static $count = 0;
+
+    public function __construct()
+    {
+        ++static::$count;
+    }
+
+    public function __invoke()
+    {
+        return 3;
+    }
+}
+
+class CallableObject
+{
+    public $public = 4;
+
+    public function __invoke()
+    {
+        $this->line('My name is Taylor Otwell');
+
+        $this->public = 5;
+
+        return $this->getPublic();
+    }
+
+    public function getPublic()
+    {
+        return $this->public;
     }
 }

--- a/tests/Pagination/CursorPaginatorTest.php
+++ b/tests/Pagination/CursorPaginatorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Pagination;
 
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class CursorPaginatorTest extends TestCase
@@ -74,6 +75,26 @@ class CursorPaginatorTest extends TestCase
 
         $this->assertInstanceOf(CursorPaginator::class, $p);
         $this->assertSame([['id' => 6], ['id' => 7]], $p->items());
+    }
+
+    public function testReturnEmptyCursorWhenItemsAreEmpty()
+    {
+        $cursor = new Cursor(['id' => 25], true);
+
+        $p = new CursorPaginator(Collection::make(), 25, $cursor, [
+            'path' => 'http://website.com/test',
+            'cursorName' => 'cursor',
+            'parameters' => ['id'],
+        ]);
+
+        $this->assertInstanceOf(CursorPaginator::class, $p);
+        $this->assertSame([
+            'data' => [],
+            'path' => 'http://website.com/test',
+            'per_page' => 25,
+            'next_page_url' => null,
+            'prev_page_url' => null,
+        ], $p->toArray());
     }
 
     protected function getCursor($params, $isNext = true)

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -620,19 +620,25 @@ class SupportArrTest extends TestCase
         $array = ['name' => 'Desk', 'price' => 100];
         $name = Arr::pull($array, 'name');
         $this->assertSame('Desk', $name);
-        $this->assertEquals(['price' => 100], $array);
+        $this->assertSame(['price' => 100], $array);
 
         // Only works on first level keys
         $array = ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane'];
         $name = Arr::pull($array, 'joe@example.com');
         $this->assertSame('Joe', $name);
-        $this->assertEquals(['jane@localhost' => 'Jane'], $array);
+        $this->assertSame(['jane@localhost' => 'Jane'], $array);
 
         // Does not work for nested keys
         $array = ['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']];
         $name = Arr::pull($array, 'emails.joe@example.com');
         $this->assertNull($name);
-        $this->assertEquals(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
+        $this->assertSame(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
+
+        // Works with int keys
+        $array = ['First', 'Second'];
+        $first = Arr::pull($array, 0);
+        $this->assertSame('First', $first);
+        $this->assertSame([1 => 'Second'], $array);
     }
 
     public function testQuery()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2286,7 +2286,7 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf($collection, $random);
         $this->assertCount(2, $random);
 
-        $random = $data->random(fn($items) => min(10, count($items)));
+        $random = $data->random(fn ($items) => min(10, count($items)));
         $this->assertInstanceOf($collection, $random);
         $this->assertCount(6, $random);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2285,6 +2285,10 @@ class SupportCollectionTest extends TestCase
         $random = $data->random('2');
         $this->assertInstanceOf($collection, $random);
         $this->assertCount(2, $random);
+
+        $random = $data->random(fn($items) => min(10, count($items)));
+        $this->assertInstanceOf($collection, $random);
+        $this->assertCount(6, $random);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Exception;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
@@ -504,7 +505,7 @@ class SupportStrTest extends TestCase
 
     public function testItCanSpecifyAFallbackForARandomStringSequence()
     {
-        Str::createRandomStringsUsingSequence([Str::random(), Str::random()], fn () => throw new \Exception('Out of random strings.'));
+        Str::createRandomStringsUsingSequence([Str::random(), Str::random()], fn () => throw new Exception('Out of random strings.'));
         Str::random();
         Str::random();
 
@@ -1015,7 +1016,7 @@ class SupportStrTest extends TestCase
 
     public function testItCanSpecifyAFallbackForASequence()
     {
-        Str::createUuidsUsingSequence([Str::uuid(), Str::uuid()], fn () => throw new \Exception('Out of Uuids.'));
+        Str::createUuidsUsingSequence([Str::uuid(), Str::uuid()], fn () => throw new Exception('Out of Uuids.'));
         Str::uuid();
         Str::uuid();
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -898,6 +898,12 @@ class SupportStrTest extends TestCase
         $this->assertSame("<h1>hello world</h1>\n", Str::markdown('# hello world'));
     }
 
+    public function testInlineMarkdown()
+    {
+        $this->assertSame("<em>hello world</em>\n", Str::inlineMarkdown('*hello world*'));
+        $this->assertSame("<a href=\"https://laravel.com\"><strong>Laravel</strong></a>\n", Str::inlineMarkdown('[**Laravel**](https://laravel.com)'));
+    }
+
     public function testRepeat()
     {
         $this->assertSame('aaaaa', Str::repeat('a', 5));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -508,6 +508,19 @@ class SupportStrTest extends TestCase
 
         $this->assertSame('这是一***', Str::mask('这是一段中文', '*', 3));
         $this->assertSame('**一段中文', Str::mask('这是一段中文', '*', 0, 2));
+
+        $this->assertSame('ma*n@email.com', Str::mask('maan@email.com', '*', 2, 1));
+        $this->assertSame('ma***email.com', Str::mask('maan@email.com', '*', 2, 3));
+        $this->assertSame('ma************', Str::mask('maan@email.com', '*', 2));
+
+        $this->assertSame('mari*@email.com', Str::mask('maria@email.com', '*', 4, 1));
+        $this->assertSame('tamar*@email.com', Str::mask('tamara@email.com', '*', 5, 1));
+
+        $this->assertSame('*aria@email.com', Str::mask('maria@email.com', '*', 0, 1));
+        $this->assertSame('maria@email.co*', Str::mask('maria@email.com', '*', -1, 1));
+        $this->assertSame('maria@email.co*', Str::mask('maria@email.com', '*', -1));
+        $this->assertSame('***************', Str::mask('maria@email.com', '*', -15));
+        $this->assertSame('***************', Str::mask('maria@email.com', '*', 0));
     }
 
     public function testMatch()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -959,6 +959,12 @@ class SupportStringableTest extends TestCase
         $this->assertEquals("<h1>hello world</h1>\n", $this->stringable('# hello world')->markdown());
     }
 
+    public function testInlineMarkdown()
+    {
+        $this->assertEquals("<em>hello world</em>\n", $this->stringable('*hello world*')->inlineMarkdown());
+        $this->assertEquals("<a href=\"https://laravel.com\"><strong>Laravel</strong></a>\n", $this->stringable('[**Laravel**](https://laravel.com)')->inlineMarkdown());
+    }
+
     public function testMask()
     {
         $this->assertSame('tay*************', (string) $this->stringable('taylor@email.com')->mask('*', 3));

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
@@ -116,7 +117,7 @@ class TestResponseTest extends TestCase
 
     public function testAssertViewHasEloquentCollection()
     {
-        $collection = new \Illuminate\Database\Eloquent\Collection([
+        $collection = new EloquentCollection([
             new TestModel(['id' => 1]),
             new TestModel(['id' => 2]),
             new TestModel(['id' => 3]),
@@ -132,7 +133,7 @@ class TestResponseTest extends TestCase
 
     public function testAssertViewHasEloquentCollectionRespectsOrder()
     {
-        $collection = new \Illuminate\Database\Eloquent\Collection([
+        $collection = new EloquentCollection([
             new TestModel(['id' => 3]),
             new TestModel(['id' => 2]),
             new TestModel(['id' => 1]),
@@ -150,7 +151,7 @@ class TestResponseTest extends TestCase
 
     public function testAssertViewHasEloquentCollectionRespectsType()
     {
-        $actual = new \Illuminate\Database\Eloquent\Collection([
+        $actual = new EloquentCollection([
             new TestModel(['id' => 1]),
             new TestModel(['id' => 2]),
         ]);
@@ -160,7 +161,7 @@ class TestResponseTest extends TestCase
             'gatherData' => ['foos' => $actual],
         ]);
 
-        $expected = new \Illuminate\Database\Eloquent\Collection([
+        $expected = new EloquentCollection([
             new AnotherTestModel(['id' => 1]),
             new AnotherTestModel(['id' => 2]),
         ]);
@@ -172,7 +173,7 @@ class TestResponseTest extends TestCase
 
     public function testAssertViewHasEloquentCollectionRespectsSize()
     {
-        $actual = new \Illuminate\Database\Eloquent\Collection([
+        $actual = new EloquentCollection([
             new TestModel(['id' => 1]),
             new TestModel(['id' => 2]),
         ]);

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -200,6 +200,29 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testItChoosesValidRecordsUsingWhereNotRule()
+    {
+        $rule = new Exists('users', 'id');
+
+        $rule->whereNot('type', 'baz');
+
+        User::create(['id' => '1', 'type' => 'foo']);
+        User::create(['id' => '2', 'type' => 'bar']);
+        User::create(['id' => '3', 'type' => 'baz']);
+        User::create(['id' => '4', 'type' => 'other']);
+        User::create(['id' => '5', 'type' => 'baz']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+
+        $v->setData(['id' => 3]);
+        $this->assertFalse($v->passes());
+
+        $v->setData(['id' => 4]);
+        $this->assertTrue($v->passes());
+    }
+
     public function testItIgnoresSoftDeletes()
     {
         $rule = new Exists('table');

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -27,4 +27,12 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testRequiredStatementsAreCompiled()
+    {
+        $string = '<input @required(name(foo(bar)))/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'required'; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
+use Illuminate\View\Factory;
 use Mockery as m;
 
 class BladeComponentsTest extends AbstractBladeTestCase
@@ -61,7 +62,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
         $component->shouldReceive('withName', 'test');
         $component->shouldReceive('shouldRender')->andReturn(false);
 
-        $__env = m::mock(\Illuminate\View\Factory::class);
+        $__env = m::mock(Factory::class);
         $__env->shouldReceive('getContainer->make')->with('Test', ['foo' => 'bar', 'other' => 'ok'])->andReturn($component);
 
         $template = $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])');


### PR DESCRIPTION
Currently, `Artisan::command()` only supports closure as the second parameter. With this PR, it enables http route-style such as:
```php
Artisan::command('cli', [ClassName::class, '__invoke'])
```

~I'd like to add some test but I'm not sure how considering the `ClosureCommand` this class is mostly based on doesn't have test associated with it.~ Found the tests

Code for callable class binding is from https://stackoverflow.com/a/71010794