### PR TITLE
Removed redundant `elseif`

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -151,9 +151,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         if ($this->redirect) {
             return $url->to($this->redirect);
-        } elseif ($this->redirectRoute) {
+        }
+
+        if ($this->redirectRoute) {
             return $url->route($this->redirectRoute);
-        } elseif ($this->redirectAction) {
+        }
+
+        if ($this->redirectAction) {
             return $url->action($this->redirectAction);
         }
 


### PR DESCRIPTION
There's no need to use `elseif` when using `if -> return`, as well as create unnecessary extra indentation for the main code of the function.