### PR TITLE
[9.x] Add ignore param to ValidateSignature middleware

### DIFF
--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -8,6 +8,15 @@ use Illuminate\Routing\Exceptions\InvalidSignatureException;
 class ValidateSignature
 {
     /**
+     * The names of the parameters that should be ignored.
+     *
+     * @var array<int, string>
+     */
+    protected $ignore = [
+        //
+    ];
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -19,7 +28,7 @@ class ValidateSignature
      */
     public function handle($request, Closure $next, $relative = null)
     {
-        if ($request->hasValidSignature($relative !== 'relative')) {
+        if ($request->hasValidSignatureWhileIgnoring($this->ignore, $relative !== 'relative')) {
             return $next($request);
         }
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Exceptions\InvalidSignatureException;
 use Illuminate\Routing\Middleware\ValidateSignature;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
@@ -250,6 +251,34 @@ class UrlSigningTest extends TestCase
 
         $response = $this->get('/foo/relative');
         $response->assertStatus(403);
+    }
+
+    public function testSignedMiddlewareIgnoringParameter()
+    {
+        Route::get('/foo/{id}}', function (Request $request, $id) {
+        })->name('foo')->middleware('signed:relative');
+
+        $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1]).'&ignore=me');
+        $request = Request::create($url);
+        $middleware = $this->createValidateSignatureMiddleware(['ignore']);
+
+        try {
+            $middleware->handle($request, function ($request) {
+                $this->assertTrue($request->hasValidSignatureWhileIgnoring(['ignore']));
+            });
+        } catch (InvalidSignatureException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+    protected function createValidateSignatureMiddleware(array $ignore)
+    {
+        return new class ($ignore) extends ValidateSignature {
+            public function __construct(array $ignore)
+            {
+                $this->ignore = $ignore;
+            }
+        };
     }
 }
 


### PR DESCRIPTION
This provides a work around to an interesting problem with Signed URLs that I encountered and discussed here: https://twitter.com/valorin/status/1547053470389112834.

I've created a PR for the skeleton here: https://github.com/laravel/laravel/pull/5942

### Problem

The problem is that some systems, such as mailing list providers and Facebook will add their own tracking parameters onto URLs. Such as the [UTM tracking parameters](https://usefathom.com/utm-builder) (`utm_*`), and Facebook's `fbclid` parameter,  which it adds to any links clicked for tracking purposes.

Since these are added as query parameters, they break the signature and prevent the URL from being validated.

### Solution 

My solution is to replicate the design used in other core middleware (i.e. `EncryptCookies`, `PreventRequestsDuringMaintenance`, `TrimStrings`, & `VerifyCsrfToken`) and include a configurable `$ignore` parameter, which can be used to specify the query parameters to be ignored when verifying the signature.

```
class ValidateSignature extends Middleware
{
    /**
     * The names of the parameters that should be ignored.
     *
     * @var array<int, string>
     */
    protected $ignore = [
        'utm_campaign',
        'utm_source',
        'utm_medium',
        'utm_content',
        'utm_term',
        'fbclid',
    ];
}
```

### Questions...

The big question is if common tracking query parameters should be ignored by default. 

Signed URL issues are hard to debug, such as when they are [shared on Facebook](https://twitter.com/warsh33p/status/1547113243616870401), so having these default ignored would be beneficial in most cases. However it would break signed URLs that legitimately include those parameters. Although the argument could be made that you'd need to update the middleware to introduce these parameters, so it shouldn't break existing signed URLs.

I've defaulted them commented out for now to be safe, but enabled by default should be considered.