### PR TITLE
[9.x] Fix first or new method in belongs to many relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -600,7 +600,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (is_null($instance = $this->related->where($attributes)->first())) {
+        if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->related->newInstance(array_merge($attributes, $values));
         }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyFirstOrNewTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyFirstOrNewTest.php
@@ -52,11 +52,11 @@ class DatabaseEloquentBelongsToManyFirstOrNewTest extends TestCase
     {
         $this->seedData();
 
-        $user2 = BelongsToManyFirstOrNewTestUser::query()->where('id',2)->first();
+        $user2 = BelongsToManyFirstOrNewTestUser::query()->where('id', 2)->first();
 
         $this->assertSame($user2->articles()->first()->aid, $user2->articles()->firstOrNew()->aid);
 
-        $user3 = BelongsToManyFirstOrNewTestUser::query()->where('id',3)->first();
+        $user3 = BelongsToManyFirstOrNewTestUser::query()->where('id', 3)->first();
         $this->assertInstanceOf(BelongsToManyFirstOrNewTestArticle::class, $user3->articles()->firstOrNew());
         $this->assertNull($user3->articles()->firstOrNew()->aid);
 

--- a/tests/Database/DatabaseEloquentBelongsToManyFirstOrNewTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyFirstOrNewTest.php
@@ -59,8 +59,6 @@ class DatabaseEloquentBelongsToManyFirstOrNewTest extends TestCase
         $user3 = BelongsToManyFirstOrNewTestUser::query()->where('id', 3)->first();
         $this->assertInstanceOf(BelongsToManyFirstOrNewTestArticle::class, $user3->articles()->firstOrNew());
         $this->assertNull($user3->articles()->firstOrNew()->aid);
-
-
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyFirstOrNewTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyFirstOrNewTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email')->unique();
+        });
+
+        $this->schema()->create('articles', function ($table) {
+            $table->increments('aid');
+            $table->string('title');
+        });
+
+        $this->schema()->create('article_user', function ($table) {
+            $table->integer('article_id')->unsigned();
+            $table->foreign('article_id')->references('aid')->on('articles');
+            $table->integer('user_id')->unsigned();
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    public function testBelongsToChunkById()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyChunkByIdTestTestUser::query()->first();
+        $i = 0;
+
+        $user->articles()->chunkById(1, function (Collection $collection) use (&$i) {
+            $i++;
+            $this->assertEquals($i, $collection->first()->aid);
+        });
+
+        $this->assertSame(3, $i);
+    }
+
+    public function testBelongsToManyFirstOrNew()
+    {
+        $this->seedData();
+
+        $user = BelongsToManyChunkByIdTestTestUser::query()->where("id",2)->first();
+
+        $this->assertSame($user->articles()->first()->aid, $user->articles()->firstOrNew()->aid);
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('articles');
+        $this->schema()->drop('article_user');
+    }
+
+    /**
+     * Helpers...
+     */
+    protected function seedData()
+    {
+        $user = BelongsToManyChunkByIdTestTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        BelongsToManyChunkByIdTestTestArticle::query()->insert([
+            ['aid' => 1, 'title' => 'Another title'],
+            ['aid' => 2, 'title' => 'Another title'],
+            ['aid' => 3, 'title' => 'Another title'],
+        ]);
+
+        $user->articles()->sync([3, 1, 2]);
+
+        $another_user = BelongsToManyChunkByIdTestTestUser::create(['id' => 2, 'email' => 'another-user@gmail.com']);
+        BelongsToManyChunkByIdTestTestArticle::query()->insert([
+            ['aid' => 4, 'title' => 'Article of another-user'],
+            ['aid' => 5, 'title' => 'Another article of another-user'],
+        ]);
+
+        $another_user->articles()->sync([4, 5]);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class BelongsToManyChunkByIdTestTestUser extends Eloquent
+{
+    protected $table = 'users';
+    protected $fillable = ['id', 'email'];
+    public $timestamps = false;
+
+    public function articles()
+    {
+        return $this->belongsToMany(BelongsToManyChunkByIdTestTestArticle::class, 'article_user', 'user_id', 'article_id');
+    }
+}
+
+class BelongsToManyChunkByIdTestTestArticle extends Eloquent
+{
+    protected $primaryKey = 'aid';
+    protected $table = 'articles';
+    protected $keyType = 'string';
+    public $incrementing = false;
+    public $timestamps = false;
+    protected $fillable = ['aid', 'title'];
+}

--- a/tests/Database/DatabaseEloquentBelongsToManyFirstOrNewTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyFirstOrNewTest.php
@@ -52,11 +52,11 @@ class DatabaseEloquentBelongsToManyFirstOrNewTest extends TestCase
     {
         $this->seedData();
 
-        $user2 = BelongsToManyFirstOrNewTestUser::query()->where("id",2)->first();
+        $user2 = BelongsToManyFirstOrNewTestUser::query()->where('id',2)->first();
 
         $this->assertSame($user2->articles()->first()->aid, $user2->articles()->firstOrNew()->aid);
 
-        $user3 = BelongsToManyFirstOrNewTestUser::query()->where("id",3)->first();
+        $user3 = BelongsToManyFirstOrNewTestUser::query()->where('id',3)->first();
         $this->assertInstanceOf(BelongsToManyFirstOrNewTestArticle::class, $user3->articles()->firstOrNew());
         $this->assertNull($user3->articles()->firstOrNew()->aid);
 


### PR DESCRIPTION
This pr is created to fix the problem that I have described in this [issue](https://github.com/laravel/framework/issues/42967).

`firstOrNew` method's behavior in `belongsToMany` relations should be the same as `first` method  when the model exists, but it is not. It should consider the chained builder conditions. 

Currently, the `firstOrNew` method in `belongsToMany` relations always returns the model of the first record of the database, no matter the specified model already has it own relations ([described in example](https://github.com/laravel/framework/issues/42967#issuecomment-1193129527)).

Please consider checking the [issue](https://github.com/laravel/framework/issues/42967) which has more details and examples.