### PR TITLE
[9.x] Updated hydrate method to calculate array length once

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -389,11 +389,12 @@ class Builder implements BuilderContract
     public function hydrate(array $items)
     {
         $instance = $this->newModelInstance();
+        $hasMultipleItems = count($items) > 1;
 
-        return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
+        return $instance->newCollection(array_map(function ($item) use ($hasMultipleItems, $instance) {
             $model = $instance->newFromBuilder($item);
 
-            if (count($items) > 1) {
+            if ($hasMultipleItems) {
                 $model->preventsLazyLoading = Model::preventsLazyLoading();
             }
 


### PR DESCRIPTION
The method was counting the `$items` on each loop. I've added a variable to keep length of `$items` and pass it to the callback function instead of passing the full array. Just a little performance update.