### PR TITLE
[9.x] Fixes default attribute value when using enums on `model:show`

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -330,7 +330,7 @@ class ShowModelCommand extends Command
 
             if ($attribute['default'] !== null) {
                 $this->components->bulletList(
-                    [sprintf('default: %s', $attribute['default'] instanceof UnitEnum? $attribute['default']->name : $attribute['default'])],
+                    [sprintf('default: %s', $attribute['default'] instanceof UnitEnum ? $attribute['default']->name : $attribute['default'])],
                     OutputInterface::VERBOSITY_VERBOSE
                 );
             }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
+use UnitEnum;
 
 #[AsCommand(name: 'model:show')]
 class ShowModelCommand extends Command
@@ -329,7 +330,7 @@ class ShowModelCommand extends Command
 
             if ($attribute['default'] !== null) {
                 $this->components->bulletList(
-                    [sprintf('default: %s', $attribute['default'])],
+                    [sprintf('default: %s', $attribute['default'] instanceof UnitEnum? $attribute['default']->name : $attribute['default'])],
                     OutputInterface::VERBOSITY_VERBOSE
                 );
             }


### PR DESCRIPTION
## Problem

Having an `UnitEnum` or `BackedEnum` as default attribute value in a Model, like this:

```php
    protected $casts = [
        'status' => InvoiceStatus::class,
    ];

    protected $attributes = [
        'status' => InvoiceStatus::I_LOVE_LARAVEL,
    ];
```

Triggers an error on `model:show` command:

`ERROR: Object of class App\Enums\InvoiceStatus could not be converted to string`

## Fix

This PR fixes it displaying the value of enums `name` attribute:

```bash
 status fillable ................................... integer / App\Enums\InvoiceStatus
  ⇂ default: I_LOVE_LARAVEL
```
