### PR TITLE
Revert route change PR

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -535,17 +535,9 @@ class Route
      */
     public function bindingFieldFor($parameter)
     {
-        if (is_int($parameter)) {
-            $parameters = $this->parameterNames();
+        $fields = is_int($parameter) ? array_values($this->bindingFields) : $this->bindingFields;
 
-            if (! isset($parameters[$parameter])) {
-                return null;
-            }
-
-            $parameter = $parameters[$parameter];
-        }
-
-        return $this->bindingFields[$parameter] ?? null;
+        return $fields[$parameter] ?? null;
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -391,6 +391,10 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo?foo=routable', $url->route('query-string', ['foo' => $model], false));
     }
 
+    /**
+     * @todo Fix bug related to route keys
+     * @link https://github.com/laravel/framework/pull/42425
+     */
     public function testRoutableInterfaceRoutingWithSeparateBindingFieldOnlyForSecondParameter()
     {
         $this->markTestSkipped('See https://github.com/laravel/framework/pull/43255');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -393,6 +393,8 @@ class RoutingUrlGeneratorTest extends TestCase
 
     public function testRoutableInterfaceRoutingWithSeparateBindingFieldOnlyForSecondParameter()
     {
+        $this->markTestSkipped('See https://github.com/laravel/framework/pull/43255');
+
         $url = new UrlGenerator(
             $routes = new RouteCollection,
             Request::create('http://www.foo.com/')

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -393,6 +393,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
     /**
      * @todo Fix bug related to route keys
+     *
      * @link https://github.com/laravel/framework/pull/42425
      */
     public function testRoutableInterfaceRoutingWithSeparateBindingFieldOnlyForSecondParameter()


### PR DESCRIPTION
Reverts:
- https://github.com/laravel/framework/pull/42425
- https://github.com/laravel/framework/pull/42517
- https://github.com/laravel/framework/pull/42571

Brings back the way to how things worked before these PR's. I left the test by Kai in place so we can fix that some day.