### PR TITLE
feat: add singularity and plurality check methods for strings 🔬🧐

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -921,6 +921,26 @@ class Str
     }
 
     /**
+     * check if the given value is in a singular form.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isSingular(string $value){
+        return static::singular($value) === $value;
+    }
+
+    /**
+     * check if the given value is in a plural form.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isPlural(string $value){
+        return !static::isSingular($value) || $value === static::plural($value);
+    }
+
+    /**
      * Generate a URL friendly "slug" from a given string.
      *
      * @param  string  $title

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -926,7 +926,8 @@ class Str
      * @param  string  $value
      * @return bool
      */
-    public static function isSingular(string $value){
+    public static function isSingular(string $value)
+    {
         return static::singular($value) === $value;
     }
 
@@ -936,7 +937,8 @@ class Str
      * @param  string  $value
      * @return bool
      */
-    public static function isPlural(string $value){
+    public static function isPlural(string $value)
+    {
         return !static::isSingular($value) || $value === static::plural($value);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -939,7 +939,7 @@ class Str
      */
     public static function isPlural(string $value)
     {
-        return !static::isSingular($value) || $value === static::plural($value);
+        return ! static::isSingular($value) || $value === static::plural($value);
     }
 
     /**

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -113,6 +113,44 @@ class SupportPluralizerTest extends TestCase
         $this->assertPluralStudly('SomeUsers', 'SomeUser', collect(['one', 'two']));
     }
 
+    public function testIsSingular()
+    {
+        $this->assertTrue(Str::isSingular('User'));
+        $this->assertTrue(Str::isSingular('Child'));
+        $this->assertTrue(Str::isSingular('Story'));
+        $this->assertTrue(Str::isSingular('cod'));
+        $this->assertTrue(Str::isSingular('The word'));
+        $this->assertTrue(Str::isSingular('Bouqueté'));
+    }
+
+    public function testIsSingularReturnsFalse()
+    {
+        $this->assertFalse(Str::isSingular('Users'));
+        $this->assertFalse(Str::isSingular('Stories'));
+        $this->assertFalse(Str::isSingular('Children'));
+        $this->assertFalse(Str::isSingular('The words'));
+        $this->assertFalse(Str::isSingular('Bouquetés'));
+    }
+
+    public function testIsPlural()
+    {
+        $this->assertTrue(Str::isPlural('Users'));
+        $this->assertTrue(Str::isPlural('Stories'));
+        $this->assertTrue(Str::isPlural('Children'));
+        $this->assertTrue(Str::isPlural('cod'));
+        $this->assertTrue(Str::isPlural('The words'));
+        $this->assertTrue(Str::isPlural('Bouquetés'));
+    }
+
+    public function testIsPluralReturnsFalse()
+    {
+        $this->assertFalse(Str::isPlural('User'));
+        $this->assertFalse(Str::isPlural('Story'));
+        $this->assertFalse(Str::isPlural('Child'));
+        $this->assertFalse(Str::isPlural('The word'));
+        $this->assertFalse(Str::isPlural('Bouqueté'));
+    }
+
     private function assertPluralStudly($expected, $value, $count = 2)
     {
         $this->assertSame($expected, Str::pluralStudly($value, $count));


### PR DESCRIPTION
This Pull Request adds new methods to the `Support Str` class to easily check strings plurality and singularity.

Added methods:
- `Str::isSingular('cat')//true`
- `Str::isPlural('cats')//true`

## Check if the given string is in a singular form:

> Before
```php
Str::singular($value) === $value;
```

> After
```php
Str::isSingular($value);
```

## Check if the given string is in a plural form:

> Before
```php
Str::singular($value) !== $value || $value === Str::plural($value);
```

> After
```php
Str::isPlural($value);
```

## Note

In some cases, if `isSingular` method returns `true`, it doesn't mean that `isPlural` method will return `false` for the same word
```php
Str::isSingular('sheep');//true
Str::isPlural('sheep');//true
```
