### PR TITLE
[9.x] Make assertDatabaseHas failureDescription more multibyte charac…

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -64,7 +64,7 @@ class HasInDatabase extends Constraint
     {
         return sprintf(
             "a row in the table [%s] matches the attributes %s.\n\n%s",
-            $table, $this->toString(JSON_PRETTY_PRINT), $this->getAdditionalInfo($table)
+            $table, $this->toString(JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), $this->getAdditionalInfo($table)
         );
     }
 
@@ -84,7 +84,7 @@ class HasInDatabase extends Constraint
         )->limit($this->show)->get();
 
         if ($similarResults->isNotEmpty()) {
-            $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT);
+            $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
         } else {
             $query = $this->database->table($table);
 
@@ -94,7 +94,7 @@ class HasInDatabase extends Constraint
                 return 'The table is empty';
             }
 
-            $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
+            $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
         }
 
         if ($query->count() > $this->show) {


### PR DESCRIPTION
When `assertDatabaseHas` test fails, it shows you similar or found results.
While it's  helpful, sometimes it can be difficult to see for those using multibyte languages.

This PR solves that problem.

### sample test
```php
    /** @test */
    function dbtest()
    {
        User::factory()->create([
            'name' => '名無しの権兵衛',
            'email' => '太郎@example.net'
        ]);

        $this->assertDatabaseHas(User::class, [
            'name' => '名無しの権兵衛',
            'email' => '次郎@example.net'
        ]);
    }
```

### Before
![2022-07-14_15h24_45](https://user-images.githubusercontent.com/14008307/178925588-df2c86c1-8fd2-4239-a95a-3560e9aa36f1.png)

### After
![2022-07-14_15h28_24](https://user-images.githubusercontent.com/14008307/178925799-ea5d7fc3-5cd2-4a98-ab01-c40d0a2f3cfc.png)

This is a small addition, yet it helps us a lot.
Thank you always.