### PR TITLE
[9.x] Get filesystem config options using dot array syntax

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -854,13 +854,14 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
-     * Get the configuration values.
+     * Get an option from the configuration options.
      *
-     * @return array
+     * @param  string|null  $option
+     * @return mixed
      */
-    public function getConfig()
+    public function getConfig($option = null)
     {
-        return $this->config;
+        return Arr::get($this->config, $option);
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -424,6 +424,13 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('Hello World', $filesystemAdapter->getFoo());
     }
 
+    public function testGetConfig()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['foo' => 'bar']);
+        $this->assertSame(['foo' => 'bar'], $filesystemAdapter->getConfig());
+        $this->assertSame('bar', $filesystemAdapter->getConfig('foo'));
+    }
+
     public function testTemporaryUrlWithCustomCallback()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);


### PR DESCRIPTION
This makes it easier to get configuration options from a filesystem, and mirrors the same method on database connections:

```
$filesystem->getConfig();      // ['foo' => 'bar']
$filesystem->getConfig('foo'); // 'bar'
```

In my use case I'm storing additional options in the config used for logging, and this makes it easier to get at.