### PR TITLE
[9.x] Support conditionables that get condition from target object

### DIFF
--- a/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
@@ -30,7 +30,7 @@ class HigherOrderWhenProxy
      *
      * @var bool
      */
-    protected $negateCondition;
+    protected $negateConditionOnCapture;
 
     /**
      * Create a new proxy instance.
@@ -62,9 +62,9 @@ class HigherOrderWhenProxy
      *
      * @return $this
      */
-    public function negateCondition()
+    public function negateConditionOnCapture()
     {
-        $this->negateCondition = true;
+        $this->negateConditionOnCapture = true;
 
         return $this;
     }
@@ -94,7 +94,7 @@ class HigherOrderWhenProxy
         if (! $this->hasCondition) {
             $condition = $this->target->{$method}(...$parameters);
 
-            return $this->condition($this->negateCondition ? ! $condition : $condition);
+            return $this->condition($this->negateConditionOnCapture ? ! $condition : $condition);
         }
 
         return $this->condition

--- a/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
@@ -19,7 +19,7 @@ class HigherOrderWhenProxy
     protected $condition;
 
     /**
-     * Tracks whether the proxy has a condition.
+     * Indicates whether the proxy has a condition.
      *
      * @var bool
      */
@@ -51,14 +51,13 @@ class HigherOrderWhenProxy
      */
     public function condition($condition)
     {
-        $this->condition = $condition;
-        $this->hasCondition = true;
+        [$this->condition, $this->hasCondition] = [$condition, true];
 
         return $this;
     }
 
     /**
-     * Negate the condition.
+     * Indicate that the condition should be negated.
      *
      * @return $this
      */

--- a/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
@@ -19,16 +19,54 @@ class HigherOrderWhenProxy
     protected $condition;
 
     /**
+     * Tracks whether the proxy has a condition.
+     *
+     * @var bool
+     */
+    protected $hasCondition = false;
+
+    /**
+     * Determine whether the condition should be negated.
+     *
+     * @var bool
+     */
+    protected $negateCondition;
+
+    /**
      * Create a new proxy instance.
      *
      * @param  mixed  $target
-     * @param  bool  $condition
      * @return void
      */
-    public function __construct($target, $condition)
+    public function __construct($target)
     {
         $this->target = $target;
+    }
+
+    /**
+     * Set the condition on the proxy.
+     *
+     * @param bool $condition
+     * @return $this
+     */
+    public function condition($condition)
+    {
         $this->condition = $condition;
+        $this->hasCondition = true;
+
+        return $this;
+    }
+
+    /**
+     * Negate the condition.
+     *
+     * @return $this
+     */
+    public function negateCondition()
+    {
+        $this->negateCondition = true;
+
+        return $this;
     }
 
     /**
@@ -53,6 +91,12 @@ class HigherOrderWhenProxy
      */
     public function __call($method, $parameters)
     {
+        if (! $this->hasCondition) {
+            $condition = $this->target->{$method}(...$parameters);
+
+            return $this->condition($this->negateCondition ? ! $condition : $condition);
+        }
+
         return $this->condition
             ? $this->target->{$method}(...$parameters)
             : $this->target;

--- a/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
@@ -77,6 +77,12 @@ class HigherOrderWhenProxy
      */
     public function __get($key)
     {
+        if (! $this->hasCondition) {
+            $condition = $this->target->{$key};
+
+            return $this->condition($this->negateConditionOnCapture ? ! $condition : $condition);
+        }
+
         return $this->condition
             ? $this->target->{$key}
             : $this->target;

--- a/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Conditionable/HigherOrderWhenProxy.php
@@ -46,7 +46,7 @@ class HigherOrderWhenProxy
     /**
      * Set the condition on the proxy.
      *
-     * @param bool $condition
+     * @param  bool  $condition
      * @return $this
      */
     public function condition($condition)

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -55,7 +55,7 @@ trait Conditionable
         $value = $value instanceof Closure ? $value($this) : $value;
 
         if (func_num_args() === 0) {
-            return (new HigherOrderWhenProxy($this))->negateCondition();
+            return (new HigherOrderWhenProxy($this))->negateConditionOnCapture();
         }
 
         if (func_num_args() === 1) {

--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -13,17 +13,21 @@ trait Conditionable
      * @template TWhenParameter
      * @template TWhenReturnType
      *
-     * @param  (\Closure($this): TWhenParameter)|TWhenParameter  $value
+     * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null $value
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
      * @return $this|TWhenReturnType
      */
-    public function when($value, callable $callback = null, callable $default = null)
+    public function when($value = null, callable $callback = null, callable $default = null)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
+        if (func_num_args() === 0) {
+            return new HigherOrderWhenProxy($this);
+        }
+
         if (func_num_args() === 1) {
-            return new HigherOrderWhenProxy($this, $value);
+            return (new HigherOrderWhenProxy($this))->condition($value);
         }
 
         if ($value) {
@@ -41,17 +45,21 @@ trait Conditionable
      * @template TUnlessParameter
      * @template TUnlessReturnType
      *
-     * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter  $value
+     * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter|null  $value
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $callback
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
      * @return $this|TUnlessReturnType
      */
-    public function unless($value, callable $callback = null, callable $default = null)
+    public function unless($value = null, callable $callback = null, callable $default = null)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
+        if (func_num_args() === 0) {
+            return (new HigherOrderWhenProxy($this))->negateCondition();
+        }
+
         if (func_num_args() === 1) {
-            return new HigherOrderWhenProxy($this, ! $value);
+            return (new HigherOrderWhenProxy($this))->condition(! $value);
         }
 
         if (! $value) {

--- a/tests/Conditionable/ConditionableTest.php
+++ b/tests/Conditionable/ConditionableTest.php
@@ -27,6 +27,7 @@ class ConditionableTest extends TestCase
     {
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->when(true));
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->when(false));
+        $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->when());
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(false, null));
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->when(true, function () {
         }));
@@ -36,6 +37,7 @@ class ConditionableTest extends TestCase
     {
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(true));
         $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->unless(false));
