### PR TITLE
[master] Added missing PHPDoc type to Factory's hasAttached first argument

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -10,7 +10,7 @@ class BelongsToManyRelationship
     /**
      * The related factory instance.
      *
-     * @var \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+     * @var \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array
      */
     protected $factory;
 
@@ -31,7 +31,7 @@ class BelongsToManyRelationship
     /**
      * Create a new attached relationship definition.
      *
-     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model  $factory
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $factory
      * @param  callable|array  $pivot
      * @param  string  $relationship
      * @return void

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -569,7 +569,7 @@ abstract class Factory
     /**
      * Define an attached relationship for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model  $factory
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model|array  $factory
      * @param  (callable(): array<string, mixed>)|array<string, mixed>  $pivot
      * @param  string|null  $relationship
      * @return static

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -377,6 +377,29 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         unset($_SERVER['__test.role.creating-role']);
     }
+    
+    public function test_belongs_to_many_relationship_with_existing_model_instances_using_array()
+    {
+        $roles = FactoryTestRoleFactory::times(3)
+            ->afterCreating(function ($role) {
+                $_SERVER['__test.role.creating-role'] = $role;
+            })
+            ->create();
+        FactoryTestUserFactory::times(3)
+            ->hasAttached($roles->toArray(), ['admin' => 'Y'], 'roles')
+            ->create();
+
+        $this->assertCount(3, FactoryTestRole::all());
+
+        $user = FactoryTestUser::latest()->first();
+
+        $this->assertCount(3, $user->roles);
+        $this->assertSame('Y', $user->roles->first()->pivot->admin);
+
+        $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.role.creating-role']);
+
+        unset($_SERVER['__test.role.creating-role']);
+    }
 
     public function test_belongs_to_many_relationship_with_existing_model_instances_with_relationship_name_implied_from_model()
     {


### PR DESCRIPTION
## Introduction
I was working with Factories and relationships, and what I needed to do is attach 2 existing (or more) models to a Factory using relationships.

The issue is that my IDE (PHPStorm) is saying that I cannot use an `array` as the first `hasAttached`'s argument I am going to show but you can!

## What am I allowing?

I am telling the IDE that you can use an `array` when you use `->hasAttached(...)`.

## Benefits
Instead of doing this:
```php
$model1 = ModelX::factory()->createOne();
$model2 = ModelX::factory()->createOne(['field' => 'other value']);

$dealer = ParentModel::factory()
    ->has(
        ChildModel::factory()
            ->hasAttached(collect([$model1, $model2]))
        )
    ->createOne();

// Run code

// Run assertion on or using $model1 and $model2
```

Or

```php
$models = collect([
    ModelX::factory()->createOne();
    ModelX::factory()->createOne(['field' => 'other value'])
); // Or any other variation using sequence and count

$dealer = ParentModel::factory()
    ->has(
        ChildModel::factory()
            ->hasAttached($models)
        )
    ->createOne();

// Run code

$model1 = $models->first();
$model1 = $models->last();

// Run assertion on or using $model1 and $model2
```

You can do:
```php
$model1 = ModelX::factory()->createOne();
$model2 = ModelX::factory()->createOne(['field' => 'other value']);

$dealer = ParentModel::factory()
    ->has(
        ChildModel::factory()
            ->hasAttached([$model1, $model2])
        )
    ->createOne();

// Run code

// Run assertion on or using $model1 and $model2
```