### PR TITLE
[9.x] Fix type for `flatmap` collection method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -386,8 +386,9 @@ trait EnumeratesValues
     /**
      * Map a collection and flatten the result by a single level.
      *
-     * @param  callable(TValue, TKey): mixed  $callback
-     * @return static<int, mixed>
+     * @template T
+     * @param  callable(TValue, TKey): T  $callback
+     * @return (T is iterable ? static<int, value-of<T>> : static<int, mixed>)
      */
     public function flatMap(callable $callback)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -592,6 +592,25 @@ assertType('Illuminate\Support\Collection<int, mixed>', $collection::make(['stri
         return 1;
     }));
 
+assertType('Illuminate\Support\Collection<int, string>', $collection::make([['string'], ['string2']])
+    ->flatMap(function ($string, $int) {
+        assertType('array{string}', $string);
+        assertType('int', $int);
+
+        /** @var array{string} $string */
+        return $string;
+    }));
+
+assertType('Illuminate\Support\Collection<int, string>', $collection::make([$collection::make(['test']), $collection::make(['test'])])
+    ->flatMap(function ($string, $int) {
+        assertType('Illuminate\Support\Collection<int, string>', $string);
+        assertType('int', $int);
+
+        /** @var Illuminate\Support\Collection<int, string> $string */
+        return $string;
+    }));
+
+
 assertType('Illuminate\Support\Collection<int, User>', $collection->mapInto(User::class));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->make([1])->merge([2]));


### PR DESCRIPTION
This adds types for when using flatmap in collections via phpstan. 

This makes use of a special phpstan feature called `value-of`. 


The reason why it still returns `mixed` if not iterable is because that is actually how `flatMap` works compared to `flatten` (might be a bug?) 

if you flatten vs. flatmap the following you get different results
![image](https://user-images.githubusercontent.com/5870441/183410270-a63832f6-cc53-4ede-b9ea-b0dcb60bd648.png)
however instead of looking into if this is a bug, I simply resolve the types correctly.


The reason why this pr does not contain types for flatten, is because I have not figured out how to solve the depth parameter yet. 