### PR TITLE
[9.x] Add missing vite() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Foundation\Bus\PendingClosureDispatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
+use Illuminate\Foundation\Vite;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Facades\Date;
@@ -556,6 +557,22 @@ if (! function_exists('mix')) {
     function mix($path, $manifestDirectory = '')
     {
         return app(Mix::class)(...func_get_args());
+    }
+}
+
+if (! function_exists('vite')) {
+    /**
+     * Get the path to a versioned Vite file.
+     *
+     * @param  string|string[]  $entrypoints
+     * @param  string  $buildDirectory
+     * @return \Illuminate\Support\HtmlString
+     *
+     * @throws \Exception
+     */
+    function vite($path, $manifestDirectory = '')
+    {
+        return app(Vite::class)(...func_get_args());
     }
 }
 


### PR DESCRIPTION
Hello there,

Here is my proposal to add a `vite()` helper that mimic the `mix()` helper behavior.

We sometimes need to get a versioned file path outside of a Blade view and it feels that it missing from the framework right now, as we currently only have a Blade directive to use it.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
