### PR TITLE
[9.x] Add Str::join() helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -418,7 +418,7 @@ class Str
 
         return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
     }
-    
+
     /**
      * Join items into a human readable list (e.g. "one, two, three, and four")
      * Uses different glue strings when there are only two elements and for

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -418,6 +418,45 @@ class Str
 
         return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
     }
+    
+    /**
+     * Join items into a human readable list (e.g. "one, two, three, and four")
+     * Uses different glue strings when there are only two elements and for
+     * the final element. Defaults to joining using the Oxford comma.
+     *
+     * 1 item will return: $item
+     * 2 items will return: $item1 . $dyadicGlue . $item2
+     * 3+ items will return: $item1 . $glue . $item2 . $lastGlue . $item3
+     */
+    public static function join(iterable $items, string $glue = ', ', string $lastGlue = ', and ', $dyadicGlue = ' and '): string
+    {
+        $result = '';
+        $i = 0;
+        $total = count($items);
+        foreach ($items as $item) {
+            $i++;
+
+            // Only add glue if we're not on the first item
+            if ($i !== 1) {
+                // Add diadic glue between the first and last item
+                if ($i === 2 && $total === 2) {
+                    $result .= $dyadicGlue;
+
+                // Add the last glue if we're on the last item
+                } elseif ($i === $total) {
+                    $result .= $lastGlue;
+
+                // Add the normal glue otherwise
+                } else {
+                    $result .= $glue;
+                }
+            }
+
+            $result .= $item;
+        }
+
+        return $result;
+    }
 
     /**
      * Convert a string to kebab case.

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -425,6 +425,17 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isJson([]));
     }
 
+    public function testJoin()
+    {
+        $this->assertSame('bob', Str::join(['bob']));
+        $this->assertSame('bob and joe', Str::join(['bob', 'joe']));
+        $this->assertSame('bob, joe, and sally', Str::join(['bob', 'joe', 'sally']));
+        $this->assertSame('bob, joe and sally', Str::join(['bob', 'joe', 'sally'], ', ', ' and '));
+        $this->assertSame('bob, joe, and sally', Str::join(['bob', 'joe', 'sally']));
+        $this->assertSame('bob or joe', Str::join(['bob', 'joe'], ', ', ', or ', ' or '));
+        $this->assertSame('bob; joe; or sally', Str::join(['bob', 'joe', 'sally'], '; ', '; or '));
+    }
+
     public function testKebab()
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -427,6 +427,7 @@ class SupportStrTest extends TestCase
 
     public function testJoin()
     {
+        $this->assertSame('', Str::join([]));
         $this->assertSame('bob', Str::join(['bob']));
         $this->assertSame('bob and joe', Str::join(['bob', 'joe']));
         $this->assertSame('bob, joe, and sally', Str::join(['bob', 'joe', 'sally']));


### PR DESCRIPTION
This adds the Str::join() helper that joins together a list of strings using different glue strings depending on how many items there are and what the current item's index is. 

By default, it will take a list of items and join them together into a string that follows the Oxford Comma convention (i.e. "item 1, item 2, and item 3") but can be called to not use Oxford Commas (i.e. "item 1, item 2 and item 3") as well as handling lists with just one or two items total. Note that this is similar to Collection::join() but it allows for the specification of the diadic glue string separately and also operates on more than just collection instances. See https://github.com/laravel/framework/pull/27723 for the discussion around adding Collection::join()

It works on any iterable variable where each iteration can be cast to a string.

For more information on the Oxford Comma, see https://en.wikipedia.org/wiki/Serial_comma
