### PR TITLE
[9.x] Add requiredUnless, excludeUnless and prohibitedUnless Validation Methods

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -6,11 +6,14 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\ExcludeIf;
+use Illuminate\Validation\Rules\ExcludeUnless;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\ProhibitedIf;
+use Illuminate\Validation\Rules\ProhibitedUnless;
 use Illuminate\Validation\Rules\RequiredIf;
+use Illuminate\Validation\Rules\RequiredUnless;
 use Illuminate\Validation\Rules\Unique;
 
 class Rule
@@ -106,6 +109,17 @@ class Rule
     }
 
     /**
+     * Get a required_unless constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\RequiredUnless
+     */
+    public static function requiredUnless($callback)
+    {
+        return new RequiredUnless($callback);
+    }
+
+    /**
      * Get a exclude_if constraint builder instance.
      *
      * @param  callable|bool  $callback
@@ -117,6 +131,17 @@ class Rule
     }
 
     /**
+     * Get a exclude_unless constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\ExcludeUnless
+     */
+    public static function excludeUnless($callback)
+    {
+        return new ExcludeUnless($callback);
+    }
+
+    /**
      * Get a prohibited_if constraint builder instance.
      *
      * @param  callable|bool  $callback
@@ -125,6 +150,17 @@ class Rule
     public static function prohibitedIf($callback)
     {
         return new ProhibitedIf($callback);
+    }
+
+    /**
+     * Get a prohibited_unless constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\ProhibitedUnless
+     */
+    public static function prohibitedUnless($callback)
+    {
+        return new ProhibitedUnless($callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/ExcludeUnless.php
+++ b/src/Illuminate/Validation/Rules/ExcludeUnless.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use InvalidArgumentException;
+
+class ExcludeUnless
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var \Closure|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new exclude validation rule based on a condition.
+     *
+     * @param  \Closure|bool  $condition
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($condition)
+    {
+        if ($condition instanceof Closure || is_bool($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? '' : 'exclude';
+        }
+
+        return $this->condition ? '' : 'exclude';
+    }
+}

--- a/src/Illuminate/Validation/Rules/ProhibitedUnless.php
+++ b/src/Illuminate/Validation/Rules/ProhibitedUnless.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use InvalidArgumentException;
+
+class ProhibitedUnless
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var \Closure|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new prohibited validation rule based on a condition.
+     *
+     * @param  \Closure|bool  $condition
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($condition)
+    {
+        if ($condition instanceof Closure || is_bool($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? '' : 'prohibited';
+        }
+
+        return $this->condition ? '' : 'prohibited';
+    }
+}

--- a/src/Illuminate/Validation/Rules/RequiredUnless.php
+++ b/src/Illuminate/Validation/Rules/RequiredUnless.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use InvalidArgumentException;
+
+class RequiredUnless
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new required validation rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     */
+    public function __construct($condition)
+    {
+        if (! is_string($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? '' : 'required';
+        }
+
+        return $this->condition ? '' : 'required';
+    }
+}

--- a/tests/Validation/ValidationExcludeUnlessTest.php
+++ b/tests/Validation/ValidationExcludeUnlessTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Validation\Rules\ExcludeUnless;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ValidationExcludeUnlessTest extends TestCase
+{
+    public function testItClousureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new ExcludeUnless(function () {
+            return true;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new ExcludeUnless(function () {
+            return false;
+        });
+
+        $this->assertSame('exclude', (string) $rule);
+
+        $rule = new ExcludeUnless(true);
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new ExcludeUnless(false);
+
+        $this->assertSame('exclude', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        new ExcludeUnless(false);
+        new ExcludeUnless(true);
+        new ExcludeUnless(fn () => true);
+
+        foreach ([1, 1.1, 'phpinfo', new stdClass] as $condition) {
+            try {
+                new ExcludeUnless($condition);
+                $this->fail('The ExcludeUnless constructor must not accept '.gettype($condition));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertEquals('The provided condition must be a callable or boolean.', $exception->getMessage());
+            }
+        }
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new ExcludeUnless(function () {
+            return true;
+        }));
+    }
+}

--- a/tests/Validation/ValidationProhibitedUnlessTest.php
+++ b/tests/Validation/ValidationProhibitedUnlessTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Validation\Rules\ProhibitedUnless;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ValidationProhibitedUnlessTest extends TestCase
+{
+    public function testItClousureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new ProhibitedUnless(function () {
+            return true;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new ProhibitedUnless(function () {
+            return false;
+        });
+
+        $this->assertSame('prohibited', (string) $rule);
+
+        $rule = new ProhibitedUnless(true);
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new ProhibitedUnless(false);
+
+        $this->assertSame('prohibited', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new ProhibitedUnless(false);
+
+        $rule = new ProhibitedUnless(true);
+
+        foreach ([1, 1.1, 'phpinfo', new stdClass] as $condition) {
+            try {
+                $rule = new ProhibitedUnless($condition);
+                $this->fail('The ProhibitedUnless constructor must not accept '.gettype($condition));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertEquals('The provided condition must be a callable or boolean.', $exception->getMessage());
+            }
+        }
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new ProhibitedUnless(function () {
+            return true;
+        }));
+    }
+}

--- a/tests/Validation/ValidationRequiredUnlessTest.php
+++ b/tests/Validation/ValidationRequiredUnlessTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Validation\Rules\RequiredUnless;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ValidationRequiredUnlessTest extends TestCase
+{
+    public function testItClousureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new RequiredUnless(function () {
+            return true;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new RequiredUnless(function () {
+            return false;
+        });
+
+        $this->assertSame('required', (string) $rule);
+
+        $rule = new RequiredUnless(true);
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new RequiredUnless(false);
+
+        $this->assertSame('required', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new RequiredUnless(false);
+
+        $rule = new RequiredUnless(true);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $rule = new RequiredUnless('phpinfo');
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new RequiredUnless(function () {
+            return true;
+        }));
+    }
+}


### PR DESCRIPTION
Currently, validation methods exist for `Rule::requiredIf()`, `Rule::excludeIf()` and `Rule::prohibitedIf()` which allow complex conditional logic that goes beyond the simple use of the `required_if`, `exclude_if` and `prohibited_if` validation rules.

This PR seeks to bring parity by adding `Rule::requiredUnless()`, `Rule::excludeUnless()` and `Rule::prohibitedUnless()` validation method alternatives of the simple validation rules: `required_unless`, `exclude_unless` and `prohibited_unless`.

If accepted, I will PR these changes to the docs as well.

Some code examples:

```php
use Illuminate\Support\Facades\Validator;
use Illuminate\Validation\Rule;

Validator::make($request->all(), [
    'role_id' => Rule::requiredUnless($request->user()->is_expired),
]);
 
Validator::make($request->all(), [
    'role_id' => Rule::requiredUnless(fn () => $request->user()->is_expired),
]);

Validator::make($request->all(), [
    'role_id' => Rule::prohibitedUnless($request->user()->is_active),
]);
 
Validator::make($request->all(), [
    'role_id' => Rule::prohibitedUnless(fn () => $request->user()->is_active),
]);

Validator::make($request->all(), [
    'role_id' => Rule::excludeUnless($request->user()->is_active),
]);
 
Validator::make($request->all(), [
    'role_id' => Rule::excludeUnless(fn () => $request->user()->is_active),
]);
```