### PR TITLE
[9.x] Setup many-to-many relation via pivot model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -222,19 +222,6 @@ trait AsPivot
     }
 
     /**
-     * Set the pivot definitions used during the relationship setup.
-     *
-     * @param  array  $pivotKeys
-     * @return $this
-     */
-    public function definePivotKeys(array $pivotKeys)
-    {
-        $this->pivotKeys = $pivotKeys;
-
-        return $this;
-    }
-
-    /**
      * Get corresponding pivot key for class.
      *
      * @param  string  $class

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -29,6 +29,13 @@ trait AsPivot
     protected $relatedKey;
 
     /**
+     * List of pivot definitions corresponding to the model used during relationship setup.
+     *
+     * @var array<string, string>
+     */
+    protected $pivotKeys;
+
+    /**
      * Create a new pivot model instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
@@ -212,6 +219,30 @@ trait AsPivot
         $this->relatedKey = $relatedKey;
 
         return $this;
+    }
+
+    /**
+     * Set the pivot definitions used during the relationship setup.
+     *
+     * @param  array  $pivotKeys
+     * @return  $this
+     */
+    public function definePivotKeys(array $pivotKeys)
+    {
+        $this->pivotKeys = $pivotKeys;
+
+        return $this;
+    }
+
+    /**
+     * Get corresponding pivot key for class
+     *
+     * @param  string  $class
+     * @return ?string
+     */
+    protected function getPivotKeyFor(string $class)
+    {
+        return $this->pivotKeys[$class] ?? null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -225,7 +225,7 @@ trait AsPivot
      * Set the pivot definitions used during the relationship setup.
      *
      * @param  array  $pivotKeys
-     * @return  $this
+     * @return $this
      */
     public function definePivotKeys(array $pivotKeys)
     {
@@ -235,7 +235,7 @@ trait AsPivot
     }
 
     /**
-     * Get corresponding pivot key for class
+     * Get corresponding pivot key for class.
      *
      * @param  string  $class
      * @return ?string


### PR DESCRIPTION
This add ability to setup a `belongsToMany` relationship via `Pivot` model

## Problem

Currently, in order to define a `belongsToMany` relationship with custom table name and pivot keys, we need to delcare with primitive value with specific (and a bit confuse) order. For example:

```php
<?php

namespace Modules\Work\Models;

use Illuminate\Database\Eloquent\Model;

class Project extends Model
{
    protected $table = 'work__projects';

    protected $fillable = [];

    public function categories()
    {
        return $this->belongsToMany(ProjectCategory::class, 'work__project_category', 'project_id', 'category_id');
    }
}
```

```php
<?php

namespace Modules\Work\Models;

use Illuminate\Database\Eloquent\Model;

class ProjectCategory extends Model
{
    protected $table = 'work__project_categories';

    protected $fillable = [];

    public function projects()
    {
        return $this->belongsToMany(Project::class, 'work__project_category', 'category_id', 'project_id');
    }
}
```

I also notice that we have [Custom Intermediate model](https://laravel.com/docs/9.x/eloquent-relationships#defining-custom-intermediate-table-models) but since the setup relation process has no use again this `using` so we have no benefit from declare table name here!

## Concept

I would like to have nice setup with the name and the pivot keys are declared inside the pivot model. So we can setup the relation like below

```php
<?php

namespace Modules\Work\Models;

use Illuminate\Database\Eloquent\Model;

class Project extends Model
{
    protected $table = 'work__projects';

    protected $fillable = [];

    public function categories()
    {
        return $this->belongsToMany(ProjectCategory::class, ProjectCategoryPivot::class);
    }
}
```

```php
<?php

namespace Modules\Work\Models;

use Illuminate\Database\Eloquent\Model;

class ProjectCategory extends Model
{
    protected $table = 'work__project_categories';

    protected $fillable = [];

    public function projects()
    {
        return $this->belongsToMany(Project::class, ProjectCategoryPivot::class);
    }
}
```

```php
<?php

namespace Modules\Work\Models;

use Illuminate\Database\Eloquent\Relations\Pivot;

class ProjectCategoryPivot extends Pivot
{
    protected $table = 'work__project_category';

    protected $pivotKeys = [
        Project::class => 'project_id',
        ProjectCategory::class => 'category_id',
    ];
}
```

## Solution

My solution is in the setup relationship process `belongsToMany`@`Illuminate/Database/Eloquent/Concerns/HasRelationships.php`, when table name is instance of `Pivot` model, we will extract data defined and pass them to belongsToMany's constructor

## Issues

I'm not so good at english, so please look carefully at comment description and have them fixed if its not that clear
