### PR TITLE
[9.x] Support for BackedEnum in `value` helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -184,7 +184,7 @@ if (! function_exists('value')) {
      */
     function value($value, ...$args)
     {
-        if ($value instanceof \BackedEnum) {
+        if (function_exists('enum_exists') && $value instanceof \BackedEnum) {
             return $value->value;
         }
 

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -184,6 +184,10 @@ if (! function_exists('value')) {
      */
     function value($value, ...$args)
     {
+        if ($value instanceof \BackedEnum) {
+            return $value->value;
+        }
+
         return $value instanceof Closure ? $value(...$args) : $value;
     }
 }


### PR DESCRIPTION
I think it make sense when we pass BackedEnum to `value` function it should return 'value' of it not the enum itself.