### PR TITLE
[9.x] Fixes `queue:monitor` command dispatching QueueBusy

### DIFF
--- a/src/Illuminate/Queue/Console/MonitorCommand.php
+++ b/src/Illuminate/Queue/Console/MonitorCommand.php
@@ -144,7 +144,7 @@ class MonitorCommand extends Command
     protected function dispatchEvents(Collection $queues)
     {
         foreach ($queues as $queue) {
-            if ($queue['status'] == 'OK') {
+            if ($queue['status'] == '<fg=green;options=bold>OK</>') {
                 continue;
             }
 


### PR DESCRIPTION
This pull requests avoids having `queue:monitor` command dispatch `QueueBusy` all the time.

Fixes https://github.com/laravel/framework/issues/43318.