### PR TITLE
[9.x] Avoid deprecation-warnings in Str::contains with PHP 8.1

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -223,6 +223,7 @@ class Str
         if (is_null($haystack) || is_null($needles)) {
             return false;
         }
+
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', (array) $needles);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -220,6 +220,9 @@ class Str
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
+        if (is_null($haystack) || is_null($needles)) {
+            return false;
+        }
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', (array) $needles);


### PR DESCRIPTION
Hi

Not sure if this should be added in front, as it would be true, but the method is only for strings :shrug: 

        if ($haystack === $needles) {
            return true;
        }

The warning we get:

> str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/redacted/vendor/illuminate/support/Str.php on line 229

We do not use Str::contains in our custom code so i assume it's a missing check in a dependency. It would still make sense in my opinion to have this fixed at this central place :) 

This happens in Lumen 9 with illuminate/support 9.19 running with PHP 8.1.7

If somethings missed, please let me know.