### PR TITLE
[9.x] Adding `Str::isSerialized()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -290,7 +290,6 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
-        preg_match('/^(.*?)('.preg_quote((string) $phrase).')(.*)$/iu', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;
@@ -414,12 +413,12 @@ class Str
         }
 
         try {
-            unserialize($value);
+            $unserialized = @unserialize($value);
         } catch (Exception) {
             return false;
         }
 
-        return true;
+        return serialize($unserialized) === $value;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -290,6 +290,7 @@ class Str
         $radius = $options['radius'] ?? 100;
         $omission = $options['omission'] ?? '...';
 
+        preg_match('/^(.*?)('.preg_quote((string) $phrase).')(.*)$/iu', (string) $text, $matches);
 
         if (empty($matches)) {
             return null;
@@ -413,12 +414,12 @@ class Str
         }
 
         try {
-            $unserialized = @unserialize($value);
+            unserialize($value);
         } catch (Exception) {
             return false;
         }
 
-        return serialize($unserialized) === $value;
+        return true;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use Exception;
 use JsonException;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
@@ -394,6 +395,27 @@ class Str
         try {
             json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if a given value is a valid serialized string.
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isSerialized($value)
+    {
+        if (! is_string($value) || ! $value) {
+            return false;
+        }
+
+        try {
+            unserialize($value);
+        } catch (Exception) {
             return false;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -414,12 +414,12 @@ class Str
         }
 
         try {
-            unserialize($value);
+            $unserialized = @unserialize($value);
         } catch (Exception) {
             return false;
         }
 
-        return true;
+        return serialize($unserialized) === $value;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -308,6 +308,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given value is a valid serialized string.
+     *
+     * @return bool
+     */
+    public function isSerialized()
+    {
+        return Str::isSerialized($this->value);
+    }
+
+    /**
      * Determine if a given string is a valid UUID.
      *
      * @return bool

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -430,6 +430,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::isSerialized('d:24.04;'));
         $this->assertTrue(Str::isSerialized('s:1:"0";'));
         $this->assertTrue(Str::isSerialized('a:0:{}'));
+        $this->assertTrue(Str::isSerialized('b:0;'));
         $this->assertTrue(Str::isSerialized('N;'));
         $this->assertTrue(Str::isSerialized('O:8:"stdClass":0:{}'));
         $this->assertTrue(Str::isSerialized('a:1:{s:3:"foo";s:3:"bar";}'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -424,6 +424,24 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isJson([]));
     }
 
+    public function testIsSerialized()
+    {
+        $this->assertTrue(Str::isSerialized('i:0;'));
+        $this->assertTrue(Str::isSerialized('d:24.04;'));
+        $this->assertTrue(Str::isSerialized('s:1:"0";'));
+        $this->assertTrue(Str::isSerialized('a:0:{}'));
+        $this->assertTrue(Str::isSerialized('N;'));
+        $this->assertTrue(Str::isSerialized('O:8:"stdClass":0:{}'));
+        $this->assertTrue(Str::isSerialized('a:1:{s:3:"foo";s:3:"bar";}'));
+
+        $this->assertFalse(Str::isSerialized(''));
+        $this->assertFalse(Str::isSerialized('error'));
+        $this->assertFalse(Str::isSerialized('a:1'));
+        $this->assertFalse(Str::isSerialized('a:1:{42}'));
+        $this->assertFalse(Str::isSerialized('a:2:{s:3:"foo";s:3:"bar";}'));
+        $this->assertFalse(Str::isSerialized(null));
+    }
+
     public function testKebab()
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -61,6 +61,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('d:24.04;')->isSerialized());
         $this->assertTrue($this->stringable('s:1:"0";')->isSerialized());
         $this->assertTrue($this->stringable('a:0:{}')->isSerialized());
+        $this->assertTrue($this->stringable('b:0;')->isSerialized());
         $this->assertTrue($this->stringable('N;')->isSerialized());
         $this->assertTrue($this->stringable('O:8:"stdClass":0:{}')->isSerialized());
         $this->assertTrue($this->stringable('a:1:{s:3:"foo";s:3:"bar";}')->isSerialized());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -55,6 +55,24 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable(null)->isJson());
     }
 
+    public function testIsSerialized()
+    {
+        $this->assertTrue($this->stringable('i:0;')->isSerialized());
+        $this->assertTrue($this->stringable('d:24.04;')->isSerialized());
+        $this->assertTrue($this->stringable('s:1:"0";')->isSerialized());
+        $this->assertTrue($this->stringable('a:0:{}')->isSerialized());
+        $this->assertTrue($this->stringable('N;')->isSerialized());
+        $this->assertTrue($this->stringable('O:8:"stdClass":0:{}')->isSerialized());
+        $this->assertTrue($this->stringable('a:1:{s:3:"foo";s:3:"bar";}')->isSerialized());
+
+        $this->assertFalse($this->stringable('')->isSerialized());
+        $this->assertFalse($this->stringable('error')->isSerialized());
+        $this->assertFalse($this->stringable('a:1')->isSerialized());
+        $this->assertFalse($this->stringable('a:1:{42}')->isSerialized());
+        $this->assertFalse($this->stringable('a:2:{s:3:"foo";s:3:"bar";}')->isSerialized());
+        $this->assertFalse($this->stringable(null)->isSerialized());
+    }
+
     public function testIsEmpty()
     {
         $this->assertTrue($this->stringable('')->isEmpty());


### PR DESCRIPTION
Adding `isSerialized()` to `Str` and `Stringable`.

```php
Str::isSerialized($value);  //bool

Str::of($value)->isSerialized()  //bool

str($value)->isSerialized();  //bool
```