### PR TITLE
[9.x] Support CSP nonce, SRI, and arbitrary attributes with Vite

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
 use Illuminate\Foundation\MaintenanceModeManager;
+use Illuminate\Foundation\Vite;
 use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\AggregateServiceProvider;
@@ -22,6 +23,15 @@ class FoundationServiceProvider extends AggregateServiceProvider
     protected $providers = [
         FormRequestServiceProvider::class,
         ParallelTestingServiceProvider::class,
+    ];
+
+    /**
+     * The singletons to register into the container.
+     *
+     * @var array
+     */
+    public $singletons = [
+        Vite::class => Vite::class,
     ];
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -120,6 +120,21 @@ trait InteractsWithContainer
             {
                 return '';
             }
+
+            public function useIntegrityKey()
+            {
+                return $this;
+            }
+
+            public function useAttributesForScriptTag()
+            {
+                return $this;
+            }
+
+            public function useAttributesForStylesheetTag()
+            {
+                return $this;
+            }
         });
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -126,12 +126,12 @@ trait InteractsWithContainer
                 return $this;
             }
 
-            public function useAttributesForScriptTag()
+            public function useScriptTagAttributes()
             {
                 return $this;
             }
 
-            public function useAttributesForStylesheetTag()
+            public function useStyleTagAttributes()
             {
                 return $this;
             }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -3,11 +3,108 @@
 namespace Illuminate\Foundation;
 
 use Exception;
