### PR TITLE
[9.x] Add pseudo namespace for tables for `make:model` command 

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -289,7 +289,9 @@ abstract class GeneratorCommand extends Command
     {
         $stub = $this->files->get($this->getStub());
 
-        return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+        return $this->replaceNamespace($stub, $name)
+                     ->replaceTable($stub, $name)
+                     ->replaceClass($stub, $name);
     }
 
     /**
@@ -327,6 +329,22 @@ abstract class GeneratorCommand extends Command
     protected function getNamespace($name)
     {
         return trim(implode('\\', array_slice(explode('\\', $name), 0, -1)), '\\');
+    }
+
+    /**
+     * Replace the table name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return $this
+     */
+    protected function replaceTable(&$stub, $name)
+    {
+        $table = Str::snake(Str::pluralStudly(Str::studly(Str::replace('\\', '_', $this->getNameInput()))));
+
+        $stub = str_replace(['DummyTable', '{{ table }}', '{{table}}'], $table, $stub);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -108,7 +108,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function createMigration()
     {
-        $table = Str::snake(Str::pluralStudly(class_basename($this->argument('name'))));
+        $table = Str::snake(Str::pluralStudly(Str::studly(Str::replace('\\', '_', $this->argument('name')))));
 
         if ($this->option('pivot')) {
             $table = Str::singular($table);

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -8,4 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 class {{ class }} extends Model
 {
     use HasFactory;
+
+	/**
+	 * The table associated with the model.
+	 *
+	 * @var string
+	 */
+	protected $table = '{{ table }}';
+
 }


### PR DESCRIPTION
Laravel makes extensive use of php namespaces to allow packages to co-exist, however the same is not true of SQL tables, with the consequence that the package that creates tables cannot easily be identified and increasing the chances of clashes on table names between packages.

This pull request adds pseudo namespace support for tables to the `make:model` command by pre-pending the path specified on the command line to the table name in the model and migration files. So currently...
* `php artisan make:model Test` uses `test` as the table name
* `php artisan make:model Project\Test` also uses `test` as the table name

This pull request prepends the path to the table name in the migration and model files as follows:
* `php artisan make:model Test` still uses `test` as the table name
* `php artisan make:model Project\SubProj\Test` now uses `project_subproj_test` as the table name

Obviously the `make:model` command only creates stub files, and the user then has the option to change the table names, so this PR should not introduce any real backward compatibility issues, but hopefully this change will encourage package providers to group their tables.

Note: This is my first PR on Laravel so please excuse any mistakes in the coding or submission. 