### PR TITLE
[8.x] Fix broken regex rule in single string-based rule case

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -306,7 +306,7 @@ class ValidationRuleParser
     /**
      * Determine if the rule is a regular expression rule.
      *
-     * @param string $rule
+     * @param  string  $rule
      * @return bool
      */
     protected static function ruleIsRegex(string $rule): bool

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -71,6 +71,7 @@ class ValidationRuleParser
                 $rules[$key] = $this->explodeExplicitRule($rule);
             }
         }
+
         return $rules;
     }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -315,4 +315,3 @@ class ValidationRuleParser
         return in_array(strtolower($rule), ['regex', 'not_regex', 'notregex'], true);
     }
 }
-

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -71,7 +71,6 @@ class ValidationRuleParser
                 $rules[$key] = $this->explodeExplicitRule($rule);
             }
         }
-
         return $rules;
     }
 
@@ -84,7 +83,9 @@ class ValidationRuleParser
     protected function explodeExplicitRule($rule)
     {
         if (is_string($rule)) {
-            return explode('|', $rule);
+            $name = static::parseStringRule($rule)[0];
+
+            return static::ruleIsRegex($name) ? [$rule] : explode('|', $rule);
         } elseif (is_object($rule)) {
             return [$this->prepareRule($rule)];
         }
@@ -305,4 +306,16 @@ class ValidationRuleParser
             })->filter()->flatten(1)->values()->all()];
         })->all();
     }
+
+    /**
+     * Determine if the rule is a regular expression rule.
+     *
+     * @param string $rule
+     * @return bool
+     */
+    protected static function ruleIsRegex(string $rule): bool
+    {
+        return in_array(strtolower($rule), ['regex', 'not_regex', 'notregex'], true);
+    }
 }
+

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -251,11 +251,7 @@ class ValidationRuleParser
     {
         $rule = strtolower($rule);
 
-        if (in_array($rule, ['regex', 'not_regex', 'notregex'], true)) {
-            return [$parameter];
-        }
-
-        return str_getcsv($parameter);
+        return static::ruleIsRegex($rule) ? [$parameter] : str_getcsv($parameter);
     }
 
     /**

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -80,4 +80,38 @@ class ValidationRuleParserTest extends TestCase
             'password' => ['string', 'max:10'],
         ], $rules);
     }
+
+    public function test_explode_method_parses_string_regex_rule()
+    {
+        $data = ['users' => [['name' => 'Abdlrahman']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['users.*.name' => 'regex:/^(Abdlrahman|james)$/i']
+        );
+
+        $this->assertEquals('regex:/^(Abdlrahman|james)$/i', $exploded->rules['users.0.name'][0]);
+    }
+
+    public function test_explode_method_parses_array_regex_rule()
+    {
+        $data = ['users' => [['name' => 'Abdlrahman']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['users.*.name' => ['regex:/^(Abdlrahman|james)$/i']]
+        );
+
+        $this->assertEquals('regex:/^(Abdlrahman|james)$/i', $exploded->rules['users.0.name'][0]);
+    }
+
+    public function test_explode_method_parses_regex_rule_with_other_array_of_rules()
+    {
+        $data = ['users' => [['name' => 'Abdlrahman']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['users.*.name' => ['ends_with:man', 'regex:/^(Abdlrahman|james)$/i']]
+        );
+
+        $this->assertEquals('ends_with:man', $exploded->rules['users.0.name'][0]);
+        $this->assertEquals('regex:/^(Abdlrahman|james)$/i', $exploded->rules['users.0.name'][1]);
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3882,6 +3882,9 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => 12], ['x' => 'Regex:/^12$/i']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ['y' => ['z' => 'taylor']]], ['x.*.z' => 'Regex:/^(taylor|james)$/i']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateNotRegex()
@@ -3895,6 +3898,9 @@ class ValidationValidatorTest extends TestCase
 
         // Ensure commas are not interpreted as parameter separators
         $v = new Validator($trans, ['x' => 'foo bar'], ['x' => 'NotRegex:/x{3,}/i']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ['y' => ['z' => 'Abdlrahman']]], ['x.*.z' => 'NotRegex:/^(taylor|james)$/i']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
The current behavior in Laravel 8.x when using a single string-based rule, ex 
```
  $data = ['users' => [['name' => 'john']]]
  
  // Fails. preg_match throws malformed regex exception.
  $rules = ['users.*' => 'regex:/^(john|doe)$/i'];

  // Fails. preg_match throws malformed regex exception.
 $rules = ['users.*' => 'not_regex:/^(john|doe)$/i'];
```

after debugging I figure out that when pass `regex` contains `|` it broke the `regex` string to different arrays.

Now you can supply a regex validation rule inside of a single string-based rule, ex:

```
  $data = ['users' => [['name' => 'john']]]
  
  // passes
  $rules = ['users.*' => 'regex:/^(john|doe)$/i'];

  // passes
  $rules = ['users.*' => 'not_regex:/^(john|doe)$/i'];
```