### PR TITLE
[9.x] Revert "[9.x] Avoid deprecation-warnings in Str::contains with PHP 8.1"

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -224,10 +224,6 @@ class Str
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
-        if (is_null($haystack) || is_null($needles)) {
-            return false;
-        }
-
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', (array) $needles);


### PR DESCRIPTION
I want to propose to revert laravel/framework#43125. We've gotten more PR's like this in the past and always denied them to prevent an influx of PR's that will type-check every `Str` method in the framework that requires a string to be passed. We're flexible on signatures and I don't feel we should do type-checks in these methods. Developers can easily cast to a string before passing arguments.