### PR TITLE
add the beforeCompilers feature

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -23,7 +23,7 @@ namespace Illuminate\Support\Facades;
  * @method static void extend(callable $compiler)
  * @method static void if(string $name, callable $callback)
  * @method static void include(string $path, string|null $alias = null)
- * @method static void beforeCompiler(callable $beforeCompiler)
+ * @method static self beforeCompiler(callable $beforeCompiler)
  * @method static void precompiler(callable $precompiler)
  * @method static void setEchoFormat(string $format)
  * @method static void setPath(string $path)

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -23,6 +23,7 @@ namespace Illuminate\Support\Facades;
  * @method static void extend(callable $compiler)
  * @method static void if(string $name, callable $callback)
  * @method static void include(string $path, string|null $alias = null)
+ * @method static void beforeCompiler(callable $beforeCompiler)
  * @method static void precompiler(callable $precompiler)
  * @method static void setEchoFormat(string $format)
  * @method static void setPath(string $path)

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -55,6 +55,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $conditions = [];
 
     /**
+     * All of the registered beforeCompilers.
+     * These compilers will run before the default Blade compiler.
+     * @var array
+     */
+    protected $beforeCompilers = [];
+
+    /**
      * All of the registered precompilers.
      *
      * @var array
@@ -239,6 +246,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function compileString($value)
     {
         [$this->footer, $result] = [[], ''];
+
+        foreach ($this->beforeCompilers as $compiler) {
+            $value = call_user_func($compiler, $value);
+        }
 
         // First we will compile the Blade component tags. This is a precompile style
         // step which compiles the component Blade tags into @component directives
@@ -806,6 +817,19 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function getCustomDirectives()
     {
         return $this->customDirectives;
+    }
+
+    /**
+     * Register a new beforeCompiler.
+     *
+     * @param  callable  $beforeCompiler
+     * @return self
+     */
+    public function beforeCompiler(callable $beforeCompiler)
+    {
+        $this->beforeCompilers[] = $beforeCompiler;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -57,6 +57,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     /**
      * All of the registered beforeCompilers.
      * These compilers will run before the default Blade compiler.
+     *
      * @var array
      */
     protected $beforeCompilers = [];

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -287,13 +287,13 @@ class ViewBladeCompilerTest extends TestCase
         });
 
         $this->assertEquals(
-            <<<EOT
+            <<<'EOT'
                 #removed
                 @notRemoveIt
                 #removed
                 <icon name="user" />
             EOT,
-            $compiler->compileString(<<<EOT
+            $compiler->compileString(<<<'EOT'
                 @removeIt
                 @notRemoveIt
                 <x-non-component />


### PR DESCRIPTION
At the moment we can't add a blade compiler to be run before the default blade compiler, this PR will add the ability to process the blade as we want before laravel process the blade.
I'm building a icons components [package](https://github.com/wireui/heroicons), I don't want to register all icons components in a loop or to use the namespace syntax

It works if register a components namespace (but it now includes the Icon class, just the blade file)
```
<x-icons::user />
<x-icons::home /> 
```

But it is better.
```
<x-icons.user />
<x-icons.home /> 
```
All icons use the same Icon component class but different blade views.

Thanks, Laravel team