### PR TITLE
[9.x] Restore job id in worker command logs

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -214,17 +214,17 @@ class WorkCommand extends Command
 
             $formattedStartedAt = Carbon::now()->format('Y-m-d H:i:s');
 
-            return $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
+            return $this->output->write("  <fg=gray>{$formattedStartedAt} {$job->getJobId()}</> {$job->resolveName()}");
         }
 
         if ($this->latestStatus && $this->latestStatus != 'starting') {
             $formattedStartedAt = Carbon::createFromTimestamp($this->latestStartedAt)->format('Y-m-d H:i:s');
 
-            $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
+            $this->output->write("  <fg=gray>{$formattedStartedAt} {$job->getJobId()}</> {$job->resolveName()}");
         }
 
         $runTime = number_format((microtime(true) - $this->latestStartedAt) * 1000, 2).'ms';
-        $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - mb_strlen($runTime) - 31, 0);
+        $dots = max(terminal()->width() - mb_strlen($job->resolveName().$runTime.$job->getJobId()) - 32, 0);
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
         $this->output->write(" <fg=gray>$runTime</>");


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR restore the job id in worker command log that was removed in https://github.com/laravel/framework/pull/43065.
I think it's important to display the job id for better debugging. 

Previous logs looks like:

```
2022-07-20 07:40:51 App\Jobs\Mobile\Posted .................... 22.32ms DONE
```

New log looks like:

```
2022-07-20 08:12:57 ea280c14-90ee-4ec0-ba1f-b7237291371f App\Jobs\SetUserAway  25.57ms DONE
```
