### PR TITLE
Update RouteRegistrar.php

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -25,6 +25,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method \Illuminate\Routing\RouteRegistrar where(array  $where)
+ * @method \Illuminate\Routing\RouteRegistrar whereIn(array|string  $parameters, array  $values)
  * @method \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string  $middleware)
  */
 class RouteRegistrar
@@ -67,6 +68,7 @@ class RouteRegistrar
         'prefix',
         'scopeBindings',
         'where',
+        'whereIn',
         'withoutMiddleware',
     ];
 


### PR DESCRIPTION
Allow a route groups to also call the dynamic where methods described in https://laravel.com/docs/9.x/routing#parameters-regular-expression-constraints

E.g.
```php
Route::prefix('/{something}')->whereIn('something', ['foo', 'bar'])->group(function() {});
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
