### PR TITLE
[9.x]: drop column if exists

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -292,9 +292,13 @@ class Builder
      */
     public function dropColumns($table, $columns)
     {
-        $this->table($table, function (Blueprint $blueprint) use ($columns) {
-            $blueprint->dropColumn($columns);
-        });
+        array_map(function ($column) use ($table) {
+            if ($this->hasColumn($table, $column)) {
+                $this->table($table, function (Blueprint $blueprint) use ($column) {
+                    $blueprint->dropColumn($column);
+                });
+            }
+        }, is_array($columns) ? $columns : [$columns]);
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -120,13 +120,20 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
         // drop single columns
         $this->assertTrue($this->schemaBuilder()->hasColumn('pandemic_table', 'stay_home'));
+        $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'unknown_column'));
         $this->schemaBuilder()->dropColumns('pandemic_table', 'stay_home');
+        $this->schemaBuilder()->dropColumns('pandemic_table', 'unkown_column');
+        $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'unkown_column'));
         $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'stay_home'));
 
         // drop multiple columns
         $this->assertTrue($this->schemaBuilder()->hasColumn('pandemic_table', 'covid19'));
+        $this->assertTrue($this->schemaBuilder()->hasColumn('pandemic_table', 'wear_mask'));
+        $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'unkown_column'));
         $this->schemaBuilder()->dropColumns('pandemic_table', ['covid19', 'wear_mask']);
+        $this->schemaBuilder()->dropColumns('pandemic_table', ['stay_home', 'unkown_column']);
         $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'wear_mask'));
+        $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'unkown_column'));
         $this->assertFalse($this->schemaBuilder()->hasColumn('pandemic_table', 'covid19'));
     }
 


### PR DESCRIPTION
Unfortunately, when we use `->dropColumn` it triggers errors if the column doesn't exist. This PR adds a check if the table has the column and deletes it. 