### PR TITLE
[9.x] Add `BadRequest` assertion to `TestResponse`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -147,16 +147,6 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the response has a bad request status code.
-     *
-     * @return $this
-     */
-    public function assertBadRequest()
-    {
-        return $this->assertStatus(400);
-    }
-
-    /**
      * Assert that the response has an unauthorized status code.
      *
      * @return $this
@@ -164,6 +154,16 @@ class TestResponse implements ArrayAccess
     public function assertUnauthorized()
     {
         return $this->assertStatus(401);
+    }
+
+    /**
+     * Assert that the response has a bad request status code.
+     *
+     * @return $this
+     */
+    public function assertBadRequest()
+    {
+        return $this->assertStatus(400);
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -147,6 +147,16 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has a bad request status code.
+     *
+     * @return $this
+     */
+    public function assertBadRequest()
+    {
+        return $this->assertStatus(400);
+    }
+
+    /**
      * Assert that the response has an unauthorized status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -541,6 +541,22 @@ class TestResponseTest extends TestCase
         $response->assertUnauthorized();
     }
 
+    public function testAssertBadRequest()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Expected response status code');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertBadRequest();
+    }
+
     public function testAssertUnprocessable()
     {
         $statusCode = 500;


### PR DESCRIPTION
### About
We have conventional methods for `40x` HTTP responses, like `assertNotFound`, `assertForbidden`, `assertUnauthorized`. But the main `400` (Bad Request) is missing. This PR adds `assertBadRequest` method to the pool of available assertions.

```php
$response->assertBadRequest();
```

