### PR TITLE
[9.x] Handle varying `composer -V` output

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -123,6 +123,10 @@ class Composer
 
         $output = $process->getOutput();
 
+        if (preg_match('/(\d+(\.\d+){2})/', $output, $version)) {
+            return $version[1];
+        }
+
         return explode(' ', $output)[2] ?? null;
     }
 }


### PR DESCRIPTION
It [appears](https://twitter.com/amit_merchant/status/1549420303217876995) that Composer prints the output of `-V` differently. This PR uses a regex to fetch the version more reliably.