### PR TITLE
[9.x] Allow a special log channel to report exceptions

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -271,6 +271,10 @@ class Handler implements ExceptionHandlerContract
             ['exception' => $e]
         );
 
+        if (method_exists($logger, 'channel')) {
+            $logger = $logger->channel(config('logging.exceptions'));
+        }
+
         method_exists($logger, $level)
             ? $logger->{$level}($e->getMessage(), $context)
             : $logger->log($level, $e->getMessage(), $context);


### PR DESCRIPTION
Currently, the `Handler` class logs the exceptions in the default log channel, and since the exceptions stack trace is bulky, it kinda gets in the way of other application log messages like: `Log::info('Hello')`. It is better to have a special log channel to store only the exception logs so that they can be downloaded or deleted from the storage folder separately.

- This change is fully backward compatible since if the config is null the default channel will be chosen. (if accepted, I add the new config into the `laravel/laravel` repository as well.)

- This PR is based on our real-world problem of having a multi-gigabyte `laravel.log` file on the server that is now hard to process and remove the old exception logs from it.

- I am not sure if it is better to check for `channel` method or check that the `$logger` is an instace of the `LogManager` class before calling the `channel` method.
```php
if ($logger instanceof LogManager)) {
    $logger = $logger->channel(config('logging.exceptions'));
}
```

--------

- ‍**config/logging.php**
```php
[
    'default' => env('LOG_CHANNEL', 'stack'),

   'exceptions' => env('EXCEPTION_LOG_CHANNEL', 'exceptions'),  //<== channel name for exceptions

        ...

   'channels' => [

     'daily' => [
            'driver' => 'daily',
            'path' => storage_path('logs/laravel.log'),
            'level' => env('LOG_LEVEL', 'debug'),
            'days' => 14,
        ],

        'exceptions' => [
            'driver' => 'daily',
            'path' => storage_path('logs/exceptions.log'),   //<== special file name for exceptions.
            'level' => 'error',
            'days' => 2,
        ],

        ...
    ]
]
```

- Then we will have two series of .log files in the `storage/logs/` folder:

`logs/exceptions-2022-07-14.log` **<=== stores only unhandled exception logs.**

`logs/laravel-2022-07-14.log`       **<===  stores `Log::info('hello')`**

![image](https://user-images.githubusercontent.com/6961695/179085267-67c2482e-77b6-4880-9b02-e212854e1067.png)

