### PR TITLE
[9.x] Make `Config` repository macroable

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -5,9 +5,12 @@ namespace Illuminate\Config;
 use ArrayAccess;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\Macroable;
 
 class Repository implements ArrayAccess, ConfigContract
 {
+    use Macroable;
+
     /**
      * All of the configuration items.
      *

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -217,4 +217,13 @@ class RepositoryTest extends TestCase
         $this->assertArrayHasKey('associate', $this->repository->all());
         $this->assertNull($this->repository->get('associate'));
     }
+
+    public function testsItIsMacroable()
+    {
+        $this->repository->macro('foo', function () {
+            return 'macroable';
+        });
+
+        $this->assertSame('macroable', $this->repository->foo());
+    }
 }


### PR DESCRIPTION
Make the `Config` repository macroable so users can extend it in their own apps.

**Reasoning:** Since #43520 was closed without merging I was hoping to implement `Config::collect()` via a macro, however the `Config` repository is _not_ currently macroable.