### PR TITLE
[10.x] Add support for multiple hash algorithms

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -167,6 +167,7 @@ class Filesystem
      * Get the hash of the file at the given path.
      *
      * @param  string  $path
+     * @param  string  $algorithm
      * @return string
      */
     public function hash($path, $algorithm = 'md5')

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -164,14 +164,14 @@ class Filesystem
     }
 
     /**
-     * Get the MD5 hash of the file at the given path.
+     * Get the hash of the file at the given path.
      *
      * @param  string  $path
      * @return string
      */
-    public function hash($path)
+    public function hash($path, $algorithm = 'md5')
     {
-        return md5_file($path);
+        return hash_file($algorithm, $path);
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -572,11 +572,19 @@ class FilesystemTest extends TestCase
         $this->assertContainsOnlyInstancesOf(SplFileInfo::class, $files->allFiles(self::$tempDir));
     }
 
-    public function testHash()
+    public function testHashWithDefaultValue()
     {
         file_put_contents(self::$tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;
         $this->assertSame('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash(self::$tempDir.'/foo.txt'));
+    }
+
+    public function testHash()
+    {
+        file_put_contents(self::$tempDir.'/foo.txt', 'foo');
+        $filesystem = new Filesystem;
+        $this->assertSame('0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33 ', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha1'));
+        $this->assertSame('76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01 ', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha3-256'));
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -583,8 +583,8 @@ class FilesystemTest extends TestCase
     {
         file_put_contents(self::$tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;
-        $this->assertSame('0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33 ', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha1'));
-        $this->assertSame('76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01 ', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha3-256'));
+        $this->assertSame('0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha1'));
+        $this->assertSame('76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01', $filesystem->hash(self::$tempDir.'/foo.txt', 'sha3-256'));
     }
 
     /**


### PR DESCRIPTION
Hello.

Is this modification valid?
We often need the `sha256` of the file, it would be interesting for `Filesystem` to get it.
If it is already valid, I can include it in the tests.

I was always confused by the original implementation, as "hash" refers me to all sorts of algorithms. That way we don't break what already exists (md5 default) and enable hashing like sha256 or sha512.

https://www.php.net/manual/en/function.hash-algos.php


```php

File::hash($path)
// 196b0f14eba66e10fba74dbf9e99c22f => default md5

File::hash($path, 'sha256')
// 19c451aedfb24c338a9a2a5c31d553ed77e7cdefc655035f390176ac24066051

```