### PR TITLE
fix: Fix empty arrays on request bodies

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -683,7 +683,7 @@ class PendingRequest
     public function post(string $url, $data = [])
     {
         return $this->send('POST', $url, [
-            $this->bodyFormat => $data,
+            $this->bodyFormat => empty($data) ? null : $data,
         ]);
     }
 
@@ -697,7 +697,7 @@ class PendingRequest
     public function patch($url, $data = [])
     {
         return $this->send('PATCH', $url, [
-            $this->bodyFormat => $data,
+            $this->bodyFormat => empty($data) ? null : $data,
         ]);
     }
 
@@ -711,7 +711,7 @@ class PendingRequest
     public function put($url, $data = [])
     {
         return $this->send('PUT', $url, [
-            $this->bodyFormat => $data,
+            $this->bodyFormat => empty($data) ? null : $data,
         ]);
     }
 
@@ -725,7 +725,7 @@ class PendingRequest
     public function delete($url, $data = [])
     {
         return $this->send('DELETE', $url, empty($data) ? [] : [
-            $this->bodyFormat => $data,
+            $this->bodyFormat => empty($data) ? null : $data,
         ]);
     }
 


### PR DESCRIPTION
This PR fixes a problem I've encountered some times. The problem is that on some APIs, an empty array as the request's body may lead to false errors regarding parsing the payload. While it may seem that sending nothing on an Http::post($url) method may suffice it, it still sends an empty "[]" array.

**TEST:**
![proof](https://user-images.githubusercontent.com/99927086/179264890-cfac3453-4823-40ef-9a89-e1d636b90344.png)

Making the request using solely _curl_ worked as expected.