### PR TITLE
New method Str::end added. Should do the opposite of Str::start.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -892,6 +892,20 @@ class Str
     }
 
     /**
+     * End a string with a single instance of a given value.
+     *
+     * @param  string  $value
+     * @param  string  $postfix
+     * @return string
+     */
+    public static function end($value, $postfix)
+    {
+        $quoted = preg_quote($postfix, '/');
+
+        return preg_replace('/('.$quoted.')+$/u', '', $value).$postfix;
+    }
+
+    /**
      * Convert the given string to upper-case.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -327,6 +327,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('/test/string', Str::start('//test/string', '/'));
     }
 
+    public function testStrEnd()
+    {
+        $this->assertSame('/test/string/', Str::end('/test/string', '/'));
+        $this->assertSame('/test/string/', Str::end('/test/string/', '/'));
+        $this->assertSame('/test/string/', Str::end('/test/string//', '/'));
+        $this->assertSame('//test//string/', Str::end('//test//string//', '/'));
+    }
+
     public function testFlushCache()
     {
         $reflection = new ReflectionClass(Str::class);


### PR DESCRIPTION
Surprised me that Str::end method is missing, because there is a method Str::start and also Str::startsWith and Str::endsWith both versions are implemented. On purpose missing?
