### PR TITLE
[9.x] Adds simpler JSON builder class

### DIFF
--- a/src/Illuminate/Collections/Json.php
+++ b/src/Illuminate/Collections/Json.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Tappable;
+use JsonSerializable;
+use Stringable;
+
+class Json implements ArrayAccess, Arrayable, JsonSerializable, Jsonable, Stringable
+{
+    use Conditionable;
+    use Tappable;
+
+    /**
+     * The underlying JSON data.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Create a new Json instance.
+     *
+     * @param  iterable  $data
+     */
+    public function __construct($data = [])
+    {
+        foreach ($data as $key => $value) {
+            $this->data[$key] = $value;
+        }
+    }
+
+    /**
+     * Returns a JSON value in "dot" notation.
+     *
+     * @param  array|string|int|null  $key
+     * @param  mixed|null  $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        return data_get($this->data, $key, $default);
+    }
+
+    /**
+     * Sets a JSON value in "dot" notation.
+     *
+     * @param  array|string|int  $key
+     * @param  mixed  $value
+     * @param  bool  $overwrite
+     * @return $this
+     */
+    public function set($key, $value, $overwrite = true)
+    {
+        data_set($this->data, $key, $value, $overwrite);
+
+        return $this;
+    }
+
+    /**
+     * Determine a given key in "dot" notation exists in the JSON data.
+     *
+     * @param  string|int  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return $this->get($key) !== null;
+    }
+
+    /**
+     * Removes a JSON key.
+     *
+     * @param  string|int  $key
+     * @return $this
+     */
+    public function forget($key)
+    {
+        $segment = &$this->data;
+
+        $keys = explode('.', $key) ?: [$key];
+
+        foreach ($keys as $index => $name) {
+            if (count($keys) === 1) {
+                break;
+            }
+
+            unset($keys[$index]);
+
+            if (is_array($segment) && array_key_exists($name, $segment)) {
+                $segment = &$segment[$name];
+            } elseif (is_object($segment) && property_exists($segment, $name)) {
+                $segment = &$segment->{$name};
+            }
+        }
+
+        if (is_array($segment)) {
+            unset($segment[array_shift($keys)]);
+        } elseif(is_object($segment)) {
+            unset($segment->{array_shift($keys)});
+        }
+
+        return $this;
+    }
+
+    /**
+     * Dynamically get JSON values.
+     *
+     * @param  string  $name
+     * @return mixed
+     */
+    public function __get(string $name): mixed
+    {
+        return $this->get($name);
+    }
+
+    /**
+     * Dynamically set JSON values.
+     *
+     * @param  string  $name
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set(string $name, mixed $value): void
+    {
+        $this->set($name, $value);
+    }
+
+    /**
+     * Dynamically check a JSON key is set.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function __isset(string $name): bool
+    {
+        return $this->has($name);
+    }
+
+    /**
+     * Dynamically unset a JSON key.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function __unset(string $name): void
+    {
+        $this->forget($name);
+    }
+
+    /**
+     * Whether an offset exists.
+     *
+     * @param  mixed
+     * @return bool
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->has($offset);
+    }
+
+    /**
+     * Offset to retrieve.
+     *
+     * @param  mixed  $offset
+     * @return mixed
+     */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * Offset to set.
+     *
+     * @param  mixed  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->set($offset, $value);
+    }
+
+    /**
+     * Offset to unset.
+     *
+     * @param  mixed  $offset
+     * @return void
+     */
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->forget($offset);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->data;
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Convert the Json instance to JSON.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Returns string representation of the object.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->toJson();
+    }
+
+    /**
+     * Create a new Json instance.
+     *
+     * @param  string|iterable  $json
+     * @return static
+     */
+    public static function make($json = null)
+    {
+        if (is_string($json)) {
+            $json = json_decode($json, true);
+        }
+
+        return new static((array) $json);
+    }
+}

