### PR TITLE
[9.x]Improve Test ArrayAccess for Container

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -217,7 +217,6 @@ class ContainerTest extends TestCase
         $this->assertSame('text', $container['something']);
         unset($container['something']);
         $this->assertFalse(isset($container['something']));
-
     }
 
     public function testAliases()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -199,13 +199,25 @@ class ContainerTest extends TestCase
     public function testArrayAccess()
     {
         $container = new Container;
+        $this->assertFalse(isset($container['something']));
         $container['something'] = function () {
             return 'foo';
         };
         $this->assertTrue(isset($container['something']));
+        $this->assertNotEmpty($container['something']);
         $this->assertSame('foo', $container['something']);
         unset($container['something']);
         $this->assertFalse(isset($container['something']));
+
+        //test offsetSet when it's not instanceof Closure
+        $container = new Container;
+        $container['something'] = 'text';
+        $this->assertTrue(isset($container['something']));
+        $this->assertNotEmpty($container['something']);
+        $this->assertSame('text', $container['something']);
+        unset($container['something']);
+        $this->assertFalse(isset($container['something']));
+
     }
 
     public function testAliases()


### PR DESCRIPTION
test offsetSet when it's not instanceof Closure
offsetExists using isset() or empty()
