### PR TITLE
Using model's $table property (if available) as table name in foreignIdFor methods

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1259,7 +1259,7 @@ class Blueprint
      * Create a new UUID column on the table with a foreign key constraint.
      *
      * @param  string  $column
-     * @param  string|null $table
+     * @param  string|null  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
     public function foreignUuid($column, $table = null)

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -906,15 +906,17 @@ class Blueprint
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
+     * @param  string|null  $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignId($column)
+    public function foreignId($column, $table = null)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'bigInteger',
             'name' => $column,
             'autoIncrement' => false,
             'unsigned' => true,
+            'table' => $table,
         ]));
     }
 
@@ -932,8 +934,8 @@ class Blueprint
         }
 
         return $model->getKeyType() === 'int' && $model->getIncrementing()
-                    ? $this->foreignId($column ?: $model->getForeignKey())
-                    : $this->foreignUuid($column ?: $model->getForeignKey());
+                    ? $this->foreignId($column ?: $model->getForeignKey(), $model->getTable())
+                    : $this->foreignUuid($column ?: $model->getForeignKey(), $model->getTable());
     }
 
     /**
@@ -1257,13 +1259,15 @@ class Blueprint
      * Create a new UUID column on the table with a foreign key constraint.
      *
      * @param  string  $column
+     * @param  string|null $table
      * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
      */
-    public function foreignUuid($column)
+    public function foreignUuid($column, $table = null)
     {
         return $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
             'type' => 'uuid',
             'name' => $column,
+            'table' => $table,
         ]));
     }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -12,7 +12,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      * @var \Illuminate\Database\Schema\Blueprint
      */
     protected $blueprint;
-    public $table = NULL;
+    public $table = null;
 
     /**
      * Create a new foreign ID column definition.
@@ -26,7 +26,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
         parent::__construct($attributes);
 
         $this->blueprint = $blueprint;
-        $this->table = $attributes['table'] ?? NULL;
+        $this->table = $attributes['table'] ?? null;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -39,6 +39,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     public function constrained($table = null, $column = 'id')
     {
         $table = $table ?? $this->table ?? Str::plural(Str::beforeLast($this->name, '_'.$column));
+
         return $this->references($column)->on($table);
     }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -12,6 +12,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      * @var \Illuminate\Database\Schema\Blueprint
      */
     protected $blueprint;
+    public $table = NULL;
 
     /**
      * Create a new foreign ID column definition.
@@ -25,6 +26,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
         parent::__construct($attributes);
 
         $this->blueprint = $blueprint;
+        $this->table = $attributes['table'] ?? NULL;
     }
 
     /**
@@ -36,7 +38,8 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function constrained($table = null, $column = 'id')
     {
-        return $this->references($column)->on($table ?? Str::plural(Str::beforeLast($this->name, '_'.$column)));
+        $table = $table ?? $this->table ?? Str::plural(Str::beforeLast($this->name, '_'.$column));
+        return $this->references($column)->on($table);
     }
 
     /**


### PR DESCRIPTION
Hello,

I'm new at "pull requesting". I hope I'm doing things right.

Currently, the $table->foreignIdFor always uses the plural version of table part of the foreign key to determines the foreign table name. So if the name is changed in the model, the name will be wrong.

I made small changes to account for the $table property. Hope that will be helpful (it is for me).

P.S.: Since getTable() returns the plural version of the model and getForeignKey() is also based on the model, I think we could get rid of the Str::plural(...) part, but I didn't dare to.

Best regards.
Martin Boudreau
