### PR TITLE
[9.x] Add pivot default columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -334,6 +334,10 @@ class BelongsToMany extends Relation
     {
         $this->using = $class;
 
+        $this->pivotColumns = array_merge(
+            $this->pivotColumns, (new $this->using)->getDefaultColumns(),
+        );
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -22,4 +22,21 @@ class Pivot extends Model
      * @var array
      */
     protected $guarded = [];
+
+    /**
+     * The columns to eager load on every query.
+     *
+     * @var array
+     */
+    protected $withColumns = [];
+
+    /**
+     * Get the columns to eager load on every query.
+     *
+     * @return array
+     */
+    public function getDefaultColumns()
+    {
+        return $this->withColumns;
+    }
 }

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -147,6 +147,14 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
         $pivot = $project->collaborators()->newPivot();
 
         $this->assertEquals(['permissions' => ['create', 'update']], $pivot->toArray());
+
+        $user = CustomPivotCastTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $pivot = $user->projects()->newPivot();
+
+        $this->assertEquals(['permissions' => ['create', 'update']], $pivot->toArray());
     }
 }
 
@@ -154,6 +162,13 @@ class CustomPivotCastTestUser extends Model
 {
     public $table = 'users';
     public $timestamps = false;
+
+    public function projects()
+    {
+        return $this->belongsToMany(
+            CustomPivotCastTestProject::class, 'project_users', 'user_id', 'project_id'
+        )->using(CustomPivotCastTestCollaborator::class);
+    }
 }
 
 class CustomPivotCastTestProject extends Model
@@ -165,7 +180,7 @@ class CustomPivotCastTestProject extends Model
     {
         return $this->belongsToMany(
             CustomPivotCastTestUser::class, 'project_users', 'project_id', 'user_id'
-        )->using(CustomPivotCastTestCollaborator::class)->withPivot('permissions');
+        )->using(CustomPivotCastTestCollaborator::class);
     }
 }
 
@@ -177,5 +192,9 @@ class CustomPivotCastTestCollaborator extends Pivot
 
     protected $casts = [
         'permissions' => 'json',
+    ];
+
+    protected $withColumns = [
+        'permissions',
     ];
 }


### PR DESCRIPTION
Currently, loading columns for a `Pivot` class in a many-to-many relation requires manually adding all column names on the relation method. This is [slightly confusing sometimes](https://github.com/laravel/framework/issues/23298), and moreover leads to some code duplication if you want to query the same pivot columns from both sides of the relation.

This PR adds a `withColumn` property to the `Pivot` class, where one can mark columns that should be loaded on all relations referencing the pivot.

Alternative approaches: 
- use the `attributes` property, though this would require adding a default value for all columns
- use the `casts` property, though this would require adding a cast-type for all columns