### PR TITLE
[9.x] Add union type for expectedListener argument on assertListening method.

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Testing\Fakes\EventFake;
  * @method static void assertDispatchedTimes(string $event, int $times = 1)
  * @method static void assertNotDispatched(string|\Closure $event, callable|int $callback = null)
  * @method static void assertNothingDispatched()
- * @method static void assertListening(string $expectedEvent, string $expectedListener)
+ * @method static void assertListening(string $expectedEvent, string|array $expectedListener)
  * @method static void flush(string $event)
  * @method static void forget(string $event)
  * @method static void forgetPushed()


### PR DESCRIPTION
Added an array as a union type for the assertListening method.

The assert listening method can also be used to assert an event is being listened for on a subscriber but in order to do that you need to pass in an array like so

![carbon](https://user-images.githubusercontent.com/9604666/182509686-edd8cc85-9398-4dd9-81ae-48a3228d5a23.png)

But the current implementation displays a type warning because it doesn't have a union. 

