### PR TITLE
[9.x] Improves `queue:work` command

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -6,9 +6,9 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobFailed;
-use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
@@ -235,7 +235,7 @@ class WorkCommand extends Command
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
         $this->output->write(" <fg=gray>$runTime</>");
-        $label = match($status) {
+        $label = match ($status) {
             'success' => '<fg=green;options=bold>DONE</>',
             'released' => '<fg=yellow;options=bold>FAIL</>',
             default => '<fg=red;options=bold>FAIL</>',

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -228,15 +228,12 @@ class WorkCommand extends Command
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
         $this->output->write(" <fg=gray>$runTime</>");
-        $label = match ($status) {
-            'success' => '<fg=green;options=bold>DONE</>',
-            'released' => '<fg=yellow;options=bold>FAIL</>',
-            default => '<fg=red;options=bold>FAIL</>',
-        };
 
-        $this->output->writeln(" $label");
-
-        $this->latestStatus = $status;
+        $this->output->writeln(match ($this->latestStatus = $status) {
+            'success' => ' <fg=green;options=bold>DONE</>',
+            'released' => ' <fg=yellow;options=bold>FAIL</>',
+            default => ' <fg=red;options=bold>FAIL</>',
+        });
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Queue\Events\JobReleased;
+use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
@@ -188,8 +188,8 @@ class WorkCommand extends Command
             $this->writeOutput($event->job, 'success');
         });
 
-        $this->laravel['events']->listen(JobReleased::class, function ($event) {
-            $this->writeOutput($event->job, 'released');
+        $this->laravel['events']->listen(JobReleasedAfterException::class, function ($event) {
+            $this->writeOutput($event->job, 'released_after_exception');
         });
 
         $this->laravel['events']->listen(JobFailed::class, function ($event) {
@@ -231,7 +231,7 @@ class WorkCommand extends Command
 
         $this->output->writeln(match ($this->latestStatus = $status) {
             'success' => ' <fg=green;options=bold>DONE</>',
-            'released' => ' <fg=yellow;options=bold>FAIL</>',
+            'released_after_exception' => ' <fg=yellow;options=bold>FAIL</>',
             default => ' <fg=red;options=bold>FAIL</>',
         });
     }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -212,7 +212,7 @@ class WorkCommand extends Command
             return $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
         }
 
-        if ($this->latestStatus != 'starting') {
+        if ($this->latestStatus && $this->latestStatus != 'starting') {
             $formattedStartedAt = Carbon::createFromTimestamp($this->latestStartedAt)->format('Y-m-d H:i:s');
 
             $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -294,4 +294,19 @@ class WorkCommand extends Command
     {
         return $this->option('force') ? false : $this->laravel->isDownForMaintenance();
     }
+
+    /**
+     * Ensures there is a status printed on the console for the latest job.
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        if ($this->latestStatus == 'starting') {
+            $dots = max(terminal()->width() - mb_strlen($this->latestJobName) - 40, 0);
+
+            $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
+            $this->output->writeln(' <fg=yellow;options=bold>Retrying later</>');
+        }
+    }
 }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -74,13 +74,6 @@ class WorkCommand extends Command
     protected $cache;
 
     /**
-     * Holds the last processed job name, if any.
-     *
-     * @var string|null
-     */
-    protected $latestJobName;
-
-    /**
      * Holds the start time of the last processed job, if any.
      *
      * @var float|null

--- a/src/Illuminate/Queue/Events/JobReleased.php
+++ b/src/Illuminate/Queue/Events/JobReleased.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobReleased
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job
+     */
+    public $job;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    public function __construct($connectionName, $job)
+    {
+        $this->job = $job;
+        $this->connectionName = $connectionName;
+    }
+}

--- a/src/Illuminate/Queue/Events/JobReleasedAfterException.php
+++ b/src/Illuminate/Queue/Events/JobReleasedAfterException.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Queue\Events;
 
-class JobReleased
+class JobReleasedAfterException
 {
     /**
      * The connection name.

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -10,6 +10,7 @@ use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobReleased;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
@@ -469,6 +470,10 @@ class Worker
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
                 $job->release($this->calculateBackoff($job, $options));
+
+                $this->events->dispatch(new JobReleased(
+                    $connectionName, $job
+                ));
             }
         }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -10,7 +10,7 @@ use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Queue\Events\JobReleased;
+use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Support\Carbon;
@@ -471,7 +471,7 @@ class Worker
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
                 $job->release($this->calculateBackoff($job, $options));
 
-                $this->events->dispatch(new JobReleased(
+                $this->events->dispatch(new JobReleasedAfterException(
                     $connectionName, $job
                 ));
             }


### PR DESCRIPTION
This pull request fixes two things:

- The first, is when the job class code contains a `$this->fail()`:

In Laravel `v9.19.0`:
<img width="627" alt="Screenshot 2022-07-18 at 09 17 38" src="https://user-images.githubusercontent.com/5457236/179499879-01dc2bfb-ddc8-46da-b6e9-111617a9a6c1.png">

In `9.x-dev`:
<img width="1043" alt="Screenshot 2022-07-18 at 12 20 06" src="https://user-images.githubusercontent.com/5457236/179500636-53b6115a-706e-46bb-9deb-84b3871653f5.png">

 
If this pull request gets merged:
<img width="946" alt="Screenshot 2022-07-18 at 09 18 04" src="https://user-images.githubusercontent.com/5457236/179500242-d292f2f2-6030-48b4-b5dc-b676d76a1de6.png">

- The second, is when jobs a requeued to be retried later:

In Laravel `v9.19.0`:
<img width="655" alt="Screenshot 2022-07-18 at 12 02 56" src="https://user-images.githubusercontent.com/5457236/179500296-63111805-f9c5-4a43-85ac-1f058b081a80.png">

In `9.x-dev`:
<img width="1077" alt="Screenshot 2022-07-18 at 12 03 47" src="https://user-images.githubusercontent.com/5457236/179500317-06d74654-255b-4498-b2a3-bad60bb73e4d.png">

If this pull request gets merged:
<img width="938" alt="Screenshot 2022-07-18 at 15 13 14" src="https://user-images.githubusercontent.com/5457236/179530861-018d5e8c-5dcb-4e67-92c2-3662e3c0ef8d.png">

