### PR TITLE
[9.x] Add specific queue parameter when pending mail

### DIFF
--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -128,11 +128,12 @@ class PendingMail
      * Push the given mailable onto the queue.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     * @param  string|null  $queue
      * @return mixed
      */
-    public function queue(MailableContract $mailable)
+    public function queue(MailableContract $mailable, $queue = null)
     {
-        return $this->mailer->queue($this->fill($mailable));
+        return $this->mailer->queue($this->fill($mailable), $queue);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -33,10 +33,11 @@ class PendingMailFake extends PendingMail
      * Push the given mailable onto the queue.
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     * @param  string|null  $queue
      * @return mixed
      */
-    public function queue(Mailable $mailable)
+    public function queue(Mailable $mailable, $queue = null)
     {
-        return $this->mailer->queue($this->fill($mailable));
+        return $this->mailer->queue($this->fill($mailable), $queue);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
it's easier to use Mail facade to dispatch different queue.

`Mail::to($users)->queue(new Mailable(), 'mail');`