+use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 class Vite
 {
+    /**
+     * The Content Security Policy nonce to apply to all generated tags.
+     *
+     * @var string|null
+     */
+    protected $nonce;
+
+    /**
+     * The key to check for integrity hashes within the manifest.
+     *
+     * @var string|false
+     */
+    protected $integrityKey = 'integrity';
+
+    /**
+     * The script tag attributes resolvers.
+     *
+     * @var array
+     */
+    protected $scriptTagAttributesResolvers = [];
+
+    /**
+     * The stylesheet tag attributes resolvers.
+     *
+     * @var array
+     */
+    protected $stylesheetTagAttributesResolvers = [];
+
+    /**
+     * Generate or set a Content Security Policy nonce to apply to all generated tags.
+     *
+     * @param  ?string  $nonce
+     * @return string
+     */
+    public function useCspNonce($nonce = null)
+    {
+        return $this->nonce = $nonce ?? Str::random(40);
+    }
+
+    /**
+     * Get the Content Security Policy nonce applied to all generated tags.
+     *
+     * @return string|null
+     */
+    public function cspNonce()
+    {
+        return $this->nonce;
+    }
+
+    /**
+     * Use the given key to detect integrity hashes in the manifest.
+     *
+     * @param  string|false  $key
+     * @return $this
+     */
+    public function useIntegrityKey($key)
+    {
+        $this->integrityKey = $key;
+
+        return $this;
+    }
+
+    /**
+     * Use the given callback to resolve attributes for script tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return $this
+     */
+    public function useAttributesForScriptTag($attributes)
+    {
+        if (! is_callable($attributes)) {
+            $attributes = fn () => $attributes;
+        }
+
+        $this->scriptTagAttributesResolvers[] = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * Use the given callback to resolve attributes for stylesheet tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return $this
+     */
+    public function useAttributesForStylesheetTag($attributes)
+    {
+        if (! is_callable($attributes)) {
+            $attributes = fn () => $attributes;
+        }
+
+        $this->stylesheetTagAttributesResolvers[] = $attributes;
+
+        return $this;
+    }
+
     /**
      * Generate Vite tags for an entrypoint.
      *
@@ -29,8 +126,8 @@ class Vite
 
             return new HtmlString(
                 $entrypoints
-                    ->map(fn ($entrypoint) => $this->makeTag("{$url}/{$entrypoint}"))
-                    ->prepend($this->makeScriptTag("{$url}/@vite/client"))
+                    ->prepend('@vite/client')
+                    ->map(fn ($entrypoint) => $this->makeTagForChunk($entrypoint, "{$url}/{$entrypoint}", null, null))
                     ->join('')
             );
         }
@@ -54,21 +151,32 @@ class Vite
                 throw new Exception("Unable to locate file in Vite manifest: {$entrypoint}.");
             }
 
-            $tags->push($this->makeTag(asset("{$buildDirectory}/{$manifest[$entrypoint]['file']}")));
+            $tags->push($this->makeTagForChunk(
+                $entrypoint,
+                asset("{$buildDirectory}/{$manifest[$entrypoint]['file']}"),
+                $manifest[$entrypoint],
+                $manifest
+            ));
 
-            if (isset($manifest[$entrypoint]['css'])) {
-                foreach ($manifest[$entrypoint]['css'] as $css) {
-                    $tags->push($this->makeStylesheetTag(asset("{$buildDirectory}/{$css}")));
-                }
+            foreach ($manifest[$entrypoint]['css'] ?? [] as $css) {
+                $tags->push($this->makeTagForChunk(
+                    $entrypoint,
+                    asset("{$buildDirectory}/{$css}"),
+                    $manifest[$entrypoint],
+                    $manifest
+                ));
             }
 
-            if (isset($manifest[$entrypoint]['imports'])) {
-                foreach ($manifest[$entrypoint]['imports'] as $import) {
-                    if (isset($manifest[$import]['css'])) {
-                        foreach ($manifest[$import]['css'] as $css) {
-                            $tags->push($this->makeStylesheetTag(asset("{$buildDirectory}/{$css}")));
-                        }
-                    }
+            foreach ($manifest[$entrypoint]['imports'] ?? [] as $import) {
+                foreach ($manifest[$import]['css'] ?? [] as $css) {
+                    $partialManifest = Collection::make($manifest)->where('file', $css);
+
+                    $tags->push($this->makeTagForChunk(
+                        $partialManifest->keys()->first(),
+                        asset("{$buildDirectory}/{$css}"),
+                        $partialManifest->first(),
+                        $manifest
+                    ));
                 }
             }
         }
@@ -108,7 +216,86 @@ class Vite
     }
 
     /**
-     * Generate an appropriate tag for the given URL.
+     * Make tag for the given chunk.
+     *
+     * @param  string  $src
+     * @param  string  $url
+     * @param  ?array  $chunk
+     * @param  ?array  $manifest
+     * @return string
+     */
+    protected function makeTagForChunk($src, $url, $chunk, $manifest)
+    {
+        if (
+            $this->nonce === null
+            && $this->integrityKey !== false
+            && ! array_key_exists($this->integrityKey, $chunk ?? [])
+            && $this->scriptTagAttributesResolvers === []
+            && $this->stylesheetTagAttributesResolvers === []) {
+            return $this->makeTag($url);
+        }
+
+        if ($this->isCssPath($url)) {
+            return $this->makeStylesheetTagWithAttributes(
+                $url,
+                $this->resolveStylesheetTagAttributes($src, $url, $chunk, $manifest)
+            );
+        }
+
+        return $this->makeScriptTagWithAttributes(
+            $url,
+            $this->resolveScriptTagAttributes($src, $url, $chunk, $manifest)
+        );
+    }
+
+    /**
+     * Resolve the attributes for the chunks generated script tag.
+     *
+     * @param  string  $src
+     * @param  string  $url
+     * @param  ?array  $chunk
+     * @param  ?array  $manifest
+     * @return array
+     */
+    protected function resolveScriptTagAttributes($src, $url, $chunk, $manifest)
+    {
+        $attributes = $this->integrityKey !== false
+            ? ['integrity' => $chunk[$this->integrityKey] ?? false]
+            : [];
+
+        foreach ($this->scriptTagAttributesResolvers as $resolver) {
+            $attributes = array_merge($attributes, $resolver($src, $url, $chunk, $manifest));
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Resolve the attributes for the chunks generated stylesheet tag.
+     *
+     * @param  string  $src
+     * @param  string  $url
+     * @param  ?array  $chunk
+     * @param  ?array  $manifest
+     * @return array
+     */
+    protected function resolveStylesheetTagAttributes($src, $url, $chunk, $manifest)
+    {
+        $attributes = $this->integrityKey !== false
+            ? ['integrity' => $chunk[$this->integrityKey] ?? false]
+            : [];
+
+        foreach ($this->stylesheetTagAttributesResolvers as $resolver) {
+            $attributes = array_merge($attributes, $resolver($src, $url, $chunk, $manifest));
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Generate an appropriate tag for the given URL in HMR mode.
+     *
+     * @deprecated Will be removed in a future Laravel version.
      *
      * @param  string  $url
      * @return string
@@ -125,23 +312,63 @@ class Vite
     /**
      * Generate a script tag for the given URL.
      *
+     * @deprecated Will be removed in a future Laravel version.
+     *
      * @param  string  $url
      * @return string
      */
     protected function makeScriptTag($url)
     {
-        return sprintf('<script type="module" src="%s"></script>', $url);
+        return $this->makeScriptTagWithAttributes($url, []);
     }
 
     /**
-     * Generate a stylesheet tag for the given URL.
+     * Generate a stylesheet tag for the given URL in HMR mode.
+     *
+     * @deprecated Will be removed in a future Laravel version.
      *
      * @param  string  $url
      * @return string
      */
     protected function makeStylesheetTag($url)
     {
-        return sprintf('<link rel="stylesheet" href="%s" />', $url);
+        return $this->makeStylesheetTagWithAttributes($url, []);
+    }
+
+    /**
+     * Generate a script tag with attributes for the given URL.
+     *
+     * @param  string  $url
+     * @param  array  $attributes
+     * @return string
+     */
+    protected function makeScriptTagWithAttributes($url, $attributes)
+    {
+        $attributes = $this->parseAttributes(array_merge([
+            'type' => 'module',
+            'src' => $url,
+            'nonce' => $this->nonce ?? false,
+        ], $attributes));
+
+        return '<script '.implode(' ', $attributes).'></script>';
+    }
+
+    /**
+     * Generate a link tag with attributes for the given URL.
+     *
+     * @param  string  $url
+     * @param  array  $attributes
+     * @return string
+     */
+    protected function makeStylesheetTagWithAttributes($url, $attributes)
+    {
+        $attributes = $this->parseAttributes(array_merge([
+            'rel' => 'stylesheet',
+            'href' => $url,
+            'nonce' => $this->nonce ?? false,
+        ], $attributes));
+
+        return '<link '.implode(' ', $attributes).' />';
     }
 
     /**
@@ -153,5 +380,21 @@ class Vite
     protected function isCssPath($path)
     {
         return preg_match('/\.(css|less|sass|scss|styl|stylus|pcss|postcss)$/', $path) === 1;
+    }
+
+    /**
+     * Parse the attributes into key="value" strings.
+     *
+     * @param  array  $attributes
+     * @return array
+     */
+    protected function parseAttributes($attributes)
+    {
+        return Collection::make($attributes)
+            ->reject(fn ($value, $key) => in_array($value, [false, null], true))
+            ->flatMap(fn ($value, $key) => $value === true ? [$key] : [$key => $value])
+            ->map(fn ($value, $key) => is_int($key) ? $value : $key.'="'.$value.'"')
+            ->values()
+            ->all();
     }
 }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -293,6 +293,7 @@ abstract class Facade
             'URL' => URL::class,
             'Validator' => Validator::class,
             'View' => View::class,
+            'Vite' => Vite::class,
         ]);
     }
 

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * @method static string useCspNonce(?string $nonce = null)
+ * @method static string|null cspNonce()
+ * @method static \Illuminte\Foundation\Vite useIntegrityKey(string|false $key)
+ * @method static \Illuminte\Foundation\Vite useAttributesForScriptTag(callable|array $callback)
+ * @method static \Illuminte\Foundation\Vite useAttributesForStylesheetTag(callable|array $callback)
+ *
+ * @see \Illuminate\Foundation\Vite
+ */
+class Vite extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return \Illuminate\Foundation\Vite::class;
+    }
+}

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -6,8 +6,8 @@ namespace Illuminate\Support\Facades;
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
  * @method static \Illuminte\Foundation\Vite useIntegrityKey(string|false $key)
