### PR TITLE
[9.x] Add withoutUpdatedTimestamp()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1067,7 +1067,8 @@ class Builder implements BuilderContract
     protected function addUpdatedAtColumn(array $values)
     {
         if (! $this->model->usesTimestamps() ||
-            is_null($this->model->getUpdatedAtColumn())) {
+            is_null($this->model->getUpdatedAtColumn()) ||
+            $this->model::isIgnoringUpdatedTimestamp()) {
             return $values;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1126,7 +1126,7 @@ class Builder implements BuilderContract
      */
     protected function addUpdatedAtToUpsertColumns(array $update)
     {
-        if (! $this->model->usesTimestamps()) {
+        if (! $this->model->usesTimestamps() || $this->model::isIgnoringUpdatedTimestamp()) {
             return $update;
         }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1889,6 +1889,21 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
     }
 
+    public function testWithoutTouchingStillUpdatesTheSameModel()
+    {
+        $before = Carbon::now();
+
+        $user = EloquentTouchingUser::create(['id' => 1, 'email' => 'taylor@laravel.com']);
+
+        Carbon::setTestNow($future = $before->copy()->addDays(3));
+
+        EloquentTouchingUser::withoutTouching(function () use ($user) {
+            $user->update(['email' => 'taylorotwell@gmail.com']);
+        });
+
+        $this->assertTrue($future->isSameDay($user->fresh()->updated_at));
+    }
+
     public function testUpdatingChildPostRespectsNoTouchingDefinition()
     {
         $before = Carbon::now();

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2066,6 +2066,23 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue($now->isSameSecond($user->updated_at));
     }
 
+    public function testUpdatingMulitpleModelsFromQueryBuilderIgnoresUpdatedTimestamp()
+    {
+        $now = now();
+        Carbon::setTestNow($now);
+
+        User::query()->create(['email' => 'pat@domain.com']);
+        User::query()->create(['email' => 'eve@domain.com']);
+
+        Carbon::setTestNow($now->copy()->addDays(3));
+
+        User::withoutUpdatedTimestamp(function () {
+            User::query()->update(['name' => 'Twins']);
+        });
+
+        $this->assertTrue($now->isSameSecond(User::first()->updated_at));
+    }
+
     public function testIgnoringUpdatedTimestampIgnoresModal()
     {
         $before = Carbon::now();


### PR DESCRIPTION
Many times I've needed to run a command that updates a model without updating the `updated_at` column. This might be migrating data or a client wants to make a batch change to their data without losing the existing `updated_at`.

Usually I reach for one of the two options:

```php
// iterate over and set timestamps to false - slow
$users->each(function ($user) {
    $user->timestamps = false;
    $user->update(['something' => 'here']);
});

// extend the model in the command and set timestamps to false - dirty
UserWithoutTimestamps::query()->update(['something' => 'here']);

// ...
class UserWithoutTimestamps extends User {
    public $timestamps = false;
}
```

Recently I've come across the `withoutTouching` static method, which had me thinking "why don't we have this for `updated_at`?" 🤔 

So here it is.

You can now ignore all models `updated_at` timestamps via `Model::withoutUpdatedTimestamp()`

```php
Model::withoutUpdatedTimestamp(function () use ($user, $post, $comment) {
    // no change to updated_at
    $user->update(['something' => 'here']);
    $post->update(['something' => 'here']);
    $comment->update(['something' => 'here']);
});
```

...or ignore mulitple models `updated_at` timestamp via `Model::withoutUpdatedTimestampOn()`

```php
Model::withoutUpdatedTimestampOn([User::class, Post::class], function () use ($user, $post, $comment) {
    // no change to updated_at
    $user->update(['something' => 'here']);
    $post->update(['something' => 'here']);
    // updated_at will be set
    $comment->update(['something' => 'here']);
});
```

...or ignore a single model `updated_at` timestamp via `User::withoutUpdatedTimestamp()`

```php
User::withoutUpdatedTimestamp(function () use ($user, $post, $comment) {
    // no change to updated_at
    $user->update(['something' => 'here']);
    // updated_at will be set
    $post->update(['something' => 'here']);
    $comment->update(['something' => 'here']);
});
```

Laravel sets both `updated_at` and `created_at` when a model is created. This functionality has stayed the same as it's a data integrity issue. So creating models in the callback will still have `updated_at` set.

```php
User::withoutUpdatedTimestamp(function() use ($user) {
    // no change to updated_at
    $user->update(['something' => 'here']);

    // updated_at will be set as usual
    $player = User::create(['name' => 'Patrick']);
});
```

This also works for the query builder

```php
User::withoutUpdatedTimestamp(function() use ($user) {
    // no change to updated_at
    User::query()
        ->where('something', 'there')
        ->update(['something' => 'here']);
});
```

and upserting

```php

User::create(['email' => 'taylor@laravel.com']);

User::withoutUpdatedTimestamp(function() use ($user) {
    User::upsert(
        [
            // no change to updated_at
            ['email' => 'taylor@laravel.com', 'name' => 'Taylor'],
            // updated_at will be set with created_at as the model is new
            ['email' => 'pat@domain.com', 'name' => 'Pat'],
        ], 
        ['email'], 
        ['name'],
    );
});
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
