### PR TITLE
[9.x] Allow authorization responses to specify HTTP status codes

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -73,6 +73,16 @@ class AuthorizationException extends Exception
     }
 
     /**
+     * Set the HTTP response status code to 404.
+     *
+     * @return $this
+     */
+    public function asNotFound()
+    {
+        return $this->withStatus(404);
+    }
+
+    /**
      * Determine if the HTTP status code has been set.
      *
      * @return bool

--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -15,6 +15,13 @@ class AuthorizationException extends Exception
     protected $response;
 
     /**
+     * The HTTP response status code.
+     *
+     * @var int|null
+     */
+    protected $status;
+
+    /**
      * Create a new authorization exception instance.
      *
      * @param  string|null  $message
@@ -53,12 +60,45 @@ class AuthorizationException extends Exception
     }
 
     /**
+     * Set the HTTP response status code.
+     *
+     * @param  int|null  $status
+     * @return $this
+     */
+    public function withStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the HTTP status code has been set.
+     *
+     * @return bool
+     */
+    public function hasStatus()
+    {
+        return $this->status !== null;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return int|null
+     */
+    public function status()
+    {
+        return $this->status;
+    }
+
+    /**
      * Create a deny response object from this exception.
      *
      * @return \Illuminate\Auth\Access\Response
      */
     public function toResponse()
     {
-        return Response::deny($this->message, $this->code);
+        return Response::deny($this->message, $this->code)->withStatus($this->status);
     }
 }

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -40,4 +40,16 @@ trait HandlesAuthorization
     {
         return Response::denyWithStatus($status, $message, $code);
     }
