### PR TITLE
[8.x] Fix forceCreate on MorphMany not returning newly created object

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -57,6 +57,6 @@ class MorphMany extends MorphOneOrMany
     {
         $attributes[$this->getMorphType()] = $this->morphClass;
 
-        parent::forceCreate($attributes);
+        return parent::forceCreate($attributes);
     }
 }

--- a/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphOneOfManyTest.php
@@ -97,9 +97,11 @@ class DatabaseEloquentMorphOneOfManyTest extends TestCase
     public function testForceCreateMorphType()
     {
         $product = MorphOneOfManyTestProduct::create();
-        $product->states()->forceCreate([
+        $state = $product->states()->forceCreate([
             'state' => 'active',
         ]);
+
+        $this->assertNotNull($state);
         $this->assertSame(MorphOneOfManyTestProduct::class, $product->current_state->stateful_type);
     }
 


### PR DESCRIPTION
The forceCreate on MorphMany was not returning the newly created model in order to save re-querying to get this object.

Added the return and a test to check the return value is not null.
