### PR TITLE
[9.x] Ability to attach an array of files in MailMessage

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -874,13 +874,11 @@ class Mailable implements MailableContract, Renderable
      */
     public function attach($files, array $options = [])
     {
-        if(!is_iterable($files))
-        {
+        if(!is_iterable($files)) {
             $files = explode(',', $files);
         };
         
-        foreach ($files as $file)
-        {
+        foreach ($files as $file) {
             if ($file instanceof Attachable) {
                 $file = $file->toMailAttachment();
             }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -872,7 +872,7 @@ class Mailable implements MailableContract, Renderable
      * @param  array  $options
      * @return $this
      */
-    public function attach($files, array $options = [])
+    public function attach($file, array $options = [])
     {
         if ($file instanceof Attachable) {
             $file = $file->toMailAttachment();

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -877,19 +877,19 @@ class Mailable implements MailableContract, Renderable
         if ($file instanceof Attachable) {
             $file = $file->toMailAttachment();
         }
-    
+
         if ($file instanceof Attachment) {
             return $file->attachTo($this);
         }
-    
+
         $this->attachments = collect($this->attachments)
-            ->push(compact('file', 'options'))
-            ->unique('file')
-            ->all();
+                    ->push(compact('file', 'options'))
+                    ->unique('file')
+                    ->all();
 
         return $this;
     }
-    
+
     /**
      * Attach multiple files to the message.
      *
@@ -908,7 +908,7 @@ class Mailable implements MailableContract, Renderable
         } else {
             $this->attach($files, $options = []);
         }
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -874,25 +874,41 @@ class Mailable implements MailableContract, Renderable
      */
     public function attach($files, array $options = [])
     {
-        if(!is_iterable($files)) {
-            $files = explode(',', $files);
-        };
-        
-        foreach ($files as $file) {
-            if ($file instanceof Attachable) {
-                $file = $file->toMailAttachment();
-            }
-    
-            if ($file instanceof Attachment) {
-                return $file->attachTo($this);
-            }
-    
-            $this->attachments = collect($this->attachments)
-                ->push(compact('file', 'options'))
-                ->unique('file')
-                ->all();
+        if ($file instanceof Attachable) {
+            $file = $file->toMailAttachment();
         }
+    
+        if ($file instanceof Attachment) {
+            return $file->attachTo($this);
+        }
+    
+        $this->attachments = collect($this->attachments)
+            ->push(compact('file', 'options'))
+            ->unique('file')
+            ->all();
 
+        return $this;
+    }
+    
+    /**
+     * Attach multiple files to the message.
+     *
+     * @param  array|object  $files
+     * @param  array  $options
+     * @return $this
+     */
+    public function attachMany($files, array $options = [])
+    {
+        if(is_array($files))
+        {
+            foreach ($files as $file => $options)
+            {
+                $this->attach((is_int($file) ? $options : $file), (is_int($file) ? [] : $options));
+            }
+        } else {
+            $this->attach($files, $options = []);
+        }
+        
         return $this;
     }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -872,20 +872,28 @@ class Mailable implements MailableContract, Renderable
      * @param  array  $options
      * @return $this
      */
-    public function attach($file, array $options = [])
+    public function attach($files, array $options = [])
     {
-        if ($file instanceof Attachable) {
-            $file = $file->toMailAttachment();
+        if(!is_iterable($files))
+        {
+            $files = explode(',', $files);
+        };
+        
+        foreach ($files as $file)
+        {
+            if ($file instanceof Attachable) {
+                $file = $file->toMailAttachment();
+            }
+    
+            if ($file instanceof Attachment) {
+                return $file->attachTo($this);
+            }
+    
+            $this->attachments = collect($this->attachments)
+                ->push(compact('file', 'options'))
+                ->unique('file')
+                ->all();
         }
-
-        if ($file instanceof Attachment) {
-            return $file->attachTo($this);
-        }
-
-        $this->attachments = collect($this->attachments)
-                    ->push(compact('file', 'options'))
-                    ->unique('file')
-                    ->all();
 
         return $this;
     }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -893,20 +893,17 @@ class Mailable implements MailableContract, Renderable
     /**
      * Attach multiple files to the message.
      *
-     * @param  array|object  $files
-     * @param  array  $options
+     * @param  array  $files
      * @return $this
      */
-    public function attachMany($files, array $options = [])
+    public function attachMany($files)
     {
-        if(is_array($files))
-        {
-            foreach ($files as $file => $options)
-            {
-                $this->attach((is_int($file) ? $options : $file), (is_int($file) ? [] : $options));
+        foreach ($files as $file => $options) {
+            if (is_int($file)) {
+                $this->attach($options);
+            } else {
+                $this->attach($file, $options);
             }
-        } else {
-            $this->attach($files, $options = []);
         }
 
         return $this;

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -497,6 +497,43 @@ class MailMailableTest extends TestCase
         $this->assertStringContainsString('X-Tag: foo', $sentMessage->toString());
     }
 
+    public function testItCanAttachMultipleFiles()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attachMany([
+            '/forge.svg',
+            '/vapor.svg' => ['as' => 'Vapor Logo.svg', 'mime' => 'text/css'],
+            new class() implements Attachable
+            {
+                public function toMailAttachment()
+                {
+                    return Attachment::fromPath('/foo.jpg')->as('bar')->withMime('image/png');
+                }
+            }
+        ]);
+
+        $this->assertCount(3, $mailable->attachments);
+        $this->assertSame([
+            'file' => '/forge.svg',
+            'options' => []
+        ], $mailable->attachments[0]);
+        $this->assertSame([
+            'file' => '/vapor.svg',
+            'options' => [
+                'as' => 'Vapor Logo.svg',
+                'mime' => 'text/css',
+            ]
+        ], $mailable->attachments[1]);
+        $this->assertSame([
+            'file' => '/foo.jpg',
+            'options' => [
+                'as' => 'bar',
+                'mime' => 'image/png',
+            ]
+        ], $mailable->attachments[2]);
+    }
+
     public function testItAttachesFilesViaAttachableContractFromPath()
     {
         $mailable = new WelcomeMailableStub;

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -510,27 +510,27 @@ class MailMailableTest extends TestCase
                 {
                     return Attachment::fromPath('/foo.jpg')->as('bar')->withMime('image/png');
                 }
-            }
+            },
         ]);
 
         $this->assertCount(3, $mailable->attachments);
         $this->assertSame([
             'file' => '/forge.svg',
-            'options' => []
+            'options' => [],
         ], $mailable->attachments[0]);
         $this->assertSame([
             'file' => '/vapor.svg',
             'options' => [
                 'as' => 'Vapor Logo.svg',
                 'mime' => 'text/css',
-            ]
+            ],
         ], $mailable->attachments[1]);
         $this->assertSame([
             'file' => '/foo.jpg',
             'options' => [
                 'as' => 'bar',
                 'mime' => 'image/png',
-            ]
+            ],
         ], $mailable->attachments[2]);
     }
 


### PR DESCRIPTION
Passing a filepath or an array of filepaths will now attach one or multiple files in mail.

```
$files = ['file.jpeg', 'file2.jpeg'];
```
Then in ***build*** method
```
return $this->view('welcome')
        ->attach($files)
        ->with('order', $this->order);
```


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