--- a/tests/Support/SupportJsonTest.php
+++ b/tests/Support/SupportJsonTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Json;
+use PHPUnit\Framework\TestCase;
+
+class SupportJsonTest extends TestCase
+{
+    protected const DATA = [
+        'foo' => 'bar',
+        'baz' => [
+            'quz' => ['qux'],
+            'quuz' => [
+                'quux' => 'fred',
+            ],
+        ],
+        'corge' => 'thud',
+        'null' => null,
+    ];
+
+    protected Json $json;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->json = new Json(static::DATA);
+    }
+
+    public function test_get()
+    {
+        $this->assertSame('fred', $this->json->get('baz.quuz.quux'));
+        $this->assertNull($this->json->get('invalid'));
+        $this->assertSame('foo', $this->json->get('invalid', 'foo'));
+        $this->assertSame('foo', $this->json->get('invalid', fn() => 'foo'));
+    }
+
+
+    public function test_set()
+    {
+        $this->json->set('foo', 'quz');
+        $this->assertSame('quz', $this->json->get('foo'));
+
+        $this->json->set('baz.quuz.quux', 'corge');
+        $this->assertSame('corge', $this->json->get('baz.quuz.quux'));
+    }
+
+    public function test_set_no_overwrite()
+    {
+        $this->json->set('foo', 'quz', false);
+        $this->assertSame('bar', $this->json->get('foo'));
+
+        $this->json->set('baz.quuz.quux', 'corge', false);
+        $this->assertSame('fred', $this->json->get('baz.quuz.quux'));
+    }
+
+    public function test_has()
+    {
+        $this->assertTrue($this->json->has('foo'));
+        $this->assertTrue($this->json->has('baz.quuz.quux'));
+        $this->assertFalse($this->json->has('null'));
+    }
+
+
+    public function test_forget()
+    {
+        $this->json->forget('foo');
+        $this->assertFalse($this->json->has('foo'));
+
+        $this->json->forget('baz.quuz.quux');
+        $this->assertFalse($this->json->has('baz.quuz.quux'));
+
+        $this->json->forget('invalid');
+        $this->assertArrayNotHasKey('invalid', $this->json->toArray());
+    }
+
+    public function test_forget_with_object()
+    {
+        $this->json->set('bar', (object) ['baz' => (object) ['quz' => 'qux']]);
+
+        $this->json->forget('bar.baz.quz');
+        $this->assertFalse($this->json->has('bar.baz.quz'));
+    }
+
+    public function test_forgets_not_applied_to_value()
+    {
+        $this->json->forget('foo.bar');
+        $this->assertSame('bar', $this->json->get('foo'));
+    }
+
+    public function test_dynamic_access()
+    {
+        $this->assertSame('bar', $this->json->foo);
+
+        $this->json->bar = 'quz';
+        $this->assertSame('quz', $this->json->bar);
+
+        $this->assertTrue(isset($this->json->bar));
+        $this->assertFalse(isset($this->json->null));
+        $this->assertFalse(isset($this->json->invalid));
+
+        unset($this->json->foo);
+
+        $this->assertFalse($this->json->has('foo'));
+    }
+
+    public function test_array_access()
+    {
+        $this->assertSame('bar', $this->json['foo']);
+
+        $this->json['bar'] = 'quz';
+        $this->assertSame('quz', $this->json['bar']);
+
+        $this->assertTrue(isset($this->json['bar']));
+        $this->assertFalse(isset($this->json['null']));
+        $this->assertFalse(isset($this->json['invalid']));
+
+        unset($this->json['foo']);
+
+        $this->assertFalse($this->json->has('foo'));
+    }
+
+    public function test_to_string()
+    {
+        $this->assertSame(
+            '{"foo":"bar","baz":{"quz":["qux"],"quuz":{"quux":"fred"}},"corge":"thud","null":null}',
+            (string) $this->json
+        );
+    }
+
+    public function test_json_serializable()
+    {
+        $this->assertSame(
+            '{"foo":"bar","baz":{"quz":["qux"],"quuz":{"quux":"fred"}},"corge":"thud","null":null}',
+            json_encode($this->json)
+        );
+    }
+
+    public function test_to_array()
+    {
+        $this->assertSame(static::DATA, $this->json->toArray());
+    }
+
+    public function test_to_json()
+    {
+        $this->assertSame(
+            '{"foo":"bar","baz":{"quz":["qux"],"quuz":{"quux":"fred"}},"corge":"thud","null":null}',
+            $this->json->toJson()
+        );
+    }
+
+    public function test_make()
+    {
+        $this->assertEmpty(Json::make()->toArray());
+        $this->assertSame(['foo' => 'bar'], Json::make(['foo' => 'bar'])->toArray());
+    }
+
+    public function test_make_with_json_string()
+    {
+        $this->assertSame(
+            static::DATA,
+            Json::make(
+                '{"foo":"bar","baz":{"quz":["qux"],"quuz":{"quux":"fred"}},"corge":"thud","null":null}'
+            )->toArray()
+        );
+    }
+}


### PR DESCRIPTION
## What?

Retry of #42938. Simpler version of the JSON builder object, which allows to build complex JSON trees easily across the application.

```php
use Illuminate\Support\Json;
use Illuminate\Support\Arr;

// Before
$json = ['this' => ['is' => 'cool']]);

Arr::set($json, 'this.is', 'cool');

// Now
$json = Json::make()->set('this.is', 'cool');
```

Features:
- Supports get, set and unset from nested arrays or objects.
- Serializes into JSON automatically.
- Supports dynamic access, array access.
- The `make()` method supports creating from an iterable or a JSON-encoded string.

There is potential to adopt this class in multiple JSON-responsable services, like translation, requests, responses and Model JSON column casting (sign me up for that!).

## Why?

Because Collection and Fluent are focused on single-dimensional lists. Playing with multidimensional arrays quickly becomes spaghettis code.

## BC?

Only adds a class and its tests. 