### PR TITLE
[9.x] Eloquent Accessing Nested Array Value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -447,6 +447,13 @@ trait HasAttributes
             return;
         }
 
+        // If this attribute contains a JSON ->, we'll get the proper value in the
+        // attribute's underlying array. This takes care of properly nesting an
+        // attribute in the array's value in the case of deeply nested items.
+        if (str_contains($key, '->')) {
+            return $this->getJsonAttribute($key);
+        }
+
         return $this->getRelationValue($key);
     }
 
@@ -1053,6 +1060,19 @@ trait HasAttributes
     {
         return in_array($key, $this->getDates(), true) ||
             $this->isDateCastable($key);
+    }
+
+    /**
+     * Get a given JSON attribute from the model.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function getJsonAttribute($key)
+    {
+        [$key, $path] = explode('->', $key, 2);
+
+        return Arr::get($this->getArrayAttributeByKey($key), str_replace('->', '.', $path));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -451,7 +451,7 @@ trait HasAttributes
         // attribute's underlying array. This takes care of properly nesting an
         // attribute in the array's value in the case of deeply nested items.
         if (str_contains($key, '->')) {
-            return $this->getJsonAttribute($key);
+            return $this->getJsonAttributeValue($key);
         }
 
         return $this->getRelationValue($key);
@@ -1068,7 +1068,7 @@ trait HasAttributes
      * @param  string  $key
      * @return mixed
      */
-    public function getJsonAttribute($key)
+    public function getJsonAttributeValue($key)
     {
         [$key, $path] = explode('->', $key, 2);
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1225,6 +1225,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(21, $model->id);
     }
 
+    public function testGettingJSONAttributes()
+    {
+        $model = new EloquentModelStub(['meta' => json_encode(['name' => 'foo', 'size' => ['width' => 'baz']])]);
+
+        $this->assertEquals('foo', $model->{'meta->name'});
+        $this->assertEquals('baz', $model->{'meta->size->width'});
+    }
+
     public function testFillingJSONAttributes()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1227,10 +1227,11 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testGettingJSONAttributes()
     {
-        $model = new EloquentModelStub(['meta' => json_encode(['name' => 'foo', 'size' => ['width' => 'baz']])]);
+        $model = new EloquentModelCastingStub;
+        $model->arrayAttribute = ['name' => 'foo', 'size' => ['width' => 'baz']];
 
-        $this->assertEquals('foo', $model->{'meta->name'});
-        $this->assertEquals('baz', $model->{'meta->size->width'});
+        $this->assertEquals('foo', $model->{'arrayAttribute->name'});
+        $this->assertEquals('baz', $model->{'arrayAttribute->size->width'});
     }
 
     public function testFillingJSONAttributes()


### PR DESCRIPTION
Fix inconsistence for dealing with nested array on Eloquent.

Currently you can set nested array values, but not access them:

```php
$model = new Model;
$model->{'a->b'} = 'something'; // this works

dump($model->{'a->b'}) // this will return null
```

This PR fixes this behavior.