### PR TITLE
[9.x] Fix inconsistent content type when using ResponseSequence

### DIFF
--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -51,8 +51,6 @@ class ResponseSequence
      */
     public function push($body = null, int $status = 200, array $headers = [])
     {
-        $body = is_array($body) ? json_encode($body) : $body;
-
         return $this->pushResponse(
             Factory::response($body, $status, $headers)
         );

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -478,6 +478,7 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory->get('https://example.com');
         $this->assertSame(['fact' => 'Cats are great!'], $response->json());
+        $this->assertSame('application/json', $response->header('Content-Type'));
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');


### PR DESCRIPTION
This PR fixes an inconsistency when using the `ResponseSequence::push` method.

## Summary

The `\Illuminate\Http\Client\Factory::response()` method sets the response’s `Content-Type` header to `application/json` and JSON encodes the response body if an `array` was passed as the `$body` parameter.

```php
Http::fake(fn () => Http::response(['foo' => 'bar']));
$response = Http::get('http://example.com');
$response->header('Content-Type');
// => "application/json"
```

The `push` method of the `ResponseSequence` internally calls `Factory::response` to create a new `Response` object. However, the `ResponseSequence::push` method _also_ JSON encodes the request body if an array was passed _before_ calling `Factory::response`. This means that the `Content-Type` header will not get set to `application/json` in this case because `$body` will be a string instead of an array.

```php
Http::fakeSequence()->push(['foo' => 'bar']);
$response = Http::get('http://example.com');
$response->header('Content-Type');
// => ""
```

The fix is to simply not JSON serialize the `$body` variable inside `ResponseSequence::push` as `Factory::response` already does that.