### PR TITLE
[10.x] Remove trailing slash from ASSET_URL

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -253,7 +253,7 @@ class UrlGenerator implements UrlGeneratorContract
         // Once we get the root URL, we will check to see if it contains an index.php
         // file in the paths. If it does, we will remove it since it is not needed
         // for asset paths, but only for routes to endpoints in the application.
-        $root = $this->assetRoot ?: $this->formatRoot($this->formatScheme($secure));
+        $root = $this->assetRoot ?? $this->formatRoot($this->formatScheme($secure));
 
         return $this->removeIndex($root).'/'.trim($path, '/');
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -253,7 +253,9 @@ class UrlGenerator implements UrlGeneratorContract
         // Once we get the root URL, we will check to see if it contains an index.php
         // file in the paths. If it does, we will remove it since it is not needed
         // for asset paths, but only for routes to endpoints in the application.
-        $root = $this->assetRoot ?? $this->formatRoot($this->formatScheme($secure));
+        $root = $this->assetRoot
+            ? Str::of($this->assetRoot)->rtrim('/')
+            : $this->formatRoot($this->formatScheme($secure));
 
         return $this->removeIndex($root).'/'.trim($path, '/');
     }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -54,16 +54,23 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
     }
 
-    public function testAssetGenerationWithEmptyAssetRoot()
+    public function testAssetGenerationWithAssetRoot()
     {
         $url = new UrlGenerator(
             new RouteCollection,
             Request::create('http://www.foo.com/index.php/'),
-            ''
+            'http://www.bar.com/assets/'
+        );
+
+        $this->assertSame('http://www.bar.com/assets/foo/bar', $url->asset('foo/bar'));
+
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/index.php/'),
+            '/'
         );
 
         $this->assertSame('/foo/bar', $url->asset('foo/bar'));
-        $this->assertSame('/foo/bar', $url->asset('foo/bar', true));
     }
 
     public function testBasicGenerationWithHostFormatting()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -54,6 +54,18 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
     }
 
+    public function testAssetGenerationWithEmptyAssetRoot()
+    {
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/index.php/'),
+            ''
+        );
+
+        $this->assertSame('/foo/bar', $url->asset('foo/bar'));
+        $this->assertSame('/foo/bar', $url->asset('foo/bar', true));
+    }
+
     public function testBasicGenerationWithHostFormatting()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Update: The description below is outdated (and doesn't match the title of the PR). See the discussion in the comments below.

Setting `ASSET_URL` to an empty string in your env file currently yield asset urls that are prefixed your `APP_URL` (e.g. `<APP_URL>/path/to/asset`).

This PR changes this behaviour so that setting `ASSET_URL` to an empty string yield asset urls that are prefixed with a single slash (i.e. `/path/to/asset`).

The need for this change came up when moving from Mix to Vite.
Mix always output the assets with a single slash in front (i.e. `/path/to/asset`). However, Vite uses the `asset()` helper, which by default prefixes the asset urls with the `APP_URL` env variable (i.e. `<APP_URL>/path/to/asset`). This becomes a problem when trying to access the site using different hostnames (usually locally during testing and such). A solution would be to remove the `<APP_URL>` part of the asset urls, but as far as I can tell that's not possible without the changes in this PR.

This will be a breaking change for anyone that has currently set `ASSET_URL` to an empty string.