### PR TITLE
Queue worker daemon should also listen for SIGQUIT

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -680,6 +680,10 @@ class Worker
     {
         pcntl_async_signals(true);
 
+        pcntl_signal(SIGQUIT, function () {
+            $this->shouldQuit = true;
+        });
+
         pcntl_signal(SIGTERM, function () {
             $this->shouldQuit = true;
         });


### PR DESCRIPTION
This PR adds a listener for the `SIGQUIT` signal.

The queue worker currently listens for `SIGTERM` to gracefully exit.

However, the official Docker PHP-FPM images (and most images based on them) have the stop signal set to `SIGQUIT` instead:

```shell
$ docker inspect php:8.1-fpm | jq '.[0].ContainerConfig.StopSignal'
> "SIGQUIT"
```

This means that when Docker executes a stop/restart/etc command, the `SIGQUIT` signal sent by Docker is not detected. The queue worker continues to run jobs up until it's `SIGKILL`ed by Docker - potentially halfway through a job.