### PR TITLE
Change successful status hardcoded number to constant in console.stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -27,6 +27,6 @@ class {{ class }} extends Command
      */
     public function handle()
     {
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In console.stub file when returning the handle method result, it's beneficial to use Console constants as result, so that developer know what is exactly the zero in here and what are the alternate values to use.
