### PR TITLE
[9.x] Add "trashing" event for soft deletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -75,10 +75,14 @@ trait SoftDeletes
     /**
      * Perform the actual delete query on this model instance.
      *
-     * @return void
+     * @return bool|null
      */
     protected function runSoftDelete()
     {
+        if ($this->fireModelEvent('trashing') === false) {
+            return false;
+        }
+
         $query = $this->setKeysForSaveQuery($this->newModelQuery());
 
         $time = $this->freshTimestamp();
@@ -146,6 +150,17 @@ trait SoftDeletes
     public function trashed()
     {
         return ! is_null($this->{$this->getDeletedAtColumn()});
+    }
+
+    /**
+     * Register a "softDeleting" model event callback with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function softDeleting($callback)
+    {
+        static::registerModelEvent('trashing', $callback);
     }
 
     /**


### PR DESCRIPTION
There is no event fired before trying to soft-delete a model.
This PR makes soft deletes consistent other operations on models which include two events before and after each operation.

- This event is only fired when the model is being "**soft-deleted**" and it is `not fired` when the model is being "**force-deleted**".

- Currently, the `deleteing` and `deleted` events are fired when soft-deleting models, but they are not exclusive to soft-deletes and are also fired when the model is being `force-deleted`.
