### PR TITLE
[9.x] Prevent error in db/model commands when using unsupported columns

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -17,6 +17,25 @@ use Symfony\Component\Process\Process;
 abstract class DatabaseInspectionCommand extends Command
 {
     /**
+     * Database column type map.
+     *
+     * @var array
+     */
+    protected $typeMappings = [
+        'bit' => 'string',
+        'enum' => 'string',
+        'geometry' => 'string',
+        'geomcollection' => 'string',
+        'linestring' => 'string',
+        'multilinestring' => 'string',
+        'multipoint' => 'string',
+        'multipolygon' => 'string',
+        'point' => 'string',
+        'polygon' => 'string',
+        'sysname' => 'string',
+    ];
+
+    /**
      * The Composer instance.
      *
      * @var \Illuminate\Support\Composer
@@ -202,7 +221,8 @@ abstract class DatabaseInspectionCommand extends Command
      */
     protected function registerTypeMapping(AbstractPlatform $platform)
     {
-        $platform->registerDoctrineTypeMapping('enum', 'string');
-        $platform->registerDoctrineTypeMapping('sysname', 'string');
+        foreach ($this->typeMappings as $type => $value) {
+            $platform->registerDoctrineTypeMapping($type, $value);
+        }
     }
 }

--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -198,10 +198,9 @@ abstract class DatabaseInspectionCommand extends Command
      * Register custom Doctrine type mappings.
      *
      * @param  \Doctrine\DBAL\Platforms\AbstractPlatform  $platform
-     * @param  string  $database
      * @return void
      */
