### PR TITLE
[9.x] Added support for custom proxy urls

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -27,6 +27,12 @@ class Vite
         if (is_file(public_path('/hot'))) {
             $url = rtrim(file_get_contents(public_path('/hot')));
 
+            $customUrl = app('config')->get('app.vite_hot_proxy_url');
+
+            if (! empty($customUrl)) {
+                $url = $customUrl;
+            }
+
             return new HtmlString(
                 $entrypoints
                     ->map(fn ($entrypoint) => $this->makeTag("{$url}/{$entrypoint}"))
@@ -90,6 +96,12 @@ class Vite
         }
 
         $url = rtrim(file_get_contents(public_path('/hot')));
+
+        $customUrl = app('config')->get('app.vite_hot_proxy_url');
+
+        if (! empty($customUrl)) {
+            $url = $customUrl;
+        }
 
         return new HtmlString(
             sprintf(


### PR DESCRIPTION
Implementation of this feature #43262 

This pull request adds the option to manually specify the base url of the vite development server, so it can be used behind a reverse proxy. 
If the config option `app.vite_hot_proxy_url` is present, all tags generated with the `@vite` directive, will have the specified value as it's base URL. 
Mix has a similar feature with `app.mix_hot_proxy_url`.