### PR TITLE
[9.x] Fixes the issue of overriding `$wrap` property

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -80,6 +80,10 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+            
+            if (property_exists(static::class, 'wrap')) {
+                $collection::$wrap = static::$wrap;
+            }
         });
     }
 


### PR DESCRIPTION
So, let me explain the issue in more detail:

Laravel [says](https://laravel.com/docs/9.x/eloquent-resources#data-wrapping) that I can change `data` keyword via defining a `$wrap` attribute on the resource class like so,

```PHP
/**
 * The "data" wrapper that should be applied.
 *
 * @var string|null
 */
 public static $wrap = 'user';
```

But when I tried this way nothing changed as we can see in the next figure:

![before-this-PR](https://user-images.githubusercontent.com/48416569/181569531-dc28cf8a-627d-45c7-b44f-739fac5f4545.png "Before This PR")

- - -

**If this PR gets merged**

As we can see in the next figure that this issue has been solved 🎉

![after-PR-was-accepted](https://user-images.githubusercontent.com/48416569/181570233-86a7fef0-2a6e-4f3c-ae14-0d59afcb3280.png "If this PR gets merged")
