### PR TITLE
[9.x] Allow type int on Eloquent Collection::contains $key parameter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -295,7 +295,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Determine if a key exists in the collection.
      *
-     * @param  (callable(TModel, TKey): bool)|TModel|string  $key
+     * @param  (callable(TModel, TKey): bool)|TModel|string|int  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return bool


### PR DESCRIPTION
Accidentally discovered today:

The Eloquent Collection `contains` method is missing `int` as type on $key parameter. PHPStan complains when an int is given.

Example usage:
```php
$users = User::all();
$users->contains(1);
```


Affacted code:
```php
public function contains($key, $operator = null, $value = null)
{
    // ...

    return parent::contains(function ($model) use ($key) {
        return $model->getKey() == $key; // <- $key could also be an int
    });
}
```