### PR TITLE
[9.x] Collection->random() add preserve keys option

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -979,21 +979,22 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  (callable(TValue): int)|int|null  $number
+     * @param  bool  $preserveKeys
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException
      */
-    public function random($number = null)
+    public function random($number = null, $preserveKeys = false)
     {
         if (is_null($number)) {
             return Arr::random($this->items);
         }
 
         if (is_callable($number)) {
-            return new static(Arr::random($this->items, $number($this)));
+            return new static(Arr::random($this->items, $number($this), $preserveKeys));
         }
 
-        return new static(Arr::random($this->items, $number));
+        return new static(Arr::random($this->items, $number, $preserveKeys));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2286,9 +2286,19 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf($collection, $random);
         $this->assertCount(2, $random);
 
+        $random = $data->random(2, true);
+        $this->assertInstanceOf($collection, $random);
+        $this->assertCount(2, $random);
+        $this->assertCount(2, array_intersect_assoc($random->all(), $data->all()));
+
         $random = $data->random(fn ($items) => min(10, count($items)));
         $this->assertInstanceOf($collection, $random);
         $this->assertCount(6, $random);
+
+        $random = $data->random(fn ($items) => min(10, count($items) - 1), true);
+        $this->assertInstanceOf($collection, $random);
+        $this->assertCount(5, $random);
+        $this->assertCount(5, array_intersect_assoc($random->all(), $data->all()));
     }
 
     /**


### PR DESCRIPTION
This PR adds preserveKeys parameter to `Collection->random()`

before:
```php
Arr::random($collection->all(), 2, true);
```

after:
```php
$collection->random(2, true);
```