### PR TITLE
[9.x] Added conditional lines to MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -158,6 +158,22 @@ class SimpleMessage
     }
 
     /**
+     * Add a line of text to the notification if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  mixed  $line
+     * @return $this
+     */
+    public function lineIf($boolean, $line)
+    {
+        if ($boolean) {
+            return $this->line($line);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add lines of text to the notification.
      *
      * @param  iterable  $lines
@@ -167,6 +183,22 @@ class SimpleMessage
     {
         foreach ($lines as $line) {
             $this->line($line);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add lines of text to the notification if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  iterable  $lines
+     * @return $this
+     */
+    public function linesIf($boolean, $lines)
+    {
+        if ($boolean) {
+            return $this->lines($lines);
         }
 
         return $this;


### PR DESCRIPTION
Currently, If we need to add a line to a MailMessage based on a condition, we have to do something like this:

```php
public function toMail($notifiable)
{
    $message = new MailMessage();
    $message->greeting('Hello there!');
    $message->line('Your order has been canceled');
    if ($this->amount > 0) {
        $message->line("The refunded amount is {$this->amount}");
    }
    $message->line('...');
    return $message;
}
```

With these methods, we can do:

```php
public function toMail($notifiable)
{
    return (new MailMessage)
        ->greeting('Hello there!')
        ->line('Your order has been canceled')
        ->lineIf($this->amount > 0, "The refunded amount is {$this->amount}")
        ->line('...');
}
```

Which looks similar to the docs.