### PR TITLE
[9.x] Allow customization of script and stylesheet tag generation with Vite

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -9,6 +9,20 @@ use Illuminate\Support\Str;
 class Vite
 {
     /**
+     * The callback to be used when making script tags.
+     *
+     * @var \Closure|null
+     */
+    protected static $scriptTagCallback;
+
+    /**
+     * The callback to be used when making stylesheet tags.
+     *
+     * @var \Closure|null
+     */
+    protected static $stylesheetTagCallback;
+
+    /**
      * Generate Vite tags for an entrypoint.
      *
      * @param  string|string[]  $entrypoints
@@ -130,7 +144,22 @@ class Vite
      */
     protected function makeScriptTag($url)
     {
+        if (isset(static::$scriptTagCallback)) {
+            return (static::$scriptTagCallback)($url);
+        }
+
         return sprintf('<script type="module" src="%s"></script>', $url);
+    }
+
+    /**
+     * Specify a callback to be used when making script tags.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function makeScriptTagUsing($callback)
+    {
+        static::$scriptTagCallback = $callback;
     }
 
     /**
@@ -141,7 +170,22 @@ class Vite
      */
     protected function makeStylesheetTag($url)
     {
+        if (isset(static::$stylesheetTagCallback)) {
+            return (static::$stylesheetTagCallback)($url);
+        }
+
         return sprintf('<link rel="stylesheet" href="%s" />', $url);
+    }
+
+    /**
+     * Specify a callback to be used when making stylesheet tags.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function makeStylesheetTagUsing($callback)
+    {
+        static::$stylesheetTagCallback = $callback;
     }
 
     /**

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -24,6 +24,8 @@ class FoundationViteTest extends TestCase
         $this->cleanViteManifest();
         $this->cleanViteHotFile();
         m::close();
+        Vite::makeScriptTagUsing(null);
+        Vite::makeStylesheetTagUsing(null);
     }
 
     public function testViteWithJsOnly()
@@ -96,6 +98,42 @@ class FoundationViteTest extends TestCase
         $this->assertSame(
             '<script type="module" src="http://localhost:3000/@vite/client"></script>'
             .'<link rel="stylesheet" href="http://localhost:3000/resources/css/app.css" />'
+            .'<script type="module" src="http://localhost:3000/resources/js/app.js"></script>',
+            $result->toHtml()
+        );
+    }
+
+    public function testViteCustomScriptTagGeneration()
+    {
+        $this->makeViteHotFile();
+
+        Vite::makeScriptTagUsing(function (string $url) {
+            return sprintf('<script type="module" src="%s" defer></script>', $url);
+        });
+
+        $result = (new Vite)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame(
+            '<script type="module" src="http://localhost:3000/@vite/client" defer></script>'
+            .'<link rel="stylesheet" href="http://localhost:3000/resources/css/app.css" />'
+            .'<script type="module" src="http://localhost:3000/resources/js/app.js" defer></script>',
+            $result->toHtml()
+        );
+    }
+
+    public function testViteCustomStylesheetTagGeneration()
+    {
+        $this->makeViteHotFile();
+
+        Vite::makeStylesheetTagUsing(function (string $url) {
+            return sprintf('<link rel="stylesheet" href="%s" crossorigin />', $url);
+        });
+
+        $result = (new Vite)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame(
+            '<script type="module" src="http://localhost:3000/@vite/client"></script>'
+            .'<link rel="stylesheet" href="http://localhost:3000/resources/css/app.css" crossorigin />'
             .'<script type="module" src="http://localhost:3000/resources/js/app.js"></script>',
             $result->toHtml()
         );


### PR DESCRIPTION
When using the new Vite plugin to compile assets its currently not possible to define how style and script tags are generated, this PR aims to change that.

This will allow developers to change the tags for their assets to their specific needs (my own use-case being a CSP nonce).

Usage would be:

```php
use Illuminate\Foundation\Vite;

Vite::makeScriptTagUsing(function (string $url) {
    return sprintf('<script type="module" src="%s" defer></script>', $url);
});

Vite::makeStylesheetTagUsing(function (string $url) {
    return sprintf('<link rel="stylesheet" href="%s" crossorigin />', $url);
});
```