### PR TITLE
[9.x] Introduce artisan docs command

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,9 @@
 php:
   preset: laravel
   version: 8.1
+  finder:
+    not-name:
+      - bad-syntax-strategy.php
 js:
   finder:
     not-name:

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/log": "^1.0|^2.0|^3.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "ramsey/uuid": "^4.2.2",
-        "symfony/console": "^6.0",
+        "symfony/console": "^6.0.3",
         "symfony/error-handler": "^6.0",
         "symfony/finder": "^6.0",
         "symfony/http-foundation": "^6.0",

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -1,0 +1,509 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Carbon\CarbonInterval;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Http\Client\Factory as Http;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Env;
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+class DocsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'docs {page? : The documentation page to open} {section? : The section of the page to open}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Access the Laravel documentation with ease.';
+
+    /**
+     * The console command help text.
+     *
+     * @var string
+     */
+    protected $help = 'If you would like to perform a content search against the documention, you may call: <fg=green>php artisan docs -- </><fg=green;options=bold;>search query here</>';
+
+    /**
+     * The HTTP client.
+     *
+     * @var \Illuminate\Http\Client\Factory
+     */
+    protected $http;
+
+    /**
+     * The cache.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cache;
+
+    /**
+     * The custom url opener.
+     *
+     * @var callable|null
+     */
+    protected $urlOpener;
+
+    /**
+     * The custom documentation version to open.
+     *
+     * @var string|null
+     */
+    protected $version;
+
+    /**
+     * The operating system family.
+     *
+     * @var string
+     */
+    protected $systemOsFamily = PHP_OS_FAMILY;
+
+    public function __construct(Http $http, Cache $cache)
+    {
+        parent::__construct();
+
+        $this->http = $http;
+
+        $this->cache = $cache;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        try {
+            $this->openUrl();
+        } catch (ProcessFailedException $e) {
+            if ($e->getProcess()->getExitCodeText() === 'Interrupt') {
+                return $e->getProcess()->getExitCode();
+            }
+
+            throw $e;
+        }
+
+        $this->refreshDocs();
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Open the documentation URL.
+     *
+     * @return void
+     */
+    protected function openUrl()
+    {
+        with($this->url(), function ($url) {
+            $this->components->info("Opening the docs to: <fg=yellow>{$url}</>");
+
+            $this->open($url);
+        });
+    }
+
+    /**
+     * The URL to the documentation page.
+     *
+     * @return string
+     */
+    protected function url()
+    {
+        if ($this->isSearching()) {
+            return "https://laravel.com/docs/{$this->version()}?".Arr::query([
+                'q' => $this->searchQuery(),
+            ]);
+        }
+
+        return with($this->page(), function ($page) {
+            return trim("https://laravel.com/docs/{$this->version()}/{$page}#{$this->section($page)}", '#/');
+        });
+    }
+
+    /**
+     * The page the user is opening.
+     *
+     * @return string
+     */
+    protected function page()
+    {
+        return with($this->resolvePage(), function ($page) {
+            if ($page === null) {
+                $this->components->warn('Unable to determine the page you are trying to visit.');
+
+                return '/';
+            }
+
+            return $page;
+        });
+    }
+
+    /**
+     * Determine the page to open.
+     *
+     * @return ?string
+     */
+    protected function resolvePage()
+    {
+        if ($this->option('no-interaction') && $this->didNotRequestPage()) {
+            return '/';
+        }
+
+        return $this->didNotRequestPage()
+            ? $this->askForPage()
+            : $this->guessPage();
+    }
+
+    /**
+     * Determine if the user requested a specific page when calling the command.
+     *
+     * @return bool
+     */
+    protected function didNotRequestPage()
+    {
+        return $this->argument('page') === null;
+    }
+
+    /**
+     * Ask the user which page they would like to open.
+     *
+     * @return ?string
+     */
+    protected function askForPage()
+    {
+        return $this->askForPageViaCustomStrategy() ?? $this->askForPageViaAutocomplete();
+    }
+
+    /**
+     * Ask the user which page they would like to open via a custom strategy.
+     *
+     * @return ?string
+     */
+    protected function askForPageViaCustomStrategy()
+    {
+        try {
+            $strategy = require Env::get('ARTISAN_DOCS_ASK_STRATEGY');
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        if (! is_callable($strategy)) {
+            return null;
+        }
+
+        return $strategy($this) ?? '/';
+    }
+
+    /**
+     * Ask the user which page they would like to open using autocomplete.
+     *
+     * @return ?string
+     */
+    protected function askForPageViaAutocomplete()
+    {
+        $choice = $this->components->choice(
+            'Which page would you like to open?',
+            $this->pages()->mapWithKeys(fn ($option) => [
+                Str::lower($option['title']) => $option['title'],
+            ])->all(),
+            'installation',
+            3
+        );
+
+        return $this->pages()->filter(
+            fn ($page) => $page['title'] === $choice || Str::lower($page['title']) === $choice
+        )->keys()->first() ?: null;
+    }
+
+    /**
+     * Guess the page the user is requesting to open.
+     *
+     * @return ?string
+     */
+    protected function guessPage()
+    {
+        return $this->pages()
+            ->filter(fn ($page) => str_starts_with(
+                Str::slug($page['title'], ' '),
+                Str::slug($this->argument('page'), ' ')
+            ))->keys()->first() ?? $this->pages()->map(fn ($page) => similar_text(
+                Str::slug($page['title'], ' '),
+                Str::slug($this->argument('page'), ' '),
+            ))
+            ->filter(fn ($score) => $score >= min(3, Str::length($this->argument('page'))))
+            ->sortDesc()
+            ->keys()
+            ->sortByDesc(fn ($slug) => Str::contains(
+                Str::slug($this->pages()[$slug]['title'], ' '),
+                Str::slug($this->argument('page'), ' ')
+            ) ? 1 : 0)
+            ->first();
+    }
+
+    /**
+     * The section the user specifically asked to open.
+     *
+     * @param  string  $page
+     * @return ?string
+     */
+    protected function section($page)
+    {
+        return $this->didNotRequestSection()
+            ? null
+            : $this->guessSection($page);
+    }
+
+    /**
+     * Determine if the user requested a specific section when calling the command.
+     *
+     * @return bool
+     */
+    protected function didNotRequestSection()
+    {
+        return $this->argument('section') === null;
+    }
+
+    /**
+     * Guess the section the user is requesting to open.
+     *
+     * @param  string  $page
+     * @return ?string
+     */
+    protected function guessSection($page)
+    {
+        return $this->sectionsFor($page)
+            ->filter(fn ($section) => str_starts_with(
+                Str::slug($section['title'], ' '),
+                Str::slug($this->argument('section'), ' ')
+            ))->keys()->first() ?? $this->sectionsFor($page)->map(fn ($section) => similar_text(
+                Str::slug($section['title'], ' '),
+                Str::slug($this->argument('section'), ' '),
+            ))
+            ->filter(fn ($score) => $score >= min(3, Str::length($this->argument('section'))))
+            ->sortDesc()
+            ->keys()
+            ->sortByDesc(fn ($slug) => Str::contains(
+                Str::slug($this->sectionsFor($page)[$slug]['title'], ' '),
+                Str::slug($this->argument('section'), ' ')
+            ) ? 1 : 0)
+            ->first();
+    }
+
+    /**
+     * Open the URL.
+     *
+     * @param  string  $url
+     * @return void
+     */
+    protected function open($url)
+    {
+        ($this->urlOpener ?? function ($url) {
+            if (Env::get('ARTISAN_DOCS_OPEN_STRATEGY')) {
+                $this->openViaCustomStrategy($url);
+            } elseif (in_array($this->systemOsFamily, ['Darwin', 'Windows', 'Linux'])) {
+                $this->openViaBuiltInStrategy($url);
+            } else {
+                $this->components->warn('Unable to open the URL on your system. You will need to open it yourself.');
+            }
+        })($url);
+    }
+
+    /**
+     * Open the URL via a custom strategy.
+     *
+     * @param  string  $url
+     * @return void
+     */
+    protected function openViaCustomStrategy($url)
+    {
+        try {
+            $command = require Env::get('ARTISAN_DOCS_OPEN_STRATEGY');
+        } catch (Throwable $e) {
+            $command = null;
+        }
+
+        if (! is_callable($command)) {
+            $this->components->warn('Unable to open the URL with your custom strategy. You will need to open it yourself.');
+
+            return;
+        }
+
+        $command($url);
+    }
+
+    /**
+     * Open the URL via the built in strategy.
+     *
+     * @param  string  $url
+     * @return void
+     */
+    protected function openViaBuiltInStrategy($url)
+    {
+        $process = tap(Process::fromShellCommandline(match ($this->systemOsFamily) {
+            'Darwin' => 'open',
+            'Windows' => 'start',
+            'Linux' => 'xdg-open',
+        }.' '.escapeshellarg($url)))->run();
+
+        if (! $process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+
+    /**
+     * The available sections for the page.
+     *
+     * @param  string  $page
+     * @return \Illuminate\Support\Collection
+     */
+    public function sectionsFor($page)
+    {
+        return new Collection($this->pages()[$page]['sections']);
+    }
+
+    /**
+     * The pages available to open.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function pages()
+    {
+        return new Collection($this->docs()['pages']);
+    }
+
+    /**
+     * The documentation.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function docs()
+    {
+        return $this->cache->remember(
+            "artisan.docs.{{$this->version()}}.index",
+            CarbonInterval::months(2),
+            fn () => $this->fetchDocs()->throw()->collect()
+        );
+    }
+
+    /**
+     * Refresh the documentation.
+     *
+     * @return void
+     */
+    protected function refreshDocs()
+    {
+        with($this->fetchDocs(), function ($response) {
+            if ($response->successful()) {
+                $this->cache->put("artisan.docs.{{$this->version()}}.index", $response->collect(), CarbonInterval::months(2));
+            }
+        });
+    }
+
+    /**
+     * Fetch the documentation.
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    protected function fetchDocs()
+    {
+        return $this->http->get("https://laravel.com/docs/{$this->version()}/index.json");
+    }
+
+    /**
+     * The version of the docs to open.
+     *
+     * @return string
+     */
+    protected function version()
+    {
+        return Str::before(($this->version ?? $this->laravel->version()), '.').'.x';
+    }
+
+    /**
+     * The search to perform.
+     *
+     * @return string
+     */
+    protected function searchQuery()
+    {
+        return Collection::make($_SERVER['argv'])->skip(3)->implode(' ');
+    }
+
+    /**
+     * Determine if the command is intended to perform a search.
+     *
+     * @return bool
+     */
+    protected function isSearching()
+    {
+        return ($_SERVER['argv'][2] ?? null) === '--';
+    }
+
+    /**
+     * Configures the current command.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        if ($this->isSearching()) {
+            $this->ignoreValidationErrors();
+        }
+    }
+
+    /**
+     * Set the documentation version.
+     *
+     * @param  string  $version
+     * @return $this
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    /**
+     * Set a custom URL opener.
+     *
+     * @param  callable|null  $opener
+     * @return $this
+     */
+    public function setUrlOpener($opener)
+    {
+        $this->urlOpener = $opener;
+
+        return $this;
+    }
+
+    /**
+     * Set the system operating system family.
+     *
+     * @param  string  $family
+     * @return $this
+     */
+    public function setSystemOsFamily($family)
+    {
+        $this->systemOsFamily = $family;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -28,6 +28,7 @@ use Illuminate\Foundation\Console\ComponentMakeCommand;
 use Illuminate\Foundation\Console\ConfigCacheCommand;
 use Illuminate\Foundation\Console\ConfigClearCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
+use Illuminate\Foundation\Console\DocsCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
 use Illuminate\Foundation\Console\EventCacheCommand;
@@ -154,6 +155,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ComponentMake' => ComponentMakeCommand::class,
         'ConsoleMake' => ConsoleMakeCommand::class,
         'ControllerMake' => ControllerMakeCommand::class,
+        'Docs' => DocsCommand::class,
         'EventGenerate' => EventGenerateCommand::class,
         'EventMake' => EventMakeCommand::class,
         'ExceptionMake' => ExceptionMakeCommand::class,
@@ -390,6 +392,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerDbWipeCommand()
     {
         $this->app->singleton(WipeCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerDocsCommand()
+    {
+        $this->app->singleton(DocsCommand::class);
     }
 
     /**

--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -325,6 +325,8 @@ Working directory: expected-working-directory');
 
     protected function command()
     {
+        $this->app->forgetInstance(DocsCommand::class);
+
         return $this->app->make(DocsCommand::class)
             ->setVersion('8.30.12')
             ->setUrlOpener(function ($url) {

--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Console\DocsCommand;
+use Illuminate\Support\Facades\Http;
+use Orchestra\Testbench\TestCase;
+use RuntimeException;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class FoundationDocsCommandTest extends TestCase
+{
+    /**
+     * The URL opened by the command.
+     *
+     * @var ?string
+     */
+    protected $openedUrl;
+
+    /**
+     * The command registered to the container.
+     *
+     * @var \Illuminate\Foundation\Console\DocsCommand
+     */
+    protected $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Http::preventStrayRequests()->fake([
+            'https://laravel.com/docs/8.x/index.json' => Http::response(file_get_contents(__DIR__.'/fixtures/docs.json')),
+        ]);
+
+        $this->app[Kernel::class]->registerCommand($this->command());
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        putenv('ARTISAN_DOCS_ASK_STRATEGY');
+        putenv('ARTISAN_DOCS_OPEN_STRATEGY');
+    }
+
+    public function testItCanOpenTheLaravelDocumentation(): void
+    {
+        $this->artisan('docs')
+            ->expectsQuestion('Which page would you like to open?', '')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x');
+    }
+
+    public function testItCanSpecifyAutocompleteInOriginalCasing(): void
+    {
+        $this->artisan('docs')
+            ->expectsQuestion('Which page would you like to open?', 'Laravel Dusk')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+    }
+
+    public function testItCanSpecifyAutocompleteInLowerCasing(): void
+    {
+        $this->artisan('docs')
+            ->expectsQuestion('Which page would you like to open?', 'laravel dusk')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+    }
+
+    public function testItMatchesSectionsThatStartWithInput()
+    {
+        $this->artisan('docs el-col uni')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections#method-unique')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections#method-unique');
+    }
+
+    public function testItMatchesSectionsWithFuzzyMatching()
+    {
+        $this->artisan('docs el-col qery')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections#method-toquery')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections#method-toquery');
+    }
+
+    public function testItCanProvidePageToVisit(): void
+    {
+        $this->artisan('docs eloquent\ collections')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections');
+    }
+
+    public function testItCanUseHyphensInsteadOfEscapingSpaces(): void
+    {
+        $this->artisan('docs eloquent-collections')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections');
+    }
+
+    public function testItHasMinimumScoreToMatch(): void
+    {
+        $this->artisan('docs zag')
+            ->expectsOutputToContain('Unable to determine the page you are trying to visit.')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x');
+    }
+
+    public function testItMinimumScoreAccountsForInputLength(): void
+    {
+        $this->artisan('docs z')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/localization')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/localization');
+    }
+
+    public function testItCanUseCustomAskStrategy()
+    {
+        putenv('ARTISAN_DOCS_ASK_STRATEGY='.__DIR__.'/fixtures/always-dusk-ask-strategy.php');
+
+        $this->artisan('docs')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+    }
+
+    public function testItFallsbackToAutocompleteWhenAskStrategyContainsBadSyntax(): void
+    {
+        putenv('ARTISAN_DOCS_ASK_STRATEGY='.__DIR__.'/fixtures/bad-syntax-strategy.php');
+
+        $this->artisan('docs')
+            ->expectsQuestion('Which page would you like to open?', 'laravel dusk')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+    }
+
+    public function testItFallsbackToAutocompleteWithBadAskStrategyReturnValue(): void
+    {
+        putenv('ARTISAN_DOCS_ASK_STRATEGY='.__DIR__.'/fixtures/bad-return-strategy.php');
+
+        $this->artisan('docs')
+            ->expectsQuestion('Which page would you like to open?', 'laravel dusk')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/dusk')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/dusk');
+    }
+
+    public function testItCatchesAndHandlesProcessInterruptExceptionsInAskStrategies()
+    {
+        putenv('ARTISAN_DOCS_ASK_STRATEGY='.__DIR__.'/fixtures/process-interrupt-strategy.php');
+
+        $this->artisan('docs')->assertExitCode(130);
+    }
+
+    public function testItBubblesUpAskStrategyExceptions()
+    {
+        putenv('ARTISAN_DOCS_ASK_STRATEGY='.__DIR__.'/fixtures/exception-throwing-strategy.php');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('strategy failed');
+
+        $this->artisan('docs');
+    }
+
+    public function testItBubblesUpNonProcessInterruptExceptionsInAskStratgies()
+    {
+        putenv('ARTISAN_DOCS_ASK_STRATEGY='.__DIR__.'/fixtures/process-failure-strategy.php');
+
+        $this->expectException(ProcessFailedException::class);
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->expectExceptionMessage('The command "expected-command" failed.
+
+Exit Code: 1(General error)
+
+Working directory: expected-working-directory');
+        } else {
+            $this->expectExceptionMessage('The command "\'expected-command\'" failed.
+
+Exit Code: 1(General error)
+
+Working directory: expected-working-directory');
+        }
+
+        $this->artisan('docs');
+    }
+
+    public function testItCanGuessTheRequestedPageWhenItIsTheStartOfAPageTitle()
+    {
+        $this->artisan('docs elo')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent');
+    }
+
+    public function testItCanGuessTheRequestedPageWhenItIsContainedSomewhereInThePageTitle()
+    {
+        $this->artisan('docs quent')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent');
+    }
+
+    public function testItCanGuessTheWithTopAndTailMatching()
+    {
+        $this->artisan('docs elo-col')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/eloquent-collections')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/eloquent-collections');
+    }
+
+    public function testItCanSpecifyCustomOpenCommandsViaEnvVariables()
+    {
+        $GLOBALS['open-strategy-output-path'] = __DIR__.'/output.txt';
+        putenv('ARTISAN_DOCS_OPEN_STRATEGY='.__DIR__.'/fixtures/open-strategy.php');
+        $this->app[Kernel::class]->registerCommand($this->command()->setUrlOpener(null));
+
+        @unlink($GLOBALS['open-strategy-output-path']);
+
+        $this->artisan('docs installation')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/installation')
+            ->assertSuccessful();
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->assertSame('"https://laravel.com/docs/8.x/installation?expected-query=1"', trim(file_get_contents($GLOBALS['open-strategy-output-path'])));
+        } else {
+            $this->assertSame('https://laravel.com/docs/8.x/installation?expected-query=1', trim(file_get_contents($GLOBALS['open-strategy-output-path'])));
+        }
+
+        @unlink($GLOBALS['open-strategy-output-path']);
+        unset($GLOBALS['open-strategy-output-path']);
+    }
+
+    public function testItHandlesBadSyntaxInOpeners()
+    {
+        putenv('ARTISAN_DOCS_OPEN_STRATEGY='.__DIR__.'/fixtures/bad-syntax-strategy.php');
+        $this->app[Kernel::class]->registerCommand($this->command()->setUrlOpener(null));
+
+        $this->artisan('docs installation')
+            ->expectsOutputToContain('Unable to open the URL with your custom strategy. You will need to open it yourself.')
+            ->assertSuccessful();
+    }
+
+    public function testItHandlesBadReturnTypesInOpeners()
+    {
+        putenv('ARTISAN_DOCS_OPEN_STRATEGY='.__DIR__.'/fixtures/bad-return-strategy.php');
+        $this->app[Kernel::class]->registerCommand($this->command()->setUrlOpener(null));
+
+        $this->artisan('docs installation')
+            ->expectsOutputToContain('Unable to open the URL with your custom strategy. You will need to open it yourself.')
+            ->assertSuccessful();
+    }
+
+    public function testItCanPerformSearchAgainstLaravelDotCom()
+    {
+        $argCache = $_SERVER['argv'];
+        $_SERVER['argv'] = explode(' ', 'artisan docs -- here is my search term for the laravel website');
+        $this->app[Kernel::class]->registerCommand($this->command());
+
+        $this->artisan('docs -- here is my search term for the laravel website')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x?q=here%20is%20my%20search%20term%20for%20the%20laravel%20website')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x?q=here%20is%20my%20search%20term%20for%20the%20laravel%20website');
+
+        $_SERVER['argv'] = $argCache;
+    }
+
+    public function testUnknownSystemNotifiedToOpenManualy()
+    {
+        $this->app[Kernel::class]->registerCommand($this->command()->setUrlOpener(null)->setSystemOsFamily('Laravel OS'));
+
+        $this->artisan('docs validation')
+            ->expectsOutputToContain('Unable to open the URL on your system. You will need to open it yourself.')
+            ->assertSuccessful();
+    }
+
+    public function testGuessedMatchesThatDirectlyContainTheGivenStringRankHigerThanArbitraryMatches()
+    {
+        $this->artisan('docs ora')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/filesystem')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/filesystem');
+    }
+
+    public function testItHandlesPoorSpelling()
+    {
+        $this->artisan('docs vewis')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x/views')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x/views');
+    }
+
+    public function testItHandlesNoInteractionOption()
+    {
+        $this->artisan('docs -n')
+            ->expectsOutputToContain('Opening the docs to: https://laravel.com/docs/8.x')
+            ->assertSuccessful();
+
+        $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x');
+    }
+
+    protected function command()
+    {
+        return $this->app->make(DocsCommand::class)
+            ->setVersion('8.30.12')
+            ->setUrlOpener(function ($url) {
+                $this->openedUrl = $url;
+            });
+    }
+}

