### PR TITLE
[10.x] Set `SessionGuard::$name` as readonly

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -37,7 +37,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @var string
      */
-    protected $name;
+    public readonly $name;
 
     /**
      * The user we last attempted to retrieve.

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -37,7 +37,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @var string
      */
-    public readonly $name;
+    public readonly string $name;
 
     /**
      * The user we last attempted to retrieve.


### PR DESCRIPTION
Alternative to #43138 and make it easier to do the following:

![image](https://user-images.githubusercontent.com/172966/178703467-43fd5e69-0daa-4964-9e5a-46010bfc29aa.png)


Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>