### PR TITLE
[9.x] Add increment() and decrement() Arr helpers

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -835,6 +835,7 @@ class Arr
     {
         $value += Arr::get($array, $key, 0);
         Arr::set($array, $key, $value);
+
         return $value;
     }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -828,7 +828,7 @@ class Arr
      *
      * @param  \ArrayAccess|array  $array
      * @param  string|int  $key
-     * @param  int|float $value
+     * @param  int|float  $value
      * @return int|float
      */
     public static function increment($array, $key, $value = 1)
@@ -843,7 +843,7 @@ class Arr
      *
      * @param  \ArrayAccess|array  $array
      * @param  string|int  $key
-     * @param  int|float $value
+     * @param  int|float  $value
      * @return int|float
      */
     public static function decrement($array, $key, $value = 1)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -822,4 +822,32 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Increment the value at a given key, and return the new value.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  int|float $value
+     * @return int|float
+     */
+    public static function increment($array, $key, $value = 1)
+    {
+        $value += Arr::get($array, $key, 0);
+        Arr::set($array, $key, $value);
+        return $value;
+    }
+
+    /**
+     * Decrement the value at a given key, and return the new value.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int|null  $key
+     * @param  int|float $value
+     * @return int|float
+     */
+    public static function decrement($array, $key, $value = 1)
+    {
+        return Arr::increment($array, $key, $value * -1);
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -827,7 +827,7 @@ class Arr
      * Increment the value at a given key, and return the new value.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
+     * @param  string|int  $key
      * @param  int|float $value
      * @return int|float
      */
@@ -842,7 +842,7 @@ class Arr
      * Decrement the value at a given key, and return the new value.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
+     * @param  string|int  $key
      * @param  int|float $value
      * @return int|float
      */

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -17,11 +17,11 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::accessible([]));
         $this->assertTrue(Arr::accessible([1, 2]));
         $this->assertTrue(Arr::accessible(['a' => 1, 'b' => 2]));
-        $this->assertTrue(Arr::accessible(new Collection));
+        $this->assertTrue(Arr::accessible(new Collection()));
 
         $this->assertFalse(Arr::accessible(null));
         $this->assertFalse(Arr::accessible('abc'));
-        $this->assertFalse(Arr::accessible(new stdClass));
+        $this->assertFalse(Arr::accessible(new stdClass()));
         $this->assertFalse(Arr::accessible((object) ['a' => 1, 'b' => 2]));
     }
 
@@ -1003,7 +1003,7 @@ class SupportArrTest extends TestCase
     {
         $string = 'a';
         $array = ['a'];
-        $object = new stdClass;
+        $object = new stdClass();
         $object->value = 'a';
         $this->assertEquals(['a'], Arr::wrap($string));
         $this->assertEquals($array, Arr::wrap($array));
@@ -1017,7 +1017,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([false], Arr::wrap([false]));
         $this->assertEquals([0], Arr::wrap(0));
 
-        $obj = new stdClass;
+        $obj = new stdClass();
         $obj->value = 'a';
         $obj = unserialize(serialize($obj));
         $this->assertEquals([$obj], Arr::wrap($obj));
@@ -1111,5 +1111,47 @@ class SupportArrTest extends TestCase
                 'key' => 1,
             ],
         ], Arr::prependKeysWith($array, 'test.'));
+    }
+
+    public function testIncrement()
+    {
+        $array = [
+            'id' => '123',
+            'data' => '456',
+            'list' => [1, 2, 3],
+            'meta' => [
+                'key' => 1.333,
+            ],
+            'string' => 'foo',
+        ];
+
+        $this->assertEquals(124, Arr::increment($array, 'id'));
+        $this->assertEquals(3, Arr::increment($array, 'list.0', 2));
+        $this->assertEquals(2.666, Arr::increment($array, 'meta.key', 1.333));
+        $this->assertEquals(1, Arr::increment($array, 'missing', 1));
+
+        $this->expectException(\TypeError::class);
+        Arr::increment($array, 'string', 1);
+    }
+
+    public function testDecrement()
+    {
+        $array = [
+            'id' => '123',
+            'data' => '456',
+            'list' => [1, 2, 3],
+            'meta' => [
+                'key' => 1.333,
+            ],
+            'string' => 'foo',
+        ];
+
+        $this->assertEquals(122, Arr::decrement($array, 'id'));
+        $this->assertEquals(-1, Arr::decrement($array, 'list.0', 2));
+        $this->assertEquals(0, Arr::decrement($array, 'meta.key', 1.333));
+        $this->assertEquals(-1, Arr::decrement($array, 'missing', 1));
+
+        $this->expectException(\TypeError::class);
+        Arr::decrement($array, 'string', 1);
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -21,7 +21,7 @@ class SupportArrTest extends TestCase
 
         $this->assertFalse(Arr::accessible(null));
         $this->assertFalse(Arr::accessible('abc'));
-        $this->assertFalse(Arr::accessible(new stdClass()));
+        $this->assertFalse(Arr::accessible(new stdClass));
         $this->assertFalse(Arr::accessible((object) ['a' => 1, 'b' => 2]));
     }
 
@@ -1003,7 +1003,7 @@ class SupportArrTest extends TestCase
     {
         $string = 'a';
         $array = ['a'];
-        $object = new stdClass();
+        $object = new stdClass;
         $object->value = 'a';
         $this->assertEquals(['a'], Arr::wrap($string));
         $this->assertEquals($array, Arr::wrap($array));
@@ -1017,7 +1017,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals([false], Arr::wrap([false]));
         $this->assertEquals([0], Arr::wrap(0));
 
-        $obj = new stdClass();
+        $obj = new stdClass;
         $obj->value = 'a';
         $obj = unserialize(serialize($obj));
         $this->assertEquals([$obj], Arr::wrap($obj));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -17,7 +17,7 @@ class SupportArrTest extends TestCase
         $this->assertTrue(Arr::accessible([]));
         $this->assertTrue(Arr::accessible([1, 2]));
         $this->assertTrue(Arr::accessible(['a' => 1, 'b' => 2]));
-        $this->assertTrue(Arr::accessible(new Collection()));
+        $this->assertTrue(Arr::accessible(new Collection));
 
         $this->assertFalse(Arr::accessible(null));
         $this->assertFalse(Arr::accessible('abc'));


### PR DESCRIPTION
This pull request makes it easy to increment or decrement a value inside a nested array. While not hard to write manually, this PR makes it a one-liner.

The methods both accept the array, a key in dot notation, and optionally the amount to increment/decrement by (the default is 1). If the key does not exist, it will be created and set to the specified value.

    $array = [
        'nested' => [
            'key' => [1, 2, 3]
        ]
    ];

    Arr::increment($array, 'nested.key.1', 10) // 12
    Arr::decrement($array, 'missing', 10) // -10