### PR TITLE
[8.x] Preventing ambiguous columns when generating delete queries.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -146,8 +146,14 @@ trait AsPivot
     protected function getDeleteQuery()
     {
         return $this->newQueryWithoutRelationships()->where([
-            $this->foreignKey => $this->getOriginal($this->foreignKey, $this->getAttribute($this->foreignKey)),
-            $this->relatedKey => $this->getOriginal($this->relatedKey, $this->getAttribute($this->relatedKey)),
+            $this->qualifyColumn($this->foreignKey) => $this->getOriginal(
+                $this->foreignKey,
+                $this->getAttribute($this->foreignKey)
+            ),
+            $this->qualifyColumn($this->relatedKey) => $this->getOriginal(
+                $this->relatedKey,
+                $this->getAttribute($this->relatedKey)
+            ),
         ]);
     }
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -124,7 +124,10 @@ class DatabaseEloquentPivotTest extends TestCase
         $pivot->foreign = 'foreign.value';
         $pivot->other = 'other.value';
         $query = m::mock(stdClass::class);
-        $query->shouldReceive('where')->once()->with(['foreign' => 'foreign.value', 'other' => 'other.value'])->andReturn($query);
+        $query->shouldReceive('where')->once()->with([
+            $pivot->getTable() . '.foreign' => 'foreign.value',
+            $pivot->getTable() . '.other' => 'other.value'
+        ])->andReturn($query);
         $query->shouldReceive('delete')->once()->andReturn(true);
         $pivot->expects($this->once())->method('newQueryWithoutRelationships')->willReturn($query);
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -125,8 +125,8 @@ class DatabaseEloquentPivotTest extends TestCase
         $pivot->other = 'other.value';
         $query = m::mock(stdClass::class);
         $query->shouldReceive('where')->once()->with([
-            $pivot->getTable() . '.foreign' => 'foreign.value',
-            $pivot->getTable() . '.other' => 'other.value'
+            $pivot->getTable().'.foreign' => 'foreign.value',
+            $pivot->getTable().'.other' => 'other.value',
         ])->andReturn($query);
         $query->shouldReceive('delete')->once()->andReturn(true);
         $pivot->expects($this->once())->method('newQueryWithoutRelationships')->willReturn($query);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When attempting to detach a record from a model which has a global scope joining another table, the delete query fails to qualify the field names in the where clause. In turn, this means there is an opportunity to cause an ambiguous field error.
This change is making use of pre-existing functions to qualify the pivot keys and is non-breaking, test updated accordingly.


### Example Scenario:
**User**
```php
public function entities(): MorphToMany
    {
        return $this
            ->morphedByMany(Entity::class, 'group', 'user_groups')
            ->using(UserGroup::class)
            ->withTimestamps();
    }
```

**UserGroupScope**
```php
    public function apply(Builder $builder, Model $model): void
    {
        $userEntityModel = new UserEntity();

        $builder
            ->join(
                $userEntityModel->getTable(),
                fn(JoinClause $join) => $join
                    ->on(
                        $userEntityModel->qualifyColumn('user_id'),
                        '=',
                        $model->qualifyColumn('user_id')
                    )
                    ->on(
                        $userEntityModel->qualifyColumn('entity_id'),
                        '=',
                        $model->qualifyColumn('entity_id')
                    )
            )
            ->where($userEntityModel->qualifyColumn('status'), UserStatus::ACTIVE);
    }
```

**Function Call**
```php
$user->entities()->detach({{ID}})
```

This would result in an error similar to the following:
`SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'user_id' in where clause is ambiguous`
```sql
delete `user_groups` 
from `user_groups` 
inner join `user_entity` 
on `user_entity`.`user_id` = `user_groups`.`user_id` 
and `user_entity`.`entity_id` = `user_groups`.`entity_id` 
where (`user_id` = 2659 and `group_id` = 2) 
and `group_type` = ENTITY 
and `user_entity`.`status` = 1
```


This change will change the query to:
```sql
delete `user_groups` 
from `user_groups` 
inner join `user_entity` 
on `user_entity`.`user_id` = `user_groups`.`user_id` 
and `user_entity`.`entity_id` = `user_groups`.`entity_id` 
where (`user_groups`.`user_id` = 2659 and `user_groups`.`group_id` = 2) 
and `group_type` = ENTITY
and `user_entity`.`status` = 1
```