### PR TITLE
[9.x] Adds `to_path` helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -825,6 +825,22 @@ if (! function_exists('storage_path')) {
     }
 }
 
+if (! function_exists('to_path')) {
+    /**
+     * Create a new redirect response to the given path.
+     *
+     * @param  string  $path
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool|null  $secure
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    function to_path($path, $status = 302, $headers = [], $secure = null)
+    {
+        return redirect()->to($path, $status, $headers, $secure);
+    }
+}
+
 if (! function_exists('to_route')) {
     /**
      * Create a new redirect response to a named route.


### PR DESCRIPTION
In the spirit of the ```to_route``` helper introduced in #40522, this PR adds a `to_path` helper for readability when returning to a path.

As an example of how it'd read compared to how it currently reads:
```php
// return redirect()->to('/welcome');
return to_path('/welcome');
```