### PR TITLE
[9.x] Override notification display name

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -111,6 +111,10 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function displayName()
     {
+        if (method_exists($this->notification, 'displayName')) {
+            return $this->notification->displayName();
+        }
+
         return get_class($this->notification);
     }
 

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -83,7 +83,6 @@ class NotifiableUser extends Model
 
 class NotificationWithDefaultName extends Notification
 {
-
 }
 
 class NotificationWithOverriddenName extends Notification

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Support\Collection;
 use Mockery as m;
@@ -52,6 +53,24 @@ class NotificationSendQueuedNotificationTest extends TestCase
 
         $this->assertStringContainsString($serializedNotifiable, $serialized);
     }
+
+    public function testDefaultDisplayName()
+    {
+        $notifiable = new AnonymousNotifiable;
+
+        $job = new SendQueuedNotifications($notifiable, new NotificationWithDefaultName);
+
+        $this->assertSame(NotificationWithDefaultName::class, $job->displayName());
+    }
+
+    public function testOverriddenDisplayName()
+    {
+        $notifiable = new AnonymousNotifiable;
+
+        $job = new SendQueuedNotifications($notifiable, new NotificationWithOverriddenName('overridden-name'));
+
+        $this->assertSame('overridden-name', $job->displayName());
+    }
 }
 
 class NotifiableUser extends Model
@@ -60,4 +79,26 @@ class NotifiableUser extends Model
 
     public $table = 'users';
     public $timestamps = false;
+}
+
+class NotificationWithDefaultName extends Notification
+{
+
+}
+
+class NotificationWithOverriddenName extends Notification
+{
+    /** @var string */
+    private $displayName;
+
+    public function __construct(string $displayName)
+    {
+        $this->displayName = $displayName;
+    }
+
+    /** @return string */
+    public function displayName()
+    {
+        return $this->displayName;
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, it's impossible to override the notification display name. The `\Illuminate\Notifications\SendQueuedNotifications::displayName` method simply returns the notification class name, which is not favorable in some cases. 

The expected behavior is to allow notifications to override display name, while maintaining backward compatibility.

This PR adds a simple check to allow notifications to override the displayed name, while reverting to the default class name for backward compatibility.
