### PR TITLE
Using parent::getActualClassNameForMorph() instead of Model::getActualClassNameForMorph() 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -231,7 +231,7 @@ trait QueriesRelationships
         }
 
         foreach ($types as &$type) {
-            $type = $this->model::getActualClassNameForMorph($type) ?? Relation::getMorphedModel($type) ?? $type;
+            $type = $this->model::getActualClassNameForMorph($type) ?? $type;
         }
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -231,7 +231,7 @@ trait QueriesRelationships
         }
 
         foreach ($types as &$type) {
-            $type = Relation::getMorphedModel($type) ?? $type;
+            $type = $this->model::getActualClassNameForMorph($type) ?? Relation::getMorphedModel($type) ?? $type;
         }
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -231,7 +231,7 @@ trait QueriesRelationships
         }
 
         foreach ($types as &$type) {
-            $type = $this->model::getActualClassNameForMorph($type) ?? $type;
+            $type = $this->model::getActualClassNameForMorph($type);
         }
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -181,7 +181,7 @@ class MorphTo extends BelongsTo
      */
     public function createModelByType($type)
     {
-        $class = Model::getActualClassNameForMorph($type);
+        $class = $this->parent::getActualClassNameForMorph($type);
 
         return tap(new $class, function ($instance) {
             if (! $instance->getConnectionName()) {


### PR DESCRIPTION
#43330 43330