### PR TITLE
[9.x] Added required directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -339,6 +339,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile a required block into valid PHP.
+     *
+     * @param  string  $condition
+     * @return string
+     */
+    protected function compileRequired($condition)
+    {
+        return "<?php if{$condition}: echo 'required'; endif; ?>";
+    }
+
+    /**
      * Compile a readonly block into valid PHP.
      *
      * @param  string  $condition

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -27,4 +27,12 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testRequiredStatementsAreCompiled()
+    {
+        $string = '<input @required(name(foo(bar)))/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'required'; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
Closes #43102

This PR provides the use of the common HTML directive `required` through a shorthand syntax via a Blade directive. Allowing developers to have a more enjoyable method of required a input, for example, could improve the smooth flow that we Laravel developers are consistently being treated too. Simple yet, effective. Example
```blade
 <input type='email' name="email" @required( !auth()->user()->is_admin )>
 <input type='password' name="password" @required( !auth()->user()->is_admin )>
```
 
<!-- Editing for documentation PR: [laravel/docs#7690](https://github.com/laravel/docs/pull/7690) -->

I will add it on `laravel/docs` if it is merged