### PR TITLE
[9.x] Add supportsTemporaryUrl to FilesystemAdapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -671,6 +671,17 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Check if temporary urls are supported.
+     *
+     * @return bool
+     */
+    public function supportsTemporaryUrl(): bool
+    {
+        return method_exists($this->adapter, 'getTemporaryUrl')
+            || $this->temporaryUrlCallback;
+    }
+
+    /**
      * Get a temporary URL for the file at the given path.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -521,4 +521,35 @@ class FilesystemAdapterTest extends TestCase
 
         $this->assertSame($filesystemAdapter->files(), ['body.txt', 'existing.txt', 'file.txt', 'file1.txt']);
     }
+
+    public function testSupportsTemporaryUrl()
+    {
+        $localAdapter = new class($this->tempDir) extends LocalFilesystemAdapter {
+            function getTemporaryUrl($path, Carbon $expiration, $options): string
+            {
+                return $path.$expiration->toString().implode('', $options);
+            }
+        };
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $localAdapter);
+
+        $this->assertTrue($filesystemAdapter->supportsTemporaryUrl());
+    }
+
+    public function testSupportsTemporaryUrlWithCustomCallback()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $filesystemAdapter->buildTemporaryUrlsUsing(function ($path, Carbon $expiration, $options) {
+            return $path.$expiration->toString().implode('', $options);
+        });
+
+        $this->assertTrue($filesystemAdapter->supportsTemporaryUrl());
+    }
+
+    public function testSupportsTemporaryUrlForAdapterWithoutTemporaryUrlSupport()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $this->assertFalse($filesystemAdapter->supportsTemporaryUrl());
+    }
 }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -524,8 +524,9 @@ class FilesystemAdapterTest extends TestCase
 
     public function testSupportsTemporaryUrl()
     {
-        $localAdapter = new class($this->tempDir) extends LocalFilesystemAdapter {
-            function getTemporaryUrl($path, Carbon $expiration, $options): string
+        $localAdapter = new class($this->tempDir) extends LocalFilesystemAdapter
+        {
+            public function getTemporaryUrl($path, Carbon $expiration, $options): string
             {
                 return $path.$expiration->toString().implode('', $options);
             }


### PR DESCRIPTION
This PR adds a `supportsTemporaryUrl()` method to `FilesystemAdapter` that checks if the adapter has `getTemporaryUrl` or a `temporaryUrlCallback`.