### PR TITLE
[9.x] Fixes usage of Migrator without output

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrator
@@ -726,9 +727,9 @@ class Migrator
      */
     protected function write($component, ...$arguments)
     {
-        if ($this->output) {
-            with(new $component($this->output))->render(...$arguments);
-        }
+        with(new $component(
+            $this->output ?: new NullOutput()
+        ))->render(...$arguments);
     }
 
     /**

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -39,6 +39,18 @@ class MigratorTest extends TestCase
         $this->assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'last_name'));
     }
 
+    public function testMigrateWithoutOutput()
+    {
+        $this->app->forgetInstance('migrator');
+        $this->subject = $this->app->make('migrator');
+
+        $this->subject->run([__DIR__.'/fixtures']);
+
+        $this->assertTrue(DB::getSchemaBuilder()->hasTable('people'));
+        $this->assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'first_name'));
+        $this->assertTrue(DB::getSchemaBuilder()->hasColumn('people', 'last_name'));
+    }
+
     public function testRollback()
     {
         $this->getConnection()->statement('CREATE TABLE people(id INT, first_name VARCHAR, last_name VARCHAR);');


### PR DESCRIPTION
This pull request fixes an issue on the Migrator that may not run pending migrations if there is no `Output` instance on the class itself. This was a bug introduced at https://github.com/laravel/framework/pull/43065, as the given closure only runs if there is an `Output`:

```php
        $this->write(Task::class, $name, fn () => $this->runMigration($migration, 'up'));
        
     // ...

    protected function write($component, ...$arguments)
    {
        if ($this->output) {
            with(new $component($this->output))->render(...$arguments);
        }
    }
```

This pull requests addresses this issue, by giving a null output to the `Task` component, ensuring this way that the given task always run:

```php
    protected function write($component, ...$arguments)
    {
        with(new $component(
            $this->output ?: new NullOutput()
        ))->render(...$arguments);
    }
```

Fixes https://github.com/laravel/framework/issues/43325.