### PR TITLE
[9.x] Ability to attach an array of files in MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -261,6 +261,23 @@ class MailMessage extends SimpleMessage implements Renderable
 
         return $this;
     }
+    
+    /**
+     * Attach an array of files to the message.
+     *
+     * @param  array  $files
+     * @param  array  $options
+     * @return $this
+     */
+    public function attachFiles($files, array $options = [])
+    {
+        foreach($files as $file)
+        {
+            $this->attachments[] = compact('file', 'options');
+        }
+
+        return $this;
+    }
 
     /**
      * Attach in-memory data as an attachment.


### PR DESCRIPTION
From Notifications ```toMail()``` method:

```
$attachments = [
            public_path('file1.xlsx'),
            public_path('file2.mp4')
        ];
```
```
return (new MailMessage)
            ->view('mails.mail-template')
            ->attachFiles($attachments);
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
