### PR TITLE
[9.x] Fixes Artisan `serve` command on Windows

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -226,7 +226,7 @@ class ServeCommand extends Command
      */
     protected function handleProcessOutput()
     {
-        return fn ($type, $buffer) => str($buffer)->explode(PHP_EOL)->each(function ($line) {
+        return fn ($type, $buffer) => str($buffer)->explode("\n")->each(function ($line) {
             $parts = explode(']', $line);
 
             if (str($line)->contains('Development Server (http')) {


### PR DESCRIPTION
This pull request fixes the `serve` command when being used on Windows.

Fixes https://github.com/laravel/framework/issues/43433.