### PR TITLE
[9.x] Improve some syntax in Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -84,11 +84,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $callback = $this->valueRetriever($callback);
 
-        $items = $this->map(function ($value) use ($callback) {
-            return $callback($value);
-        })->filter(function ($value) {
-            return ! is_null($value);
-        });
+        $items = $this->map(fn($value) => $callback($value))
+            ->filter(fn($value) => !is_null($value));
 
         if ($count = $items->count()) {
             return $items->sum() / $count;
@@ -329,14 +326,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     protected function duplicateComparator($strict)
     {
         if ($strict) {
-            return function ($a, $b) {
-                return $a === $b;
-            };
+            return fn($a, $b) => $a === $b;
         }
 
-        return function ($a, $b) {
-            return $a == $b;
-        };
+        return fn($a, $b) => $a == $b;
+
     }
 
     /**
@@ -1095,9 +1089,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $chunks = floor(($this->count() - $size) / $step) + 1;
 
-        return static::times($chunks, function ($number) use ($size, $step) {
-            return $this->slice(($number - 1) * $step, $size);
-        });
+        return static::times($chunks, fn($number) => $this->slice(($number - 1) * $step, $size));
     }
 
     /**
@@ -1578,13 +1570,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function zip($items)
     {
-        $arrayableItems = array_map(function ($items) {
-            return $this->getArrayableItems($items);
-        }, func_get_args());
+        $arrayableItems = array_map(fn($items) => $this->getArrayableItems($items), func_get_args());
 
-        $params = array_merge([function () {
-            return new static(func_get_args());
-        }, $this->items], $arrayableItems);
+        $params = array_merge(
+            [fn() => new static(func_get_args()), $this->items],
+            $arrayableItems);
 
         return new static(array_map(...$params));
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -330,7 +330,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         }
 
         return fn ($a, $b) => $a == $b;
-
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -85,7 +85,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $callback = $this->valueRetriever($callback);
 
         $items = $this->map(fn ($value) => $callback($value))
-            ->filter(fn ($value) => !is_null($value));
+            ->filter(fn ($value) => ! is_null($value));
 
         if ($count = $items->count()) {
             return $items->sum() / $count;
@@ -1573,7 +1573,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $arrayableItems = array_map(fn ($items) => $this->getArrayableItems($items), func_get_args());
 
         $params = array_merge(
-            [fn() => new static(func_get_args()), $this->items],
+            [fn () => new static(func_get_args()), $this->items],
             $arrayableItems);
 
         return new static(array_map(...$params));

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -84,8 +84,8 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $callback = $this->valueRetriever($callback);
 
-        $items = $this->map(fn($value) => $callback($value))
-            ->filter(fn($value) => !is_null($value));
+        $items = $this->map(fn ($value) => $callback($value))
+            ->filter(fn ($value) => !is_null($value));
 
         if ($count = $items->count()) {
             return $items->sum() / $count;
@@ -326,10 +326,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     protected function duplicateComparator($strict)
     {
         if ($strict) {
-            return fn($a, $b) => $a === $b;
+            return fn ($a, $b) => $a === $b;
         }
 
-        return fn($a, $b) => $a == $b;
+        return fn ($a, $b) => $a == $b;
 
     }
 
@@ -1089,7 +1089,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $chunks = floor(($this->count() - $size) / $step) + 1;
 
-        return static::times($chunks, fn($number) => $this->slice(($number - 1) * $step, $size));
+        return static::times($chunks, fn ($number) => $this->slice(($number - 1) * $step, $size));
     }
 
     /**
@@ -1570,7 +1570,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function zip($items)
     {
-        $arrayableItems = array_map(fn($items) => $this->getArrayableItems($items), func_get_args());
+        $arrayableItems = array_map(fn ($items) => $this->getArrayableItems($items), func_get_args());
 
         $params = array_merge(
             [fn() => new static(func_get_args()), $this->items],


### PR DESCRIPTION
arrow functions can automatically access variables from their parent scopes
