### PR TITLE
[9.x] Added env_as_array helper.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -136,11 +136,11 @@ if (! function_exists('env')) {
 
 if (! function_exists('env_as_array')) {
     /**
-     * Gets the value of an environment variable as array
+     * Gets the value of an environment variable as array.
      *
-     * @param string $key
-     * @param string $separator
-     * @param array $default
+     * @param  string  $key
+     * @param  string  $separator
+     * @param  array  $default
      * @return array
      */
     function env_as_array(string $key, string $separator = ',', array $default = []): array

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -134,6 +134,26 @@ if (! function_exists('env')) {
     }
 }
 
+if (! function_exists('env_as_array')) {
+    /**
+     * Gets the value of an environment variable as array
+     *
+     * @param string $key
+     * @param string $separator
+     * @param array $default
+     * @return array
+     */
+    function env_as_array(string $key, string $separator = ',', array $default = []): array
+    {
+        $value = env($key);
+        if (null === $value) {
+            return $default;
+        }
+
+        return explode($separator, $value);
+    }
+}
+
 if (! function_exists('filled')) {
     /**
      * Determine if a value is "filled".

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -770,6 +770,29 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('x"null"x', env('foo'));
     }
 
+    public function testGetEnvAsArrayValue()
+    {
+        $_SERVER['foo'] = 'bar,baz';
+
+        $this->assertSame(['bar', 'baz'], env_as_array('foo'));
+    }
+
+    public function testGetEnvAsArrayDefault()
+    {
+        $_SERVER['foo'] = 'bar';
+        $this->assertSame(['bar'], env_as_array(key: 'foo', default: ['baz']));
+
+        unset($_SERVER['foo']);
+        $this->assertSame(['baz'], env_as_array(key: 'foo', default: ['baz']));
+    }
+
+    public function testEnvAsArraySeparator()
+    {
+        $_SERVER['foo'] = 'bar|baz';
+
+        $this->assertSame(['bar', 'baz'], env_as_array('foo', '|'));
+    }
+
     public function testGetFromSERVERFirst()
     {
         $_ENV['foo'] = 'From $_ENV';


### PR DESCRIPTION
This PR adds `env_as_array` helper.
Sometimes it's useful to be able to set array values in an env variable. Here is an example of usage in a config file:
`'foo' => env_as_array('FOO'),`
or with a defined values separator and a default value
`'foo' => env_as_array('FOO', '|', ['bar', 'baz']),`
And in `.env` file it looks like that:
`FOO=bar,baz`