### PR TITLE
[9.x] Support not stringables messages

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -262,10 +262,14 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     {
         return collect((array) $messages)
             ->map(function ($message) use ($format, $messageKey) {
+                if (! is_scalar($message) && ! method_exists($message, '__toString')) {
+                    return $message;
+                }
+
                 // We will simply spin through the given messages and transform each one
                 // replacing the :message place holder with the real message allowing
                 // the messages to be easily formatted to each developer's desires.
-                return str_replace([':message', ':key'], [$message, $messageKey], $format);
+                return str_replace([':message', ':key'], [(string) $message, $messageKey], $format);
             })->all();
     }
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/discussions/43130#discussioncomment-3129481

After [1e02bc - "summarization" feature](https://github.com/laravel/framework/commit/1e02bc2b1508a9a73f76f33405053278983064f0)
```diff
-parent::__construct('The given data was invalid.');
+parent::__construct(static::summarize($validator));
```
**PHP throws a string conversion exception** if you already are using custom descriptive messages on error bag and trying to get the latest laravel version, this PR prevent application 500 when the message is not a string, and helps to easy upgrade

**This PR takes back old functionality without changing the new one**