### PR TITLE
refactor: clean up test helper assertions in ConditionableTest

### DIFF
--- a/tests/Conditionable/ConditionableTest.php
+++ b/tests/Conditionable/ConditionableTest.php
@@ -32,6 +32,7 @@ class ConditionableTest extends TestCase
         }));
     }
 
+    
     public function testUnless(): void
     {
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(true));


### PR DESCRIPTION
Tidy up ConditionableTest helpers block to align with PHPUnit 9 test structure.