### PR TITLE
Adds new function `clean` for base collection 

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1705,4 +1705,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Get an instance of the base support collection from this collection by converting each of the items into array
+     *
+     * @return static<int, TValue>
+     */
+    public function clean()
+    {
+        return new self($this->toArray());
+    }
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -591,6 +591,19 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertContainsOnly('bool', $commentsExists);
     }
 
+    public function testConvertItemsToArrayAndReturnsABaseCollection()
+    {
+        $model1 = (new TestEloquentCollectionModel)->forceFill(['id' => 1]);
+        $model1->makeVisible('id');
+
+        $modelCollection = new Collection([$model1]);
+        $cleanArray = $modelCollection->clean();
+
+        $this->assertEquals(BaseCollection::class, get_class($cleanArray));
+        $this->assertIsArray($cleanArray[0]);
+        $this->assertEquals($model1->toArray(), $cleanArray[0]);
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
Added a new method for the base collection `clean`, which allows you to get a clean collection. What does it mean? Each of the items of the collection will be converted into  into array.

Often in work it is required to get a collection from DB that does not contain Eloquent objects, or any other. First of all, this is required to protect yourself, and not accidentally change the data where it is not required, but at the same time use all the features of `Collection`

Example, for an inexperienced developer, we make a contract according to which he must generate a document. At the same time, it should not change anything, only generate a report. At the moment I need to do like so:

```php
$users = User::query()->get()->toArray(); 
$users = collect($users);

$report = new Report($users);
```

With the new `clean` function, I can do it quite easily and still work with BaseCollection. It's more convenient when you only need a set of data.

```php
$users = User::query()->get()->clean(); 

$report = new Report($users);
```