### PR TITLE
[8.x] Protect against ambiguous columns

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -49,7 +49,7 @@ class EloquentUserProvider implements UserProvider
         $model = $this->createModel();
 
         return $this->newModelQuery($model)
-                    ->where($model->getAuthIdentifierName(), $identifier)
+                    ->where($model->qualifyColumn($model->getAuthIdentifierName()), $identifier)
                     ->first();
     }
 
@@ -65,7 +65,7 @@ class EloquentUserProvider implements UserProvider
         $model = $this->createModel();
 
         $retrievedModel = $this->newModelQuery($model)->where(
-            $model->getAuthIdentifierName(), $identifier
+            $model->qualifyColumn($model->getAuthIdentifierName()), $identifier
         )->first();
 
         if (! $retrievedModel) {

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -22,7 +22,8 @@ class AuthEloquentUserProviderTest extends TestCase
         $mock = m::mock(stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
-        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('qualifyColumn')->with('id')->andReturn('users.id');
+        $mock->shouldReceive('where')->once()->with('users.id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn('bar');
         $provider->expects($this->once())->method('createModel')->willReturn($mock);
         $user = $provider->retrieveById(1);
@@ -39,7 +40,8 @@ class AuthEloquentUserProviderTest extends TestCase
         $mock = m::mock(stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
-        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('qualifyColumn')->with('id')->andReturn('users.id');
+        $mock->shouldReceive('where')->once()->with('users.id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn($mockUser);
         $provider->expects($this->once())->method('createModel')->willReturn($mock);
         $user = $provider->retrieveByToken(1, 'a');
@@ -53,7 +55,8 @@ class AuthEloquentUserProviderTest extends TestCase
         $mock = m::mock(stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
-        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('qualifyColumn')->with('id')->andReturn('users.id');
+        $mock->shouldReceive('where')->once()->with('users.id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn(null);
         $provider->expects($this->once())->method('createModel')->willReturn($mock);
         $user = $provider->retrieveByToken(1, 'a');
@@ -78,7 +81,8 @@ class AuthEloquentUserProviderTest extends TestCase
         $mock = m::mock(stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
         $mock->shouldReceive('getAuthIdentifierName')->once()->andReturn('id');
-        $mock->shouldReceive('where')->once()->with('id', 1)->andReturn($mock);
+        $mock->shouldReceive('qualifyColumn')->with('id')->andReturn('users.id');
+        $mock->shouldReceive('where')->once()->with('users.id', 1)->andReturn($mock);
         $mock->shouldReceive('first')->once()->andReturn($mockUser);
         $provider->expects($this->once())->method('createModel')->willReturn($mock);
         $user = $provider->retrieveByToken(1, 'a');


### PR DESCRIPTION
Resolving https://github.com/laravel/framework/issues/43274

When applying a global scope to a User model that joins a secondary table, which also has an ID field, the `retrieveById` and `retrieveByToken` functions of Illuminate\Auth\EloquentUserProvider do not qualify the identifier field name in the where clause which. This subsequently causes a "Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous" error.

Wrapping `$model->getAuthIdentifierName()` in `$model->qualifyColumn()` on both methods protects against this. 
This is a non-breaking change and is in-line with other abstract queries/builders. Tests updated accordingly.

Example global scope:
```
class ActiveUsersScope extends AbstractGlobalScope implements Scope
{
    /**
     * Apply the scope to a given Eloquent query builder.
     *
     * @param Builder $builder
     * @param Model $model
     * @return void
     */
    public function apply(Builder $builder, Model $model): void
    {
        $userOrganizationModel = new UserOrganization();

        $builder
            ->join(
                $userOrganizationModel->getTable(),
                $userOrganizationModel->qualifyColumn('user_id'),
                '=',
                $model->qualifyColumn('id')
            )
            ->where($userOrganizationModel->qualifyColumn('status'), UserStatus::ACTIVE);
    }
}
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
