### PR TITLE
[9.x] Proposal to change the  behavior of all "before" model events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -202,7 +202,7 @@ trait HasEvents
             return null;
         }
 
-        $eventResponses = array_map(function($response) {
+        $eventResponses = array_map(function ($response) {
             return ! ($response === false);
         }, Arr::wrap($eventResponses));
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -194,20 +194,10 @@ trait HasEvents
     {
         $eventResponses = $this->fireModelEvent($event, false);
 
-        if ($eventResponses === false) {
-            return false;
-        }
-
-        if ($eventResponses === null) {
-            return null;
-        }
-
-        $eventResponses = array_map(function ($response) {
-            return ! ($response === false);
-        }, Arr::wrap($eventResponses));
-
-        if (in_array(false, $eventResponses)) {
-            return false;
+        foreach (Arr::wrap($eventResponses) as $response) {
+            if ($response === false) {
+                return false;
+            }
         }
 
         return true;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -190,6 +190,29 @@ trait HasEvents
         );
     }
 
+    protected function fireModelBeforeEvent($event)
+    {
+        $eventResponses = $this->fireModelEvent($event, false);
+
+        if ($eventResponses === false) {
+            return false;
+        }
+
+        if ($eventResponses === null) {
+            return null;
+        }
+
+        $eventResponses = array_map(function($response) {
+            return ! ($response === false);
+        }, Arr::wrap($eventResponses));
+
+        if (in_array(false, $eventResponses)) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * Fire a custom model event for the given event.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -222,7 +222,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         if (! isset(static::$booted[static::class])) {
             static::$booted[static::class] = true;
 
-            $this->fireModelEvent('booting', false);
+            $this->fireModelBeforeEvent('booting');
 
             static::booting();
             static::boot();
@@ -858,7 +858,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->forceFill($extra);
 
-        if ($this->fireModelEvent('updating') === false) {
+        if ($this->fireModelBeforeEvent('updating') === false) {
             return false;
         }
 
@@ -1007,7 +1007,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // If the "saving" event returns false we'll bail out of the save and return
         // false, indicating that the save failed. This provides a chance for any
         // listeners to cancel save operations if validations fail or whatever.
-        if ($this->fireModelEvent('saving') === false) {
+        if ($this->fireModelBeforeEvent('saving') === false) {
             return false;
         }
 
@@ -1084,7 +1084,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         // If the updating event returns false, we will cancel the update operation so
         // developers can hook Validation systems into their models and cancel this
         // operation if the model does not pass validation. Otherwise, we update.
-        if ($this->fireModelEvent('updating') === false) {
+        if ($this->fireModelBeforeEvent('updating') === false) {
             return false;
         }
 
@@ -1165,7 +1165,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function performInsert(Builder $query)
     {
-        if ($this->fireModelEvent('creating') === false) {
+        if ($this->fireModelBeforeEvent('creating') === false) {
             return false;
         }
 
@@ -1282,7 +1282,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return;
         }
 
-        if ($this->fireModelEvent('deleting') === false) {
+        if ($this->fireModelBeforeEvent('deleting') === false) {
             return false;
         }
 
@@ -1615,7 +1615,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
             $instance->setRelations($this->relations);
 
-            $instance->fireModelEvent('replicating', false);
+            $instance->fireModelBeforeEvent('replicating', false);
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -126,7 +126,7 @@ trait AsPivot
             return (int) parent::delete();
         }
 
-        if ($this->fireModelEvent('deleting') === false) {
+        if ($this->fireModelBeforeEvent('deleting') === false) {
             return 0;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -59,7 +59,7 @@ class MorphPivot extends Pivot
             return (int) parent::delete();
         }
 
-        if ($this->fireModelEvent('deleting') === false) {
+        if ($this->fireModelBeforeEvent('deleting') === false) {
             return 0;
         }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -110,7 +110,7 @@ trait SoftDeletes
         // If the restoring event does not return false, we will proceed with this
         // restore operation. Otherwise, we bail out so the developer will stop
         // the restore totally. We will clear the deleted timestamp and save.
-        if ($this->fireModelEvent('restoring') === false) {
+        if ($this->fireModelBeforeEvent('restoring') === false) {
             return false;
         }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -259,6 +259,7 @@ class Dispatcher implements DispatcherContract
             // the event to any further listeners down in the chain, else we keep on
             // looping through the listeners and firing every one in our sequence.
             if ($response === false) {
+                $responses[] = false;
                 break;
             }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -506,8 +506,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
 
@@ -528,8 +528,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('update')->once()->with(['created_at' => 'foo', 'updated_at' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until');
-        $events->shouldReceive('dispatch');
+        $events->shouldReceive('dispatch')->times(4);
 
         $model->id = 1;
         $model->syncOriginal();
@@ -545,7 +544,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
 
         $this->assertFalse($model->save());
@@ -557,8 +556,8 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
         $model->foo = 'bar';
 
@@ -571,7 +570,7 @@ class DatabaseEloquentModelTest extends TestCase
         $query = m::mock(Builder::class);
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with(m::type(EloquentModelSavingEventStub::class))->andReturn(false);
+        $events->shouldReceive('dispatch')->once()->with(m::type(EloquentModelSavingEventStub::class))->andReturn(false);
         $model->exists = true;
 
         $this->assertFalse($model->save());
@@ -604,8 +603,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->expects($this->once())->method('updateTimestamps');
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
 
@@ -750,8 +749,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('updateTimestamps');
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
         $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
 
@@ -770,8 +769,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setIncrementing(false);
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->once()->with('eloquent.created: '.get_class($model), $model);
         $events->shouldReceive('dispatch')->once()->with('eloquent.saved: '.get_class($model), $model);
 
@@ -789,8 +788,8 @@ class DatabaseEloquentModelTest extends TestCase
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-        $events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
 
         $this->assertFalse($model->save());
         $this->assertFalse($model->exists);
@@ -1690,7 +1689,7 @@ class DatabaseEloquentModelTest extends TestCase
             $model->save();
         });
 
-        $events->shouldReceive('until')->once()->with('eloquent.saving: Illuminate\Tests\Database\EloquentModelSaveStub', $model);
+        $events->shouldReceive('dispatch')->once()->with('eloquent.saving: Illuminate\Tests\Database\EloquentModelSaveStub', $model);
         $events->shouldReceive('dispatch')->once()->with('eloquent.saved: Illuminate\Tests\Database\EloquentModelSaveStub', $model);
 
         $model->last_name = 'Otwell';
@@ -2424,6 +2423,26 @@ class EloquentTestAnotherObserverStub
     }
 }
 
+class EloquentModelWithBeforeEvents extends Model
+{
+    public $connection;
+
+    protected static function booted()
+    {
+        static::creating(function ($model) {
+            return null;
+        });
+
+        static::creating(function ($model) {
+            return true;
+        });
+
+        static::creating(function ($model) {
+            return false;
+        });
+    }
+}
+
 class EloquentModelStub extends Model
 {
     public $connection;
@@ -2568,7 +2587,7 @@ class EloquentModelSaveStub extends Model
 
     public function save(array $options = [])
     {
-        if ($this->fireModelEvent('saving') === false) {
+        if ($this->fireModelBeforeEvent('saving') === false) {
             return false;
         }
 

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -38,7 +38,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
     {
         $model = m::mock(DatabaseSoftDeletingTraitStub::class);
         $model->makePartial();
-        $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(true);
+        $model->shouldReceive('fireModelBeforeEvent')->with('restoring')->andReturn(true);
         $model->shouldReceive('save')->once();
         $model->shouldReceive('fireModelEvent')->with('restored', false)->andReturn(true);
 
@@ -51,7 +51,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
     {
         $model = m::mock(DatabaseSoftDeletingTraitStub::class);
         $model->makePartial();
-        $model->shouldReceive('fireModelEvent')->with('restoring')->andReturn(false);
+        $model->shouldReceive('fireModelBeforeEvent')->with('restoring')->andReturn(false);
         $model->shouldReceive('save')->never();
 
         $this->assertFalse($model->restore());

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -88,7 +88,7 @@ class EventsDispatcherTest extends TestCase
         $response = $d->dispatch('foo', ['bar']);
 
         $this->assertSame('bar', $_SERVER['__event.test']);
-        $this->assertEquals(['bar'], $response);
+        $this->assertEquals(['bar', null], $response);
     }
 
     public function testReturningFalsyValuesContinuesPropagation()

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -75,7 +75,7 @@ class EventFakeTest extends TestCase
             $this->fail('should not be called');
         });
 
-        $this->assertEquals([null], Event::dispatch('test'));
+        $this->assertEquals([null, false], Event::dispatch('test'));
 
         Event::assertNotDispatched(NonImportantEvent::class);
     }
@@ -155,7 +155,7 @@ class Post extends Model
 
     public function save(array $options = [])
     {
-        if ($this->fireModelEvent('saving') === false) {
+        if ($this->fireModelBeforeEvent('saving') === false) {
             return false;
         }
     }


### PR DESCRIPTION
As discussed in #42952, currently, all model events ending in `-ing`, are dispatched using `Dispatcher@until`, which will stop in the first non-null response from a listener, so we can't define any listeners that return any truthly value.

For example, in the code snipeed below, the framework will try to insert the model after executing the second `creating` callback, and this insertion will fail because the `required_column` is missing until the fourth callback executes.
In this example, I could easily perform all actions in a single `creating` callback, but in a real world project, there might be a third party package defining their own `creating` listeners, and if one of them returns a non-null value, then the following callbacks won't be executed.

```php
// Migration
return new class extends Migration {
    public function up(): void
    {
        Schema::create('my_models', function(Blueprint $table) {
            $table->increments('id');
            $table->string('optional_column')->nullable();
            $table->string('required_column');
            $table->timestamps();
        });
    }
}

//Model
class MyModel extends Model
{
    protected $fillable = [
        'optional_column',
        'required_column',
    ];

    protected static function booted(): void
    {
        // 1: Log a message with the Model's initial (empty) attributes when it's being created
        // (This behaves "normally", it logs and continues execution to the next callback as we'd expect.)
        static::creating(static fn(Model $model) => Log::info('Log 1', $model->getAttributes()));

        // 2A: Assign an optional value to the Model, if not already set, using arrow syntax.
        // (🧨 This causes an SQL INSERT error. Returning the model in the callback caused an immediate insert.)
        static::creating(static fn(Model $model) => $model->optional_column === null
            ? $model->optional_column = 'hello world'
            : $model
        );

        // 2B: Assign an optional value to the Model, if not already set, WITHOUT using arrow syntax.
        // (✅ This works as expected. The model attribute is updated and the next callback is handled.)
        static::creating(static function(Model $model) {
            $model->optional_column === null
                ? $model->optional_column = 'hello world'
                : $model;
        });
        
        // 4: Assign a required value to the Model.
        // After this callback executes, the model will be saved successfully.
        static::creating(static function(Model $model) {
            $model->required_column = 'lorem ipsum';
        });
    }
}
```

This PR changes all before events to be dispatched without using event halting, which allows to run all the defined callbacks before returning the response.

We can't just pass `false` as the second param for the `fireModelEvent` method where `before` events  are dispatched, because we still want to stop the execution if some of the listeners return false.

I can add some tests if Taylor and the laravel team consider to merge this PR. Also, I'd appreciate a review from @rodrigopedra and @JackWH here.

If this should go to 10.x please let me know.