### PR TITLE
[9.x] Add conditionable trait to Filesystem adapters

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -3,11 +3,14 @@
 namespace Illuminate\Filesystem;
 
 use Aws\S3\S3Client;
+use Illuminate\Support\Traits\Conditionable;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter as S3Adapter;
 use League\Flysystem\FilesystemOperator;
 
 class AwsS3V3Adapter extends FilesystemAdapter
 {
+    use Conditionable;
+
     /**
      * The AWS S3 client.
      *

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -6,6 +6,7 @@ use ErrorException;
 use FilesystemIterator;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 use SplFileObject;
@@ -15,6 +16,7 @@ use Symfony\Component\Mime\MimeTypes;
 
 class Filesystem
 {
+    use Conditionable;
     use Macroable;
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -9,6 +9,7 @@ use Illuminate\Http\File;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
@@ -38,6 +39,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class FilesystemAdapter implements CloudFilesystemContract
 {
+    use Conditionable;
     use Macroable {
         __call as macroCall;
     }

--- a/tests/Integration/Filesystem/StorageTest.php
+++ b/tests/Integration/Filesystem/StorageTest.php
@@ -63,4 +63,20 @@ class StorageTest extends TestCase
         Storage::disk('public')->assertMissing('StardewTaylor.png');
         $this->assertFalse(Storage::disk('public')->exists('StardewTaylor.png'));
     }
+
+    public function testConditionable()
+    {
+        Storage::disk('public')->assertExists('StardewTaylor.png');
+        $this->assertTrue(Storage::disk('public')->exists('StardewTaylor.png'));
+
+        Storage::disk('public')->when(false)->delete('StardewTaylor.png');
+
+        Storage::disk('public')->assertExists('StardewTaylor.png');
+        $this->assertTrue(Storage::disk('public')->exists('StardewTaylor.png'));
+
+        Storage::disk('public')->when(true)->delete('StardewTaylor.png');
+
+        Storage::disk('public')->assertMissing('StardewTaylor.png');
+        $this->assertFalse(Storage::disk('public')->exists('StardewTaylor.png'));
+    }
 }


### PR DESCRIPTION
This PR adds the `Conditionable` trait to the Filesystem adapters. This allows people to use the handy `->when()` and `->unless()` methods when using the Storage facade. 

Adding the `Conditionable` trait will pair very nicely with a PR I'll submit in a minute (#43449).