### PR TITLE
[9.x] Improved check on long Blade strings

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -74,7 +74,7 @@ abstract class Component
         $resolver = function ($view) {
             $factory = Container::getInstance()->make('view');
 
-            return strlen($view) <= PHP_MAXPATHLEN && $factory->exists($view)
+            return $factory->exists($view)
                         ? $view
                         : $this->createBladeViewFromString($factory, $view);
         };

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -128,7 +128,8 @@ class FileViewFinder implements ViewFinderInterface
     {
         foreach ((array) $paths as $path) {
             foreach ($this->getPossibleViewFiles($name) as $file) {
-                if ($this->files->exists($viewPath = $path.'/'.$file)) {
+                $viewPath = $path.'/'.$file;
+                if (strlen($viewPath) <= PHP_MAXPATHLEN && $this->files->exists($viewPath)) {
                     return $viewPath;
                 }
             }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\View;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Str;
 use Illuminate\View\Component;
 use Orchestra\Testbench\TestCase;
 
@@ -28,6 +29,13 @@ class BladeTest extends TestCase
         $component = new HelloComponent('Taylor');
 
         $this->assertSame('Hello Taylor', Blade::renderComponent($component));
+    }
+
+    public function test_rendering_large_blade_component_instance()
+    {
+        $component = new LargeComponent();
+
+        $this->assertSame($component->contents, Blade::renderComponent($component));
     }
 
     public function test_basic_blade_rendering()
@@ -140,5 +148,20 @@ class HelloComponent extends Component
     public function render()
     {
         return 'Hello {{ $name }}';
+    }
+}
+
+class LargeComponent extends Component
+{
+    public $contents;
+
+    public function __construct()
+    {
+        $this->contents = Str::random(PHP_MAXPATHLEN);
+    }
+
+    public function render()
+    {
+        return $this->contents;
     }
 }


### PR DESCRIPTION
Further improvement of #41956, as commented in #32254.

The full concatenation of a Component's Blade string AND the Views' folder path must be considered to avoid that a string longer than `PHP_MAXPATHLEN` characters arrives to `Filesystem::exists()`, triggering an error like `File name is longer than the maximum allowed path length on this platform`.