### PR TITLE
Created vite() helper to replicate functionality of mix() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Foundation\Bus\PendingClosureDispatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
+use Illuminate\Foundation\Vite;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Facades\Date;
@@ -556,6 +557,26 @@ if (! function_exists('mix')) {
     function mix($path, $manifestDirectory = '')
     {
         return app(Mix::class)(...func_get_args());
+    }
+}
+
+if (! function_exists('vite')) {
+
+    /**
+     * Get the path to a Vite asset.
+     *
+     * @param  string  $resourcePath  The asset entrypoint to load
+     * @param  string  $buildDirectory  Vite build directory
+     * @return string
+     *
+     * @throws \Exception
+     */
+    function vite($resourcePath, $buildDirectory = 'build')
+    {
+        /** @var Vite $vite */
+        $vite = app(Vite::class);
+
+        return $vite->resourceUrl($resourcePath, $buildDirectory);
     }
 }
 

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -101,6 +101,24 @@ class FoundationViteTest extends TestCase
         );
     }
 
+    public function testViteHotModuleSingleFileUriResolution()
+    {
+        $this->makeViteHotFile();
+
+        $result = (new Vite)->resourceUrl('resources/css/app.css');
+
+        $this->assertEquals('http://localhost:3000/resources/css/app.css', $result);
+    }
+
+    public function testViteBuildSingleFileManifestResolution()
+    {
+        $this->makeViteManifest();
+
+        $result = (new Vite)->resourceUrl('resources/css/app.css');
+
+        $this->assertEquals('https://example.com/build/assets/app.versioned.css', $result);
+    }
+
     protected function makeViteManifest()
     {
         app()->singleton('path.public', fn () => __DIR__);


### PR DESCRIPTION
For my project, I was using the `mix()` helper function in various areas to load the absolute path to compiled mix assets.

With the addition of Vite (which is awesome!), there is no such helper to retrieve absolute file paths, only strings bundled with style & script tags.

This helper allows a user to retrieve an absolute path to a Vite asset, either in hot reload or built asset mode.

Example:

`@vite('resources/css/app.scss')` results in a compiled HTML tag - 

```
<link rel="stylesheet" href="http://localhost/build/assets/app.3c62ae02.css" />
```

whereas `{{ vite('resources/css/app.scss') }}` results in an absolute file path - 

```
http://localhost/build/assets/app.3c62ae02.css
```

I hope you'll see this as a useful contribution to Laravel! I'd be happy to write up some documentation on this addition.