### PR TITLE
[9.x] Provide userstamps (like timestamps)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -14,29 +14,6 @@ trait HasTimestamps
     public $timestamps = true;
 
     /**
-     * Update the model's update timestamp.
-     *
-     * @param  string|null  $attribute
-     * @return bool
-     */
-    public function touch($attribute = null)
-    {
-        if ($attribute) {
-            $this->$attribute = $this->freshTimestamp();
-
-            return $this->save();
-        }
-
-        if (! $this->usesTimestamps()) {
-            return false;
-        }
-
-        $this->updateTimestamps();
-
-        return $this->save();
-    }
-
-    /**
      * Update the creation and update timestamps.
      *
      * @return $this

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUserstamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUserstamps.php
@@ -93,7 +93,7 @@ trait HasUserstamps
      */
     public function freshUserstamp()
     {
-        return Auth::user() ? Auth::id() : Null;
+        return Auth::user() ? Auth::id() : null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUserstamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUserstamps.php
@@ -11,7 +11,7 @@ trait HasUserstamps
      *
      * @var bool
      */
-    public $userstamps = true;
+    public $userstamps = false;
 
     /**
      * Update the creation and update userstamps.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUserstamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUserstamps.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Support\Facades\Auth;
+
+trait HasUserstamps
+{
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $userstamps = true;
+
+    /**
+     * Update the model's update timestamp.
+     *
+     * @param  string|null  $attribute
+     * @return bool
+     */
+    public function touch($attribute = null)
+    {
+        if ($attribute) {
+            $this->$attribute = $this->freshUserstamp();
+
+            return $this->save();
+        }
+
+        if (! $this->usesUserstamps()) {
+            return false;
+        }
+
+        $this->updateUserstamps();
+
+        return $this->save();
+    }
+
+    /**
+     * Update the creation and update timestamps.
+     *
+     * @return $this
+     */
+    public function updateUserstamps()
+    {
+        $user = $this->freshUserstamp();
+
+        $updatedByColumn = $this->getUpdatedByColumn();
+
+        if (! is_null($updatedByColumn) && ! $this->isDirty($updatedByColumn)) {
+            $this->setUpdatedBy($user);
+        }
+
+        $createdByColumn = $this->getCreatedByColumn();
+
+        if (! $this->exists && ! is_null($createdByColumn) && ! $this->isDirty($createdByColumn)) {
+            $this->setCreatedBy($user);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the value of the "created at" attribute.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setCreatedBy($value)
+    {
+        $this->{$this->getCreatedByColumn()} = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of the "updated at" attribute.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function setUpdatedBy($value)
+    {
+        $this->{$this->getUpdatedByColumn()} = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get a fresh userstamp for the model.
+     *
+     * @return string|null
+     */
+    public function freshUserstamp()
+    {
+        return Auth::user() ? Auth::id() : Null;
+    }
+
+    /**
+     * Determine if the model uses timestamps.
+     *
+     * @return bool
+     */
+    public function usesUserstamps()
+    {
+        return $this->userstamps;
+    }
+
+    /**
+     * Get the name of the "created at" column.
+     *
+     * @return string|null
+     */
+    public function getCreatedByColumn()
+    {
+        return static::CREATED_BY;
+    }
+
+    /**
+     * Get the name of the "updated at" column.
+     *
+     * @return string|null
+     */
+    public function getUpdatedByColumn()
+    {
+        return static::UPDATED_BY;
+    }
+
+    /**
+     * Get the fully qualified "created at" column.
+     *
+     * @return string|null
+     */
+    public function getQualifiedCreatedByColumn()
+    {
+        return $this->qualifyColumn($this->getCreatedByColumn());
+    }
+
+    /**
+     * Get the fully qualified "updated at" column.
+     *
+     * @return string|null
+     */
+    public function getQualifiedUpdatedByColumn()
+    {
+        return $this->qualifyColumn($this->getUpdatedByColumn());
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUserstamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUserstamps.php
@@ -7,37 +7,14 @@ use Illuminate\Support\Facades\Auth;
 trait HasUserstamps
 {
     /**
-     * Indicates if the model should be timestamped.
+     * Indicates if the model should be userstamped.
      *
      * @var bool
      */
     public $userstamps = true;
 
     /**
-     * Update the model's update timestamp.
-     *
-     * @param  string|null  $attribute
-     * @return bool
-     */
-    public function touch($attribute = null)
-    {
-        if ($attribute) {
-            $this->$attribute = $this->freshUserstamp();
-
-            return $this->save();
-        }
-
-        if (! $this->usesUserstamps()) {
-            return false;
-        }
-
-        $this->updateUserstamps();
-
-        return $this->save();
-    }
-
-    /**
-     * Update the creation and update timestamps.
+     * Update the creation and update userstamps.
      *
      * @return $this
      */
@@ -93,7 +70,7 @@ trait HasUserstamps
      */
     public function freshUserstamp()
     {
-        return Auth::user() ? Auth::id() : null;
+        return Auth::check() ? Auth::id() : null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -373,8 +373,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $class = $class ?: static::class;
 
         if (
-            ! get_class_vars($class)['timestamps'] && ! $class::UPDATED_AT &&
-            ! get_class_vars($class)['userstamps'] && ! $class::UPDATED_BY
+            (! get_class_vars($class)['timestamps'] || ! $class::UPDATED_AT) &&
+            (! get_class_vars($class)['userstamps'] || ! $class::UPDATED_BY)
         ) {
             return true;
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -30,6 +30,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HasGlobalScopes,
         Concerns\HasRelationships,
         Concerns\HasTimestamps,
+        Concerns\HasUserstamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
         ForwardsCalls;
@@ -358,6 +359,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $class = $class ?: static::class;
 
         if (! get_class_vars($class)['timestamps'] || ! $class::UPDATED_AT) {
+            return true;
+        }
+
+        if (! get_class_vars($class)['userstamps'] || ! $class::UPDATED_BY) {
             return true;
         }
 
@@ -1089,10 +1094,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         // First we need to create a fresh query instance and touch the creation and
-        // update timestamp on the model which are maintained by us for developer
+        // update timestamp / userstamp on the model which are maintained by us for developer
         // convenience. Then we will just continue saving the model instances.
         if ($this->usesTimestamps()) {
             $this->updateTimestamps();
+        }
+        if ($this->usesUserstamps()) {
+            $this->updateUserstamps();
         }
 
         // Once we have run the update operation, we will fire the "updated" event for
@@ -1170,10 +1178,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         // First we'll need to create a fresh query instance and touch the creation and
-        // update timestamps on this model, which are maintained by us for developer
+        // update timestamps / userstamps on this model, which are maintained by us for developer
         // convenience. After, we will just continue saving these model instances.
         if ($this->usesTimestamps()) {
             $this->updateTimestamps();
+        }
+        if ($this->usesUserstamps()) {
+            $this->updateUserstamps();
         }
 
         // If the model has an incrementing key, we can use the "insertGetId" method on

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -197,6 +197,20 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     const UPDATED_AT = 'updated_at';
 
     /**
+     * The name of the "created by" column.
+     *
+     * @var string|null
+     */
+    const CREATED_BY = 'created_by';
+
+    /**
+     * The name of the "updated by" column.
+     *
+     * @var string|null
+     */
+    const UPDATED_BY = 'updated_by';
+
+    /**
      * Create a new Eloquent model instance.
      *
      * @param  array  $attributes
@@ -358,11 +372,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     {
         $class = $class ?: static::class;
 
-        if (! get_class_vars($class)['timestamps'] || ! $class::UPDATED_AT) {
-            return true;
-        }
-
-        if (! get_class_vars($class)['userstamps'] || ! $class::UPDATED_BY) {
+        if (
+            ! get_class_vars($class)['timestamps'] && ! $class::UPDATED_AT &&
+            ! get_class_vars($class)['userstamps'] && ! $class::UPDATED_BY
+        ) {
             return true;
         }
 
@@ -373,6 +386,35 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         return false;
+    }
+
+    /**
+     * Update the model's update timestamp.
+     *
+     * @param  string|null  $attribute
+     * @return bool
+     */
+    public function touch($attribute = null)
+    {
+        if ($attribute) {
+            $this->$attribute = $this->freshTimestamp();
+
+            return $this->save();
+        }
+
+        if (! $this->usesTimestamps() && ! $this->usesUserstamps()) {
+            return false;
+        }
+
+        if ($this->usesTimestamps()) {
+            $this->updateTimestamps();
+        }
+
+        if ($this->usesUserstamps()) {
+            $this->updateUserstamps();
+        }
+
+        return $this->save();
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1250,7 +1250,10 @@ class Blueprint
      */
     public function userstamp($column)
     {
-        return $this->string($column, 255);
+        $stamp = $this->foreignId($column);
+        $this->foreign($column)->references('id')->on('users')
+
+        return $stamp
     }
 
     /**
@@ -1261,9 +1264,11 @@ class Blueprint
      */
     public function userstamps()
     {
-        $this->string('created_by', 255)->nullable();
+        $this->foreignId('created_by')->nullable();
+        $this->foreign('created_by')->references('id')->on('users')
 
-        $this->string('updated_by', 255)->nullable();
+        $this->foreignId('updated_by')->nullable();
+        $this->foreign('updated_by')->references('id')->on('users')
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1251,9 +1251,9 @@ class Blueprint
     public function userstamp($column)
     {
         $stamp = $this->foreignId($column);
-        $this->foreign($column)->references('id')->on('users')
+        $this->foreign($column)->references('id')->on('users');
 
-        return $stamp
+        return $stamp;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1265,10 +1265,10 @@ class Blueprint
     public function userstamps()
     {
         $this->foreignId('created_by')->nullable();
-        $this->foreign('created_by')->references('id')->on('users')
+        $this->foreign('created_by')->references('id')->on('users');
 
         $this->foreignId('updated_by')->nullable();
-        $this->foreign('updated_by')->references('id')->on('users')
+        $this->foreign('updated_by')->references('id')->on('users');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -458,6 +458,16 @@ class Blueprint
     }
 
     /**
+     * Indicate that the userstamp columns should be dropped.
+     *
+     * @return void
+     */
+    public function dropUserstamps()
+    {
+        $this->dropColumn('created_by', 'updated_by');
+    }
+
+    /**
      * Indicate that the timestamp columns should be dropped.
      *
      * @return void
@@ -1229,6 +1239,31 @@ class Blueprint
     public function year($column)
     {
         return $this->addColumn('year', $column);
+    }
+
+    /**
+     * Create a new userstamp column on the table.
+     *
+     * @param  string  $column
+     * @param  int|null  $precision
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function userstamp($column)
+    {
+        return $this->string($column, 255);
+    }
+
+    /**
+     * Add nullable creation and update userstamps to the table.
+     *
+     * @param  int|null  $precision
+     * @return void
+     */
+    public function userstamps()
+    {
+        $this->string('created_by', 255)->nullable();
+
+        $this->string('updated_by', 255)->nullable();
     }
 
     /**


### PR DESCRIPTION
The idea of this PR is to provide in Migration and Model support for specifying UserStamps (created_by, updated_by) to automatically hold the user details of whoever created / last saved the record.

This is a first draft PR - it is not yet complete or tested nor have I written unit tests for it.

I am submitting it now to find out whether this will be accepted as new functionality once I complete the work. If so, then I will complete the above and submit it for full review.