### PR TITLE
[9.x] Allow terser singleton bindings

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -696,6 +696,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
         if (property_exists($provider, 'singletons')) {
             foreach ($provider->singletons as $key => $value) {
+                $key = is_int($key) ? $value : $key;
+
                 $this->singleton($key, $value);
             }
         }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -67,6 +67,7 @@ class FoundationApplicationTest extends TestCase
         $app->register($provider = new class($app) extends ServiceProvider
         {
             public $singletons = [
+                NonContractBackedClass::class,
                 AbstractClass::class => ConcreteClass::class,
             ];
         });
@@ -77,6 +78,11 @@ class FoundationApplicationTest extends TestCase
 
         $this->assertInstanceOf(ConcreteClass::class, $instance);
         $this->assertSame($instance, $app->make(AbstractClass::class));
+
+        $instance = $app->make(NonContractBackedClass::class);
+
+        $this->assertInstanceOf(NonContractBackedClass::class, $instance);
+        $this->assertSame($instance, $app->make(NonContractBackedClass::class));
     }
 
     public function testServiceProvidersAreCorrectlyRegisteredWhenRegisterMethodIsNotFilled()
@@ -609,6 +615,11 @@ abstract class AbstractClass
 }
 
 class ConcreteClass extends AbstractClass
+{
+    //
+}
+
+class NonContractBackedClass
 {
     //
 }


### PR DESCRIPTION
It is currently possible to bind singletons to a service provider using the following:

```php
class AppServiceProvider
{
    public $singletons = [
        Abstract::class => Concrete::class,
    ];
}
```

Often I want to bind a singleton to the container that isn't backed by contract:

```php
class AppServiceProvider
{
    public $singletons = [
        Concrete::class => Concrete::class,
    ];
}
```

This always trips me up, as I first try:

```php
class AppServiceProvider
{
    public $singletons = [
        Concrete::class,
    ];
}
```

This PR makes that work. I expect that to work as it is possible within the register function, thus this also creates symmetry between the two methods of registering singletons:


```php
class AppServiceProvider
{
    public function register()
    {
        $this->app->singleton(Concrete::class);
    }
}
```