### PR TITLE
Add a Terminate method to the Job Middleware so it operated the same as Request Middleware

### DIFF
--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -87,10 +87,6 @@ class QueueSyncQueueTest extends TestCase
         $container->bind(\Illuminate\Contracts\Container\Container::class, \Illuminate\Container\Container::class);
         $sync->setContainer($container);
 
-        SyncQueue::createPayloadUsing(function ($connection, $queue, $payload) {
-            return ['data' => ['extra' => 'extraValue']];
-        });
-
         try {
             $sync->push(new SyncQueueJobWithMiddleware());
         } catch (LogicException $e) {
@@ -106,10 +102,6 @@ class QueueSyncQueueTest extends TestCase
         $container->bind(\Illuminate\Contracts\Bus\Dispatcher::class, \Illuminate\Bus\Dispatcher::class);
         $container->bind(\Illuminate\Contracts\Container\Container::class, \Illuminate\Container\Container::class);
         $sync->setContainer($container);
-
-        SyncQueue::createPayloadUsing(function ($connection, $queue, $payload) {
-            return ['data' => ['extra' => 'extraValue']];
-        });
 
         try {
             $sync->push(new SyncQueueJobWithTerminatingMiddleware());


### PR DESCRIPTION
Hello there. 

I've recently needed to incorporate a Job Middleware into my project. I want to be able to run something at the end of the job without having to mess with the `handle` method of the job. 

The job middleware does a great job of handling something BEFORE the job runs. But i'd love to trigger something at the end. 

This is my attempt at demonstrating what i mean. I'm not 100% sure on the position of the method within the Queue Handler or whether i've completely misplaced it. I just found the `dispatchThroughMiddleware` method and based it on that. 

I've added some tests as well and am happy to receive feedback on how to make those a bit nicer. I noticed there wasn't a test for proving the Middleware's handle method was called so i added that as well. 

Thank you!

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
