### PR TITLE
[9.x] Adds fluent `File` validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+
+class File implements Rule, DataAwareRule, ValidatorAwareRule
+{
+    use Conditionable;
+    use Macroable;
+
+    /**
+     * The mimetypes that the given file should match. This array may also contain file extensions.
+     *
+     * @var array
+     */
+    protected $allowedMimetypes = [];
+
+    /**
+     * The minimum size in kilobytes that the file can be.
+     *
+     * @var null|int
+     */
+    protected $minimumFileSize = null;
+
+    /**
+     * The maximum size in kilobytes that the file can be.
+     *
+     * @var null|int
+     */
+    protected $maximumFileSize = null;
+
+    /**
+     * An array of custom rules that will be merged into the validation rules.
+     *
+     * @var array
+     */
+    protected $customRules = [];
+
+    /**
+     * The error message after validation, if any.
+     *
+     * @var array
+     */
+    protected $messages = [];
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The callback that will generate the "default" version of the restrict file rule.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultCallback;
+
+    /**
+     * Set the default callback to be used for determining the restrict file default rules.
+     *
+     * If no arguments are passed, the default restrict file rule configuration will be returned.
+     *
+     * @param  static|callable|null  $callback
+     * @return static|null
+     */
+    public static function defaults($callback = null)
+    {
+        if (is_null($callback)) {
+            return static::default();
+        }
+
+        if (! is_callable($callback) && ! $callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of '.static::class);
+        }
+
+        static::$defaultCallback = $callback;
+    }
+
+    /**
+     * Get the default configuration of the restrict file rule.
+     *
+     * @return static
+     */
+    public static function default()
+    {
+        $restrictFile = is_callable(static::$defaultCallback)
+            ? call_user_func(static::$defaultCallback)
+            : static::$defaultCallback;
+
+        return $restrictFile instanceof Rule ? $restrictFile : new self();
+    }
+
+    /**
+     * Limit the uploaded file to the given mimetypes or file extensions.
+     *
+     * @param  string|array<int, string>  $mimetypes
+     * @return static
+     */
+    public static function types($mimetypes)
+    {
+        $restrictFile = new static();
+
+        $restrictFile->allowedMimetypes = (array) $mimetypes;
+
+        return $restrictFile;
+    }
+
+    /**
+     * Limit the uploaded file to only image types.
+     *
+     * @return ImageFile
+     */
+    public static function image()
+    {
+        return new ImageFile();
+    }
+
+    /**
+     * Indicate that the uploaded file should be exactly a certain size in kilobytes.
+     *
+     * @param  int  $kilobytes
+     * @return $this
+     */
+    public function exactly($kilobytes)
+    {
+        $this->minimumFileSize = $kilobytes;
+        $this->maximumFileSize = $kilobytes;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the uploaded file should be between a minimum and maximum size in kilobytes.
+     *
+     * @param  int  $minKilobytes
+     * @param  int  $maxKilobytes
+     * @return $this
+     */
+    public function between($minKilobytes, $maxKilobytes)
+    {
+        $this->minimumFileSize = $minKilobytes;
+        $this->maximumFileSize = $maxKilobytes;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the uploaded file should be no less than the given number of kilobytes.
+     *
+     * @param  int  $kilobytes
+     * @return $this
+     */
+    public function atLeast($kilobytes)
+    {
+        $this->minimumFileSize = $kilobytes;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the uploaded file must be larger than the given number of kilobytes.
+     *
+     * @param  int  $kilobytes
+     * @return $this
+     */
+    public function largerThan($kilobytes)
+    {
+        $this->minimumFileSize = $kilobytes + 1;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the uploaded file should be no more than the given number of kilobytes.
+     *
+     * @param  int  $kilobytes
+     * @return $this
+     */
+    public function atMost($kilobytes)
+    {
+        $this->maximumFileSize = $kilobytes;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the uploaded file must be smaller than the given number of kilobytes.
+     *
+     * @param  int  $kilobytes
+     * @return $this
+     */
+    public function smallerThan($kilobytes)
+    {
+        $this->maximumFileSize = $kilobytes - 1;
+
+        return $this;
+    }
+
+    /**
+     * Adds the given failures, and return false.
+     *
+     * @param  array|string  $messages
+     * @return bool
+     */
+    protected function fail($messages)
+    {
+        $messages = collect(Arr::wrap($messages))->map(function ($message) {
+            return $this->validator->getTranslator()->get($message);
+        })->all();
+
+        $this->messages = array_merge($this->messages, $messages);
+
+        return false;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->messages = [];
+
+        $validator = Validator::make(
+            $this->data,
+            [$attribute => $this->buildValidationRules()],
+            $this->validator->customMessages,
+            $this->validator->customAttributes
+        );
+
+        if ($validator->fails()) {
+            return $this->fail($validator->messages()->all());
+        }
+
+        return true;
+    }
+
+    /**
+     * Build the array of underlying validation rules based on the current state.
+     *
+     * @return array
+     */
+    protected function buildValidationRules()
+    {
+        $rules = ['file'];
+
+        $rules = array_merge($rules, $this->buildMimetypes());
+
+        $rules[] = match (true) {
+            is_null($this->minimumFileSize) && is_null($this->maximumFileSize) => null,
+            is_null($this->maximumFileSize) => "min:{$this->minimumFileSize}",
+            is_null($this->minimumFileSize) => "max:{$this->maximumFileSize}",
+            $this->minimumFileSize !== $this->maximumFileSize => "between:{$this->minimumFileSize},{$this->maximumFileSize}",
+            default => "size:{$this->minimumFileSize}",
+        };
+
+        return array_merge(array_filter($rules), $this->customRules);
+    }
+
+    /**
+     * Separate given mimetypes from extensions and return an array of correct rules to validate against.
+     *
+     * @return array
+     */
+    protected function buildMimetypes()
+    {
+        if (count($this->allowedMimetypes) === 0) {
+            return [];
+        }
+
+        $rules = [];
+
+        $mimetypes = array_filter(
+            $this->allowedMimetypes,
+            fn ($type) => str_contains($type, '/')
+        );
+
+        $mimes = array_diff($this->allowedMimetypes, $mimetypes);
+
+        if (count($mimetypes) > 0) {
+            $rules[] = 'mimetypes:'.implode(',', $mimetypes);
+        }
+
+        if (count($mimes) > 0) {
+            $rules[] = 'mimes:'.implode(',', $mimes);
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Specify additional validation rules that should be merged with the default rules during validation.
+     *
+     * @param  string|array  $rules
+     * @return $this
+     */
+    public function rules($rules)
+    {
+        $this->customRules = array_merge($this->customRules, Arr::wrap($rules));
+
+        return $this;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Set the performing validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Set the data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Validation/Rules/File.php
+++ b/src/Illuminate/Validation/Rules/File.php
@@ -66,16 +66,16 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     protected $validator;
 
     /**
-     * The callback that will generate the "default" version of the restrict file rule.
+     * The callback that will generate the "default" version of the file rule.
      *
      * @var string|array|callable|null
      */
     public static $defaultCallback;
 
     /**
-     * Set the default callback to be used for determining the restrict file default rules.
+     * Set the default callback to be used for determining the file default rules.
      *
-     * If no arguments are passed, the default restrict file rule configuration will be returned.
+     * If no arguments are passed, the default file rule configuration will be returned.
      *
      * @param  static|callable|null  $callback
      * @return static|null
@@ -94,17 +94,17 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
-     * Get the default configuration of the restrict file rule.
+     * Get the default configuration of the file rule.
      *
      * @return static
      */
     public static function default()
     {
-        $restrictFile = is_callable(static::$defaultCallback)
+        $file = is_callable(static::$defaultCallback)
             ? call_user_func(static::$defaultCallback)
             : static::$defaultCallback;
 
-        return $restrictFile instanceof Rule ? $restrictFile : new self();
+        return $file instanceof Rule ? $file : new self();
     }
 
     /**
@@ -115,11 +115,11 @@ class File implements Rule, DataAwareRule, ValidatorAwareRule
      */
     public static function types($mimetypes)
     {
-        $restrictFile = new static();
+        $file = new static();
 
-        $restrictFile->allowedMimetypes = (array) $mimetypes;
+        $file->allowedMimetypes = (array) $mimetypes;
 
-        return $restrictFile;
+        return $file;
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class ImageFile extends File
+{
+    public function __construct()
+    {
+        $this->rules('image');
+    }
+
+    /**
+     * The dimension constraints for the uploaded file.
+     *
+     * @param Dimensions $dimensions
+     */
+    public function dimensions($dimensions)
+    {
+        $this->rules($dimensions);
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -4,6 +4,11 @@ namespace Illuminate\Validation\Rules;
 
 class ImageFile extends File
 {
+    /**
+     * Create a new image file rule instance.
+     *
+     * @return void
+     */
     public function __construct()
     {
         $this->rules('image');
@@ -12,7 +17,7 @@ class ImageFile extends File
     /**
      * The dimension constraints for the uploaded file.
      *
-     * @param  Dimensions  $dimensions
+     * @param  \Illuminate\Validation\Rules\Dimensions  $dimensions
      */
     public function dimensions($dimensions)
     {

--- a/src/Illuminate/Validation/Rules/ImageFile.php
+++ b/src/Illuminate/Validation/Rules/ImageFile.php
@@ -12,7 +12,7 @@ class ImageFile extends File
     /**
      * The dimension constraints for the uploaded file.
      *
-     * @param Dimensions $dimensions
+     * @param  Dimensions  $dimensions
      */
     public function dimensions($dimensions)
     {

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\File;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationFileRuleTest extends TestCase
+{
+    public function testBasic()
+    {
+        $this->fails(
+            File::default(),
+            'foo',
+            ['validation.file'],
+        );
+
+        $this->passes(
+            File::default(),
+            UploadedFile::fake()->create('foo.bar'),
+        );
+
+        $this->passes(File::default(), null);
+    }
+
+    protected function fails($rule, $values, $messages)
+    {
+        $this->assertValidationRules($rule, $values, false, $messages);
+    }
+
+    protected function assertValidationRules($rule, $values, $result, $messages)
+    {
+        $values = Arr::wrap($values);
+
+        foreach ($values as $value) {
+            $v = new Validator(
+                resolve('translator'),
+                ['my_file' => $value],
+                ['my_file' => is_object($rule) ? clone $rule : $rule]
+            );
+
+            $this->assertSame($result, $v->passes());
+
+            $this->assertSame(
+                $result ? [] : ['my_file' => $messages],
+                $v->messages()->toArray()
+            );
+        }
+    }
+
+    protected function passes($rule, $values)
+    {
+        $this->assertValidationRules($rule, $values, true, []);
+    }
+
+    public function testSingleMimetype()
+    {
+        $this->fails(
+            File::types('text/plain'),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.mimetypes']
+        );
+
+        $this->passes(
+            File::types('image/png'),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
+    public function testMultipleMimeTypes()
+    {
+        $this->fails(
+            File::types(['text/plain', 'image/jpeg']),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.mimetypes']
+        );
+
+        $this->passes(
+            File::types(['text/plain', 'image/png']),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
+    public function testSingleMime()
+    {
+        $this->fails(
+            File::types('txt'),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+            ['validation.mimes']
+        );
+
+        $this->passes(
+            File::types('png'),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
+    public function testMultipleMimes()
+    {
+        $this->fails(
+            File::types(['png', 'jpg', 'jpeg', 'svg']),
+            UploadedFile::fake()->createWithContent('foo.txt', 'Hello World!'),
+            ['validation.mimes']
+        );
+
+        $this->passes(
+            File::types(['png', 'jpg', 'jpeg', 'svg']),
+            [
+                UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+                UploadedFile::fake()->createWithContent('foo.svg', file_get_contents(__DIR__.'/fixtures/image.svg')),
+            ]
+        );
+    }
+
+    public function testMixOfMimetypesAndMimes()
+    {
+        $this->fails(
+            File::types(['png', 'image/png']),
+            UploadedFile::fake()->createWithContent('foo.txt', 'Hello World!'),
+            ['validation.mimetypes', 'validation.mimes']
+        );
+
+        $this->passes(
+            File::types(['png', 'image/png']),
+            UploadedFile::fake()->createWithContent('foo.png', file_get_contents(__DIR__.'/fixtures/image.png')),
+        );
+    }
+
+    public function testImage()
+    {
+        $this->fails(
+            File::image(),
+            UploadedFile::fake()->createWithContent('foo.txt', 'Hello World!'),
+            ['validation.image']
+        );
+
+        $this->passes(
+            File::image(),
+            UploadedFile::fake()->image('foo.png'),
+        );
+    }
+
+    public function testExactly()
+    {
+        $this->fails(
+            File::default()->exactly(1024),
+            [
+                UploadedFile::fake()->create('foo.txt', 1025),
+                UploadedFile::fake()->create('foo.txt', 1023),
+            ],
+            ['validation.size.file']
+        );
+
+        $this->passes(
+            File::default()->exactly(1024),
+            UploadedFile::fake()->create('foo.txt', 1024),
+        );
+    }
+
+    public function testBetween()
+    {
+        $this->fails(
+            File::default()->between(1024, 2048),
+            [
+                UploadedFile::fake()->create('foo.txt', 1023),
+                UploadedFile::fake()->create('foo.txt', 2049),
+            ],
+            ['validation.between.file']
+        );
+
+        $this->passes(
+            File::default()->between(1024, 2048),
+            [
+                UploadedFile::fake()->create('foo.txt', 1024),
+                UploadedFile::fake()->create('foo.txt', 2048),
+                UploadedFile::fake()->create('foo.txt', 1025),
+                UploadedFile::fake()->create('foo.txt', 2047),
+            ]
+        );
+    }
+
+    public function testAtLeast()
+    {
+        $this->fails(
+            File::default()->atLeast(1024),
+            UploadedFile::fake()->create('foo.txt', 1023),
+            ['validation.min.file']
+        );
+
+        $this->passes(
+            File::default()->atLeast(1024),
+            [
+                UploadedFile::fake()->create('foo.txt', 1024),
+                UploadedFile::fake()->create('foo.txt', 1025),
+                UploadedFile::fake()->create('foo.txt', 2048),
+            ]
+        );
+    }
+
+    public function testLargerThan()
+    {
+        $this->fails(
+            File::default()->largerThan(1024),
+            UploadedFile::fake()->create('foo.txt', 1024),
+            ['validation.min.file']
+        );
+
+        $this->passes(
+            File::default()->largerThan(1024),
+            [
+                UploadedFile::fake()->create('foo.txt', 1025),
+                UploadedFile::fake()->create('foo.txt', 2048),
+            ]
+        );
+    }
+
+    public function testAtMost()
+    {
+        $this->fails(
+            File::default()->atMost(1024),
+            UploadedFile::fake()->create('foo.txt', 1025),
+            ['validation.max.file']
+        );
+
+        $this->passes(
+            File::default()->atMost(1024),
+            [
+                UploadedFile::fake()->create('foo.txt', 1024),
+                UploadedFile::fake()->create('foo.txt', 1023),
+                UploadedFile::fake()->create('foo.txt', 512),
+            ]
+        );
+    }
+
+    public function testSmallerThan()
+    {
+        $this->fails(
+            File::default()->smallerThan(1024),
+            UploadedFile::fake()->create('foo.txt', 1024),
+            ['validation.max.file']
+        );
+
+        $this->passes(
+            File::default()->smallerThan(1024),
+            [
+                UploadedFile::fake()->create('foo.txt', 1023),
+                UploadedFile::fake()->create('foo.txt', 512),
+            ]
+        );
+    }
+
+    public function testMacro()
+    {
+        File::macro('toDocument', function () {
+            return static::default()->rules('mimes:txt,csv');
+        });
+
+        $this->fails(
+            File::toDocument(),
+            UploadedFile::fake()->create('foo.png'),
+            ['validation.mimes']
+        );
+
+        $this->passes(
+            File::toDocument(),
+            [
+                UploadedFile::fake()->create('foo.txt'),
+                UploadedFile::fake()->create('foo.csv'),
+            ]
+        );
+    }
+
+    public function testItCanSetDefaultUsing()
+    {
+        $this->assertInstanceOf(File::class, File::default());
+
+        File::defaults(function () {
+            return File::types('txt')->atMost(12 * 1024);
+        });
+
+        $this->fails(
+            File::default(),
+            UploadedFile::fake()->create('foo.png', 13 * 1024),
+            [
+                'validation.mimes',
+                'validation.max.file',
+            ]
+        );
+
+        File::defaults(File::image()->between(1024, 2048));
+
+        $this->passes(
+            File::default(),
+            UploadedFile::fake()->create('foo.png', 1.5 * 1024),
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+}

--- a/tests/Validation/ValidationFileRuleTest.php
+++ b/tests/Validation/ValidationFileRuleTest.php
@@ -148,10 +148,10 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testExactly()
+    public function testSize()
     {
         $this->fails(
-            File::default()->exactly(1024),
+            File::default()->size(1024),
             [
                 UploadedFile::fake()->create('foo.txt', 1025),
                 UploadedFile::fake()->create('foo.txt', 1023),
@@ -160,7 +160,7 @@ class ValidationFileRuleTest extends TestCase
         );
 
         $this->passes(
-            File::default()->exactly(1024),
+            File::default()->size(1024),
             UploadedFile::fake()->create('foo.txt', 1024),
         );
     }
@@ -187,16 +187,16 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testAtLeast()
+    public function testMin()
     {
         $this->fails(
-            File::default()->atLeast(1024),
+            File::default()->min(1024),
             UploadedFile::fake()->create('foo.txt', 1023),
             ['validation.min.file']
         );
 
         $this->passes(
-            File::default()->atLeast(1024),
+            File::default()->min(1024),
             [
                 UploadedFile::fake()->create('foo.txt', 1024),
                 UploadedFile::fake()->create('foo.txt', 1025),
@@ -205,52 +205,18 @@ class ValidationFileRuleTest extends TestCase
         );
     }
 
-    public function testLargerThan()
+    public function testMax()
     {
         $this->fails(
-            File::default()->largerThan(1024),
-            UploadedFile::fake()->create('foo.txt', 1024),
-            ['validation.min.file']
-        );
-
-        $this->passes(
-            File::default()->largerThan(1024),
-            [
-                UploadedFile::fake()->create('foo.txt', 1025),
-                UploadedFile::fake()->create('foo.txt', 2048),
-            ]
-        );
-    }
-
-    public function testAtMost()
-    {
-        $this->fails(
-            File::default()->atMost(1024),
+            File::default()->max(1024),
             UploadedFile::fake()->create('foo.txt', 1025),
             ['validation.max.file']
         );
 
         $this->passes(
-            File::default()->atMost(1024),
+            File::default()->max(1024),
             [
                 UploadedFile::fake()->create('foo.txt', 1024),
-                UploadedFile::fake()->create('foo.txt', 1023),
-                UploadedFile::fake()->create('foo.txt', 512),
-            ]
-        );
-    }
-
-    public function testSmallerThan()
-    {
-        $this->fails(
-            File::default()->smallerThan(1024),
-            UploadedFile::fake()->create('foo.txt', 1024),
-            ['validation.max.file']
-        );
-
-        $this->passes(
-            File::default()->smallerThan(1024),
-            [
                 UploadedFile::fake()->create('foo.txt', 1023),
                 UploadedFile::fake()->create('foo.txt', 512),
             ]
@@ -283,7 +249,7 @@ class ValidationFileRuleTest extends TestCase
         $this->assertInstanceOf(File::class, File::default());
 
         File::defaults(function () {
-            return File::types('txt')->atMost(12 * 1024);
+            return File::types('txt')->max(12 * 1024);
         });
 
         $this->fails(

--- a/tests/Validation/ValidationImageFileRuleTest.php
+++ b/tests/Validation/ValidationImageFileRuleTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationImageFileRuleTest extends TestCase
+{
+    public function testDimensions()
+    {
+        $this->fails(
+            File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
+            UploadedFile::fake()->image('foo.png', 101, 101),
+            ['validation.dimensions'],
+        );
+
+        $this->passes(
+            File::image()->dimensions(Rule::dimensions()->width(100)->height(100)),
+            UploadedFile::fake()->image('foo.png', 100, 100),
+        );
+    }
+
+    protected function fails($rule, $values, $messages)
+    {
+        $this->assertValidationRules($rule, $values, false, $messages);
+    }
+
+    protected function assertValidationRules($rule, $values, $result, $messages)
+    {
+        $values = Arr::wrap($values);
+
+        foreach ($values as $value) {
+            $v = new Validator(
+                resolve('translator'),
+                ['my_file' => $value],
+                ['my_file' => is_object($rule) ? clone $rule : $rule]
+            );
+
+            $this->assertSame($result, $v->passes());
+
+            $this->assertSame(
+                $result ? [] : ['my_file' => $messages],
+                $v->messages()->toArray()
+            );
+        }
+    }
+
+    protected function passes($rule, $values)
+    {
+        $this->assertValidationRules($rule, $values, true, []);
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+}


### PR DESCRIPTION
Hello there!

This PR aims to provide a similar experience to the `Password` validation rule for file uploads. It does so by providing a fluent, extendable `File` rule object.

## Basic usage

```php
// Before
$request->validate([
  'file' => ['required', 'file', 'mimes:mp3,wav,aac', 'max:12287'],
  'image' => ['required', 'file', 'image', 'min:2048', 'max:12287', Rule::dimensions()->maxWidth(1000)->maxHeight(500)],
]);

// After
$request->validate([
  'file' => ['required', File::types(['mp3', 'wav', 'aac'])->smallerThan(12 * 1024)],
  'image' => ['required', File::image()->atLeast(2 * 1024)->smallerThan(12 * 1024)->dimensions(Rule::dimensions()->maxWidth(1000)->maxHeight(500))],
]);
```

## Available methods

The following methods are available on the rule:

- `::types`: equivalent to the `mimetypes` and `mimes` rules
- `::image`: equivalent to the `image` rule
- `exactly`: equivalent to the `size` rule
- `between`: equivalent to the `between` rule
- `atLeast`: equivalent to the `min` rule
- `atMost`: equivalent to the `max` rule
- `largerThan`: equivalent to the `min` rule + 1kb
- `smallerThan`: equivalent to the `max` rule - 1kb
- `dimensions`: only available after calling `::image`, allows specifying `Rule::dimensions()` constraints

## `mimetypes` vs `mimes`

When using Laravel today, you will either use `mimetypes` or `mimes`. Remembering which rule accepts which types can be cumbersome, so the `File::types` method accepts either mimetypes (eg: `text/plain`) *or* file extensions (eg: `mp3`) and will intelligently decide on the correct validation rule to use accordingly.

It's important to note that if both mimetypes and extensions are used, both `mimetypes` and `mimes` validation rules will be present in the request. As such, it is best practice to stick to one approach or the other.

## Extending for custom types

Whilst the `File` rule only ships with the `::image` method as a custom type, the rule is `Macroable`, allowing each application to specify more granular file permissions as required.

```php
// AppServiceProvider
public function boot()
{
  File::macro('document', function () {
    return File::types(['doc', 'docx', 'pdf', 'txt']);
  });
}

// Usage
$request->validate([
  'cv' => ['required', File::document()->atMost(2048)]
]);
```

## Open for discussion

I've added `default` and `defaults` methods similar to the `Password` rule, but there is something to be said for not including these, as the fact that the class is macroable would basically accomplish the same thing in a more granular fashion. Happy to remove those methods if you can't see a use-case for them :-)

Thanks to @nedwors and @owenvoke for ideas and feedback whilst developing this PR.

As always, thanks for all the hard work maintaining and caring for this awesome framework and community 💪

Kind Regards,
Luke