### PR TITLE
[9.x] wasChanged and isDirty phpdoc fix

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1834,7 +1834,7 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the model or any of the given attribute(s) have been modified.
+     * Determine if the model or any of the given attribute(s) have been modified since last save.
      *
      * @param  array|string|null  $attributes
      * @return bool
@@ -1858,7 +1858,7 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the model or any of the given attribute(s) have been modified.
+     * Determine if the model or any of the given attribute(s) were changed on save.
      *
      * @param  array|string|null  $attributes
      * @return bool


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Right now methods **isDirty()** and **wasChanged()** have the same phpdoc comment and since their functionality is quite similar it is very confusing sometimes and may lead to bugs.

This PR proposes a fix to PHPDoc comments of those methods to make the difference and their purpose clearer.

The comment for **wasChanged()** is taken from Laravel docs
> method determines if any attributes were changed when the model **was last saved** within the current request cycle

The comment for **isDirty()** is not something I am sure of. The Laravel documentation might be wrong since it says
> The `isDirty` method determines if any of the model's attributes have been changed since the model was **retrieved**

When actually it checks if attribute(s) were changed since last sync (which happens on save)

Better suggestions for phpdoc comments are welcome