### PR TITLE
Adds Str::stringAfter

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1276,4 +1276,16 @@ class Str
         static::$camelCache = [];
         static::$studlyCache = [];
     }
+    
+    /**
+     * Return string after the first occurrence of a given value in the string.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     */
+    public static function stringAfter(string $subject, string $search)
+    {
+        $pos = strpos($subject, $search);
+        return $pos ? mb_substr($subject, $pos + strlen($search), null, 'UTF-8') : false;
+    }
 }


### PR DESCRIPTION
This PR adds stringAfter() to Str

```
Str::stringAfter('Hello world. The world is nice.', 'world');
//. The world is nice.
```