### PR TITLE
[8.x] clear Facade resolvedInstances in queue worker resetScope callback

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Queue\Failed\DatabaseUuidFailedJobProvider;
 use Illuminate\Queue\Failed\DynamoDbFailedJobProvider;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 use Laravel\SerializableClosure\SerializableClosure;
 
@@ -200,7 +201,9 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
                     $app['log']->withoutContext();
                 }
 
-                return $app->forgetScopedInstances();
+                $app->forgetScopedInstances();
+
+                return Facade::clearResolvedInstances();
             };
 
             return new Worker(


### PR DESCRIPTION
Fixes #43151

Ensure scoped bindings are cleared from resolved facade instances when a worker resets its scope, as per https://github.com/laravel/octane/blob/1.x/src/CurrentApplication.php#L24
