### PR TITLE
[9.x] Gracefully fail when unable to locate expected binary on the system for `artisan docs` command

### DIFF
--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -292,7 +292,7 @@ Working directory: expected-working-directory');
         $this->app[Kernel::class]->registerCommand($this->command()->setUrlOpener(null)->setSystemOsFamily('Laravel OS'));
 
         $this->artisan('docs validation')
-            ->expectsOutputToContain('Unable to open the URL on your system. You will need to open it yourself.')
+            ->expectsOutputToContain('Unable to open the URL on your system. You will need to open it yourself or create a custom opener for your system.')
             ->assertSuccessful();
     }
 


### PR DESCRIPTION
The expected binaries may not actually be present on the system. This is generally going to be the case on linux systems.

This PR ensures we detect the binary before attempting to call it.

We now suggest opening the URL manually (which is now in the command line output) or creating a custom opener.


<img width="1237" alt="Screen Shot 2022-08-03 at 11 05 52 am" src="https://user-images.githubusercontent.com/24803032/182502778-b901b798-caf6-42b5-859a-ae5aee3bc580.png">
