### PR TITLE
[9.x] Alternative database name in Postgres DSN, allow pgbouncer aliased databases to continue working on 9.x

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -163,6 +163,11 @@ class PostgresConnector extends Connector implements ConnectorInterface
 
         $host = isset($host) ? "host={$host};" : '';
 
+        // User may need to connect using a different database name than is used
+        // during information_schema queries. This can occur when using connection
+        // pooling software with aliased database names.
+        $database = $database_connect ?? $database;
+
         $dsn = "pgsql:{$host}dbname='{$database}'";
 
         // If a port was specified, we will add it to this Postgres DSN connections

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -163,10 +163,10 @@ class PostgresConnector extends Connector implements ConnectorInterface
 
         $host = isset($host) ? "host={$host};" : '';
 
-        // User may need to connect using a different database name than is used
-        // during information_schema queries. This can occur when using connection
-        // pooling software with aliased database names.
-        $database = $database_connect ?? $database;
+        // Sometimes - users may need to connect to a database that has a different
+        // name than the database used for "information_schema" queries. This is
+        // typically the case if using "pgbouncer" type software when pooling.
+        $database = $connect_via_database ?? $database;
 
         $dsn = "pgsql:{$host}dbname='{$database}'";
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -219,7 +219,7 @@ class DatabaseConnectorTest extends TestCase
     public function testPostgresApplicationUseAlternativeDatabaseName()
     {
         $dsn = 'pgsql:dbname=\'baz\'';
-        $config = ['database' => 'bar', 'database_connect' => 'baz'];
+        $config = ['database' => 'bar', 'connect_via_database' => 'baz'];
         $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
         $connection = m::mock(stdClass::class);
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -216,6 +216,22 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testPostgresApplicationUseAlternativeDatabaseName()
+    {
+        $dsn = 'pgsql:dbname=\'baz\'';
+        $config = ['database' => 'bar', 'database_connect' => 'baz'];
+        $connector = $this->getMockBuilder(PostgresConnector::class)->onlyMethods(['createConnection', 'getOptions'])->getMock();
+        $connection = m::mock(stdClass::class);
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->willReturn(['options']);
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->willReturn($connection);
+        $statement = m::mock(PDOStatement::class);
+        $connection->shouldReceive('prepare')->zeroOrMoreTimes()->andReturn($statement);
+        $statement->shouldReceive('execute')->zeroOrMoreTimes();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testPostgresConnectorReadsIsolationLevelFromConfig()
     {
         $dsn = 'pgsql:host=foo;dbname=\'bar\';port=111';


### PR DESCRIPTION
I encountered this issue that prevented migrations from running after upgrading to Laravel 9:  https://github.com/laravel/framework/discussions/43536 (`php artisan migrate` fails after attempting to create `migrations` table that already exists)

It is caused by my (fringe?) pgbouncer setup + the introduction of the `table_catalog` parameter into queries in 9.x via https://github.com/laravel/framework/pull/35530 

Here's a repo to reproduce the issue: https://github.com/AlbinoDrought/l9-pgsql-pgbouncer-alias

When using pgbouncer, the "database" name used to connect is just a pool name - pgbouncer can connect to a differently-named database behind the scenes. As an example, a `sample_app` database could have a `sample_app_background` pool and a `sample_app_web` pool. In Laravel you would specify `['database' => 'sample_app_background']` or `['database' => 'sample_app_web']` to connect.

In Laravel <9, the `database` config var does not appear to be referenced by the `PostgresConnector` after DSN generation. The above pgbouncer setup works transparently.

In Laravel 9, the `database` config var is referenced during `PostgresConnector` DSN generation, `hasTable`, and `getColumnListing`. The above pgbouncer setup now causes issues.

If we're connected to the `sample_app_web` pool, `hasTable` and `getColumnListing` query `information_schema` about the `sample_app_web` database, but that database doesn't exist. This causes `hasTable` to always return `false` which is problematic during migrations. We want `hasTable` and `getColumListing` to query about the `sample_app` database instead.

I don't know what `getColumnListing` is used for (something about guarded attributes?) but it also references the `database` config var, possibly outside of migrations.
 
This proposed fix allows specifying a different database name used only during `PostgresConnector` DSN generation. The pool name should be specified here. I currently chose the config name `database_connect` but don't really like it. Users would specify a config like `['database' => 'sample_app', 'database_connect' => 'sample_app_web']` to continue using a pgbouncer setup like above. 

I'm not sure how common this kind of setup is. If this change isn't wanted upstream, it can be accomplished by overriding PostgresConnector in a third-party package (this is what I'm currently doing).

Thanks!