### PR TITLE
[9.x] Add autocomplete directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -361,6 +361,20 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile an autocomplete block into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileAutocomplete($expression)
+    {
+        $parts = explode(',', $this->stripParentheses($expression), 2);
+        $parts[1] = Str::of($parts[1] ?? 'on')->trim()->remove('\'')->remove('"');
+
+        return "<?php if({$parts[0]}): echo 'autocomplete=\"{$parts[1]}\"'; endif; ?>";
+    }
+
+    /**
      * Compile the push statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeCheckedStatementsTest.php
+++ b/tests/View/Blade/BladeCheckedStatementsTest.php
@@ -35,4 +35,25 @@ class BladeCheckedStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testReadonlyStatementsAreCompiled()
+    {
+        $string = '<input @readonly(name(foo(bar)))/>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'readonly'; endif; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testAutocompleteStatementsAreCompiled()
+    {
+        $string = '<input @autocomplete(name(foo(bar)), "off")>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'autocomplete=\"off\"'; endif; ?>>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = '<input @autocomplete(name(foo(bar)))>';
+        $expected = "<input <?php if(name(foo(bar))): echo 'autocomplete=\"on\"'; endif; ?>>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
I know that there have been a flurry of similar directives added recently, but I believe that this adds value and allows for a smooth developer experience.

This PR allows use of the `autocomplete` HTML attribute through a shorthand syntax via a Blade directive. While my use case for this directive is to disable autocomplete, this attribute has many accepted values ('on', 'name', 'email', etc). Since this attribute requires a value, my implementation of this directive works a little differently from the `@required()`, `@readonly()` and `@disabled()` directives:

```
<input type="text" @autocomplete($conditional, 'off') />
```

If a second argument is not provided, the value will default to `on`.

If merged, I will PR to the docs.

Note that I have also added a missing test for the recently added `@readonly()` directive.
