### PR TITLE
[9.x] Improve getter for morphed model alias

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -749,7 +749,7 @@ trait HasRelationships
      *
      * @return int|string|false
      */
-    public static function morphMapAlias()
+    public static function morphAlias()
     {
         return Relation::getMorphedModelAlias(static::class);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -745,7 +745,7 @@ trait HasRelationships
     }
 
     /**
-     * Get Morph Map Alias
+     * Get Morph Map Alias.
      *
      * @return int|string|false
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -745,6 +745,16 @@ trait HasRelationships
     }
 
     /**
+     * Get Morph Map Alias
+     *
+     * @return int|string|false
+     */
+    public static function morphMapAlias()
+    {
+        return Relation::getMorphedModelKey(static::class);
+    }
+
+    /**
      * Create a new model instance for a related model.
      *
      * @param  string  $class

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -738,7 +738,7 @@ trait HasRelationships
         }
 
         if (Relation::requiresMorphMap()) {
-            throw new ClassMorphViolationException($this);
+            throw new ClassMorphViolationException(new static);
         }
 
         return static::class;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -725,7 +725,7 @@ trait HasRelationships
      *
      * @return string
      */
-    public function getMorphClass()
+    public static function getMorphClass()
     {
         $morphMap = Relation::morphMap();
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -751,7 +751,7 @@ trait HasRelationships
      */
     public static function morphMapAlias()
     {
-        return Relation::getMorphedModelKey(static::class);
+        return Relation::getMorphedModelAlias(static::class);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -725,7 +725,7 @@ trait HasRelationships
      *
      * @return string
      */
-    public static function getMorphClass()
+    public function getMorphClass()
     {
         $morphMap = Relation::morphMap();
 
@@ -738,7 +738,7 @@ trait HasRelationships
         }
 
         if (Relation::requiresMorphMap()) {
-            throw new ClassMorphViolationException(new static);
+            throw new ClassMorphViolationException($this);
         }
 
         return static::class;

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -476,12 +476,12 @@ abstract class Relation implements BuilderContract
     }
 
     /**
-     * Get the morphed model key.
+     * Get the morphed model alias.
      *
      * @param string $class
      * @return int|string|false
      */
-    public static function getMorphedModelKey($class) 
+    public static function getMorphedModelAlias($class) 
     {
         return array_search($class, static::$morphMap);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -476,6 +476,17 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Get the morphed model key.
+     *
+     * @param string $class
+     * @return int|string|false
+     */
+    public static function getMorphedModelKey($class) 
+    {
+        return array_search($class, static::$morphMap);
+    }
+
+    /**
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -478,10 +478,10 @@ abstract class Relation implements BuilderContract
     /**
      * Get the morphed model alias.
      *
-     * @param string $class
+     * @param  string  $class
      * @return int|string|false
      */
-    public static function getMorphedModelAlias($class) 
+    public static function getMorphedModelAlias($class)
     {
         return array_search($class, static::$morphMap);
     }

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -239,15 +239,15 @@ class DatabaseEloquentRelationTest extends TestCase
     {
         Relation::morphMap(['user' => 'App\Models\User']);
 
-        $this->assertEquals('user', Relation::getMorphMapKey('App\Models\User'));
+        $this->assertEquals('user', Relation::getMorphedModelAlias('App\Models\User'));
 
         Relation::morphMap([3 => 'App\Models\Model']);
 
-        $this->assertEquals(3, Relation::getMorphMapKey('App\Models\Model'));
+        $this->assertEquals(3, Relation::getMorphedModelAlias('App\Models\Model'));
 
         Relation::morphMap(['not_found' => 'App\Models\NotFound']);
 
-        $this->assertFalse(Relation::getMorphMapKey('App\Models\NotFound'));
+        $this->assertFalse(Relation::getMorphedModelAlias('App\Models\NotFound'));
     }
 
     public function testWithoutRelations()

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -235,6 +235,21 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([], false);
     }
 
+    public function testCanGetMorphMapKey()
+    {
+        Relation::morphMap(['user' => 'App\Models\User']);
+
+        $this->assertEquals('user', Relation::getMorphMapKey('App\Models\User'));
+
+        Relation::morphMap([3 => 'App\Models\Model']);
+
+        $this->assertEquals(3, Relation::getMorphMapKey('App\Models\Model'));
+
+        Relation::morphMap(['not_found' => 'App\Models\NotFound']);
+
+        $this->assertFalse(Relation::getMorphMapKey('App\Models\NotFound'));
+    }
+
     public function testWithoutRelations()
     {
         $original = new EloquentNoTouchingModelStub;

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -247,7 +247,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
         Relation::morphMap(['not_found' => 'App\Models\NotFound']);
 
-        $this->assertFalse(Relation::getMorphedModelAlias('App\Models\NotFound'));
+        $this->assertFalse(Relation::getMorphedModelAlias('App\Models\ModelNotFound'));
     }
 
     public function testWithoutRelations()

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -36,6 +36,8 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
 
         $morphName = $model->getMorphClass();
         $this->assertSame('test', $morphName);
+
+        $this->assertSame('test', TestModel::morphAlias());
     }
 
     public function testMapsCanBeEnforcedInOneMethod()

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -24,8 +24,6 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
         $model = new TestModel;
 
         $model->getMorphClass();
-
-        TestModel::getMorphClass();
     }
 
     public function testStrictModeDoesNotThrowExceptionWhenMorphMap()

--- a/tests/Database/DatabaseEloquentStrictMorphsTest.php
+++ b/tests/Database/DatabaseEloquentStrictMorphsTest.php
@@ -24,6 +24,8 @@ class DatabaseEloquentStrictMorphsTest extends TestCase
         $model = new TestModel;
 
         $model->getMorphClass();
+
+        TestModel::getMorphClass();
     }
 
     public function testStrictModeDoesNotThrowExceptionWhenMorphMap()


### PR DESCRIPTION
Background, I uses polymorphic models heavily in apps, which at times requires to do something like
```
Relation::enforceMorphMap(['user' => 'App\Models\User']);

Model::query()->whereModelType('user');
```

now, what if we updated the morph map from 'user' to 'other_user'?

Of couse we can imagine how many code we need to change.

```
// current way
User::make()->getMorphClass(); // we can do this better
User::morphAlias(); // 😍 returns 'other_user'
Relation::getMorphedModelAlias('App\Models\User') // 👍 also returns 'other_user'
```

Of course, suggestions are welcomed