### PR TITLE
allow asserting a jsonresouce

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -551,7 +551,7 @@ trait MakesHttpRequests
             $response = $this->followRedirects($response);
         }
 
-        return $this->createTestResponse($response);
+        return $this->createTestResponse($response, $request);
     }
 
     /**
@@ -673,11 +673,12 @@ trait MakesHttpRequests
      * Create the test response instance from the given response.
      *
      * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Testing\TestResponse
      */
-    protected function createTestResponse($response)
+    protected function createTestResponse($response, $request)
     {
-        return tap(TestResponse::fromBaseResponse($response), function ($response) {
+        return tap(TestResponse::fromBaseResponse($response, $request), function ($response) {
             $response->withExceptions(
                 $this->app->bound(LoggedExceptionCollection::class)
                     ? $this->app->make(LoggedExceptionCollection::class)

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -40,6 +41,13 @@ class TestResponse implements ArrayAccess
     public $baseResponse;
 
     /**
+     * The request that was used to make the application return our response.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+    /**
      * The collection of logged exceptions for the request.
      *
      * @var \Illuminate\Support\Collection
@@ -57,11 +65,13 @@ class TestResponse implements ArrayAccess
      * Create a new test response instance.
      *
      * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Request  $request
      * @return void
      */
-    public function __construct($response)
+    public function __construct($response, $request)
     {
         $this->baseResponse = $response;
+        $this->request = $request;
         $this->exceptions = new Collection;
     }
 
@@ -69,11 +79,12 @@ class TestResponse implements ArrayAccess
      * Create a new TestResponse from another response.
      *
      * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Request  $request
      * @return static
      */
-    public static function fromBaseResponse($response)
+    public static function fromBaseResponse($response, $request)
     {
-        return new static($response);
+        return new static($response, $request);
     }
 
     /**
@@ -834,6 +845,21 @@ EOF;
     public function assertJsonStructure(array $structure = null, $responseData = null)
     {
         $this->decodeResponseJson()->assertStructure($structure, $responseData);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response is formed by a JsonResource
+     *
+     * @param JsonResource $resource
+     * @return $this
+     */
+    public function assertJsonResource(JsonResource $resource)
+    {
+        $this->assertExactJson(
+            $resource->response($this->request)->getData(true),
+        );
 
         return $this;
     }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -146,6 +146,54 @@ class MakesHttpRequestsTest extends TestCase
             ->assertSee('OK');
     }
 
+    public function testTestResponseHasGetRequest()
+    {
+        $router = $this->app->make(Registrar::class);
+        $router->get('something', function () {
+            return 'OK';
+        });
+
+        $response = $this->get('something?query=value');
+        $response->assertOk();
+
+        $request = $response->request;
+        $this->assertNotNull($request);
+        $this->assertEquals('GET', $request->getRealMethod());
+        $this->assertEquals('value', $request->input('query'));
+    }
+
+    public function testTestResponseHasPostRequest()
+    {
+        $router = $this->app->make(Registrar::class);
+        $router->post('something', function () {
+            return 'OK';
+        });
+
+        $response = $this->post('something', ['post' => 'value']);
+        $response->assertOk();
+
+        $request = $response->request;
+        $this->assertNotNull($request);
+        $this->assertEquals('POST', $request->getRealMethod());
+        $this->assertEquals('value', $request->input('post'));
+    }
+
+    public function testTestResponseHasJsonRequest()
+    {
+        $router = $this->app->make(Registrar::class);
+        $router->post('something', function () {
+            return 'OK';
+        });
+
+        $response = $this->postJson('something', ['json' => 'value']);
+        $response->assertOk();
+
+        $request = $response->request;
+        $this->assertNotNull($request);
+        $this->assertTrue($request->isJson());
+        $this->assertEquals('value', $request->input('json'));
+    }
+
     public function testFollowingRedirectsTerminatesInExpectedOrder()
     {
         $router = $this->app->make(Registrar::class);


### PR DESCRIPTION
As requested by @driesvints here https://github.com/laravel/framework/pull/43613 and here https://github.com/laravel/framework/pull/43612, because of minor breaking changes, creating pull request to master.

Added the ability to assert a json response equals a used JsonResource instead of having to fully write-out an array.
Based on https://stackoverflow.com/a/61960799/3017716

E.g.
```php
        $model = SomeModel::factory()->create();
        $route = route('api.some-model.show', $model);
        $response = $this->getJson($route);
        $response->assertOk();

        $resource = new TestModelJsonResource($model);
        $response->assertJsonResource($resource);
```
```php
        $model = SomeModel::factory(2)->create();
        $route = route('api.some-model.index');
        $response = $this->getJson($route);
        $response->assertOk();

        $paginator = new LengthAwarePaginator($models, 2, 15, 1);
        $resource = TestModelJsonResource::collection($paginator);
        $response->assertJsonResource($resource);
```
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
