### PR TITLE
Add Gate helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -953,3 +953,27 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('gate')) {
+    /**
+     * Get the gate and inspect the ability if any.
+     *
+     * @param  string|null  $ability
+     * @param bool|null $shouldReturnResponse
+     * @return \Illuminate\Contracts\Auth\Access\Gate|\Illuminate\Auth\Access\Response|bool
+     */
+    function gate($ability = null, $shouldReturnResponse = false)
+    {
+        if (is_null($ability)) {
+            return app(Gate::class);
+        }
+
+        $response = app(Gate::class)->inspect($ability);
+
+        if ($shouldReturnResponse) {
+            return $response;
+        }
+
+        return $response->allowed();
+    }
+}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -959,7 +959,7 @@ if (! function_exists('gate')) {
      * Get the gate and inspect the ability if any.
      *
      * @param  string|null  $ability
-     * @param bool|null $shouldReturnResponse
+     * @param  bool|null  $shouldReturnResponse
      * @return \Illuminate\Contracts\Auth\Access\Gate|\Illuminate\Auth\Access\Response|bool
      */
     function gate($ability = null, $shouldReturnResponse = false)

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
-use Illuminate\Auth\Access\Response;
+use Illuminate\Auth\AuthServiceProvider;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Mix;
+use Illuminate\Session\SessionServiceProvider;
 use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -279,10 +280,14 @@ class FoundationHelpersTest extends TestCase
 
     public function testGate()
     {
+        config()->set('session.driver', 'array');
+        config()->set('auth.providers.users.model', User::class);
+        config()->set('auth.providers.users.driver', 'eloquent');
+        config()->set('auth.guards.web.driver', 'session');
+        config()->set('auth.defaults.guard', 'web');
+        app()->register(SessionServiceProvider::class);
+        app()->register(AuthServiceProvider::class);
+
         $this->assertInstanceOf(Gate::class, gate());
-
-        $this->assertIsBool(gate('foo'));
-
-        $this->assertInstanceOf(Response::class, gate('foo', true));
     }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
+use Illuminate\Auth\Access\Response;
 use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Mix;
@@ -273,5 +275,14 @@ class FoundationHelpersTest extends TestCase
 
         // Should fallback to en_US
         $this->assertSame('Australian Capital Territory', fake()->state());
+    }
+
+    public function testGate()
+    {
+        $this->assertInstanceOf(Gate::class, gate());
+
+        $this->assertIsBool(gate('foo'));
+
+        $this->assertInstanceOf(Response::class, gate('foo', true));
     }
 }


### PR DESCRIPTION
I think it's nice to simply gate('some-ability') instead of Gate::allows(), especially when you're dealing with inspect().

Hopefully can reduce boilerplate code.

gate('can-do-this'); // true
gate('can-do-that', true); // Response::deny();
gate(); // Gate instance