### PR TITLE
[9.x] Add queued command function to scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Application;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -135,6 +136,26 @@ class Schedule
         return $this->exec(
             Application::formatCommandString($command), $parameters
         );
+    }
+
+    /**
+     * Add a new queued command callback event to the schedule.
+     *
+     * @param  object|string  $job
+     * @param  array  $parameters
+     * @param  string|null  $queue
+     * @param  string|null  $connection
+     * @return \Illuminate\Console\Scheduling\CallbackEvent
+     */
+    public function queuedCommand($command, array $parameters = [], $queue = null, $connection = null)
+    {
+        return $this->call(function () use ($command, $parameters, $queue, $connection) {
+            Container::getInstance()
+                ->make(Kernel::class)
+                ->queue($command, $parameters)
+                ->onQueue($queue)
+                ->onConnection($connection);
+        });
     }
 
     /**

--- a/tests/Integration/Console/QueuedCommandSchedulingTest.php
+++ b/tests/Integration/Console/QueuedCommandSchedulingTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\QueuedCommand;
+use Illuminate\Support\Facades\Queue;
+use Orchestra\Testbench\TestCase;
+
+class QueuedCommandSchedulingTest extends TestCase
+{
+    public function testJobQueuingRespectsJobQueue()
+    {
+        Queue::fake();
+
+        /** @var \Illuminate\Console\Scheduling\Schedule $scheduler */
+        $scheduler = $this->app->make(Schedule::class);
+        $scheduler->queuedCommand(FooCommand::class)->name('')->everyMinute();
+        $scheduler->queuedCommand(FooCommand::class, ['foo' => 'bar'], 'test-queue')->name('')->everyMinute();
+        $scheduler->queuedCommand(FooCommand::class, ['foo' => 'bar'], 'another-queue')->name('')->everyMinute();
+
+        $events = $scheduler->events();
+        foreach ($events as $event) {
+            $event->run($this->app);
+        }
+
+        Queue::assertPushedOn('test-queue', QueuedCommand::class);
+        Queue::assertPushedOn('another-queue', QueuedCommand::class);
+        Queue::assertPushedOn(null, QueuedCommand::class);
+    }
+
+    public function testJobQueuingRespectsJobConnection()
+    {
+        Queue::fake();
+
+        /** @var \Illuminate\Console\Scheduling\Schedule $scheduler */
+        $scheduler = $this->app->make(Schedule::class);
+        $scheduler->queuedCommand(FooCommand::class)->name('')->everyMinute();
+        $scheduler->queuedCommand(FooCommand::class, ['foo' => 'bar'], null, 'foo')->name('')->everyMinute();
+        $scheduler->queuedCommand(FooCommand::class, ['foo' => 'bar'], null, 'bar')->name('')->everyMinute();
+
+        $events = $scheduler->events();
+        foreach ($events as $event) {
+            $event->run($this->app);
+        }
+
+        $this->assertSame(1, Queue::pushed(QueuedCommand::class, function (QueuedCommand $job, $pushedQueue) {
+            return $job->connection === null;
+        })->count());
+
+        $this->assertSame(1, Queue::pushed(QueuedCommand::class, function (QueuedCommand $job, $pushedQueue) {
+            return $job->connection === 'foo';
+        })->count());
+
+        $this->assertSame(1, Queue::pushed(QueuedCommand::class, function (QueuedCommand $job, $pushedQueue) {
+            return $job->connection === 'bar';
+        })->count());
+    }
+}
+
+class FooCommand extends Command
+{
+    protected $signature = 'foo:run';
+
+    public function handle()
+    {
+        //
+    }
+}


### PR DESCRIPTION
**Description**
```php
$schedule->queuedCommand(FooCommand::class)->everyMinute();
$schedule->queuedCommand(FooCommand::class, ['some-argument' => 'foo']);
$schedule->queuedCommand(FooCommand::class, ['some-argument' => 'foo'], 'queue');
$schedule->queuedCommand(FooCommand::class, ['some-argument' => 'foo'], 'queue', 'connection');
```
Adds `queuedCommand` function to the scheduler that executes the equivalent of `Artisan::queue(...)` on the given schedule. It also provides the ability to optionally customise the queue and connection if needed.

**Motivation**
When running Laravel on serverless (e.g. Laravel Vapor) applications we cannot reliably use the `->runInBackground()` as the Lambda instance could be stopped before the background processes are executed. 

When a package wants you to stick something in the scheduler they usually provide this as an artisan command, for example, the `PruneBatchesCommand`, `PruneFailedJobsCommand` and other `prune:*` commands in Telescope/Horizon etc. It would be great if we could have a function like this so we can choose to queue these commands if we want to. 