### PR TITLE
[9.x] Fix Bootstrap 5 pagination

### DIFF
--- a/src/Illuminate/Pagination/resources/views/bootstrap-5.blade.php
+++ b/src/Illuminate/Pagination/resources/views/bootstrap-5.blade.php
@@ -30,11 +30,11 @@
             <div>
                 <p class="small text-muted">
                     {!! __('Showing') !!}
-                    <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                    <span class="fw-semibold">{{ $paginator->firstItem() }}</span>
                     {!! __('to') !!}
-                    <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                    <span class="fw-semibold">{{ $paginator->lastItem() }}</span>
                     {!! __('of') !!}
-                    <span class="font-medium">{{ $paginator->total() }}</span>
+                    <span class="fw-semibold">{{ $paginator->total() }}</span>
                     {!! __('results') !!}
                 </p>
             </div>


### PR DESCRIPTION
The `font-medium` class is not a valid Bootstrap 5 class, so I updated it to a similar one, which would be `fw-semibold` class. Reference: [getbootstrap.com/docs/5.2/utilities/text/#font-weight-and-italics](https://getbootstrap.com/docs/5.2/utilities/text/#font-weight-and-italics)