### PR TITLE
[9.x] ValidationException summarize only when use strings

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -87,7 +87,7 @@ class ValidationException extends Exception
     {
         $messages = $validator->errors()->all();
 
-        if (! count($messages)) {
+        if (! count($messages) || ! is_string($messages[0])) {
             return 'The given data was invalid.';
         }
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/discussions/43130

On [[1e02bc] src/Illuminate/Validation/ValidationException.php](https://github.com/laravel/framework/commit/1e02bc2b1508a9a73f76f33405053278983064f0), laravel adds the first error with a summarize count, but when you try to `->add` custom data to error message bag, it throws `ErrorException to string conversion`

I'm trying to upgrade from laravel 8.x, and this is the only exception that i have, on previous versions we did can add custom data to errors on message bag, it is not the best but helps with third party plugins

This PR takes back old functionality without changing the new one