### PR TITLE
[9.x] Fixes `ensureDependenciesExist` runtime error

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -149,17 +149,15 @@ abstract class DatabaseInspectionCommand extends Command
     /**
      * Ensure the dependencies for the database commands are available.
      *
-     * @return int|null
+     * @return bool
      */
     protected function ensureDependenciesExist()
     {
-        if (! interface_exists('Doctrine\DBAL\Driver')) {
-            if (! $this->components->confirm('Displaying model information requires the Doctrine DBAL (doctrine/dbal) package. Would you like to install it?')) {
-                return 1;
+        return tap(interface_exists('Doctrine\DBAL\Driver'), function ($dependenciesExist) {
+            if (! $dependenciesExist && $this->components->confirm('Inspecting database information requires the Doctrine DBAL (doctrine/dbal) package. Would you like to install it?')) {
+                $this->installDependencies();
             }
-
-            return $this->installDependencies();
-        }
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -38,7 +38,9 @@ class ShowCommand extends DatabaseInspectionCommand
      */
     public function handle(ConnectionResolverInterface $connections)
     {
-        $this->ensureDependenciesExist();
+        if (! $this->ensureDependenciesExist()) {
+            return 1;
+        }
 
         $connection = $connections->connection($database = $this->input->getOption('database'));
 

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -37,7 +37,9 @@ class TableCommand extends DatabaseInspectionCommand
      */
     public function handle(ConnectionResolverInterface $connections)
     {
-        $this->ensureDependenciesExist();
+        if (! $this->ensureDependenciesExist()) {
+            return 1;
+        }
 
         $connection = $connections->connection($this->input->getOption('database'));
 

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -81,7 +81,9 @@ class ShowModelCommand extends DatabaseInspectionCommand
      */
     public function handle()
     {
-        $this->ensureDependenciesExist();
+        if (! $this->ensureDependenciesExist()) {
+            return 1;
+        }
 
         $class = $this->qualifyModel($this->argument('model'));
 


### PR DESCRIPTION
This pull request fixes a small regression introduced on https://github.com/laravel/framework/pull/43367, where installing the necessary composer dependencies for "db:show", "db:table", and "model:show" is not causing the command to terminate, consequentially displays a runtime exception:

<img width="781" alt="Screenshot 2022-08-09 at 18 59 24" src="https://user-images.githubusercontent.com/5457236/183726157-2bcebc1c-1d5f-4656-bef6-73c10fbfd498.png">

With this pull request, when `doctrine/dbal` is not installed for the current execution, we simply exit the command even if the user decides to install `doctrine/dbal`. Just like it was before https://github.com/laravel/framework/pull/43367.

<img width="1194" alt="Screenshot 2022-08-09 at 19 01 17" src="https://user-images.githubusercontent.com/5457236/183726497-6238c60a-434e-450e-bd49-d2064733e4f7.png">

