### PR TITLE
Fix Addition of Validation Rules When Validating Fields Named By Integers

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1124,9 +1124,13 @@ class Validator implements ValidatorContract
         $response = (new ValidationRuleParser($this->data))
                             ->explode(ValidationRuleParser::filterConditionalRules($rules, $this->data));
 
-        $this->rules = array_merge_recursive(
-            $this->rules, $response->rules
-        );
+        if (empty($this->rules)) {
+            $this->rules = $response->rules;
+        } else {
+            $this->rules = array_merge(
+                $this->rules, $response->rules
+            );
+        }
 
         $this->implicitAttributes = array_merge(
             $this->implicitAttributes, $response->implicitAttributes


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a small change to how rules are added to a validator, which while admittedly less elegant, provides the right functionality when validating requests from forms who's inputs are labeled with integer keys.

This fixes #43581 which contains are more thorough explanation of what this fixes.