### PR TITLE
[9.x] Support modifying timestampTz and timestamp column types

### DIFF
--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -35,9 +35,19 @@ class TimestampType extends Type implements PhpDateTimeMappingType
      */
     protected function getMySqlPlatformSQLDeclaration(array $fieldDeclaration)
     {
-        return $fieldDeclaration['precision'] ?? false
-                    ? 'TIMESTAMP('.$fieldDeclaration['precision'].')'
-                    : 'TIMESTAMP';
+        $columnType = 'TIMESTAMP';
+
+        if ($fieldDeclaration['precision']) {
+            $columnType = 'TIMESTAMP('.$fieldDeclaration['precision'].')';
+        }
+
+        $notNull = $fieldDeclaration['notnull'] ?? false;
+
+        if (! $notNull) {
+            return $columnType.' NULL';
+        }
+
+        return $columnType;
     }
 
     /**

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -35,19 +35,9 @@ class TimestampType extends Type implements PhpDateTimeMappingType
      */
     protected function getMySqlPlatformSQLDeclaration(array $fieldDeclaration)
     {
-        $columnType = 'TIMESTAMP';
-
-        if ($fieldDeclaration['precision']) {
-            $columnType = 'TIMESTAMP('.$fieldDeclaration['precision'].')';
-        }
-
-        $notNull = $fieldDeclaration['notnull'] ?? false;
-
-        if (! $notNull) {
-            return $columnType.' NULL';
-        }
-
-        return $columnType;
+        return $fieldDeclaration['precision'] ?? false
+                    ? 'TIMESTAMP('.$fieldDeclaration['precision'].')'
+                    : 'TIMESTAMP';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -129,6 +129,12 @@ class ChangeColumn
             $options['fixed'] = true;
         }
 
+        if ($fluent['type'] === 'timestamp') {
+            $options['platformOptions'] = [
+                'version' => true,
+            ];
+        }
+
         if (static::doesntNeedCharacterOptions($fluent['type'])) {
             $options['customSchemaOptions'] = [
                 'collation' => '',
@@ -156,6 +162,8 @@ class ChangeColumn
             'binary' => 'blob',
             'uuid' => 'guid',
             'char' => 'string',
+            'timestamp' => 'datetime',
+            'timestamptz' => 'datetimetz',
             default => $type,
         });
     }
@@ -189,6 +197,7 @@ class ChangeColumn
             'boolean',
             'date',
             'dateTime',
+            'dateTimeTz',
             'decimal',
             'double',
             'float',
@@ -197,6 +206,8 @@ class ChangeColumn
             'mediumInteger',
             'smallInteger',
             'time',
