### PR TITLE
[9.x] Str::contains(All) - parameter-datatypes to avoid warnings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -222,12 +222,8 @@ class Str
      * @param  bool  $ignoreCase
      * @return bool
      */
-    public static function contains($haystack, $needles, $ignoreCase = false)
+    public static function contains(string $haystack, string $needles, $ignoreCase = false)
     {
-        if (is_null($haystack) || is_null($needles)) {
-            return false;
-        }
-
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', (array) $needles);
@@ -250,7 +246,7 @@ class Str
      * @param  bool  $ignoreCase
      * @return bool
      */
-    public static function containsAll($haystack, array $needles, $ignoreCase = false)
+    public static function containsAll(string $haystack, array $needles, $ignoreCase = false)
     {
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);


### PR DESCRIPTION
Hi,

First, thanks again for merging my last PR that fast, @taylorotwell  i felt honored!

The comment from @GrahamCampbell  made be a bit unhappy, since i see it isn't the cleanest code. So i wanted to suggest this as well as a clean, but really strict solution that would crash if you try to pass null. It's in my perspective the better approach but obviusly causes more work.
What's the solution you people want to do should match the mindset of the Laravel-team, not mine (in case it's too strict, pls just close it). But i'm really glad if we can stop the flood of those warnings in one or the other way :)
