### PR TITLE
Add transpose method for Arr

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -784,6 +784,17 @@ class Arr
     }
 
     /**
+     * Transposes an array.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function transpose($array)
+    {
+        return array_map(fn ($k) => static::pluck($array, $k), array_keys(static::first($array)));
+    }
+
+    /**
      * Filter the array using the given callback.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -920,6 +920,15 @@ class SupportArrTest extends TestCase
         $this->assertSame('font-bold mt-4 ml-2', $classes);
     }
 
+    public function testTranspose()
+    {
+        $array = [['foo', 'bar', 'baz'], ['foo2', 'bar2', 'baz2']];
+
+        $array = Arr::transpose($array);
+
+        $this->assertEquals([['foo', 'foo2'], ['bar', 'bar2'], ['baz', 'baz2']], $array);
+    }
+
     public function testWhere()
     {
         $array = [100, '200', 300, '400', 500];


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


This PR introduces an `Arr::transpose` method similar to [Ruby's `Array#transpose` method](https://ruby-doc.org/core-3.1.0/Array.html#method-i-transpose).

Example usage can be seen in the provided test.