+
+    /**
+     * Deny with a 404 HTTP status code.
+     *
+     * @param  ?string  $message
+     * @param  ?int  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function denyAsNotFound($message = null, $code = null)
+    {
+        return Response::denyWithStatus(404, $message, $code);
+    }
 }

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -27,4 +27,17 @@ trait HandlesAuthorization
     {
         return Response::deny($message, $code);
     }
+
+    /**
+     * Deny with a HTTP status code.
+     *
+     * @param  int  $status
+     * @param  ?string  $message
+     * @param  ?int  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function denyWithStatus($status, $message = null, $code = null)
+    {
+        return Response::denyWithStatus($status, $message, $code);
+    }
 }

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -87,6 +87,18 @@ class Response implements Arrayable
     }
 
     /**
+     * Create a new "deny" Response with a 404 HTTP status code.
+     *
+     * @param  string|null  $message
+     * @param  mixed  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public static function denyAsNotFound($message = null, $code = null)
+    {
+        return static::denyWithStatus(404, $message, $code);
+    }
+
+    /**
      * Determine if the response was allowed.
      *
      * @return bool
@@ -155,6 +167,16 @@ class Response implements Arrayable
         $this->status = $status;
 
         return $this;
+    }
+
+    /**
+     * Set the HTTP response status code to 404.
+     *
+     * @return $this
+     */
+    public function asNotFound()
+    {
+        return $this->withStatus(404);
     }
 
     /**

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -28,6 +28,13 @@ class Response implements Arrayable
     protected $code;
 
     /**
+     * The HTTP response status code.
+     *
+     * @var int|null
+     */
+    protected $status;
+
+    /**
      * Create a new response.
      *
      * @param  bool  $allowed
@@ -64,6 +71,19 @@ class Response implements Arrayable
     public static function deny($message = null, $code = null)
     {
         return new static(false, $message, $code);
+    }
+
+    /**
+     * Create a new "deny" Response with a HTTP status code.
+     *
+     * @param  int  $status
+     * @param  string|null  $message
+     * @param  mixed  $code
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public static function denyWithStatus($status, $message = null, $code = null)
+    {
+        return static::deny($message, $code)->withStatus($status);
     }
 
     /**
@@ -117,10 +137,34 @@ class Response implements Arrayable
     {
         if ($this->denied()) {
             throw (new AuthorizationException($this->message(), $this->code()))
-                        ->setResponse($this);
+                ->setResponse($this)
+                ->withStatus($this->status);
         }
 
         return $this;
+    }
+
+    /**
+     * Set the HTTP response status code.
+     *
+     * @param  null|int  $status
+     * @return $this
+     */
+    public function withStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Get the HTTP status code.
+     *
+     * @return int|null
+     */
+    public function status()
+    {
+        return $this->status;
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -375,7 +375,8 @@ class Handler implements ExceptionHandlerContract
         return match (true) {
             $e instanceof BackedEnumCaseNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
             $e instanceof ModelNotFoundException => new NotFoundHttpException($e->getMessage(), $e),
-            $e instanceof AuthorizationException => new AccessDeniedHttpException($e->getMessage(), $e),
+            $e instanceof AuthorizationException && $e->hasStatus() => new HttpException($e->status(), $e->getMessage(), $e),
+            $e instanceof AuthorizationException && ! $e->hasStatus() => new AccessDeniedHttpException($e->getMessage(), $e),
             $e instanceof TokenMismatchException => new HttpException(419, $e->getMessage(), $e),
             $e instanceof SuspiciousOperationException => new NotFoundHttpException('Bad hostname provided.', $e),
             $e instanceof RecordsNotFoundException => new NotFoundHttpException('Not found.', $e),

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class AuthAccessResponseTest extends TestCase
 {
@@ -33,6 +34,36 @@ class AuthAccessResponseTest extends TestCase
         $response = Response::deny();
 
         $this->assertNull($response->message());
+    }
+
+    public function testItSetsEmptyStatusOnExceptionWhenAuthorizing()
+    {
+        try {
+            Response::deny()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertNull($e->status());
+            $this->assertFalse($e->hasStatus());
+        }
+    }
+
+    public function testItSetsStatusOnExceptionWhenAuthorizing()
+    {
+        try {
+            Response::deny()->withStatus(404)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+        }
+
+        try {
+            Response::denyWithStatus(404)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+        }
     }
 
     public function testAuthorizeMethodThrowsAuthorizationExceptionWhenResponseDenied()

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 class AuthAccessResponseTest extends TestCase
 {

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -38,30 +38,76 @@ class AuthAccessResponseTest extends TestCase
     public function testItSetsEmptyStatusOnExceptionWhenAuthorizing()
     {
         try {
-            Response::deny()->authorize();
+            Response::deny('foo', 3)->authorize();
             $this->fail();
         } catch (AuthorizationException $e) {
             $this->assertNull($e->status());
             $this->assertFalse($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
         }
     }
 
     public function testItSetsStatusOnExceptionWhenAuthorizing()
     {
         try {
-            Response::deny()->withStatus(404)->authorize();
+            Response::deny('foo', 3)->withStatus(418)->authorize();
             $this->fail();
         } catch (AuthorizationException $e) {
-            $this->assertSame(404, $e->status());
+            $this->assertSame(418, $e->status());
             $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
         }
 
         try {
-            Response::denyWithStatus(404)->authorize();
+            Response::deny('foo', 3)->asNotFound()->authorize();
             $this->fail();
         } catch (AuthorizationException $e) {
             $this->assertSame(404, $e->status());
             $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+
+        try {
+            Response::denyWithStatus(444)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(444, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        try {
+            Response::denyWithStatus(444, 'foo', 3)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(444, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+
+        try {
+            Response::denyAsNotFound()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        try {
+            Response::denyAsNotFound('foo', 3)->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertSame(404, $e->status());
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
         }
     }
 

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -59,7 +59,50 @@ class AuthHandlesAuthorizationTest extends TestCase
 
             public function __invoke()
             {
-                return $this->denyWithStatus(404);
+                return $this->denyWithStatus(418);
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(418, $e->status());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyWithStatus(418, 'foo', 3);
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(418, $e->status());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
+        }
+    }
+
+    public function testItCanDenyAsNotFound()
+    {
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyAsNotFound();
             }
         };
 
@@ -69,6 +112,28 @@ class AuthHandlesAuthorizationTest extends TestCase
         } catch (AuthorizationException $e) {
             $this->assertTrue($e->hasStatus());
             $this->assertSame(404, $e->status());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+
+        $class = new class()
+        {
+            use HandlesAuthorization;
+
+            public function __invoke()
+            {
+                return $this->denyAsNotFound('foo', 3);
+            }
+        };
+
+        try {
+            $class()->authorize();
+            $this->fail();
+        } catch (AuthorizationException $e) {
+            $this->assertTrue($e->hasStatus());
+            $this->assertSame(404, $e->status());
+            $this->assertSame('foo', $e->getMessage());
+            $this->assertSame(3, $e->getCode());
         }
     }
 }

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -32,7 +32,8 @@ class AuthHandlesAuthorizationTest extends TestCase
 
     public function testDenyHasNullStatus()
     {
-        $class = new class () {
+        $class = new class()
+        {
             use HandlesAuthorization;
 
             public function __invoke()
@@ -52,7 +53,8 @@ class AuthHandlesAuthorizationTest extends TestCase
 
     public function testItCanDenyWithStatus()
     {
-        $class = new class () {
+        $class = new class()
+        {
             use HandlesAuthorization;
 
             public function __invoke()

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Closure;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Tests\Integration\Auth\User;
+use Orchestra\Testbench\Exceptions\Handler;
+use Orchestra\Testbench\TestCase;
+use Throwable;
+
+class ExceptionHandlerTest extends TestCase
+{
+    public function testItRendersAuthorizationExceptions()
+    {
+        Route::get('test-route', fn () => Response::deny('expected message', 321)->authorize());
+
+        // HTTP request...
+        $this->get('test-route')
+            ->assertStatus(403)
+            ->assertSeeText('expected message');
+
+        // JSON request...
+        $this->getJson('test-route')
+            ->assertStatus(403)
+            ->assertExactJson([
+                'message' => 'expected message',
+            ]);
+    }
+
+    public function testItRendersAuthorizationExceptionsWithCustomStatusCode()
+    {
+        Route::get('test-route', fn () => Response::deny('expected message', 321)->withStatus(404)->authorize());
+
+        // HTTP request...
+        $this->get('test-route')
+            ->assertStatus(404)
+            ->assertSeeText('Not Found');
+
+        // JSON request...
+        $this->getJson('test-route')
+            ->assertStatus(404)
+            ->assertExactJson([
+                'message' => 'expected message',
+            ]);
+    }
+}

--- a/tests/Integration/Foundation/ExceptionHandlerTest.php
+++ b/tests/Integration/Foundation/ExceptionHandlerTest.php
@@ -2,20 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Foundation;
 
-use Closure;
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
-use Illuminate\Contracts\Debug\ExceptionHandler;
-use Illuminate\Contracts\Routing\UrlRoutable;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Tests\Integration\Auth\User;
-use Orchestra\Testbench\Exceptions\Handler;
 use Orchestra\Testbench\TestCase;
-use Throwable;
 
 class ExceptionHandlerTest extends TestCase
 {


### PR DESCRIPTION
This PR introduces the ability to set the status code for a denied authorization action in policies, gates, and wherever `Auth\Access\Response` or `AuthorizationException` are handled by the framework.

Let's take the following example policy where only the authenticated user can view themselves...

```php
Route::get('users/{user}', fn () => UserResource::make($user))->can('view', 'user');

class UserPolicy
{
    use HandlesAuthorization;

    public function view(User $authenticated, User $user)
    {
        return $authenticated->is($user)
            ? $this->allow()
            : $this->deny();
    }
}
```

Given the above scenario, any user is now able to determine how many users the system currently has if the system is using auto-incrementing IDS...

```php
actingAs($me)->get('users/9991') // 403 😏
actingAs($me)->get('users/9992') // 403 😏
actingAs($me)->get('users/9993') // 404 😮
```

This PR drastically improves (but does not totally solve[**](#note)) this scenario by allowing developers to specify the HTTP response code that should be returned when a "forbidden" action is attempted.

```php
class UserPolicy
{
    use HandlesAuthorization;

    public function view(User $authenticated, User $user)
    {
        return $authenticated->is($user)
            ? $this->allow()
            : $this->deny()->asNotFound(); // 404 status code
    }
}

actingAs($me)->get('users/9991') // 404 🤔
actingAs($me)->get('users/9992') // 404 🤔
actingAs($me)->get('users/9993') // 404 🤔
```

This is what I would consider a security "best practice" in many, but not all, scenarios. You can see it all across the web. GitHub, for example, will show a `404` for repositories that exist or not when you are not allowed to access them, for example...

[https://github.com/timacdonald/config-differ](https://github.com/timacdonald/config-differ)

The above repository exists...

<img width="631" alt="Screen Shot 2022-06-26 at 4 47 18 pm" src="https://user-images.githubusercontent.com/24803032/175802895-254c2d14-adcd-44db-9d4d-3bccad2bde50.png">

but because it is private, everyone else except for myself will see a `404` response, thus keeping its existence secret.

As you can see from my initial example and then this GitHub example, this feature is not only useful for incrementing IDs, but generally for hiding the existence of any resource[**](#note).

## Full API

Using `Illuminate\Auth\Access\HandlesAuthorization` e.g. Policies...

```php
use HandlesAuthorization;

public function view(User $user, Post $post)
{
    return $this->deny(/* ... */)->withStatus(404);

    return $this->deny(/* ... */)->asNotFound();

    return $this->denyWithStatus(418);

    return $this->denyWithStatus(418, 'foo', 3);

    return $this->denyAsNotFound();

    return $this->denyAsNotFound('foo', 3);
}
```

Returning `Illuminate\Auth\Access\Response` e.g. Gates...

```php
Gate::define('implode-universe', function (User $user) {
    return Response::deny(/* ... */)->withStatus(418);

    return Response::deny(/* ... */)->asNotFound();

    return Response::denyWithStatus(418);

    return Response::denyWithStatus(418, 'foo', 3);

    return Response::denyAsNotFound();

    return Response::denyAsNotFound('foo', 3);
});
```

Directly throwing the exception....

```php
throw (new AuthorizationException)->withStatus(418);

throw (new AuthorizationException)->asNotFound();
```

The exception is translated in the exception handler to send the appropriate HTTP status response.

## Why not just use `abort()`

I'm glad you asked! There is an argument to just utilise the `abort` helper here...

```php
public function view(User $user, Post $post)
{
    /* ... */
    
    // return $this->denyWithStatus(404);

    abort(404);
}
```

However this has a few downfalls.

1. It bubbles up a HTTP exception, which means in the exception handler you have lost the context of the exception. Knowing the type of exception can be important for logging and detecting bad actors, threat detection, etc. Having the `AuthorizationException` bubble up to the exception handler allows you to categorize and appropriately handle that _type_ of exception as needed by your application.
2. You lose the ability to specify an exception code. The abort helper allows you to specify a HTTP status code, but not the underlying exception code. status code != exception code. Exception codes are generally utilised on applications as internal mappings to *exact* issues within the application. The following example is how that may be used...

```php
public function view(User $user, Post $post)
{
    /* ... */
    
    if ($user->isInactive()) {
        return $this->deny(Errors::INACTIVE_USER['message'], Errors::INACTIVE_USER['code'])
            ->withStatus(404);
    }

    if ($user->isNotAdmin()) {
        return $this->deny(Errors::NOT_ADMIN['message'], Errors::NOT_ADMIN['code'])
            ->withStatus(404);
    }
    
    // etc...
}
```

This allows developers to handle the exception **type** while logging an exception message, exception code, and translating to an appropriate HTTP status code for security reasons.

## Form Requests

Another place to perform authorization is within Form Requests. You can set a response status in the form request by using the new helpers on the exception.

```php
class StoreUserRequest extends FormRequest
{
    /**
     * Handle a failed authorization attempt.
     *
     * @return void
     *
     * @throws \Illuminate\Auth\Access\AuthorizationException
     */
    protected function failedAuthorization()
    {
        throw (new AuthorizationException)->asNotFound();
    }

    /* ... */
}
```

## Not supporting default status per policy

In my initial implementation, I supported a default deny status per policy. This status was then shared to all the deny responses on the policy. This worked by having the policy implement an "implicit property contract" e.g.

```php
class PostPolicy
{
    use HandlesAuthorization;

    protected $defaultDenyStatus = 404;

    public function view(User $user, Post $post)
    {
        return $this->deny(); // gets "404"
    }

    public function viewAny(User $user)
    {
        return $this->deny()->withStatus(403); // gets "403"
    }
}
```

This felt really nice and I felt smart 🤓  The implementation for this was housed on the `HandlesAuthorization` trait. In my opinion, this starts to break down. Take the following policy...


```php
class PostPolicy
{
    use HandlesAuthorization;

    protected $defaultDenyStatus = 404;

    public function view(User $user, Post $post)
    {
        return false;
    }

    public function viewAny(User $user)
    {
        return Response::deny();
    }

    public function create(User $user)
    {
        return $this->deny();
    }
}
```

Should these _all_ get the default 404 response status? I feel  like developers might feel like they should and I was worried it might create some confusion. As it stands,  only the `create` would get the `404`, as the implementation was handled in the `HandlesAuthorization` trait.

I could look at pushing this functionality up into the Gate, where it could apply the default status if it is denied with `false`, `Response::deny()`, or `$this->deny()`, but then I'm wondering if it would have to be an actual interface as I believe our implicit property contracts are usually internal and thus `protected`. We could make it that the property needs to be `public`, but that feels flakey and like it could also cause issues as people might declare it as protected.

So then you'd need to implement an interface to support the default functionality...and that feels like more work than just being explicit in the policy.

## Converting to 404 globally and just handling other cases

It might be the case that developers actually want _all_ authorization exceptions to be rendered as 404, and instead be explicit about what denied actions should show a `403` instead. This would be achievable by doing the following in the exception handler...

```php
protected function prepareException(Throwable $e)
{
    return match(true) {
        $e instanceof AuthorizationException && ! $e->hasStatus() => new NotFoundHttpException($e->getMessage(), $e),
        default => parent::prepareException($e)
    };
}
```

This now converts all `AuthorizationException` that do not have an explicit status set to a `404` response. Developers are then able to opt back into a `403` response with the following...

```php
class PostPolicy
{
    use HandlesAuthorization;

    public function view(User $user, Post $post)
    {
        return $this->denyWithStatus(403);
    }
}
```

## Notes

<a name="note"></a>
- **This PR improves, but does not completely solve the problem, as there is still the possibility of timing attacks.
- It is possible to set the status on an "allow" action, however it is discarded in the same way that the "message" and exception "code" are discarded.