### PR TITLE
[9.x] Round milliseconds in console output runtime

### DIFF
--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -38,7 +38,7 @@ class Task extends Component
             throw $e;
         } finally {
             $runTime = $task
-                ? (' '.number_format((microtime(true) - $startTime) * 1000, 2).'ms')
+                ? (' '.number_format((microtime(true) - $startTime) * 1000).'ms')
                 : '';
 
             $runTimeWidth = mb_strlen($runTime);


### PR DESCRIPTION
Commands always show how long they took to run in milliseconds with 2 decimal precision. This PR rounds the milliseconds, because having 2 decimal precision on milliseconds is unnecessary.

Before:
<img width="170" alt="image" src="https://user-images.githubusercontent.com/7202674/180703874-759f3ef3-b8b3-4981-845c-c52150a7e385.png">


After:
<img width="170" alt="image" src="https://user-images.githubusercontent.com/7202674/180702693-9e468baa-72e9-4214-8673-61a47d4fc3cd.png">
