### PR TITLE
Update return type hint for Validator::make()

### DIFF
--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Contracts\Validation\Validator make(array $data, array $rules, array $messages = [], array $customAttributes = [])
+ * @method static \Illuminate\Contracts\Validation\Validator|\Illuminate\Validation\Validator make(array $data, array $rules, array $messages = [], array $customAttributes = [])
  * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
  * @method static void extend(string $rule, \Closure|string $extension, string $message = null)


### PR DESCRIPTION
I've added `\Illuminate\Validation\Validator` as one of the allowed return types of the `Validator::make()` method of the `Validator` Facade.

without it the `->validateWithBag` will be not be detected by the IDE, rendering an error of `Undefined method 'validateWithBag'.`

Fortify Actions created by jetstream is using `->validateWithBag()` method and it's really annoying me that my IDE is telling me that there is an error in the file.

I know this is kinda personal but I think it helps.
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