- * @method static \Illuminte\Foundation\Vite useAttributesForScriptTag(callable|array $callback)
- * @method static \Illuminte\Foundation\Vite useAttributesForStylesheetTag(callable|array $callback)
+ * @method static \Illuminte\Foundation\Vite useScriptTagAttributes(callable|array $callback)
+ * @method static \Illuminte\Foundation\Vite useStyleTagAttributes(callable|array $callback)
  *
  * @see \Illuminate\Foundation\Vite
  */

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -272,10 +272,10 @@ class FoundationViteTest extends TestCase
     public function testItCanSpecifyArbitraryAttributesForScriptTagsWhenBuilt()
     {
         $this->makeViteManifest();
-        ViteFacade::useAttributesForScriptTag([
+        ViteFacade::useScriptTagAttributes([
             'general' => 'attribute',
         ]);
-        ViteFacade::useAttributesForScriptTag(function ($src, $url, $chunk, $manifest) {
+        ViteFacade::useScriptTagAttributes(function ($src, $url, $chunk, $manifest) {
             $this->assertSame('resources/js/app.js', $src);
             $this->assertSame('https://example.com/build/assets/app.versioned.js', $url);
             $this->assertSame(['file' => 'assets/app.versioned.js'], $chunk);
@@ -334,10 +334,10 @@ class FoundationViteTest extends TestCase
     public function testItCanSpecifyArbitraryAttributesForStylesheetTagsWhenBuild()
     {
         $this->makeViteManifest();
-        ViteFacade::useAttributesForStylesheetTag([
+        ViteFacade::useStyleTagAttributes([
             'general' => 'attribute',
         ]);
-        ViteFacade::useAttributesForStylesheetTag(function ($src, $url, $chunk, $manifest) {
+        ViteFacade::useStyleTagAttributes(function ($src, $url, $chunk, $manifest) {
             $this->assertSame('resources/css/app.css', $src);
             $this->assertSame('https://example.com/build/assets/app.versioned.css', $url);
             $this->assertSame(['file' => 'assets/app.versioned.css'], $chunk);
@@ -393,14 +393,14 @@ class FoundationViteTest extends TestCase
     public function testItCanSpecifyArbitraryAttributesForScriptTagsWhenHotModuleReloading()
     {
         $this->makeViteHotFile();
-        ViteFacade::useAttributesForScriptTag([
+        ViteFacade::useScriptTagAttributes([
             'general' => 'attribute',
         ]);
         $expectedArguments = [
             ['src' => '@vite/client', 'url' => 'http://localhost:3000/@vite/client'],
             ['src' => 'resources/js/app.js', 'url' => 'http://localhost:3000/resources/js/app.js'],
         ];
-        ViteFacade::useAttributesForScriptTag(function ($src, $url, $chunk, $manifest) use (&$expectedArguments) {
+        ViteFacade::useScriptTagAttributes(function ($src, $url, $chunk, $manifest) use (&$expectedArguments) {
             $args = array_shift($expectedArguments);
 
             $this->assertSame($args['src'], $src);
@@ -429,10 +429,10 @@ class FoundationViteTest extends TestCase
     public function testItCanSpecifyArbitraryAttributesForStylesheetTagsWhenHotModuleReloading()
     {
         $this->makeViteHotFile();
-        ViteFacade::useAttributesForStylesheetTag([
+        ViteFacade::useStyleTagAttributes([
             'general' => 'attribute',
         ]);
-        ViteFacade::useAttributesForStylesheetTag(function ($src, $url, $chunk, $manifest) {
+        ViteFacade::useStyleTagAttributes(function ($src, $url, $chunk, $manifest) {
             $this->assertSame('resources/css/app.css', $src);
             $this->assertSame('http://localhost:3000/resources/css/app.css', $url);
             $this->assertNull($chunk);
@@ -459,11 +459,11 @@ class FoundationViteTest extends TestCase
     public function testItCanOverrideAllAttributes()
     {
         $this->makeViteManifest();
-        ViteFacade::useAttributesForStylesheetTag([
+        ViteFacade::useStyleTagAttributes([
             'rel' => 'expected-rel',
             'href' => 'expected-href',
         ]);
-        ViteFacade::useAttributesForScriptTag([
+        ViteFacade::useScriptTagAttributes([
             'type' => 'expected-type',
             'src' => 'expected-src',
         ]);

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -4,6 +4,9 @@ namespace Illuminate\Tests\Foundation;
 
 use Illuminate\Foundation\Vite;
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Vite as ViteFacade;
+use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -17,12 +20,16 @@ class FoundationViteTest extends TestCase
                 ->shouldReceive('asset')
                 ->andReturnUsing(fn ($value) => "https://example.com{$value}")
         ));
+
+        app()->singleton(Vite::class);
+        Facade::setFacadeApplication(app());
     }
 
     protected function tearDown(): void
     {
         $this->cleanViteManifest();
         $this->cleanViteHotFile();
+        Facade::clearResolvedInstances();
         m::close();
     }
 
@@ -30,7 +37,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest();
 
-        $result = (new Vite)('resources/js/app.js');
+        $result = app(Vite::class)('resources/js/app.js');
 
         $this->assertSame('<script type="module" src="https://example.com/build/assets/app.versioned.js"></script>', $result->toHtml());
     }
@@ -39,7 +46,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest();
 
-        $result = (new Vite)(['resources/css/app.css', 'resources/js/app.js']);
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
 
         $this->assertSame(
             '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" />'
@@ -52,7 +59,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest();
 
-        $result = (new Vite)('resources/js/app-with-css-import.js');
+        $result = app(Vite::class)('resources/js/app-with-css-import.js');
 
         $this->assertSame(
             '<link rel="stylesheet" href="https://example.com/build/assets/imported-css.versioned.css" />'
@@ -65,7 +72,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest();
 
-        $result = (new Vite)(['resources/js/app-with-shared-css.js']);
+        $result = app(Vite::class)(['resources/js/app-with-shared-css.js']);
 
         $this->assertSame(
             '<link rel="stylesheet" href="https://example.com/build/assets/shared-css.versioned.css" />'
@@ -78,7 +85,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteHotFile();
 
-        $result = (new Vite)('resources/js/app.js');
+        $result = app(Vite::class)('resources/js/app.js');
 
         $this->assertSame(
             '<script type="module" src="http://localhost:3000/@vite/client"></script>'
@@ -91,7 +98,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteHotFile();
 
-        $result = (new Vite)(['resources/css/app.css', 'resources/js/app.js']);
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
 
         $this->assertSame(
             '<script type="module" src="http://localhost:3000/@vite/client"></script>'
@@ -101,15 +108,384 @@ class FoundationViteTest extends TestCase
         );
     }
 
-    protected function makeViteManifest()
+    public function testItCanGenerateCspNonceWithHotFile()
+    {
+        Str::createRandomStringsUsing(fn ($length) => "random-string-with-length:{$length}");
+        $this->makeViteHotFile();
+
+        $nonce = ViteFacade::useCspNonce();
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame('random-string-with-length:40', $nonce);
+        $this->assertSame('random-string-with-length:40', ViteFacade::cspNonce());
+        $this->assertSame(
+            '<script type="module" src="http://localhost:3000/@vite/client" nonce="random-string-with-length:40"></script>'
+            .'<link rel="stylesheet" href="http://localhost:3000/resources/css/app.css" nonce="random-string-with-length:40" />'
+            .'<script type="module" src="http://localhost:3000/resources/js/app.js" nonce="random-string-with-length:40"></script>',
+            $result->toHtml()
+        );
+
+        Str::createRandomStringsNormally();
+    }
+
+    public function testItCanGenerateCspNonceWithManifest()
+    {
+        Str::createRandomStringsUsing(fn ($length) => "random-string-with-length:{$length}");
+        $this->makeViteManifest();
+
+        $nonce = ViteFacade::useCspNonce();
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame('random-string-with-length:40', $nonce);
+        $this->assertSame('random-string-with-length:40', ViteFacade::cspNonce());
+        $this->assertSame(
+            '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" nonce="random-string-with-length:40" />'
+            .'<script type="module" src="https://example.com/build/assets/app.versioned.js" nonce="random-string-with-length:40"></script>',
+            $result->toHtml()
+        );
+
+        Str::createRandomStringsNormally();
+    }
+
+    public function testItCanSpecifyCspNonceWithHotFile()
+    {
+        $this->makeViteHotFile();
+
+        $nonce = ViteFacade::useCspNonce('expected-nonce');
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame('expected-nonce', $nonce);
+        $this->assertSame('expected-nonce', ViteFacade::cspNonce());
+        $this->assertSame(
+            '<script type="module" src="http://localhost:3000/@vite/client" nonce="expected-nonce"></script>'
+            .'<link rel="stylesheet" href="http://localhost:3000/resources/css/app.css" nonce="expected-nonce" />'
+            .'<script type="module" src="http://localhost:3000/resources/js/app.js" nonce="expected-nonce"></script>',
+            $result->toHtml()
+        );
+    }
+
+    public function testItCanSpecifyCspNonceWithManifest()
+    {
+        $this->makeViteManifest();
+
+        $nonce = ViteFacade::useCspNonce('expected-nonce');
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame('expected-nonce', $nonce);
+        $this->assertSame('expected-nonce', ViteFacade::cspNonce());
+        $this->assertSame(
+            '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" nonce="expected-nonce" />'
+            .'<script type="module" src="https://example.com/build/assets/app.versioned.js" nonce="expected-nonce"></script>',
+            $result->toHtml()
+        );
+    }
+
+    public function testItCanInjectIntegrityWhenPresentInManifest()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest([
+            'resources/js/app.js' => [
+                'file' => 'assets/app.versioned.js',
+                'integrity' => 'expected-app.js-integrity',
+            ],
+            'resources/css/app.css' => [
+                'file' => 'assets/app.versioned.css',
+                'integrity' => 'expected-app.css-integrity',
+            ],
+        ], $buildDir);
+
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js'], $buildDir);
+
+        $this->assertSame(
+            '<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/app.versioned.css" integrity="expected-app.css-integrity" />'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js" integrity="expected-app.js-integrity"></script>',
+            $result->toHtml()
+        );
+
+        unlink(public_path("{$buildDir}/manifest.json"));
+        rmdir(public_path($buildDir));
+    }
+
+    public function testItCanInjectIntegrityWhenPresentInManifestForImportedCss()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest([
+            'resources/js/app.js' => [
+                'file' => 'assets/app.versioned.js',
+                'imports' => [
+                    '_import.versioned.js',
+                ],
+                'integrity' => 'expected-app.js-integrity',
+            ],
+            '_import.versioned.js' => [
+                'file' => 'assets/import.versioned.js',
+                'css' => [
+                    'assets/imported-css.versioned.css',
+                ],
+                'integrity' => 'expected-import.js-integrity',
+            ],
+            'imported-css.css' => [
+                'file' => 'assets/imported-css.versioned.css',
+                'integrity' => 'expected-imported-css.css-integrity',
+            ],
+        ], $buildDir);
+
+        $result = app(Vite::class)('resources/js/app.js', $buildDir);
+
+        $this->assertSame(
+            '<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/imported-css.versioned.css" integrity="expected-imported-css.css-integrity" />'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js" integrity="expected-app.js-integrity"></script>',
+            $result->toHtml()
+        );
+
+        unlink(public_path("{$buildDir}/manifest.json"));
+        rmdir(public_path($buildDir));
+    }
+
+    public function testItCanSpecifyIntegrityKey()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest([
+            'resources/js/app.js' => [
+                'file' => 'assets/app.versioned.js',
+                'different-integrity-key' => 'expected-app.js-integrity',
+            ],
+            'resources/css/app.css' => [
+                'file' => 'assets/app.versioned.css',
+                'different-integrity-key' => 'expected-app.css-integrity',
+            ],
+        ], $buildDir);
+        ViteFacade::useIntegrityKey('different-integrity-key');
+
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js'], $buildDir);
+
+        $this->assertSame(
+            '<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/app.versioned.css" integrity="expected-app.css-integrity" />'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js" integrity="expected-app.js-integrity"></script>',
+            $result->toHtml()
+        );
+
+        unlink(public_path("{$buildDir}/manifest.json"));
+        rmdir(public_path($buildDir));
+    }
+
+    public function testItCanSpecifyArbitraryAttributesForScriptTagsWhenBuilt()
+    {
+        $this->makeViteManifest();
+        ViteFacade::useAttributesForScriptTag([
+            'general' => 'attribute',
+        ]);
+        ViteFacade::useAttributesForScriptTag(function ($src, $url, $chunk, $manifest) {
+            $this->assertSame('resources/js/app.js', $src);
+            $this->assertSame('https://example.com/build/assets/app.versioned.js', $url);
+            $this->assertSame(['file' => 'assets/app.versioned.js'], $chunk);
+            $this->assertSame([
+                'resources/js/app.js' => [
+                    'file' => 'assets/app.versioned.js',
+                ],
+                'resources/js/app-with-css-import.js' => [
+                    'file' => 'assets/app-with-css-import.versioned.js',
+                    'css' => [
+                        'assets/imported-css.versioned.css',
+                    ],
+                ],
+                'resources/css/imported-css.css' => [
+                    'file' => 'assets/imported-css.versioned.css',
+                ],
+                'resources/js/app-with-shared-css.js' => [
+                    'file' => 'assets/app-with-shared-css.versioned.js',
+                    'imports' => [
+                        '_someFile.js',
+                    ],
+                ],
+                'resources/css/app.css' => [
+                    'file' => 'assets/app.versioned.css',
+                ],
+                '_someFile.js' => [
+                    'css' => [
+                        'assets/shared-css.versioned.css',
+                    ],
+                ],
+                'resources/css/shared-css' => [
+                    'file' => 'assets/shared-css.versioned.css',
+                ],
+            ], $manifest);
+
+            return [
+                'crossorigin',
+                'data-persistent-across-pages' => 'YES',
+                'remove-me' => false,
+                'keep-me' => true,
+                'null' => null,
+                'empty-string' => '',
+                'zero' => 0,
+            ];
+        });
+
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame(
+            '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" />'
+            .'<script type="module" src="https://example.com/build/assets/app.versioned.js" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me empty-string="" zero="0"></script>',
+            $result->toHtml()
+        );
+    }
+
+    public function testItCanSpecifyArbitraryAttributesForStylesheetTagsWhenBuild()
+    {
+        $this->makeViteManifest();
+        ViteFacade::useAttributesForStylesheetTag([
+            'general' => 'attribute',
+        ]);
+        ViteFacade::useAttributesForStylesheetTag(function ($src, $url, $chunk, $manifest) {
+            $this->assertSame('resources/css/app.css', $src);
+            $this->assertSame('https://example.com/build/assets/app.versioned.css', $url);
+            $this->assertSame(['file' => 'assets/app.versioned.css'], $chunk);
+            $this->assertSame([
+                'resources/js/app.js' => [
+                    'file' => 'assets/app.versioned.js',
+                ],
+                'resources/js/app-with-css-import.js' => [
+                    'file' => 'assets/app-with-css-import.versioned.js',
+                    'css' => [
+                        'assets/imported-css.versioned.css',
+                    ],
+                ],
+                'resources/css/imported-css.css' => [
+                    'file' => 'assets/imported-css.versioned.css',
+                ],
+                'resources/js/app-with-shared-css.js' => [
+                    'file' => 'assets/app-with-shared-css.versioned.js',
+                    'imports' => [
+                        '_someFile.js',
+                    ],
+                ],
+                'resources/css/app.css' => [
+                    'file' => 'assets/app.versioned.css',
+                ],
+                '_someFile.js' => [
+                    'css' => [
+                        'assets/shared-css.versioned.css',
+                    ],
+                ],
+                'resources/css/shared-css' => [
+                    'file' => 'assets/shared-css.versioned.css',
+                ],
+            ], $manifest);
+
+            return [
+                'crossorigin',
+                'data-persistent-across-pages' => 'YES',
+                'remove-me' => false,
+                'keep-me' => true,
+            ];
+        });
+
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame(
+            '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me />'
+            .'<script type="module" src="https://example.com/build/assets/app.versioned.js"></script>',
+            $result->toHtml()
+        );
+    }
+
+    public function testItCanSpecifyArbitraryAttributesForScriptTagsWhenHotModuleReloading()
+    {
+        $this->makeViteHotFile();
+        ViteFacade::useAttributesForScriptTag([
+            'general' => 'attribute',
+        ]);
+        $expectedArguments = [
+            ['src' => '@vite/client', 'url' => 'http://localhost:3000/@vite/client'],
+            ['src' => 'resources/js/app.js', 'url' => 'http://localhost:3000/resources/js/app.js'],
+        ];
+        ViteFacade::useAttributesForScriptTag(function ($src, $url, $chunk, $manifest) use (&$expectedArguments) {
+            $args = array_shift($expectedArguments);
+
+            $this->assertSame($args['src'], $src);
+            $this->assertSame($args['url'], $url);
+            $this->assertNull($chunk);
+            $this->assertNull($manifest);
+
+            return [
+                'crossorigin',
+                'data-persistent-across-pages' => 'YES',
+                'remove-me' => false,
+                'keep-me' => true,
+            ];
+        });
+
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame(
+            '<script type="module" src="http://localhost:3000/@vite/client" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me></script>'
+            .'<link rel="stylesheet" href="http://localhost:3000/resources/css/app.css" />'
+            .'<script type="module" src="http://localhost:3000/resources/js/app.js" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me></script>',
+            $result->toHtml()
+        );
+    }
+
+    public function testItCanSpecifyArbitraryAttributesForStylesheetTagsWhenHotModuleReloading()
+    {
+        $this->makeViteHotFile();
+        ViteFacade::useAttributesForStylesheetTag([
+            'general' => 'attribute',
+        ]);
+        ViteFacade::useAttributesForStylesheetTag(function ($src, $url, $chunk, $manifest) {
+            $this->assertSame('resources/css/app.css', $src);
+            $this->assertSame('http://localhost:3000/resources/css/app.css', $url);
+            $this->assertNull($chunk);
+            $this->assertNull($manifest);
+
+            return [
+                'crossorigin',
+                'data-persistent-across-pages' => 'YES',
+                'remove-me' => false,
+                'keep-me' => true,
+            ];
+        });
+
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame(
+            '<script type="module" src="http://localhost:3000/@vite/client"></script>'
+            .'<link rel="stylesheet" href="http://localhost:3000/resources/css/app.css" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me />'
+            .'<script type="module" src="http://localhost:3000/resources/js/app.js"></script>',
+            $result->toHtml()
+        );
+    }
+
+    public function testItCanOverrideAllAttributes()
+    {
+        $this->makeViteManifest();
+        ViteFacade::useAttributesForStylesheetTag([
+            'rel' => 'expected-rel',
+            'href' => 'expected-href',
+        ]);
+        ViteFacade::useAttributesForScriptTag([
+            'type' => 'expected-type',
+            'src' => 'expected-src',
+        ]);
+
+        $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
+
+        $this->assertSame(
+            '<link rel="expected-rel" href="expected-href" />'
+            .'<script type="expected-type" src="expected-src"></script>',
+            $result->toHtml()
+        );
+    }
+
+    protected function makeViteManifest($contents = null, $path = 'build')
     {
         app()->singleton('path.public', fn () => __DIR__);
 
-        if (! file_exists(public_path('build'))) {
-            mkdir(public_path('build'));
+        if (! file_exists(public_path($path))) {
+            mkdir(public_path($path));
         }
 
-        $manifest = json_encode([
+        $manifest = json_encode($contents ?? [
             'resources/js/app.js' => [
                 'file' => 'assets/app.versioned.js',
             ],
@@ -118,6 +494,9 @@ class FoundationViteTest extends TestCase
                 'css' => [
                     'assets/imported-css.versioned.css',
                 ],
+            ],
+            'resources/css/imported-css.css' => [
+                'file' => 'assets/imported-css.versioned.css',
             ],
             'resources/js/app-with-shared-css.js' => [
                 'file' => 'assets/app-with-shared-css.versioned.js',
@@ -133,9 +512,12 @@ class FoundationViteTest extends TestCase
                     'assets/shared-css.versioned.css',
                 ],
             ],
+            'resources/css/shared-css' => [
+                'file' => 'assets/shared-css.versioned.css',
+            ],
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
-        file_put_contents(public_path('build/manifest.json'), $manifest);
+        file_put_contents(public_path("{$path}/manifest.json"), $manifest);
     }
 
     protected function cleanViteManifest()


### PR DESCRIPTION
This PR introduces support for three distinct, but related, Vite features. Content security policy nonce (security), sub-resource integrity (security), and arbitrary tag attributes (security / app specific features).

They are combined in a single PR to create a holistic solution, as they all share the same problem space with regards to implementation, which is putting attributes on a HTML tag.


## Content Security Policy (CSP) Nonce

You can read about what a CSP nonce is over on the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce), but summary it is a security feature where all script and style tags must contain the same nonce specified by the `Content-Security-Policy` header or else the browser will not execute them.

Our Vite implementation now has first party support for creating a nonce that will be used on all generated script and style tags.

> **Warning**: You still need to return the content security policy header manually.

Here is an example of its usage:

```php
use Illuminate\Support\Facades\Vite;

class ContentSecurityPolicy
{
    public function handle($request, $next)
    {
        // You need to call this function **before** resolving the response
        // so that 3rd parties can use the same nonce throughout the request
        // lifecycle e.g. Ziggy

        Vite::useCspNonce();

        return $next($response)->withHeaders([
            'Content-Security-Policy' => "script-src 'nonce-".Vite::cspNonce()."'",
        ]);
    }
}
```

All script and style tags generated with Vite will now have the `nonce="{cryptographically_secure_nonce}"` attribute.


```html
<link
    rel="stylesheet"
    href="https://laravel.com/build/assets/app.j3j28sk1l.css"
    nonce="{cryptographically_secure_nonce}"
/>
```

You can additionally retrieve the nonce throughout your application, for example in you blade views:


```blade
{{-- Use Ziggy with the same nonce --}}
{{-- See: https://github.com/tighten/ziggy#using-routes-with-a-content-security-policy --}}

@routes(nonce: Vite::cspNonce())
```

If you do not want to use Laravel's default nonce generation, and would like to use your own, you may pass a nonce to the `Vite::useCspNonce()` function. When generation tags, Vite will then use the given value in the `nonce` attribute.

```php
use Illuminate\Support\Facades\Vite;

class CspMiddleware
{
    public function handle($request, $next)
    {
        // You need to specify this **before** resolving the response...

        Vite::useCspNonce(generateMyOwnNonce());

        return $next($response)->withHeaders([
            'Content-Security-Policy' => "script-src 'nonce-".Vite::cspNonce()."'",
        ]);
    }
}
```

When specifying your own nonce to use, it is still possible to retrieve the value specified via the Vite class as seen above:

```blade
@routes(nonce: Vite::cspNonce())
```

## Subresource integrity (SRI)

You can read about what a SRI nonce is over on the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity), but summary it is a security feature where the hash of the resource contents must match the hash in the `integrity` attribute of the tag loading the resource, or else the browser will not execute them.

By convention, Laravel's Vite integration works on the convention of having an "integrity" property specified in the manifest for the given chunk. Here is an example manifest:

```json
{
  "resources/js/app.js": {
    "file": "assets/app.88ad0043.js",
    "src": "resources/js/app.js",
    "isEntry": true,
    "integrity": "sha384-NLhywiqRzeFT85dJzotJfHlfYU3tGCDj5BshD4to8kXVQZwrhTrluhYFbweDmEyL"
  },
  "resources/css/app.css": {
    "file": "assets/app.3f8f484f.css",
    "src": "app.css",
    "isEntry": true,
    "integrity": "sha384-e3Eztracy2WEqhl/vLFMx+hjnDmvYQnO7pLNvrDeUfMU9T7hq+M/Iv9ace+GCbBV"
  }
}
```

When chunks within the Vite manifest has the given shape, generated tags will contain have the `"integrity"` attribute added.

```html
<link
    rel="stylesheet"
    href="https://laravel.com/build/assets/app.versioned.css"
    integrity="sha384-e3Eztracy2WEqhl/vLFMx+hjnDmvYQnO7pLNvrDeUfMU9T7hq+M/Iv9ace+GCbBV"
/>
<script
    type="module"
    src="https://laravel.com/build/assets/app.versioned.js"
    integrity="sha384-NLhywiqRzeFT85dJzotJfHlfYU3tGCDj5BshD4to8kXVQZwrhTrluhYFbweDmEyL"
></script>
``` 

But generating these integrity tags manually in each application is a PITA. I recommend instead of recreating the wheel, to lean on the [vite-plugin-manifest-sri](https://github.com/ElMassimo/vite-plugin-manifest-sri). When using this plugin, everything will "Just Work™️" without any additional work by the developer.

So to setup SRI in your application, you can install the plugin:

```
npm i -D vite-plugin-manifest-sri
```

Add it to your `vite.config.js`

```diff
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';
+ import manifestSRI from 'vite-plugin-manifest-sri'

export default defineConfig({
    plugins: [
        laravel({
            // ...
        }),
+       manifestSRI(),
    ],
});
```

...and Bob's your uncle.

If you use a different plugin that does not use the `"integrity"` key in the manifest, you may configure the key used by Vite to find the integrity hash. If the plugin creates the following manifest structure...

```diff
{
  "resources/js/app.js": {
    "file": "assets/app.88ad0043.js",
    "src": "resources/js/app.js",
    "isEntry": true,
-   "integrity": "sha384-NLhywiqRzeFT85dJzotJfHlfYU3tGCDj5BshD4to8kXVQZwrhTrluhYFbweDmEyL"
+   "SRI": "sha384-NLhywiqRzeFT85dJzotJfHlfYU3tGCDj5BshD4to8kXVQZwrhTrluhYFbweDmEyL"
  },
  "resources/css/app.css": {
    "file": "assets/app.3f8f484f.css",
    "src": "app.css",
    "isEntry": true,
-   "integrity": "sha384-e3Eztracy2WEqhl/vLFMx+hjnDmvYQnO7pLNvrDeUfMU9T7hq+M/Iv9ace+GCbBV"
+   "SRI": "sha384-e3Eztracy2WEqhl/vLFMx+hjnDmvYQnO7pLNvrDeUfMU9T7hq+M/Iv9ace+GCbBV"
  }
}
```

You can tell Vite to check the `"SRI"` key in the manifest instead:

```php
Illuminate\Support\Facades\Vite::useIntegrityKey('SRI');
```

If you want to disable this auto-detection completely, you can opt out of it:

```php
Illuminate\Support\Facades\Vite::useIntegrityKey(false);
```

## Arbitrary attributes

The above features have been about providing first party support for some key security features with loaded script / css resources, however it is also useful for developers to be able to add arbitrary attributes to the generated tags without creating first party solutions for everything under the sun.

With the following API, developers may specify attributes to add to their script and stylesheet tags. 

```php
use Illuminate\Support\Facades\Vite;

Vite::useAttributesForScriptTag([
    'data-turbolinks-track' => 'reload',
]);

Vite::useAttributesForStyleTag([
    'data-turbolinks-track' => 'reload',
]);

```

If you need to conditionally add attributes to tags based on the chunk, you may use a callback that receives the src, url, chunk, and the entire manifest:

```php
use Illuminate\Support\Facades\Vite;

Vite::useAttributesForScriptTag(fn (string $src, string $url, array|null $chunk, array|null $manifest) => [
    //
]);

Vite::useAttributesForStyleTag(fn (string $src, string $url, array|null $chunk, array|null $manifest) => [
    //
]);
```

> **Note**: The `$chunk` and `$manifest` arguments will be `null` in HMR mode.

The attributes specified have some logic behind them to be aware of...

```php
Vite::useAttributesForStyleTag([
    'attribute-only',
    'attribute-with' => 'value',
    'attribute-with-zero' => 0,
    'attribute-with-true-value' => true,
    'attribute-with-false-value' => false,
    'attribute-with-empty-string' => '',
    'attribute-with-null' => null,
]);
```

The notable things here are that attributes with values `=== false` will filtered out, while `true` values will return only the attribute, which is the HTML attribute conventions.

```html
<script
    type="module"
    src="..."
    attribute-only
    attribute-with="value"
    attribute-with-zero="0"
    attribute-with-true-value
    attribute-with-empty-string=""
></script>
```

Note that:
- `attribute-with-false-value` is not present in the output HTML. We filter them out as `false` attributes are simply missing attributes.
- `attribute-with-empty-string` is present and maintains it's empty string value. This is considered a `true` attribute in HTML land.
- `attribute-with-null` is not present in the output HTML. I wasn't 100% sure about this, but I feel that in HTML an "empty" value is a missing attribute, so this feels like the right move to me.

You can read more about how boolean attributes work in the [HTML specification](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes).

Finally, any attributes you return from the closure will be merged with the default attributes - but your returned attributes will have precedence - so you have the ability to override anything and everything if you have some wild use-case where you need to do that.

## Introducing these in a non-breaking way

Some of the changes I've made feel a little bit funky in one spot, as I've needed to keep the current functionality in place to not break current functionality for those who have extended the `Vite` class, while introducing new functionality that requires different method signatures.

As such, I've left the old `makeTag` function in place and that continues to be called unless any of these new features is utilised. I've deprecated 3 methods and we can clean them up in `10.x`.

## ~API~

~I've built this using a static API. I would have preferred to go down the path of an instance API, but I felt for this it did make sense to match the more static style API even thought it is not a Facade. If we want to pursue an instance API we would need to bind the Vite class as a singleton and then have the API used as follows:~

## Documentation

I'll work on a follow up PR for the docs.