### PR TITLE
Add support for BackedEnums in Blueprint::enum() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.1",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0.2",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "^2.0",

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1051,6 +1051,7 @@ class Blueprint
             }
             $allowed = $cases;
         }
+
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1038,10 +1038,10 @@ class Blueprint
     public function enum($column, array|string $allowed)
     {
         if (is_string($allowed)) {
-            if (!enum_exists($allowed)) {
+            if (! enum_exists($allowed)) {
                 throw new \InvalidArgumentException("$allowed is not a recognized Enum");
             }
-            if (!is_subclass_of($allowed,'\BackedEnum')) {
+            if (! is_subclass_of($allowed,'\BackedEnum')) {
                 throw new \InvalidArgumentException("$allowed is not a Backed Enum. Only Backed Enums are supported at this time");
             }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1032,11 +1032,24 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array  $allowed
+     * @param  array|string  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, array|string $allowed)
     {
+        if(is_string($allowed)){
+            if(!enum_exists($allowed)){
+                throw new \InvalidArgumentException("$allowed is not a recognized Enum");
+            }
+            if(!is_subclass_of($allowed,'\BackedEnum')){
+                throw new \InvalidArgumentException("$allowed is not a Backed Enum. Only Backed Enums are supported at this time");
+            }
+            $cases = array();
+            foreach ($allowed::cases() as $case){
+                array_push($cases,$case->value);
+            }
+            $allowed = $cases;
+        }
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1037,15 +1037,16 @@ class Blueprint
      */
     public function enum($column, array|string $allowed)
     {
-        if(is_string($allowed)){
-            if(!enum_exists($allowed)){
+        if (is_string($allowed)) {
+            if (!enum_exists($allowed)) {
                 throw new \InvalidArgumentException("$allowed is not a recognized Enum");
             }
-            if(!is_subclass_of($allowed,'\BackedEnum')){
+            if (!is_subclass_of($allowed,'\BackedEnum')) {
                 throw new \InvalidArgumentException("$allowed is not a Backed Enum. Only Backed Enums are supported at this time");
             }
-            $cases = array();
-            foreach ($allowed::cases() as $case){
+
+            $cases = [];
+            foreach ($allowed::cases() as $case) {
                 array_push($cases,$case->value);
             }
             $allowed = $cases;

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1041,13 +1041,13 @@ class Blueprint
             if (! enum_exists($allowed)) {
                 throw new \InvalidArgumentException("$allowed is not a recognized Enum");
             }
-            if (! is_subclass_of($allowed,'\BackedEnum')) {
+            if (! is_subclass_of($allowed, '\BackedEnum')) {
                 throw new \InvalidArgumentException("$allowed is not a Backed Enum. Only Backed Enums are supported at this time");
             }
 
             $cases = [];
             foreach ($allowed::cases() as $case) {
-                array_push($cases,$case->value);
+                array_push($cases, $case->value);
             }
             $allowed = $cases;
         }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -765,6 +766,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add `role` enum(\'test\') not null', $statements[0]);
     }
 
     public function testAddingSet()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -624,6 +625,13 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'test\')) not null', $statements[0]);
     }
 
     public function testAddingDate()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -498,6 +499,13 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'test\')) not null', $statements[0]);
     }
 
     public function testAddingJson()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
+use Illuminate\Tests\Database\stubs\TestEnum;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -543,6 +544,13 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->enum('role', TestEnum::class);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'test\')) not null', $statements[0]);
     }
 
     public function testAddingJson()


### PR DESCRIPTION
This allows you to pass the class name of a Backed Enum to the Blueprint::enum() method as well as an array. It now supports both cases below when creating an enum column.
```
Schema::table('table_name', function (Blueprint $table) {
    $table->enum('my_enum',MyEnum::class);
    $table->enum('another_enum',['foo','bar']);
});
```