### PR TITLE
[9.x] Enhance getConnectionCount's class detection

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
+use Illuminate\Database\SqlServerConnection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Composer;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
@@ -121,14 +122,14 @@ abstract class DatabaseInspectionCommand extends Command
      * Get the number of open connections for a database.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
-     * @return null
+     * @return int|null
      */
     protected function getConnectionCount(ConnectionInterface $connection)
     {
-        return match (class_basename($connection)) {
-            'MySqlConnection' => (int) $connection->selectOne($connection->raw('show status where variable_name = "threads_connected"'))->Value,
-            'PostgresConnection' => (int) $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections,
-            'SqlServerConnection' => (int) $connection->selectOne('SELECT COUNT(*) connections FROM sys.dm_exec_sessions WHERE status = ?', ['running'])->connections,
+        return match (true) {
+            $connection instanceof MySqlConnection => (int) $connection->selectOne($connection->raw('show status where variable_name = "threads_connected"'))->Value,
+            $connection instanceof PostgresConnection => (int) $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections,
+            $connection instanceof SqlServerConnection => (int) $connection->selectOne('SELECT COUNT(*) connections FROM sys.dm_exec_sessions WHERE status = ?', ['running'])->connections,
             default => null,
         };
     }


### PR DESCRIPTION
Change getConnectionCount method to use better class detection like getTableSize method.
I use a custom connection that inherits MySqlConnection and with this change it works correctly like getTableSize method.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
