### PR TITLE
[9.x] Improves output capture from `serve` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -227,39 +227,35 @@ class ServeCommand extends Command
     protected function handleProcessOutput()
     {
         return fn ($type, $buffer) => str($buffer)->explode("\n")->each(function ($line) {
-            $parts = explode(']', $line);
-
             if (str($line)->contains('Development Server (http')) {
                 $this->components->info("Server running on [http://{$this->host()}:{$this->port()}].");
                 $this->comment('  <fg=yellow;options=bold>Press Ctrl+C to stop the server</>');
 
                 $this->newLine();
             } elseif (str($line)->contains(' Accepted')) {
-                $startDate = Carbon::createFromFormat('D M d H:i:s Y', ltrim($parts[0], '['));
+                $requestPort = $this->getRequestPortFromLine($line);
 
-                preg_match('/\:(\d+)/', $parts[1], $matches);
-
-                $this->requestsPool[$matches[1]] = [$startDate, false];
+                $this->requestsPool[$requestPort] = [
+                    $this->getDateFromLine($line),
+                    false,
+                ];
             } elseif (str($line)->contains([' [200]: GET '])) {
-                preg_match('/\:(\d+)/', $parts[1], $matches);
+                $requestPort = $this->getRequestPortFromLine($line);
 
-                $this->requestsPool[$matches[1]][1] = trim(explode('[200]: GET', $line)[1]);
+                $this->requestsPool[$requestPort][1] = trim(explode('[200]: GET', $line)[1]);
             } elseif (str($line)->contains(' Closing')) {
-                preg_match('/\:(\d+)/', $parts[1], $matches);
-
-                $request = $this->requestsPool[$matches[1]];
-
+                $requestPort = $this->getRequestPortFromLine($line);
+                $request = $this->requestsPool[$requestPort];
                 [$startDate, $file] = $request;
                 $formattedStartedAt = $startDate->format('Y-m-d H:i:s');
 
-                unset($this->requestsPool[$matches[1]]);
+                unset($this->requestsPool[$requestPort]);
 
                 [$date, $time] = explode(' ', $formattedStartedAt);
 
                 $this->output->write("  <fg=gray>$date</> $time");
 
-                $runTime = Carbon::createFromFormat('D M d H:i:s Y', ltrim($parts[0], '['))
-                                ->diffInSeconds($startDate);
+                $runTime = $this->getDateFromLine($line)->diffInSeconds($startDate);
 
                 if ($file) {
                     $this->output->write($file = " $file");
@@ -269,14 +265,39 @@ class ServeCommand extends Command
 
                 $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
                 $this->output->writeln(" <fg=gray>~ {$runTime}s</>");
-            } elseif (str($line)->contains(['Closed without sending a request', ']: '])) {
+            } elseif (str($line)->contains(['Closed without sending a request'])) {
                 // ...
-            } elseif (isset($parts[1])) {
-                $this->components->warn($parts[1]);
             } elseif (! empty($line)) {
-                $this->components->warn($line);
+                $warning = explode('] ', $line);
+                $this->components->warn(count($warning) > 1 ? $warning[1] : $warning[0]);
             }
         });
+    }
+
+    /**
+     * Returns the date from the given PHP Built-in server output.
+     *
+     * @param  string  $line
+     * @return \Illuminate\Support\Carbon
+     */
+    protected function getDateFromLine($line)
+    {
+        preg_match('/^\[([^\]]+)\]/', $line, $matches);
+
+        return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);
+    }
+
+    /**
+     * Returns the request port from the given PHP Built-in server output.
+     *
+     * @param  string  $line
+     * @return int
+     */
+    protected function getRequestPortFromLine($line)
+    {
+        preg_match('/:(\d+)\s(?:(?:\w+$)|(?:\[.*))/', $line, $matches);
+
+        return (int) $matches[1];
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -246,7 +246,9 @@ class ServeCommand extends Command
             } elseif (str($line)->contains(' Closing')) {
                 $requestPort = $this->getRequestPortFromLine($line);
                 $request = $this->requestsPool[$requestPort];
+
                 [$startDate, $file] = $request;
+
                 $formattedStartedAt = $startDate->format('Y-m-d H:i:s');
 
                 unset($this->requestsPool[$requestPort]);
@@ -275,7 +277,7 @@ class ServeCommand extends Command
     }
 
     /**
-     * Returns the date from the given PHP Built-in server output.
+     * Get the date from the given PHP server output.
      *
      * @param  string  $line
      * @return \Illuminate\Support\Carbon
@@ -288,7 +290,7 @@ class ServeCommand extends Command
     }
 
     /**
-     * Returns the request port from the given PHP Built-in server output.
+     * Get the request port from the given PHP server output.
      *
      * @param  string  $line
      * @return int


### PR DESCRIPTION
This pull request handles the following edge case, where `php artisan serve --host=nuno.francisco.localhost` produces the following output by the PHP Built-in Server:

```
[Thu Jul 28 15:50:52 2022] [::1]:60815 Accepted
[Thu Jul 28 15:50:47 2022] [::1]:60815 Closing
```

Previously, the code was not ready for this case, causing an runtime exception. Now, we handle this properly.