### PR TITLE
[9.x] Filter out disabled default timestamps

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1376,10 +1376,10 @@ trait HasAttributes
             return $this->dates;
         }
 
-        $defaults = [
+        $defaults = array_filter([
             $this->getCreatedAtColumn(),
             $this->getUpdatedAtColumn(),
-        ];
+        ]);
 
         return array_unique(array_merge($this->dates, $defaults));
     }


### PR DESCRIPTION
I can't seem to find it in the documentation anymore, but setting `public const CREATED_AT = null;` (or similarly for `UPDATED_AT`) in a model would disable that timestamp attribute, while keeping the functionality for the other intact. This is for when you only want to disable either `created_at` or `updated_at`, not both.

If one of these default timestamp attributes is disabled, the `getDates()` function would return a `null` for that attribute's name rather than omitting it.
```
[null, 'updated_at']
```
whereas the correct return value should be
```
['updated_at']
```