### PR TITLE
[9.x] Add `whenCounted` to JsonResource

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -559,6 +559,17 @@ trait HasAttributes
     }
 
     /**
+     * Determine if an attribute exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasAttribute($key)
+    {
+        return isset($this->attributes[$key]);
+    }
+
+    /**
      * Determine if a get mutator exists for an attribute.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -559,17 +559,6 @@ trait HasAttributes
     }
 
     /**
-     * Determine if an attribute exists.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function hasAttribute($key)
-    {
-        return isset($this->attributes[$key]);
-    }
-
-    /**
      * Determine if a get mutator exists for an attribute.
      *
      * @param  string  $key

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -221,7 +221,7 @@ trait ConditionallyLoadsAttributes
 
         $attribute = Str::finish($relationship, '_count');
 
-        if (! $this->resource->hasAttribute($attribute)) {
+        if (! isset($this->resource->getAttributes()[$attribute])) {
             return value($default);
         }
 

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Resources;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 trait ConditionallyLoadsAttributes
 {
@@ -218,7 +219,7 @@ trait ConditionallyLoadsAttributes
             $default = new MissingValue();
         }
 
-        $attribute = $relationship . '_count';
+        $attribute = Str::finish($relationship, '_count');
 
         if (! $this->resource->hasAttribute($attribute)) {
             return value($default);
@@ -232,7 +233,7 @@ trait ConditionallyLoadsAttributes
             return;
         }
 
-        return value($value);
+        return value($value, $this->resource->{$attribute});
     }
 
     /**

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -229,7 +229,7 @@ trait ConditionallyLoadsAttributes
             return $this->resource->{$attribute};
         }
 
-        if (null === $this->resource->{$attribute}) {
+        if ($this->resource->{$attribute} === null) {
             return;
         }
 

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -205,6 +205,37 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
+     * Retrieve a relationship count if it exists.
+     *
+     * @param  string  $relationship
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    public function whenCounted($relationship, $value = null, $default = null)
+    {
+        if (func_num_args() < 3) {
+            $default = new MissingValue();
+        }
+
+        $attribute = $relationship . '_count';
+
+        if (! $this->resource->hasAttribute($attribute)) {
+            return value($default);
+        }
+
+        if (func_num_args() === 1) {
+            return $this->resource->{$attribute};
+        }
+
+        if (null === $this->resource->{$attribute}) {
+            return;
+        }
+
+        return value($value);
+    }
+
+    /**
      * Execute a callback if the given pivot table has been loaded.
      *
      * @param  string  $table

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipCounts.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipCounts.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class PostResourceWithOptionalRelationshipCounts extends PostResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'authors' => $this->whenCounted('authors_count'),
+            'comments' => $this->whenCounted('comments', function ($count) {
+                return "$count comments";
+            }, 'None'),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -33,6 +33,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipCounts;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithoutWrap;
 use Illuminate\Tests\Integration\Http\Fixtures\ReallyEmptyPostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\ResourceWithPreservedKeys;
@@ -279,6 +280,59 @@ class ResourceTest extends TestCase
         $response->assertExactJson([
             'data' => [
                 'id' => 5,
+            ],
+        ]);
+    }
+
+    public function testResourcesMayHaveOptionalRelationshipCounts()
+    {
+        Route::get('/', function () {
+            $post = new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+            ]);
+
+            return new PostResourceWithOptionalRelationshipCounts($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'comments' => 'None'
+            ],
+        ]);
+    }
+
+    public function testResourcesMayLoadOptionalRelationshipCounts()
+    {
+        Route::get('/', function () {
+            $post = new Post([
+                'id' => 5,
+                'title' => 'Test Title',
+                'authors_count' => 2,
+                'comments_count' => 5,
+            ]);
+
+            return new PostResourceWithOptionalRelationshipCounts($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
+                'authors' => 2,
+                'comments' => '5 comments',
             ],
         ]);
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -310,7 +310,7 @@ class ResourceTest extends TestCase
     }
 
     public function testResourcesMayLoadOptionalRelationshipCounts()
-    {   
+    {
         Route::get('/', function () {
             $post = new Post([
                 'id' => 5,

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -304,13 +304,13 @@ class ResourceTest extends TestCase
         $response->assertExactJson([
             'data' => [
                 'id' => 5,
-                'comments' => 'None'
+                'comments' => 'None',
             ],
         ]);
     }
 
     public function testResourcesMayLoadOptionalRelationshipCounts()
-    {
+    {   
         Route::get('/', function () {
             $post = new Post([
                 'id' => 5,


### PR DESCRIPTION
## Description

This PR adds a `whenCounted` method to the JSON resource class giving us the ability to conditionally include attributes in a response when a relation count is set on the model via `Post::withCount('comments')`.

This method acts nearly identically to `whenLoaded`, with the exception that the retrieved count attribute value will be passed into the `$value` callback (if one is provided).

I've also added a `hasAttribute` method to models to easily determine if an attribute exists inside of the models raw `$attributes` array, so I didn't have to fetch all of the models attributes to determine if it exists:

```php
if (! isset($this->resource->getAttributes()[$attribute])) {
    // ...
}
```

## Example

```php
class PostController
{
    public function show(Post $post)
    {
        return new PostResource($post->loadCount('comments'));
    }
}
```

```php
class PostResource extends PostResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'comments_count' => $this->whenCounted('comments'),
        ];
    }
}
```

## Important

If you'd prefer not having the `hasAttribute` method added onto Eloquent models, let me know and I can remove it!

Thanks for your time! ❤️ 