### PR TITLE
Add test for functional values (wrapped in parens) in wrap()

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -70,6 +70,14 @@ abstract class Grammar
             return $this->wrapJsonSelector($value);
         }
 
+        // If the given value is functional (wrapped in parentheses), we cannot make any
+        // assumptions, and should just return the value as is.  For example, as of MySQL
+        // 8.0.13, indexes can include functional key parts wrapped in parens, like
+        // (COALESCE(`scan_code`, "")), as well as simple column names.
+        if ($this->isFunctional($value)) {
+            return $value;
+        }
+
         return $this->wrapSegments(explode('.', $value));
     }
 
@@ -146,6 +154,17 @@ abstract class Grammar
     protected function isJsonSelector($value)
     {
         return str_contains($value, '->');
+    }
+
+    /**
+     * Determine if the given string is functional (wrapped in parentheses).
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    protected function isFunctional($value)
+    {
+        return $value[0] === '(' && $value[-1] === ')';
     }
 
     /**


### PR DESCRIPTION
As of MySQL 8.0.13 (or thereabouts), indexes can be specified with [functional key parts](https://dev.mysql.com/doc/refman/8.0/en/create-index.html), a very powerful feature which allows us to to customize performance and functionality of indexes.  But in Laravel migrations, this would require something like this ...

``            $table->unique(['name', '(COALESCE(`scan_code`, ""))', '(COALESCE(`global_scan_type_id`, 0))'], 'global_manufacturer_aliases_unique_index');``

This currently won't work, because the Grammar wrap() method simply wraps the entire parenthesized expression in backticks.  My inclination was to modify wrapValue() in MySqlGrammar and test to see if the value already contained a backtick, and if so leave it untouched (on the "let's assume they know what they are doing" basis).  But for reasons not clear to me, that function already converts single backticks to double backticks.  Hence a modification to wrap() in the main Garmmar.

Thank you for your consideration.