### PR TITLE
[9.x] Add configurable 'hot' file path to Vite

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -110,19 +110,21 @@ class Vite
      *
      * @param  string|string[]  $entrypoints
      * @param  string  $buildDirectory
+     * @param  string  $hotPath
      * @return \Illuminate\Support\HtmlString
      *
      * @throws \Exception
      */
-    public function __invoke($entrypoints, $buildDirectory = 'build')
+    public function __invoke($entrypoints, $buildDirectory = 'build', $hotPath = 'hot')
     {
         static $manifests = [];
 
         $entrypoints = collect($entrypoints);
         $buildDirectory = Str::start($buildDirectory, '/');
+        $hotPath = Str::start($hotPath, '/');
 
-        if (is_file(public_path('/hot'))) {
-            $url = rtrim(file_get_contents(public_path('/hot')));
+        if (is_file(public_path($hotPath))) {
+            $url = rtrim(file_get_contents(public_path($hotPath)));
 
             return new HtmlString(
                 $entrypoints


### PR DESCRIPTION
I'm using Vite for one of my packages as well, instead of mix. However the `hot` file path is not configurable, and it make not possible to run the Vite dev server correctly from a package.

-----
My package comes with pre-bundled assets, and they are being published to `public/vendor/package-name` when running composer update. For development I just make a symlink to fake the published status of the assets.

However with Vite I can't run the dev server properly from the package itself:

```sh
cd packages/conedevelopment/package-name

# works well
yarn build

# runs, but does not connect to the dev server
yarn dev
```

In my package base layout I use the following `@vite` blade directive:

```blade
@vite('resources/js/app.js', '/vendor/package-name/build')
```

By customizing the `build` directory path, it allows to have access to the published or symlinked assets for production and development as well.

However right now it's not possible to configure the path to the `hot` file. When running the `yarn dev` command from the package, the hot file is placed in the `packages/conedevelopment/package-name/public/hot` that is linked to the `public/vendor/package-name/hot` path.

-------

This PR attempts to make configurable the path to the `hot` file.

So we could do the following:

```blade
@vite('resources/js/app.js', '/vendor/package-name/build', '/vendor/package-name/hot')
```

------

This PR is only additive, should not hold any BC.

Also, I was not sure how to add tests for this, but if you are willing to merge this, I can add some tests as well.