### PR TITLE
[9.x] Fixes the issue of overriding `$wrap` property

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -80,6 +80,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+            
+            if (property_exists(static::class, 'wrap')) {
+                static::wrap(static::$wrap);
+            }
         });
     }
 


### PR DESCRIPTION
When I tried to override the `$wrap` property to use a custom key instead of `data`, as Laravel [says](https://laravel.com/docs/9.x/eloquent-resources#data-wrapping) and nothing happens, so I tried to add this condition to update the wrapper key.