### PR TITLE
[9.x] Make Command components Factory extensible

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -118,7 +118,7 @@ class Command extends SymfonyCommand
             OutputStyle::class, ['input' => $input, 'output' => $output]
         );
 
-        $this->components = new Factory($this->output);
+        $this->components = $this->laravel->make(Factory::class, [$this->output]);
 
         return parent::run(
             $this->input = $input, $this->output

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -118,7 +118,7 @@ class Command extends SymfonyCommand
             OutputStyle::class, ['input' => $input, 'output' => $output]
         );
 
-        $this->components = $this->laravel->make(Factory::class, [$this->output]);
+        $this->components = $this->laravel->make(Factory::class, ['output' => $this->output]);
 
         return parent::run(
             $this->input = $input, $this->output

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Console;
 use Illuminate\Console\Application;
 use Illuminate\Console\Command;
 use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -35,7 +36,9 @@ class CommandTest extends TestCase
 
         $input = new ArrayInput([]);
         $output = new NullOutput;
-        $application->shouldReceive('make')->with(OutputStyle::class, ['input' => $input, 'output' => $output])->andReturn(m::mock(OutputStyle::class));
+        $outputStyle = m::mock(OutputStyle::class);
+        $application->shouldReceive('make')->with(OutputStyle::class, ['input' => $input, 'output' => $output])->andReturn($outputStyle);
+        $application->shouldReceive('make')->with(Factory::class, ['output' => $outputStyle])->andReturn(m::mock(Factory::class));
 
         $application->shouldReceive('call')->with([$command, 'handle'])->andReturnUsing(function () use ($command, $application) {
             $commandCalled = m::mock(Command::class);

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface;
@@ -23,6 +24,7 @@ class SeedCommandTest extends TestCase
     {
         $input = new ArrayInput(['--force' => true, '--database' => 'sqlite']);
         $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
 
         $seeder = m::mock(Seeder::class);
         $seeder->shouldReceive('setContainer')->once()->andReturnSelf();
@@ -38,7 +40,10 @@ class SeedCommandTest extends TestCase
         $container->shouldReceive('environment')->once()->andReturn('testing');
         $container->shouldReceive('make')->with('DatabaseSeeder')->andReturn($seeder);
         $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
-            new OutputStyle($input, $output)
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
         );
 
         $command = new SeedCommand($resolver);
@@ -59,6 +64,7 @@ class SeedCommandTest extends TestCase
             '--class' => UserWithoutModelEventsSeeder::class,
         ]);
         $output = new NullOutput;
+        $outputStyle = new OutputStyle($input, $output);
 
         $instance = new UserWithoutModelEventsSeeder();
 
@@ -75,7 +81,10 @@ class SeedCommandTest extends TestCase
         $container->shouldReceive('environment')->once()->andReturn('testing');
         $container->shouldReceive('make')->with(UserWithoutModelEventsSeeder::class)->andReturn($seeder);
         $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
-            new OutputStyle($input, $output)
+            $outputStyle
+        );
+        $container->shouldReceive('make')->with(Factory::class, m::any())->andReturn(
+            new Factory($outputStyle)
         );
 
         $command = new SeedCommand($resolver);


### PR DESCRIPTION
Make it possible for extending the Command component Factory by the end user. Allowing for custom formatting of the output.

It may be useful if the output environment support a different type of encoding or even to accomodate logging specifications by removing default text output in the case of bulletList and taks.
