### PR TITLE
[10.x] Added missing method to CursorPaginator interface

### DIFF
--- a/src/Illuminate/Contracts/Pagination/CursorPaginator.php
+++ b/src/Illuminate/Contracts/Pagination/CursorPaginator.php
@@ -30,6 +30,13 @@ interface CursorPaginator
     public function fragment($fragment = null);
 
     /**
+     * Add all current query string values to the paginator.
+     *
+     * @return $this
+     */
+    public function withQueryString();
+
+    /**
      * Get the URL for the previous page, or null.
      *
      * @return string|null


### PR DESCRIPTION
Autocompletion in IDEs doesn't recognise the `withQueryString` method because `paginate`, `simplePaginate` and `cursorPaginate` returns the CursorPaginator interface that doesn't contain the method `withQueryString`.

The interface method can be safely added because the class that implements `CursorPaginator`, has a base class with the `withQueryString` implemented.