### PR TITLE
[9.x] allow to chain jobs when condition is true

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -147,7 +147,7 @@ class PendingDispatch
      */
     public function chainWhen($condition, $chain, $defaultChain = null)
     {
-        if($condition) {
+        if ($condition) {
             $this->job->chain($chain);
         } elseif ($defaultChain) {
             $this->job->chain($defaultChain);

--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -138,6 +138,25 @@ class PendingDispatch
     }
 
     /**
+     * Set the jobs that should run if this job is successful and the condition is true.
+     *
+     * @param  bool  $condition
+     * @param  array  $chain
+     * @param  array|null  $defaultChain
+     * @return $this
+     */
+    public function chainWhen($condition, $chain, $defaultChain = null)
+    {
+        if($condition) {
+            $this->job->chain($chain);
+        } elseif ($defaultChain) {
+            $this->job->chain($defaultChain);
+        }
+
+        return $this;
+    }
+
+    /**
      * Indicate that the job should be dispatched after the response is sent to the browser.
      *
      * @return $this

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -244,6 +244,33 @@ class JobChainingTest extends TestCase
 
         $this->assertNotNull(JobChainAddingAddedJob::$ranAt);
     }
+
+    public function testChainJobsCanBeAppendedOnlyWhenConditionIsTrue()
+    {
+        JobChainingTestFirstJob::dispatch()->chainWhen(false, [
+            new JobChainingTestSecondJob
+        ])
+        ->chainWhen(true, [
+            new JobChainingTestThirdJob
+        ]);
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertFalse(JobChainingTestSecondJob::$ran);
+        $this->assertTrue(JobChainingTestThirdJob::$ran);
+    }
+
+    public function testChainDefaultJobsCanBeAppendedOnlyWhenConditionIsFalse()
+    {
+        JobChainingTestFirstJob::dispatch()->chainWhen(false, [
+            new JobChainingTestSecondJob
+        ], [
+            new JobChainingTestThirdJob
+        ]);
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertFalse(JobChainingTestSecondJob::$ran);
+        $this->assertTrue(JobChainingTestThirdJob::$ran);
+    }
 }
 
 class JobChainingTestFirstJob implements ShouldQueue

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -248,10 +248,10 @@ class JobChainingTest extends TestCase
     public function testChainJobsCanBeAppendedOnlyWhenConditionIsTrue()
     {
         JobChainingTestFirstJob::dispatch()->chainWhen(false, [
-            new JobChainingTestSecondJob
+            new JobChainingTestSecondJob,
         ])
         ->chainWhen(true, [
-            new JobChainingTestThirdJob
+            new JobChainingTestThirdJob,
         ]);
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);
@@ -262,9 +262,9 @@ class JobChainingTest extends TestCase
     public function testChainDefaultJobsCanBeAppendedOnlyWhenConditionIsFalse()
     {
         JobChainingTestFirstJob::dispatch()->chainWhen(false, [
-            new JobChainingTestSecondJob
+            new JobChainingTestSecondJob,
         ], [
-            new JobChainingTestThirdJob
+            new JobChainingTestThirdJob,
         ]);
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);


### PR DESCRIPTION
This PR adds a new `when`-like method, which allows to chain an array of jobs when a condition is `true`.

For example:
```php
JobChainingTestFirstJob::dispatch()->chainWhen(false, [
            new JobChainingTestSecondJob // won't be chained because the condition is false
        ])
        ->chainWhen(true, [
            new JobChainingTestThirdJob // will be chained because the condition is true
        ]);
```

Of course, it is possible to chain a default array of jobs, if the condition is `false` and if the third parameter is not `null`.
```php
JobChainingTestFirstJob::dispatch()->chainWhen(false, [
            new JobChainingTestSecondJob // Won't be chained because the condition is false
        ], [
            new JobChainingTestThirdJob // Will be chained because the condition is false
        ]);
```