### PR TITLE
[9.x] Remove unused lines

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -80,9 +80,6 @@ class ContainerTest extends TestCase
     public function testSingletonIfDoesRegisterIfBindingNotRegisteredYet()
     {
         $container = new Container;
-        $container->singleton('class', function () {
-            return new stdClass;
-        });
         $container->singletonIf('otherClass', function () {
             return new ContainerConcreteStub;
         });

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -56,9 +56,6 @@ class ContainerTest extends TestCase
     public function testBindIfDoesRegisterIfServiceNotRegisteredYet()
     {
         $container = new Container;
-        $container->bind('surname', function () {
-            return 'Taylor';
-        });
         $container->bindIf('name', function () {
             return 'Dayle';
         });


### PR DESCRIPTION
I just was reading the container tests and found some lines of code useless and do't effect on the tests and removed them