### PR TITLE
[9.x] Add handy filled blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -171,6 +171,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the filled statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileFilled($expression)
+    {
+        return "<?php if (! empty({$expression})): ?>";
+    }
+
+    /**
      * Compile the else-if statements into valid PHP.
      *
      * @param  string  $expression
@@ -207,6 +218,16 @@ trait CompilesConditionals
      * @return string
      */
     protected function compileEndunless()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-filled statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndfilled()
     {
         return '<?php endif; ?>';
     }

--- a/tests/View/Blade/BladeFilledStatementsTest.php
+++ b/tests/View/Blade/BladeFilledStatementsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeFilledStatementsTest extends AbstractBladeTestCase
+{
+    public function testFilledStatementsAreCompiled()
+    {
+        $string = '@filled (name(foo(bar)))
+breeze
+@endfilled';
+        $expected = '<?php if (! empty((name(foo(bar))))): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
### Added
- A handy way to do `if-not-empty` checks in Blade via a Blade Directive.

### Backward Compatible
- Yes

### Motivation

Currently in we have many very useful blade conditional directives like `@if(condition)`, `@unless(condition)`, `@empty(condition)`, and many more.

It was initially cumbersome to write `@if(!condition)` so we introduced a cleaner `@unless(condition)`.

But in our view files, on many occasions, we feel the need to write the `IF-NOT-EMPTY` condition. As of today we can do that with,

**Existing Approach:**

```blade
// Using IF
@if(! empty($order->instruction))
  <h4>Customer Instruction:</h4>
  {{ $order->instruction }}
@endif

// Using UNLESS
@unless(empty($order->instruction))
  <h4>Customer Instruction:</h4>
  {{ $order->instruction }}
@endunless
// It is a lot cleaner and so good
```

**Proposed Approach:**

```blade
@filled($order->instruction)
  <h4>Customer Instruction:</h4>
  {{ $order->instruction }}
@endfilled
```

**Output:**

```blade
<?php if (! empty($order->instruction)) : ?>
  <h4>Customer Instruction:</h4>
  ...
<?php endif; ?>
```

### Support

We can compose it with the exiting `@else` directive,

```blade
@filled($order->instruction)
  <h4>Direction Instruction:</h4>
  {{ $order->instruction }}
@else
  <a href="/order/1/instruction/new">Add Direction Instruction</a>
@endfilled
```
