### PR TITLE
[8.x] Disable Column Statistics for `php artisan schema:dump` on MariaDB

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -85,10 +85,10 @@ class MySqlSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
-        $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc';
+        $command = 'mysqldump '.$this->connectionString().' --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc --column-statistics=0';
 
         if (! $this->connection->isMaria()) {
-            $command .= ' --column-statistics=0 --set-gtid-purged=OFF';
+            $command .= ' --set-gtid-purged=OFF';
         }
 
         return $command.' "${:LARAVEL_LOAD_DATABASE}"';


### PR DESCRIPTION
The `php artisan schema:dump` command fails on v10.x MariaDB. This is a resubmission of the fix by @domainregistrar in https://github.com/laravel/framework/pull/40832. (Feel free to merge that one instead to give him credit.)

The previous PR was closed as Taylor was awaiting feedback to confirm the fix. I just ran into this issue myself. The proposed fix solves it and was verified by a few others before me:

---

<img width="1358" alt="Screenshot 2022-02-08 at 16 36 18" src="https://user-images.githubusercontent.com/15707543/153020935-86eb3e32-7da9-4ac3-b13b-0dfb75b34260.png">
@taylorotwell can confirm that this problem exists.

EDIT: Using Laravel 9.x but should also happen in 8.x

_Originally posted by @Jubeki in https://github.com/laravel/framework/issues/40832#issuecomment-1032743482_

---

Can confirm this fix works for me 👍🏼 

I'm using Laravel version: 8.83.1 and Sail with  `image: 'mariadb:10'`
**mysqldump version:**  Ver 10.19 Distrib 10.6.5-MariaDB, for debian-linux-gnu (x86_64) 

Before applying this fix:
```
sail artisan schema:dump
mysqldump: [Warning] Using a password on the command line interface can be insecure.
mysqldump: Couldn't execute 'SELECT COLUMN_NAME,                       JSON_EXTRACT(HISTOGRAM, '$."number-of-buckets-specified"')                FROM information_schema.COLUMN_STATISTICS                WHERE SCHEMA_NAME = 'intranet' AND TABLE_NAME = 'attendance_reasons';': Unknown table 'COLUMN_STATISTICS' in information_schema (1109)

   Symfony\Component\Process\Exception\ProcessFailedException 

  The command "mysqldump  --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --no-tablespaces --skip-add-locks --skip-comments --skip-set-charset --tz-utc "${:LARAVEL_LOAD_DATABASE}" --routines --result-file="${:LARAVEL_LOAD_PATH}" --no-data" failed.

Exit Code: 2(Misuse of shell builtins)

Working directory: /var/www/html

Output:
================


Error Output:
================
mysqldump: [Warning] Using a password on the command line interface can be insecure.
mysqldump: Couldn't execute 'SELECT COLUMN_NAME,                       JSON_EXTRACT(HISTOGRAM, '$."number-of-buckets-specified"')                FROM information_schema.COLUMN_STATISTICS                WHERE SCHEMA_NAME = 'intranet' AND TABLE_NAME = 'attendance_reasons';': Unknown table 'COLUMN_STATISTICS' in information_schema (1109)

  at vendor/symfony/process/Process.php:272
    268▕      */
    269▕     public function mustRun(callable $callback = null, array $env = []): self
    270▕     {
    271▕         if (0 !== $this->run($callback, $env)) {
  ➜ 272▕             throw new ProcessFailedException($this);
    273▕         }
    274▕ 
    275▕         return $this;
    276▕     }

      +16 vendor frames 
  17  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()

```

After applying this fix:
```
sail artisan schema:dump
mysqldump: [Warning] Using a password on the command line interface can be insecure.
Database schema dumped successfully.

```

_Originally posted by @22Nick22 in https://github.com/laravel/framework/issues/40832#issuecomment-1059227907_

---

Confirming: just got snagged by this myself (fresh Laravel 9 install using MariaDB via Sail)

Making the changes in this PR got it to work

_Originally posted by @benmag in https://github.com/laravel/framework/issues/40832#issuecomment-1163905244_