### PR TITLE
[9.x] Support closures as values for `about` command

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -120,7 +120,7 @@ class AboutCommand extends Command
             foreach ($data as $detail) {
                 [$label, $value] = $detail;
 
-                $this->components->twoColumnDetail($label, $value);
+                $this->components->twoColumnDetail($label, value($value));
             }
         });
     }
@@ -134,7 +134,7 @@ class AboutCommand extends Command
     protected function displayJson($data)
     {
         $output = $data->flatMap(function ($data, $section) {
-            return [(string) Str::of($section)->snake() => collect($data)->mapWithKeys(fn ($item, $key) => [(string) Str::of($item[0])->lower()->snake() => $item[1]])];
+            return [(string) Str::of($section)->snake() => collect($data)->mapWithKeys(fn ($item, $key) => [(string) Str::of($item[0])->lower()->snake() => value($item[1])])];
         });
 
         $this->output->writeln(strip_tags(json_encode($output)));


### PR DESCRIPTION
## What
The PR proposes to support closures as values for the `about` command e.g

```php
AboutCommand::add('Settings', [
    'value' => fn() => SettingModel::first()->value,
    'App Balance' => fn() => BalanceService::fetch(),
    'Computed Metric' => fn() => 6 ÷ 2(2+1),
]);
```

## Why

I can see how handy to delay computation of some metrics and not have to evaluate the same with every request. 
Also since its intended that Packages would be able to add sections to `about` command output

## Tests

I couldn't find tests from the inital PR to add to but can add if requested.

Thanks for the great work