### PR TITLE
Revert "[9.x] Allow using static closures as callable for macros"

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support\Traits;
 use BadMethodCallException;
 use Closure;
 use ReflectionClass;
-use ReflectionFunction;
 use ReflectionMethod;
 
 trait Macroable
@@ -119,15 +118,7 @@ trait Macroable
         $macro = static::$macros[$method];
 
         if ($macro instanceof Closure) {
-            $reflection = new ReflectionFunction($macro);
-
-            $bindable = $reflection->getClosureScopeClass() === null || $reflection->getClosureThis() !== null;
-
-            if ($bindable) {
-                $macro = $macro->bindTo($this, static::class);
-            } else {
-                $macro = $macro->bindTo(null, static::class);
-            }
+            $macro = $macro->bindTo($this, static::class);
         }
 
         return $macro(...$parameters);

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -75,18 +75,6 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('foo', $instance->methodThree());
     }
 
-    public function testSettingMacroUsingStaticClosures()
-    {
-        TestMacroable::macro('staticFn', static function () {
-            return 'I am unbound.';
-        });
-        TestMacroable::macro('speed', static fn () => 'I am speed.');
-        $instance = new TestMacroable;
-
-        $this->assertSame('I am unbound.', $instance->staticFn());
-        $this->assertSame('I am speed.', $instance->speed());
-    }
-
     public function testFlushMacros()
     {
         TestMacroable::macro('flushMethod', function () {


### PR DESCRIPTION
Reverts laravel/framework#43589