### PR TITLE
Factory `for` method support for dynamic relationship name with existing model instance 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -864,7 +864,10 @@ abstract class Factory
         }
 
         if (str_starts_with($method, 'for')) {
-            return $this->for($factory->state($parameters[0] ?? []), $relationship);
+            return $this->for(
+                $parameters[0] instanceof Model ? $parameters[0] : $factory->state($parameters[0] ?? []),
+                $relationship
+            );
         } elseif (str_starts_with($method, 'has')) {
             return $this->has(
                 $factory

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -574,7 +574,7 @@ class DatabaseEloquentFactoryTest extends TestCase
     public function test_dynamic_has_and_for_methods()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
-            return $model.'Factory';
+            return $model . 'Factory';
         });
 
         $user = FactoryTestUserFactory::new()->hasPosts(3)->create();
@@ -589,6 +589,43 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertInstanceOf(FactoryTestUser::class, $post->author);
         $this->assertSame('Taylor Otwell', $post->author->name);
         $this->assertCount(2, $post->comments);
+    }
+
+    public function test_dynamic_has_and_for_methods_with_existing_model_instance()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model . 'Factory';
+        });
+
+        $user = FactoryTestUserFactory::new()->hasPosts(3)->create();
+
+        $this->assertCount(3, $user->posts);
+
+        $post = FactoryTestPostFactory::new()
+            ->forAuthor(['name' => 'Taylor Otwell'])
+            ->hasComments(2)
+            ->create();
+
+        $this->assertInstanceOf(FactoryTestUser::class, $post->author);
+        $this->assertSame('Taylor Otwell', $post->author->name);
+        $this->assertCount(2, $post->comments);
+    }
+
+    public function test_belongs_to_relationship_with_existing_model_instance_with_dynamic_relationship_name()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model . 'Factory';
+        });
+        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
+        $posts = FactoryTestPostFactory::times(3)
+            ->forAuthor($user)
+            ->create();
+
+        $this->assertCount(3, $posts->filter(function ($post) use ($user) {
+            return $post->factoryTestUser->is($user);
+        }));
+        $this->assertCount(1, FactoryTestUser::all());
+        $this->assertCount(3, FactoryTestPost::all());
     }
 
     public function test_can_be_macroable()


### PR DESCRIPTION
Since `for` method already support dynamic relationship name for state, we can support passing model instance directly and infer the relationship name from the call:
```PHP
// Before
$postFactory->for($model, 'author');

// After
$postFactory->forAuthor($model);
```