### PR TITLE
[9.x] Add possibility to run code before and after a command

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -134,9 +134,19 @@ class Command extends SymfonyCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (method_exists($this, 'before')) {
+            $this->laravel->call([$this, 'before']);
+        }
+
         $method = method_exists($this, 'handle') ? 'handle' : '__invoke';
 
-        return (int) $this->laravel->call([$this, $method]);
+        $code = (int) $this->laravel->call([$this, $method]);
+
+        if (method_exists($this, 'after')) {
+            $this->laravel->call([$this, 'after']);
+        }
+
+        return $code;
     }
 
     /**


### PR DESCRIPTION
This PR introduces a possibility to run code before and after a command.

An example of using this would be to create a Laravel package which provides a set of commands and there is some specific logic to execute before and/or after every command of this package. In some of these cases `$this->error` and `$this->components->error` are required, which are not available in the constructor.

**MakeDataObjectCommand.php**
```
class MakeDataObjectCommand extends Command
{
    protected $signature = 'package:make:data {name}';

    protected $description = 'Make a new data object';
    
    protected $requiredPackages = [
        'spatie/laravel-data',
    ];

    public function before(): void
    {
        $composer = Composer::getInstance();

        if ($composer->packagesAreInstalled($this->requiredPackages) === false) {
            $this->components->error('There are some missing dependencies.');
        }
    }

    public function handle(): void
    {
        // ...
    }
    
    public function after(): void
    {
        // ...
    }
}
```