### PR TITLE
[9.x] Remove null default attributes names when UPDATED_AT or CREATED_AT is null at Model::replicate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1600,11 +1600,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function replicate(array $except = null)
     {
-        $defaults = array_filter([
+        $defaults = array_values(array_filter([
             $this->getKeyName(),
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
-        ]);
+        ]));
 
         $attributes = Arr::except(
             $this->getAttributes(), $except ? array_unique(array_merge($except, $defaults)) : $defaults

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1600,11 +1600,11 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function replicate(array $except = null)
     {
-        $defaults = [
+        $defaults = array_filter([
             $this->getKeyName(),
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
-        ];
+        ]);
 
         $attributes = Arr::except(
             $this->getAttributes(), $except ? array_unique(array_merge($except, $defaults)) : $defaults


### PR DESCRIPTION
https://github.com/laravel/framework/blob/d425952e8cc664b01de8bd654336c1be8dcf7444/src/Illuminate/Database/Eloquent/Model.php#L1606

Generates on PHP 8.0
`PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated`

Example:
```php
class Order extends Model
{
    public const CREATED_AT = 'created_at';
    public const UPDATED_AT = null;
```

Code at database Model:
```php
    public function replicate(array $except = null)
    {
        $defaults = [
            $this->getKeyName(),
            $this->getCreatedAtColumn(),
            $this->getUpdatedAtColumn(), // <---- null here
        ];

        $attributes = Arr::except( // <-- call Arr::forget
            $this->getAttributes(), $except ? array_unique(array_merge($except, $defaults)) : $defaults
        );
```

Trigger warning at Arr::forget:
```php
public static function forget(&$array, $keys)
    {
        ...
        foreach ($keys as $key) {
            ...
            $parts = explode('.', $key); // <-- $key is null where but explode requires strict string type (null not allowed)
```