### PR TITLE
[9.x] Stub publish flag that restricts to only existing files

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -14,7 +14,9 @@ class StubPublishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'stub:publish {--force : Overwrite any existing files}';
+    protected $signature = 'stub:publish
+                    {--existing : Publish and overwrite only the files that have already been published}
+                    {--force : Overwrite any existing files}';
 
     /**
      * The name of the console command.
@@ -88,7 +90,8 @@ class StubPublishCommand extends Command
         ];
 
         foreach ($files as $from => $to) {
-            if (! file_exists($to) || $this->option('force')) {
+            if (! $this->option('existing') && (! file_exists($to) || $this->option('force'))
+                || ($this->option('existing') && file_exists($to))) {
                 file_put_contents($to, file_get_contents($from));
             }
         }

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -90,7 +90,7 @@ class StubPublishCommand extends Command
         ];
 
         foreach ($files as $from => $to) {
-            if (! $this->option('existing') && (! file_exists($to) || $this->option('force'))
+            if ((! $this->option('existing') && (! file_exists($to) || $this->option('force')))
                 || ($this->option('existing') && file_exists($to))) {
                 file_put_contents($to, file_get_contents($from));
             }


### PR DESCRIPTION
Similar to the addition of the `--existing` flag to the `vendor:publish` command in #43212, this PR adds the `--existing` flag to the `stub:publish` command. Usage of this flag instructs the `stub:publish` command to only publish and overwrite stub files that already exist.