### PR TITLE
Arr::except add support for asterisks as wildcard

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -286,7 +286,13 @@ class Arr
             while (count($parts) > 1) {
                 $part = array_shift($parts);
 
-                if (isset($array[$part]) && static::accessible($array[$part])) {
+                if ($part === '*' && static::accessible($array)) {
+                    // handle wildcard within "dot" notation
+                    foreach ($array as &$inner) {
+                        static::forget($inner, implode('.', $parts));
+                    }
+                    continue 2;
+                } elseif (isset($array[$part]) && static::accessible($array[$part])) {
                     $array = &$array[$part];
                 } else {
                     continue 2;

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -150,6 +150,22 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['name' => 'taylor', 'framework' => ['name' => 'Laravel']], Arr::except($array, 'framework.language'));
         $this->assertEquals(['framework' => ['language' => 'PHP']], Arr::except($array, ['name', 'framework.name']));
 
+        $array = ['name' => 'taylor', 'friends' => [['name' => 'Jakob', 'phone' => '1234'], ['name' => 'Nuno', 'phone' => '5678']]];
+        $this->assertEquals(['name' => 'taylor', 'friends' => [['name' => 'Jakob'], ['name' => 'Nuno']]], Arr::except($array, ['friends.*.phone']));
+        $this->assertEquals(['name' => 'taylor', 'friends' => [['phone' => '1234'], ['phone' => '5678']]], Arr::except($array, ['friends.*.name']));
+
+        $array = ['name' => 'Taylor', 'friends' => [['name' => 'Jakob', 'phone' => '1234', 'friends' => [['name' => 'Jakob', 'phone' => '1234'], ['name' => 'Tylor', 'phone' => '5678']]], ['name' => 'Nuno', 'phone' => '5678', 'friends' => [['name' => 'Jakob', 'phone' => '1234'], ['name' => 'Tylor', 'phone' => '5678']]]]];
+        $this->assertEquals(['name' => 'Taylor', 'friends' => [['name' => 'Jakob', 'friends' => [['name' => 'Jakob'], ['name' => 'Tylor']]], ['name' => 'Nuno', 'friends' => [['name' => 'Jakob'], ['name' => 'Tylor']]]]], Arr::except($array, ['friends.*.phone', 'friends.*.friends.*.phone']));
+        $this->assertEquals(['name' => 'Taylor', 'friends' => [['phone' => '1234', 'friends' => [['phone' => '1234'], ['phone' => '5678']]], ['phone' => '5678', 'friends' => [['phone' => '1234'], ['phone' => '5678']]]]], Arr::except($array, ['friends.*.name', 'friends.*.friends.*.name']));
+
+        $array = [['name' => 'Jakob', 'phone' => '1234'], ['name' => 'Nuno', 'phone' => '5678']];
+        $this->assertEquals([['name' => 'Jakob'], ['name' => 'Nuno']], Arr::except($array, ['*.phone']));
+        $this->assertEquals([['phone' => '1234'], ['phone' => '5678']], Arr::except($array, ['*.name']));
+
+        $array = [[['name' => 'Jakob', 'phone' => '1234'], ['name' => 'Taylor', 'phone' => '5678']], [['name' => 'Nuno', 'phone' => '4567'], ['name' => 'Dries', 'phone' => '0987']]];
+        $this->assertEquals([[['name' => 'Jakob'], ['name' => 'Taylor']], [['name' => 'Nuno'], ['name' => 'Dries']]], Arr::except($array, ['*.*.phone']));
+        $this->assertEquals([[['phone' => '1234'], ['phone' => '5678']], [['phone' => '4567'], ['phone' => '0987']]], Arr::except($array, ['*.*.name']));
+
         $array = [1 => 'hAz', 2 => [5 => 'foo', 12 => 'baz']];
         $this->assertEquals([1 => 'hAz'], Arr::except($array, 2));
         $this->assertEquals([1 => 'hAz', 2 => [12 => 'baz']], Arr::except($array, 2.5));


### PR DESCRIPTION
This MR makes it possible to use asterisks as wildcard for Arr::except.
Imagine having an array like this:
```
use Illuminate\Support\Arr;

$array = [
    "users" => [
        [
            "name" => "Jakob",
            "secret" => "Jakob's secret", // should be removed
            "phone" => "123456",
        ],
        [
            "name" => "Tylor",
            "secret" => "Tylor's secret", // should be removed
            "phone" => "123456",
        ],
    ],
];
```
and you want to remove all "secret" keys.
You can now simply use this syntax:
```php
$filtered = Arr::except($array, ["users.*.secret"])
```
Before you had to write this:
```php
$filtered = Arr::except($array, ["users.0.secret", ""users.1.secret"])
```
The solution works, but it cannot handle a dynamic number of items.