### PR TITLE
[9.x] Fixes output when running `db:seed` or using `--seed` in migrate commands

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\View\Components\TwoColumnDetail;
-use Illuminate\Console\View\Components\Task;
 use Illuminate\Container\Container;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Arr;

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\View\Components\TwoColumnDetail;
 use Illuminate\Console\View\Components\Task;
 use Illuminate\Container\Container;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
@@ -49,20 +50,29 @@ abstract class Seeder
 
             $name = get_class($seeder);
 
-            if ($silent || ! isset($this->command)) {
-                $seeder->__invoke($parameters);
-            } else {
-                with(new Task($this->command->getOutput()))->render(
+            if ($silent === false && isset($this->command)) {
+                with(new TwoColumnDetail($this->command->getOutput()))->render(
                     $name,
-                    fn () => $seeder->__invoke($parameters),
+                    '<fg=yellow;options=bold>RUNNING</>'
                 );
             }
 
-            static::$called[] = $class;
-        }
+            $startTime = microtime(true);
 
-        if (! $silent && $this->command->getOutput()) {
-            $this->command->getOutput()->writeln('');
+            $seeder->__invoke($parameters);
+
+            if ($silent === false && isset($this->command)) {
+                $runTime = number_format((microtime(true) - $startTime) * 1000, 2);
+
+                with(new TwoColumnDetail($this->command->getOutput()))->render(
+                    $name,
+                    "<fg=gray>$runTime ms</> <fg=green;options=bold>DONE</>"
+                );
+
+                $this->command->getOutput()->writeln('');
+            }
+
+            static::$called[] = $class;
         }
 
         return $this;

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -38,7 +38,7 @@ class DatabaseSeederTest extends TestCase
         $seeder = new TestSeeder;
         $seeder->setContainer($container = m::mock(Container::class));
         $output = m::mock(OutputInterface::class);
-        $output->shouldReceive('writeln')->twice();
+        $output->shouldReceive('writeln')->times(3);
         $command = m::mock(Command::class);
         $command->shouldReceive('getOutput')->times(3)->andReturn($output);
         $seeder->setCommand($command);
@@ -46,7 +46,6 @@ class DatabaseSeederTest extends TestCase
         $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);
         $child->shouldReceive('setCommand')->once()->with($command)->andReturn($child);
         $child->shouldReceive('__invoke')->once();
-        $output->shouldReceive('write')->times(3);
 
         $seeder->call('ClassName');
     }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/43515.

Recently, we have introduced a fresh new output for Artisan, and the `db:seed` command:

<img width="950" alt="1" src="https://user-images.githubusercontent.com/5457236/183427736-70caa6fa-6e5a-4a57-ab0e-cd7fed5121b6.png">

While this output is insanely pretty it does not play well when the user uses the `$this->command->info`, or similar methods, to print output in the middle of the task:

<img width="950" alt="2" src="https://user-images.githubusercontent.com/5457236/183427863-5324bb06-c140-410b-81f0-e5232b187d16.png">

To address this issue, this pull request adopts a different approach that supports output being printed in the middle of a task:

| Without output             |  With output |
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/5457236/183428003-c12446bc-1476-4b58-b165-9c380fd390b1.png) | ![](https://user-images.githubusercontent.com/5457236/183427996-7bc785d7-77f5-415b-8192-d574b46fd13d.png)