### PR TITLE
[9.x] Prevent redis crash when large number of jobs are scheduled for a specific time

### DIFF
--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -47,7 +47,8 @@ class RedisConnector implements ConnectorInterface
             $config['connection'] ?? $this->connection,
             $config['retry_after'] ?? 60,
             $config['block_for'] ?? null,
-            $config['after_commit'] ?? null
+            $config['after_commit'] ?? null,
+            $config['migration_batch_size'] ?? -1
         );
     }
 }

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -106,7 +106,7 @@ LUA;
     {
         return <<<'LUA'
 -- Get all of the jobs with an expired "score"...
-local val = redis.call('zrangebyscore', KEYS[1], '-inf', ARGV[1])
+local val = redis.call('zrangebyscore', KEYS[1], '-inf', ARGV[1], 'offset', 0, ARGV[2])
 
 -- If we have values in the array, we will remove them from the first queue
 -- and add them onto the destination queue in chunks of 100, which moves

--- a/src/Illuminate/Queue/LuaScripts.php
+++ b/src/Illuminate/Queue/LuaScripts.php
@@ -106,7 +106,7 @@ LUA;
     {
         return <<<'LUA'
 -- Get all of the jobs with an expired "score"...
-local val = redis.call('zrangebyscore', KEYS[1], '-inf', ARGV[1], 'offset', 0, ARGV[2])
+local val = redis.call('zrangebyscore', KEYS[1], '-inf', ARGV[1], 'limit', 0, ARGV[2])
 
 -- If we have values in the array, we will remove them from the first queue
 -- and add them onto the destination queue in chunks of 100, which moves

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -46,6 +46,13 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected $blockFor = null;
 
     /**
+     * The batch size of expired jobs migration.
+     *
+     * @var int
+     */
+    protected $migrationBatchSize = -1;
+
+    /**
      * Create a new Redis queue instance.
      *
      * @param  \Illuminate\Contracts\Redis\Factory  $redis
@@ -54,6 +61,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      * @param  int  $retryAfter
      * @param  int|null  $blockFor
      * @param  bool  $dispatchAfterCommit
+     * @param  int  $migrationBatchSize
      * @return void
      */
     public function __construct(Redis $redis,
@@ -61,7 +69,8 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
                                 $connection = null,
                                 $retryAfter = 60,
                                 $blockFor = null,
-                                $dispatchAfterCommit = false)
+                                $dispatchAfterCommit = false,
+                                $migrationBatchSize = -1)
     {
         $this->redis = $redis;
         $this->default = $default;
@@ -69,6 +78,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         $this->connection = $connection;
         $this->retryAfter = $retryAfter;
         $this->dispatchAfterCommit = $dispatchAfterCommit;
+        $this->migrationBatchSize = $migrationBatchSize;
     }
 
     /**
@@ -243,12 +253,13 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @param  string  $from
      * @param  string  $to
+     * @param  int  $limit
      * @return array
      */
     public function migrateExpiredJobs($from, $to)
     {
         return $this->getConnection()->eval(
-            LuaScripts::migrateExpiredJobs(), 3, $from, $to, $to.':notify', $this->currentTime()
+            LuaScripts::migrateExpiredJobs(), 3, $from, $to, $to.':notify', $this->currentTime(), $this->migrationBatchSize
         );
     }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -46,7 +46,9 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
     protected $blockFor = null;
 
     /**
-     * The batch size of expired jobs migration.
+     * The batch size to use when migrating delayed / expired jobs onto the primary queue.
+     *
+     * Negative values are infinite.
      *
      * @var int
      */


### PR DESCRIPTION
Currently, scheduling a large number of jobs for a specific time causes Redis to halt since migrate script is a heavy script.
In this pull request, support for limiting the number of migrated jobs from the delayed queue to the main queue is added.

Steps to reproduce the problem:
- Schedule >10000 delayed jobs for a specific time.
- Then run `php artisan queue:work`

When the time reaches, Redis will be busy moving these jobs for minutes.

![image](https://user-images.githubusercontent.com/13760442/179972859-a701273c-da92-4033-bcd3-d47de07bac53.png)

By limiting the number of jobs to migrate, the problem would be easily fixed.
It is also fully backward compatible since the default value passed as the limit is -1 which means no limit.