### PR TITLE
[9.x] Fix bullet output transparency in Artisan commands

### DIFF
--- a/src/Illuminate/Console/resources/views/components/bullet-list.php
+++ b/src/Illuminate/Console/resources/views/components/bullet-list.php
@@ -1,7 +1,7 @@
 <div>
     <?php foreach ($elements as $element) { ?>
-        <div class="text-gray mx-2">
-            ⇂ <?php echo htmlspecialchars($element) ?>
+        <div class="text-green-500 mx-2">
+            <span class="text-violet-800">⇂</span> <?php echo htmlspecialchars($element) ?>
         </div>
     <?php } ?>
 </div>

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -120,7 +120,7 @@ class MigratorTest extends TestCase
     {
         $this->output->shouldReceive('writeln')->once()->with(m::on(function ($argument) use ($elements) {
             foreach ($elements as $element) {
-                if (! str($argument)->contains("⇂ $element")) {
+                if (! str($argument)->contains($element)) {
                     return false;
                 }
             }


### PR DESCRIPTION
The transparency of the bullet list was not as good as it should be, especially in IDEs' terminal with dark mode and the readability is 

Before:
![before](https://user-images.githubusercontent.com/29504334/182921321-7a560dbc-8fd1-4d60-9312-8916d5baba06.png)

After:
![Screenshot 2022-08-04 230803](https://user-images.githubusercontent.com/29504334/182928233-4dcf3b89-fe4e-4d34-8c9b-30ec9b5a06e0.png)

