### PR TITLE
[9.x] PHP 8.2 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,8 @@ name: tests
 on:
   push:
   pull_request:
-  # schedule:
-  #   - cron: '0 0 * * *'
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   linux_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,8 @@ name: tests
 on:
   push:
   pull_request:
-  schedule:
-    - cron: '0 0 * * *'
+  # schedule:
+  #   - cron: '0 0 * * *'
 
 jobs:
   linux_tests:
@@ -38,6 +38,13 @@ jobs:
       matrix:
         php: ['8.0', '8.1']
         stability: [prefer-lowest, prefer-stable]
+        experimental: [false]
+      include:
+        - php: '8.2'
+          stability: prefer-stable
+          experimental: true
+
+    continue-on-error: ${{ matrix.experimental }}
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
@@ -106,6 +113,13 @@ jobs:
       matrix:
         php: ['8.0', '8.1']
         stability: [prefer-lowest, prefer-stable]
+        experimental: [false]
+      include:
+        - php: '8.2'
+          stability: prefer-stable
+          experimental: true
+
+    continue-on-error: ${{ matrix.experimental }}
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         experimental: [false]
         include:
           - php: '8.2'
-            stability: prefer-stable
+            stability: prefer-stable --ignore-platform-reqs
             experimental: true
 
     continue-on-error: ${{ matrix.experimental }}
@@ -116,7 +116,7 @@ jobs:
         experimental: [false]
         include:
           - php: '8.2'
-            stability: prefer-stable
+            stability: prefer-stable --ignore-platform-reqs
             experimental: true
 
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,10 +39,10 @@ jobs:
         php: ['8.0', '8.1']
         stability: [prefer-lowest, prefer-stable]
         experimental: [false]
-      include:
-        - php: '8.2'
-          stability: prefer-stable
-          experimental: true
+        include:
+          - php: '8.2'
+            stability: prefer-stable
+            experimental: true
 
     continue-on-error: ${{ matrix.experimental }}
 
@@ -114,10 +114,10 @@ jobs:
         php: ['8.0', '8.1']
         stability: [prefer-lowest, prefer-stable]
         experimental: [false]
-      include:
-        - php: '8.2'
-          stability: prefer-stable
-          experimental: true
+        include:
+          - php: '8.2'
+            stability: prefer-stable
+            experimental: true
 
     continue-on-error: ${{ matrix.experimental }}
 


### PR DESCRIPTION
I don't think there is much to explain.

I extended the matrix to run tests with PHP 8.2 on linux and windows.
These tests are marked as `continue-on-error` so that there should be no problems with normal pull requests.

Additional Note:
PHP 8.2 will be released ...
- ... after Laravel 6 supports ends. Should the tests still be run there?
- ... before Laravel 8 support ends. Tests probably should also be run there. Should I send the PR for Laravel 8 instead?

You can simply close this PR if you think it is too early to start testing against PHP 8.2