### PR TITLE
[9.x] Bind a Vite Null Object to the Container instead of a Closure

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -111,12 +111,7 @@ trait InteractsWithContainer
 
         $this->swap(Vite::class, new class
         {
-            public function __invoke()
-            {
-                return '';
-            }
-
-            public function reactRefresh()
+            public function __call($name, $arguments)
             {
                 return '';
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -111,6 +111,11 @@ trait InteractsWithContainer
 
         $this->swap(Vite::class, new class
         {
+            public function __invoke()
+            {
+                return '';
+            }
+
             public function __call($name, $arguments)
             {
                 return '';

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -109,8 +109,16 @@ trait InteractsWithContainer
             $this->originalVite = app(Vite::class);
         }
 
-        $this->swap(Vite::class, function () {
-            return '';
+        $this->swap(Vite::class, new class {
+            public function __invoke()
+            {
+                return '';
+            }
+
+            public function reactRefresh()
+            {
+                return '';
+            }
         });
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -109,7 +109,8 @@ trait InteractsWithContainer
             $this->originalVite = app(Vite::class);
         }
 
-        $this->swap(Vite::class, new class {
+        $this->swap(Vite::class, new class
+        {
             public function __invoke()
             {
                 return '';

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -17,6 +17,14 @@ class InteractsWithContainerTest extends TestCase
         $this->assertSame($this, $instance);
     }
 
+    public function testWithoutViteHandlesReactRefresh()
+    {
+        $instance = $this->withoutVite();
+
+        $this->assertSame('', app(Vite::class)->reactRefresh());
+        $this->assertSame($this, $instance);
+    }
+
     public function testWithViteRestoresOriginalHandlerAndReturnsInstance()
     {
         $handler = new stdClass;


### PR DESCRIPTION
Closes #43039