### PR TITLE
[9.x] Break out quotes method

### DIFF
--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -55,6 +55,18 @@ class Inspiring
      */
     public static function quote()
     {
+        return static::quotes()
+            ->map(fn ($quote) => static::formatForConsole($quote))
+            ->random();
+    }
+
+    /**
+     * Get the collection of inspiring quotes.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public static function quotes()
+    {
         return Collection::make([
             'Act only according to that maxim whereby you can, at the same time, will that it should become a universal law. - Immanuel Kant',
             'An unexamined life is not worth living. - Socrates',
@@ -95,7 +107,7 @@ class Inspiring
             'The biggest battle is the war against ignorance. - Mustafa Kemal Atatürk',
             'Always remember that you are absolutely unique. Just like everyone else. - Margaret Mead',
             'You must be the change you wish to see in the world. - Mahatma Gandhi',
-        ])->map(fn ($quote) => static::formatForConsole($quote))->random();
+        ]);
     }
 
     /**


### PR DESCRIPTION
This is a little odd so I'm happy if this considered not worth fixing, but I've been using `Illuminate\Foundation\Inspiring::quote()` in my production app - showing a nice quote to our internal teams when they've completed the list of pending tasks.

Despite the lovely new changes to the console, it appears the quote is formatted for the console regardless of the context:

```
<options=bold>“ Happiness is not something readymade. It comes from your own actions. ”</> <fg=gray>— Dalai Lama</>
```

This breaks out a `quotes` method so the quotes can be accessed separately. It'll mean I can just do `Inspiring::quotes::random()` in my own code and not impact the existing use-cases of `quote()`.