### PR TITLE
[9.x] Avoid matching multi-line imports in GenerateCommand stub templates

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -351,7 +351,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function sortImports($stub)
     {
-        if (preg_match('/(?P<imports>(?:use [^;]+;$\n?)+)/m', $stub, $match)) {
+        if (preg_match('/(?P<imports>(?:use [^;{]+;$\n?)+)/m', $stub, $match)) {
             $imports = explode("\n", trim($match['imports']));
 
             sort($imports);


### PR DESCRIPTION
Sorting of multi-line use-imports are broken in *.stub templates.

Input:
```
use Illuminate\Foundation\Testing\{
    DatabaseTransactions,
    WithFaker,
};
```
Results in output:
```
    DatabaseTransactions,
    WithFaker,
use Illuminate\Foundation\Testing\{
};
```

This regex change avoids matching multi-line use-imports. It's an improvement in that the rendered stub is no longer generating invalid php code. The downside is that sorting will not include any multi-line imports.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
