### PR TITLE
[9.x] Add failing test for unregistered blade directive output

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -512,14 +512,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatement($match)
     {
         if (str_contains($match[1], '@')) {
-            $match[0] = isset($match[3]) ? $match[1].$match[3] : $match[1].$match[2];
+            $match[0] = isset($match[3]) ? $match[1].$match[3] : $match[1];
         } elseif (isset($this->customDirectives[$match[1]])) {
             $match[0] = $this->callCustomDirective($match[1], Arr::get($match, 3));
         } elseif (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
             $match[0] = $this->$method(Arr::get($match, 3));
+        } else {
+            return $match[0];
         }
 
-        return $match[0];
+        return isset($match[3]) ? $match[0] : $match[0].$match[2];
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -512,14 +512,14 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatement($match)
     {
         if (str_contains($match[1], '@')) {
-            $match[0] = isset($match[3]) ? $match[1].$match[3] : $match[1];
+            $match[0] = isset($match[3]) ? $match[1].$match[3] : $match[1].$match[2];
         } elseif (isset($this->customDirectives[$match[1]])) {
             $match[0] = $this->callCustomDirective($match[1], Arr::get($match, 3));
         } elseif (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
             $match[0] = $this->$method(Arr::get($match, 3));
         }
 
-        return isset($match[3]) ? $match[0] : $match[0].$match[2];
+        return isset($match[3]) ? $match[0] : $match[0];
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -519,7 +519,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             $match[0] = $this->$method(Arr::get($match, 3));
         }
 
-        return isset($match[3]) ? $match[0] : $match[0];
+        return $match[0];
     }
 
     /**

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -223,4 +223,11 @@ class BladeCustomTest extends AbstractBladeTestCase
         $expected = '<?php echo $__env->make(\'app.includes.foreach\', [], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+    
+    public function testUnescapedNonRegisteredDirective()
+    {
+        $string = '@media only screen and (min-width:480px) {';
+        $expected = '@media only screen and (min-width:480px) {';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -223,7 +223,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $expected = '<?php echo $__env->make(\'app.includes.foreach\', [], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
-    
+
     public function testUnescapedNonRegisteredDirective()
     {
         $string = '@media only screen and (min-width:480px) {';


### PR DESCRIPTION
We have quite a few `blade` templates for emails that include the css `@media` query such as...

```css
@media only screen and (min-width:480px) {
```

When these get rendered, blade outputs the following...

```diff
- @media only screen and (min-width:480px) {
+ @media  only screen and (min-width:480px) {
```

Notice the extra space between `@media` and `only`

I know we can (and currently do) escape the `@media` string like so - `@@media` but we don't always remember, and it seems like escaping should only be required for directives that _are actually_ directives.

I had a look at a potential fix for this, but didn't get very far, so thought I would create this PR with a failing test to...
1) See if it should be fixed
2) See if anyone more clued up than me had any suggested fixes

Thanks