### PR TITLE
Added a new array helper function

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -839,7 +839,7 @@ class Arr
                 },
                 $depth_array
             );
-            
+
             return max($depth_array);
         } else {
             return 0;

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -822,4 +822,26 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Finds the depth of an array, if the array passed is empty it will return 0
+     *
+     * @param  mixed $array
+     * @return void
+     */
+    public static function depth($array)
+    {
+        if (is_array($array) && !empty($array)) {
+            $depth_array = array_keys(static::dot($array));
+            $depth_array = array_map(
+                function ($value) {
+                    return substr_count($value, '.') + 1;
+                },
+                $depth_array
+            );
+            return max($depth_array);
+        } else {
+            return 0;
+        }
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -824,14 +824,14 @@ class Arr
     }
 
     /**
-     * Finds the depth of an array, if the array passed is empty it will return 0
+     * Finds the depth of an array, if the array passed is empty it will return 0.
      *
-     * @param  mixed $array
+     * @param  mixed  $array
      * @return void
      */
     public static function depth($array)
     {
-        if (is_array($array) && !empty($array)) {
+        if (is_array($array) && ! empty($array)) {
             $depth_array = array_keys(static::dot($array));
             $depth_array = array_map(
                 function ($value) {
@@ -839,6 +839,7 @@ class Arr
                 },
                 $depth_array
             );
+            
             return max($depth_array);
         } else {
             return 0;


### PR DESCRIPTION
Added a new Array helper function name `depth` which determines how nested an array is or in short the depth of an array.

> The function will return 0 for an empty array and data types other than array including `null`. This behaviour is taken from this [Flat array depth](https://aplwiki.com/wiki/Depth).

- It will be helpful as a breaking condition in cases where one has to iterate over an extremely nested array or unknown levels of array.
- It mostly implements the logic using core php functions except for the Array `dot` method which in itself isn't breaking any existing features. So, the function would be stable.