### PR TITLE
[9.x] New `db:show`, `db:table` and `db:monitor` commands

### DIFF
--- a/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
+++ b/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
@@ -9,12 +9,33 @@ use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Composer;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
 
 abstract class AbstractDatabaseCommand extends Command
 {
+    /**
+     * The Composer instance.
+     *
+     * @var \Illuminate\Support\Composer
+     */
+    protected $composer;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Support\Composer  $composer
+     * @return void
+     */
+    public function __construct(Composer $composer)
+    {
+        parent::__construct();
+
+        $this->composer = $composer;
+    }
+
     /**
      * Get a human-readable platform name.
      *

--- a/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
+++ b/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
@@ -110,33 +110,33 @@ abstract class AbstractDatabaseCommand extends Command
      * Get the number of open connections for a Postgres database.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @return mixed
+     * @return int
      */
     protected function getPgsqlConnectionCount(ConnectionInterface $connection)
     {
-        return $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections;
+        return (int) $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections;
     }
 
     /**
      * Get the number of open connections for a MySQL database.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @return mixed
+     * @return int
      */
     protected function getMySQLConnectionCount(ConnectionInterface $connection)
     {
-        return $connection->selectOne($connection->raw('show status where variable_name = "threads_connected"'))->Value;
+        return (int) $connection->selectOne($connection->raw('show status where variable_name = "threads_connected"'))->Value;
     }
 
     /**
      * Get the number of open connections for an SQL Server database.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @return mixed
+     * @return int
      */
     protected function getSqlServerConnectionCount(ConnectionInterface $connection)
     {
-        return $connection->selectOne('SELECT COUNT(*) connections FROM sys.dm_exec_sessions WHERE status = ?', ['running'])->connections;
+        return (int) $connection->selectOne('SELECT COUNT(*) connections FROM sys.dm_exec_sessions WHERE status = ?', ['running'])->connections;
     }
 
     /**

--- a/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
+++ b/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
@@ -41,7 +41,7 @@ abstract class AbstractDatabaseCommand extends Command
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @param  string  $table
-     * @return null
+     * @return int|null
      */
     protected function getTableSize(ConnectionInterface $connection, string $table)
     {

--- a/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
+++ b/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
@@ -5,6 +5,9 @@ namespace Illuminate\Database\Console;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Illuminate\Console\Command;
 use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Arr;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Exception\RuntimeException;
@@ -42,10 +45,10 @@ abstract class AbstractDatabaseCommand extends Command
      */
     protected function getTableSize(ConnectionInterface $connection, string $table)
     {
-        return match (class_basename($connection)) {
-            'MySqlConnection' => $this->getMySQLTableSize($connection, $table),
-            'PostgresConnection' => $this->getPgsqlTableSize($connection, $table),
-            'SqliteConnection' => $this->getSqliteTableSize($connection, $table),
+        return match (true) {
+            $connection instanceof MySqlConnection => $this->getMySQLTableSize($connection, $table),
+            $connection instanceof PostgresConnection => $this->getPgsqlTableSize($connection, $table),
+            $connection instanceof SQLiteConnection => $this->getSqliteTableSize($connection, $table),
             default => null,
         };
     }
@@ -158,7 +161,7 @@ abstract class AbstractDatabaseCommand extends Command
     /**
      * Ensure the dependencies for the database commands are available.
      *
-     * @return int
+     * @return int|null
      */
     protected function ensureDependenciesExist()
     {

--- a/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
+++ b/src/Illuminate/Database/Console/AbstractDatabaseCommand.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Illuminate\Console\Command;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Arr;
+
+abstract class AbstractDatabaseCommand extends Command
+{
+    /**
+     * Get a human-readable platform name.
+     *
+     * @param  \Doctrine\DBAL\Platforms\AbstractPlatform  $platform
+     * @param  string  $database
+     * @return string
+     */
+    protected function getPlatformName(AbstractPlatform $platform, $database)
+    {
+        return match(class_basename($platform)) {
+            'MySQLPlatform' => 'MySQL <= 5',
+            'MySQL57Platform' => 'MySQL 5.7',
+            'MySQL80Platform' => 'MySQL 8',
+            'PostgreSQL100Platform', 'PostgreSQLPlatform' => 'Postgres',
+            'SqlitePlatform' => 'SQLite',
+            'SQLServerPlatform' => 'SQL Server',
+            'SQLServer2012Platform' => 'SQL Server 2012',
+            default => $database,
+        };
+    }
+
+    /**
+     * Get the size of a table in bytes.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return null
+     */
+    protected function getTableSize(ConnectionInterface $connection, string $table)
+    {
+        return match(class_basename($connection)) {
+            'MySqlConnection' => $this->getMySQLTableSize($connection, $table),
+            'PostgresConnection' => $this->getPgsqlTableSize($connection, $table),
+            'SqliteConnection' => $this->getSqliteTableSize($connection, $table),
+            default => null,
+        };
+    }
+
+    /**
+     * Get the size of a MySQL table in bytes.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return mixed
+     */
+    protected function getMySQLTableSize(ConnectionInterface $connection, string $table)
+    {
+        return $connection->selectOne('SELECT (data_length + index_length) AS size FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?', [
+            $connection->getDatabaseName(),
+            $table,
+        ])->size;
+    }
+
+    /**
+     * Get the size of a Postgres table in bytes.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return mixed
+     */
+    protected function getPgsqlTableSize(ConnectionInterface $connection, string $table)
+    {
+        return $connection->selectOne('SELECT pg_total_relation_size(?) AS size;', [
+            $table,
+        ])->size;
+    }
+
+    /**
+     * Get the size of a SQLite table in bytes.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return mixed
+     */
+    protected function getSqliteTableSize(ConnectionInterface $connection, string $table)
+    {
+        return $connection->selectOne('SELECT SUM(pgsize) FROM dbstat WHERE name=?', [
+            $table,
+        ])->size;
+    }
+
+    /**
+     * Get the number of open connections for a database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return null
+     */
+    protected function getConnectionCount(ConnectionInterface $connection)
+    {
+        return match(class_basename($connection)) {
+            'MySqlConnection' => $this->getMySQLConnectionCount($connection),
+            'PostgresConnection' => $this->getPgsqlConnectionCount($connection),
+            'SqlServerConnection' => $this->getSqlServerConnectionCount($connection),
+            default => null,
+        };
+    }
+
+    /**
+     * Get the number of open connections for a Postgres database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return mixed
+     */
+    protected function getPgsqlConnectionCount(ConnectionInterface $connection)
+    {
+        return $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections;
+    }
+
+    /**
+     * Get the number of open connections for a MySQL database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return mixed
+     */
+    protected function getMySQLConnectionCount(ConnectionInterface $connection)
+    {
+        return $connection->selectOne($connection->raw('show status where variable_name = "threads_connected"'))->Value;
+    }
+
+    /**
+     * Get the number of open connections for an SQL Server database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return mixed
+     */
+    protected function getSqlServerConnectionCount(ConnectionInterface $connection)
+    {
+        return $connection->selectOne('SELECT COUNT(*) connections FROM sys.dm_exec_sessions WHERE status = ?', ['running'])->connections;
+    }
+
+    /**
+     * Get the connection details from the configuration.
+     *
+     * @param  string  $database
+     * @return array
+     */
+    protected function getConfigFromDatabase($database)
+    {
+        $database ??= config('database.default');
+
+        return Arr::except(config('database.connections.'.$database), ['password']);
+    }
+}

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Console;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface;
-use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Events\DatabaseBusy;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -128,7 +127,8 @@ class MonitorCommand extends AbstractDatabaseCommand
      * @param  \Illuminate\Support\Collection  $databases
      * @return void
      */
-    protected function dispatchEvents($databases) {
+    protected function dispatchEvents($databases)
+    {
         $databases->each(function ($database) {
             if ($database['status'] === '<fg=green;options=bold>OK</>') {
                 return;

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -57,7 +57,7 @@ class MonitorCommand extends AbstractDatabaseCommand
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $connection
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
-     * * @param  \Illuminate\Support\Composer  $composer
+     *                                                           * @param  \Illuminate\Support\Composer  $composer
      */
     public function __construct(ConnectionResolverInterface $connection, Dispatcher $events, Composer $composer)
     {
@@ -92,7 +92,7 @@ class MonitorCommand extends AbstractDatabaseCommand
     protected function parseDatabases($databases)
     {
         return collect(explode(',', $databases))->map(function ($database) {
-            if (!$database) {
+            if (! $database) {
                 $database = $this->laravel['config']['database.default'];
             }
 
@@ -119,7 +119,7 @@ class MonitorCommand extends AbstractDatabaseCommand
         $this->components->twoColumnDetail('<fg=gray>Database name</>', '<fg=gray>Connections</>');
 
         $databases->each(function ($database) {
-            $status = '[' . $database['connections'] . '] ' . $database['status'];
+            $status = '['.$database['connections'].'] '.$database['status'];
 
             $this->components->twoColumnDetail($database['database'], $status);
         });

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Composer;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'db:monitor')]
-class MonitorCommand extends AbstractDatabaseCommand
+class MonitorCommand extends DatabaseInspectionCommand
 {
     /**
      * The name and signature of the console command.
@@ -17,7 +17,7 @@ class MonitorCommand extends AbstractDatabaseCommand
      * @var string
      */
     protected $signature = 'db:monitor
-                {--databases= : The names of the databases to monitor}
+                {--databases= : The database connections to monitor}
                 {--max= : The maximum number of connections that can be open before an event is dispatched}';
 
     /**
@@ -53,7 +53,7 @@ class MonitorCommand extends AbstractDatabaseCommand
     protected $events;
 
     /**
-     * Create a new db monitor command.
+     * Create a new command instance.
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $connection
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
@@ -107,7 +107,7 @@ class MonitorCommand extends AbstractDatabaseCommand
     }
 
     /**
-     * Display the databases and their connections in the console.
+     * Display the databases and their connection counts in the console.
      *
      * @param  \Illuminate\Support\Collection  $databases
      * @return void
@@ -128,7 +128,7 @@ class MonitorCommand extends AbstractDatabaseCommand
     }
 
     /**
-     * Fire the monitoring events.
+     * Dispatch the database monitoring events.
      *
      * @param  \Illuminate\Support\Collection  $databases
      * @return void

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Events\DatabaseBusy;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'db:monitor')]
+class MonitorCommand extends AbstractDatabaseCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:monitor
+                {--databases= : The names of the databases to monitor}
+                {--max=5 : The maximum number of connections that can be open before an event is dispatched}';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'db:monitor';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Monitor the number of connections on the specified database';
+
+    /**
+     * The connection resolver instance.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $connection;
+
+    /**
+     * The events dispatcher instance.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    protected $events;
+
+    /**
+     * Create a new db monitor command.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $connection
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+     */
+    public function __construct(ConnectionResolverInterface $connection, Dispatcher $events)
+    {
+        parent::__construct();
+
+        $this->connection = $connection;
+        $this->events = $events;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $databases = $this->parseDatabases($this->option('databases'));
+
+        $this->displayConnections($databases);
+
+        $this->dispatchEvents($databases);
+    }
+
+    /**
+     * Parse the database into an array of the connections.
+     *
+     * @param  string  $databases
+     * @return \Illuminate\Support\Collection
+     */
+    protected function parseDatabases($databases)
+    {
+        return collect(explode(',', $databases))->map(function ($database) {
+            if (! $database) {
+                $database = $this->laravel['config']['database.default'];
+            }
+
+            return [
+                'database' => $database,
+                'connections' => $connections = $this->getConnectionCount($this->connection->connection($database)),
+                'status' => $connections >= $this->option('max') ? '<fg=yellow;options=bold>ALERT</>' : '<fg=green;options=bold>OK</>',
+            ];
+        });
+    }
+
+    /**
+     * Display the databases and their connections in the console.
+     *
+     * @param  \Illuminate\Support\Collection  $databases
+     * @return void
+     */
+    protected function displayConnections($databases)
+    {
+        $this->newLine();
+
+        $this->components->twoColumnDetail('<fg=gray>Database name</>', '<fg=gray>Connections</>');
+
+        $databases->each(function ($database) {
+            $status = '['.$database['connections'].'] '.$database['status'];
+
+            $this->components->twoColumnDetail($database['database'], $status);
+        });
+
+        $this->newLine();
+    }
+
+    /**
+     * Fire the monitoring events.
+     *
+     * @param  \Illuminate\Support\Collection  $databases
+     * @return void
+     */
+    protected function dispatchEvents($databases) {
+        $databases->each(function ($database) {
+            if ($database['status'] === '<fg=green;options=bold>OK</>') {
+                return;
+            }
+
+            $this->events->dispatch(
+                new DatabaseBusy(
+                    $database['database'],
+                    $database['connections']
+                )
+            );
+        });
+    }
+}

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -57,7 +57,7 @@ class MonitorCommand extends AbstractDatabaseCommand
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $connection
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
-     *                                                           * @param  \Illuminate\Support\Composer  $composer
+     * @param  \Illuminate\Support\Composer  $composer
      */
     public function __construct(ConnectionResolverInterface $connection, Dispatcher $events, Composer $composer)
     {

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -16,7 +16,7 @@ class MonitorCommand extends AbstractDatabaseCommand
      * @var string
      */
     protected $signature = 'db:monitor
-                {databases : The names of the databases to monitor}
+                {--databases= : The names of the databases to monitor}
                 {--max= : The maximum number of connections that can be open before an event is dispatched}';
 
     /**
@@ -72,7 +72,7 @@ class MonitorCommand extends AbstractDatabaseCommand
      */
     public function handle()
     {
-        $databases = $this->parseDatabases($this->argument('databases'));
+        $databases = $this->parseDatabases($this->option('databases'));
 
         $this->displayConnections($databases);
 

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -16,7 +16,7 @@ class MonitorCommand extends AbstractDatabaseCommand
      * @var string
      */
     protected $signature = 'db:monitor
-                {--databases= : The names of the databases to monitor}
+                {databases : The names of the databases to monitor}
                 {--max= : The maximum number of connections that can be open before an event is dispatched}';
 
     /**
@@ -72,7 +72,7 @@ class MonitorCommand extends AbstractDatabaseCommand
      */
     public function handle()
     {
-        $databases = $this->parseDatabases($this->option('databases'));
+        $databases = $this->parseDatabases($this->argument('databases'));
 
         $this->displayConnections($databases);
 

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -17,7 +17,7 @@ class MonitorCommand extends AbstractDatabaseCommand
      */
     protected $signature = 'db:monitor
                 {--databases= : The names of the databases to monitor}
-                {--max=5 : The maximum number of connections that can be open before an event is dispatched}';
+                {--max= : The maximum number of connections that can be open before an event is dispatched}';
 
     /**
      * The name of the console command.
@@ -76,7 +76,9 @@ class MonitorCommand extends AbstractDatabaseCommand
 
         $this->displayConnections($databases);
 
-        $this->dispatchEvents($databases);
+        if ($this->option('max')) {
+            $this->dispatchEvents($databases);
+        }
     }
 
     /**
@@ -92,10 +94,12 @@ class MonitorCommand extends AbstractDatabaseCommand
                 $database = $this->laravel['config']['database.default'];
             }
 
+            $maxConnections = $this->option('max');
+
             return [
                 'database' => $database,
                 'connections' => $connections = $this->getConnectionCount($this->connection->connection($database)),
-                'status' => $connections >= $this->option('max') ? '<fg=yellow;options=bold>ALERT</>' : '<fg=green;options=bold>OK</>',
+                'status' => $maxConnections && $connections >= $maxConnections ? '<fg=yellow;options=bold>ALERT</>' : '<fg=green;options=bold>OK</>',
             ];
         });
     }

--- a/src/Illuminate/Database/Console/MonitorCommand.php
+++ b/src/Illuminate/Database/Console/MonitorCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Console;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Events\DatabaseBusy;
+use Illuminate\Support\Composer;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'db:monitor')]
@@ -56,10 +57,11 @@ class MonitorCommand extends AbstractDatabaseCommand
      *
      * @param  \Illuminate\Database\ConnectionResolverInterface  $connection
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+     * * @param  \Illuminate\Support\Composer  $composer
      */
-    public function __construct(ConnectionResolverInterface $connection, Dispatcher $events)
+    public function __construct(ConnectionResolverInterface $connection, Dispatcher $events, Composer $composer)
     {
-        parent::__construct();
+        parent::__construct($composer);
 
         $this->connection = $connection;
         $this->events = $events;
@@ -90,7 +92,7 @@ class MonitorCommand extends AbstractDatabaseCommand
     protected function parseDatabases($databases)
     {
         return collect(explode(',', $databases))->map(function ($database) {
-            if (! $database) {
+            if (!$database) {
                 $database = $this->laravel['config']['database.default'];
             }
 
@@ -117,7 +119,7 @@ class MonitorCommand extends AbstractDatabaseCommand
         $this->components->twoColumnDetail('<fg=gray>Database name</>', '<fg=gray>Connections</>');
 
         $databases->each(function ($database) {
-            $status = '['.$database['connections'].'] '.$database['status'];
+            $status = '[' . $database['connections'] . '] ' . $database['status'];
 
             $this->components->twoColumnDetail($database['database'], $status);
         });

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -130,14 +130,15 @@ class ShowCommand extends Command
         $this->newLine();
 
         $this->components->twoColumnDetail('<fg=green;options=bold>'.$platform['name'].'</>');
+        $this->components->twoColumnDetail('Database', Arr::get($platform['config'], 'database'));
         $this->components->twoColumnDetail('Host', Arr::get($platform['config'], 'host'));
         $this->components->twoColumnDetail('Port', Arr::get($platform['config'], 'port'));
         $this->components->twoColumnDetail('Username', Arr::get($platform['config'], 'username'));
         $this->components->twoColumnDetail('URL', Arr::get($platform['config'], 'url'));
         $this->components->twoColumnDetail('Open Connections', $platform['open_connections']);
-        $this->components->twoColumnDetail('Total Tables', $tables->count());
+        $this->components->twoColumnDetail('Tables', $tables->count());
         if ($tableSizeSum = $tables->sum('size')) {
-            $this->components->twoColumnDetail('Total Table Size', number_format($tables->sum('size') / 1024 / 1024, 2) . 'Mb');
+            $this->components->twoColumnDetail('Total Size', number_format($tables->sum('size') / 1024 / 1024, 2) . 'Mb');
         }
 
         $this->newLine();
@@ -152,7 +153,7 @@ class ShowCommand extends Command
                 }
 
                 $this->components->twoColumnDetail(
-                    $table['table']. ' <fg=gray>' . $table['engine'].'</>',
+                    $table['table']. ($this->output->isVerbose() ? ' <fg=gray>' . $table['engine'].'</>' : null),
                     number_format($table['size'] / 1024 / 1024, 2).' / <fg=yellow;options=bold>'.number_format($table['rows']).'</>'
                 );
 

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -142,17 +142,16 @@ class ShowCommand extends AbstractDatabaseCommand
         $this->newLine();
 
         if ($tables->isNotEmpty()) {
-            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb) / <fg=yellow;options=bold>Rows</>');
+            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb) <fg=gray;options=bold>/</> <fg=yellow;options=bold>Rows</>');
 
             $tables->each(function ($table) {
-                $tableSize = null;
                 if ($tableSize = $table['size']) {
-
+                    $tableSize = number_format($tableSize / 1024 / 1024, 2);
                 }
 
                 $this->components->twoColumnDetail(
                     $table['table']. ($this->output->isVerbose() ? ' <fg=gray>' . $table['engine'].'</>' : null),
-                    number_format($table['size'] / 1024 / 1024, 2).' / <fg=yellow;options=bold>'.number_format($table['rows']).'</>'
+                    ($tableSize ? $tableSize . ' <fg=gray;options=bold>/</> ' : '— <fg=gray;options=bold>/</> ').'<fg=yellow;options=bold>'.number_format($table['rows']).'</>'
                 );
 
                 if ($this->output->isVerbose()) {

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -2,16 +2,14 @@
 
 namespace Illuminate\Database\Console;
 
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\View;
-use Illuminate\Console\Command;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Arr;
 
-class ShowCommand extends Command
+class ShowCommand extends AbstractDatabaseCommand
 {
     /**
      * The name and signature of the console command.
@@ -176,148 +174,5 @@ class ShowCommand extends Command
 
             $this->newLine();
         }
-    }
-
-    /**
-     * Get a human-readable platform name.
-     *
-     * @param  \Doctrine\DBAL\Platforms\AbstractPlatform  $platform
-     * @param  string  $database
-     * @return string
-     */
-    protected function getPlatformName(AbstractPlatform $platform, $database)
-    {
-        return match(class_basename($platform)) {
-            'MySQLPlatform' => 'MySQL <= 5',
-            'MySQL57Platform' => 'MySQL 5.7',
-            'MySQL80Platform' => 'MySQL 8',
-            'PostgreSQL100Platform', 'PostgreSQLPlatform' => 'Postgres',
-            'SqlitePlatform' => 'SQLite',
-            'SQLServerPlatform' => 'SQL Server',
-            'SQLServer2012Platform' => 'SQL Server 2012',
-            default => $database,
-        };
-    }
-
-    /**
-     * Get the size of a table in bytes.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @param  string  $table
-     * @return null
-     */
-    protected function getTableSize(ConnectionInterface $connection, string $table)
-    {
-        return match(class_basename($connection)) {
-            'MySqlConnection' => $this->getMySQLTableSize($connection, $table),
-            'PostgresConnection' => $this->getPgsqlTableSize($connection, $table),
-            'SqliteConnection' => $this->getSqliteTableSize($connection, $table),
-            default => null,
-        };
-    }
-
-    /**
-     * Get the size of a MySQL table in bytes.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @param  string  $table
-     * @return mixed
-     */
-    protected function getMySQLTableSize(ConnectionInterface $connection, string $table)
-    {
-        return $connection->selectOne('SELECT (data_length + index_length) AS size FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?', [
-            $connection->getDatabaseName(),
-            $table,
-        ])->size;
-    }
-
-    /**
-     * Get the size of a Postgres table in bytes.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @param  string  $table
-     * @return mixed
-     */
-    protected function getPgsqlTableSize(ConnectionInterface $connection, string $table)
-    {
-        return $connection->selectOne('SELECT pg_total_relation_size(?) AS size;', [
-            $table,
-        ])->size;
-    }
-
-    /**
-     * Get the size of a SQLite table in bytes.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @param  string  $table
-     * @return mixed
-     */
-    protected function getSqliteTableSize(ConnectionInterface $connection, string $table)
-    {
-        return $connection->selectOne('SELECT SUM(pgsize) FROM dbstat WHERE name=?', [
-            $table,
-        ])->size;
-    }
-
-    /**
-     * Get the number of open connections for a database.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @return null
-     */
-    protected function getConnectionCount(ConnectionInterface $connection)
-    {
-        return match(class_basename($connection)) {
-            'MySqlConnection' => $this->getMySQLConnectionCount($connection),
-            'PostgresConnection' => $this->getPgsqlConnectionCount($connection),
-            'SqlServerConnection' => $this->getSqlServerConnectionCount($connection),
-            default => null,
-        };
-    }
-
-    /**
-     * Get the number of open connections for a Postgres database.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @return mixed
-     */
-    protected function getPgsqlConnectionCount(ConnectionInterface $connection)
-    {
-        return $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections;
-    }
-
-    /**
-     * Get the number of open connections for a MySQL database.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @return mixed
-     */
-    protected function getMySQLConnectionCount(ConnectionInterface $connection)
-    {
-        return $connection->selectOne($connection->raw('show status where variable_name = "threads_connected"'))->Value;
-    }
-
-    /**
-     * Get the number of open connections for an SQL Server database.
-     *
-     * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @return mixed
-     */
-    protected function getSqlServerConnectionCount(ConnectionInterface $connection)
-    {
-        return $connection->selectOne('SELECT COUNT(*) connections FROM sys.dm_exec_sessions WHERE status = ?', ['running'])->connections;
-    }
-
-    /**
-     * Get the connection details from the configuration.
-     *
-     * @param  string  $database
-     * @return array
-     */
-    protected function getConfigFromDatabase($database)
-    {
-        $database ??= config('database.default');
-
-        return Arr::except(config('database.connections.'.$database), ['password']);
     }
 }

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\View;
+use Doctrine\DBAL\VersionAwarePlatformDriver;
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Support\ConfigurationUrlParser;
+use Symfony\Component\Console\Output\OutputInterface;
+use UnexpectedValueException;
+
+class ShowCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:show {--database= : The database to use}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show information about the database';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(ConnectionResolverInterface $connections)
+    {
+        $connection = $connections->connection($database = $this->input->getOption('database'));
+
+        $schema = $connection->getDoctrineSchemaManager();
+
+        $tables = collect($schema->listTables())->map(fn (Table $table, $index) => [
+            'id' => $index + 1,
+            'table' => $table->getName(),
+            'size' => $this->getTableSize($connection, $table->getName()),
+            'rows' => $connection->table($table->getName())->count(),
+            'engine' => rescue(fn() => $table->getOption('engine')),
+        ]);
+        $views = collect($schema->listViews())->reject(fn (View $view) => str($view->getName())->startsWith(['pg_catalog', 'information_schema']));
+
+        $this->newLine();
+
+        $platform = $this->getPlatformName($schema->getDatabasePlatform());
+        $connectionCount = $this->getConnectionCount($connection);
+
+        $this->components->twoColumnDetail('<fg=green;options=bold>'.$platform.'</>');
+        $this->components->twoColumnDetail('Open Connections', $connectionCount);
+        $this->components->twoColumnDetail('Total Tables', $tables->count());
+        $this->components->twoColumnDetail('Total Size', number_format($tables->sum('size') / 1024 / 1024, 2) . 'Mb');
+
+        $this->newLine();
+
+        if ($tables->isNotEmpty()) {
+            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb) / <fg=yellow;options=bold>Rows</>');
+
+            $tables->each(function ($table) {
+                $this->components->twoColumnDetail(
+                    $table['table']. ' <fg=gray>' . $table['engine'].'</>',
+                    number_format($table['size'] / 1024 / 1024, 2).' / <fg=yellow;options=bold>'.number_format($table['rows']).'</>'
+                );
+            });
+
+            $this->newLine();
+        }
+
+        if ($views->isNotEmpty()) {
+            $this->components->twoColumnDetail('<fg=green;options=bold>View</>', '<fg=green;options=bold>Rows</>');
+
+            $views->map(fn (View $view) => [
+                $view->getName(),
+                $connection->table($view->getName())->count(),
+            ])
+            ->each(fn ($view) => $this->components->twoColumnDetail($view[0], number_format($view[1])));
+
+            $this->newLine();
+        }
+
+//        $answer = $this->components->choice('Which database do you want to inspect?', $tables->pluck('table', 'id')->values()->all());
+
+        $databaseConnection = $this->getConfigFromDatabase($database);
+
+        dd($databaseConnection);
+
+        $this->components->twoColumnDetail('<fg=green;options=bold>Connection</>');
+        $this->components->twoColumnDetail('Host', $schema->get);
+
+        return 0;
+    }
+
+    protected function getPlatformName(AbstractPlatform $platform)
+    {
+        return match(class_basename($platform)) {
+            'MySQLPlatform' => 'MySQL <= 5',
+            'MySQL57Platform' => 'MySQL 5.7',
+            'MySQL80Platform' => 'MySQL 8',
+            'PostgreSQL100Platform', 'PostgreSQLPlatform' => 'Postgres',
+            'SqlitePlatform' => 'SQLite',
+            'SQLServerPlatform' => 'SQL Server',
+        };
+    }
+
+    protected function getTableSize(ConnectionInterface $connection, string $table)
+    {
+        return match(class_basename($connection)) {
+            'MySqlConnection' => $this->getMySQLTableSize($connection, $table),
+//            'PostgresConnection' => $this->getPgsqlTableSize($connection, $table),
+            'SqliteConnection' => $this->getSqliteTableSize($connection, $table),
+            default => null,
+        };
+    }
+
+    protected function getMySQLTableSize(ConnectionInterface $connection, string $table)
+    {
+        return $connection->selectOne('SELECT (data_length + index_length) AS size FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?', [
+            $connection->getDatabaseName(),
+            $table,
+        ])->size;
+    }
+
+    protected function getSqliteTableSize(ConnectionInterface $connection, string $table)
+    {
+        return $connection->selectOne('SELECT SUM(pgsize) FROM dbstat WHERE name=?', [
+            $table,
+        ])->size;
+    }
+
+    protected function getConnectionCount(ConnectionInterface $connection)
+    {
+        return match(class_basename($connection)) {
+            'MySqlConnection' => $this->getMySQLConnectionCount($connection),
+            'PostgresConnection' => $this->getPgsqlConnectionCount($connection),
+            default => null,
+        };
+    }
+
+    protected function getPgsqlConnectionCount(ConnectionInterface $connection)
+    {
+        return $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections;
+    }
+
+    protected function getMySQLConnectionCount(ConnectionInterface $connection)
+    {
+        return $connection->selectOne($connection->raw('show status where variable_name = "threads_connected"'))->Value;
+    }
+
+    protected function getConfigFromDatabase($database)
+    {
+        return config('database.connections.'.$database);
+    }
+}

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -3,17 +3,13 @@
 namespace Illuminate\Database\Console;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\View;
-use Doctrine\DBAL\VersionAwarePlatformDriver;
-use Exception;
 use Illuminate\Console\Command;
-use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\ConnectionResolverInterface;
-use Illuminate\Support\ConfigurationUrlParser;
-use Symfony\Component\Console\Output\OutputInterface;
-use UnexpectedValueException;
+use Illuminate\Support\Arr;
 
 class ShowCommand extends Command
 {
@@ -22,44 +18,127 @@ class ShowCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'db:show {--database= : The database to use}';
+    protected $signature = 'db:show {--database= : The database connection to use}
+                {--json : Output the database as JSON}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Show information about the database';
+    protected $description = 'Show information about a database';
 
     /**
      * Execute the console command.
      *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $connections
      * @return int
      */
     public function handle(ConnectionResolverInterface $connections)
     {
         $connection = $connections->connection($database = $this->input->getOption('database'));
-
         $schema = $connection->getDoctrineSchemaManager();
 
-        $tables = collect($schema->listTables())->map(fn (Table $table, $index) => [
-            'id' => $index + 1,
+        $tables = $this->collectTables($connection, $schema);
+        $views = $this->collectViews($connection, $schema);
+
+        $data = [
+            'platform' => [
+                'config' => $this->getConfigFromDatabase($database),
+                'name' => $this->getPlatformName($schema->getDatabasePlatform(), $database),
+                'open_connections' => $this->getConnectionCount($connection),
+            ],
+            'tables' => $tables,
+            'views' => $views,
+        ];
+
+        $this->display($data);
+
+        return 0;
+    }
+
+    /**
+     * Collect the tables within the database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  \Doctrine\DBAL\Schema\AbstractSchemaManager  $schema
+     * @return \Illuminate\Support\Collection
+     */
+    protected function collectTables(ConnectionInterface $connection, AbstractSchemaManager $schema)
+    {
+        return collect($schema->listTables())->map(fn (Table $table, $index) => [
             'table' => $table->getName(),
             'size' => $this->getTableSize($connection, $table->getName()),
             'rows' => $connection->table($table->getName())->count(),
             'engine' => rescue(fn() => $table->getOption('engine')),
+            'comment' => $table->getComment(),
         ]);
-        $views = collect($schema->listViews())->reject(fn (View $view) => str($view->getName())->startsWith(['pg_catalog', 'information_schema']));
+    }
+
+    /**
+     * Collect the views within the database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  \Doctrine\DBAL\Schema\AbstractSchemaManager  $schema
+     * @return \Illuminate\Support\Collection
+     */
+    protected function collectViews(ConnectionInterface $connection, AbstractSchemaManager $schema)
+    {
+        return collect($schema->listViews())
+            ->reject(fn (View $view) => str($view->getName())
+            ->startsWith(['pg_catalog', 'information_schema', 'spt_']))
+            ->map(fn (View $view) => [
+                'view' => $view->getName(),
+                'rows' => $connection->table($view->getName())->count(),
+            ]);
+    }
+
+    /**
+     * Render the database information.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    protected function display(array $data)
+    {
+        $this->option('json') ? $this->displayJson($data) : $this->displayCli($data);
+    }
+
+    /**
+     * Render the database information as JSON.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    protected function displayJson(array $data)
+    {
+        $this->output->writeln(json_encode($data));
+    }
+
+    /**
+     * Render the database information for the CLI.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    protected function displayCli(array $data)
+    {
+        $platform = $data['platform'];
+        $tables = $data['tables'];
+        $views = $data['views'];
 
         $this->newLine();
 
-        $platform = $this->getPlatformName($schema->getDatabasePlatform());
-        $connectionCount = $this->getConnectionCount($connection);
-
-        $this->components->twoColumnDetail('<fg=green;options=bold>'.$platform.'</>');
-        $this->components->twoColumnDetail('Open Connections', $connectionCount);
+        $this->components->twoColumnDetail('<fg=green;options=bold>'.$platform['name'].'</>');
+        $this->components->twoColumnDetail('Host', Arr::get($platform['config'], 'host'));
+        $this->components->twoColumnDetail('Port', Arr::get($platform['config'], 'port'));
+        $this->components->twoColumnDetail('Username', Arr::get($platform['config'], 'username'));
+        $this->components->twoColumnDetail('URL', Arr::get($platform['config'], 'url'));
+        $this->components->twoColumnDetail('Open Connections', $platform['open_connections']);
         $this->components->twoColumnDetail('Total Tables', $tables->count());
-        $this->components->twoColumnDetail('Total Size', number_format($tables->sum('size') / 1024 / 1024, 2) . 'Mb');
+        if ($tableSizeSum = $tables->sum('size')) {
+            $this->components->twoColumnDetail('Total Table Size', number_format($tables->sum('size') / 1024 / 1024, 2) . 'Mb');
+        }
 
         $this->newLine();
 
@@ -67,10 +146,23 @@ class ShowCommand extends Command
             $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb) / <fg=yellow;options=bold>Rows</>');
 
             $tables->each(function ($table) {
+                $tableSize = null;
+                if ($tableSize = $table['size']) {
+
+                }
+
                 $this->components->twoColumnDetail(
                     $table['table']. ' <fg=gray>' . $table['engine'].'</>',
                     number_format($table['size'] / 1024 / 1024, 2).' / <fg=yellow;options=bold>'.number_format($table['rows']).'</>'
                 );
+
+                if ($this->output->isVerbose()) {
+                    if ($table['comment']) {
+                        $this->components->bulletList([
+                            $table['comment'],
+                        ]);
+                    }
+                }
             });
 
             $this->newLine();
@@ -79,28 +171,20 @@ class ShowCommand extends Command
         if ($views->isNotEmpty()) {
             $this->components->twoColumnDetail('<fg=green;options=bold>View</>', '<fg=green;options=bold>Rows</>');
 
-            $views->map(fn (View $view) => [
-                $view->getName(),
-                $connection->table($view->getName())->count(),
-            ])
-            ->each(fn ($view) => $this->components->twoColumnDetail($view[0], number_format($view[1])));
+            $views->each(fn ($view) => $this->components->twoColumnDetail($view['view'], number_format($view['rows'])));
 
             $this->newLine();
         }
-
-//        $answer = $this->components->choice('Which database do you want to inspect?', $tables->pluck('table', 'id')->values()->all());
-
-        $databaseConnection = $this->getConfigFromDatabase($database);
-
-        dd($databaseConnection);
-
-        $this->components->twoColumnDetail('<fg=green;options=bold>Connection</>');
-        $this->components->twoColumnDetail('Host', $schema->get);
-
-        return 0;
     }
 
-    protected function getPlatformName(AbstractPlatform $platform)
+    /**
+     * Get a human-readable platform name.
+     *
+     * @param  \Doctrine\DBAL\Platforms\AbstractPlatform  $platform
+     * @param  string  $database
+     * @return string
+     */
+    protected function getPlatformName(AbstractPlatform $platform, $database)
     {
         return match(class_basename($platform)) {
             'MySQLPlatform' => 'MySQL <= 5',
@@ -109,19 +193,35 @@ class ShowCommand extends Command
             'PostgreSQL100Platform', 'PostgreSQLPlatform' => 'Postgres',
             'SqlitePlatform' => 'SQLite',
             'SQLServerPlatform' => 'SQL Server',
+            'SQLServer2012Platform' => 'SQL Server 2012',
+            default => $database,
         };
     }
 
+    /**
+     * Get the size of a table in bytes.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return null
+     */
     protected function getTableSize(ConnectionInterface $connection, string $table)
     {
         return match(class_basename($connection)) {
             'MySqlConnection' => $this->getMySQLTableSize($connection, $table),
-//            'PostgresConnection' => $this->getPgsqlTableSize($connection, $table),
+            'PostgresConnection' => $this->getPgsqlTableSize($connection, $table),
             'SqliteConnection' => $this->getSqliteTableSize($connection, $table),
             default => null,
         };
     }
 
+    /**
+     * Get the size of a MySQL table in bytes.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return mixed
+     */
     protected function getMySQLTableSize(ConnectionInterface $connection, string $table)
     {
         return $connection->selectOne('SELECT (data_length + index_length) AS size FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?', [
@@ -130,6 +230,27 @@ class ShowCommand extends Command
         ])->size;
     }
 
+    /**
+     * Get the size of a Postgres table in bytes.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return mixed
+     */
+    protected function getPgsqlTableSize(ConnectionInterface $connection, string $table)
+    {
+        return $connection->selectOne('SELECT pg_total_relation_size(?) AS size;', [
+            $table,
+        ])->size;
+    }
+
+    /**
+     * Get the size of a SQLite table in bytes.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @return mixed
+     */
     protected function getSqliteTableSize(ConnectionInterface $connection, string $table)
     {
         return $connection->selectOne('SELECT SUM(pgsize) FROM dbstat WHERE name=?', [
@@ -137,27 +258,65 @@ class ShowCommand extends Command
         ])->size;
     }
 
+    /**
+     * Get the number of open connections for a database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return null
+     */
     protected function getConnectionCount(ConnectionInterface $connection)
     {
         return match(class_basename($connection)) {
             'MySqlConnection' => $this->getMySQLConnectionCount($connection),
             'PostgresConnection' => $this->getPgsqlConnectionCount($connection),
+            'SqlServerConnection' => $this->getSqlServerConnectionCount($connection),
             default => null,
         };
     }
 
+    /**
+     * Get the number of open connections for a Postgres database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return mixed
+     */
     protected function getPgsqlConnectionCount(ConnectionInterface $connection)
     {
         return $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections;
     }
 
+    /**
+     * Get the number of open connections for a MySQL database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return mixed
+     */
     protected function getMySQLConnectionCount(ConnectionInterface $connection)
     {
         return $connection->selectOne($connection->raw('show status where variable_name = "threads_connected"'))->Value;
     }
 
+    /**
+     * Get the number of open connections for an SQL Server database.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @return mixed
+     */
+    protected function getSqlServerConnectionCount(ConnectionInterface $connection)
+    {
+        return $connection->selectOne('SELECT COUNT(*) connections FROM sys.dm_exec_sessions WHERE status = ?', ['running'])->connections;
+    }
+
+    /**
+     * Get the connection details from the configuration.
+     *
+     * @param  string  $database
+     * @return array
+     */
     protected function getConfigFromDatabase($database)
     {
+        $database ??= config('database.default');
+
         return config('database.connections.'.$database);
     }
 }

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -318,6 +318,6 @@ class ShowCommand extends Command
     {
         $database ??= config('database.default');
 
-        return config('database.connections.'.$database);
+        return Arr::except(config('database.connections.'.$database), ['password']);
     }
 }

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -34,6 +34,8 @@ class ShowCommand extends AbstractDatabaseCommand
      */
     public function handle(ConnectionResolverInterface $connections)
     {
+        $this->ensureDependenciesExist();
+
         $connection = $connections->connection($database = $this->input->getOption('database'));
         $schema = $connection->getDoctrineSchemaManager();
 
@@ -68,7 +70,7 @@ class ShowCommand extends AbstractDatabaseCommand
             'table' => $table->getName(),
             'size' => $this->getTableSize($connection, $table->getName()),
             'rows' => $connection->table($table->getName())->count(),
-            'engine' => rescue(fn() => $table->getOption('engine')),
+            'engine' => rescue(fn () => $table->getOption('engine')),
             'comment' => $table->getComment(),
         ]);
     }
@@ -84,7 +86,7 @@ class ShowCommand extends AbstractDatabaseCommand
     {
         return collect($schema->listViews())
             ->reject(fn (View $view) => str($view->getName())
-            ->startsWith(['pg_catalog', 'information_schema', 'spt_']))
+                ->startsWith(['pg_catalog', 'information_schema', 'spt_']))
             ->map(fn (View $view) => [
                 'view' => $view->getName(),
                 'rows' => $connection->table($view->getName())->count(),
@@ -136,7 +138,7 @@ class ShowCommand extends AbstractDatabaseCommand
         $this->components->twoColumnDetail('Open Connections', $platform['open_connections']);
         $this->components->twoColumnDetail('Tables', $tables->count());
         if ($tableSizeSum = $tables->sum('size')) {
-            $this->components->twoColumnDetail('Total Size', number_format($tables->sum('size') / 1024 / 1024, 2) . 'Mb');
+            $this->components->twoColumnDetail('Total Size', number_format($tableSizeSum / 1024 / 1024, 2).'Mb');
         }
 
         $this->newLine();
@@ -150,8 +152,8 @@ class ShowCommand extends AbstractDatabaseCommand
                 }
 
                 $this->components->twoColumnDetail(
-                    $table['table']. ($this->output->isVerbose() ? ' <fg=gray>' . $table['engine'].'</>' : null),
-                    ($tableSize ? $tableSize . ' <fg=gray;options=bold>/</> ' : '— <fg=gray;options=bold>/</> ').'<fg=yellow;options=bold>'.number_format($table['rows']).'</>'
+                    $table['table'].($this->output->isVerbose() ? ' <fg=gray>'.$table['engine'].'</>' : null),
+                    ($tableSize ? $tableSize.' <fg=gray;options=bold>/</> ' : '— <fg=gray;options=bold>/</> ').'<fg=yellow;options=bold>'.number_format($table['rows']).'</>'
                 );
 
                 if ($this->output->isVerbose()) {

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -8,7 +8,9 @@ use Doctrine\DBAL\Schema\View;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Arr;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'db:show')]
 class ShowCommand extends AbstractDatabaseCommand
 {
     /**

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Illuminate\Console\Command;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Support\Str;
+
+class TableCommand extends ShowCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:table 
+                            {table : Tha name of the table}
+                            {--database : The database to use}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show information about the given database table';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(ConnectionResolverInterface $connections)
+    {
+        $connection = $connections->connection($database = $this->input->getOption('database'));
+
+        $schema = $connection->getDoctrineSchemaManager();
+        $table = $schema->listTableDetails($table = $this->argument('table'));
+
+        $columns = collect($table->getColumns())->map(fn (Column $column) => [
+            'column' => $column->getName(),
+            'attributes' => $this->getAttributes($column),
+            'default' => $column->getDefault(),
+            'type' => $column->getType()->getName(),
+        ]);
+
+        $this->newLine();
+
+        $this->components->twoColumnDetail('<fg=green;options=bold>' . $table->getName() . '</>');
+        $this->components->twoColumnDetail('Columns', $columns->count());
+        $this->components->twoColumnDetail('Size', number_format($this->getTableSize($connection, $table->getName()) / 1024 / 1024, 2) . 'Mb');
+
+        $this->newLine();
+
+        if ($columns->isNotEmpty()) {
+            $this->components->twoColumnDetail('<fg=green;options=bold>Column</>', 'Type');
+
+            $columns->each(function ($column) use ($table) {
+                $this->components->twoColumnDetail(
+                    $column['column'] . ' <fg=gray>' . $column['attributes'] . '</>',
+                    ($column['default'] ? '<fg=gray>' . $column['default'] . '</> ' : '') . '' . $column['type'] . ''
+                );
+            });
+
+            $this->newLine();
+        }
+
+        $indexes = collect($table->getIndexes());
+
+        if ($indexes->isNotEmpty()) {
+            $this->components->twoColumnDetail('<fg=green;options=bold>Indexes</>');
+
+            $indexes->each(function ($index) {
+                $columns = implode(', ', $index->getColumns());
+                $this->components->twoColumnDetail(
+                    "{$index->getName()} <fg=gray>{$columns}</>",
+                    $this->getIndexAttributes($index)
+                );
+            });
+
+            $this->newLine();
+        }
+
+        $foreignKeys = collect($table->getForeignKeys());
+
+        if ($foreignKeys->isNotEmpty()) {
+            $this->components->twoColumnDetail('<fg=green;options=bold>Foreign Keys</>', 'On Update / On Delete');
+
+            $foreignKeys->each(function ($foreignKey) {
+                $localKeys = implode(', ', $foreignKey->getLocalColumns());
+                $foreignKeys = implode(', ', $foreignKey->getForeignColumns());
+
+                $this->components->twoColumnDetail(
+                    $foreignKey->getName() . " <fg=gray;options=bold>$localKeys reference $foreignKeys on {$foreignKey->getForeignTableName()}</>",
+                    Str::lower($foreignKey->getOption('onUpdate') . ' / ' . $foreignKey->getOption('onDelete')),
+                );
+            });
+
+            $this->newLine();
+        }
+
+        return 0;
+    }
+
+    public function getAttributes(Column $column)
+    {
+        return collect([
+            $column->getAutoincrement() ? 'autoincrement' : null,
+            'type' => $column->getType()->getName(),
+            $column->getUnsigned() ? 'unsigned' : null,
+            !$column->getNotNull() ? 'nullable' : null,
+        ])->filter()->implode(', ');
+    }
+
+    protected function getIndexAttributes(Index $index)
+    {
+        return Str::lower(
+            collect([
+                'compound' => count($index->getColumns()) > 1,
+                'unique' => $index->isUnique(),
+                'primary' => $index->isPrimary(),
+            ])->filter()->keys()->implode(', ')
+        );
+    }
+}

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -207,7 +207,7 @@ class TableCommand extends AbstractDatabaseCommand
         }
 
         if ($indexes->isNotEmpty()) {
-            $this->components->twoColumnDetail('<fg=green;options=bold>Indexes</>');
+            $this->components->twoColumnDetail('<fg=green;options=bold>Index</>');
 
             $indexes->each(function ($index) {
                 $this->components->twoColumnDetail(
@@ -220,7 +220,7 @@ class TableCommand extends AbstractDatabaseCommand
         }
 
         if ($foreignKeys->isNotEmpty()) {
-            $this->components->twoColumnDetail('<fg=green;options=bold>Foreign Keys</>', 'On Update / On Delete');
+            $this->components->twoColumnDetail('<fg=green;options=bold>Foreign Key</>', 'On Update / On Delete');
 
             $foreignKeys->each(function ($foreignKey) {
                 $this->components->twoColumnDetail(

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -4,13 +4,10 @@ namespace Illuminate\Database\Console;
 
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Schema\Table;
-use Illuminate\Console\Command;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Support\Str;
 
-class TableCommand extends ShowCommand
+class TableCommand extends AbstractDatabaseCommand
 {
     /**
      * The name and signature of the console command.

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -182,7 +182,7 @@ class TableCommand extends DatabaseInspectionCommand
     protected function displayForCli(array $data)
     {
         [$table, $columns, $indexes, $foreignKeys] = [
-            $data['table'], $data['columns'], $data['indexes'], $data['foreign_keys']
+            $data['table'], $data['columns'], $data['indexes'], $data['foreign_keys'],
         ];
 
         $this->newLine();

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -19,7 +19,7 @@ class TableCommand extends AbstractDatabaseCommand
      * @var string
      */
     protected $signature = 'db:table
-                            {table : The name of the table}
+                            {table? : The name of the table}
                             {--database= : The database to use}
                             {--json : Output the database as JSON}';
 
@@ -41,7 +41,11 @@ class TableCommand extends AbstractDatabaseCommand
 
         $connection = $connections->connection($this->input->getOption('database'));
         $schema = $connection->getDoctrineSchemaManager();
-        $table = $schema->listTableDetails($table = $this->argument('table'));
+        $table = $this->argument('table') ?: $this->components->choice(
+            'Which table would you like to view?',
+            collect($schema->listTables())->flatMap(fn (Table $table) => [$table->getName()])->toArray()
+        );
+        $table = $schema->listTableDetails($table);
 
         $columns = $this->collectColumns($table);
         $indexes = $this->collectIndexes($table);

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -17,9 +17,9 @@ class TableCommand extends ShowCommand
      *
      * @var string
      */
-    protected $signature = 'db:table 
+    protected $signature = 'db:table
                             {table : Tha name of the table}
-                            {--database : The database to use}';
+                            {--database= : The database to use}';
 
     /**
      * The console command description.

--- a/src/Illuminate/Database/Events/DatabaseBusy.php
+++ b/src/Illuminate/Database/Events/DatabaseBusy.php
@@ -5,28 +5,28 @@ namespace Illuminate\Database\Events;
 class DatabaseBusy
 {
     /**
-     * The database configuration key.
+     * The database connection name.
      *
      * @var string
      */
-    public $database;
+    public $connectionName;
 
     /**
      * The number of open connections.
      *
      * @var int
      */
-    public $openConnections;
+    public $connections;
 
     /**
      * Create a new event instance.
      *
-     * @param  string  $database
-     * @param  int  $openConnections
+     * @param  string  $connectionName
+     * @param  int  $connections
      */
-    public function __construct($database, $openConnections)
+    public function __construct($connectionName, $connections)
     {
-        $this->database = $database;
-        $this->openConnections = $openConnections;
+        $this->connectionName = $connectionName;
+        $this->connections = $connections;
     }
 }

--- a/src/Illuminate/Database/Events/DatabaseBusy.php
+++ b/src/Illuminate/Database/Events/DatabaseBusy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class DatabaseBusy
+{
+    /**
+     * The database configuration key.
+     *
+     * @var string
+     */
+    public $database;
+
+    /**
+     * The number of open connections.
+     *
+     * @var int
+     */
+    public $connections;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $database
+     * @param  int  $connections
+     */
+    public function __construct($database, $connections)
+    {
+        $this->database = $database;
+        $this->connections = $connections;
+    }
+}

--- a/src/Illuminate/Database/Events/DatabaseBusy.php
+++ b/src/Illuminate/Database/Events/DatabaseBusy.php
@@ -16,17 +16,17 @@ class DatabaseBusy
      *
      * @var int
      */
-    public $connections;
+    public $openConnections;
 
     /**
      * Create a new event instance.
      *
      * @param  string  $database
-     * @param  int  $connections
+     * @param  int  $openConnections
      */
-    public function __construct($database, $connections)
+    public function __construct($database, $openConnections)
     {
         $this->database = $database;
-        $this->connections = $connections;
+        $this->openConnections = $openConnections;
     }
 }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Types\DecimalType;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Database\Console\AbstractDatabaseCommand;
+use Illuminate\Database\Console\DatabaseInspectionCommand;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use UnitEnum;
 
 #[AsCommand(name: 'model:show')]
-class ShowModelCommand extends AbstractDatabaseCommand
+class ShowModelCommand extends DatabaseInspectionCommand
 {
     /**
      * The console command name.

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -10,7 +10,6 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Console\AbstractDatabaseCommand;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Composer;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
@@ -57,13 +56,6 @@ class ShowModelCommand extends AbstractDatabaseCommand
                 {--json : Output the model as JSON}';
 
     /**
-     * The Composer instance.
-     *
-     * @var \Illuminate\Support\Composer
-     */
-    protected $composer;
-
-    /**
      * The methods that can be called in a model to indicate a relation.
      *
      * @var array
@@ -81,19 +73,6 @@ class ShowModelCommand extends AbstractDatabaseCommand
         'morphToMany',
         'morphedByMany',
     ];
-
-    /**
-     * Create a new command instance.
-     *
-     * @param  \Illuminate\Support\Composer  $composer
-     * @return void
-     */
-    public function __construct(Composer $composer)
-    {
-        parent::__construct();
-
-        $this->composer = $composer;
-    }
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DbCommand;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
+use Illuminate\Database\Console\MonitorCommand as DatabaseMonitorCommand;
 use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
@@ -103,6 +104,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ConfigCache' => ConfigCacheCommand::class,
         'ConfigClear' => ConfigClearCommand::class,
         'Db' => DbCommand::class,
+        'DbMonitor' => DatabaseMonitorCommand::class,
         'DbPrune' => PruneCommand::class,
         'DbShow' => ShowCommand::class,
         'DbTable' => DatabaseTableCommand::class,
@@ -375,6 +377,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerDbCommand()
     {
         $this->app->singleton(DbCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerDbMonitorCommand()
+    {
+        $this->app->singleton(DatabaseMonitorCommand::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
+use Illuminate\Database\Console\ShowCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
@@ -102,6 +103,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ConfigClear' => ConfigClearCommand::class,
         'Db' => DbCommand::class,
         'DbPrune' => PruneCommand::class,
+        'DbShow' => ShowCommand::class,
         'DbWipe' => WipeCommand::class,
         'Down' => DownCommand::class,
         'Environment' => EnvironmentCommand::class,
@@ -380,6 +382,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerDbPruneCommand()
     {
         $this->app->singleton(PruneCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerDbShowCommand()
+    {
+        $this->app->singleton(ShowCommand::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\ShowCommand;
+use Illuminate\Database\Console\TableCommand as DatabaseTableCommand;
 use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\CastMakeCommand;
@@ -104,6 +105,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Db' => DbCommand::class,
         'DbPrune' => PruneCommand::class,
         'DbShow' => ShowCommand::class,
+        'DbTable' => DatabaseTableCommand::class,
         'DbWipe' => WipeCommand::class,
         'Down' => DownCommand::class,
         'Environment' => EnvironmentCommand::class,
@@ -193,7 +195,8 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     public function register()
     {
         $this->registerCommands(array_merge(
-            $this->commands, $this->devCommands
+            $this->commands,
+            $this->devCommands
         ));
     }
 
@@ -392,6 +395,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerDbShowCommand()
     {
         $this->app->singleton(ShowCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerDbTableCommand()
+    {
+        $this->app->singleton(DatabaseTableCommand::class);
     }
 
     /**


### PR DESCRIPTION
This PR adds three new Artisan commands which provide information about the database directly from a Laravel project.

In summary, it exposes information such as:

- A list of all tables with row count and table size
- Overall size of the database
- Current number of database connections
- Column types
- List of indexes
- List of foreign keys and table references
- Ability to monitor the database and listen for events when the database is under load

---

### `db:show`

This command gives you an overview of the database as a whole. Out of the box, it will utilise your default connection, but you may optionally choose the connection you wish to inspect.

Upon running the command, you will see a summary of the database including database type, connection details, number of connections, total rows and overall size.

You will also see a breakdown of tables including table size and optionally (using the `--with-counts` option), the number of rows. This is an option as it can be an expensive operation on larger databases.

Additionally, using the `--with-views` option, you may also see a summary of the database views.

The output for this command is also available in JSON using the `--json` option.

<details>
  <summary><code>Example JSON</code></summary>

  ```json
  {
    "platform": {
      "config": {
        "driver": "mysql",
        "url": null,
        "host": "127.0.0.1",
        "port": "3306",
        "database": "vapor_app",
        "username": "root",
        "unix_socket": "",
        "charset": "utf8mb4",
        "collation": "utf8mb4_unicode_ci",
        "prefix": "",
        "prefix_indexes": true,
        "strict": true,
        "engine": null,
        "options": []
      },
      "name": "MySQL 8",
      "open_connections": 2
    },
    "tables": [
      {
        "table": "failed_jobs",
        "size": 16384,
        "rows": null,
        "engine": "InnoDB",
        "comment": ""
      },
      {
        "table": "migrations",
        "size": 16384,
        "rows": null,
        "engine": "InnoDB",
        "comment": ""
      },
      {
        "table": "password_resets",
        "size": 16384,
        "rows": null,
        "engine": "InnoDB",
        "comment": ""
      },
      {
        "table": "personal_access_tokens",
        "size": 16384,
        "rows": null,
        "engine": "InnoDB",
        "comment": ""
      },
      {
        "table": "posts",
        "size": 32768,
        "rows": null,
        "engine": "InnoDB",
        "comment": ""
      },
      {
        "table": "users",
        "size": 16384,
        "rows": null,
        "engine": "InnoDB",
        "comment": ""
      }
    ]
  }
  ```
</details>

This command is really useful to get a better understanding of the health of your database.

![Example db:show command](https://user-images.githubusercontent.com/246103/180431515-312f468f-8ec7-411b-9f32-b99d120ea1a8.png)

---

### `db:table`

Where `db:show` allows you to see the state of a database as a whole, `db:table` allows you to see the state of an individual table by passing the table name as an argument or selecting the table from the list of tables provided.

As with `db:show`, the command will use your default database connection, but you may pass the connection you wish to use.

This command provides a summary of the table including the size and number of rows as well as a breakdown of every column along with its attributes and data type.

Additionally, it presents an overview of all indexes and foreign keys including the columns and tables referenced. It’s a great way to get a better understanding of a given table and how it relates to others.

The output for this command is also available in JSON using the `--json` option.

<details>
  <summary><code>Example JSON</code></summary>

  ```json
  {
    "table": {
      "name": "posts",
      "columns": 4,
      "size": 32768
    },
    "columns": {
      "id": {
        "column": "id",
        "attributes": {
          "0": "autoincrement",
          "type": "bigint",
          "1": "unsigned"
        },
        "default": null,
        "type": "bigint"
      },
      "user_id": {
        "column": "user_id",
        "attributes": {
          "type": "bigint",
          "1": "unsigned"
        },
        "default": null,
        "type": "bigint"
      },
      "created_at": {
        "column": "created_at",
        "attributes": {
          "type": "datetime",
          "2": "nullable"
        },
        "default": null,
        "type": "datetime"
      },
      "updated_at": {
        "column": "updated_at",
        "attributes": {
          "type": "datetime",
          "2": "nullable"
        },
        "default": null,
        "type": "datetime"
      }
    },
    "indexes": {
      "posts_user_id_foreign": {
        "name": "posts_user_id_foreign",
        "columns": [
          "user_id"
        ],
        "attributes": []
      },
      "primary": {
        "name": "PRIMARY",
        "columns": [
          "id"
        ],
        "attributes": [
          "unique",
          "primary"
        ]
      }
    },
    "foreign_keys": {
      "posts_user_id_foreign": {
        "name": "posts_user_id_foreign",
        "local_table": "posts",
        "local_columns": [
          "user_id"
        ],
        "foreign_table": "users",
        "foreign_columns": [
          "id"
        ],
        "on_update": "no action",
        "on_delete": "cascade"
      }
    }
  }
  ```
</details>

![Example db:table command](https://user-images.githubusercontent.com/246103/180785171-dda74093-29cd-4fa8-8021-c722ff2e7fd9.png)

---

### `db:monitor` 

Much like the `queue:monitor` command, `db:monitor` allows you to quickly see the number of connections your database is handling, which is a great indicator of the load it is currently under.

In addition, you may pass the `--max` option which will dispatch a `DatabaseBusy` event when the number of connections is ≥ the max provided. If no `--max` value is provided, no events will be dispatched. Your application may listen for this event in order to, for instance, send an email to the operations team notifying them the database is under strain.

Typically, this would be run as a scheduled command as often as you would like the check to be carried out.

![Example db:monitor command](https://user-images.githubusercontent.com/246103/180431386-449033e3-a550-4deb-b7c4-3b689879ac04.png)