### PR TITLE
[9.x] Fix issue with AssertableJson 'where' function and floating point numbers

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -14,9 +14,10 @@ trait Matching
      *
      * @param  string  $key
      * @param  mixed|\Closure  $expected
+     * @param  bool  $strict
      * @return $this
      */
-    public function where(string $key, $expected): self
+    public function where(string $key, $expected, $strict = true): self
     {
         $this->has($key);
 
@@ -38,7 +39,9 @@ trait Matching
         $this->ensureSorted($expected);
         $this->ensureSorted($actual);
 
-        PHPUnit::assertSame(
+        $assertFn = $strict ? 'assertSame' : 'assertEquals';
+
+        PHPUnit::{$assertFn}(
             $expected,
             $actual,
             sprintf('Property [%s] does not match the expected value.', $this->dotPath($key))

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Testing\Fluent;
 
 use Illuminate\Support\Collection;
+use Illuminate\Testing\AssertableJsonString;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Illuminate\Tests\Testing\Stubs\ArrayableStubObject;
 use PHPUnit\Framework\AssertionFailedError;
@@ -269,6 +270,38 @@ class AssertTest extends TestCase
         ]);
 
         $assert->where('bar', 'value');
+    }
+
+    public function testAssertWhereFailsWithFloatInStrictMode()
+    {
+        $doubleValue = (float) 1234.0;
+
+        $stringifiedData = json_encode([
+            'bar' => $doubleValue,
+        ]);
+
+        $assertableJsonString = new AssertableJsonString($stringifiedData);
+        $assert = AssertableJson::fromAssertableJsonString($assertableJsonString);
+
+        // Expect failure as 1234.0 will turn into an integer during JSON deserialization
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not match the expected value.');
+
+        $assert->where('bar', $doubleValue);
+    }
+
+    public function testAssertWhereMatchesWithFloatInNonStrictMode()
+    {
+        $doubleValue = (float) 1234.0;
+
+        $stringifiedData = json_encode([
+            'bar' => $doubleValue,
+        ]);
+
+        $assertableJsonString = new AssertableJsonString($stringifiedData);
+        $assert = AssertableJson::fromAssertableJsonString($assertableJsonString);
+
+        $assert->where('bar', $doubleValue, false);
     }
 
     public function testAssertWhereFailsWhenDoesNotMatchValue()


### PR DESCRIPTION
We encountered an issue in one of our projects where we try to assert JSON with a float value that ends with .0.

During JSON (de)serialization, the double value of "1234.0" gets converted into an integer and comparing the same value in an `AssertableJson ... ->where('value', 1234.0)` fails as the `value` has become an integer.

I have added a third property to the AssertableJson's ->where() method called `$strict` which allows the user to choose between `assertEquals` and `assertSame` functions. This allows the user to skip the type check in cases such as the one described.

I have also added two tests with this PR that confirms the functionality works.

The first test `testAssertWhereFailsWithFloatInStrictMode` confirms that the original `->where()` syntax continues working exactly as it was and also provides a repro case for the issue I encountered.

The second test `testAssertWhereMatchesWithFloatInNonStrictMode` confirms the newly added functionality works and the floating point number passes the assertion non-strict mode.