### PR TITLE
[9.x] Add support for a secondary database connection and custom migration path to the Testing/RefreshDatabase trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -58,7 +58,7 @@ trait RefreshDatabase
     {
         return array_merge([
             '--seed' => $this->shouldSeed(),
-            '--seeder' => $this->seeder()],
+            '--seeder' => $this->seeder(), ],
             $this->database() ? ['--database' => $this->database()] : [],
             $this->path() ? ['--path' => $this->path()] : []
         );

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -32,9 +32,9 @@ trait RefreshDatabase
      */
     protected function usingInMemoryDatabase()
     {
-        $default = config('database.default');
+        $database = $this->database() ?? config('database.default');
 
-        return config("database.connections.$default.database") === ':memory:';
+        return config("database.connections.$database.database") === ':memory:';
     }
 
     /**
@@ -56,10 +56,12 @@ trait RefreshDatabase
      */
     protected function migrateUsing()
     {
-        return [
+        return array_merge([
             '--seed' => $this->shouldSeed(),
-            '--seeder' => $this->seeder(),
-        ];
+            '--seeder' => $this->seeder()],
+            $this->database() ? ['--database' => $this->database()] : [],
+            $this->path() ? ['--path' => $this->path()] : []
+        );
     }
 
     /**
@@ -125,7 +127,7 @@ trait RefreshDatabase
     protected function connectionsToTransact()
     {
         return property_exists($this, 'connectionsToTransact')
-                            ? $this->connectionsToTransact : [null];
+                            ? $this->connectionsToTransact : [$this->database ?? null];
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -67,7 +67,7 @@ trait CanConfigureMigrationCommands
     }
 
     /**
-     * Determine the specific database connection that should be used when refreshing the database
+     * Determine the specific database connection that should be used when refreshing the database.
      *
      * @return mixed
      */
@@ -77,7 +77,7 @@ trait CanConfigureMigrationCommands
     }
 
     /**
-     * Determine the specific migration path that should be used when refreshing the database
+     * Determine the specific migration path that should be used when refreshing the database.
      *
      * @return mixed
      */

--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -12,13 +12,17 @@ trait CanConfigureMigrationCommands
     protected function migrateFreshUsing()
     {
         $seeder = $this->seeder();
+        $database = $this->database();
+        $path = $this->path();
 
         return array_merge(
             [
                 '--drop-views' => $this->shouldDropViews(),
                 '--drop-types' => $this->shouldDropTypes(),
             ],
-            $seeder ? ['--seeder' => $seeder] : ['--seed' => $this->shouldSeed()]
+            $seeder ? ['--seeder' => $seeder] : ['--seed' => $this->shouldSeed()],
+            $database ? ['--database' => $database] : [],
+            $path ? ['--path' => $path] : [],
         );
     }
 
@@ -60,5 +64,25 @@ trait CanConfigureMigrationCommands
     protected function seeder()
     {
         return property_exists($this, 'seeder') ? $this->seeder : false;
+    }
+
+    /**
+     * Determine the specific database connection that should be used when refreshing the database
+     *
+     * @return mixed
+     */
+    protected function database()
+    {
+        return property_exists($this, 'database') ? $this->database : false;
+    }
+
+    /**
+     * Determine the specific migration path that should be used when refreshing the database
+     *
+     * @return mixed
+     */
+    protected function path()
+    {
+        return property_exists($this, 'path') ? $this->path : false;
     }
 }

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -95,7 +95,7 @@ class RefreshDatabaseTest extends TestCase
         $refreshTestDatabaseReflection->invoke($this->traitObject);
     }
 
-	public function testRefreshTestDatabaseWithDatabaseOption()
+    public function testRefreshTestDatabaseWithDatabaseOption()
     {
         $this->traitObject->database = 'becca';
 
@@ -106,7 +106,7 @@ class RefreshDatabaseTest extends TestCase
                 '--drop-views' => false,
                 '--drop-types' => false,
                 '--seed' => false,
-				'--database' => 'becca',
+                '--database' => 'becca',
             ]);
 
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
@@ -114,7 +114,7 @@ class RefreshDatabaseTest extends TestCase
         $refreshTestDatabaseReflection->invoke($this->traitObject);
     }
 
-	public function testRefreshTestDatabaseWithPathOption()
+    public function testRefreshTestDatabaseWithPathOption()
     {
         $this->traitObject->path = 'database/migrations/becca';
 
@@ -125,7 +125,7 @@ class RefreshDatabaseTest extends TestCase
                 '--drop-views' => false,
                 '--drop-types' => false,
                 '--seed' => false,
-				'--path' => 'database/migrations/becca',
+                '--path' => 'database/migrations/becca',
             ]);
 
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
@@ -133,9 +133,9 @@ class RefreshDatabaseTest extends TestCase
         $refreshTestDatabaseReflection->invoke($this->traitObject);
     }
 
-	public function testRefreshTestDatabaseWithDatabaseAndPathOption()
+    public function testRefreshTestDatabaseWithDatabaseAndPathOption()
     {
-		$this->traitObject->database = 'becca';
+        $this->traitObject->database = 'becca';
         $this->traitObject->path = 'database/migrations/becca';
 
         $this->traitObject
@@ -145,8 +145,8 @@ class RefreshDatabaseTest extends TestCase
                 '--drop-views' => false,
                 '--drop-types' => false,
                 '--seed' => false,
-				'--database' => 'becca',
-				'--path' => 'database/migrations/becca',
+                '--database' => 'becca',
+                '--path' => 'database/migrations/becca',
             ]);
 
         $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -94,4 +94,64 @@ class RefreshDatabaseTest extends TestCase
 
         $refreshTestDatabaseReflection->invoke($this->traitObject);
     }