-    protected function regsisterTypeMapping(AbstractPlatform $platform)
+    protected function registerTypeMapping(AbstractPlatform $platform)
     {
         $platform->registerDoctrineTypeMapping('enum', 'string');
         $platform->registerDoctrineTypeMapping('sysname', 'string');

--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Schema;
 use Illuminate\Console\Command;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\MySqlConnection;
@@ -10,6 +11,7 @@ use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Composer;
+use Illuminate\Support\Str;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
@@ -143,7 +145,7 @@ abstract class DatabaseInspectionCommand extends Command
     {
         $database ??= config('database.default');
 
-        return Arr::except(config('database.connections.'.$database), ['password']);
+        return Arr::except(config('database.connections.' . $database), ['password']);
     }
 
     /**
@@ -153,8 +155,8 @@ abstract class DatabaseInspectionCommand extends Command
      */
     protected function ensureDependenciesExist()
     {
-        if (! interface_exists('Doctrine\DBAL\Driver')) {
-            if (! $this->components->confirm('Displaying model information requires the Doctrine DBAL (doctrine/dbal) package. Would you like to install it?')) {
+        if (!interface_exists('Doctrine\DBAL\Driver')) {
+            if (!$this->components->confirm('Displaying model information requires the Doctrine DBAL (doctrine/dbal) package. Would you like to install it?')) {
                 return 1;
             }
 
@@ -192,5 +194,18 @@ abstract class DatabaseInspectionCommand extends Command
                 throw $e;
             }
         }
+    }
+
+    /**
+     * Register custom Doctrine type mappings.
+     *
+     * @param  \Doctrine\DBAL\Platforms\AbstractPlatform  $platform
+     * @param  string  $database
+     * @return void
+     */
+    protected function regsisterTypeMapping(AbstractPlatform $platform)
+    {
+        $platform->registerDoctrineTypeMapping('enum', 'string');
+        $platform->registerDoctrineTypeMapping('sysname', 'string');
     }
 }

--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Process\Process;
 abstract class DatabaseInspectionCommand extends Command
 {
     /**
-     * Database column type map.
+     * A map of database column types.
      *
      * @var array
      */

--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Console;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\Schema;
 use Illuminate\Console\Command;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\MySqlConnection;
@@ -11,7 +10,6 @@ use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Composer;
-use Illuminate\Support\Str;
 use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
@@ -145,7 +143,7 @@ abstract class DatabaseInspectionCommand extends Command
     {
         $database ??= config('database.default');
 
-        return Arr::except(config('database.connections.' . $database), ['password']);
+        return Arr::except(config('database.connections.'.$database), ['password']);
     }
 
     /**
@@ -155,8 +153,8 @@ abstract class DatabaseInspectionCommand extends Command
      */
     protected function ensureDependenciesExist()
     {
-        if (!interface_exists('Doctrine\DBAL\Driver')) {
-            if (!$this->components->confirm('Displaying model information requires the Doctrine DBAL (doctrine/dbal) package. Would you like to install it?')) {
+        if (! interface_exists('Doctrine\DBAL\Driver')) {
+            if (! $this->components->confirm('Displaying model information requires the Doctrine DBAL (doctrine/dbal) package. Would you like to install it?')) {
                 return 1;
             }
 

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -135,7 +135,7 @@ class ShowCommand extends DatabaseInspectionCommand
 
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>' . $platform['name'] . '</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>'.$platform['name'].'</>');
         $this->components->twoColumnDetail('Database', Arr::get($platform['config'], 'database'));
         $this->components->twoColumnDetail('Host', Arr::get($platform['config'], 'host'));
         $this->components->twoColumnDetail('Port', Arr::get($platform['config'], 'port'));
@@ -145,13 +145,13 @@ class ShowCommand extends DatabaseInspectionCommand
         $this->components->twoColumnDetail('Tables', $tables->count());
 
         if ($tableSizeSum = $tables->sum('size')) {
-            $this->components->twoColumnDetail('Total Size', number_format($tableSizeSum / 1024 / 1024, 2) . 'Mb');
+            $this->components->twoColumnDetail('Total Size', number_format($tableSizeSum / 1024 / 1024, 2).'Mb');
         }
 
         $this->newLine();
 
         if ($tables->isNotEmpty()) {
-            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb)' . ($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>Rows</>' : ''));
+            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb)'.($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>Rows</>' : ''));
 
             $tables->each(function ($table) {
                 if ($tableSize = $table['size']) {
@@ -159,8 +159,8 @@ class ShowCommand extends DatabaseInspectionCommand
                 }
 
                 $this->components->twoColumnDetail(
-                    $table['table'] . ($this->output->isVerbose() ? ' <fg=gray>' . $table['engine'] . '</>' : null),
-                    ($tableSize ? $tableSize : '—') . ($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>' . number_format($table['rows']) . '</>' : '')
+                    $table['table'].($this->output->isVerbose() ? ' <fg=gray>'.$table['engine'].'</>' : null),
+                    ($tableSize ? $tableSize : '—').($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>'.number_format($table['rows']).'</>' : '')
                 );
 
                 if ($this->output->isVerbose()) {

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -43,6 +43,7 @@ class ShowCommand extends DatabaseInspectionCommand
         $connection = $connections->connection($database = $this->input->getOption('database'));
 
         $schema = $connection->getDoctrineSchemaManager();
+
         $this->registerTypeMapping($schema->getDatabasePlatform());
 
         $data = [

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -43,6 +43,7 @@ class ShowCommand extends DatabaseInspectionCommand
         $connection = $connections->connection($database = $this->input->getOption('database'));
 
         $schema = $connection->getDoctrineSchemaManager();
+        $this->regsisterTypeMapping($schema->getDatabasePlatform());
 
         $data = [
             'platform' => [

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -43,7 +43,7 @@ class ShowCommand extends DatabaseInspectionCommand
         $connection = $connections->connection($database = $this->input->getOption('database'));
 
         $schema = $connection->getDoctrineSchemaManager();
-        $this->regsisterTypeMapping($schema->getDatabasePlatform());
+        $this->registerTypeMapping($schema->getDatabasePlatform());
 
         $data = [
             'platform' => [

--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -75,7 +75,7 @@ class ShowCommand extends DatabaseInspectionCommand
             'table' => $table->getName(),
             'size' => $this->getTableSize($connection, $table->getName()),
             'rows' => $this->option('counts') ? $connection->table($table->getName())->count() : null,
-            'engine' => rescue(fn () => $table->getOption('engine')),
+            'engine' => rescue(fn () => $table->getOption('engine'), null, false),
             'comment' => $table->getComment(),
         ]);
     }
@@ -134,7 +134,7 @@ class ShowCommand extends DatabaseInspectionCommand
 
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>'.$platform['name'].'</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>' . $platform['name'] . '</>');
         $this->components->twoColumnDetail('Database', Arr::get($platform['config'], 'database'));
         $this->components->twoColumnDetail('Host', Arr::get($platform['config'], 'host'));
         $this->components->twoColumnDetail('Port', Arr::get($platform['config'], 'port'));
@@ -144,13 +144,13 @@ class ShowCommand extends DatabaseInspectionCommand
         $this->components->twoColumnDetail('Tables', $tables->count());
 
         if ($tableSizeSum = $tables->sum('size')) {
-            $this->components->twoColumnDetail('Total Size', number_format($tableSizeSum / 1024 / 1024, 2).'Mb');
+            $this->components->twoColumnDetail('Total Size', number_format($tableSizeSum / 1024 / 1024, 2) . 'Mb');
         }
 
         $this->newLine();
 
         if ($tables->isNotEmpty()) {
-            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb)'.($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>Rows</>' : ''));
+            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb)' . ($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>Rows</>' : ''));
 
             $tables->each(function ($table) {
                 if ($tableSize = $table['size']) {
@@ -158,8 +158,8 @@ class ShowCommand extends DatabaseInspectionCommand
                 }
 
                 $this->components->twoColumnDetail(
-                    $table['table'].($this->output->isVerbose() ? ' <fg=gray>'.$table['engine'].'</>' : null),
-                    ($tableSize ? $tableSize : '—').($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>'.number_format($table['rows']).'</>' : '')
+                    $table['table'] . ($this->output->isVerbose() ? ' <fg=gray>' . $table['engine'] . '</>' : null),
+                    ($tableSize ? $tableSize : '—') . ($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>' . number_format($table['rows']) . '</>' : '')
                 );
 
                 if ($this->output->isVerbose()) {

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -42,6 +42,7 @@ class TableCommand extends DatabaseInspectionCommand
         $connection = $connections->connection($this->input->getOption('database'));
 
         $schema = $connection->getDoctrineSchemaManager();
+        $this->regsisterTypeMapping($schema->getDatabasePlatform());
 
         $table = $this->argument('table') ?: $this->components->choice(
             'Which table would you like to inspect?',
@@ -98,7 +99,7 @@ class TableCommand extends DatabaseInspectionCommand
             $column->getAutoincrement() ? 'autoincrement' : null,
             'type' => $column->getType()->getName(),
             $column->getUnsigned() ? 'unsigned' : null,
-            ! $column->getNotNull() ? 'nullable' : null,
+            !$column->getNotNull() ? 'nullable' : null,
         ])->filter();
     }
 
@@ -187,11 +188,11 @@ class TableCommand extends DatabaseInspectionCommand
 
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>'.$table['name'].'</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>' . $table['name'] . '</>');
         $this->components->twoColumnDetail('Columns', $table['columns']);
 
         if ($size = $table['size']) {
-            $this->components->twoColumnDetail('Size', number_format($size / 1024 / 1024, 2).'Mb');
+            $this->components->twoColumnDetail('Size', number_format($size / 1024 / 1024, 2) . 'Mb');
         }
 
         $this->newLine();
@@ -201,8 +202,8 @@ class TableCommand extends DatabaseInspectionCommand
 
             $columns->each(function ($column) {
                 $this->components->twoColumnDetail(
-                    $column['column'].' <fg=gray>'.$column['attributes']->implode(', ').'</>',
-                    ($column['default'] ? '<fg=gray>'.$column['default'].'</> ' : '').''.$column['type'].''
+                    $column['column'] . ' <fg=gray>' . $column['attributes']->implode(', ') . '</>',
+                    ($column['default'] ? '<fg=gray>' . $column['default'] . '</> ' : '') . '' . $column['type'] . ''
                 );
             });
 
@@ -214,7 +215,7 @@ class TableCommand extends DatabaseInspectionCommand
 
             $indexes->each(function ($index) {
                 $this->components->twoColumnDetail(
-                    $index['name'].' <fg=gray>'.$index['columns']->implode(', ').'</>',
+                    $index['name'] . ' <fg=gray>' . $index['columns']->implode(', ') . '</>',
                     $index['attributes']->implode(', ')
                 );
             });
@@ -227,8 +228,8 @@ class TableCommand extends DatabaseInspectionCommand
 
             $foreignKeys->each(function ($foreignKey) {
                 $this->components->twoColumnDetail(
-                    $foreignKey['name'].' <fg=gray;options=bold>'.$foreignKey['local_columns']->implode(', ').' references '.$foreignKey['foreign_columns']->implode(', ').' on '.$foreignKey['foreign_table'].'</>',
-                    $foreignKey['on_update'].' / '.$foreignKey['on_delete'],
+                    $foreignKey['name'] . ' <fg=gray;options=bold>' . $foreignKey['local_columns']->implode(', ') . ' references ' . $foreignKey['foreign_columns']->implode(', ') . ' on ' . $foreignKey['foreign_table'] . '</>',
+                    $foreignKey['on_update'] . ' / ' . $foreignKey['on_delete'],
                 );
             });
 

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -42,7 +42,7 @@ class TableCommand extends DatabaseInspectionCommand
         $connection = $connections->connection($this->input->getOption('database'));
 
         $schema = $connection->getDoctrineSchemaManager();
-        $this->regsisterTypeMapping($schema->getDatabasePlatform());
+        $this->registerTypeMapping($schema->getDatabasePlatform());
 
         $table = $this->argument('table') ?: $this->components->choice(
             'Which table would you like to inspect?',

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -99,7 +99,7 @@ class TableCommand extends DatabaseInspectionCommand
             $column->getAutoincrement() ? 'autoincrement' : null,
             'type' => $column->getType()->getName(),
             $column->getUnsigned() ? 'unsigned' : null,
-            !$column->getNotNull() ? 'nullable' : null,
+            ! $column->getNotNull() ? 'nullable' : null,
         ])->filter();
     }
 
@@ -188,11 +188,11 @@ class TableCommand extends DatabaseInspectionCommand
 
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>' . $table['name'] . '</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>'.$table['name'].'</>');
         $this->components->twoColumnDetail('Columns', $table['columns']);
 
         if ($size = $table['size']) {
-            $this->components->twoColumnDetail('Size', number_format($size / 1024 / 1024, 2) . 'Mb');
+            $this->components->twoColumnDetail('Size', number_format($size / 1024 / 1024, 2).'Mb');
         }
 
         $this->newLine();
@@ -202,8 +202,8 @@ class TableCommand extends DatabaseInspectionCommand
 
             $columns->each(function ($column) {
                 $this->components->twoColumnDetail(
-                    $column['column'] . ' <fg=gray>' . $column['attributes']->implode(', ') . '</>',
-                    ($column['default'] ? '<fg=gray>' . $column['default'] . '</> ' : '') . '' . $column['type'] . ''
+                    $column['column'].' <fg=gray>'.$column['attributes']->implode(', ').'</>',
+                    ($column['default'] ? '<fg=gray>'.$column['default'].'</> ' : '').''.$column['type'].''
                 );
             });
 
@@ -215,7 +215,7 @@ class TableCommand extends DatabaseInspectionCommand
 
             $indexes->each(function ($index) {
                 $this->components->twoColumnDetail(
-                    $index['name'] . ' <fg=gray>' . $index['columns']->implode(', ') . '</>',
+                    $index['name'].' <fg=gray>'.$index['columns']->implode(', ').'</>',
                     $index['attributes']->implode(', ')
                 );
             });
@@ -228,8 +228,8 @@ class TableCommand extends DatabaseInspectionCommand
 
             $foreignKeys->each(function ($foreignKey) {
                 $this->components->twoColumnDetail(
-                    $foreignKey['name'] . ' <fg=gray;options=bold>' . $foreignKey['local_columns']->implode(', ') . ' references ' . $foreignKey['foreign_columns']->implode(', ') . ' on ' . $foreignKey['foreign_table'] . '</>',
-                    $foreignKey['on_update'] . ' / ' . $foreignKey['on_delete'],
+                    $foreignKey['name'].' <fg=gray;options=bold>'.$foreignKey['local_columns']->implode(', ').' references '.$foreignKey['foreign_columns']->implode(', ').' on '.$foreignKey['foreign_table'].'</>',
+                    $foreignKey['on_update'].' / '.$foreignKey['on_delete'],
                 );
             });
 

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -98,7 +98,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $this->display(
             $class,
             $model->getConnection()->getName(),
-            $model->getConnection()->getTablePrefix().$model->getTable(),
+            $model->getConnection()->getTablePrefix() . $model->getTable(),
             $this->getAttributes($model),
             $this->getRelations($model),
         );
@@ -113,8 +113,8 @@ class ShowModelCommand extends DatabaseInspectionCommand
     protected function getAttributes($model)
     {
         $schema = $model->getConnection()->getDoctrineSchemaManager();
-        $this->regsisterTypeMapping($schema->getDatabasePlatform());
-        $table = $model->getConnection()->getTablePrefix().$model->getTable();
+        $this->registerTypeMapping($schema->getDatabasePlatform());
+        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
         $columns = $schema->listTableColumns($table);
         $indexes = $schema->listTableIndexes($table);
 
@@ -124,7 +124,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 'name' => $column->getName(),
                 'type' => $this->getColumnType($column),
                 'increments' => $column->getAutoincrement(),
-                'nullable' => ! $column->getNotnull(),
+                'nullable' => !$column->getNotnull(),
                 'default' => $this->getColumnDefault($column, $model),
                 'unique' => $this->columnIsUnique($column->getName(), $indexes),
                 'fillable' => $model->isFillable($column->getName()),
@@ -202,12 +202,12 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 }
 
                 return collect($this->relationMethods)
-                    ->contains(fn ($relationMethod) => str_contains($code, '$this->'.$relationMethod.'('));
+                    ->contains(fn ($relationMethod) => str_contains($code, '$this->' . $relationMethod . '('));
             })
             ->map(function (ReflectionMethod $method) use ($model) {
                 $relation = $method->invoke($model);
 
-                if (! $relation instanceof Relation) {
+                if (!$relation instanceof Relation) {
                     return null;
                 }
 
@@ -275,7 +275,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     {
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>' . $class . '</>');
         $this->components->twoColumnDetail('Database', $database);
         $this->components->twoColumnDetail('Table', $table);
 
@@ -298,7 +298,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
             $second = collect([
                 $attribute['type'],
-                $attribute['cast'] ? '<fg=yellow;options=bold>'.$attribute['cast'].'</>' : null,
+                $attribute['cast'] ? '<fg=yellow;options=bold>' . $attribute['cast'] . '</>' : null,
             ])->filter()->implode(' <fg=gray>/</> ');
 
             $this->components->twoColumnDetail($first, $second);
@@ -372,7 +372,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $unsigned = $column->getUnsigned() ? ' unsigned' : '';
 
         $details = match (get_class($column->getType())) {
-            DecimalType::class => $column->getPrecision().','.$column->getScale(),
+            DecimalType::class => $column->getPrecision() . ',' . $column->getScale(),
             default => $column->getLength(),
         };
 
@@ -415,7 +415,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         if (count($model->getVisible()) > 0) {
-            return ! in_array($attribute, $model->getVisible());
+            return !in_array($attribute, $model->getVisible());
         }
 
         return false;
@@ -460,7 +460,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace.'Models\\'.$model
-            : $rootNamespace.$model;
+            ? $rootNamespace . 'Models\\' . $model
+            : $rootNamespace . $model;
     }
 }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -98,7 +98,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $this->display(
             $class,
             $model->getConnection()->getName(),
-            $model->getConnection()->getTablePrefix() . $model->getTable(),
+            $model->getConnection()->getTablePrefix().$model->getTable(),
             $this->getAttributes($model),
             $this->getRelations($model),
         );
@@ -114,7 +114,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     {
         $schema = $model->getConnection()->getDoctrineSchemaManager();
         $this->registerTypeMapping($schema->getDatabasePlatform());
-        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
+        $table = $model->getConnection()->getTablePrefix().$model->getTable();
         $columns = $schema->listTableColumns($table);
         $indexes = $schema->listTableIndexes($table);
 
@@ -124,7 +124,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 'name' => $column->getName(),
                 'type' => $this->getColumnType($column),
                 'increments' => $column->getAutoincrement(),
-                'nullable' => !$column->getNotnull(),
+                'nullable' => ! $column->getNotnull(),
                 'default' => $this->getColumnDefault($column, $model),
                 'unique' => $this->columnIsUnique($column->getName(), $indexes),
                 'fillable' => $model->isFillable($column->getName()),
@@ -202,12 +202,12 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 }
 
                 return collect($this->relationMethods)
-                    ->contains(fn ($relationMethod) => str_contains($code, '$this->' . $relationMethod . '('));
+                    ->contains(fn ($relationMethod) => str_contains($code, '$this->'.$relationMethod.'('));
             })
             ->map(function (ReflectionMethod $method) use ($model) {
                 $relation = $method->invoke($model);
 
-                if (!$relation instanceof Relation) {
+                if (! $relation instanceof Relation) {
                     return null;
                 }
 
@@ -275,7 +275,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     {
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>' . $class . '</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
         $this->components->twoColumnDetail('Database', $database);
         $this->components->twoColumnDetail('Table', $table);
 
@@ -298,7 +298,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
             $second = collect([
                 $attribute['type'],
-                $attribute['cast'] ? '<fg=yellow;options=bold>' . $attribute['cast'] . '</>' : null,
+                $attribute['cast'] ? '<fg=yellow;options=bold>'.$attribute['cast'].'</>' : null,
             ])->filter()->implode(' <fg=gray>/</> ');
 
             $this->components->twoColumnDetail($first, $second);
@@ -372,7 +372,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $unsigned = $column->getUnsigned() ? ' unsigned' : '';
 
         $details = match (get_class($column->getType())) {
-            DecimalType::class => $column->getPrecision() . ',' . $column->getScale(),
+            DecimalType::class => $column->getPrecision().','.$column->getScale(),
             default => $column->getLength(),
         };
 
@@ -415,7 +415,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         if (count($model->getVisible()) > 0) {
-            return !in_array($attribute, $model->getVisible());
+            return ! in_array($attribute, $model->getVisible());
         }
 
         return false;
@@ -460,7 +460,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace . 'Models\\' . $model
-            : $rootNamespace . $model;
+            ? $rootNamespace.'Models\\'.$model
+            : $rootNamespace.$model;
     }
 }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -98,7 +98,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $this->display(
             $class,
             $model->getConnection()->getName(),
-            $model->getConnection()->getTablePrefix() . $model->getTable(),
+            $model->getConnection()->getTablePrefix().$model->getTable(),
             $this->getAttributes($model),
             $this->getRelations($model),
         );
@@ -114,7 +114,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     {
         $schema = $model->getConnection()->getDoctrineSchemaManager();
         $this->regsisterTypeMapping($schema->getDatabasePlatform());
-        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
+        $table = $model->getConnection()->getTablePrefix().$model->getTable();
         $columns = $schema->listTableColumns($table);
         $indexes = $schema->listTableIndexes($table);
 
@@ -124,7 +124,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 'name' => $column->getName(),
                 'type' => $this->getColumnType($column),
                 'increments' => $column->getAutoincrement(),
-                'nullable' => !$column->getNotnull(),
+                'nullable' => ! $column->getNotnull(),
                 'default' => $this->getColumnDefault($column, $model),
                 'unique' => $this->columnIsUnique($column->getName(), $indexes),
                 'fillable' => $model->isFillable($column->getName()),
@@ -202,12 +202,12 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 }
 
                 return collect($this->relationMethods)
-                    ->contains(fn ($relationMethod) => str_contains($code, '$this->' . $relationMethod . '('));
+                    ->contains(fn ($relationMethod) => str_contains($code, '$this->'.$relationMethod.'('));
             })
             ->map(function (ReflectionMethod $method) use ($model) {
                 $relation = $method->invoke($model);
 
-                if (!$relation instanceof Relation) {
+                if (! $relation instanceof Relation) {
                     return null;
                 }
 
@@ -275,7 +275,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     {
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>' . $class . '</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
         $this->components->twoColumnDetail('Database', $database);
         $this->components->twoColumnDetail('Table', $table);
 
@@ -298,7 +298,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
             $second = collect([
                 $attribute['type'],
-                $attribute['cast'] ? '<fg=yellow;options=bold>' . $attribute['cast'] . '</>' : null,
+                $attribute['cast'] ? '<fg=yellow;options=bold>'.$attribute['cast'].'</>' : null,
             ])->filter()->implode(' <fg=gray>/</> ');
 
             $this->components->twoColumnDetail($first, $second);
@@ -372,7 +372,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $unsigned = $column->getUnsigned() ? ' unsigned' : '';
 
         $details = match (get_class($column->getType())) {
-            DecimalType::class => $column->getPrecision() . ',' . $column->getScale(),
+            DecimalType::class => $column->getPrecision().','.$column->getScale(),
             default => $column->getLength(),
         };
 
@@ -415,7 +415,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         if (count($model->getVisible()) > 0) {
-            return !in_array($attribute, $model->getVisible());
+            return ! in_array($attribute, $model->getVisible());
         }
 
         return false;
@@ -460,7 +460,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace . 'Models\\' . $model
-            : $rootNamespace . $model;
+            ? $rootNamespace.'Models\\'.$model
+            : $rootNamespace.$model;
     }
 }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -98,7 +98,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $this->display(
             $class,
             $model->getConnection()->getName(),
-            $model->getConnection()->getTablePrefix().$model->getTable(),
+            $model->getConnection()->getTablePrefix() . $model->getTable(),
             $this->getAttributes($model),
             $this->getRelations($model),
         );
@@ -113,7 +113,8 @@ class ShowModelCommand extends DatabaseInspectionCommand
     protected function getAttributes($model)
     {
         $schema = $model->getConnection()->getDoctrineSchemaManager();
-        $table = $model->getConnection()->getTablePrefix().$model->getTable();
+        $this->regsisterTypeMapping($schema->getDatabasePlatform());
+        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
         $columns = $schema->listTableColumns($table);
         $indexes = $schema->listTableIndexes($table);
 
@@ -123,7 +124,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 'name' => $column->getName(),
                 'type' => $this->getColumnType($column),
                 'increments' => $column->getAutoincrement(),
-                'nullable' => ! $column->getNotnull(),
+                'nullable' => !$column->getNotnull(),
                 'default' => $this->getColumnDefault($column, $model),
                 'unique' => $this->columnIsUnique($column->getName(), $indexes),
                 'fillable' => $model->isFillable($column->getName()),
@@ -201,12 +202,12 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 }
 
                 return collect($this->relationMethods)
-                    ->contains(fn ($relationMethod) => str_contains($code, '$this->'.$relationMethod.'('));
+                    ->contains(fn ($relationMethod) => str_contains($code, '$this->' . $relationMethod . '('));
             })
             ->map(function (ReflectionMethod $method) use ($model) {
                 $relation = $method->invoke($model);
 
-                if (! $relation instanceof Relation) {
+                if (!$relation instanceof Relation) {
                     return null;
                 }
 
@@ -274,7 +275,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     {
         $this->newLine();
 
-        $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
+        $this->components->twoColumnDetail('<fg=green;options=bold>' . $class . '</>');
         $this->components->twoColumnDetail('Database', $database);
         $this->components->twoColumnDetail('Table', $table);
 
@@ -297,7 +298,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
             $second = collect([
                 $attribute['type'],
-                $attribute['cast'] ? '<fg=yellow;options=bold>'.$attribute['cast'].'</>' : null,
+                $attribute['cast'] ? '<fg=yellow;options=bold>' . $attribute['cast'] . '</>' : null,
             ])->filter()->implode(' <fg=gray>/</> ');
 
             $this->components->twoColumnDetail($first, $second);
@@ -371,7 +372,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $unsigned = $column->getUnsigned() ? ' unsigned' : '';
 
         $details = match (get_class($column->getType())) {
-            DecimalType::class => $column->getPrecision().','.$column->getScale(),
+            DecimalType::class => $column->getPrecision() . ',' . $column->getScale(),
             default => $column->getLength(),
         };
 
@@ -414,7 +415,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         if (count($model->getVisible()) > 0) {
-            return ! in_array($attribute, $model->getVisible());
+            return !in_array($attribute, $model->getVisible());
         }
 
         return false;
@@ -459,7 +460,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace.'Models\\'.$model
-            : $rootNamespace.$model;
+            ? $rootNamespace . 'Models\\' . $model
+            : $rootNamespace . $model;
     }
 }


### PR DESCRIPTION
The PR resolves #43630 #43622 

The `doctrine/dbal` package does not support enum types when listing database columns. This PR adds support for mapping `enum` and `sysname` (issue with some distributions of sqlsrv) to `string`. The Artisan `db:show`, `db:table` and `model:show` commands have all been updated to use it.

Additonally, `db:show` uses the `rescue` helper to prevent an error if the engine type is not available. This PR also prevents the error from being reported. 
