### PR TITLE
[9.x] Added counts to CLI output

### DIFF
--- a/src/Illuminate/Console/View/Components/Count.php
+++ b/src/Illuminate/Console/View/Components/Count.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Console\View\Components;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Count extends Component
+{
+    /**
+     * Renders the component using the given arguments.
+     *
+     * @param  string  $string
+     * @param  int  $verbosity
+     * @return void
+     */
+    public function render($string, $verbosity = OutputInterface::VERBOSITY_NORMAL)
+    {
+        $string = $this->mutate($string, [
+            Mutators\EnsureDynamicContentIsHighlighted::class,
+        ]);
+
+        $this->renderView('count', [
+            'content' => $string,
+        ], $verbosity);
+    }
+}

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
  * @method void bulletList(array $elements, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method mixed choice(string $question, array $choices, $default = null)
  * @method bool confirm(string $question, bool $default = true)
+ * @method void count(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void error(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void info(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void line(string $style, string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)

--- a/src/Illuminate/Console/resources/views/components/count.php
+++ b/src/Illuminate/Console/resources/views/components/count.php
@@ -1,0 +1,3 @@
+<div class="w-full text-right mx-2 mb-1 mt-1">
+    <?php echo htmlspecialchars($content) ?>
+</div>

--- a/src/Illuminate/Console/resources/views/components/count.php
+++ b/src/Illuminate/Console/resources/views/components/count.php
@@ -1,3 +1,3 @@
-<div class="w-full text-right mx-2 mb-1 mt-1">
+<div class="w-full text-right mx-2 mb-1">
     <?php echo htmlspecialchars($content) ?>
 </div>

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -69,6 +69,16 @@ class StatusCommand extends BaseCommand
                     fn ($migration) => $this->components->twoColumnDetail($migration[0], $migration[1])
                 );
 
+                $runMigrationsCount = $migrations
+                    ->filter(fn ($migration) => str_contains($migration[1], 'Ran'))
+                    ->count();
+
+                $this->newLine();
+
+                $this->components->count('Total migrations: ['.$migrations->count().']');
+                $this->components->count('Ran migrations: ['.$runMigrationsCount.']');
+                $this->components->count('Pending migrations: ['.$migrations->count() - $runMigrationsCount.']');
+
                 $this->newLine();
             } else {
                 $this->components->info('No migrations found');

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -180,9 +180,12 @@ class Migrator
             }
         }
 
-        $this->output->newLine(1);
+        $this->newLine();
 
-        $this->write(Count::class, 'Ran ['.count($migrations).'] migration(s)');
+        $this->write(
+            Count::class,
+            'Ran ['.count($migrations).'] '.str('migration')->plural(count($migrations)),
+        );
 
         $this->fireMigrationEvent(new MigrationsEnded('up'));
     }
@@ -294,9 +297,12 @@ class Migrator
             );
         }
 
-        $this->output->newLine(1);
+        $this->newLine();
 
-        $this->write(Count::class, 'Rolled back ['.count($migrations).'] migration(s)');
+        $this->write(
+            Count::class,
+            'Rolled back ['.count($migrations).'] '.str('migration')->plural(count($migrations)),
+        );
 
         $this->fireMigrationEvent(new MigrationsEnded('down'));
 
@@ -739,6 +745,16 @@ class Migrator
         with(new $component(
             $this->output ?: new NullOutput()
         ))->render(...$arguments);
+    }
+
+    /**
+     * Write a new line to the console's output.
+     *
+     * @return void
+     */
+    protected function newLine()
+    {
+        $this->output?->newLine();
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -180,6 +180,8 @@ class Migrator
             }
         }
 
+        $this->output->newLine(1);
+
         $this->write(Count::class, 'Ran ['.count($migrations).'] migration(s)');
 
         $this->fireMigrationEvent(new MigrationsEnded('up'));
@@ -291,6 +293,8 @@ class Migrator
                 $options['pretend'] ?? false
             );
         }
+
+        $this->output->newLine(1);
 
         $this->write(Count::class, 'Rolled back ['.count($migrations).'] migration(s)');
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Migrations;
 
 use Doctrine\DBAL\Schema\SchemaException;
 use Illuminate\Console\View\Components\BulletList;
+use Illuminate\Console\View\Components\Count;
 use Illuminate\Console\View\Components\Error;
 use Illuminate\Console\View\Components\Info;
 use Illuminate\Console\View\Components\Task;
@@ -179,6 +180,8 @@ class Migrator
             }
         }
 
+        $this->write(Count::class, 'Ran ['.count($migrations).'] migration(s)');
+
         $this->fireMigrationEvent(new MigrationsEnded('up'));
     }
 
@@ -288,6 +291,8 @@ class Migrator
                 $options['pretend'] ?? false
             );
         }
+
+        $this->write(Count::class, 'Rolled back ['.count($migrations).'] migration(s)');
 
         $this->fireMigrationEvent(new MigrationsEnded('down'));
 

--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -50,5 +50,7 @@ class PackageDiscoverCommand extends Command
             ->keys()
             ->each(fn ($description) => $this->components->task($description))
             ->whenNotEmpty(fn () => $this->newLine());
