### PR TITLE
[9.x] Make more errors in validation error response translatable

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -94,9 +94,9 @@ class ValidationException extends Exception
         $message = array_shift($messages);
 
         if ($additional = count($messages)) {
-            $pluralized = $additional === 1 ? 'error' : 'errors';
+            $pluralized = $additional === 1 ? __("error") : __("errors");
 
-            $message .= " (and {$additional} more {$pluralized})";
+            $message .= __(" (and :additional more :pluralized)", compact("additional", "pluralized"));
         }
 
         return $message;


### PR DESCRIPTION
Right now, when validation fails and there is more than 1 errors, it returns a message like this:
```
Name is required. (and 1 more error)
```

However, let's say that you've translated validation messages. Then, the message could be something like this:
```
Meno je požadované. (and 1 more error)
```

The issue is that there's no way to translate the ```(and 1 more error)``` string and so you end up with this half-translated error message, which is not ideal.

This pull request is a response to #41230.