### PR TITLE
[9.x] Artisan `about` Command

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Composer;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'about')]
+class AboutCommand extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'about {--only= : The section to display}
+                {--json : Output the information as JSON}';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'about';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Display basic information about your application';
+
+    /**
+     * The Composer instance.
+     *
+     * @var \Illuminate\Support\Composer
+     */
+    protected $composer;
+
+    /**
+     * The data to display.
+     *
+     * @var array
+     */
+    protected static $data = [];
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Support\Composer  $composer
+     * @return void
+     */
+    public function __construct(Composer $composer)
+    {
+        parent::__construct();
+
+        $this->composer = $composer;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->gatherApplicationInformation();
+
+        collect(static::$data)->sortBy(function ($data, $key) {
+            $index = array_search($key, ['Environment', 'Cache', 'Drivers']);
+
+            if ($index === false) {
+                return 99;
+            }
+
+            return $index;
+        })
+            ->filter(function ($data, $key) {
+                return $this->option('only') ? in_array(Str::of($key)->lower()->snake(), $this->sections()) : true;
+            })
+            ->pipe(fn ($data) => $this->display($data));
+
+        return 0;
+    }
+
+    /**
+     * Display the information.
+     *
+     * @param  \Illuminate\Support\Collection  $data
+     * @return void
+     */
+    protected function display($data)
+    {
+        $this->option('json') ? $this->displayJson($data) : $this->displayDetail($data);
+    }
+
+    /**
+     * Display the information as a detail view.
+     *
+     * @param  \Illuminate\Support\Collection  $data
+     * @return void
+     */
+    protected function displayDetail($data)
+    {
+        $data->each(function ($data, $section) {
+            $this->newLine();
+
+            $this->components->twoColumnDetail('  <fg=green;options=bold>'.$section.'</>');
+
+            sort($data);
+
+            foreach ($data as $detail) {
+                [$label, $value] = $detail;
+
+                $this->components->twoColumnDetail($label, $value);
+            }
+        });
+    }
+
+    /**
+     * Display the information as JSON.
+     *
+     * @param  \Illuminate\Support\Collection  $data
+     * @return void
+     */
+    protected function displayJson($data)
+    {
+        $output = $data->flatMap(function ($data, $section) {
+            return [(string) Str::of($section)->snake() => collect($data)->mapWithKeys(fn ($item, $key) => [(string) Str::of($item[0])->lower()->snake() => $item[1]])];
+        });
+
+        $this->output->writeln(strip_tags(json_encode($output)));
+    }
+
+    /**
+     * Gather information about the application.
+     *
+     * @return array
+     */
+    protected function gatherApplicationInformation()
+    {
+        static::add('Environment', [
+            'Laravel Version' => $this->laravel->version(),
+            'PHP Version' => phpversion(),
+            'Composer Version' => $this->composer->getVersion() ?? '<fg=yellow;options=bold>-</>',
+            'Environment' => $this->laravel->environment(),
+            'Debug Mode' => config('app.debug') ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF',
+            'Application Name' => config('app.name'),
+            'URL' => Str::of(config('app.url'))->replace(['http://', 'https://'], ''),
+            'Maintenance Mode' => $this->laravel->isDownForMaintenance() ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF',
+        ]);
+
+        static::add('Cache', [
+            'Config' => file_exists($this->laravel->bootstrapPath('cache/config.php')) ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>',
+            'Routes' => file_exists($this->laravel->bootstrapPath('cache/routes-v7.php')) ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>',
+            'Events' => file_exists($this->laravel->bootstrapPath('cache/events.php')) ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>',
+            'Views' => $this->hasPhpFiles($this->laravel->storagePath('framework/views')) ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>',
+        ]);
+
+        static::add('Drivers', array_filter([
+            'Broadcasting' => config('broadcasting.default'),
+            'Cache' => config('cache.default'),
+            'Database' => config('database.default'),
+            'Mail' => config('mail.default'),
+            'Octane' => config('octane.server'),
+            'Queue' => config('queue.default'),
+            'Scout' => config('scout.driver'),
+            'Session' => config('session.driver'),
+        ]));
+    }
+
+    /**
+     * Check whether the given directory has PHP files.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    protected function hasPhpFiles(string $path): bool
+    {
+        return count(glob($path.'/*.php')) > 0;
+    }
+
+    /**
+     * Get the sections passed to the command.
+     *
+     * @return array
+     */
+    protected function sections()
+    {
+        return array_filter(explode(',', $this->option('only') ?? ''));
+    }
+
+    /**
+     * Add additional data to the output.
+     *
+     * @param  string  $section
+     * @param  string|array  $data
+     * @param  string|null  $value
+     * @return void
+     */
+    public static function add(string $section, $data, string $value = null)
+    {
+        if (is_array($data)) {
+            foreach ($data as $key => $value) {
+                self::$data[$section][] = [$key, $value];
+            }
+        } else {
+            self::$data[$section][] = [$data, $value];
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
@@ -91,6 +92,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      * @var array
      */
     protected $commands = [
+        'About' => AboutCommand::class,
         'CacheClear' => CacheClearCommand::class,
         'CacheForget' => CacheForgetCommand::class,
         'ClearCompiled' => ClearCompiledCommand::class,
@@ -204,6 +206,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         }
 
         $this->commands(array_values($commands));
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerAboutCommand()
+    {
+        $this->app->singleton(AboutCommand::class, function ($app) {
+            return new AboutCommand($app['composer']);
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -107,4 +107,22 @@ class Composer
 
         return $this;
     }
+
+    /**
+     * Get the version of Composer.
+     *
+     * @return string|null
+     */
+    public function getVersion()
+    {
+        $command = array_merge($this->findComposer(), ['-V']);
+
+        $process = $this->getProcess($command);
+
+        $process->run();
+
+        $output = $process->getOutput();
+
+        return explode(' ', $output)[2] ?? null;
+    }
 }


### PR DESCRIPTION
This PR introduces a new `about` command that displays output about the system environment and configuration of the user's application. The command is inspired by Rails' own [`about`](https://guides.rubyonrails.org/v2.3/command_line.html#about) command, though it's beautiful and has some additional powers 🪄 

![CleanShot 2022-07-13 at 12 08 46@2x](https://user-images.githubusercontent.com/246103/178720084-721affee-0a80-4d08-8aee-87c7912cb59a.png)

The command includes its own API so that applications and packages may push data into existing sections or create a new section with its own data:

```php
use Illuminate\Foundation\Console\AboutCommand;

AboutCommand::add('Laravel Vapor', 'Vapor Runtime', '1.0.0');
```

You can also add multiple items:

```php
AboutCommand::add('Environment', [
    'Laravel Cashier' => 'Stripe',
    'Laravel Nova' => '4.0.0'
]);
```

It's expected that packages will start to add their own sections of information, which could make this command output a lot of information. You can choose to filter down certain sections with `--only` and pass a comma-separated list of sections in `snake_case`.

![CleanShot 2022-07-13 at 12 10 13@2x](https://user-images.githubusercontent.com/246103/178720273-a5a1f8fe-ed95-4030-84bf-fda845035806.png)

Finally, you can choose to output this information as JSON by using the `--json` option (which can also be combined with `--only`):

![CleanShot 2022-07-13 at 12 11 40@2x](https://user-images.githubusercontent.com/246103/178720538-3df86f13-9d43-4e53-8624-aa63497a746f.png)