### PR TITLE
[9.x] New frequencies

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -186,6 +186,19 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every two hours at a given offset in the hour.
+     *
+     * @return $this
+     */
+    public function everyTwoHoursAt($offset)
+    {
+        $offset = is_array($offset) ? implode(',', $offset) : $offset;
+
+        return $this->spliceIntoPosition(1, $offset)
+            ->spliceIntoPosition(2, '*/2');
+    }
+
+    /**
      * Schedule the event to run every three hours.
      *
      * @return $this
@@ -194,6 +207,19 @@ trait ManagesFrequencies
     {
         return $this->spliceIntoPosition(1, 0)
                     ->spliceIntoPosition(2, '*/3');
+    }
+
+    /**
+     * Schedule the event to run every three hours at a given offset in the hour.
+     *
+     * @return $this
+     */
+    public function everyThreeHoursAt($offset)
+    {
+        $offset = is_array($offset) ? implode(',', $offset) : $offset;
+
+        return $this->spliceIntoPosition(1, $offset)
+            ->spliceIntoPosition(2, '*/3');
     }
 
     /**
@@ -208,6 +234,19 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every four hours at a given offset in the hour.
+     *
+     * @return $this
+     */
+    public function everyFourHoursAt($offset)
+    {
+        $offset = is_array($offset) ? implode(',', $offset) : $offset;
+
+        return $this->spliceIntoPosition(1, $offset)
+            ->spliceIntoPosition(2, '*/4');
+    }
+
+    /**
      * Schedule the event to run every six hours.
      *
      * @return $this
@@ -216,6 +255,43 @@ trait ManagesFrequencies
     {
         return $this->spliceIntoPosition(1, 0)
                     ->spliceIntoPosition(2, '*/6');
+    }
+
+    /**
+     * Schedule the event to run every six hours at a given offset in the hour.
+     *
+     * @return $this
+     */
+    public function everySixHoursAt($offset)
+    {
+        $offset = is_array($offset) ? implode(',', $offset) : $offset;
+
+        return $this->spliceIntoPosition(1, $offset)
+            ->spliceIntoPosition(2, '*/6');
+    }
+
+    /**
+     * Schedule the event to run every eight hours.
+     *
+     * @return $this
+     */
+    public function everyEightHours()
+    {
+        return $this->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, '*/8');
+    }
+
+    /**
+     * Schedule the event to run every eight hours at a given offset in the hour.
+     *
+     * @return $this
+     */
+    public function everyEightHoursAt($offset)
+    {
+        $offset = is_array($offset) ? implode(',', $offset) : $offset;
+
+        return $this->spliceIntoPosition(1, $offset)
+            ->spliceIntoPosition(2, '*/8');
     }
 
     /**

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -83,6 +83,17 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 */3 * * *', $this->event->everyThreeHours()->getExpression());
         $this->assertSame('0 */4 * * *', $this->event->everyFourHours()->getExpression());
         $this->assertSame('0 */6 * * *', $this->event->everySixHours()->getExpression());
+        $this->assertSame('0 */8 * * *', $this->event->everyEightHours()->getExpression());
+        $this->assertSame('10 */2 * * *', $this->event->everyTwoHoursAt(10)->getExpression());
+        $this->assertSame('15,45 */2 * * *', $this->event->everyTwoHoursAt([15,45])->getExpression());
+        $this->assertSame('10 */3 * * *', $this->event->everyThreeHoursAt(10)->getExpression());
+        $this->assertSame('15,45 */3 * * *', $this->event->everyThreeHoursAt([15,45])->getExpression());
+        $this->assertSame('10 */4 * * *', $this->event->everyFourHoursAt(10)->getExpression());
+        $this->assertSame('15,45 */4 * * *', $this->event->everyFourHoursAt([15,45])->getExpression());
+        $this->assertSame('10 */6 * * *', $this->event->everySixHoursAt(10)->getExpression());
+        $this->assertSame('15,45 */6 * * *', $this->event->everySixHoursAt([15,45])->getExpression());
+        $this->assertSame('10 */8 * * *', $this->event->everyEightHoursAt(10)->getExpression());
+        $this->assertSame('15,45 */8 * * *', $this->event->everyEightHoursAt([15,45])->getExpression());
     }
 
     public function testMonthly()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -85,15 +85,15 @@ class FrequencyTest extends TestCase
         $this->assertSame('0 */6 * * *', $this->event->everySixHours()->getExpression());
         $this->assertSame('0 */8 * * *', $this->event->everyEightHours()->getExpression());
         $this->assertSame('10 */2 * * *', $this->event->everyTwoHoursAt(10)->getExpression());
-        $this->assertSame('15,45 */2 * * *', $this->event->everyTwoHoursAt([15,45])->getExpression());
+        $this->assertSame('15,45 */2 * * *', $this->event->everyTwoHoursAt([15, 45])->getExpression());
         $this->assertSame('10 */3 * * *', $this->event->everyThreeHoursAt(10)->getExpression());
-        $this->assertSame('15,45 */3 * * *', $this->event->everyThreeHoursAt([15,45])->getExpression());
+        $this->assertSame('15,45 */3 * * *', $this->event->everyThreeHoursAt([15, 45])->getExpression());
         $this->assertSame('10 */4 * * *', $this->event->everyFourHoursAt(10)->getExpression());
-        $this->assertSame('15,45 */4 * * *', $this->event->everyFourHoursAt([15,45])->getExpression());
+        $this->assertSame('15,45 */4 * * *', $this->event->everyFourHoursAt([15, 45])->getExpression());
         $this->assertSame('10 */6 * * *', $this->event->everySixHoursAt(10)->getExpression());
-        $this->assertSame('15,45 */6 * * *', $this->event->everySixHoursAt([15,45])->getExpression());
+        $this->assertSame('15,45 */6 * * *', $this->event->everySixHoursAt([15, 45])->getExpression());
         $this->assertSame('10 */8 * * *', $this->event->everyEightHoursAt(10)->getExpression());
-        $this->assertSame('15,45 */8 * * *', $this->event->everyEightHoursAt([15,45])->getExpression());
+        $this->assertSame('15,45 */8 * * *', $this->event->everyEightHoursAt([15, 45])->getExpression());
     }
 
     public function testMonthly()


### PR DESCRIPTION
This PR adds new scheduling options:
- a new everyEightHours frequency
- new everyXHoursAt frequencies, enabling to set the minute offset in the hour for all everyXHours frequencies.