### PR TITLE
[10.x] Adds enum casting to `Request`

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -344,6 +344,22 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve input from the request as an enum.
+     *
+     * @param  string  $key
+     * @param  string  $enumClass
+     * @return mixed|null
+     */
+    public function enum($key, $enumClass)
+    {
+        if ($this->isNotFilled($key)) {
+            return null;
+        }
+
+        return $enumClass::tryFrom($this->input($key));
+    }
+
+    /**
      * Retrieve input from the request as a collection.
      *
      * @param  array|string|null  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -625,6 +625,20 @@ class HttpRequestTest extends TestCase
         $request->date('date', 'invalid_format');
     }
 
+    public function testEnumMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'valid_enum_value' => 'test',
+            'invalid_enum_value' => 'invalid',
+        ]);
+
+        $this->assertNull($request->enum('doesnt_exists', TestEnum::class));
+
+        $this->assertEquals(TestEnum::test, $request->enum('valid_enum_value', TestEnum::class));
+
+        $this->assertNull($request->enum('invalid_enum_value', TestEnum::class));
+    }
+
     public function testArrayAccess()
     {
         $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);

--- a/tests/Http/TestEnum.php
+++ b/tests/Http/TestEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Http;
+
+enum TestEnum: string
+{
+    case test = 'test';
+}


### PR DESCRIPTION
This PR allows to conveniently retrieve an input from the Request as an enum.

```php
// Before
public function post(Request $request)
{
    $status = StatusEnum::tryFrom($request->input('status'));

    // do stuff with status enum...
}

// After
public function post(Request $request)
{
    $status = $request->enum('status', StatusEnum::class);

    // do stuff with status enum...
}
```