### PR TITLE
[9.x] Add whereNot method to Fluent JSON testing matchers

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -48,6 +48,49 @@ trait Matching
     }
 
     /**
+     * Asserts that the property does not match the expected value.
+     *
+     * @param  string  $key
+     * @param  mixed|\Closure  $expected
+     * @return $this
+     */
+    public function whereNot(string $key, $expected): self
+    {
+        $this->has($key);
+
+        $actual = $this->prop($key);
+
+        if ($expected instanceof Closure) {
+            PHPUnit::assertFalse(
+                $expected(is_array($actual) ? Collection::make($actual) : $actual),
+                sprintf('Property [%s] was marked as invalid using a closure.', $this->dotPath($key))
+            );
+
+            return $this;
+        }
+
+        if ($expected instanceof Arrayable) {
+            $expected = $expected->toArray();
+        }
+
+        $this->ensureSorted($expected);
+        $this->ensureSorted($actual);
+
+        PHPUnit::assertNotSame(
+            $expected,
+            $actual,
+            sprintf(
+                'Property [%s] contains a value that should be missing: [%s, %s]',
+                $this->dotPath($key),
+                $key,
+                $expected
+            )
+        );
+
+        return $this;
+    }
+
+    /**
      * Asserts that all properties match their expected values.
      *
      * @param  array  $bindings

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -159,12 +159,12 @@ class AssertTest extends TestCase
             'data' => [
                 [
                     'id' => 1,
-                    'name' => 'Taylor'
+                    'name' => 'Taylor',
                 ],
                 [
                     'id' => 2,
-                    'name' => 'Nuno'
-                ]
+                    'name' => 'Nuno',
+                ],
             ],
         ]);
 
@@ -180,12 +180,12 @@ class AssertTest extends TestCase
             'data' => [
                 [
                     'id' => 1,
-                    'name' => 'Taylor'
+                    'name' => 'Taylor',
                 ],
                 [
                     'id' => 2,
-                    'name' => 'Mateus'
-                ]
+                    'name' => 'Mateus',
+                ],
             ],
         ]);
 
@@ -204,12 +204,12 @@ class AssertTest extends TestCase
             'data' => [
                 [
                     'id' => 1,
-                    'name' => 'Taylor'
+                    'name' => 'Taylor',
                 ],
                 [
                     'id' => 2,
-                    'name' => 'Mateus'
-                ]
+                    'name' => 'Mateus',
+                ],
             ],
         ]);
 
@@ -225,12 +225,12 @@ class AssertTest extends TestCase
             'data' => [
                 [
                     'id' => 1,
-                    'name' => 'Taylor'
+                    'name' => 'Taylor',
                 ],
                 [
                     'id' => 2,
-                    'name' => 'Mateus'
-                ]
+                    'name' => 'Mateus',
+                ],
             ],
         ]);
 

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -153,6 +153,96 @@ class AssertTest extends TestCase
         });
     }
 
+    public function testAssertHasWithWhereNotDoesNotFail()
+    {
+        $assert = AssertableJson::fromArray([
+            'data' => [
+                [
+                    'id' => 1,
+                    'name' => 'Taylor'
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Nuno'
+                ]
+            ],
+        ]);
+
+        $assert->has('data', function ($bar) {
+            $bar->has(2)
+                ->each(fn ($json) => $json->whereNot('id', 3)->etc());
+        });
+    }
+
+    public function testAssertHasWithWhereNotFails()
+    {
+        $assert = AssertableJson::fromArray([
+            'data' => [
+                [
+                    'id' => 1,
+                    'name' => 'Taylor'
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Mateus'
+                ]
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [data.1.id] contains a value that should be missing: [id, 2]');
+
+        $assert->has('data', function ($bar) {
+            $bar->has(2)
+                ->each(fn ($json) => $json->whereNot('id', 2)->etc());
+        });
+    }
+
+    public function testAssertHasWithWhereNotDoesNotFailClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'data' => [
+                [
+                    'id' => 1,
+                    'name' => 'Taylor'
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Mateus'
+                ]
+            ],
+        ]);
+
+        $assert->has('data', function ($bar) {
+            $bar->has(2)
+                ->each(fn ($json) => $json->whereNot('id', fn ($value) => $value === 3)->etc());
+        });
+    }
+
+    public function testAssertHasWithWhereNotFailsClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'data' => [
+                [
+                    'id' => 1,
+                    'name' => 'Taylor'
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Mateus'
+                ]
+            ],
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [data.1.id] was marked as invalid using a closure.');
+
+        $assert->has('data', function ($bar) {
+            $bar->has(2)
+                ->each(fn ($json) => $json->whereNot('id', fn ($value) => $value === 2)->etc());
+        });
+    }
+
     public function testAssertCount()
     {
         $assert = AssertableJson::fromArray([
@@ -623,6 +713,64 @@ class AssertTest extends TestCase
         $this->expectExceptionMessage('Property [example.nested] does not match the expected value.');
 
         $assert->where('example.nested', 'another-value');
+    }
+
+    public function testAssertWhereDoesNotMatchValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $assert->whereNot('bar', 'different_value');
+    }
+
+    public function testAssertWhereNotFailsWhenMatchingValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] contains a value that should be missing: [bar, value]');
+
+        $assert->whereNot('bar', 'value');
+    }
+
+    public function testAssertWhereNotFailsWhenNotMissing()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] does not exist.');
+
+        $assert->whereNot('baz', 'value');
+    }
+
+    public function testAssertWhereNotUsingClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'baz',
+        ]);
+
+        $assert->whereNot('bar', function ($value) {
+            return $value === 'foo';
+        });
+    }
+
+    public function testAssertWhereNotFailsWhenMatchesValueUsingClosure()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'baz',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] was marked as invalid using a closure.');
+
+        $assert->where('bar', function ($value) {
+            return $value === 'baz';
+        });
     }
 
     public function testScope()

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -768,7 +768,7 @@ class AssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Property [bar] was marked as invalid using a closure.');
 
-        $assert->where('bar', function ($value) {
+        $assert->whereNot('bar', function ($value) {
             return $value === 'baz';
         });
     }


### PR DESCRIPTION
I have a use case where I want to test that a given item *does* not exist on a JSON collection. 
I found it a bit difficult to do this with the existing API, but it is quite possible (and likely) that I just missed something.

Here's an example of my use case: https://twitter.com/mateusjatenee/status/1550574619995815936

The tests are a bit messy because I started out scoping then and then implementing (tried out a couple different things as well), but if the PR looks good I can make them a little better.