### PR TITLE
[9.x] Passthru implode from query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -102,6 +102,7 @@ class Builder implements BuilderContract
         'getBindings',
         'getConnection',
         'getGrammar',
+        'implode',
         'insert',
         'insertGetId',
         'insertOrIgnore',


### PR DESCRIPTION
This PR fixes the usage of the `implode()` method on a eloquent builder.

Before:

```
>>> App\Models\User::query()->take(3)->implode('id', ',')
=> Illuminate\Database\Eloquent\Builder {#5256}

>>> App\Models\User::query()->take(3)->toBase()->implode('id', ',')
=> "1,2,3"
```

After:

```
>>> App\Models\User::query()->take(3)->implode('id', ',')
=> "1,2,3"

>>> App\Models\User::query()->take(3)->toBase()->implode('id', ',')
=> "1,2,3"
```

An argument could be made that this is a breaking change, but the way this method works currently makes it unusable so its unlikely to break anyone's project. Right now developers are probably using `->toBase()->implode(...)` which will still work the same way.