### PR TITLE
Added Eloquent withCountWhereHas method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -170,6 +170,23 @@ trait QueriesRelationships
     }
 
     /**
+     * Add a relationship count / exists condition to the query with where clauses.
+     *
+     * Also load the count of the relationship with same condition.
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function withCountWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    {
+        return $this->whereHas($relation, $callback, $operator, $count)
+            ->withCount($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
+    }
+
+    /**
      * Add a relationship count / exists condition to the query with where clauses and an "or".
      *
      * @param  string  $relation


### PR DESCRIPTION
There are a lot of times that we need to count a relationship using `withCount` with the same conditions that we use for `whereHas`.

This method simplifies this selection by avoiding repeating the code used both to filter with `whereHas` and then to count the same records using `withCount`. 

### Before
```
CollectionModel::query()->whereHas('products', function ($query) {
    $query->where('is_enabled', true)->where('is_for_sale', true);
})->withCount(['products' => function ($query) {
    $query->where('is_enabled', true)->where('is_for_sale', true);
});
```
### After
```
CollectionModel::query()->withCountWhereHas('products', function ($query) {
    $query->where('is_enabled', true)->where('is_for_sale', true);
});
```

I will add tests later 😄 

PS. The idea came from this PR: https://github.com/laravel/framework/pull/42597