### PR TITLE
[9.x] - Convert locale to string to avoid null

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -413,7 +413,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     public function setLocale($locale)
     {
-        if (Str::contains($locale, ['/', '\\'])) {
+        if (Str::contains(strval($locale), ['/', '\\'])) {
             throw new InvalidArgumentException('Invalid characters present in locale.');
         }
 


### PR DESCRIPTION
Context: #43125 

This is causing the warning, at least, maybe there are more places. I know it's needed to pass a string here, so as a first action, i added a strval to the calls, which didn't helped, so i added it in the method itself. As this is solved with casting (converting in this case, to be exact i think) i wouldn't expect issues and hope you people are fine with it.

