### PR TITLE
adding an attribute to HasAttributes Class to hide elements from obse

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -75,6 +75,13 @@ trait HasAttributes
     protected $attributeCastCache = [];
 
     /**
+     * The array of columns that will be hided from the observers.
+     *
+     * @var array
+     */
+    protected $hideFromObserve = [];
+
+    /**
      * The built-in, primitive cast types supported by Eloquent.
      *
      * @var string[]
@@ -1908,7 +1915,7 @@ trait HasAttributes
         $dirty = [];
 
         foreach ($this->getAttributes() as $key => $value) {
-            if (! $this->originalIsEquivalent($key)) {
+            if (! $this->originalIsEquivalent($key) && ! in_array($key, $this->hideFromObserve)) {
                 $dirty[$key] = $value;
             }
         }


### PR DESCRIPTION
…rver

the purpose of that is when you observe a model and you don't want to get the changes of some columns like "updated_at" or some other fields. you can specify it from its Model and it will not show when you call $mode->getDirty().

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
