### PR TITLE
[8.x] Fix DynamoDB locks with 0 seconds duration

### DIFF
--- a/src/Illuminate/Cache/DynamoDbLock.php
+++ b/src/Illuminate/Cache/DynamoDbLock.php
@@ -34,9 +34,12 @@ class DynamoDbLock extends Lock
      */
     public function acquire()
     {
-        return $this->dynamo->add(
-            $this->name, $this->owner, $this->seconds
-        );
+        if ($this->seconds > 0) {
+            return $this->dynamo->add($this->name, $this->owner, $this->seconds);
+        } else {
+            // default to 1 day
+            return $this->dynamo->add($this->name, $this->owner, 86400);
+        }
     }
 
     /**

--- a/src/Illuminate/Cache/DynamoDbLock.php
+++ b/src/Illuminate/Cache/DynamoDbLock.php
@@ -37,7 +37,6 @@ class DynamoDbLock extends Lock
         if ($this->seconds > 0) {
             return $this->dynamo->add($this->name, $this->owner, $this->seconds);
         } else {
-            // default to 1 day
             return $this->dynamo->add($this->name, $this->owner, 86400);
         }
     }


### PR DESCRIPTION
I've added a default lock duration of 1 day for DynamoDB locks.

This makes the behavior consistent with `DatabaseLock`:
https://github.com/laravel/framework/blob/d425952e8cc664b01de8bd654336c1be8dcf7444/src/Illuminate/Cache/DatabaseLock.php#L92-L95


Fix #43280