### PR TITLE
typo correction

### DIFF
--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
  * @method void info(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void line(string $style, string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void task(string $description, ?callable $task = null, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
- * @method void twoColumnDetail(string $first, ?string $second = null, int $verbosity = OutputInterface::VERBOSITY_NORMAL)
+ * @method void twoColumnDetail(string $first, ?string $second = null, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void warn(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  */
 class Factory


### PR DESCRIPTION
To calm the PHPStorm IDE ("Function has a parameter whose default value is incompatible with its declared type")