+        $this->assertInstanceOf(HigherOrderWhenProxy::class, TestConditionableModel::query()->unless());
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(true, null));
         $this->assertInstanceOf(Builder::class, TestConditionableModel::query()->unless(false, function () {
         }));

--- a/tests/Support/SupportConditionableTest.php
+++ b/tests/Support/SupportConditionableTest.php
@@ -158,7 +158,7 @@ class SupportConditionableTest extends TestCase
             ->unless()->has('missing')->log('four')
             ->unless()->toggle->log('five')
             ->toggle()
-            ->unless()->toggle->log('six');;
+            ->unless()->toggle->log('six');
 
         $this->assertSame(['init', 'two', 'four', 'five'], $logger->values);
     }

--- a/tests/Support/SupportConditionableTest.php
+++ b/tests/Support/SupportConditionableTest.php
@@ -152,7 +152,7 @@ class SupportConditionableTest extends TestCase
             })
             ->log('two')
             ->unless()->has('init')->log('three')
-            ->unless()->has('missing')->log('four');;
+            ->unless()->has('missing')->log('four');
 
         $this->assertSame(['init', 'two', 'four'], $logger->values);
     }

--- a/tests/Support/SupportConditionableTest.php
+++ b/tests/Support/SupportConditionableTest.php
@@ -127,9 +127,12 @@ class SupportConditionableTest extends TestCase
             })
             ->log('two')
             ->when()->has('init')->log('three')
-            ->when()->has('missing')->log('four');
+            ->when()->has('missing')->log('four')
+            ->when()->toggle->log('five')
+            ->toggle()
+            ->when()->toggle->log('six');
 
-        $this->assertSame(['init', 'one', 'three'], $logger->values);
+        $this->assertSame(['init', 'one', 'three', 'six'], $logger->values);
     }
 
     public function testUnlessProxy()
@@ -152,9 +155,12 @@ class SupportConditionableTest extends TestCase
             })
             ->log('two')
             ->unless()->has('init')->log('three')
-            ->unless()->has('missing')->log('four');
+            ->unless()->has('missing')->log('four')
+            ->unless()->toggle->log('five')
+            ->toggle()
+            ->unless()->toggle->log('six');;
 
-        $this->assertSame(['init', 'two', 'four'], $logger->values);
+        $this->assertSame(['init', 'two', 'four', 'five'], $logger->values);
     }
 }
 
@@ -163,6 +169,8 @@ class ConditionableLogger
     use Conditionable;
 
     public $values = [];
+
+    public $toggle = false;
 
     public function log(...$values)
     {
@@ -174,5 +182,12 @@ class ConditionableLogger
     public function has($value)
     {
         return in_array($value, $this->values);
+    }
+
+    public function toggle()
+    {
+        $this->toggle = ! $this->toggle;
+
+        return $this;
     }
 }

--- a/tests/Support/SupportConditionableTest.php
+++ b/tests/Support/SupportConditionableTest.php
@@ -125,9 +125,11 @@ class SupportConditionableTest extends TestCase
             ->when(function ($logger) {
                 return $logger->has('missing');
             })
-            ->log('two');
+            ->log('two')
+            ->when()->has('init')->log('three')
+            ->when()->has('missing')->log('four');
 
-        $this->assertSame(['init', 'one'], $logger->values);
+        $this->assertSame(['init', 'one', 'three'], $logger->values);
     }
 
     public function testUnlessProxy()
@@ -148,9 +150,11 @@ class SupportConditionableTest extends TestCase
             ->unless(function ($logger) {
                 return $logger->has('missing');
             })
-            ->log('two');
+            ->log('two')
+            ->unless()->has('init')->log('three')
+            ->unless()->has('missing')->log('four');;
 
-        $this->assertSame(['init', 'two'], $logger->values);
+        $this->assertSame(['init', 'two', 'four'], $logger->values);
     }
 }
 


### PR DESCRIPTION
This PR allows people to use the `->when()` and `->unless()` methods without passing in any parameters. 

Currently, people are required to pass in the condition as the first parameter:

```php
Storage::disk('orders')
    ->when($condition = fn(Filesystem $disk) => $disk->missing('someDirectory'))
    ->makeDirectory('someDirectory');
```

The `Conditionable` will execute the closure and store that as the condition. The next method call ("makeDirectory") will be proxied to the original object based on that condition.

This PR allows to create a proxy without an initial condition. The first method call to the proxy will become the condition, and the second call will be proxied to the original object based on that condition.

With this change, the above example would become:

```php
Storage::disk('orders')
    ->when()->missing('someDirectory')
    ->makeDirectory('someDirectory');
```

(In this example I'll assume that the #43450 PR gets merged first, but you certainly can get the general idea.)

Thanks!