### PR TITLE
[9.x] Improve test for alias in Container

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -441,6 +441,18 @@ class ContainerTest extends TestCase
         $this->assertSame('ConcreteStub', $container->getAlias('foo'));
     }
 
+    public function testGetAliasRecursive()
+    {
+        $container = new Container;
+        $container->alias('ConcreteStub', 'foo');
+        $container->alias('foo', 'bar');
+        $container->alias('bar', 'baz');
+        $this->assertSame('ConcreteStub', $container->getAlias('baz'));
+        $this->assertTrue( $container->isAlias('baz'));
+        $this->assertTrue( $container->isAlias('bar'));
+        $this->assertTrue( $container->isAlias('foo'));
+    }
+
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()
     {
         $this->expectException('LogicException');

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -448,9 +448,9 @@ class ContainerTest extends TestCase
         $container->alias('foo', 'bar');
         $container->alias('bar', 'baz');
         $this->assertSame('ConcreteStub', $container->getAlias('baz'));
-        $this->assertTrue( $container->isAlias('baz'));
-        $this->assertTrue( $container->isAlias('bar'));
-        $this->assertTrue( $container->isAlias('foo'));
+        $this->assertTrue($container->isAlias('baz'));
+        $this->assertTrue($container->isAlias('bar'));
+        $this->assertTrue($container->isAlias('foo'));
     }
 
     public function testItThrowsExceptionWhenAbstractIsSameAsAlias()


### PR DESCRIPTION
getAlias method in container class, behavior recursively, and there isn't any test for that.