### PR TITLE
[9.x] Add `modelKeys()` Eloquent Builder method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -837,6 +837,16 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the array of with the values of the primary keys.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function modelKeys()
+    {
+        return $this->pluck($this->model->getKeyName());
+    }
+
+    /**
      * Get an array with the values of a given column.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -837,7 +837,7 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get the array of with the values of the primary keys.
+     * Get the array with the values of the primary keys.
      *
      * @return \Illuminate\Support\Collection
      */

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -621,6 +621,16 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame([[' First', 0], [' Second', 1], [' Third', 2]], $users);
     }
 
+    public function testModelKeys()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $primaryKeys = EloquentTestUser::oldest('id')->modelKeys()->all();
+
+        $this->assertEquals([1, 2], $primaryKeys);
+    }
+
     public function testPluck()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
This PR adds a method to easily fetch a model's primary keys via the `Model::modelKeys()` method. This provides the convenience of not having to specify the primary key yourself, and having to update the call later in case you switch primary key names (ex. UUID's).

```php
// Before...
$primaryKeys = Post::pluck('id');

// After...
$primaryKeys = Post::modelKeys();
```

This method is synonymous with the Eloquent Collection method `modelKeys()`.