### PR TITLE
Fix passing null to non-nullable parameters of `fromJson` function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -729,12 +729,12 @@ trait HasAttributes
             case 'boolean':
                 return (bool) $value;
             case 'object':
-                return $this->fromJson($value, true);
+                return $this->fromJson($value ?? '', true);
             case 'array':
             case 'json':
-                return $this->fromJson($value);
+                return $this->fromJson($value ?? '');
             case 'collection':
-                return new BaseCollection($this->fromJson($value));
+                return new BaseCollection($this->fromJson($value ?? ''));
             case 'date':
                 return $this->asDate($value);
             case 'datetime':
@@ -1144,8 +1144,8 @@ trait HasAttributes
 
         return $this->fromJson(
             $this->isEncryptedCastable($key)
-                ? $this->fromEncryptedString($this->attributes[$key])
-                : $this->attributes[$key]
+                ? $this->fromEncryptedString($this->attributes[$key]) ?? ''
+                : $this->attributes[$key] ?? ''
         );
     }
 
@@ -1950,7 +1950,7 @@ trait HasAttributes
                 $this->fromDateTime($original);
         } elseif ($this->hasCast($key, ['object', 'collection'])) {
             return $this->fromJson($attribute) ===
-                $this->fromJson($original);
+                $this->fromJson($original ?? '');
         } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
             if ($original === null) {
                 return false;


### PR DESCRIPTION
PHP version: 8.1.7
Laravel version: v9.21.6

[Deprecated Features: Passing null to non-nullable parameters of built-in functions](https://www.php.net/manual/en/migration81.deprecated.php#:~:text=Passing%20null%20to%20non%2Dnullable%20parameters%20of%20built%2Din%20functions%20%C2%B6)

The string type parameters 1 of `json_decode` function not accept null type when the PHP version greater than 8.1.