+
+	public function testRefreshTestDatabaseWithDatabaseOption()
+    {
+        $this->traitObject->database = 'becca';
+
+        $this->traitObject
+            ->expects($this->once())
+            ->method('artisan')
+            ->with('migrate:fresh', [
+                '--drop-views' => false,
+                '--drop-types' => false,
+                '--seed' => false,
+				'--database' => 'becca',
+            ]);
+
+        $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
+
+        $refreshTestDatabaseReflection->invoke($this->traitObject);
+    }
+
+	public function testRefreshTestDatabaseWithPathOption()
+    {
+        $this->traitObject->path = 'database/migrations/becca';
+
+        $this->traitObject
+            ->expects($this->once())
+            ->method('artisan')
+            ->with('migrate:fresh', [
+                '--drop-views' => false,
+                '--drop-types' => false,
+                '--seed' => false,
+				'--path' => 'database/migrations/becca',
+            ]);
+
+        $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
+
+        $refreshTestDatabaseReflection->invoke($this->traitObject);
+    }
+
+	public function testRefreshTestDatabaseWithDatabaseAndPathOption()
+    {
+		$this->traitObject->database = 'becca';
+        $this->traitObject->path = 'database/migrations/becca';
+
+        $this->traitObject
+            ->expects($this->once())
+            ->method('artisan')
+            ->with('migrate:fresh', [
+                '--drop-views' => false,
+                '--drop-types' => false,
+                '--seed' => false,
+				'--database' => 'becca',
+				'--path' => 'database/migrations/becca',
+            ]);
+
+        $refreshTestDatabaseReflection = $this->__reflectAndSetupAccessibleForProtectedTraitMethod('refreshTestDatabase');
+
+        $refreshTestDatabaseReflection->invoke($this->traitObject);
+    }
+
 }

--- a/tests/Foundation/Testing/RefreshDatabaseTest.php
+++ b/tests/Foundation/Testing/RefreshDatabaseTest.php
@@ -153,5 +153,4 @@ class RefreshDatabaseTest extends TestCase
 
         $refreshTestDatabaseReflection->invoke($this->traitObject);
     }
-
 }

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -76,27 +76,27 @@ class CanConfigureMigrationCommandsTest extends TestCase
 
         $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
 
-   		$expected = [
+        $expected = [
             '--drop-views' => true,
             '--drop-types' => true,
             '--seed' => false,
-    		'--database' => 'becca',
+            '--database' => 'becca',
         ];
 
-		$this->traitObject->database = 'becca';
+        $this->traitObject->database = 'becca';
 
         $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
 
-		$expected = [
+        $expected = [
             '--drop-views' => true,
             '--drop-types' => true,
             '--seed' => false,
-    		'--database' => 'becca',
-			'--path' => 'database/migrations/becca',
+            '--database' => 'becca',
+            '--path' => 'database/migrations/becca',
         ];
 
-		$this->traitObject->database = 'becca';
-		$this->traitObject->path = 'database/migrations/becca';
+        $this->traitObject->database = 'becca';
+        $this->traitObject->path = 'database/migrations/becca';
 
         $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
     }

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -75,5 +75,29 @@ class CanConfigureMigrationCommandsTest extends TestCase
         $this->traitObject->dropTypes = true;
 
         $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
+
+   		$expected = [
+            '--drop-views' => true,
+            '--drop-types' => true,
+            '--seed' => false,
+    		'--database' => 'becca',
+        ];
+
+		$this->traitObject->database = 'becca';
+
+        $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
+
+		$expected = [
+            '--drop-views' => true,
+            '--drop-types' => true,
+            '--seed' => false,
+    		'--database' => 'becca',
+			'--path' => 'database/migrations/becca',
+        ];
+
+		$this->traitObject->database = 'becca';
+		$this->traitObject->path = 'database/migrations/becca';
+
+        $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
     }
 }


### PR DESCRIPTION
# Type: Improvement

This pull requests allows users to specify a custom `$database` and/or  migration `$path` when using the RefreshDatabase trait.

## Use case
My application uses the default database and a secondary database with its own custom migration files path. My FeatureTests require the secondary database and I wasn't able to use the RefreshDatabase trait because it only supports the default database and the default migration files path.
The purpose of this PR is to make devs life easier and be able to use RefreshDatabase out of the box when your tests require a database that's not the default one, without the need to call custom artisan commands on setup() 

## How it works
This works pretty much like the `$seeder` [property](https://laravel.com/docs/9.x/database-testing#running-seeders). Simply specify in your test case a `$database` and/or a `$path` and the RefreshDatabase trait will add these as parameters to the `migrate:fresh` artisan command.

```
class BeccaTest extends TestCase
{
    use RefreshDatabase;

    /**
     * Use a custom database connection
     *
     * @var string
     */
    protected $database = 'becca';

    /**
     * Use a custom migration files path
     *
     * @var string
     */
    protected $path = 'database/migrations/becca';
}
```
After setting these 2 properties the migrate:fresh command will be executed with these params:

```
->with('migrate:fresh', [
                '--drop-views' => false,
                '--drop-types' => false,
                '--seed' => false,
		'--database' => 'becca',
		'--path' => 'database/migrations/becca'
```

The Feature tests are passing and I also added few more to test these new properties.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
