### PR TITLE
[10.x] Allow JSON flags in HTTP request methods [testing]

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -310,11 +310,12 @@ trait MakesHttpRequests
      *
      * @param  string  $uri
      * @param  array  $headers
+     * @param  int  $options
      * @return \Illuminate\Testing\TestResponse
      */
-    public function getJson($uri, array $headers = [])
+    public function getJson($uri, array $headers = [], $options = 0)
     {
-        return $this->json('GET', $uri, [], $headers);
+        return $this->json('GET', $uri, [], $headers, $options);
     }
 
     /**
@@ -339,11 +340,12 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  int  $options
      * @return \Illuminate\Testing\TestResponse
      */
-    public function postJson($uri, array $data = [], array $headers = [])
+    public function postJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('POST', $uri, $data, $headers);
+        return $this->json('POST', $uri, $data, $headers, $options);
     }
 
     /**
@@ -368,11 +370,12 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  int  $options
      * @return \Illuminate\Testing\TestResponse
      */
-    public function putJson($uri, array $data = [], array $headers = [])
+    public function putJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('PUT', $uri, $data, $headers);
+        return $this->json('PUT', $uri, $data, $headers, $options);
     }
 
     /**
@@ -397,11 +400,12 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  int  $options
      * @return \Illuminate\Testing\TestResponse
      */
-    public function patchJson($uri, array $data = [], array $headers = [])
+    public function patchJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('PATCH', $uri, $data, $headers);
+        return $this->json('PATCH', $uri, $data, $headers, $options);
     }
 
     /**
@@ -426,11 +430,12 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  int  $options
      * @return \Illuminate\Testing\TestResponse
      */
-    public function deleteJson($uri, array $data = [], array $headers = [])
+    public function deleteJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('DELETE', $uri, $data, $headers);
+        return $this->json('DELETE', $uri, $data, $headers, $options);
     }
 
     /**
@@ -456,11 +461,12 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  int  $options
      * @return \Illuminate\Testing\TestResponse
      */
-    public function optionsJson($uri, array $data = [], array $headers = [])
+    public function optionsJson($uri, array $data = [], array $headers = [], $options = 0)
     {
-        return $this->json('OPTIONS', $uri, $data, $headers);
+        return $this->json('OPTIONS', $uri, $data, $headers, $options);
     }
 
     /**
@@ -486,13 +492,14 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
+     * @param  int  $options
      * @return \Illuminate\Testing\TestResponse
      */
-    public function json($method, $uri, array $data = [], array $headers = [])
+    public function json($method, $uri, array $data = [], array $headers = [], $options = 0)
     {
         $files = $this->extractFilesFromDataArray($data);
 
-        $content = json_encode($data);
+        $content = json_encode($data, $options);
 
         $headers = array_merge([
             'CONTENT_LENGTH' => mb_strlen($content, '8bit'),


### PR DESCRIPTION
(This PR related to #43106)

I'm testing the webhook requests from GitHub.

I generate a hash from the request content and test if it is equal to the [`X-Hub-Signature`](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#delivery-headers) in the headers.

However, an invalid hash is generated in the [`json()`](https://github.com/laravel/framework/blob/6dd688461ff7a402efc7f939267087ccafebcc96/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php#L495) method. This is because the `json_encode()` options/flags need to be set as follows:

```php
json_encode($data, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE);
```

- [PHP Sandbox](https://onlinephp.io?s=dZBfC4IwFMWfC_oOewhmMIierUR00F-NlkREjKXGinRDKwj68G2ZaIEwtp27c3_3sKEluey0W13JnlfBIjACeyUBgCchIBiNP5d-_8gyiNTDwVSb9sdpKKJY2S-5SGmhjJLSMyvL9nzjvrydRZo3uBGYEd-jgYeJY6-wS8nCJhNMXn_lwJs6vot7ZQTOcq6Q-qA8YaEBc84GEIHvZATgckcJdtZ4Qzf-HHuwCKY7fmM1Mmq2JpxaD5bR6J5I4_N15fhCaDSq1-vIyvJX1WRr_AY%2C&v=8.1.8)


```php
$this->postJson(
    route('api.webhook'),
    $payloadStub,
    [
        'X-Hub-Signature' => [$validSignature],
    ],
    JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE
);
```

Similar usage:

https://github.com/spatie/spatie.be/blob/e4253bab447c9bc8ef89fb71ed46a60e02263e5f/app/Http/Api/Controllers/HandleGitHubRepositoryWebhookController.php#L27-L46