### PR TITLE
Fix passing null to non-nullable parameters of `fromJson` function 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1189,7 +1189,7 @@ trait HasAttributes
      */
     public function fromJson($value, $asObject = false)
     {
-        return json_decode($value, ! $asObject);
+        return json_decode($value ?? '', ! $asObject);
     }
 
     /**


### PR DESCRIPTION
PHP version: 8.1.7
Laravel version: v9.21.6

[Deprecated Features: Passing null to non-nullable parameters of built-in functions](https://www.php.net/manual/en/migration81.deprecated.php#:~:text=Passing%20null%20to%20non%2Dnullable%20parameters%20of%20built%2Din%20functions%20%C2%B6)

The string type parameters 1 of `json_decode` function not accept null type when the PHP version greater than 8.1.
