### PR TITLE
[9.x] Allow using backed enums as route parameters

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -479,9 +480,13 @@ class UrlGenerator implements UrlGeneratorContract
     public function toRoute($route, $parameters, $absolute)
     {
         $parameters = collect(Arr::wrap($parameters))->map(function ($value, $key) use ($route) {
-            return $value instanceof UrlRoutable && $route->bindingFieldFor($key)
+            $value = $value instanceof UrlRoutable && $route->bindingFieldFor($key)
                     ? $value->{$route->bindingFieldFor($key)}
                     : $value;
+
+            return function_exists('enum_exists') && $value instanceof BackedEnum
+                ? $value->value
+                : $value;
         })->all();
 
         return $this->routeUrl()->to(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -14,6 +14,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
+if (PHP_VERSION_ID >= 80100) {
+    include_once 'Enums.php';
+}
+
 class RoutingUrlGeneratorTest extends TestCase
 {
     public function testBasicGeneration()
@@ -846,6 +850,22 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->expectExceptionMessage('reserved');
 
         Request::create($url->signedRoute('foo', ['expires' => 253402300799]));
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testRouteGenerationWithBackedEnums()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $namedRoute = new Route(['GET'], '/foo/{bar}', ['as' => 'foo.bar']);
+        $routes->add($namedRoute);
+
+        $this->assertSame('http://www.foo.com/foo/fruits', $url->route('foo.bar', CategoryBackedEnum::Fruits));
     }
 }
 


### PR DESCRIPTION
This PR adds support for using backed enum values as route parameters.

# Example/Reasoning
I have a project where I have 2 models, Model1 and Model2. Where Model1 hasMany Model2.
Each Model1 can have one Model2 for each backed enum case. In my DB there is a unique constraint on `model1_id` and `enum_value`.
Then I have a route `/model1/{model1}/model2/{model2:enum_value}` (scoped).

This works fine, except every time I want to generate an URL from a named route I have to specify `$model2->enum_value->value` instead of just `$model2`.

# Breaking changes
I can't think of any, except for if you expect an `Object of class <YourBackedEnum> could not be converted to string` error. Correct me if I'm wrong tho.