### PR TITLE
Revert "Update RouteRegistrar.php"

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -25,7 +25,6 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method \Illuminate\Routing\RouteRegistrar where(array  $where)
- * @method \Illuminate\Routing\RouteRegistrar whereIn(array|string  $parameters, array  $values)
  * @method \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string  $middleware)
  */
 class RouteRegistrar
@@ -68,7 +67,6 @@ class RouteRegistrar
         'prefix',
         'scopeBindings',
         'where',
-        'whereIn',
         'withoutMiddleware',
     ];
 


### PR DESCRIPTION
Reverts laravel/framework#43509

@taylorotwell This does not work and should be reverted. It seems the RouteRegistrar::__call() method does not pass the parameters correctly. The passed array is omitted there. I don't see a clear solution other then adding another if exception for the 'whereIn' just like the `if ($method === 'middleware') {` statement in that __call method.
Do you think that would be an acceptable solution?