### PR TITLE
[9.x] Present exception before logging

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -268,12 +268,23 @@ class Handler implements ExceptionHandlerContract
         $context = array_merge(
             $this->exceptionContext($e),
             $this->context(),
-            ['exception' => $e]
+            ['exception' => $this->presentException((string) $e)]
         );
 
         method_exists($logger, $level)
             ? $logger->{$level}($e->getMessage(), $context)
             : $logger->log($level, $e->getMessage(), $context);
+    }
+
+    /**
+     * Present the exception to be logged.
+     *
+     * @param  string  $exception
+     * @return string
+     */
+    public function presentException(string $exception)
+    {
+        return $exception;
     }
 
     /**


### PR DESCRIPTION
Currently, the logged exceptions have a comprehensive stack trace including a lot of called methods in the Laravel core which makes it hard to scroll through and filter out the application code by eye.

What we need in our application level (`App\Exception\Handler@presentException`) is to remove the lines containing:
`vendor\laravel\framework\src\Illuminate\Pipeline\Pipeline.php`
and
`vendor\laravel\framework\src\Illuminate\Routing\Router.php`
and etc...
Exploding the string by "\n" then loop through all lines, modify them, and imploding by "\n" at the end.

- Sample fluffy stack trace:
[laravel-2022-07-13.log](https://github.com/laravel/framework/files/9099928/laravel-2022-07-13.log)

- Sample affiliated stack trace:
[laravel-2022-07-13-after.log](https://github.com/laravel/framework/files/9099923/laravel-2022-07-13-after.log)





