### PR TITLE
[9.x] foreignIdFor() with custom column name: use correct table, fixes #42519

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -934,7 +934,7 @@ class Blueprint
         $foreignIdDefinition = $model->getKeyType() === 'int' && $model->getIncrementing()
                     ? $this->foreignId($column ?: $model->getForeignKey())
                     : $this->foreignUuid($column ?: $model->getForeignKey());
-        
+
         return $foreignIdDefinition->withTable($model->getTable());
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -931,9 +931,11 @@ class Blueprint
             $model = new $model;
         }
 
-        return $model->getKeyType() === 'int' && $model->getIncrementing()
+        $foreignIdDefinition = $model->getKeyType() === 'int' && $model->getIncrementing()
                     ? $this->foreignId($column ?: $model->getForeignKey())
                     : $this->foreignUuid($column ?: $model->getForeignKey());
+        
+        return $foreignIdDefinition->withTable($model->getTable());
     }
 
     /**

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -14,6 +14,11 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     protected $blueprint;
 
     /**
+     * The table used for constrained() if not directly specified
+     */
+    protected ?string $table = null;
+
+    /**
      * Create a new foreign ID column definition.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
@@ -27,6 +32,12 @@ class ForeignIdColumnDefinition extends ColumnDefinition
         $this->blueprint = $blueprint;
     }
 
+    public function withTable(string $table): static
+    {
+        $this->table = $table;
+        return $this;
+    }
+
     /**
      * Create a foreign key constraint on this column referencing the "id" column of the conventionally related table.
      *
@@ -36,7 +47,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function constrained($table = null, $column = 'id')
     {
-        return $this->references($column)->on($table ?? Str::plural(Str::beforeLast($this->name, '_'.$column)));
+        return $this->references($column)->on($table ?? $this->table ?? Str::plural(Str::beforeLast($this->name, '_'.$column)));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -14,7 +14,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     protected $blueprint;
 
     /**
-     * The table used for constrained() if not directly specified
+     * The table used for constrained() if not directly specified.
      */
     protected ?string $table = null;
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -35,6 +35,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     public function withTable(string $table): static
     {
         $this->table = $table;
+
         return $this;
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -471,16 +471,18 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
+        $blueprint->foreignIdFor('Illuminate\Foundation\Auth\User', 'my_user_id')->constrained();
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
-            'alter table `users` add `foo` bigint unsigned not null, add `company_id` bigint unsigned not null, add `laravel_idea_id` bigint unsigned not null, add `team_id` bigint unsigned not null, add `team_column_id` bigint unsigned not null',
+            'alter table `users` add `foo` bigint unsigned not null, add `company_id` bigint unsigned not null, add `laravel_idea_id` bigint unsigned not null, add `team_id` bigint unsigned not null, add `team_column_id` bigint unsigned not null, add `my_user_id` bigint unsigned not null',
             'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
             'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
             'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
             'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
+            'alter table `users` add constraint `users_my_user_id_foreign` foreign key (`my_user_id`) references `users` (`id`)',
         ], $statements);
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -388,16 +388,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
+        $blueprint->foreignIdFor('Illuminate\Foundation\Auth\User', 'my_user_id')->constrained();
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
-            'alter table "users" add column "foo" bigint not null, add column "company_id" bigint not null, add column "laravel_idea_id" bigint not null, add column "team_id" bigint not null, add column "team_column_id" bigint not null',
+            'alter table "users" add column "foo" bigint not null, add column "company_id" bigint not null, add column "laravel_idea_id" bigint not null, add column "team_id" bigint not null, add column "team_column_id" bigint not null, add column "my_user_id" bigint not null',
             'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
             'alter table "users" add constraint "users_laravel_idea_id_foreign" foreign key ("laravel_idea_id") references "laravel_ideas" ("id")',
             'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',
             'alter table "users" add constraint "users_team_column_id_foreign" foreign key ("team_column_id") references "teams" ("id")',
+            'alter table "users" add constraint "users_my_user_id_foreign" foreign key ("my_user_id") references "users" ("id")',
         ], $statements);
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -308,6 +308,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
+        $blueprint->foreignIdFor('Illuminate\Foundation\Auth\User', 'my_user_id')->constrained();
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
@@ -318,6 +319,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
             'alter table "users" add column "laravel_idea_id" integer not null',
             'alter table "users" add column "team_id" integer not null',
             'alter table "users" add column "team_column_id" integer not null',
+            'alter table "users" add column "my_user_id" integer not null',
         ], $statements);
     }
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -353,16 +353,18 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->foreignId('laravel_idea_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
         $blueprint->foreignId('team_column_id')->constrained('teams');
+        $blueprint->foreignIdFor('Illuminate\Foundation\Auth\User', 'my_user_id')->constrained();
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
         $this->assertSame([
-            'alter table "users" add "foo" bigint not null, "company_id" bigint not null, "laravel_idea_id" bigint not null, "team_id" bigint not null, "team_column_id" bigint not null',
+            'alter table "users" add "foo" bigint not null, "company_id" bigint not null, "laravel_idea_id" bigint not null, "team_id" bigint not null, "team_column_id" bigint not null, "my_user_id" bigint not null',
             'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
             'alter table "users" add constraint "users_laravel_idea_id_foreign" foreign key ("laravel_idea_id") references "laravel_ideas" ("id")',
             'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',
             'alter table "users" add constraint "users_team_column_id_foreign" foreign key ("team_column_id") references "teams" ("id")',
+            'alter table "users" add constraint "users_my_user_id_foreign" foreign key ("my_user_id") references "users" ("id")',
         ], $statements);
     }
 


### PR DESCRIPTION
Currently, `foreignIdFor(App\Models\User::class, 'author_user_id')->constrained()` calls create SQL that wrongly tries to guess the table name from the custom column name (`'author_user_id'` => `author_users`) instead of using the table name from the model (to get the correct `users` table in this example).

I explained the problem in a bit more detail in #42519.

This PR adds `ForeignIdColumnDefinition::$table` that can be set via `ForeignIdColumnDefinition::withTabl('users')`. This table name is used instead of guessing the table name when present. Also `Blueprint::foreignIdFor()` was changed to set the table name from the model.

There is one test for each of the 4 SQL grammars included for this usage of `foreignIdFor()` with a custom column name & subsequent `constrained()` call.