### PR TITLE
[9.x] Extract child route model relationship name into a method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1995,7 +1995,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Retrieve the child model relationship.
+     * Retrieve the child route model binding relationship name for the given child type.
      *
      * @param  string  $childType
      * @return string

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1980,7 +1980,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     protected function resolveChildRouteBindingQuery($childType, $value, $field)
     {
-        $relationship = $this->{Str::plural(Str::camel($childType))}();
+        $relationship = $this->{$this->childRouteBindingRelationshipName($childType)}();
 
         $field = $field ?: $relationship->getRelated()->getRouteKeyName();
 
@@ -1992,6 +1992,17 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         return $relationship instanceof Model
                 ? $relationship->resolveRouteBindingQuery($relationship, $value, $field)
                 : $relationship->getRelated()->resolveRouteBindingQuery($relationship, $value, $field);
+    }
+    
+    /**
+     * Retrieve the child model relationship.
+     *
+     * @param  string  $childType
+     * @return string
+     */
+    protected function childRouteBindingRelationshipName($childType)
+    {
+        return Str::plural(Str::camel($childType));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1993,7 +1993,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
                 ? $relationship->resolveRouteBindingQuery($relationship, $value, $field)
                 : $relationship->getRelated()->resolveRouteBindingQuery($relationship, $value, $field);
     }
-    
+
     /**
      * Retrieve the child model relationship.
      *


### PR DESCRIPTION
This small change extracts the child route model relationship name into a dedicated protected method.

The previous approach always assumes that the plural name of the relationship is going to be used for the relationship. But this is not always the case, if the parent is using the `hasOne` relationship, usually the method name for this relationship is in a singular form, not plural. But the previous approach always tries to resolve it as plural.

Having a dedicated method for child route relationship name makes it possible to conditionally provide different relationship name depending on `$childType`.