### PR TITLE
Fixes the issue of running `docs` command on windows

### DIFF
--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -400,7 +400,8 @@ class DocsCommand extends Command
             return;
         }
 
-        $process = tap(Process::fromShellCommandline($binary.' '.escapeshellarg($url)))->run();
+        $binaryExecutable = ['Darwin' => 'open', 'Windows' => 'start', 'Linux' => 'xdg-open'][$this->systemOsFamily];
+        $process = tap(Process::fromShellCommandline($binaryExecutable.' '.escapeshellcmd($url)))->run();
 
         if (! $process->isSuccessful()) {
             throw new ProcessFailedException($process);

--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -400,7 +400,12 @@ class DocsCommand extends Command
             return;
         }
 
-        $binaryExecutable = ['Darwin' => 'open', 'Windows' => 'start', 'Linux' => 'xdg-open'][$this->systemOsFamily];
+        $binaryExecutable = [
+            'Darwin' => 'open', 
+            'Windows' => 'start', 
+            'Linux' => 'xdg-open'
+        ][$this->systemOsFamily];
+
         $process = tap(Process::fromShellCommandline($binaryExecutable.' '.escapeshellcmd($url)))->run();
 
         if (! $process->isSuccessful()) {


### PR DESCRIPTION
The old version of that charming command was not working on Windows (my OS type), it was opening CMD only not the browser as it should have done so, I tried to change `escapeshellargs` to `escapeshellcmd` and FINALLY, it works perfectly 🎉

**In the old version**
was using `start` ONLY on my OS so, the command was run perfectly.

**In the new version**
When @timacdonald introduces a new [PR](https://github.com/laravel/framework/pull/43521), the command is getting to use a full path for an executable file like `C:\Program Files\Git\usr\bin\start.COM` but, this command does not work perfectly on my OS so, I introduce this PR to solve `The command "C:\Program Files\Git\usr\bin\start.COM https://laravel.com/docs/9.x/views" failed`. I see it's IMPORTANT to check about the executable file as he has done but, then we can use the keywords according to OS type like `open`, `start` with `escapeshellcmd` function to make sure that the command will work perfectly.