### PR TITLE
[9.x] Change checking null condition for $key parameter in Arr::prepend()

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -575,7 +575,7 @@ class Arr
      */
     public static function prepend($array, $value, $key = null)
     {
-        if (func_num_args() == 2) {
+        if (is_null($key)) {
             array_unshift($array, $value);
         } else {
             $array = [$key => $value] + $array;


### PR DESCRIPTION
Change checking null condition for $key parameter in Arr::prepend()

`if (func_num_args() == 2)`
to
`if (is_null($key))`