### PR TITLE
[9.x] Ensure relation names are properly "snaked" in `JsonResource::whenCounted()` method

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -219,7 +219,7 @@ trait ConditionallyLoadsAttributes
             $default = new MissingValue();
         }
 
-        $attribute = Str::finish($relationship, '_count');
+        $attribute = (string) Str::of($relationship)->snake()->finish('_count');
 
         if (! isset($this->resource->getAttributes()[$attribute])) {
             return value($default);

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipCounts.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalRelationshipCounts.php
@@ -9,6 +9,7 @@ class PostResourceWithOptionalRelationshipCounts extends PostResource
         return [
             'id' => $this->id,
             'authors' => $this->whenCounted('authors_count'),
+            'favourite_posts' => $this->whenCounted('favouritedPosts'),
             'comments' => $this->whenCounted('comments', function ($count) {
                 return "$count comments";
             }, 'None'),

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -317,6 +317,7 @@ class ResourceTest extends TestCase
                 'title' => 'Test Title',
                 'authors_count' => 2,
                 'comments_count' => 5,
+                'favourited_posts_count' => 1,
             ]);
 
             return new PostResourceWithOptionalRelationshipCounts($post);
@@ -332,6 +333,7 @@ class ResourceTest extends TestCase
             'data' => [
                 'id' => 5,
                 'authors' => 2,
+                'favourite_posts' => 1,
                 'comments' => '5 comments',
             ],
         ]);


### PR DESCRIPTION
This PR fixes a bug that I introduced in the new `JsonResource::whenCounted($relation)` method (https://github.com/laravel/framework/pull/43101) where a relation name would not be snaked in the event of using a multi-word relationship.