### PR TITLE
[9.x] Allow `@class()` for component tags

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -112,6 +112,10 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
+                                @(?:class)(\( (?: (?>[^()]+) | (?-1) )* \))
+                            )
+                            |
+                            (?:
                                 \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
                             )
                             |
@@ -164,6 +168,10 @@ class ComponentTagCompiler
                     (?:
                         \s+
                         (?:
+                            (?:
+                                @(?:class)(\( (?: (?>[^()]+) | (?-1) )* \))
+                            )
+                            |
                             (?:
                                 \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
                             )
@@ -433,6 +441,10 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
+                                @(?:class)(\( (?: (?>[^()]+) | (?-1) )* \))
+                            )
+                            |
+                            (?:
                                 \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
                             )
                             |
@@ -487,6 +499,8 @@ class ComponentTagCompiler
     protected function getAttributesFromAttributeString(string $attributeString)
     {
         $attributeString = $this->parseAttributeBag($attributeString);
+
+        $attributeString = $this->parseStatements($attributeString);
 
         $attributeString = $this->parseBindAttributes($attributeString);
 
@@ -570,6 +584,25 @@ class ComponentTagCompiler
         /xm";
 
         return preg_replace($pattern, ' bind:$1=', $attributeString);
+    }
+
+    /**
+     * Parse statements in a given attribute string into their fully-qualified syntax.
+     *
+     * @param  string  $attributeString
+     * @return string
+     */
+    protected function parseStatements(string $attributeString)
+    {
+         return preg_replace_callback(
+             '/@(class)(\( ( (?>[^()]+) | (?2) )* \))/x', function ($match) {
+                 if($match[1] === 'class') {
+                     $match[2] = str_replace('"', "'", $match[2]);
+                     return ":class=\"\Illuminate\Support\Arr::toCssClasses{$match[2]}\"";
+                 }
+                 return $match[0];
+             }, $attributeString
+        );
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -499,9 +499,7 @@ class ComponentTagCompiler
     protected function getAttributesFromAttributeString(string $attributeString)
     {
         $attributeString = $this->parseAttributeBag($attributeString);
-
-        $attributeString = $this->parseStatements($attributeString);
-
+        $attributeString = $this->parseComponentTagClassStatements($attributeString);
         $attributeString = $this->parseBindAttributes($attributeString);
 
         $pattern = '/
@@ -569,6 +567,27 @@ class ComponentTagCompiler
     }
 
     /**
+     * Parse @class statements in a given attribute string into their fully-qualified syntax.
+     *
+     * @param  string  $attributeString
+     * @return string
+     */
+    protected function parseComponentTagClassStatements(string $attributeString)
+    {
+         return preg_replace_callback(
+             '/@(class)(\( ( (?>[^()]+) | (?2) )* \))/x', function ($match) {
+                 if ($match[1] === 'class') {
+                     $match[2] = str_replace('"', "'", $match[2]);
+
+                     return ":class=\"\Illuminate\Support\Arr::toCssClasses{$match[2]}\"";
+                 }
+
+                 return $match[0];
+             }, $attributeString
+        );
+    }
+
+    /**
      * Parse the "bind" attributes in a given attribute string into their fully-qualified syntax.
      *
      * @param  string  $attributeString
@@ -584,25 +603,6 @@ class ComponentTagCompiler
         /xm";
 
         return preg_replace($pattern, ' bind:$1=', $attributeString);
-    }
-
-    /**
-     * Parse statements in a given attribute string into their fully-qualified syntax.
-     *
-     * @param  string  $attributeString
-     * @return string
-     */
-    protected function parseStatements(string $attributeString)
-    {
-         return preg_replace_callback(
-             '/@(class)(\( ( (?>[^()]+) | (?2) )* \))/x', function ($match) {
-                 if($match[1] === 'class') {
-                     $match[2] = str_replace('"', "'", $match[2]);
-                     return ":class=\"\Illuminate\Support\Arr::toCssClasses{$match[2]}\"";
-                 }
-                 return $match[0];
-             }, $attributeString
-        );
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -76,6 +76,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("@slot('foo', null, ['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$classes)]) \n".' @endslot', trim($result));
     }
 
+    public function testSlotsWithClassDirectiveCanBeCompiled()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot name="foo" @class($classes)>
+</x-slot>');
+
+        $this->assertSame("@slot('foo', null, ['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\Illuminate\Support\Arr::toCssClasses(\$classes))]) \n".' @endslot', trim($result));
+    }
+
     public function testBasicComponentParsing()
     {
         $this->mockViewFactory();
@@ -149,6 +157,18 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
 <?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
+    public function testClassDirective()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile @class(["bar"=>true])></x-profile>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes(['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\Illuminate\Support\Arr::toCssClasses(['bar'=>true]))]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testColonNestedComponentParsing()


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/42977. Example of use:
```blade
<x-icon @class(['lg' => $large]) />
```

### Description
My attempt to allow `@class()` directive alongside component tag attributes. I've adapted the regex used for statements in the blade compiler.

I have made 2 choices in this PR:
- The regex only match the statement `class` with an expression. Because it's the only one allowed here, it's seems more comprehensible instead of compiling the component and ignoring not handled directives.
- Double quotes are naively converted to single quotes inside the directive expression. Since we compile to `:class="..."`, double quotes would break the compiled code.