### PR TITLE
[9.x] Enhance column modifying

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -139,6 +139,10 @@ class ChangeColumn
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }
 
+        if ($fluent['type'] === 'binary') {
+            $options['length'] = AbstractMySQLPlatform::LENGTH_LIMIT_BLOB;
+        }
+
         if ($fluent['type'] === 'char') {
             $options['fixed'] = true;
         }

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -128,11 +128,11 @@ class ChangeColumn
      */
     protected static function getDoctrineColumnChangeOptions(Fluent $fluent)
     {
-        $dcType = static::getDoctrineColumnType($fluent['type']);
+        $doctrineType = static::getDoctrineColumnType($fluent['type']);
 
-        $options = ['type' => $dcType];
+        $options = ['type' => $doctrineType];
 
-        if ($dcType->getName() === Types::TEXT) {
+        if ($doctrineType->getName() === Types::TEXT) {
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }
 
@@ -156,7 +156,7 @@ class ChangeColumn
             ];
         }
 
-        if (static::doesntNeedCharacterOptions($dcType->getName())) {
+        if (static::doesntNeedCharacterOptions($doctrineType->getName())) {
             $options['customSchemaOptions'] = [
                 'collation' => '',
                 'charset' => '',

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -149,6 +149,12 @@ class ChangeColumn
             ];
         }
 
+        if ($fluent['type'] === 'jsonb') {
+            $options['platformOptions'] = [
+                'jsonb' => true,
+            ];
+        }
+
         if (static::doesntNeedCharacterOptions($dcType->getName())) {
             $options['customSchemaOptions'] = [
                 'collation' => '',

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -178,7 +178,9 @@ class ChangeColumn
 
         $type = match ($type) {
             'biginteger' => Types::BIGINT,
+            'mediuminteger' => 'mediumint',
             'smallinteger' => Types::SMALLINT,
+            'tinyinteger' => 'tinyint',
             'binary' => Types::BLOB,
             'uuid' => Types::GUID,
             default => $type,

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -65,8 +65,7 @@ class ChangeColumn
         Blueprint $blueprint,
         SchemaManager $schema,
         AbstractPlatform $platform
-    )
-    {
+    ) {
         $current = $schema->listTableDetails($grammar->getTablePrefix().$blueprint->getTable());
 
         return (new Comparator)->diffTable(


### PR DESCRIPTION
Before this PR, we were manually map Laravel column types to its Doctrine equivalent and many types were missing, this PR uses each database platform own map instead. So we can support modifying many more columns, e.g. `double`, `float`, `jsonb`, `set`, `timeTz`, `timestamp` (no need to register a custom Doctrine type class), `timestampTz`, `tinyText`, `unsignedDecimal`, `unsignedDouble`, `unsignedFloat`, `year`, etc.

It also fix a bug when modifying a `binary` column that were being changed to `LONGBLOB` instead of `BLOB`.

Here is the Doctrine type mapping of:
* MySQL: https://github.com/doctrine/dbal/blob/de42378d0e521fd45d375020472caf37a003d289/src/Platforms/AbstractMySQLPlatform.php#L1041-L1072
* PostreSQL: https://github.com/doctrine/dbal/blob/de42378d0e521fd45d375020472caf37a003d289/src/Platforms/PostgreSQLPlatform.php#L1083-L1125
* SQLServer: https://github.com/doctrine/dbal/blob/de42378d0e521fd45d375020472caf37a003d289/src/Platforms/SQLServerPlatform.php#L1392-L1423
* SQLite : https://github.com/doctrine/dbal/blob/de42378d0e521fd45d375020472caf37a003d289/src/Platforms/SqlitePlatform.php#L663-L696