### PR TITLE
[9.x] Update NotificationFake with notifications getter

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -362,4 +362,14 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
 
         return $this;
     }
+
+    /**
+     * Get the notifications that have been sent.
+     *
+     * @return array
+     */
+    public function sentNotifications()
+    {
+        return $this->notifications;
+    }
 }


### PR DESCRIPTION
When testing notifications this is super handy for testing whether the correct notifications have been sent. A similar method is available in the QueueFake with `Queue::pushedJobs()`. Having `Notification::sentNotifications()` adds consistency between the Fake Facades.
Relates to: https://github.com/laravel/framework/pull/27089