### PR TITLE
[9.x] Drop column if exists

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -298,6 +298,24 @@ class Builder
     }
 
     /**
+     * Drop columns if exists from a table schema.
+     *
+     * @param  string  $table
+     * @param  string|array  $columns
+     * @return void
+     */
+    public function dropColumnsIfExists($table, $columns)
+    {
+        array_map(function ($column) use ($table) {
+            if ($this->hasColumn($table, $column)) {
+                $this->table($table, function (Blueprint $blueprint) use ($column) {
+                    $blueprint->dropColumn($column);
+                });
+            }
+        }, is_array($columns) ? $columns : [$columns]);
+    }
+
+    /**
      * Drop all tables from the database.
      *
      * @return void

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -15,6 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasColumn(string $table, string $column)
  * @method static bool hasColumns(string $table, array $columns)
  * @method static bool dropColumns(string $table, array $columns)
+ * @method static bool dropColumnsIfExists(string $table, array $columns)
  * @method static void whenTableHasColumn(string $table, string $column, \Closure $callback)
  * @method static void whenTableDoesntHaveColumn(string $table, string $column, \Closure $callback)
  * @method static bool hasTable(string $table)

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -130,6 +130,27 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
         $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'covid19'));
     }
 
+    public function testDropColumnIfExists()
+    {
+        $this->schemaBuilder()->create('pandemic_table', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('stay_home');
+            $table->string('covid19');
+            $table->string('wear_mask');
+        });
+
+        $this->assertTrue($this->schemaBuilder()->hasColumn('pandemic_table', 'stay_home'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('pandemic_table', 'wear_mask'));
+        $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'undefined_column'));
+
+        $this->schemaBuilder()->dropColumnsIfExists('pandemic_table', ['stay_home', 'undefined_column']);
+        $this->schemaBuilder()->dropColumnsIfExists('pandemic_table', 'wear_mask');
+
+        $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'stay_home'));
+        $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'wear_mask'));
+        $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'undefined_column'));
+    }
+
     private function schemaBuilder()
     {
         return $this->db->connection()->getSchemaBuilder();


### PR DESCRIPTION
Unfortunately, when we use `->dropColumn` it triggers errors if the column doesn't exist. This PR adds a check if the table has the column and deletes it. 