+            'timestamp',
+            'timestampTz',
             'tinyInteger',
         ]);
     }

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -155,7 +155,7 @@ class ChangeColumn
     {
         $type = strtolower($type);
 
-        return Type::getType(match ($type) {
+        return Type::getType(Type::hasType($type) ? $type : match ($type) {
             'biginteger' => 'bigint',
             'smallinteger' => 'smallint',
             'mediumtext', 'longtext' => 'text',

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -119,7 +119,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
             $expected = [
                 'ALTER TABLE test ALTER datetime_column TYPE TIMESTAMP(0) WITH TIME ZONE',
-                'ALTER TABLE test ALTER datetime_column SET NOT NULL',
+                'ALTER TABLE test ALTER datetime_column DROP DEFAULT',
             ];
 
             $this->assertEquals($expected, $queries);

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -95,38 +95,31 @@ class SchemaBuilderTest extends DatabaseTestCase
         }
 
         Schema::create('test', function ($table) {
-            $table->dateTime('datetime_column_foo');
-            $table->dateTime('datetime_column_bar');
-            $table->dateTime('datetime_column_baz');
+            $table->dateTime('datetime_column');
         });
 
-        if (in_array($this->driver, ['pgsql', 'mysql'])) {
+        if ($this->driver === 'mysql') {
             $blueprint = new Blueprint('test', function ($table) {
-                $table->timestamp('datetime_column_foo')->change();
+                $table->timestamp('datetime_column')->change();
             });
 
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
-            $expected = $this->driver === 'mysql'
-                ? ['ALTER TABLE test CHANGE datetime_column_foo datetime_column_foo TIMESTAMP NOT NULL']
-                : [
-                    'ALTER TABLE test ALTER datetime_column_foo TYPE TIMESTAMP(0) WITHOUT TIME ZONE',
-                    'ALTER TABLE test ALTER datetime_column_foo SET NOT NULL',
-                ];
+            $expected = ['ALTER TABLE test CHANGE datetime_column datetime_column TIMESTAMP NOT NULL'];
 
             $this->assertEquals($expected, $queries);
         }
 
         if ($this->driver === 'pgsql') {
             $blueprint = new Blueprint('test', function ($table) {
-                $table->timestampTz('datetime_column_bar')->change();
+                $table->timestampTz('datetime_column')->change();
             });
 
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
             $expected = [
-                'ALTER TABLE test ALTER datetime_column_bar TYPE TIMESTAMP(0) WITH TIME ZONE',
-                'ALTER TABLE test ALTER datetime_column_bar SET NOT NULL',
+                'ALTER TABLE test ALTER datetime_column TYPE TIMESTAMP(0) WITH TIME ZONE',
+                'ALTER TABLE test ALTER datetime_column SET NOT NULL',
             ];
 
             $this->assertEquals($expected, $queries);
@@ -134,12 +127,12 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         if ($this->driver === 'sqlsrv') {
             $blueprint = new Blueprint('test', function ($table) {
-                $table->dateTimeTz('datetime_column_baz')->change();
+                $table->dateTimeTz('datetime_column')->change();
             });
 
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
-            $expected = ['ALTER TABLE test ALTER COLUMN datetime_column_baz DATETIMEOFFSET(6) NOT NULL'];
+            $expected = ['ALTER TABLE test ALTER COLUMN datetime_column DATETIMEOFFSET(6) NOT NULL'];
 
             $this->assertEquals($expected, $queries);
         }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -108,9 +108,11 @@ class SchemaBuilderTest extends DatabaseTestCase
             $expected = $this->driver === 'mysql'
                 ? ['ALTER TABLE test CHANGE datetime_column datetime_column TIMESTAMP NOT NULL']
                 : [
-                      'ALTER TABLE test ALTER datetime_column TYPE TIMESTAMP(0) WITH TIME ZONE',
-                      'ALTER TABLE test ALTER datetime_column SET NOT NULL',
-                  ];
+                    'ALTER TABLE test ALTER datetime_column TYPE TIMESTAMP(0) WITHOUT TIME ZONE',
+                    'ALTER TABLE test ALTER datetime_column SET NOT NULL',
+                ];
+
+            $this->assertEquals($expected, $queries);
         }
 
         if ($this->driver === 'pgsql') {
@@ -120,7 +122,12 @@ class SchemaBuilderTest extends DatabaseTestCase
 
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
-            $expected = ['ALTER TABLE test CHANGE datetime_column datetime_column TIMESTAMP(0) WITH TIME ZONE NOT NULL'];
+            $expected = [
+                'ALTER TABLE test ALTER datetime_column TYPE TIMESTAMP(0) WITH TIME ZONE',
+                'ALTER TABLE test ALTER datetime_column SET NOT NULL',
+            ];
+
+            $this->assertEquals($expected, $queries);
         }
 
         if ($this->driver === 'sqlsrv') {
@@ -131,8 +138,8 @@ class SchemaBuilderTest extends DatabaseTestCase
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
             $expected = ['ALTER TABLE test ALTER COLUMN datetime_column DATETIMEOFFSET(6) NOT NULL'];
-        }
 
-        $this->assertEquals($expected, $queries);
+            $this->assertEquals($expected, $queries);
+        }
     }
 }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -107,7 +107,10 @@ class SchemaBuilderTest extends DatabaseTestCase
 
             $expected = $this->driver === 'mysql'
                 ? ['ALTER TABLE test CHANGE datetime_column datetime_column TIMESTAMP NOT NULL']
-                : ['ALTER TABLE test CHANGE datetime_column datetime_column TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL'];
+                : [
+                      'ALTER TABLE test ALTER datetime_column TYPE TIMESTAMP(0) WITH TIME ZONE',
+                      'ALTER TABLE test ALTER datetime_column SET NOT NULL',
+                  ];
         }
 
         if ($this->driver === 'pgsql') {
@@ -127,7 +130,7 @@ class SchemaBuilderTest extends DatabaseTestCase
 
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
-            $expected = ['ALTER TABLE test CHANGE datetime_column datetime_column DATETIMEOFFSET(6) NOT NULL'];
+            $expected = ['ALTER TABLE test ALTER COLUMN datetime_column DATETIMEOFFSET(6) NOT NULL'];
         }
 
         $this->assertEquals($expected, $queries);

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -95,21 +95,23 @@ class SchemaBuilderTest extends DatabaseTestCase
         }
 
         Schema::create('test', function ($table) {
-            $table->dateTime('datetime_column');
+            $table->dateTime('datetime_column_foo');
+            $table->dateTime('datetime_column_bar');
+            $table->dateTime('datetime_column_baz');
         });
 
         if (in_array($this->driver, ['pgsql', 'mysql'])) {
             $blueprint = new Blueprint('test', function ($table) {
-                $table->timestamp('datetime_column')->change();
+                $table->timestamp('datetime_column_foo')->change();
             });
 
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
             $expected = $this->driver === 'mysql'
-                ? ['ALTER TABLE test CHANGE datetime_column datetime_column TIMESTAMP NOT NULL']
+                ? ['ALTER TABLE test CHANGE datetime_column_foo datetime_column_foo TIMESTAMP NOT NULL']
                 : [
-                    'ALTER TABLE test ALTER datetime_column TYPE TIMESTAMP(0) WITHOUT TIME ZONE',
-                    'ALTER TABLE test ALTER datetime_column SET NOT NULL',
+                    'ALTER TABLE test ALTER datetime_column_foo TYPE TIMESTAMP(0) WITHOUT TIME ZONE',
+                    'ALTER TABLE test ALTER datetime_column_foo SET NOT NULL',
                 ];
 
             $this->assertEquals($expected, $queries);
@@ -117,14 +119,14 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         if ($this->driver === 'pgsql') {
             $blueprint = new Blueprint('test', function ($table) {
-                $table->timestampTz('datetime_column')->change();
+                $table->timestampTz('datetime_column_bar')->change();
             });
 
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
             $expected = [
-                'ALTER TABLE test ALTER datetime_column TYPE TIMESTAMP(0) WITH TIME ZONE',
-                'ALTER TABLE test ALTER datetime_column SET NOT NULL',
+                'ALTER TABLE test ALTER datetime_column_bar TYPE TIMESTAMP(0) WITH TIME ZONE',
+                'ALTER TABLE test ALTER datetime_column_bar SET NOT NULL',
             ];
 
             $this->assertEquals($expected, $queries);
@@ -132,12 +134,12 @@ class SchemaBuilderTest extends DatabaseTestCase
 
         if ($this->driver === 'sqlsrv') {
             $blueprint = new Blueprint('test', function ($table) {
-                $table->dateTimeTz('datetime_column')->change();
+                $table->dateTimeTz('datetime_column_baz')->change();
             });
 
             $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
-            $expected = ['ALTER TABLE test ALTER COLUMN datetime_column DATETIMEOFFSET(6) NOT NULL'];
+            $expected = ['ALTER TABLE test ALTER COLUMN datetime_column_baz DATETIMEOFFSET(6) NOT NULL'];
 
             $this->assertEquals($expected, $queries);
         }


### PR DESCRIPTION
This PR provides support for modifying timestampTz and timestamp column types, [without adding `Illuminate\Database\DBAL\TimestampType` class to database configuration](https://laravel.com/docs/9.x/migrations#prerequisites).

```
Schema::table('users', function (Blueprint $table) {
    $table->timestamp('bar')->nullable()->change();
    $table->timestampTz('foo')->nullable()->change();
});
```

Before this PR, modifying these column types led to an error:

> Unknown column type \"timestampTz\" requested. Any Doctrine type that you use has to be registered with \\Doctrine\\DBAL\\Types\\Type::addType(). You can get a list of all the known types with \\Doctrine\\DBAL\\Types\\Type::getTypesMap(). If this error occurs during database introspection then you might have forgotten to register all database types for a Doctrine Type. Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement Type#getMappedDatabaseTypes(). If the type name is empty you might have a problem with the cache or forgot some mapping information

But doctrine/dbal package actually supports modifying timestamp column types as dateTime type.

So this PR, maps Laravel timestamp and timestampTz to its Doctrine equivalent dateTime and dateTimeTz types and version option of the platform options to true that finally [gets the SQL snippet to declare a TIMESTAMP column](https://github.com/doctrine/dbal/blob/de42378d0e521fd45d375020472caf37a003d289/src/Platforms/AbstractMySQLPlatform.php#L251-L253).