### PR TITLE
[9.x] Improve pop method in Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -878,6 +878,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function pop($count = 1)
     {
+        if ($count <= 0) {
+           return;
+        }
+
         if ($count === 1) {
             return array_pop($this->items);
         }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -879,7 +879,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public function pop($count = 1)
     {
         if ($count <= 0) {
-           return;
+            return;
         }
 
         if ($count === 1) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -371,6 +371,17 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(new Collection(['baz', 'bar', 'foo']), (new Collection(['foo', 'bar', 'baz']))->pop(6));
     }
 
+    public function testPopDontChangeCollectionWhenPassCountNegativeOrZero()
+    {
+        $c = new Collection(['foo', 'bar', 'baz']);
+        $this->assertNull($c->pop(0));
+        $this->assertEquals(['foo', 'bar', 'baz'], $c->all());
+
+        $c = new Collection(['foo', 'bar', 'baz']);
+        $this->assertNull($c->pop(-4));
+        $this->assertEquals(['foo', 'bar', 'baz'], $c->all());
+    }
+
     public function testShiftReturnsAndRemovesFirstItemInCollection()
     {
         $data = new Collection(['Taylor', 'Otwell']);


### PR DESCRIPTION
when we use pop with count zero or negative, doesn't remove items correctly. I fix that and add some tests for this purpose. 