### PR TITLE
[9.x] Add serialized cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -103,6 +103,7 @@ trait HasAttributes
         'json',
         'object',
         'real',
+        'serialized',
         'string',
         'timestamp',
     ];
@@ -747,6 +748,8 @@ trait HasAttributes
                 return $this->asDateTime($value)->toImmutable();
             case 'timestamp':
                 return $this->asTimestamp($value);
+            case 'serialized':
+                return $this->fromSerialized($value);
         }
 
         if ($this->isEnumCastable($key)) {
@@ -947,6 +950,10 @@ trait HasAttributes
 
         if (! is_null($value) && $this->isEncryptedCastable($key)) {
             $value = $this->castAttributeAsEncryptedString($key, $value);
+        }
+
+        if (! is_null($value) && $this->hasCast($key, 'serialized')) {
+            $value = $this->asSerialized($value);
         }
 
         $this->attributes[$key] = $value;
@@ -1190,6 +1197,29 @@ trait HasAttributes
     public function fromJson($value, $asObject = false)
     {
         return json_decode($value, ! $asObject);
+    }
+
+    /**
+     * Serialize the given value.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function asSerialized($value)
+    {
+        return serialize($value);
+    }
+
+    /**
+     * Unserialize the given serialized value.
+     *
+     * @param  string  $value
+     * @param  array  $options
+     * @return mixed
+     */
+    public function fromSerialized($value, array $options = [])
+    {
+        return unserialize($value, $options);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -11,8 +11,8 @@ use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
-use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -1959,6 +1959,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->datetimeAttribute = '1969-07-20 22:56:00';
         $model->timestampAttribute = '1969-07-20 22:56:00';
         $model->collectionAttribute = new BaseCollection;
+        $model->serializedAttribute = ['foo' => 'bar'];
 
         $this->assertIsInt($model->intAttribute);
         $this->assertIsFloat($model->floatAttribute);
@@ -1980,6 +1981,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('1969-07-20', $model->dateAttribute->toDateString());
         $this->assertSame('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
         $this->assertEquals(-14173440, $model->timestampAttribute);
+        $this->assertSame(['foo' => 'bar'], $model->serializedAttribute);
+        $this->assertSame('a:1:{s:3:"foo";s:3:"bar";}', $model->serializedAttributeValue());
 
         $arr = $model->toArray();
 
@@ -2000,6 +2003,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('1969-07-20 00:00:00', $arr['dateAttribute']);
         $this->assertSame('1969-07-20 22:56:00', $arr['datetimeAttribute']);
         $this->assertEquals(-14173440, $arr['timestampAttribute']);
+        $this->assertSame(['foo' => 'bar'], $arr['serializedAttribute']);
     }
 
     public function testModelDateAttributeCastingResetsTime()
@@ -2777,6 +2781,7 @@ class EloquentModelCastingStub extends Model
         'dateAttribute' => 'date',
         'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
+        'serializedAttribute' => 'serialized',
         'asarrayobjectAttribute' => AsArrayObject::class,
         'ascollectionAttribute' => AsCollection::class,
         'asStringableAttribute' => AsStringable::class,
@@ -2787,6 +2792,11 @@ class EloquentModelCastingStub extends Model
     public function jsonAttributeValue()
     {
         return $this->attributes['jsonAttribute'];
+    }
+
+    public function serializedAttributeValue()
+    {
+        return $this->attributes['serializedAttribute'];
     }
 
     protected function serializeDate(DateTimeInterface $date)

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;
@@ -1266,7 +1265,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
 
-        EloquentModelStub::setConnectionResolver($resolver = m::mock(Resolver::class));
+        EloquentModelStub::setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
         $resolver->shouldReceive('connection')->andReturn($connection = m::mock(stdClass::class));
         $connection->shouldReceive('getSchemaBuilder->getColumnListing')->andReturn(['name', 'age', 'foo']);
 


### PR DESCRIPTION
This PR adds the `serialized` model attribute cast.

Recently, I found myself serializing/unserializing model attributes with accessors and mutators.
However I think, it would be better to have a native support for serialized value casting.

This is only additive, should not contain any BC.