### PR TITLE
[9.x] Early return when message format is the default

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -260,6 +260,10 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
      */
     protected function transform($messages, $format, $messageKey)
     {
+        if ($format == ':message') {
+            return (array) $messages;
+        }
+
         return collect((array) $messages)
             ->map(function ($message) use ($format, $messageKey) {
                 // We will simply spin through the given messages and transform each one


### PR DESCRIPTION
Avoid going through all the arrays and replacing the strings with the same when the format is the default `:message`

After [1e02bc - "summarization" feature](https://github.com/laravel/framework/commit/1e02bc2b1508a9a73f76f33405053278983064f0) `all` method is always called when validator fails
```diff
-parent::__construct('The given data was invalid.');
+parent::__construct(static::summarize($validator));
```
https://github.com/laravel/framework/blob/904bf5630a95ecf1d6623eb502ba7b751875faf4/src/Illuminate/Support/MessageBag.php#L261-L269