### PR TITLE
`valueOr` method added to Eloquent query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -640,6 +640,22 @@ class Builder implements BuilderContract
     }
 
     /**
+     *  Get a single column's value from the first result of a query or call a callback.
+     *
+     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  \Closure|null  $callback
+     * @return mixed
+     */
+    public function valueOr($column, Closure $callback = null)
+    {
+        if (!is_null($result = $this->first([$column]))) {
+            return $result;
+        }
+
+        return $callback();
+    }
+
+    /**
      * Get a single column's value from the first result of a query if it's the sole matching record.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -648,10 +648,10 @@ class Builder implements BuilderContract
      */
     public function valueOr($column, Closure $callback = null)
     {
-        if (!is_null($value = $this->value($column))) {
+        if (! is_null($value = $this->value($column))) {
             return $value;
         }
-        return $callback();;
+        return $callback();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -651,6 +651,7 @@ class Builder implements BuilderContract
         if (! is_null($value = $this->value($column))) {
             return $value;
         }
+
         return $callback();
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -648,11 +648,7 @@ class Builder implements BuilderContract
      */
     public function valueOr($column, Closure $callback = null)
     {
-        if (!is_null($result = $this->first([$column]))) {
-            return $result;
-        }
-
-        return $callback();
+        return $this->value($column) ?: $callback();;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -648,7 +648,10 @@ class Builder implements BuilderContract
      */
     public function valueOr($column, Closure $callback = null)
     {
-        return $this->value($column) ?: $callback();;
+        if (!is_null($value = $this->value($column))) {
+            return $value;
+        }
+        return $callback();;
     }
 
     /**

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1159,10 +1159,13 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     {
         $user1 = User::create(['name' => Str::random()]);
         $user2 = User::create(['name' => Str::random()]);
-        $post1 = Post::create(['title' => Str::random()]);
+        $user3 = User::create(['name' => Str::random()]);
+        $post1 = Post::create(['title' => 'Str::random()']);
         $post2 = Post::create(['title' => Str::random()]);
+        $post3 = Post::create(['title' => '']);
     
         $user1->posts()->sync([$post1->uuid, $post2->uuid]);
+        $user3->posts()->sync([$post3->uuid]);
     
         $this->assertEquals(
             $post1->title,
@@ -1176,6 +1179,13 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             $fallbackValue,
             $user2->posts()->valueOr('title', function () use ($fallbackValue) {
                 return $fallbackValue;
+            })
+        );
+
+        $this->assertEquals(
+            $post3->title,
+            $user3->posts()->valueOr('title', function () {
+                return Str::random();
             })
         );
     }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1155,6 +1155,31 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
     }
 
+    public function testValueOrMethod()
+    {
+        $user1 = User::create(['name' => Str::random()]);
+        $user2 = User::create(['name' => Str::random()]);
+        $post1 = Post::create(['title' => Str::random()]);
+        $post2 = Post::create(['title' => Str::random()]);
+    
+        $user1->posts()->sync([$post1->uuid, $post2->uuid]);
+    
+        $this->assertEquals(
+            $post1->title,
+            $user1->posts()->valueOr('title', function () {
+                return Str::random();
+            })
+        );
+    
+        $fallbackValue = Str::random();
+        $this->assertEquals(
+            $fallbackValue,
+            $user2->posts()->valueOr('title', function () use ($fallbackValue) {
+                return $fallbackValue;
+            })
+        );
+    }
+
     public function testUpdateOrCreateQueryBuilderIsolation()
     {
         $user = User::create(['name' => Str::random()]);

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -1163,17 +1163,17 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post1 = Post::create(['title' => 'Str::random()']);
         $post2 = Post::create(['title' => Str::random()]);
         $post3 = Post::create(['title' => '']);
-    
+
         $user1->posts()->sync([$post1->uuid, $post2->uuid]);
         $user3->posts()->sync([$post3->uuid]);
-    
+
         $this->assertEquals(
             $post1->title,
             $user1->posts()->valueOr('title', function () {
                 return Str::random();
             })
         );
-    
+
         $fallbackValue = Str::random();
         $this->assertEquals(
             $fallbackValue,


### PR DESCRIPTION
In addition to the `value` and `valueOrFail` methods, this method will serve as a way to provide a fallback default value if the `value === null`.

This feature is inspired from the `firstOr` method.

**Note:** Blank string will be treated as a valid value and will not return the fallback value.

Relevant tests have also been written.