### PR TITLE
[9.x] Add tests for `whereNot` database rule

### DIFF
--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -200,6 +200,29 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testItChoosesValidRecordsUsingWhereNotRule()
+    {
+        $rule = new Exists('users', 'id');
+
+        $rule->whereNot('type', 'baz');
+
+        User::create(['id' => '1', 'type' => 'foo']);
+        User::create(['id' => '2', 'type' => 'bar']);
+        User::create(['id' => '3', 'type' => 'baz']);
+        User::create(['id' => '4', 'type' => 'other']);
+        User::create(['id' => '5', 'type' => 'baz']);
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['id' => $rule]);
+        $v->setPresenceVerifier(new DatabasePresenceVerifier(Eloquent::getConnectionResolver()));
+
+        $v->setData(['id' => 3]);
+        $this->assertFalse($v->passes());
+
+        $v->setData(['id' => 4]);
+        $this->assertTrue($v->passes());
+    }
+
     public function testItIgnoresSoftDeletes()
     {
         $rule = new Exists('table');


### PR DESCRIPTION
This PR is related to #42990

I've added a test that uses the `whereNot` database rule with the `exists` one, and it appears to be working as expected.