--- a/tests/Foundation/fixtures/always-dusk-ask-strategy.php
+++ b/tests/Foundation/fixtures/always-dusk-ask-strategy.php
@@ -1,0 +1,3 @@
+<?php
+
+return fn ($command) => 'dusk';

--- a/tests/Foundation/fixtures/bad-return-strategy.php
+++ b/tests/Foundation/fixtures/bad-return-strategy.php
@@ -1,0 +1,3 @@
+<?php
+
+return 9; // should return a callable

--- a/tests/Foundation/fixtures/bad-syntax-strategy.php
+++ b/tests/Foundation/fixtures/bad-syntax-strategy.php
@@ -1,0 +1,4 @@
+<?php
+
+); // bad syntax
+

--- a/tests/Foundation/fixtures/docs.json
+++ b/tests/Foundation/fixtures/docs.json
@@ -1,0 +1,96 @@
+{
+    "pages": {
+        "installation": {
+            "title": "Installation",
+            "sections": {}
+        },
+        "views": {
+            "title": "Views",
+            "sections": {}
+        },
+        "validation": {
+            "title": "Validation",
+            "sections": {}
+        },
+        "filesystem": {
+            "title": "File Storage",
+            "sections": {}
+        },
+        "localization": {
+            "title": "Localization",
+            "sections": {}
+        },
+        "eloquent": {
+            "title": "Eloquent: Getting Started",
+            "sections": {
+            }
+        },
+        "eloquent-collections": {
+            "title": "Eloquent: Collections",
+            "sections": {
+                "introduction": {
+                    "title": "Introduction"
+                },
+                "eloquent-collection-conversion": {
+                    "title": "Eloquent Collection Conversion"
+                },
+                "available-methods": {
+                    "title": "Available Methods"
+                },
+                "method-append": {
+                    "title": "`append($attributes)` {.collection-method .first-collection-method}"
+                },
+                "method-contains": {
+                    "title": "`contains($key, $operator = null, $value = null)` {.collection-method}"
+                },
+                "method-diff": {
+                    "title": "`diff($items)` {.collection-method}"
+                },
+                "method-except": {
+                    "title": "`except($keys)` {.collection-method}"
+                },
+                "method-find": {
+                    "title": "`find($key)` {.collection-method}"
+                },
+                "method-fresh": {
+                    "title": "`fresh($with = [])` {.collection-method}"
+                },
+                "method-intersect": {
+                    "title": "`intersect($items)` {.collection-method}"
+                },
+                "method-load": {
+                    "title": "`load($relations)` {.collection-method}"
+                },
+                "method-loadMissing": {
+                    "title": "`loadMissing($relations)` {.collection-method}"
+                },
+                "method-modelKeys": {
+                    "title": "`modelKeys()` {.collection-method}"
+                },
+                "method-makeVisible": {
+                    "title": "`makeVisible($attributes)` {.collection-method}"
+                },
+                "method-makeHidden": {
+                    "title": "`makeHidden($attributes)` {.collection-method}"
+                },
+                "method-only": {
+                    "title": "`only($keys)` {.collection-method}"
+                },
+                "method-toquery": {
+                    "title": "`toQuery()` {.collection-method}"
+                },
+                "method-unique": {
+                    "title": "`unique($key = null, $strict = false)` {.collection-method}"
+                },
+                "custom-collections": {
+                    "title": "Custom Collections"
+                }
+            }
+        },
+        "dusk": {
+            "title": "Laravel Dusk",
+            "sections": {}
+        }
+    }
+}
+

