### PR TITLE
Add `table` option to `make:model` command

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/model.morph-pivot.table.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.morph-pivot.table.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
+
+class {{ class }} extends MorphPivot
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = '{{ tableName }}';
+}

--- a/src/Illuminate/Foundation/Console/stubs/model.pivot.table.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.pivot.table.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class {{ class }} extends Pivot
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = '{{ tableName }}';
+}

--- a/src/Illuminate/Foundation/Console/stubs/model.table.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.table.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class {{ class }} extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = '{{ tableName }}';
+}


### PR DESCRIPTION
Sometimes we create models that do not meet the naming conventions in laravel, this is often encountered when migrating projects to laravel and using existing databases, or on projects that are not based on English.

Currently we have to create a model and then add the `$table` property manually. By adding the `table` option then we can use the following command `artisan make:model Foo --table=bar`, this will create a model with the name Foo associated with the table `bar`. It will also create a table with the name `bar` if we use the `migration` option.