### PR TITLE
[9.x] Add "Logs" driver to the `about` command

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -165,10 +165,23 @@ class AboutCommand extends Command
             'Views' => $this->hasPhpFiles($this->laravel->storagePath('framework/views')) ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>',
         ]);
 
+        $logChannel = config('logging.default');
+        $logChannelDriver = config('logging.channels.'.$logChannel.'.driver');
+
+        if ($logChannelDriver === 'stack') {
+            $secondary = collect(config('logging.channels.'.$logChannel.'.channels'))
+                ->implode(', ');
+
+            $logs = '<fg=yellow;options=bold>'.$logChannel.'</> <fg=gray;options=bold>/</> '.$secondary;
+        } else {
+            $logs = $logChannel;
+        }
+
         static::add('Drivers', array_filter([
             'Broadcasting' => config('broadcasting.default'),
             'Cache' => config('cache.default'),
             'Database' => config('database.default'),
+            'Logs' => $logs,
             'Mail' => config('mail.default'),
             'Octane' => config('octane.server'),
             'Queue' => config('queue.default'),


### PR DESCRIPTION
This PR adds a missing Logs driver entry for the `about` command.

When using a `stack` driver, the output will include the list of drivers within that stack.

![image](https://user-images.githubusercontent.com/246103/179953079-413575dd-15a4-4e6d-b332-e9f99ef8eade.png)

Otherwise, you'll see just the usual output.

![CleanShot 2022-07-20 at 10 50 22](https://user-images.githubusercontent.com/246103/179953305-ff907fe1-6d60-4197-b353-7930cd741861.png)
