### PR TITLE
refactoring

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -609,7 +609,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public static function useBootstrap()
     {
-        static::useBootstrapFour();
+        static::useBootstrapAboveThree(4);
     }
 
     /**
@@ -623,26 +623,16 @@ abstract class AbstractPaginator implements Htmlable
         static::defaultSimpleView('pagination::simple-default');
     }
 
-    /**
-     * Indicate that Bootstrap 4 styling should be used for generated links.
+  /**
+     * Indicate that above Bootstrap v3 styling should be used for generated links.
      *
+     * @param  int  $version
      * @return void
      */
-    public static function useBootstrapFour()
+    public static function useBootstrapAboveThree(int $version)
     {
-        static::defaultView('pagination::bootstrap-4');
-        static::defaultSimpleView('pagination::simple-bootstrap-4');
-    }
-
-    /**
-     * Indicate that Bootstrap 5 styling should be used for generated links.
-     *
-     * @return void
-     */
-    public static function useBootstrapFive()
-    {
-        static::defaultView('pagination::bootstrap-5');
-        static::defaultSimpleView('pagination::simple-bootstrap-5');
+        static::defaultView('pagination::bootstrap-'.$version);
+        static::defaultSimpleView('pagination::simple-bootstrap-'.$version);
     }
 
     /**


### PR DESCRIPTION
This PR reduces the complexity of the class, because in the future when Bootstrap releases version 6 So, Laravel will add a new function for this version and so on with other new releases, and this approach will make the class fatter, for illuminate, see the next example

## Before this PR

**AbstractPaginator.php**

```PHP
/**
 * Indicate that Bootstrap 6 styling should be used for generated links.
 *
 * @return void
 */
pubic static function useBootstrapSix()
{
    static::defaultView('pagination::bootstrap-6');
    static::defaultSimpleView('pagination::simple-bootstrap-6');
}
```

then you will use this function in **AppServiceProvider.php** like so,

```PHP
/**
 * Bootstrap any application services.
 *
 * @return void
 */
function boot()
{
    Paginator::useBootstrapSix();
}
```


## After This PR

Laravel will not add any function more to handle the new releases of Bootstrap, and the code in **AppServiceProvider.php** will be like so,

```PHP
/**
 * Bootstrap any application services.
 *
 * @return void
 */
function boot()
{
    Paginator::useBootstrapAboveThree(6);
}
```