### PR TITLE
[9.x] Disallow routes with duplicate URIs

### DIFF
--- a/src/Illuminate/Routing/Exceptions/RouteAlreadyRegisteredException.php
+++ b/src/Illuminate/Routing/Exceptions/RouteAlreadyRegisteredException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Routing\Exceptions;
+
+use Exception;
+use Illuminate\Routing\Route;
+
+class RouteAlreadyRegisteredException extends Exception
+{
+    /**
+     * @param  \Illuminate\Routing\Route  $route
+     * @return static
+     */
+    public static function forRoute(Route $route)
+    {
+        $fullUri = $route->getDomain()
+            ? $route->getDomain().'/'.$route->uri()
+            : $route->uri();
+
+        $message = sprintf('Route [%s] has already been registered.', $fullUri);
+
+        return new static($message);
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -130,7 +130,7 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @var bool
      */
-    protected static $enforceUniqueRoutes = false;
+    protected $enforceUniqueRoutes = false;
 
     /**
      * Create a new Router instance.
@@ -480,7 +480,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function validateDuplicatesIfNeeded(Route $newRoute)
     {
-        if (! static::$enforceUniqueRoutes) {
+        if (! $this->enforceUniqueRoutes) {
             return;
         }
 
@@ -1392,9 +1392,9 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param bool $value
      * @return void
      */
-    public static function enforceUniqueRoutes($value = true)
+    public function enforceUniqueRoutes($value = true)
     {
-        static::$enforceUniqueRoutes = $value;
+        $this->enforceUniqueRoutes = $value;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -485,10 +485,8 @@ class Router implements BindingRegistrar, RegistrarContract
             return;
         }
 
-        $routes = collect($this->routes->getRoutes());
         $cleanUriParameters = fn (string $uri) => preg_replace('/{(.*?)\}/s', '', $uri);
-
-        $route = $routes->first(fn (Route $route) =>
+        $route = collect($this->routes->getRoutes())->first(fn (Route $route) =>
             $route->methods() === $methods && $cleanUriParameters($route->uri) === $cleanUriParameters($uri)
         );
 
@@ -1390,6 +1388,7 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Instruct the application to throw an exception if a duplicate route is registered.
      *
+     * @param bool $value
      * @return void
      */
     public static function enforceUniqueRoutes($value = true)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -462,6 +462,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  string  $uri
      * @param  array|string|callable|null  $action
      * @return \Illuminate\Routing\Route
+     *
      * @throws \Illuminate\Routing\Exceptions\RouteAlreadyRegisteredException
      */
     public function addRoute($methods, $uri, $action)
@@ -474,8 +475,9 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Throw an exception if a route with the same path already exists.
      *
-     * @param  \Illuminate\Routing\Route $newRoute
+     * @param  \Illuminate\Routing\Route  $newRoute
      * @return void
+     *
      * @throws \Illuminate\Routing\Exceptions\RouteAlreadyRegisteredException
      */
     protected function validateDuplicatesIfNeeded(Route $newRoute)
@@ -1389,7 +1391,7 @@ class Router implements BindingRegistrar, RegistrarContract
     /**
      * Instruct the application to throw an exception if a duplicate route is registered.
      *
-     * @param bool $value
+     * @param  bool  $value
      * @return void
      */
     public function enforceUniqueRoutes($value = true)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1393,7 +1393,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public static function enforceUniqueRoutes($value = true)
     {
-        static::$enforceUniqueRoutes = true;
+        static::$enforceUniqueRoutes = $value;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -130,7 +130,7 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @var bool
      */
-    protected static $protectRoutes = false;
+    protected static $enforceUniqueRoutes = false;
 
     /**
      * Create a new Router instance.
@@ -481,7 +481,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function validateDuplicatesIfNeeded($methods, $uri)
     {
-        if (! static::$protectRoutes) {
+        if (! static::$enforceUniqueRoutes) {
             return;
         }
 
@@ -1392,9 +1392,9 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @return void
      */
-    public static function blockDuplicateRoutes()
+    public static function enforceUniqueRoutes($value = true)
     {
-        static::$protectRoutes = true;
+        static::$enforceUniqueRoutes = true;
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -887,7 +887,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDuplicateRoutesThrowAnException()
     {
-        $this->router::blockDuplicateRoutes();
+        $this->router::enforceUniqueRoutes();
         $this->expectException(RouteAlreadyRegisteredException::class);
         $this->expectExceptionMessage('Route [foo] has already been registered.');
 
@@ -897,7 +897,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDuplicateRoutesWithTheSameDomainThrowAnException()
     {
-        $this->router::blockDuplicateRoutes();
+        $this->router::enforceUniqueRoutes();
         $this->expectException(RouteAlreadyRegisteredException::class);
         $this->expectExceptionMessage('Route [laravel.com/foo] has already been registered.');
 
@@ -909,7 +909,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDuplicateRoutesWithDifferentDomainsDoNotThrowAnException()
     {
-        $this->router::blockDuplicateRoutes();
+        $this->router::enforceUniqueRoutes();
         $this->router->domain('laravel.com')->group(function () {
             $this->router->get('foo', fn () => true);
         });
@@ -923,7 +923,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDuplicateRoutesWithParametersThrowAnException()
     {
-        $this->router::blockDuplicateRoutes();
+        $this->router::enforceUniqueRoutes();
         $this->expectException(RouteAlreadyRegisteredException::class);
         $this->expectExceptionMessage('Route [foo/{foo}/baz] has already been registered.');
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -29,6 +29,8 @@ class RouteRegistrarTest extends TestCase
 
     protected function tearDown(): void
     {
+        $this->router::enforceUniqueRoutes(false);
+
         m::close();
     }
 
@@ -893,7 +895,6 @@ class RouteRegistrarTest extends TestCase
 
         $this->router->get('foo', fn () => true);
         $this->router->get('foo', fn () => false);
-        $this->router::enforceUniqueRoutes(false);
     }
 
     public function testDuplicateRoutesWithTheSameDomainThrowAnException()
@@ -906,8 +907,6 @@ class RouteRegistrarTest extends TestCase
             $this->router->get('foo', fn () => true);
             $this->router->get('foo', fn () => false);
         });
-
-        $this->router::enforceUniqueRoutes(false);
     }
 
     public function testDuplicateRoutesWithDifferentDomainsDoNotThrowAnException()
@@ -922,7 +921,6 @@ class RouteRegistrarTest extends TestCase
         });
 
         $this->assertCount(2, $this->router->getRoutes());
-        $this->router::enforceUniqueRoutes(false);
     }
 
     public function testDuplicateRoutesWithParametersThrowAnException()
@@ -933,8 +931,6 @@ class RouteRegistrarTest extends TestCase
 
         $this->router->get('foo/{foo}/baz', fn () => true);
         $this->router->get('foo/{bar}/baz', fn () => false);
-
-        $this->router::enforceUniqueRoutes(false);
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -897,6 +897,16 @@ class RouteRegistrarTest extends TestCase
         $this->router->get('foo', fn () => false);
     }
 
+    public function testDifferentRoutesWithParametersDoNotThrowARouteAlreadyRegisteredException()
+    {
+        $this->router::enforceUniqueRoutes();
+
+        $this->router->get('foo/{foo}/baz/{baz}', fn () => true);
+        $this->router->get('foo/{bar}/bar/{baz}', fn () => false);
+
+        $this->assertCount(2, $this->router->getRoutes());
+    }
+
     public function testDuplicateRoutesWithTheSameDomainThrowAnException()
     {
         $this->router::enforceUniqueRoutes();

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -29,7 +29,7 @@ class RouteRegistrarTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->router::enforceUniqueRoutes(false);
+        $this->router->enforceUniqueRoutes(false);
 
         m::close();
     }
@@ -889,7 +889,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDuplicateRoutesThrowAnException()
     {
-        $this->router::enforceUniqueRoutes();
+        $this->router->enforceUniqueRoutes();
         $this->expectException(RouteAlreadyRegisteredException::class);
         $this->expectExceptionMessage('Route [foo] has already been registered.');
 
@@ -899,7 +899,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDifferentRoutesWithParametersDoNotThrowARouteAlreadyRegisteredException()
     {
-        $this->router::enforceUniqueRoutes();
+        $this->router->enforceUniqueRoutes();
 
         $this->router->get('foo/{foo}/baz/{baz}', fn () => true);
         $this->router->get('foo/{bar}/bar/{baz}', fn () => false);
@@ -909,7 +909,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDuplicateRoutesWithTheSameDomainThrowAnException()
     {
-        $this->router::enforceUniqueRoutes();
+        $this->router->enforceUniqueRoutes();
         $this->expectException(RouteAlreadyRegisteredException::class);
         $this->expectExceptionMessage('Route [laravel.com/foo] has already been registered.');
 
@@ -921,7 +921,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDuplicateRoutesWithDifferentDomainsDoNotThrowAnException()
     {
-        $this->router::enforceUniqueRoutes();
+        $this->router->enforceUniqueRoutes();
         $this->router->domain('laravel.com')->group(function () {
             $this->router->get('foo', fn () => true);
         });
@@ -935,7 +935,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testDuplicateRoutesWithParametersThrowAnException()
     {
-        $this->router::enforceUniqueRoutes();
+        $this->router->enforceUniqueRoutes();
         $this->expectException(RouteAlreadyRegisteredException::class);
         $this->expectExceptionMessage('Route [foo/{foo}/baz] has already been registered.');
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -893,6 +893,7 @@ class RouteRegistrarTest extends TestCase
 
         $this->router->get('foo', fn () => true);
         $this->router->get('foo', fn () => false);
+        $this->router::enforceUniqueRoutes(false);
     }
 
     public function testDuplicateRoutesWithTheSameDomainThrowAnException()
@@ -905,6 +906,8 @@ class RouteRegistrarTest extends TestCase
             $this->router->get('foo', fn () => true);
             $this->router->get('foo', fn () => false);
         });
+
+        $this->router::enforceUniqueRoutes(false);
     }
 
     public function testDuplicateRoutesWithDifferentDomainsDoNotThrowAnException()
@@ -919,6 +922,7 @@ class RouteRegistrarTest extends TestCase
         });
 
         $this->assertCount(2, $this->router->getRoutes());
+        $this->router::enforceUniqueRoutes(false);
     }
 
     public function testDuplicateRoutesWithParametersThrowAnException()
@@ -929,6 +933,8 @@ class RouteRegistrarTest extends TestCase
 
         $this->router->get('foo/{foo}/baz', fn () => true);
         $this->router->get('foo/{bar}/baz', fn () => false);
+
+        $this->router::enforceUniqueRoutes(false);
     }
 
     /**


### PR DESCRIPTION
I recently had to deal with an annoying issue on an existing application where routes were being registered twice by mistake. 

This feature would be opt-in. 
I couldn't figure out how to deal with different domains (the failing test), but if you think this isn't a shit idea I can work on it and figure it out.