### PR TITLE
[9.x] Include Eloquent Model Observers in model:show command

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -270,7 +270,10 @@ class ShowModelCommand extends Command
         $formatted = [];
 
         foreach($listeners as $key => $observerMethods) {
-            $formatted[] = ['event' => $extractVerb($key), 'observer' => $observerMethods];
+            $formatted[] = [
+                'event' => $extractVerb($key),
+                'observer' => array_map(fn ($obs) => is_string($obs) ? $obs : 'Closure', $observerMethods),
+            ];
         }
 
         return collect($formatted);

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -251,6 +251,7 @@ class ShowModelCommand extends Command
     /**
      * Get the Observers watching this model.
      * @return Illuminate\Support\Collection
+     * 
      */
     protected function getObservers($model)
     {
@@ -269,7 +270,7 @@ class ShowModelCommand extends Command
 
         $formatted = [];
 
-        foreach($listeners as $key => $observerMethods) {
+        foreach ($listeners as $key => $observerMethods) {
             $formatted[] = [
                 'event' => $extractVerb($key),
                 'observer' => array_map(fn ($obs) => is_string($obs) ? $obs : 'Closure', $observerMethods),
@@ -377,9 +378,11 @@ class ShowModelCommand extends Command
 
         $this->components->twoColumnDetail('<fg=green;options=bold>Eloquent Observers</>');
 
-        if ($observers->count()) foreach ($observers as $observer) {
-            $this->components->twoColumnDetail(
-                sprintf('%s', $observer['event']), implode(', ', $observer['observer']));
+        if ($observers->count()) {
+            foreach ($observers as $observer) {
+                $this->components->twoColumnDetail(
+                    sprintf('%s', $observer['event']), implode(', ', $observer['observer']));
+            }
         }
 
         $this->newLine();

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -250,8 +250,8 @@ class ShowModelCommand extends Command
 
     /**
      * Get the Observers watching this model.
+     *
      * @return Illuminate\Support\Collection
-     * 
      */
     protected function getObservers($model)
     {


### PR DESCRIPTION
This PR builds on the new `artisan model:show` command to also list Model Observers. They could be handy to see on the Model information as it's not always obvious that a Model is being observed.

It handles cases where multiple observers are attached to an action.

![console output listing Model Observers](https://user-images.githubusercontent.com/4055366/198176768-d54990c9-b29a-40c1-bd53-772e7edf5ea5.png)
