### PR TITLE
[9.x] Adds Str::space() helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -950,6 +950,19 @@ class Str
     }
 
     /**
+     * Join strings with a single space, ignoring nullable values.
+     *
+     * @param  mixed  ...$words
+     * @return string
+     */
+    public static function space(mixed ...$words): string
+    {
+        return join(' ', array_filter(
+            $words, fn ($value) => ! is_null($value)
+        ));
+    }
+
+    /**
      * Convert a string to snake case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -958,7 +958,7 @@ class Str
     public static function space(mixed ...$words): string
     {
         return join(' ', array_filter(
-            $words, fn ($value) => ! is_null($value)
+            $words, fn ($value) => ! is_null($value) && trim($value) !== ''
         ));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -585,6 +585,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('❤MultiByte☆', Str::reverse('☆etyBitluM❤'));
     }
 
+    public function testSpace()
+    {
+        $this->assertSame('John Jacob Jingleheimer Schmidt', Str::space('John', 'Jacob', 'Jingleheimer', 'Schmidt'));
+        $this->assertSame('John Schmidt', Str::space('John', null, null, 'Schmidt'));
+    }
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -589,6 +589,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('John Jacob Jingleheimer Schmidt', Str::space('John', 'Jacob', 'Jingleheimer', 'Schmidt'));
         $this->assertSame('John Schmidt', Str::space('John', null, null, 'Schmidt'));
+        $this->assertSame('John Schmidt', Str::space('John', '', 'Schmidt'));
     }
 
     public function testSnake()


### PR DESCRIPTION
While this is a pretty nominal feature, I have reached for the functionality in many projects, so I thought I would see about getting it merged into the framework. This pull request adds a `Str::space()` helper that will join the passed words with a space and ignore nullable values. In particular, this is useful when joining model attributes that could be `null`. For example:

```php
// Could be: "John", "John Doe", or "John James Doe"

Str::space($contact->first_name, $contact->middle_name, $contact->last_name);
```

The filter callback itself specifically checks for a nullable value or an empty string so as to allow for things like the digit `0` in the scenario that someone might desire to pass that.