### PR TITLE
[9.x] Allow schema path configuration in connection configuration

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -181,6 +181,10 @@ class MigrateCommand extends BaseCommand
             return $this->option('schema-path');
         }
 
+        if ($connection->getConfig('schema_path') !== null) {
+            return database_path($connection->getConfig('schema_path'));
+        }
+
         if (file_exists($path = database_path('schema/'.$connection->getName().'-schema.dump'))) {
             return $path;
         }


### PR DESCRIPTION
When [squashed migrations](https://laravel.com/docs/9.x/migrations#squashing-migrations) are used, a schema file is created which includes the connection name. Subsequent migrate commands look for a schema file with that connection name included.

If there are multiple connections with the same database structure (for example for production and testing as production might have read/write connections and testing does not), to get these squashed migrations working you have to either have one schema for each connection and make sure these schemas are equal, or always use the ```--schema-path``` command line option, which becomes really cumbersome.

This PR adds the missing ```schema-path``` option to the database configuration. 