### PR TITLE
[9.x] Avoids colors being captured on composer version in `about` command

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -115,7 +115,7 @@ class Composer
      */
     public function getVersion()
     {
-        $command = array_merge($this->findComposer(), ['-V']);
+        $command = array_merge($this->findComposer(), ['-V','--no-ansi']);
 
         $process = $this->getProcess($command);
 

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -115,7 +115,7 @@ class Composer
      */
     public function getVersion()
     {
-        $command = array_merge($this->findComposer(), ['-V','--no-ansi']);
+        $command = array_merge($this->findComposer(), ['-V', '--no-ansi']);
 
         $process = $this->getProcess($command);
 


### PR DESCRIPTION
This pull request avoids colors being captured on composer version in `about` command:

Before:
<img width="220" alt="Screenshot 2022-07-19 at 12 04 28" src="https://user-images.githubusercontent.com/5457236/179736101-21cec135-82e5-4e08-b239-cb49afe7062a.png">

After
<img width="186" alt="Screenshot 2022-07-19 at 12 04 33" src="https://user-images.githubusercontent.com/5457236/179736114-86fbad66-134d-4427-aaf6-4fb639c32856.png">
: