### PR TITLE
[9.x] Allows to install `doctrine/dbal` from `model:show` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -103,7 +103,7 @@ class ShowModelCommand extends Command
     public function handle()
     {
         if (! interface_exists('Doctrine\DBAL\Driver')) {
-            if (! $this->components->confirm('Displaying model information requires the [doctrine/dbal] package. Would you like to install it?')) {
+            if (! $this->components->confirm('Displaying model information requires the Doctrine DBAL (doctrine/dbal) package. Would you like to install it?')) {
                 return 1;
             }
 

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -457,6 +457,7 @@ class ShowModelCommand extends Command
      * Install the command needed dependencies.
      *
      * @return void
+     *
      * @throws \Symfony\Component\Process\Exception\ProcessSignaledException
      */
     protected function installDependencies()

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -472,7 +472,7 @@ class ShowModelCommand extends Command
             try {
                 $process->setTty(true);
             } catch (RuntimeException $e) {
-                $this->components->warning($e->getMessage());
+                $this->components->warn($e->getMessage());
             }
         }
 

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -41,13 +41,6 @@ class ShowModelCommand extends Command
     protected static $defaultName = 'model:show';
 
     /**
-     * The Composer instance.
-     *
-     * @var \Illuminate\Support\Composer
-     */
-    protected $composer;
-
-    /**
      * The console command description.
      *
      * @var string
@@ -62,6 +55,13 @@ class ShowModelCommand extends Command
     protected $signature = 'model:show {model : The model to show}
                 {--database= : The database connection to use}
                 {--json : Output the model as JSON}';
+
+    /**
+     * The Composer instance.
+     *
+     * @var \Illuminate\Support\Composer
+     */
+    protected $composer;
 
     /**
      * The methods that can be called in a model to indicate a relation.
@@ -103,7 +103,7 @@ class ShowModelCommand extends Command
     public function handle()
     {
         if (! interface_exists('Doctrine\DBAL\Driver')) {
-            if (! $this->components->confirm('Displaying model information requires [doctrine/dbal]. Do you wish to install it?')) {
+            if (! $this->components->confirm('Displaying model information requires the [doctrine/dbal] package. Would you like to install it?')) {
                 return 1;
             }
 
@@ -454,7 +454,36 @@ class ShowModelCommand extends Command
     }
 
     /**
-     * Install the command needed dependencies.
+     * Qualify the given model class base name.
+     *
+     * @param  string  $model
+     * @return string
+     *
+     * @see \Illuminate\Console\GeneratorCommand
+     */
+    protected function qualifyModel(string $model)
+    {
+        if (str_contains($model, '\\') && class_exists($model)) {
+            return $model;
+        }
+
+        $model = ltrim($model, '\\/');
+
+        $model = str_replace('/', '\\', $model);
+
+        $rootNamespace = $this->laravel->getNamespace();
+
+        if (Str::startsWith($model, $rootNamespace)) {
+            return $model;
+        }
+
+        return is_dir(app_path('Models'))
+            ? $rootNamespace.'Models\\'.$model
+            : $rootNamespace.$model;
+    }
+
+    /**
+     * Install the command's dependencies.
      *
      * @return void
      *
@@ -483,34 +512,5 @@ class ShowModelCommand extends Command
                 throw $e;
             }
         }
-    }
-
-    /**
-     * Qualify the given model class base name.
-     *
-     * @param  string  $model
-     * @return string
-     *
-     * @see \Illuminate\Console\GeneratorCommand
-     */
-    protected function qualifyModel(string $model)
-    {
-        if (str_contains($model, '\\') && class_exists($model)) {
-            return $model;
-        }
-
-        $model = ltrim($model, '\\/');
-
-        $model = str_replace('/', '\\', $model);
-
-        $rootNamespace = $this->laravel->getNamespace();
-
-        if (Str::startsWith($model, $rootNamespace)) {
-            return $model;
-        }
-
-        return is_dir(app_path('Models'))
-            ? $rootNamespace.'Models\\'.$model
-            : $rootNamespace.$model;
     }
 }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -103,7 +103,7 @@ class ShowModelCommand extends Command
     public function handle()
     {
         if (! interface_exists('Doctrine\DBAL\Driver')) {
-            if (! $this->components->confirm('Displaying model information requires [doctrine/dbal]. Do you wish to install it as a dev dependency?')) {
+            if (! $this->components->confirm('Displaying model information requires [doctrine/dbal]. Do you wish to install it?')) {
                 return 1;
             }
 
@@ -463,7 +463,7 @@ class ShowModelCommand extends Command
     protected function installDependencies()
     {
         $command = collect($this->composer->findComposer())
-            ->push('require doctrine/dbal --dev')
+            ->push('require doctrine/dbal')
             ->implode(' ');
 
         $process = Process::fromShellCommandline($command, null, null, null, null);

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -65,7 +65,7 @@ class Composer
      *
      * @return array
      */
-    protected function findComposer()
+    public function findComposer()
     {
         if ($this->files->exists($this->workingPath.'/composer.phar')) {
             return [$this->phpBinary(), 'composer.phar'];


### PR DESCRIPTION
This pull request addresses https://github.com/laravel/framework/issues/43284, by asking the user if he wants to install `doctrine/dbal`.

<img width="1466" alt="Screenshot 2022-07-19 at 17 20 42" src="https://user-images.githubusercontent.com/5457236/179802141-b159f3aa-064b-4623-abe7-ac662b128cf0.png">

---

Update: I've modified the message, and the "composer require", to install this package as regular dependency, and not as "dev" dependency.