### PR TITLE
[9.x] Attribute Cast Performance Improvements

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -882,8 +882,8 @@ trait HasAttributes
      */
     protected function isImmutableCustomDateTimeCast($cast)
     {
-        return strncmp($cast, 'immutable_date:', 15) === 0 ||
-               strncmp($cast, 'immutable_datetime:', 19) === 0;
+        return str_starts_with($cast, 'immutable_date:') ||
+                str_starts_with($cast, 'immutable_datetime:');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1491,11 +1491,13 @@ trait HasAttributes
      */
     protected function isClassCastable($key)
     {
-        if (! array_key_exists($key, $this->getCasts())) {
+        $casts = $this->getCasts();
+
+        if (! array_key_exists($key, $casts)) {
             return false;
         }
 
-        $castType = $this->parseCasterClass($this->getCasts()[$key]);
+        $castType = $this->parseCasterClass($casts[$key]);
 
         if (in_array($castType, static::$primitiveCastTypes)) {
             return false;
@@ -1516,11 +1518,13 @@ trait HasAttributes
      */
     protected function isEnumCastable($key)
     {
-        if (! array_key_exists($key, $this->getCasts())) {
+        $casts = $this->getCasts();
+
+        if (! array_key_exists($key, $casts)) {
             return false;
         }
 
-        $castType = $this->getCasts()[$key];
+        $castType = $casts[$key];
 
         if (in_array($castType, static::$primitiveCastTypes)) {
             return false;


### PR DESCRIPTION
Performance improvements to casts-related functions:
1. Reduce number of repeated calls to `getCasts()` in methods
2. Replace `strncmp` with `str_starts_with` in cast type check
3. Add cache for `getCastType()` to eliminate repeated string comparisons for cast types.  

------------

Background: 
I process millions of rows via scout and was curious if there were any obvious bottlenecks in the process to help speed things along.  I discovered through profiling that casts-related code represented a significant number of overall calls and time spent processing my models.  

In particular calls to `getCasts()` were unusually high as well and the time spent in `getCastType()` was higher than any other function.

First step was to update any methods where `getCasts()` was called multiple times.  `getCastType()` seemed to be the primary culprit for the high number of calls to `getCasts()`.

When profiling again this helped reduce the calls to `getCasts()` but the time spent in `getCastType()` was still rather high.  I found `isImmutableCustomDateTimeCast()` still was using `strncmp` comparisons when `str_starts_with` would do instead.  This change is not only an improvement to readability while matching the code of the other similar functions, but there's also a small improvement in performance with the change as an added bonus. 

I then noticed that `getCastType()` can be cached as the results of checking the cast types are deterministic and do not need to be repeated for the same input.

--------

Results:
With these changes I saw a 5-25% reduction in processing time depending on the complexity, number of casts, and number of attributes of a particular model.  From my tests I have noticed significant improvements on both eloquent load times and serialization.

--------

Potential risks:
This introduces a new static member variable `$castTypeCache` to `Model` that could cause conflicts if a subclass already defines one by that name.  An alternative for this that is to introduce `$castTypeCache` as a static variable to the `getCastType()` method only, which is often considered bad form but does not introduce any risk of naming collision and results in the same benefit.  

-------

End user benefits:

General users will likely see negligible benefits as the changes are only really beneficial when processing a lot of models.  At scale, any bulk loading and serializing of models will yield note-worthy performance improvements. 

-------

Other things to note about casts:

There are further significant performance improvements in caching `hasCast()`, however that is a bit more complex as there's no easy to trust that `$casts` or the results of `getCasts()` does not change during the lifecycle of a model.  If a future version of Laravel introduced immutability to `$casts` and an expectation of determinism for `getCasts()` the expensive and repeated calls to `hasCast()` could be cached and save a significant amount of time.