### PR TITLE
[9.x] Fix type for `instance` container method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -459,9 +459,11 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Register an existing instance as shared in the container.
      *
+     * @template T
+     *
      * @param  string  $abstract
-     * @param  mixed  $instance
-     * @return mixed
+     * @param  T  $instance
+     * @return T
      */
     public function instance($abstract, $instance)
     {

--- a/types/Container/Container.php
+++ b/types/Container/Container.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Container\Container;
+use function PHPStan\Testing\assertType;
+
+$container = new Container();
+$user = new User();
+
+assertType('User', $container->instance(User::class, $user));


### PR DESCRIPTION
A small type fix for `instance` method on Container class