### PR TITLE
[9.x] Add colon to database cache driver prefix key

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          convertWarningsToExceptions="true"
          printerClass="Illuminate\Tests\IgnoreSkippedPrinter"
          processIsolation="false"
-         stopOnError="true"
+         stopOnError="false"
          stopOnFailure="false"
          verbose="true"
 >

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          convertWarningsToExceptions="true"
          printerClass="Illuminate\Tests\IgnoreSkippedPrinter"
          processIsolation="false"
-         stopOnError="false"
+         stopOnError="true"
          stopOnFailure="false"
          verbose="true"
 >

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -75,7 +75,7 @@ class DatabaseStore implements LockProvider, Store
                                 $lockLottery = [2, 100])
     {
         $this->table = $table;
-        $this->prefix = $prefix;
+        $this->setPrefix($prefix);
         $this->connection = $connection;
         $this->lockTable = $lockTable;
         $this->lockLottery = $lockLottery;
@@ -359,6 +359,17 @@ class DatabaseStore implements LockProvider, Store
     public function getPrefix()
     {
         return $this->prefix;
+    }
+    
+    /**
+     * Set the cache key prefix.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = ! empty($prefix) ? $prefix.':' : '';
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -360,7 +360,7 @@ class DatabaseStore implements LockProvider, Store
     {
         return $this->prefix;
     }
-    
+
     /**
      * Set the cache key prefix.
      *

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -23,7 +23,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', '=', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
 
         $this->assertNull($store->get('foo'));
@@ -34,7 +34,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', '=', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['expiration' => 1]);
         $store->expects($this->once())->method('forget')->with($this->equalTo('foo'))->willReturn(null);
 
@@ -46,7 +46,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', '=', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['value' => serialize('bar'), 'expiration' => 999999999999999]);
 
         $this->assertSame('bar', $store->get('foo'));
@@ -57,7 +57,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getPostgresStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', '=', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]);
 
         $this->assertSame('bar', $store->get('foo'));
@@ -69,7 +69,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
-        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnTrue();
+        $table->shouldReceive('insert')->once()->with(['key' => 'prefix:foo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnTrue();
 
         $result = $store->put('foo', 'bar', 60);
         $this->assertTrue($result);
@@ -81,10 +81,10 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
-        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnUsing(function () {
+        $table->shouldReceive('insert')->once()->with(['key' => 'prefix:foo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnUsing(function () {
             throw new Exception;
         });
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize('bar'), 'expiration' => 61])->andReturnTrue();
 
         $result = $store->put('foo', 'bar', 60);
@@ -97,7 +97,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
-        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61])->andReturnTrue();
+        $table->shouldReceive('insert')->once()->with(['key' => 'prefix:foo', 'value' => base64_encode(serialize("\0")), 'expiration' => 61])->andReturnTrue();
 
         $result = $store->put('foo', "\0", 60);
         $this->assertTrue($result);
@@ -116,7 +116,7 @@ class CacheDatabaseStoreTest extends TestCase
         $store = $this->getStore();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', '=', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('delete')->once();
 
         $store->forget('foo');
@@ -143,7 +143,7 @@ class CacheDatabaseStoreTest extends TestCase
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
         $this->assertFalse($store->increment('foo'));
@@ -153,7 +153,7 @@ class CacheDatabaseStoreTest extends TestCase
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn($cache);
         $this->assertFalse($store->increment('foo'));
@@ -163,11 +163,11 @@ class CacheDatabaseStoreTest extends TestCase
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn($cache);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize(3)]);
         $this->assertEquals(3, $store->increment('foo'));
     }
@@ -182,7 +182,7 @@ class CacheDatabaseStoreTest extends TestCase
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn(null);
         $this->assertFalse($store->decrement('foo'));
@@ -192,7 +192,7 @@ class CacheDatabaseStoreTest extends TestCase
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:foo')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn($cache);
         $this->assertFalse($store->decrement('foo'));
@@ -202,11 +202,11 @@ class CacheDatabaseStoreTest extends TestCase
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixbar')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:bar')->andReturn($table);
         $table->shouldReceive('lockForUpdate')->once()->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn($cache);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
-        $table->shouldReceive('where')->once()->with('key', 'prefixbar')->andReturn($table);
+        $table->shouldReceive('where')->once()->with('key', 'prefix:bar')->andReturn($table);
         $table->shouldReceive('update')->once()->with(['value' => serialize(2)]);
         $this->assertEquals(2, $store->decrement('bar'));
     }


### PR DESCRIPTION
This PR makes the database cache driver prefix key consistent with the other drivers by adding a colon to the end of it, separating the prefix from the key name like so: `laravel_cache:key`.

This solves the issue presented by laravel/laravel#5817 in a more efficient manner by targeting the fix only on the database driver rather than adding an excessive underscore to the prefix keys across all of the cache drivers.

Also see laravel/laravel#5938 for the PR that ties into this one.