### PR TITLE
[9.x] allow Collection `random()` to accept a callable

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -978,7 +978,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get one or a specified number of items randomly from the collection.
      *
-     * @param  int|null  $number
+     * @param  (callable(TValue): int)|int|null  $number
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException
@@ -987,6 +987,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         if (is_null($number)) {
             return Arr::random($this->items);
+        }
+
+        if (is_callable($number)) {
+            return new static(Arr::random($this->items, $number($this)));
         }
 
         return new static(Arr::random($this->items, $number));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2285,6 +2285,10 @@ class SupportCollectionTest extends TestCase
         $random = $data->random('2');
         $this->assertInstanceOf($collection, $random);
         $this->assertCount(2, $random);
+
+        $random = $data->random(fn($items) => min(10, count($items)));
+        $this->assertInstanceOf($collection, $random);
+        $this->assertCount(6, $random);
     }
 
     /**


### PR DESCRIPTION
this allows the user to, rather than passing an int directly, pass a closure that can reference back to the original Collection in case they need to reference the size of the Collection

a little confusing, so here's an example:

We have a `User` and `Comment`s. `User`s can have many `Comment`s.  Let's say we want to show 5 random comments from a `User` on a dashboard.

```php
$comments = $user->comments->random(5);
```

This probably seems fine, but we run into an issue if the `User` doesn't have at least 5 comments, and Laravel will throw an `InvalidArgumentException`.  So we want to amend this to say we want 5 comments **or** the total count of the comments, whichever is smaller.  In order to do this currently, you need to use a temporary variable.

```php
$comments = $user->comments;
$comments = $comments->random(min(5, count($comments)));
```

With this PR you'll now be able to chain this entire call:

```php
$comments = $user->comments->random(fn($items) => min(5, count($items)));
```

---

I'm still a little new to the generics docblocks, so LMK if that needs an adjustment.