### PR TITLE
[9.x] Fix overriding global locale

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -451,9 +451,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->headers->replace($from->headers->all());
 
-        $request->locale = $from->getLocale();
+        $request->setPlainLocale($from->getLocale());
 
-        $request->defaultLocale = $from->getDefaultLocale();
+        $request->setPlainDefaultLocale($from->getDefaultLocale());
 
         $request->setJson($from->json());
 
@@ -570,6 +570,28 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function setLaravelSession($session)
     {
         $this->session = $session;
+    }
+
+    /**
+     * Sets the locale.
+     *
+     * @param  string  $locale
+     * @return void
+     */
+    public function setPlainLocale(string $locale)
+    {
+        $this->locale = $locale;
+    }
+
+    /**
+     * Sets the default locale.
+     *
+     * @param  string  $locale
+     * @return void
+     */
+    public function setPlainDefaultLocale(string $locale)
+    {
+        $this->defaultLocale = $locale;
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -573,7 +573,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Sets the locale for the request instance.
+     * Set the locale for the request instance.
      *
      * @param  string  $locale
      * @return void
@@ -584,7 +584,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Sets the default locale for the request instance.
+     * Set the default locale for the request instance.
      *
      * @param  string  $locale
      * @return void

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -451,9 +451,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->headers->replace($from->headers->all());
 
-        $request->setLocale($from->getLocale());
+        $request->locale = $from->getLocale();
 
-        $request->setDefaultLocale($from->getDefaultLocale());
+        $request->defaultLocale = $from->getDefaultLocale();
 
         $request->setJson($from->json());
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -451,9 +451,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $request->headers->replace($from->headers->all());
 
-        $request->setPlainLocale($from->getLocale());
+        $request->setRequestLocale($from->getLocale());
 
-        $request->setPlainDefaultLocale($from->getDefaultLocale());
+        $request->setDefaultRequestLocale($from->getDefaultLocale());
 
         $request->setJson($from->json());
 
@@ -573,23 +573,23 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
-     * Sets the locale.
+     * Sets the locale for the request instance.
      *
      * @param  string  $locale
      * @return void
      */
-    public function setPlainLocale(string $locale)
+    public function setRequestLocale(string $locale)
     {
         $this->locale = $locale;
     }
 
     /**
-     * Sets the default locale.
+     * Sets the default locale for the request instance.
      *
      * @param  string  $locale
      * @return void
      */
-    public function setPlainDefaultLocale(string $locale)
+    public function setDefaultRequestLocale(string $locale)
     {
         $this->defaultLocale = $locale;
     }


### PR DESCRIPTION
This PR fixes a bug where the global Locale value would be overwritten by calling setLocale. Underneath this method, Symfony sets the global Locale. Since we're not initializing the original request of the application but 
rather copying an existing request, we need to prevent from overwriting the default PHP locale. We can achieve this by just setting the plain locale and plain default locale without modifying the PHP locale. I've added new methods to achieve this so there's no side effects.

Fixes #43371
