### PR TITLE
[9.x] Vendor publish flag that restricts to only existing files

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -44,7 +44,9 @@ class VendorPublishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'vendor:publish {--force : Overwrite any existing files}
+    protected $signature = 'vendor:publish
+                    {--existing : Publish and overwrite only existing files}
+                    {--force : Overwrite any existing files}
                     {--all : Publish assets for all service providers without prompt}
                     {--provider= : The service provider that has assets you want to publish}
                     {--tag=* : One or many tags that have assets you want to publish}';
@@ -236,17 +238,27 @@ class VendorPublishCommand extends Command
      */
     protected function publishFile($from, $to)
     {
-        if (! $this->files->exists($to) || $this->option('force')) {
+        if (
+            (! $this->option('existing') && (! $this->files->exists($to) || $this->option('force')))
+            || ($this->option('existing') && $this->files->exists($to))
+        ) {
             $this->createParentDirectory(dirname($to));
 
             $this->files->copy($from, $to);
 
             $this->status($from, $to, 'file');
         } else {
-            $this->components->twoColumnDetail(sprintf(
-                'File [%s] already exist',
-                str_replace(base_path().'/', '', realpath($to)),
-            ), '<fg=yellow;options=bold>SKIPPED</>');
+            if ($this->option('existing')) {
+                $this->components->twoColumnDetail(sprintf(
+                    'File [%s] does not exist',
+                    str_replace(base_path().'/', '', $to),
+                ), '<fg=yellow;options=bold>SKIPPED</>');
+            } else {
+                $this->components->twoColumnDetail(sprintf(
+                    'File [%s] already exists',
+                    str_replace(base_path().'/', '', realpath($to)),
+                ), '<fg=yellow;options=bold>SKIPPED</>');
+            }
         }
     }
 
@@ -280,7 +292,13 @@ class VendorPublishCommand extends Command
         foreach ($manager->listContents('from://', true) as $file) {
             $path = Str::after($file['path'], 'from://');
 
-            if ($file['type'] === 'file' && (! $manager->fileExists('to://'.$path) || $this->option('force'))) {
+            if (
+                $file['type'] === 'file'
+                && (
+                    (! $this->option('existing') && (! $manager->fileExists('to://'.$path) || $this->option('force')))
+                    || ($this->option('existing') && $manager->fileExists('to://'.$path))
+                )
+            ) {
                 $manager->write('to://'.$path, $manager->read($file['path']));
             }
         }

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -45,7 +45,7 @@ class VendorPublishCommand extends Command
      * @var string
      */
     protected $signature = 'vendor:publish
-                    {--existing : Publish and overwrite only existing files}
+                    {--existing : Publish and overwrite only the files that have already been published}
                     {--force : Overwrite any existing files}
                     {--all : Publish assets for all service providers without prompt}
                     {--provider= : The service provider that has assets you want to publish}
@@ -238,10 +238,8 @@ class VendorPublishCommand extends Command
      */
     protected function publishFile($from, $to)
     {
-        if (
-            (! $this->option('existing') && (! $this->files->exists($to) || $this->option('force')))
-            || ($this->option('existing') && $this->files->exists($to))
-        ) {
+        if ((! $this->option('existing') && (! $this->files->exists($to) || $this->option('force')))
+            || ($this->option('existing') && $this->files->exists($to))) {
             $this->createParentDirectory(dirname($to));
 
             $this->files->copy($from, $to);


### PR DESCRIPTION
I often find myself overriding a specific view file for a vendor package and then losing track of whether the package eventually updated that file or not. While I could simply run `php artisan vendor:publish --tag=filament-config --force`, that publishes ALL of the view files when I am only interested in files that I have created manually. Since many packages have dozens, if not hundreds, of view files - this can be burdensome.

This PR introduces a new `--existing` flag that instructs the `vendor:publish` command to only publish and overwrite files that already exist.

I did consider naming the flag `--force-only-existing`, or some variation thereof and would be open to any change you felt would be more appropriate.