### PR TITLE
[10.x] Make incrementQuietly and decrementQuietly public to enforce consistency with similar features #43220

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -929,7 +929,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $extra
      * @return int
      */
-    protected function incrementQuietly($column, $amount = 1, array $extra = [])
+    public function incrementQuietly($column, $amount = 1, array $extra = [])
     {
         return static::withoutEvents(function () use ($column, $amount, $extra) {
             return $this->incrementOrDecrement($column, $amount, $extra, 'increment');
@@ -944,7 +944,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $extra
      * @return int
      */
-    protected function decrementQuietly($column, $amount = 1, array $extra = [])
+    public function decrementQuietly($column, $amount = 1, array $extra = [])
     {
         return static::withoutEvents(function () use ($column, $amount, $extra) {
             return $this->incrementOrDecrement($column, $amount, $extra, 'decrement');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1783,10 +1783,10 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
 
-        $model->publicIncrementQuietly('foo', 1);
+        $model->incrementQuietly('foo', 1);
         $this->assertFalse($model->isDirty());
 
-        $model->publicIncrementQuietly('foo', 1, ['category' => 1]);
+        $model->incrementQuietly('foo', 1, ['category' => 1]);
         $this->assertEquals(4, $model->foo);
         $this->assertEquals(1, $model->category);
         $this->assertTrue($model->isDirty('category'));
@@ -1810,10 +1810,10 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('dispatch')->never()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
         $events->shouldReceive('dispatch')->never()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
 
-        $model->publicDecrementQuietly('foo', 1);
+        $model->decrementQuietly('foo', 1);
         $this->assertFalse($model->isDirty());
 
-        $model->publicDecrementQuietly('foo', 1, ['category' => 1]);
+        $model->decrementQuietly('foo', 1, ['category' => 1]);
         $this->assertEquals(2, $model->foo);
         $this->assertEquals(1, $model->category);
         $this->assertTrue($model->isDirty('category'));
@@ -2365,16 +2365,6 @@ class EloquentModelStub extends Model
     public function publicIncrement($column, $amount = 1, $extra = [])
     {
         return $this->increment($column, $amount, $extra);
-    }
-
-    public function publicIncrementQuietly($column, $amount = 1, $extra = [])
-    {
-        return $this->incrementQuietly($column, $amount, $extra);
-    }
-
-    public function publicDecrementQuietly($column, $amount = 1, $extra = [])
-    {
-        return $this->decrementQuietly($column, $amount, $extra);
     }
 
     public function belongsToStub()


### PR DESCRIPTION
This PR enforces the consistency for the incrementQuietly and decrementQuietly to make the methods public. The reasoning behind this is that the usage for this method should be accessible from any model instead a developing having to worry about implementing the identical code himself.

**This could be a breaking change! But its a worthy one.**

**Why shouldn't you just do this at the subclass level?**

In my opinion, 

- to keep the code consistent with similar features like saveQuietly and updateQuietly which both also have a public access modifier. 
- a user model shouldn't have to implement the incrementQuietly() code on its own to call the parent method, this would violate the single responsibility principle.
- why repeat yourself if Laravel provides you with this identical logic? :-)

Thanks,

Eduance