### PR TITLE
[9.x] Allow section payload to be lazy in the "about" command

### DIFF
--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -87,7 +87,7 @@ class AboutCommand extends Command
                         ->map(fn ($value, $key) => [$key, $value])
                         ->values()
                         ->all();
-                })->flatten(1)->all()
+                })->flatten(1)
             )
             ->sortBy(function ($data, $key) {
                 $index = array_search($key, ['Environment', 'Cache', 'Drivers']);
@@ -132,13 +132,11 @@ class AboutCommand extends Command
 
             $this->components->twoColumnDetail('  <fg=green;options=bold>'.$section.'</>');
 
-            sort($data);
-
-            foreach ($data as $detail) {
+            $data->sort()->each(function ($detail) {
                 [$label, $value] = $detail;
 
                 $this->components->twoColumnDetail($label, value($value));
-            }
+            });
         });
     }
 
@@ -151,7 +149,7 @@ class AboutCommand extends Command
     protected function displayJson($data)
     {
         $output = $data->flatMap(function ($data, $section) {
-            return [(string) Str::of($section)->snake() => collect($data)->mapWithKeys(fn ($item, $key) => [(string) Str::of($item[0])->lower()->snake() => value($item[1])])];
+            return [(string) Str::of($section)->snake() => $data->mapWithKeys(fn ($item, $key) => [(string) Str::of($item[0])->lower()->snake() => value($item[1])])];
         });
 
         $this->output->writeln(strip_tags(json_encode($output)));

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -160,7 +160,7 @@ class AboutCommand extends Command
     /**
      * Gather information about the application.
      *
-     * @return array
+     * @return void
      */
     protected function gatherApplicationInformation()
     {

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -242,7 +242,7 @@ class AboutCommand extends Command
             foreach ($data as $key => $value) {
                 self::$data[$section][] = [$key, $value];
             }
-        } elseif (is_callable($data) || class_exists($data)) {
+        } elseif (is_callable($data) || ($value === null && class_exists($data))) {
             self::$data[$section][] = $data;
         } else {
             self::$data[$section][] = [$data, $value];

--- a/src/Illuminate/Foundation/Console/AboutCommand.php
+++ b/src/Illuminate/Foundation/Console/AboutCommand.php
@@ -162,7 +162,7 @@ class AboutCommand extends Command
      */
     protected function gatherApplicationInformation()
     {
-        static::add('Environment', [
+        static::add('Environment', fn () => [
             'Laravel Version' => $this->laravel->version(),
             'PHP Version' => phpversion(),
             'Composer Version' => $this->composer->getVersion() ?? '<fg=yellow;options=bold>-</>',
@@ -173,7 +173,7 @@ class AboutCommand extends Command
             'Maintenance Mode' => $this->laravel->isDownForMaintenance() ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF',
         ]);
 
-        static::add('Cache', [
+        static::add('Cache', fn () => [
             'Config' => file_exists($this->laravel->bootstrapPath('cache/config.php')) ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>',
             'Routes' => file_exists($this->laravel->bootstrapPath('cache/routes-v7.php')) ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>',
             'Events' => file_exists($this->laravel->bootstrapPath('cache/events.php')) ? '<fg=green;options=bold>CACHED</>' : '<fg=yellow;options=bold>NOT CACHED</>',
@@ -192,7 +192,7 @@ class AboutCommand extends Command
             $logs = $logChannel;
         }
 
-        static::add('Drivers', array_filter([
+        static::add('Drivers', fn () => array_filter([
             'Broadcasting' => config('broadcasting.default'),
             'Cache' => config('cache.default'),
             'Database' => config('database.default'),


### PR DESCRIPTION
With the [introduction of the new fancy (💅) artisan about command](https://github.com/laravel/framework/pull/43147), all data registered was done able to be done in an eager manner:

```php
AboutCommand::add('Settings', [
    'value' => SettingModel::first()->value,
    'App Balance' => BalanceService::fetch(),
    'Computed Metric' => 6 ÷ 2,
]);
```

A [follow up PR](https://github.com/laravel/framework/pull/43225) was submitted to allow individual items to be lazily evaluated:

```php
AboutCommand::add('Settings', [
    'value' => fn () => SettingModel::first()->value,
    'App Balance' => fn () => BalanceService::fetch(),
    'Computed Metric' => fn () => 6 ÷ 2,
]);
```

This PR pushes this lazy feature further by allowing the entire data payload lazy, rather than individual entries:

```php
AboutCommand::add('Settings', fn () => [
    'value' => SettingModel::first()->value,
    'App Balance' => BalanceService::fetch(),
    'Computed Metric' => 6 ÷ 2,
    'version' => app(Package::class)->version(),
]);
```

This will improve DX (not having to define a new closure on each line) and also improve boot performance / memory usage.

Not only does it allow a Closure to be passed, as seen above, but it will also allow invokable classes. This allows packages and apps to specify their "about" data in a dedicated class, which also has the benefits of constructor and method injection (which is possible in the service provider, but feels more noisy).


```php

namespace Acme;

class About
{
    public function __invoke(Package $package)
    {
        return [
            'value' => SettingModel::first()->value,
            'App Balance' => BalanceService::fetch(),
            'Computed Metric' => 6 ÷ 2,
            'version' => $package->version(),
        ];
    }
}

// App service provider...

AboutCommand::add('Acme', About::class);
```

Although it has not actual benefit to the framework, I've modified the built in data registration to demonstrate lazy loading. When looking on how to do things, a lot of developers look at how Laravel does things under the hood. As I believe this should be the Laravel prescribed way of registering data to guide developers in the best direction for performant application booting - I thought it also made sense to make our data registration model this way of doing things.

I also believe the lazy evaluation should be the way we document things in the Laravel docs by default to promote this practice. If we don't want to do this, we should probably recommend specifying things in the boot function rather than the register function, otherwise if people try to pull things out of the cache or something they might run into trouble if things haven't finished registering into the container.


## Example...

```php
<?php

namespace App\Providers;

use Illuminate\Foundation\Application;
use Illuminate\Foundation\Console\AboutCommand;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    public function register()
    {
        //
    }

    public function boot()
    {
        AboutCommand::add('Eager', ['eager' => 'load']);
        AboutCommand::add('Lazy', fn () => ['lazy' => 'load']);
        AboutCommand::add('lazy with class', About::class);
    }
}

class About
{
    public function __invoke(Application $app)
    {
        return [
            'version' => $app->version(),
        ];
    }
}
```

![Screen Shot 2022-07-21 at 11 51 21 am](https://user-images.githubusercontent.com/24803032/180112403-518aec96-7411-4177-9e7a-8d6b6ef46595.png)
