### PR TITLE
Add `withoutAppends` scope to prevent appended attributes being loaded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -333,7 +333,7 @@ trait HasAttributes
      */
     protected function getArrayableAppends()
     {
-        if (self::$withoutAppends) {
+        if ($this->withoutAppends) {
             return [];
         }
 
@@ -2062,7 +2062,7 @@ trait HasAttributes
      */
     public function scopeWithoutAppends($query)
     {
-        self::$withoutAppends = true;
+        $this->withoutAppends = true;
 
         return $query;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -173,7 +173,7 @@ trait HasAttributes
     public static $encrypter;
 
     /**
-     * Indicates whether models should be loaded without appended attributes. 
+     * Indicates whether models should be loaded without appended attributes.
      */
     public static $withoutAppends = false;
 
@@ -2057,7 +2057,7 @@ trait HasAttributes
     /**
      * Scope a query to load models without appended attributes.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWithoutAppends($query)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -175,7 +175,7 @@ trait HasAttributes
     /**
      * Indicates whether models should be loaded without appended attributes.
      */
-    public static $withoutAppends = false;
+    public $withoutAppends = false;
 
     /**
      * Convert the model's attributes to an array.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -173,6 +173,11 @@ trait HasAttributes
     public static $encrypter;
 
     /**
+     * Indicates whether models should be loaded without appended attributes. 
+     */
+    public static $withoutAppends = false;
+
+    /**
      * Convert the model's attributes to an array.
      *
      * @return array
@@ -328,6 +333,10 @@ trait HasAttributes
      */
     protected function getArrayableAppends()
     {
+        if (self::$withoutAppends) {
+            return [];
+        }
+
         if (! count($this->appends)) {
             return [];
         }
@@ -2043,6 +2052,19 @@ trait HasAttributes
     public function hasAppended($attribute)
     {
         return in_array($attribute, $this->appends);
+    }
+
+    /**
+     * Scope a query to load models without appended attributes.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWithoutAppends($query)
+    {
+        self::$withoutAppends = true;
+
+        return $query;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

From personal experience, there's often times where you may wish to load an Eloquent model but without any of the appended attributes also being loaded in.

Where I work, we have some applications with appended attributes that do queries and sometimes if we're loading just the ID and Name of a model, we probably don't want that query to be executed also.

**Introducing the `withoutAppends` scope:**

```php
Programme::query()
    ->withoutAppends()
    ->select('id', 'name')
    ->get();
```

When used, this scope will mean the `getArrayableAppends` method will return an empty array, 'tricking' it into thinking there's no appended attributes to bother with.

I've used this same code, but in a model trait on some recent applications and it's worked a charm and improved performance in a lot of cases.

And... just for demonstration purposes, this scope can be used when eager loading another relationship, like so:

```php
File::query()
    ->with([
        'programme' => function ($query) {
            $query->withoutAppends();
        },
    ])
    ->get();
```

For transparency - the code for this came from this StackOverflow answer: https://stackoverflow.com/questions/47182217/get-data-without-appends-and-relations-in-laravel-from-eloquent