### PR TITLE
[9.x] Fix negated comment in Http::preventStrayRequests description

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -231,7 +231,7 @@ class Factory
     }
 
     /**
-     * Indicate that an exception should not be thrown if any request is not faked.
+     * Indicate that an exception should be thrown if any request is not faked.
      *
      * @param  bool  $prevent
      * @return $this


### PR DESCRIPTION
In Laravel 9, the `Http::preventStrayRequests()` function (among others) was added. The comment on the function, however, is negated. That is, currently, the function description is equal to the description of the `Http::allowStrayRequests()` function, indicating that you specify whether an exception should *not* be thrown, which is the other way around for this function.

Having two functions with opposite behavior but equal description like this can be confusing. Thus, I looked at the functionality and the comment on the variable it sets, and altered the comment to adhere to it.