### PR TITLE
[9.x] improve finding model namespace in Model:show command

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -481,13 +481,23 @@ class ShowModelCommand extends Command
 
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (Str::startsWith($model, $rootNamespace)) {
+        $pattern = is_dir(app_path('Models'))
+            ? app_path('Models').DIRECTORY_SEPARATOR.$model.'.php'
+            : app_path().DIRECTORY_SEPARATOR.$model.'.php';
+
+        $modelPath = glob($pattern);
+
+        if (! count($modelPath)) {
             return $model;
         }
 
-        return is_dir(app_path('Models'))
-            ? $rootNamespace.'Models\\'.$model
-            : $rootNamespace.$model;
+        //get namespace from model path
+        $classes = get_declared_classes();
+        include $modelPath[0];
+        $model = array_diff(get_declared_classes(), $classes);
+        $model = reset($model);
+
+        return $model;
     }
 
     /**


### PR DESCRIPTION
### hi
in this PR update method `qualifyModel` of `model:show` command to improvement finding the models.

in this method first find with `glob` function in models folder, After finding the matched files, return **exact namespace** of the file.

actually if model namespace failure to follow PSR-4 rule, old version can't show model detail because **namespace generated manually** ,  but in new method if matched file name with argument, return namespace of model to continue command processing.

thanks.