### PR TITLE
[9.x] Add unique locking to broadcast events

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -149,13 +149,11 @@ class BroadcastManager implements FactoryContract
      */
     public function queue($event)
     {
-        $broadcastEvent = $event instanceof ShouldBeUnique ? UniqueBroadcastEvent::class : BroadcastEvent::class;
-
         if ($event instanceof ShouldBroadcastNow ||
             (is_object($event) &&
              method_exists($event, 'shouldBroadcastNow') &&
              $event->shouldBroadcastNow())) {
-            return $this->app->make(BusDispatcherContract::class)->dispatchNow(new $broadcastEvent(clone $event));
+            return $this->app->make(BusDispatcherContract::class)->dispatchNow(new BroadcastEvent(clone $event));
         }
 
         $queue = null;
@@ -169,7 +167,7 @@ class BroadcastManager implements FactoryContract
         }
 
         $this->app->make('queue')->connection($event->connection ?? null)->pushOn(
-            $queue, new $broadcastEvent(clone $event)
+            $queue, $event instanceof ShouldBeUnique ? new UniqueBroadcastEvent(clone $event) : new BroadcastEvent(clone $event)
         );
     }
 

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -167,7 +167,10 @@ class BroadcastManager implements FactoryContract
         }
 
         $this->app->make('queue')->connection($event->connection ?? null)->pushOn(
-            $queue, $event instanceof ShouldBeUnique ? new UniqueBroadcastEvent(clone $event) : new BroadcastEvent(clone $event)
+            $queue,
+            $event instanceof ShouldBeUnique
+                    ? new UniqueBroadcastEvent(clone $event)
+                    : new BroadcastEvent(clone $event)
         );
     }
 

--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -41,7 +41,12 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
             $this->uniqueFor = $event->uniqueFor;
         }
 
