### PR TITLE
Fix merging casts with dates for PHP 8.0

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -345,10 +345,9 @@ class ShowModelCommand extends Command
      */
     protected function getCastsWithDates($model)
     {
-        return collect([
-            ...collect($model->getDates())->flip()->map(fn () => 'datetime'),
-            ...$model->getCasts(),
-        ]);
+        return collect(
+            array_fill_keys($model->getDates(), 'datetime')
+        )->merge($model->getCasts());
     }
 
     /**


### PR DESCRIPTION
When running `php artisan model:show` in PHP 8.0, the following error is thrown:

 **Cannot unpack Traversable with string keys**

```
  at vendor/laravel/framework/src/Illuminate/Foundation/Console/ShowModelCommand.php:349
    345▕      */
    346▕     protected function getCastsWithDates($model)
    347▕     {
    348▕         return collect([
  ➜ 349▕             ...collect($model->getDates())->flip()->map(fn () => 'datetime'),
    350▕             ...$model->getCasts(),
    351▕         ]);
    352▕     }
    353▕
```

That is because array unpacking with string keys was implemented in PHP 8.1.
A simple merge will fix this BC break.