### PR TITLE
[9.x] Add isJsPath() to Vite

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -154,4 +154,15 @@ class Vite
     {
         return preg_match('/\.(css|less|sass|scss|styl|stylus|pcss|postcss)$/', $path) === 1;
     }
+
+    /**
+     * Determine whether the given path is a JavaScript file.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    protected function isJsPath($path)
+    {
+        return preg_match('/\.(mjs|js|ts|jsx|tsx|json|vue)$/', $path) === 1;
+    }
 }


### PR DESCRIPTION
This PR for determine whether the given path is a JavaScript file.
It can be used in makeTag() method.

```
$this->isJsPath($url)
// true | false
```

[https://vitejs.dev/config/shared-options.html#resolve-extensions](https://vitejs.dev/config/shared-options.html#resolve-extensions)
