### PR TITLE
[9.x] Add configurable paths to Vite

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -57,7 +57,7 @@ class Vite implements Htmlable
      *
      * @var string
      */
-    protected $hotFilePath = '/hot';
+    protected $hotFilePath = null;
 
     /**
      * The path to the build directory.
@@ -514,6 +514,16 @@ class Vite implements Htmlable
         $this->hotFilePath = $path;
 
         return $this;
+    }
+
+    /**
+     * Get the hot file path.
+     *
+     * @return string
+     */
+    protected function hotFilePath()
+    {
+        return $this->hotFilePath ?? public_path('/hot');
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -138,14 +138,15 @@ class Vite implements Htmlable
      * Generate Vite tags for an entrypoint.
      *
      * @param  string|string[]  $entrypoints
-     * @param  string  $buildDirectory
+     * @param  string|null  $buildDirectory
      * @return \Illuminate\Support\HtmlString
      *
      * @throws \Exception
      */
-    public function __invoke($entrypoints, $buildDirectory = 'build')
+    public function __invoke($entrypoints, $buildDirectory = null)
     {
         $entrypoints = collect($entrypoints);
+        $buildDirectory ??= $this->buildDirectory ?? 'build';
 
         if ($this->isRunningHot()) {
             return new HtmlString(
@@ -545,6 +546,6 @@ class Vite implements Htmlable
      */
     public function toHtml()
     {
-        return $this->__invoke($this->entryPoints, $this->buildDirectory)->toHtml();
+        return $this->__invoke($this->entryPoints)->toHtml();
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Foundation;
 
 use Exception;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
-class Vite
+class Vite implements Htmlable
 {
     /**
      * The Content Security Policy nonce to apply to all generated tags.
@@ -43,6 +44,27 @@ class Vite
      * @var array
      */
     protected static $manifests = [];
+
+    /**
+     * The registered entry points.
+     *
+     * @var array
+     */
+    protected $entryPoints = [];
+
+    /**
+     * The path to the hot file.
+     *
+     * @var string
+     */
+    protected $hotFilePath = '/hot';
+
+    /**
+     * The path to the build directory.
+     *
+     * @var string
+     */
+    protected $buildDirectory = '/build';
 
     /**
      * Get the Content Security Policy nonce applied to all generated tags.
@@ -466,5 +488,54 @@ class Vite
     protected function isRunningHot()
     {
         return is_file(public_path('/hot'));
+    }
+
+    /**
+     * Merge the given entry points.
+     *
+     * @param  array  $entryPoints
+     * @return $this
+     */
+    public function withEntryPoints(array $entryPoints)
+    {
+        $this->entryPoints = array_merge($this->entryPoints, $entryPoints);
+
+        return $this;
+    }
+
+    /**
+     * Set the hot file path attribute.
+     *
+     * @param  string
+     * @return $this
+     */
+    public function useHotFile(string $path)
+    {
+        $this->hotFilePath = Str::start($path, '/');
+
+        return $this;
+    }
+
+    /**
+     * Set the build directory attribute.
+     *
+     * @param  string
+     * @return $this
+     */
+    public function useBuildDirectory(string $path)
+    {
+        $this->buildDirectory = Str::start($path, '/');
+
+        return $this;
+    }
+
+    /**
+     * Get content as a string of HTML.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return $this->__invoke($this->entryPoints, $this->buildDirectory);
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -511,7 +511,7 @@ class Vite implements Htmlable
      */
     public function useHotFile(string $path)
     {
-        $this->hotFilePath = Str::start($path, '/');
+        $this->hotFilePath = $path;
 
         return $this;
     }
@@ -524,7 +524,7 @@ class Vite implements Htmlable
      */
     public function useBuildDirectory(string $path)
     {
-        $this->buildDirectory = Str::start($path, '/');
+        $this->buildDirectory = $path;
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -536,6 +536,6 @@ class Vite implements Htmlable
      */
     public function toHtml()
     {
-        return $this->__invoke($this->entryPoints, $this->buildDirectory);
+        return $this->__invoke($this->entryPoints, $this->buildDirectory)->toHtml();
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -25,6 +25,27 @@ class Vite implements Htmlable
     protected $integrityKey = 'integrity';
 
     /**
+     * The configured entry points.
+     *
+     * @var array
+     */
+    protected $entryPoints = [];
+
+    /**
+     * The path to the "hot" file.
+     *
+     * @var string|null
+     */
+    protected $hotFile;
+
+    /**
+     * The path to the build directory.
+     *
+     * @var string
+     */
+    protected $buildDirectory = 'build';
+
+    /**
      * The script tag attributes resolvers.
      *
      * @var array
@@ -44,27 +65,6 @@ class Vite implements Htmlable
      * @var array
      */
     protected static $manifests = [];
-
-    /**
-     * The entry points.
-     *
-     * @var array
-     */
-    protected $entryPoints = [];
-
-    /**
-     * The path to the hot file.
-     *
-     * @var string|null
-     */
-    protected $hotFile;
-
-    /**
-     * The path to the build directory.
-     *
-     * @var string
-     */
-    protected $buildDirectory = 'build';
 
     /**
      * Get the Content Security Policy nonce applied to all generated tags.
@@ -96,6 +96,55 @@ class Vite implements Htmlable
     public function useIntegrityKey($key)
     {
         $this->integrityKey = $key;
+
+        return $this;
+    }
+
+    /**
+     * Set the Vite entry points.
+     *
+     * @param  array  $entryPoints
+     * @return $this
+     */
+    public function withEntryPoints($entryPoints)
+    {
+        $this->entryPoints = $entryPoints;
+
+        return $this;
+    }
+
+    /**
+     * Set the Vite "hot" file path.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function useHotFile($path)
+    {
+        $this->hotFile = $path;
+
+        return $this;
+    }
+
+    /**
+     * Get the Vite "hot" file path.
+     *
+     * @return string
+     */
+    protected function hotFile()
+    {
+        return $this->hotFile ?? public_path('/hot');
+    }
+
+    /**
+     * Set the Vite build directory.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function useBuildDirectory($path)
+    {
+        $this->buildDirectory = $path;
 
         return $this;
     }
@@ -422,65 +471,6 @@ class Vite implements Htmlable
     }
 
     /**
-     * Set the entry points.
-     *
-     * @param  array  $entryPoints
-     * @return $this
-     */
-    public function withEntryPoints($entryPoints)
-    {
-        $this->entryPoints = $entryPoints;
-
-        return $this;
-    }
-
-    /**
-     * Set the hot file path.
-     *
-     * @param  string  $path
-     * @return $this
-     */
-    public function useHotFile($path)
-    {
-        $this->hotFile = $path;
-
-        return $this;
-    }
-
-    /**
-     * Get the hot file path.
-     *
-     * @return string
-     */
-    protected function hotFile()
-    {
-        return $this->hotFile ?? public_path('/hot');
-    }
-
-    /**
-     * Set the build directory.
-     *
-     * @param  string  $path
-     * @return $this
-     */
-    public function useBuildDirectory($path)
-    {
-        $this->buildDirectory = $path;
-
-        return $this;
-    }
-
-    /**
-     * Get content as a string of HTML.
-     *
-     * @return string
-     */
-    public function toHtml()
-    {
-        return $this->__invoke($this->entryPoints)->toHtml();
-    }
-
-    /**
      * Get the URL for an asset.
      *
      * @param  string  $asset
@@ -524,7 +514,7 @@ class Vite implements Htmlable
     }
 
     /**
-     * The path to the manifest file for the given build directory.
+     * Get the path to the manifest file for the given build directory.
      *
      * @param  string  $buildDirectory
      * @return string
@@ -560,5 +550,15 @@ class Vite implements Htmlable
     protected function isRunningHot()
     {
         return is_file($this->hotFile());
+    }
+
+    /**
+     * Get the Vite tag content as a string of HTML.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return $this->__invoke($this->entryPoints)->toHtml();
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -114,6 +114,16 @@ class Vite implements Htmlable
     }
 
     /**
+     * Get the Vite "hot" file path.
+     *
+     * @return string
+     */
+    protected function hotFile()
+    {
+        return $this->hotFile ?? public_path('/hot');
+    }
+
+    /**
      * Set the Vite "hot" file path.
      *
      * @param  string  $path
@@ -124,16 +134,6 @@ class Vite implements Htmlable
         $this->hotFile = $path;
 
         return $this;
-    }
-
-    /**
-     * Get the Vite "hot" file path.
-     *
-     * @return string
-     */
-    protected function hotFile()
-    {
-        return $this->hotFile ?? public_path('/hot');
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -55,16 +55,16 @@ class Vite implements Htmlable
     /**
      * The path to the hot file.
      *
-     * @var string
+     * @var string|null
      */
-    protected $hotFilePath = null;
+    protected $hotFilePath;
 
     /**
      * The path to the build directory.
      *
      * @var string
      */
-    protected $buildDirectory = '/build';
+    protected $buildDirectory = 'build';
 
     /**
      * Get the Content Security Policy nonce applied to all generated tags.
@@ -146,7 +146,6 @@ class Vite implements Htmlable
     public function __invoke($entrypoints, $buildDirectory = 'build')
     {
         $entrypoints = collect($entrypoints);
-        $buildDirectory = Str::start($buildDirectory, '/');
 
         if ($this->isRunningHot()) {
             return new HtmlString(
@@ -506,10 +505,10 @@ class Vite implements Htmlable
     /**
      * Set the hot file path attribute.
      *
-     * @param  string
+     * @param  string  $path
      * @return $this
      */
-    public function useHotFile(string $path)
+    public function useHotFile($path)
     {
         $this->hotFilePath = $path;
 
@@ -529,10 +528,10 @@ class Vite implements Htmlable
     /**
      * Set the build directory attribute.
      *
-     * @param  string
+     * @param  string  $path
      * @return $this
      */
-    public function useBuildDirectory(string $path)
+    public function useBuildDirectory($path)
     {
         $this->buildDirectory = $path;
 

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -6,13 +6,12 @@ namespace Illuminate\Support\Facades;
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
  * @method static string asset(string $asset, string|null $buildDirectory)
- * @method static string toHtml()
+ * @method static \Illuminate\Foundation\Vite useBuildDirectory(string $path)
+ * @method static \Illuminate\Foundation\Vite useHotFile(string $path)
  * @method static \Illuminate\Foundation\Vite useIntegrityKey(string|false $key)
  * @method static \Illuminate\Foundation\Vite useScriptTagAttributes(callable|array $callback)
  * @method static \Illuminate\Foundation\Vite useStyleTagAttributes(callable|array $callback)
- * @method static \Illuminte\Foundation\Vite withEntryPoints(array $entryPoints)
- * @method static \Illuminte\Foundation\Vite useHotFile(string $path)
- * @method static \Illuminte\Foundation\Vite useBuildDirectory(string $path)
+ * @method static \Illuminate\Foundation\Vite withEntryPoints(array $entryPoints)
  *
  * @see \Illuminate\Foundation\Vite
  */

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -2,13 +2,19 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Foundation\Vite as Factory;
+
 /**
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
  * @method static string asset(string $asset, string|null $buildDirectory)
+ * @method static string toHtml()
  * @method static \Illuminate\Foundation\Vite useIntegrityKey(string|false $key)
  * @method static \Illuminate\Foundation\Vite useScriptTagAttributes(callable|array $callback)
  * @method static \Illuminate\Foundation\Vite useStyleTagAttributes(callable|array $callback)
+ * @method static \Illuminte\Foundation\Vite withEntryPoints(array $entryPoints)
+ * @method static \Illuminte\Foundation\Vite useHotFile(string $path)
+ * @method static \Illuminte\Foundation\Vite useBuildDirectory(string $path)
  *
  * @see \Illuminate\Foundation\Vite
  */
@@ -21,6 +27,6 @@ class Vite extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return \Illuminate\Foundation\Vite::class;
+        return Factory::class;
     }
 }

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Support\Facades;
 
-use Illuminate\Foundation\Vite as Factory;
-
 /**
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
@@ -27,6 +25,6 @@ class Vite extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return Factory::class;
+        return \Illuminate\Foundation\Vite::class;
     }
 }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -192,8 +192,7 @@ class FoundationViteTest extends TestCase
             $result->toHtml()
         );
 
-        unlink(public_path("{$buildDir}/manifest.json"));
-        rmdir(public_path($buildDir));
+        $this->cleanViteManifest($buildDir);
     }
 
     public function testItCanInjectIntegrityWhenPresentInManifestForCss()
@@ -228,8 +227,7 @@ class FoundationViteTest extends TestCase
             $result->toHtml()
         );
 
-        unlink(public_path("{$buildDir}/manifest.json"));
-        rmdir(public_path($buildDir));
+        $this->cleanViteManifest($buildDir);
     }
 
     public function testItCanInjectIntegrityWhenPresentInManifestForImportedCss()
@@ -264,8 +262,7 @@ class FoundationViteTest extends TestCase
             $result->toHtml()
         );
 
-        unlink(public_path("{$buildDir}/manifest.json"));
-        rmdir(public_path($buildDir));
+        $this->cleanViteManifest($buildDir);
     }
 
     public function testItCanSpecifyIntegrityKey()
@@ -291,8 +288,7 @@ class FoundationViteTest extends TestCase
             $result->toHtml()
         );
 
-        unlink(public_path("{$buildDir}/manifest.json"));
-        rmdir(public_path($buildDir));
+        $this->cleanViteManifest($buildDir);
     }
 
     public function testItCanSpecifyArbitraryAttributesForScriptTagsWhenBuilt()
@@ -539,7 +535,7 @@ class FoundationViteTest extends TestCase
         ViteFacade::asset('resources/js/missing.js');
     }
 
-    public function testViteCanMergeEntryPoints()
+    public function testViteCanSetEntryPointsWithFluentBuilder()
     {
         $this->makeViteManifest();
 
@@ -573,12 +569,11 @@ class FoundationViteTest extends TestCase
 
     public function testViteCanOverrideHotFilePath()
     {
-        $this->makeViteManifest();
-        $this->makeViteHotFile('build/hot');
+        $this->makeViteHotFile('cold');
 
         $vite = app(Vite::class);
 
-        $vite->withEntryPoints(['resources/js/app.js'])->useHotFile(public_path('build/hot'));
+        $vite->withEntryPoints(['resources/js/app.js'])->useHotFile('cold');
 
         $this->assertSame(
             '<script type="module" src="http://localhost:3000/@vite/client"></script>'
@@ -586,7 +581,7 @@ class FoundationViteTest extends TestCase
             $vite->toHtml()
         );
 
-        $this->cleanViteHotFile('build/hot');
+        $this->cleanViteHotFile('cold');
     }
 
     protected function makeViteManifest($contents = null, $path = 'build')
@@ -643,17 +638,21 @@ class FoundationViteTest extends TestCase
         }
     }
 
-    protected function makeViteHotFile($path = 'hot')
+    protected function makeViteHotFile($path = null)
     {
         app()->singleton('path.public', fn () => __DIR__);
 
-        file_put_contents(public_path($path), 'http://localhost:3000');
+        $path ??= public_path('hot');
+
+        file_put_contents($path, 'http://localhost:3000');
     }
 
-    protected function cleanViteHotFile($path = 'hot')
+    protected function cleanViteHotFile($path = null)
     {
-        if (file_exists(public_path($path))) {
-            unlink(public_path($path));
+        $path ??= public_path('hot');
+
+        if (file_exists($path)) {
+            unlink($path);
         }
     }
 }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -578,7 +578,7 @@ class FoundationViteTest extends TestCase
 
         $vite = app(Vite::class);
 
-        $vite->withEntryPoints(['resources/js/app.js'])->useHotFile('build/hot');
+        $vite->withEntryPoints(['resources/js/app.js'])->useHotFile(public_path('build/hot'));
 
         $this->assertSame(
             '<script type="module" src="http://localhost:3000/@vite/client"></script>'


### PR DESCRIPTION
This PR is a followup of #43546.

As discussed, the following new functions should be added to the `Vite` class:

1. New func `withEntryPoints` that accepts entry points and is merged into an array on the class.
2. New func `useHotFile` that accepts a path.
3. New func `useBuildDirectory` that accepts a path.
4. Make the `Vite` class `Htmlable`, with toHtml invoking the class.

--------

- [x] Add new functions
- [x] Add tests

