### PR TITLE
[9.x] PHPDoc fix: Add missing `null` return type for `min` method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -413,7 +413,7 @@ trait EnumeratesValues
      * Get the min value of a given key.
      *
      * @param  (callable(TValue):mixed)|string|null  $callback
-     * @return TValue
+     * @return TValue|null
      */
     public function min($callback = null)
     {


### PR DESCRIPTION
The `min` method can also return `null`, which is currently not reflected in the PHPDoc of the method. This PR adds `null` as a possible return type, which improves IDE experience and reduces unnecessary static analysis errors.