### PR TITLE
[8.x] Fix breaks in tests according to psr/container changes

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -191,7 +191,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @return bool
      */
-    public function has($id)
+    public function has($id):bool
     {
         return $this->bound($id);
     }

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -110,7 +110,6 @@ class ValidationPasswordRuleTest extends TestCase
             '123456',
             'password',
             'welcome',
-            'ninja',
             'abc123',
             '123456789',
             '12345678',


### PR DESCRIPTION
This PR fix two breaks happen when run `tests`

# First
According to `psr/container` changes should put data type to return value in `has` method, check this changes https://github.com/php-fig/container/commit/6c2bc7fc1619d0f3f3442be69f177e6103d27dc7

# Second
seems that the `ninja` password appears in data leaks so it was returning true instead of returning false.
 