### PR TITLE
[9.x] Remove redundant @group annotation

### DIFF
--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1651,9 +1651,6 @@ class TestResponseTest extends TestCase
         );
     }
 
-    /**
-     * @group 1
-     */
     public function testResponseCanBeReturnedAsCollection()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
Thid PR removes redundant ```@group``` annotation on  ```testResponseCanBeReturnedAsCollection()```