### PR TITLE
[9.x] Allow using static closures as callable for macros

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Traits;
 use BadMethodCallException;
 use Closure;
 use ReflectionClass;
+use ReflectionFunction;
 use ReflectionMethod;
 
 trait Macroable
@@ -118,7 +119,14 @@ trait Macroable
         $macro = static::$macros[$method];
 
         if ($macro instanceof Closure) {
-            $macro = $macro->bindTo($this, static::class);
+            $fn = new ReflectionFunction($macro);
+            $bindable = $fn->getClosureScopeClass() === null || $fn->getClosureThis() !== null;
+
+            if ($bindable) {
+                $macro = $macro->bindTo($this, static::class);
+            } else {
+                $macro = $macro->bindTo(null, static::class);
+            }
         }
 
         return $macro(...$parameters);

--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -119,8 +119,9 @@ trait Macroable
         $macro = static::$macros[$method];
 
         if ($macro instanceof Closure) {
-            $fn = new ReflectionFunction($macro);
-            $bindable = $fn->getClosureScopeClass() === null || $fn->getClosureThis() !== null;
+            $reflection = new ReflectionFunction($macro);
+
+            $bindable = $reflection->getClosureScopeClass() === null || $reflection->getClosureThis() !== null;
 
             if ($bindable) {
                 $macro = $macro->bindTo($this, static::class);

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -75,6 +75,18 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('foo', $instance->methodThree());
     }
 
+    public function testSettingMacroUsingStaticClosures()
+    {
+        TestMacroable::macro('staticFn', static function () {
+            return 'I am unbound.';
+        });
+        TestMacroable::macro('speed', static fn () => 'I am speed.');
+        $instance = new TestMacroable;
+
+        $this->assertSame('I am unbound.', $instance->staticFn());
+        $this->assertSame('I am speed.', $instance->speed());
+    }
+
     public function testFlushMacros()
     {
         TestMacroable::macro('flushMethod', function () {


### PR DESCRIPTION
This PR allows using static closures as the callable when registering a macro.
```php
TestMacroable::macro('speed', static fn () => 'I am speed.');
echo (new TestMacroable)->speed(); // 'I am speed.'
```

I am using PHP-CS-Fixer's [`static_lambda`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/function_notation/static_lambda.rst) rule. So, whenever a closure is not referencing `$this` in the closure body, it will be converted to static. This conversion, however, currently breaks macroable binding to the calling class since we'll get a `Cannot bind an instance to a static closure` error when the macro is called through `__call`.