### PR TITLE
[9.x] Support connection to MySql with minimal interactions

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -71,7 +71,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
         $collation = $this->getCollation($config);
 
         if ($collation) {
-            $connection->exec("set names '{$config['charset']}'" . $collation);
+            $connection->exec("set names '{$config['charset']}'".$collation);
         }
     }
 
@@ -115,7 +115,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
                             : $this->getHostDsn($config);
 
         if (isset($config['charset'])) {
-            $dsn .= ';charset=' . $config['charset'];
+            $dsn .= ';charset='.$config['charset'];
         }
 
         return $dsn;

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -36,10 +36,7 @@ class DatabaseConnectorTest extends TestCase
         $connection = m::mock(PDO::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
-        $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($statement);
-        $statement->shouldReceive('execute')->once();
-        $connection->shouldReceive('exec')->zeroOrMoreTimes();
+        $connection->shouldReceive('exec')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'');
         $result = $connector->connect($config);
 
         $this->assertSame($result, $connection);
@@ -48,15 +45,15 @@ class DatabaseConnectorTest extends TestCase
     public function mySqlConnectProvider()
     {
         return [
-            ['mysql:host=foo;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
-            ['mysql:host=foo;port=111;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
-            ['mysql:unix_socket=baz;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
+            ['mysql:host=foo;dbname=bar;charset=utf8', ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
+            ['mysql:host=foo;port=111;dbname=bar;charset=utf8', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
+            ['mysql:unix_socket=baz;dbname=bar;charset=utf8', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
         ];
     }
 
     public function testMySqlConnectCallsCreateConnectionWithIsolationLevel()
     {
-        $dsn = 'mysql:host=foo;dbname=bar';
+        $dsn = 'mysql:host=foo;dbname=bar;charset=utf8';
         $config = ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8', 'isolation_level' => 'REPEATABLE READ'];
 
         $connector = $this->getMockBuilder(MySqlConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
@@ -64,7 +61,7 @@ class DatabaseConnectorTest extends TestCase
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
         $statement = m::mock(PDOStatement::class);
-        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($statement);
+        $connection->shouldReceive('exec')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'');
         $connection->shouldReceive('prepare')->once()->with('SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ')->andReturn($statement);
         $statement->shouldReceive('execute')->zeroOrMoreTimes();
         $connection->shouldReceive('exec')->zeroOrMoreTimes();


### PR DESCRIPTION
Reducing configuration statements issued to MySql Server on connect, like 'use db' or 'set names', helps taking full advantage of a connection proxy, minimizing chances of connection pinning [1].
Such configuration statements can also be executed once per connection, via proxy's initialization query, instead of once per Request lifecycle.

A support for a minimal interaction upon connection can also be useful in some conditions (es: tests, low resources).


Actually, on connect, MySqlConnector executes:
- Connect (via new PDO)
- use db query (if set $database)
- SET SESSION TRANSACTION ISOLATION (if set $isolation_level, as prepared statement)
- set names (if set $charset, as prepared statement)
- set time_zone (if set $timezone, as prepared statement)
- set session sql_mode (if set $modes or $strict, as prepared statement)

This PR:
- removes the 'use db' query, already specified into the DSN
- adds the charset (if set) into the DSN, with the same effect of 'set names' [2],
  also ensuring proper PDO::quote functionality, not affected by 'set names' statement [3].
  'set names' will be executed necessarily if a collation is set but not as prepared statement, useful when not using the default one, but unsetting it allows skipping this step.
- adapts existing tests to reflect changes

Setting these database options to NULL (isolation_level, collation, timezone, modes and strict) allows having a minimal interaction on a connect, like:
```
2020-07-24T12:51:18.507740Z	    2 Connect	db_user@127.0.0.1 on db_schema using TCP/IP
2020-07-24T12:51:18.509693Z	    2 Query	select true
```


[1] - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-managing.html#rds-proxy-pinning
[2] - https://dev.mysql.com/doc/refman/8.0/en/charset-connection.html
[3] - https://www.php.net/manual/en/mysqlinfo.concepts.charset.php