--- a/tests/Foundation/fixtures/exception-throwing-strategy.php
+++ b/tests/Foundation/fixtures/exception-throwing-strategy.php
@@ -1,0 +1,3 @@
+<?php
+
+return fn () => throw new RuntimeException('strategy failed');

--- a/tests/Foundation/fixtures/open-strategy.php
+++ b/tests/Foundation/fixtures/open-strategy.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+return function ($url) {
+    Process::fromShellCommandline(sprintf('echo %s > %s', escapeshellarg($url.'?expected-query=1'), escapeshellarg($GLOBALS['open-strategy-output-path'])))->run();
+};

--- a/tests/Foundation/fixtures/process-failure-strategy.php
+++ b/tests/Foundation/fixtures/process-failure-strategy.php
@@ -1,0 +1,27 @@
+<?php
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+return fn () => throw new ProcessFailedException(new class(['expected-command']) extends Process
+{
+    public function isSuccessful(): bool
+    {
+        return false;
+    }
+
+    public function getExitCode(): ?int
+    {
+        return 1;
+    }
+
+    public function isOutputDisabled(): bool
+    {
+        return true;
+    }
+
+    public function getWorkingDirectory(): ?string
+    {
+        return 'expected-working-directory';
+    }
+});

--- a/tests/Foundation/fixtures/process-interrupt-strategy.php
+++ b/tests/Foundation/fixtures/process-interrupt-strategy.php
@@ -1,0 +1,22 @@
+<?php
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+return fn () => throw new ProcessFailedException(new class([]) extends Process
+{
+    public function isSuccessful(): bool
+    {
+        return false;
+    }
+
+    public function getExitCode(): ?int
+    {
+        return 130;
+    }
+
+    public function isOutputDisabled(): bool
+    {
+        return true;
+    }
+});