+
+        $this->components->count('Discovered ['.count($manifest->manifest).'] packages');
     }
 }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -60,6 +60,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         $output = m::mock(OutputStyle::class);
         $output->shouldReceive('write');
+        $output->shouldReceive('newLine');
+        $output->shouldReceive('write');
         $output->shouldReceive('writeln');
         $output->shouldReceive('newLineWritten');
 

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -106,7 +106,6 @@ class MigratorTest extends TestCase
 
     protected function expectCount($message): void
     {
-        // TODO Update assertions
         $this->output->shouldReceive('writeln')->once()->with(m::on(
             fn ($argument) => str($argument)->contains($message),
         ), m::any());

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -33,7 +33,7 @@ class MigratorTest extends TestCase
         $this->expectTask('2016_10_04_000000_modify_people_table', 'DONE');
 
         $this->expectNewLine();
-        $this->expectCount('Ran <options=bold>[3]</> migration(s)');
+        $this->expectCount('Ran <options=bold>[3]</> migrations');
 
         $this->subject->run([__DIR__.'/fixtures']);
 
@@ -68,7 +68,7 @@ class MigratorTest extends TestCase
         $this->expectTask('2014_10_12_000000_create_people_table', 'DONE');
 
         $this->expectNewLine();
-        $this->expectCount('Rolled back <options=bold>[3]</> migration(s)');
+        $this->expectCount('Rolled back <options=bold>[3]</> migrations');
 
         $this->subject->rollback([__DIR__.'/fixtures']);
 
@@ -92,7 +92,7 @@ class MigratorTest extends TestCase
         $this->expectBulletList(['alter table "people" add column "last_name" varchar']);
 
         $this->expectNewLine();
-        $this->expectCount('Ran <options=bold>[3]</> migration(s)');
+        $this->expectCount('Ran <options=bold>[3]</> migrations');
 
         $this->subject->run([__DIR__.'/fixtures'], ['pretend' => true]);
 

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -32,6 +32,9 @@ class MigratorTest extends TestCase
         $this->expectTask('2015_10_04_000000_modify_people_table', 'DONE');
         $this->expectTask('2016_10_04_000000_modify_people_table', 'DONE');
 
+        $this->expectNewLine();
+        $this->expectCount('Ran <options=bold>[3]</> migration(s)');
+
         $this->subject->run([__DIR__.'/fixtures']);
 
         $this->assertTrue(DB::getSchemaBuilder()->hasTable('people'));
@@ -64,6 +67,9 @@ class MigratorTest extends TestCase
         $this->expectTask('2015_10_04_000000_modify_people_table', 'DONE');
         $this->expectTask('2014_10_12_000000_create_people_table', 'DONE');
 
+        $this->expectNewLine();
+        $this->expectCount('Rolled back <options=bold>[3]</> migration(s)');
+
         $this->subject->rollback([__DIR__.'/fixtures']);
 
         $this->assertFalse(DB::getSchemaBuilder()->hasTable('people'));
@@ -85,9 +91,25 @@ class MigratorTest extends TestCase
         $this->expectTwoColumnDetail('2016_10_04_000000_modify_people_table');
         $this->expectBulletList(['alter table "people" add column "last_name" varchar']);
 
+        $this->expectNewLine();
+        $this->expectCount('Ran <options=bold>[3]</> migration(s)');
+
         $this->subject->run([__DIR__.'/fixtures'], ['pretend' => true]);
 
         $this->assertFalse(DB::getSchemaBuilder()->hasTable('people'));
+    }
+
+    private function expectNewLine(): void
+    {
+        $this->output->shouldReceive('newLine');
+    }
+
+    protected function expectCount($message): void
+    {
+        // TODO Update assertions
+        $this->output->shouldReceive('writeln')->once()->with(m::on(
+            fn ($argument) => str($argument)->contains($message),
+        ), m::any());
     }
 
     protected function expectInfo($message): void


### PR DESCRIPTION
Hey! This PR adds counts to several commands (similar to the PR I made to add the count to the `route:list` output in #42551). Even though the addition is small, I thought this could be a pretty useful change to get a quick overview of what the different commands have run (or might run).

If this is something that you think might be worth merging, please give me a shout if you'd anything updating 😄

Here are examples of the counts that have been added:

`php artisan migrate`:

<img width="993" alt="migrate" src="https://user-images.githubusercontent.com/39652331/180664225-30d6a433-5659-41b9-8149-fc7e5d2eaddb.png">

`php artisan migrate:rollback`:

<img width="981" alt="migrate rollback" src="https://user-images.githubusercontent.com/39652331/180664227-5d20f6c9-ac09-461d-95f7-abb288be81c2.png">


`migrate` and `migrate:rollback` being used together in `php artisan migrate:refresh`:

<img width="989" alt="migrate refresh" src="https://user-images.githubusercontent.com/39652331/180664226-31832da7-cd99-4837-8ea3-67aa20d8bb05.png">

`php artisan migrate:status`:

<img width="979" alt="migrate status" src="https://user-images.githubusercontent.com/39652331/180664228-a1850072-fb85-4f55-9c55-d39e45f5d684.png">

`php artisan package:discover`:

<img width="984" alt="package discover" src="https://user-images.githubusercontent.com/39652331/180664229-4069255d-8995-413f-ab17-a4dbfc584f42.png">
