### PR TITLE
fix: select maximum supported timestamp precision

### DIFF
--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -4,6 +4,14 @@ namespace Illuminate\Database\DBAL;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MySQL57Platform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\DBAL\Types\Type;
 
@@ -11,37 +19,39 @@ class TimestampType extends Type implements PhpDateTimeMappingType
 {
     /**
      * {@inheritdoc}
+     *
+     * @throws DBALException
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return match ($name = $platform->getName()) {
-            'mysql',
-            'mysql2' => $this->getMySqlPlatformSQLDeclaration($fieldDeclaration),
-            'postgresql',
-            'pgsql',
-            'postgres' => $this->getPostgresPlatformSQLDeclaration($fieldDeclaration),
-            'mssql' => $this->getSqlServerPlatformSQLDeclaration($fieldDeclaration),
-            'sqlite',
-            'sqlite3' => $this->getSQLitePlatformSQLDeclaration($fieldDeclaration),
-            default => throw new DBALException('Invalid platform: '.$name),
+        return match (get_class($platform)) {
+            MySQLPlatform::class,
+            MySQL57Platform::class,
+            MySQL80Platform::class,
+            MariaDb1027Platform::class => $this->getMySqlPlatformSQLDeclaration($column),
+            PostgreSQL94Platform::class,
+            PostgreSQL100Platform::class => $this->getPostgresPlatformSQLDeclaration($column),
+            SQLServer2012Platform::class => $this->getSqlServerPlatformSQLDeclaration($column),
+            SqlitePlatform::class => 'DATETIME',
+            default => throw new DBALException('Invalid platform: '. substr(strrchr(get_class($platform), '\\'), 1)),
         };
     }
 
     /**
      * Get the SQL declaration for MySQL.
      *
-     * @param  array  $fieldDeclaration
+     * @param  array  $column
      * @return string
      */
-    protected function getMySqlPlatformSQLDeclaration(array $fieldDeclaration)
+    protected function getMySqlPlatformSQLDeclaration(array $column): string
     {
         $columnType = 'TIMESTAMP';
 
-        if ($fieldDeclaration['precision']) {
-            $columnType = 'TIMESTAMP('.$fieldDeclaration['precision'].')';
+        if ($column['precision']) {
+            $columnType = 'TIMESTAMP('.min((int) $column['precision'], 6).')';
         }
 
-        $notNull = $fieldDeclaration['notnull'] ?? false;
+        $notNull = $column['notnull'] ?? false;
 
         if (! $notNull) {
             return $columnType.' NULL';
@@ -53,36 +63,25 @@ class TimestampType extends Type implements PhpDateTimeMappingType
     /**
      * Get the SQL declaration for PostgreSQL.
      *
-     * @param  array  $fieldDeclaration
+     * @param  array  $column
      * @return string
      */
-    protected function getPostgresPlatformSQLDeclaration(array $fieldDeclaration)
+    protected function getPostgresPlatformSQLDeclaration(array $column): string
     {
-        return 'TIMESTAMP('.(int) $fieldDeclaration['precision'].')';
+        return 'TIMESTAMP('.min((int) $column['precision'], 6).')';
     }
 
     /**
      * Get the SQL declaration for SQL Server.
      *
-     * @param  array  $fieldDeclaration
+     * @param  array  $column
      * @return string
      */
-    protected function getSqlServerPlatformSQLDeclaration(array $fieldDeclaration)
+    protected function getSqlServerPlatformSQLDeclaration(array $column): string
     {
-        return $fieldDeclaration['precision'] ?? false
-                    ? 'DATETIME2('.$fieldDeclaration['precision'].')'
-                    : 'DATETIME';
-    }
-
-    /**
-     * Get the SQL declaration for SQLite.
-     *
-     * @param  array  $fieldDeclaration
-     * @return string
-     */
-    protected function getSQLitePlatformSQLDeclaration(array $fieldDeclaration)
-    {
-        return 'DATETIME';
+        return $column['precision'] ?? false
+            ? 'DATETIME2('.min((int) $column['precision'], 7).')'
+            : 'DATETIME';
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When renaming a timestamp column it does not correctly gets the precision using the `TIMESTAMP()` function in the alter statement.
While I did not investigate why we're getting too big precision to beging with, I made sure that we're not passing in higer precision than supported by the platforms.
There are no tests as test currently are using sqlite I think. It has however fixed the issue I had with renaming.
Can you please advise how this is tested with mysql? (I can see workflows referencing it)

The test would be something akin to
```php
public function testItDoesNotSetPrecisionHigherThanSupportedWhenRenamingTimestamps()
{
    $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
        $table->timestamp('created_at');
    });
    $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
        $table->renameColumn('created_at', 'new_created_at');
    });
    // Illuminate\Database\QueryException::class was not thrown
}
```

Rest of the changes are updates advised by deprecations.
Please see linked issue for context.

closes #41154
