### PR TITLE
[9.x] Solve Blade component showing quote formatted for the console

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -92,7 +92,7 @@ class ComponentMakeCommand extends GeneratorCommand
         file_put_contents(
             $path,
             '<div>
-    <!-- '.Inspiring::quote().' -->
+    <!-- '.Inspiring::quotes()->random().' -->
 </div>'
         );
 
@@ -112,7 +112,7 @@ class ComponentMakeCommand extends GeneratorCommand
         if ($this->option('inline')) {
             return str_replace(
                 ['DummyView', '{{ view }}'],
-                "<<<'blade'\n<div>\n    <!-- ".Inspiring::quote()." -->\n</div>\nblade",
+                "<<<'blade'\n<div>\n    <!-- ".Inspiring::quotes()->random()." -->\n</div>\nblade",
                 parent::buildClass($name)
             );
         }


### PR DESCRIPTION
With the fresh new look for Artisan, the quotes are being formatted for the console.

**Currently:**
```html
<div>
    <!-- 
  <options=bold>“ An unexamined life is not worth living. ”</>
  <fg=gray>— Socrates</>
 -->
</div>
```

**Expected:**
```html
<div>
    <!-- An unexamined life is not worth living. - Socrates -->
</div>
```

The change has been made following the pull request https://github.com/laravel/framework/pull/43397