### PR TITLE
Add missing translation prefix to pagination file

### DIFF
--- a/src/Illuminate/Pagination/resources/views/bootstrap-5.blade.php
+++ b/src/Illuminate/Pagination/resources/views/bootstrap-5.blade.php
@@ -29,13 +29,13 @@
         <div class="d-none flex-sm-fill d-sm-flex align-items-sm-center justify-content-sm-between">
             <div>
                 <p class="small text-muted">
-                    {!! __('Showing') !!}
+                    {!! __('pagination.showing') !!}
                     <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                    {!! __('to') !!}
+                    {!! __('pagination.to') !!}
                     <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                    {!! __('of') !!}
+                    {!! __('pagination.of') !!}
                     <span class="font-medium">{{ $paginator->total() }}</span>
-                    {!! __('results') !!}
+                    {!! __('pagination.results') !!}
                 </p>
             </div>
 

--- a/src/Illuminate/Pagination/resources/views/tailwind.blade.php
+++ b/src/Illuminate/Pagination/resources/views/tailwind.blade.php
@@ -25,17 +25,17 @@
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
             <div>
                 <p class="text-sm text-gray-700 leading-5">
-                    {!! __('Showing') !!}
+                    {!! __('pagination.showing') !!}
                     @if ($paginator->firstItem())
                         <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                        {!! __('to') !!}
+                        {!! __('pagination.to') !!}
                         <span class="font-medium">{{ $paginator->lastItem() }}</span>
                     @else
                         {{ $paginator->count() }}
                     @endif
-                    {!! __('of') !!}
+                    {!! __('pagination.of') !!}
                     <span class="font-medium">{{ $paginator->total() }}</span>
-                    {!! __('results') !!}
+                    {!! __('pagination.results') !!}
                 </p>
             </div>
 


### PR DESCRIPTION
Currently some translations of the pagination templates are not translated. Since the prefix for the strings is missing, a translation is also not easily possible without adapting the template.

The strings have now been translated in the language file and the prefixes added.

This ticket belongs to this ticket:
https://github.com/laravel/laravel/pull/5937