### PR TITLE
for php 8.0.x support

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -345,10 +345,8 @@ class ShowModelCommand extends Command
      */
     protected function getCastsWithDates($model)
     {
-        return collect([
-            ...collect($model->getDates())->flip()->map(fn () => 'datetime'),
-            ...$model->getCasts(),
-        ]);
+        return collect($model->getDates())->flip()->map(fn () => 'datetime')
+            ->merge($model->getCasts());
     }
 
     /**


### PR DESCRIPTION
fix "Cannot unpack Traversable with string keys" on PHP 8.0.x