### PR TITLE
Added Feature `Str::acronym()` method to generate acronym from given string.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1255,15 +1255,16 @@ class Str
     }
 
     /**
-     * Generates acronym for given string
+     * Generates acronym for given string.
      *
      * @param  string  $string
-     * @param  boolean $upper   returns acronym in upper if true
+     * @param  bool  $upper  returns acronym in upper if true
      * @return string
      */
     public static function acronym($string, $upper = false)
     {
         $acronym = preg_replace('/\b(\w)\w*\W*/', '\1', $string);
+
         return $upper ? static::upper($acronym) : $acronym;
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1253,7 +1253,7 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
-    
+
     /**
      * Generates acronym for given string
      *
@@ -1261,8 +1261,9 @@ class Str
      * @param  boolean $upper   returns acronym in upper if true
      * @return string
      */
-    public static function accronym($string, $upper = false)
+    public static function acronym($string, $upper = false)
     {
-        return preg_replace('/\b(\w)\w*\W*/', '\1', $string);
+        $acronym = preg_replace('/\b(\w)\w*\W*/', '\1', $string);
+        return $upper ? static::upper($acronym) : $acronym;
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1253,4 +1253,16 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+    
+    /**
+     * Generates acronym for given string
+     *
+     * @param  string  $string
+     * @param  boolean $upper   returns acronym in upper if true
+     * @return string
+     */
+    public static function accronym($string, $upper = false)
+    {
+        return preg_replace('/\b(\w)\w*\W*/', '\1', $string);
+    }
 }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1124,7 +1124,6 @@ class Stringable implements JsonSerializable
         return (string) $this->value;
     }
 
-
     /**
      * Generates acronym for given string.
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1123,4 +1123,16 @@ class Stringable implements JsonSerializable
     {
         return (string) $this->value;
     }
+
+
+    /**
+     * Generates acronym for given string.
+     *
+     * @param  bool  $upper  returns acronym in upper if true
+     * @return static
+     */
+    public function acronym($upper = false)
+    {
+        return new static(Str::acronym($this->value, $upper));
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1028,6 +1028,18 @@ class SupportStrTest extends TestCase
             Str::createUuidsNormally();
         }
     }
+
+    public function testDefaultAcronymIsGeneratedCorrect()
+    {
+        $this->assertSame('Tfais', Str::acronym('Test for acronym is succeeded'));
+    }
+
+    public function testAcronymWithUpperParameterReturnsInUpperCase()
+    {
+        $this->assertSame('TFAIS', Str::acronym('Test for acronym is succeeded', true));
+
+        $this->assertNotSame('Tfais', Str::acronym('Test for acronym is succeeded', true));
+    }
 }
 
 class StringableObjectStub

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1041,7 +1041,7 @@ class SupportStringableTest extends TestCase
 
     public function testAcronym()
     {
-        $string = "Acronym is generated Same";
+        $string = 'Acronym is generated Same';
         $this->assertSame(Str::acronym($string), (string) $this->stringable($string)->acronym());
 
         $this->assertSame(Str::acronym($string, true), (string) $this->stringable($string)->acronym(true));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use PHPUnit\Framework\TestCase;
 
@@ -1036,5 +1037,13 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('Foo')->exactly('foo'));
         $this->assertFalse($this->stringable('[]')->exactly([]));
         $this->assertFalse($this->stringable('0')->exactly(0));
+    }
+
+    public function testAcronym()
+    {
+        $string = "Acronym is generated Same";
+        $this->assertSame(Str::acronym($string), (string) $this->stringable($string)->acronym());
+
+        $this->assertSame(Str::acronym($string, true), (string) $this->stringable($string)->acronym(true));
     }
 }


### PR DESCRIPTION
This method will be helpful to end users when they needs to generate acronym for the longer string. Many users doesn't comfortable with regular expression or they have to iterate string by exploding it in parts and then concatenating first character. But this method will help users to make it quick and easier.

Tests are also created for the same.
