### PR TITLE
add getters methods to view finder interface

### DIFF
--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -68,4 +68,25 @@ interface ViewFinderInterface
      * @return void
      */
     public function flush();
+
+    /**
+     * Get the active view paths.
+     *
+     * @return array
+     */
+    public function getPaths();
+
+    /**
+     * Get the views that have been located.
+     *
+     * @return array
+     */
+    public function getViews();
+
+    /**
+     * Get the namespace to file path hints.
+     *
+     * @return array
+     */
+    public function getHints();
 }


### PR DESCRIPTION
Hello all, I think that adding some getters methods to the `ViewFinderInterface` can be helpful when creating packages for laravel.
I know this interface can be used outside laravel, if so this PR will break the compatibility in other projects, maybe the next laravel version can have more interface types?