### PR TITLE
[9.x] Add joinRelation to Eloquent query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -593,7 +593,6 @@ trait QueriesRelationships
      * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
      * @param  string  $type
      * @param  bool  $where
-     *
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\RelationNotFoundException

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -574,7 +574,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Add an "BelongsTo" relationship with an "or where" clause to the query.
+     * Add a "BelongsTo" relationship with an "or where" clause to the query.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $related
      * @param  string|null  $relationshipName
@@ -585,6 +585,34 @@ trait QueriesRelationships
     public function orWhereBelongsTo($related, $relationshipName = null)
     {
         return $this->whereBelongsTo($related, $relationshipName, 'or');
+    }
+
+    /**
+     * Add a join clause to the query based on the relationship constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\Relation|string  $relation
+     * @param  string  $type
+     * @param  bool  $where
+     *
+     * @return $this
+     *
+     * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
+     */
+    public function joinRelation($relation, $type = 'inner', $where = false)
+    {
+        if (is_string($relation)) {
+            try {
+                $relation = $this->model->{$relation}();
+            } catch (BadMethodCallException) {
+                throw RelationNotFoundException::make($this->model, $relation);
+            }
+
+            if (! $relation instanceof Relation) {
+                throw RelationNotFoundException::make($this->model, $relation);
+            }
+        }
+
+        return $relation->addJoinClause($this, $type, $where);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -157,6 +157,29 @@ class BelongsTo extends Relation
     }
 
     /**
+     * Add a join clause to the query based on the relationship constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|null  $query
+     * @param  string  $type
+     * @param  bool  $where
+     *
+     * @return  \Illuminate\Database\Eloquent\Builder
+     */
+    public function addJoinClause($query = null, $type = 'inner', $where = false)
+    {
+        $query = $query ?: $this->query;
+
+        return $query->join(
+            $this->getModel()->getTable(),
+            $this->getQualifiedForeignKeyName(),
+            '=',
+            $this->getQualifiedOwnerKeyName(),
+            $type,
+            $where
+        );
+    }
+
+    /**
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -162,8 +162,7 @@ class BelongsTo extends Relation
      * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @param  string  $type
      * @param  bool  $where
-     *
-     * @return  \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function addJoinClause($query = null, $type = 'inner', $where = false)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -270,7 +270,7 @@ class BelongsToMany extends Relation
      * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @param  string  $type
      * @param  bool  $where
-     * @return  \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function addJoinClause($query = null, $type = 'inner', $where = false)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -265,6 +265,35 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Add a join clause to the query based on the relationship constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|null  $query
+     * @param  string  $type
+     * @param  bool  $where
+     * @return  \Illuminate\Database\Eloquent\Builder
+     */
+    public function addJoinClause($query = null, $type = 'inner', $where = false)
+    {
+        $query = $query ?: $this->query;
+
+        return $query->join(
+            $this->table,
+            $this->getQualifiedParentKeyName(),
+            '=',
+            $this->getQualifiedForeignPivotKeyName(),
+            $type,
+            $where
+        )->join(
+            $this->getModel()->getTable(),
+            $this->getQualifiedRelatedPivotKeyName(),
+            '=',
+            $this->getQualifiedRelatedKeyName(),
+            $type,
+            $where
+        );
+    }
+
+    /**
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -182,6 +182,33 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Add a join clause to the query based on the relationship constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|null  $query
+     * @param  string  $type
+     * @param  bool  $where
+     * @return  \Illuminate\Database\Eloquent\Builder
+     */
+    public function addJoinClause($query = null, $type = 'inner', $where = false)
+    {
+        $query = $query ?: $this->query;
+
+        return $query->join(
+            $this->throughParent->getTable(),
+            $this->getQualifiedLocalKeyName(),
+            '=',
+            $this->getQualifiedFirstKeyName()
+        )->join(
+            $this->getModel()->getTable(),
+            $this->throughParent->qualifyColumn($this->getSecondLocalKeyName()),
+            '=',
+            $this->getQualifiedFarKeyName(),
+            $type,
+            $where
+        );
+    }
+
+    /**
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -187,7 +187,7 @@ class HasManyThrough extends Relation
      * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @param  string  $type
      * @param  bool  $where
-     * @return  \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function addJoinClause($query = null, $type = 'inner', $where = false)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -43,6 +43,28 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Add a join clause to the query based on the relationship constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|null  $query
+     * @param  string  $type
+     * @param  bool  $where
+     * @return  \Illuminate\Database\Eloquent\Builder
+     */
+    public function addJoinClause($query = null, $type = 'inner', $where = false)
+    {
+        $query = $query ?: $this->query;
+
+        return $query->join(
+            $this->getRelated()->getTable(),
+            $this->getQualifiedParentKeyName(),
+            '=',
+            $this->getQualifiedForeignKeyName(),
+            $type,
+            $where
+        );
+    }
+
+    /**
      * Create and return an un-saved instance of the related model.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -48,7 +48,7 @@ abstract class HasOneOrMany extends Relation
      * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @param  string  $type
      * @param  bool  $where
-     * @return  \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function addJoinClause($query = null, $type = 'inner', $where = false)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -74,13 +74,13 @@ abstract class MorphOneOrMany extends HasOneOrMany
      * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @param  string  $type
      * @param  bool  $where
-     * @return  \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function addJoinClause($query = null, $type = 'inner', $where = false)
     {
         $query = $query ?: $this->query;
 
-        return $query->join($this->getModel()->getTable(), function(JoinClause $join) {
+        return $query->join($this->getModel()->getTable(), function (JoinClause $join) {
             $join->on(
                 $this->getQualifiedParentKeyName(),
                 '=',

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\JoinClause;
 
 abstract class MorphOneOrMany extends HasOneOrMany
 {
@@ -65,6 +66,27 @@ abstract class MorphOneOrMany extends HasOneOrMany
         parent::addEagerConstraints($models);
 
         $this->getRelationQuery()->where($this->morphType, $this->morphClass);
+    }
+
+    /**
+     * Add a join clause to the query based on the relationship constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|null  $query
+     * @param  string  $type
+     * @param  bool  $where
+     * @return  \Illuminate\Database\Eloquent\Builder
+     */
+    public function addJoinClause($query = null, $type = 'inner', $where = false)
+    {
+        $query = $query ?: $this->query;
+
+        return $query->join($this->getModel()->getTable(), function(JoinClause $join) {
+            $join->on(
+                $this->getQualifiedParentKeyName(),
+                '=',
+                $this->getQualifiedForeignKeyName()
+            )->where($this->getQualifiedMorphType(), '=', $this->getMorphClass());
+        }, null, null, $type, $where);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -132,6 +132,16 @@ abstract class Relation implements BuilderContract
     abstract public function initRelation(array $models, $relation);
 
     /**
+     * Add a join clause to the query based on the relationship constraints.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|null  $query
+     * @param  string  $type
+     * @param  bool  $where
+     * @return  $this
+     */
+    abstract public function addJoinClause($query, $type = 'inner', $where = false);
+
+    /**
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -137,7 +137,7 @@ abstract class Relation implements BuilderContract
      * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @param  string  $type
      * @param  bool  $where
-     * @return  $this
+     * @return $this
      */
     abstract public function addJoinClause($query, $type = 'inner', $where = false);
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -307,6 +307,11 @@ class EloquentRelationStub extends Relation
         //
     }
 
+    public function addJoinClause($query = null, $type = 'inner', $where = false)
+    {
+        //
+    }
+
     public function match(array $models, Collection $results, $relation)
     {
         //


### PR DESCRIPTION
When we want to add a join clause to an Eloquent query, we need to either give the raw table name, or instantiate the related model in order to get the table name dynamically.

This PR adds a way to add this join clause taking advantage of the relationship, by doing this:
```php
// using the relation name
$model->joinRelation('relationName');

// using the relation instance
$model->joinRelation($model->relation());
```

This was implemented for the following relation types: `BelongsTo`, `HasOne`, `HasMany`, `MorphOne`, `MorphMany`, `BelongsToMany`, `HasManyThrough` and `HasOneThrough`. Of course, for the last 3 type, two join clauses will be added.

If anyone thinks that there's a better way to do this, or there's anything wrong or missing, please let me know.

This PR doesn't add any breaking changes, as it only introduces new functionality.