### PR TITLE
[9.x] Improves `serve` Artisan command

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -283,6 +283,14 @@ class ServeCommand extends Command
 
                     continue;
                 }
+
+                if (str($line)->contains('Closed without sending a request')) {
+                    continue;
+                }
+
+                if (isset($parts[1])) {
+                    $this->components->warn($parts[1]);
+                }
             }
         };
     }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -244,19 +244,19 @@ class ServeCommand extends Command
         return fn ($type, $buffer) => str($buffer)->explode(PHP_EOL)->each(function ($line) {
             $parts = explode(']', $line);
 
-            if (str($line)->contains('started')) {
+            if (str($line)->contains('Development Server (http')) {
                 $this->components->info("Server running on [http://{$this->host()}:{$this->port()}].");
                 $this->comment('  <fg=yellow;options=bold>Press Ctrl+C to stop the server</>');
                 $this->newLine();
-            } elseif (str($line)->contains('Accepted')) {
+            } elseif (str($line)->contains(' Accepted')) {
                 $startDate = Carbon::createFromFormat('D M d H:i:s Y', ltrim($parts[0], '['));
                 preg_match('/\:(\d+)/', $parts[1], $matches);
 
                 $this->requestsPool[$matches[1]] = [$startDate, false];
-            } elseif (str($line)->contains(['[200]: GET'])) {
+            } elseif (str($line)->contains([' [200]: GET '])) {
                 preg_match('/\:(\d+)/', $parts[1], $matches);
                 $this->requestsPool[$matches[1]][1] = trim(explode('[200]: GET', $line)[1]);
-            } elseif (str($line)->contains('Closing')) {
+            } elseif (str($line)->contains(' Closing')) {
                 preg_match('/\:(\d+)/', $parts[1], $matches);
 
                 $request = $this->requestsPool[$matches[1]];

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -284,12 +284,12 @@ class ServeCommand extends Command
                     continue;
                 }
 
-                if (str($line)->contains('Closed without sending a request')) {
+                if (str($line)->contains(['Closed without sending a request', ']: '])) {
                     continue;
                 }
 
-                if (isset($parts[1])) {
-                    $this->components->warn($parts[1]);
+                if (! empty($line)) {
+                    $this->components->warn($line);
                 }
             }
         };


### PR DESCRIPTION
This pull request improves Laravel's `serve` artisan command. Here is the difference:

<img width="1761" alt="Screenshot 2022-07-22 at 18 32 56" src="https://user-images.githubusercontent.com/5457236/180493445-01619535-f403-42cf-8aa4-a03ed81bf57f.png">

So, the output got improved. The "time" is the only information highlighted, as is the only thing that actually changes. And we got to see a "rounded" duration of the request.

Note that, because we are using PHP's built-in server using a file such as "server.php", we don't have information regarding the Method, Uri, Response Code, etc.

In addition, unexpected output such as port already in use, or `.env` got changed, is displayed this way:

<img width="1182" alt="Screenshot 2022-07-22 at 18 00 50" src="https://user-images.githubusercontent.com/5457236/180488545-af46cbba-b527-4d69-9d78-eae5dd6c3ad3.png">

<img width="727" alt="Screenshot 2022-07-22 at 18 01 53" src="https://user-images.githubusercontent.com/5457236/180488786-155167e2-6d67-4ef5-926b-13d156e325ba.png">