### PR TITLE
[9.x] Add `Config::collect()` method

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -5,6 +5,7 @@ namespace Illuminate\Config;
 use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 class Repository implements ArrayAccess, ConfigContract
 {
@@ -72,6 +73,18 @@ class Repository implements ArrayAccess, ConfigContract
         }
 
         return $config;
+    }
+
+    /**
+     * Get the specified configuration value as a Collection.
+     *
+     * @param  string  $key
+     * @param  iterable  $default
+     * @return Collection
+     */
+    public function collect($key, $default = [])
+    {
+        return Collection::make(Arr::get($this->items, $key, $default));
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -6,6 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static array all()
  * @method static bool has($key)
  * @method static mixed get($key, $default = null)
+ * @method static \Illuminate\Support\Collection collect($key, $default = [])
  * @method static void prepend($key, $value)
  * @method static void push($key, $value)
  * @method static void set($key, $value = null)

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -141,18 +141,18 @@ class RepositoryTest extends TestCase
     public function testCollect()
     {
         $this->assertInstanceOf(Collection::class, $this->repository->collect('associate'));
-        $this->assertSame(['x' => 'xxx', 'y' => 'yyy'], $this->repository->collect('associate')->toArray());
-        $this->assertSame(['aaa', 'zzz'], $this->repository->collect('array')->toArray());
-        $this->assertSame(['bar'], $this->repository->collect('foo')->toArray());
-        $this->assertSame([true], $this->repository->collect('boolean')->toArray());
-        $this->assertSame([], $this->repository->collect('null')->toArray());
-        $this->assertSame([], $this->repository->collect('not-exist')->toArray());
+        $this->assertSame(['x' => 'xxx', 'y' => 'yyy'], $this->repository->collect('associate')->all());
+        $this->assertSame(['aaa', 'zzz'], $this->repository->collect('array')->all());
+        $this->assertSame(['bar'], $this->repository->collect('foo')->all());
+        $this->assertSame([true], $this->repository->collect('boolean')->all());
+        $this->assertSame([], $this->repository->collect('null')->all());
+        $this->assertSame([], $this->repository->collect('not-exist')->all());
     }
 
     public function testCollectWithDefault()
     {
-        $this->assertSame(['foo', 'bar', 'baz'], $this->repository->collect('not-exist', ['foo', 'bar', 'baz'])->toArray());
-        $this->assertSame(['foo', 'bar', 'baz'], $this->repository->collect('not-exist', Collection::make(['foo', 'bar', 'baz']))->toArray());
+        $this->assertSame(['foo', 'bar', 'baz'], $this->repository->collect('not-exist', ['foo', 'bar', 'baz'])->all());
+        $this->assertSame(['foo', 'bar', 'baz'], $this->repository->collect('not-exist', Collection::make(['foo', 'bar', 'baz']))->all());
     }
 
     public function testSet()

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Config;
 
 use Illuminate\Config\Repository;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class RepositoryTest extends TestCase
@@ -135,6 +136,23 @@ class RepositoryTest extends TestCase
     public function testGetWithDefault()
     {
         $this->assertSame('default', $this->repository->get('not-exist', 'default'));
+    }
+
+    public function testCollect()
+    {
+        $this->assertInstanceOf(Collection::class, $this->repository->collect('associate'));
+        $this->assertSame(['x' => 'xxx', 'y' => 'yyy'], $this->repository->collect('associate')->toArray());
+        $this->assertSame(['aaa', 'zzz'], $this->repository->collect('array')->toArray());
+        $this->assertSame(['bar'], $this->repository->collect('foo')->toArray());
+        $this->assertSame([true], $this->repository->collect('boolean')->toArray());
+        $this->assertSame([], $this->repository->collect('null')->toArray());
+        $this->assertSame([], $this->repository->collect('not-exist')->toArray());
+    }
+
+    public function testCollectWithDefault()
+    {
+        $this->assertSame(['foo', 'bar', 'baz'], $this->repository->collect('not-exist', ['foo', 'bar', 'baz'])->toArray());
+        $this->assertSame(['foo', 'bar', 'baz'], $this->repository->collect('not-exist', Collection::make(['foo', 'bar', 'baz']))->toArray());
     }
 
     public function testSet()


### PR DESCRIPTION
When retrieving configuration values sometimes the value needs to be converted to a collection for further processing. This is trivial to do by wrapping the `config()` call with `Collection::make()` or `collect()`, however this feels unnecessarily verbose.

This PR introduces the `Config::collect()` method to combine these actions and allow retrieving a configuration value as a collection in one call. Also, since `Config::collect()` returns an instance of `Collection` this allows fluent chaining for cleaner, more enjoyable code.

#### Implementation Details

  - `Config::collect()` will return an empty collection by default if the configuration value is not found by it's key
  - The `$default` parameter accepts any [`iterable`](https://www.php.net/manual/en/language.types.iterable.php) value including an array, a `Collection` object or an object that implements the `Traversable` interface
  - When retrieving a non-array configuration value it will be wrapped and returned as a collection (same behavior as `Collection::make()`)

## Examples

#### Given a confiuration file of `config/test.php`

```php
return [
    'array' => ['foo', 'bar', 'baz'],
    'associative' => [
        'foo' => 123,
        'bar' => 456,
    ],
    'text' => 'foobar',
    'boolean' => true,
];
```

```php
// Retrieve a configuration value as a collection
$words = Config::collect('test.array'); // Collection<'foo', 'bar', 'baz'>

// Retrieve a value and fluently chain collection methods
Config::collect('test.array')->map(fn ($word) => Str::title($word))->toArray(); // ['Foo', 'Bar', 'Baz']

// Wrap a non-array value in a collection on retrieval
Config::collect('test.boolean'); // Collection<true>

// Retrieve with default values for non-existent items
Config::collect('non.existent.item', ['apple', 'orange']); // Collection<'apple', 'orange'>
```

---

Comments and criticisms welcome. Let me know if there's any way I can improve this PR.