### PR TITLE
[9.x] Added createMany method to HasManyThrough

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -259,6 +259,23 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Create a Collection of new instances of the related model.
+     *
+     * @param  iterable  $records
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function createMany(iterable $records)
+    {
+        $instances = $this->related->newCollection();
+
+        foreach ($records as $record) {
+            $instances->push($this->create($record));
+        }
+
+        return $instances;
+    }
+
+    /**
      * Add a basic where clause to the query, and return the first result.
      *
      * @param  \Closure|string|array  $column


### PR DESCRIPTION
Maybe I didn't understand the concept of HasManyThrough relationship and therefore it seemed strange to me that there was no "createMany" method! After all, it fits perfectly, works and has practical importance (in my opinion)! If not, then I will be glad to know why this method is not available in HasManyThrough! It would be useful to me in the project, if it is still needed, then I can modify it and cover it with tests from above