### PR TITLE
[9.x] Fixes for `model:show` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -437,7 +437,7 @@ class ShowModelCommand extends Command
      */
     protected function qualifyModel(string $model)
     {
-        if (class_exists($model)) {
+        if (str_contains($model, '\\') && class_exists($model)) {
             return $model;
         }
 

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -345,10 +345,10 @@ class ShowModelCommand extends Command
      */
     protected function getCastsWithDates($model)
     {
-        return collect([
-            ...collect($model->getDates())->flip()->map(fn () => 'datetime'),
-            ...$model->getCasts(),
-        ]);
+        return collect($model->getDates())
+            ->flip()
+            ->map(fn () => 'datetime')
+            ->merge($model->getCasts());
     }
 
     /**


### PR DESCRIPTION
This PR fixes a few issues with the `model:show` command:

* Fixes compatibility with PHP 8.0
* Prevents throwing an error when the relation detection returns a false positive
* Fixes an issue when a model has the same name as a facade

Fixes #43298
Fixes #43285
Fixes #43289