### PR TITLE
[10.x] Support setting ASSET_URL to "/"

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -255,7 +255,13 @@ class UrlGenerator implements UrlGeneratorContract
         // for asset paths, but only for routes to endpoints in the application.
         $root = $this->assetRoot ?: $this->formatRoot($this->formatScheme($secure));
 
-        return $this->removeIndex($root).'/'.trim($path, '/');
+
+        $postfix = trim($path, '/');
+        if ($root === '/') {
+            return "/$postfix";
+        }
+
+        return $this->removeIndex($root).'/'. $postfix;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -255,13 +255,12 @@ class UrlGenerator implements UrlGeneratorContract
         // for asset paths, but only for routes to endpoints in the application.
         $root = $this->assetRoot ?: $this->formatRoot($this->formatScheme($secure));
 
-
         $postfix = trim($path, '/');
         if ($root === '/') {
             return "/$postfix";
         }
 
-        return $this->removeIndex($root).'/'. $postfix;
+        return $this->removeIndex($root).'/'.$postfix;
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -54,6 +54,18 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
     }
 
+    public function testAssetGenerationWithAssetRootAsSlash()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/index.php/'),
+            '/'
+        );
+
+        $this->assertSame('/foo/bar', $url->asset('foo/bar'));
+        $this->assertSame('/foo/bar', $url->asset('foo/bar', true));
+    }
+
     public function testBasicGenerationWithHostFormatting()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Setting `ASSET_URL` to `/` in your env file currently yields asset urls that are prefixed with two slashes (i.e. `//path/to/asset`).

This PR changes this behaviour so that setting `ASSET_URL` to `/` yields asset urls that are prefixed with a single slash (i.e. `/path/to/asset`).

The need for this change came up when moving from Mix to Vite.
Mix always output the assets with a single slash in front (i.e. `/path/to/asset`). However, Vite uses the `asset()` helper, which by default prefixes the asset urls with the `APP_URL` env variable (i.e. `<APP_URL>/path/to/asset`). This becomes a problem when trying to access the site using different hostnames (usually locally during testing and such). A solution would be to remove the `<APP_URL>` part of the asset urls, but as far as I can tell that's not possible without the changes in this PR.

This will be a breaking change for anyone that has currently set `ASSET_URL` to `/`, although I personally can't think of any use-case where that would be a useful thing to do with the current code.