### PR TITLE
[9.x] Fixes `confirm` component default value

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -29,6 +29,8 @@ trait ConfirmableTrait
             $confirmed = $this->components->confirm('Do you really wish to run this command?');
 
             if (! $confirmed) {
+                $this->newLine();
+
                 $this->components->warn('Command canceled.');
 
                 return false;

--- a/src/Illuminate/Console/View/Components/Confirm.php
+++ b/src/Illuminate/Console/View/Components/Confirm.php
@@ -11,7 +11,7 @@ class Confirm extends Component
      * @param  bool  $default
      * @return bool
      */
-    public function render($question, $default = true)
+    public function render($question, $default = false)
     {
         return $this->usingQuestionHelper(
             fn () => $this->output->confirm($question, $default),

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -66,11 +66,19 @@ class ComponentsTest extends TestCase
         $output = m::mock(OutputStyle::class);
 
         $output->shouldReceive('confirm')
-               ->with('Question?', true)
+               ->with('Question?', false)
                ->once()
                ->andReturnTrue();
 
         $result = with(new Components\Confirm($output))->render('Question?');
+        $this->assertTrue($result);
+
+        $output->shouldReceive('confirm')
+               ->with('Question?', true)
+               ->once()
+               ->andReturnTrue();
+
+        $result = with(new Components\Confirm($output))->render('Question?', true);
         $this->assertTrue($result);
     }
 


### PR DESCRIPTION
This pull request fixes the confirm component default value, setting the default value to `false` exactly as the `$this->confirm` method.

Fixes https://github.com/laravel/framework/issues/43332.