### PR TITLE
[9.x] Add syntactic sugar travelIntoThePast() method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithTime.php
@@ -41,6 +41,19 @@ trait InteractsWithTime
     }
 
     /**
+     * Begin traveling into the past.
+     *
+     * @param  int  $value
+     * @return \Illuminate\Foundation\Testing\Wormhole
+     */
+    public function travelIntoThePast($value)
+    {
+        $this->assertGreaterThanOrEqual(1, $value, 'The given value should be a positive integer');
+
+        return new Wormhole($value * -1);
+    }
+
+    /**
      * Travel to another time.
      *
      * @param  \DateTimeInterface|\Closure|\Illuminate\Support\Carbon|string|bool|null  $date


### PR DESCRIPTION
This adds syntactic sugar to `InteractsWithTime` trait. Basically it's very similar to `travel()` method but instead, it will pass the `$value` argument as a negative integer to the `Wormhole:class`, thus it'll travel to the past.

Before:
```
$this->travel(-2)->days();
```

Now:
```
$this->travelIntoThePast(2)->days();
```
