### PR TITLE
[8.x] Preventing ambiguous columns when using relational pivot tables.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -495,7 +495,10 @@ trait InteractsWithPivotTable
 
             $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true);
 
-            return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
+            return $pivot->setPivotKeys(
+                $this->getQualifiedForeignPivotKeyName(),
+                $this->getQualifiedRelatedPivotKeyName()
+            );
         });
     }
 
@@ -512,7 +515,10 @@ trait InteractsWithPivotTable
             $this->parent, $attributes, $this->table, $exists, $this->using
         );
 
-        return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
+        return $pivot->setPivotKeys(
+            $this->getQualifiedForeignPivotKeyName(),
+            $this->getQualifiedRelatedPivotKeyName()
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -154,7 +154,7 @@ class MorphToMany extends BelongsToMany
         $pivot = $using ? $using::fromRawAttributes($this->parent, $attributes, $this->table, $exists)
                         : MorphPivot::fromAttributes($this->parent, $attributes, $this->table, $exists);
 
-        $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey)
+        $pivot->setPivotKeys($this->getQualifiedForeignPivotKeyName(), $this->getQualifiedRelatedPivotKeyName())
               ->setMorphType($this->morphType)
               ->setMorphClass($this->morphClass);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When setting Pivot keys, they are currently set without qualifying the field names. In turn, this means there is an opportunity to cause an ambiguous field error. 
This change is making use of pre-existing functions to qualify the pivot keys and is non-breaking.