-        $this->uniqueId = $event->uniqueId();
+        $this->uniqueId = get_class($event);
+        if (method_exists($event, 'uniqueId')) {
+            $this->uniqueId = $event->uniqueId();
+        } elseif (property_exists($event, 'uniqueId')) {
+            $this->uniqueId = $event->uniqueId;
+        }
 
         if (method_exists($event, 'uniqueVia')) {
             $this->uniqueVia = $event->uniqueVia();

--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Broadcasting;
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
+{
+    /**
+     * How long the lock should last in seconds
+     *
+     * @var int
+     */
+    public $uniqueFor;
+
+    /**
+     * Identifier for lock
+     *
+     * @var mixed
+     */
+    public $uniqueId;
+
+    /**
+     * Cache repository that should be used for lock
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    public $uniqueVia;
+
+    /**
+     * Create a new job handler instance.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function __construct($event)
+    {
+        if (method_exists($event, 'uniqueFor')) {
+            $this->uniqueFor = $event->uniqueFor();
+        } elseif (property_exists($event, 'uniqueFor')) {
+            $this->uniqueFor = $event->uniqueFor;
+        }
+
+        $this->uniqueId = $event->uniqueId();
+
+        if (method_exists($event, 'uniqueVia')) {
+            $this->uniqueVia = $event->uniqueVia();
+        } elseif (property_exists($event, 'uniqueVia')) {
+            $this->uniqueVia = $event->uniqueVia;
+        }
+
+        parent::__construct($event);
+    }
+}

--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -7,21 +7,21 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
 {
     /**
-     * How long the lock should last in seconds
-     *
-     * @var int
-     */
-    public $uniqueFor;
-
-    /**
-     * Identifier for lock
+     * The unique lock identifier.
      *
      * @var mixed
      */
     public $uniqueId;
 
     /**
-     * Cache repository that should be used for lock
+     * The number of seconds the unique lock should be maintained.
+     *
+     * @var int
+     */
+    public $uniqueFor;
+
+    /**
+     * The cache repository implementation that should be used to obtain unique locks.
      *
      * @var \Illuminate\Contracts\Cache\Repository
      */
@@ -35,17 +35,18 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
      */
     public function __construct($event)
     {
-        if (method_exists($event, 'uniqueFor')) {
-            $this->uniqueFor = $event->uniqueFor();
-        } elseif (property_exists($event, 'uniqueFor')) {
-            $this->uniqueFor = $event->uniqueFor;
-        }
-
         $this->uniqueId = get_class($event);
+
         if (method_exists($event, 'uniqueId')) {
             $this->uniqueId = $event->uniqueId();
         } elseif (property_exists($event, 'uniqueId')) {
             $this->uniqueId = $event->uniqueId;
+        }
+
+        if (method_exists($event, 'uniqueFor')) {
+            $this->uniqueFor = $event->uniqueFor();
+        } elseif (property_exists($event, 'uniqueFor')) {
+            $this->uniqueFor = $event->uniqueFor;
         }
 
         if (method_exists($event, 'uniqueVia')) {

--- a/src/Illuminate/Contracts/Broadcasting/ShouldBeUnique.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldBeUnique.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Broadcasting;
+
+interface ShouldBeUnique
+{
+    /**
+     * Unique identifier for lock
+     *
+     * @return mixed
+     */
+    public function uniqueId();
+}

--- a/src/Illuminate/Contracts/Broadcasting/ShouldBeUnique.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldBeUnique.php
@@ -4,10 +4,5 @@ namespace Illuminate\Contracts\Broadcasting;
 
 interface ShouldBeUnique
 {
-    /**
-     * Unique identifier for lock
-     *
-     * @return mixed
-     */
-    public function uniqueId();
+    //
 }

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -47,7 +47,7 @@ class BroadcastManagerTest extends TestCase
         Bus::assertNotDispatched(UniqueBroadcastEvent::class);
         Queue::assertPushed(UniqueBroadcastEvent::class);
         
-        $lockKey = 'laravel_unique_job:'.UniqueBroadcastEvent::class.'test';
+        $lockKey = 'laravel_unique_job:'.UniqueBroadcastEvent::class.TestEventUnique::class;
         $this->assertTrue($this->app->get(Cache::class)->lock($lockKey, 10)->get());
     }
 }
@@ -88,15 +88,5 @@ class TestEventUnique implements ShouldBroadcast, ShouldBeUnique
     public function broadcastOn()
     {
         //
-    }
-
-    /**
-     * Unique identifier for lock
-     *
-     * @return mixed
-     */
-    public function uniqueId()
-    {
-        return 'test';
     }
 }

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -3,8 +3,11 @@
 namespace Illuminate\Tests\Integration\Broadcasting;
 
 use Illuminate\Broadcasting\BroadcastEvent;
+use Illuminate\Broadcasting\UniqueBroadcastEvent;
+use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
@@ -33,6 +36,20 @@ class BroadcastManagerTest extends TestCase
         Bus::assertNotDispatched(BroadcastEvent::class);
         Queue::assertPushed(BroadcastEvent::class);
     }
+
+    public function testUniqueEventsCanBeBroadcast()
+    {
+        Bus::fake();
+        Queue::fake();
+
+        Broadcast::queue(new TestEventUnique);
+
+        Bus::assertNotDispatched(UniqueBroadcastEvent::class);
+        Queue::assertPushed(UniqueBroadcastEvent::class);
+        
+        $lockKey = 'laravel_unique_job:'.UniqueBroadcastEvent::class.'test';
+        $this->assertTrue($this->app->get(Cache::class)->lock($lockKey, 10)->get());
+    }
 }
 
 class TestEvent implements ShouldBroadcast
@@ -58,5 +75,28 @@ class TestEventNow implements ShouldBroadcastNow
     public function broadcastOn()
     {
         //
+    }
+}
+
+class TestEventUnique implements ShouldBroadcast, ShouldBeUnique
+{
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|\Illuminate\Broadcasting\Channel[]
+     */
+    public function broadcastOn()
+    {
+        //
+    }
+
+    /**
+     * Unique identifier for lock
+     *
+     * @return mixed
+     */
+    public function uniqueId()
+    {
+        return 'test';
     }
 }


### PR DESCRIPTION
Queueing broadcast events is incredibly important, especially at scale. Unfortunately at the moment there is no out-of-the-box method to prevent queues from being overloaded with repeated events. This can lead to redundant broadcast events that eat up data allowances.

I'm proposing a new `Illuminate\Contracts\Broadcasting\ShouldBeUnique` contract that tells the dispatcher to use a separate `UniqueBroadcastEvent` class. If no `uniqueId` method or property is defined, the event's class name is used as the identifier. You can also set `uniqueFor` and `uniqueVia` like other unique queue jobs via a property or method.