### PR TITLE
Add `query()` method to docblock DB facade

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -6,6 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Doctrine\DBAL\Driver\PDOConnection getPdo()
  * @method static \Illuminate\Database\ConnectionInterface connection(string $name = null)
  * @method static \Illuminate\Database\Query\Builder table(string $table, string $as = null)
+ * @method static \Illuminate\Database\Query\Builder query()
  * @method static \Illuminate\Database\Query\Expression raw($value)
  * @method static array getQueryLog()
  * @method static array prepareBindings(array $bindings)


### PR DESCRIPTION
When creating a query with a DB facade, we don't always use the `table()` method. Because it doesn't use the `table()` method, the IDE can't auto-complete from `\Illuminate\Database\Query\Builder`.

For example, using the DB facade of a sub query that doesn't require the `table()` method.

```php
$data = DB::query()
    ->selectRaw("
        CASE 
            WHEN jpm < 50 THEN '<50'
            WHEN jpm <= 75 THEN '50-75' 
            WHEN jpm <= 90 THEN '75-90' 
            ELSE '>90' 
	END AS range,
        count(*) total
    ")
    ->fromSub($jpm, 'result')
    ->groupBy('range')
    ->get();
```
Auto complete in VS code
![image](https://user-images.githubusercontent.com/27954794/177455529-9a85687a-55f9-4b64-84e1-275309f96093.png)
![image](https://user-images.githubusercontent.com/27954794/177455772-5d0693a3-ee30-4567-b596-f4568b11d780.png)

