### PR TITLE
Typehints the real model in Auth()->user

### DIFF
--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -21,7 +21,7 @@ interface Guard
     /**
      * Get the currently authenticated user.
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * @return \Illuminate\Contracts\Auth\Authenticatable|\app\Models\User|null
      */
     public function user();
 


### PR DESCRIPTION
Only way to get intellisense typehinting in the code editor is to have it point to the original app\models\user and in there one can use @property int $id etc for each param.
This way there is no need to create a wrapper for Auth or extend it, or even edit vendor files.