### PR DESCRIPTION
(sorry for the length of this description. Just wanted to get everything out of my head) 

This PR introduces a new artisan command focused on giving developers quick access to documentation pages of the [Laravel documentation site](https://laravel.com/docs).

```sh
$ php artisan docs
```

The introduction of this feature was driven by my constant want to be able to access specific pages in the documentation quickly, such as the collection methods or validation rules, and is also inspired by the `npm docs {package}` command that opens the repository (and generally documentation) for different packages:

```sh
$ npm docs picomatch
```

For developers that spend a lot of time with `artisan` and a lot of time in the terminal, often you find yourself aliasing `php artisan` to `a`. With this in mind, I can now access the unique validation rule documentation with the following command:

```sh
$ a docs va un

> Opening the docs to: https://laravel.com/docs/9.x/validation#rule-unique
```

The new command also provides ways to perform an Algolia powered general search across the documentation site, as well as a few other handy features.

## `artisan docs`

The bare `artisan docs` command takes the approach of asking the user what page they would like to visit. This is done via the `choice` mechanism, which is useful for asking for input from a known list of options.

The choice list is populated with the top level pages of the Laravel documentation site.

https://user-images.githubusercontent.com/24803032/180363209-13a04235-d645-4488-b8f8-2751f103cba3.mov

### Default choice

The default choice for the interaction is `installation`. This allows developers to simply hit `<Enter>` and they will be taken to the entry point for the documentation (i.e. the same page you land on when you visit [https://laravel.com/docs](https://laravel.com/docs). See the following example where `<Enter>` represents you hitting the Enter / Return key on your keyboard.

```sh
$ php artisan docs<Enter><Enter>

> Opening the docs to: https://laravel.com/docs/9.x/installation
```

Alternatively, the command also respect the global `--no-interaction` flag, so the following will also take you to the entry point of the documentation without asking you for input:

```sh
$ php artisan docs -n

> Opening the docs to: https://laravel.com/docs/9.x
```

### Note: Casing

In order to provide a good user experience when using the `choice` mechanism, the optional key passed to the choice command uses a lower-cased version of the page title. This is why you will see the following in the output:
```
[laravel mix    ] Laravel Mix
[laravel octane ] Laravel Octane
 
 ^ lower case     ^ normal case
```
This means that users do not have to perfectly match the casing of the title, and can enter, for example: `validation` or `Validation` and will get the correct matches. Without this, only `Validation` would match correctly. This is a limitation of the `choice` mechanism, but I think this solution works well enough.

## `artisan docs {page}`


After using the command a few times, or when knowing where it is you want to go, it becomes nice to no longer be asked where you want to open, but instead to tell the command where you want to go.

The first argument of the command allows developers to specify a page to open.

```sh
$ php artisan docs validation

> Opening the docs to: https://laravel.com/docs/9.x/validation
```

> **Note** I've made it somewhat of a rule that the command always results in opening the docs, so there isn't a blocking step even on some kind of failure.

The command attempts to be smart when trying to determine the page the user is attempting to visit. First the command finds any page titles that begin with the argument provided, thus I don't need to enter `validation` completely, instead I can just enter `va`:

```sh
$ php artisan docs va

> Opening the docs to: https://laravel.com/docs/9.x/validation
```

If multiple pages begin with the argument, then the first match is selected, which results in the first matching page from the Laravel documentation sidebar being selected. To demo this, take the following command:

```sh
$ php artisan docs v
```

This command could match either "Validation" or "Views". However because "Views" comes first in the documentation sidebar, it is matched.

![Screen Shot 2022-07-22 at 3 18 16 pm](https://user-images.githubusercontent.com/24803032/180369499-9a2408bd-e4d0-4a81-b273-35734f26c15d.png)

```sh
$ php artisan docs v

> Opening the docs to: https://laravel.com/docs/9.x/views
```

If no pages start with the given argument, then the command attempts to "guess" what page the user was requesting. This is done with the `similar_text` function and also by giving priority to matches that contain the given argument exactly.

Given the misspelling of "views"

```sh
$ php artisan docs veiws

> Opening the docs to: https://laravel.com/docs/9.x/views
```

or given "ora" which is contained in "File stORAge". (remember that the matches are based on the page title, not the URL slug)

```sh
$ php artisan docs ora

> Opening the docs to: https://laravel.com/docs/9.x/filesystem
```

I have found the current algorithm to be rather forgiving and seems to work pretty well. No doubt when the community take a look there could be potential improvements. Perhaps a finely tuned [`levenshtein`](https://www.php.net/levenshtein) call would improve results, but I've personally been really happy with how it currently works and I'm not concerned about cost factor as it is all in-memory and not a production concern at all.

The algorithm does reject low quality matches (< 3) unless the argument passed in less than 3 characters long. There is probably room for improvement here as well where "low quality" always determined by the length of the argument.

Finally, the argument and page title are slugified (is that a word?!) before matching. This allows developers to not have to escape spaces in their arguments (although you still can) and instead utilise `-` characters instead.


This means that `a docs art-con` is equivilent to calling `a docs art\ con` 

```sh
$ php artisan docs art-con

> Opening the docs to: https://laravel.com/docs/9.x/artisan
```

That being said, `php artisan docs a` does the same thing due to the previously discussed matching criteria.


## `artisan docs {page} {section}`

Now that you can quickly and easily get to the validation page, you’re going to be soon asking yourself: 

> 🤔 Why the heck can't I just go straight to the available rules?!?
> 
> **- You (probably)**

Well have I got good new for you!

```sh
$ php artisan docs va rules

> Opening the docs to: https://laravel.com/docs/9.x/validation#available-validation-rules
```

And again, based on the above rules the shorter `php artisan docs va ru` also opens this link.

The section argument has the same guessing logic that the page argument has, however it only looks at sections of the already determined page.

There is future scope to improve this further still be providing extra weighting to higher level headings, I.e. `h2` headings might get priority over `h3` headings. Everything has been designed with this kind of enhancement in mind.

## `php artisan docs -- query string here`

In addition to being able to target specific pages, the command also allows you to open a global Algolia powered search on the Laravel documentation.

```sh
$ php artisan docs -- service container

> Opening the docs to: https://laravel.com/docs/9.x?q=service%20container
```

which will result in the following on page load...

![Screen Shot 2022-07-22 at 4 10 04 pm](https://user-images.githubusercontent.com/24803032/180374604-eab4baf6-5779-440b-8123-3f70ab4deee8.png)

I've documented this affordance in the commands help:

![Screen Shot 2022-07-22 at 4 18 07 pm](https://user-images.githubusercontent.com/24803032/180375892-f802cc98-7008-4e1f-b1bb-2a0c0718a681.png)

## Documentation version

The application version is read from the `Illuminate\Foundation\Application::version()` to generate the documentation links. This means that when Laravel X is released (🕵️‍♂️), projects using it will be directed to the appropriate documentation version.

```sh
$ composer create-project laravel/laravel:^10.0

$ php artisan docs -n

> Opening the docs to: https://laravel.com/docs/10.x
```

## Opening the URL

Out of the box, the command comes with some common ways of opening URLs across operating systems.

Window: `start {url}`
Mac: `open {url}`
Linux: `xdg-open {url}`

However, this doesn't cover every possible system. The command allows developer to customise how URLs are opened. But what's more is that the way this is customised is not on a project by project basis, but instead on a system level basis.

This means that I can customise the way the artisan docs command opens URLs once on my system, and it will be used across multiple projects without customisation within the project itself.

To customise the way the command opens URLs, a user may create an environment variable in their shell, that points to a PHP script.

For example, with ZSH on Mac I could do the following...

```zsh
# file: /Users/tim/.zshrc

export ARTISAN_DOCS_OPEN_STRATEGY="/Users/tim/artisan-open.php"
```

then at the path specified above, you can create a PHP script that returns a function. The function receives the URL to open as the first parameter.

```php
<?php

// file: /Users/tim/artisan-open.php

return fn ($url) => dump("my custom handler to open: {$url}");
```

This is nice as it allows each user to globally customise how their personal system opens URLs via the `artisan docs` command, however it is also interesting as it allows developers to come up with interesting things and share them as well.

It would be plausible that someone could, instead of opening the URL in the  browser, instead pipe the documentation as some kind of terminal friendly output, so you never leave the terminal. This could be done with something like [tty-markdown](https://github.com/piotrmurach/tty-markdown) or maybe [termwind](https://github.com/nunomaduro/termwind), however for this to be a first party solution, I believe we would need to put some work across the docs to make it happen. I would absolutely think this is something we should investigate further and potentially introduce behind a flag in 9.x and then, if it works well, we could make it the default in 10.x.

The shape of the docs `json` representation generated by the Laravel website has been specifically designed with this and other future enhancements in mind. 

The command also tries to recover from bad openers. This is again so that the user always lands on the docs even when an error occurs.

## Caching

When the command is first used, the data required to power the command is downloaded from the Laravel website.

This data is then cached for 2 months. During this month, whenever the command is used again, the cache is used to determine the page to visit, however the cached data is also _lazily_ refreshed in the background after the command has opened the user to the documentation site.

This means that the user doesn't have to wait for the data to be downloaded every time the command runs, but also gets the benefit of having fresh data in the cache if used often.

## Custom ask strategies

Although the Symfony choice mechanism does work, it isn't as user friendly as I had hoped. This drove me to see what else I could come up with for the command to improve the experience of being asked a question, which might drive others to come up with interesting approaches as well.

_I'm not 100% sure this feature should be included, but it is novel, so I've left it in for now._

Just like with opening the URL, a developer may globally change how they are asked for pages from the command.

On my system I have installed the cross-platform [`fzf` fuzzy finder](https://github.com/junegunn/fzf). I'm going to create a strategy to allow me to use FZF in place of the `choice` mechanism.

```zsh
# file: /Users/tim/.zshrc

export ARTISAN_DOCS_ASK_STRATEGY="/Users/tim/artisan-ask.php"
```

Then in my ask strategy I return a function. The function accepts the command as it's first argument. Note I have full access to Laravel and other installed dependencies - however you should keep your requirements to a minimum as they need to be cross-project.

```php
<?php

// file: /Users/tim/artisan-ask.php

use Illuminate\Support\Str;
use Symfony\Component\Process\Exception\ProcessFailedException;
use Symfony\Component\Process\ExecutableFinder;
use Symfony\Component\Process\Process;

return function ($command) {
    $path = tempnam(sys_get_temp_dir(), 'artisan-docs-fzf');

    $options = $command->pages()->flatMap(fn ($page, $pageSlug) => [
        $pageSlug . ': ' . $page['title'],
        //
        // Un-comment this to include page sections as well...
        //
        // ...$command->sectionsFor($pageSlug)->map(fn ($section, $sectionSlug) => $pageSlug.'#'.$sectionSlug.': '.$page['title'].' / '.$section['title'])->all()
        //
    ]);

    $process = tap(Process::fromShellCommandline(sprintf(
        "echo %s | %s > %s",
        escapeshellarg($options->implode(PHP_EOL)),
        escapeshellarg((new ExecutableFinder())->find('fzf')),
        escapeshellarg($path)
    ))->setTty(true))->run();

    if (! $process->isSuccessful()) {
        throw new ProcessFailedException($process);
    }

    return Str::before(file_get_contents($path), ':');
};
```

Now I am using `fzf` as my ask strategy for ultimate goodness...

https://user-images.githubusercontent.com/24803032/180382183-5bd63f03-5639-45de-bef2-1c8fff992435.mov

## Taking it for a spin

This PR is dependent on some other PRs (list below) to "just work". In the meantime however, you may run the following script on a Mac to get it working locally. You may need to make adjustments for other systems.

```sh
composer create-project laravel/laravel artisan-docs-command \
  && cd artisan-docs-command \
  && wget -O pages.json https://github.com/laravel/laravel.com/files/9178424/pages.json.txt \
  && mkdir app/Console/Commands \
  && wget -O app/Console/Commands/DocsCommand.php https://raw.githubusercontent.com/timacdonald/framework/artisan-docs/src/Illuminate/Foundation/Console/DocsCommand.php \
  && sed -i "s/namespace Illuminate\\\\Foundation\\\\Console/namespace App\\\\Console\\\\Commands/" app/Console/Commands/DocsCommand.php \
  && echo "<?php namespace App\Providers;use Illuminate\Support\Facades\Http;use Illuminate\Support\ServiceProvider;class AppServiceProvider extends ServiceProvider {public function boot() {Http::preventStrayRequests()->fake(['https://laravel.com/docs/9.x/index.json' => Http::response(file_get_contents(base_path('pages.json')))]);}}" > app/Providers/AppServiceProvider.php
```

## Future scope

- Showing docs in the terminal as previously mentioned
- Passing a class / namespace and being taken to the most relevant docs for that FQCN 
- Give weighting to different heading levels for sections.
- Improved first-party console based fuzzy finding / matching.

## Dependent PRs

- https://github.com/laravel/laravel.com/pull/242
- https://github.com/laravel/laravel.com/pull/243