### PR TITLE
[9.x] Add `merge` methods for `HidesAttributes` concern

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -78,6 +78,19 @@ trait HidesAttributes
     }
 
     /**
+     * Merge new visible attributes with existing visible attributes on the model.
+     *
+     * @param  array<string>  $visible
+     * @return $this
+     */
+    public function mergeVisible(array $visible)
+    {
+        $this->visible = array_merge($this->visible, $visible);
+
+        return $this;
+    }
+
+    /**
      * Make the given, typically hidden, attributes visible.
      *
      * @param  array<string>|string|null  $attributes

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -42,6 +42,19 @@ trait HidesAttributes
     }
 
     /**
+     * Merge new hidden attributes with existing hidden attributes on the model.
+     *
+     * @param  array<string>  $hidden
+     * @return $this
+     */
+    public function mergeHidden(array $hidden)
+    {
+        $this->hidden = array_merge($this->hidden, $hidden);
+
+        return $this;
+    }
+
+    /**
      * Get the visible attributes for the model.
      *
      * @return array<string>


### PR DESCRIPTION
### Provides two new methods to classes implementing `Illuminate\Database\Eloquent\Concerns\HidesAttributes`:
- `mergeHidden`
- `mergeVisible`

These methods are convenience methods that are mirrors to the `mergeFillable` & `mergeGuarded` from `Illuminate\Database\Eloquent\Concerns\GuardsAttributes` and `mergeCasts` from `Illuminate\Database\Eloquent\Concerns\HasAttributes`.

Serves to provide another slice of consistency for the framework <3