### PR TITLE
Allow adding of more faker providers

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -96,7 +96,7 @@ class DatabaseServiceProvider extends ServiceProvider
             $extraFakerProviders = $app['config']->get('app.extra_faker_providers', []);
 
             foreach ($extraFakerProviders as $fakerProvider) {
-                static::$fakers[$locale]->addProvider(new $extraProvider(static::$fakers[$locale]));
+                static::$fakers[$locale]->addProvider(new $fakerProvider(static::$fakers[$locale]));
             }
 
             static::$fakers[$locale]->unique(true);

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -93,6 +93,12 @@ class DatabaseServiceProvider extends ServiceProvider
                 static::$fakers[$locale] = FakerFactory::create($locale);
             }
 
+            $extraFakerProviders = $app['config']->get('app.extra_faker_providers', []);
+
+            foreach ($extraFakerProviders as $fakerProvider) {
+                static::$fakers[$locale]->addProvider(new $extraProvider(static::$fakers[$locale]));
+            }
+
             static::$fakers[$locale]->unique(true);
 
             return static::$fakers[$locale];


### PR DESCRIPTION
Sometimes we want to add additional faker providers or do overriding

https://fakerphp.github.io/#faker-internals-understanding-providers

With this PR

in our config/app.php we can then do

```php
'extra_faker_providers' => [
    // let's say we want to generate Chinese names instead but keep everything else en_US
    \Faker\Provider\zh_CN\Person::class,
   // we may also want to add some 3rd party package faker providers to be used in all factories
  // or our own
];
```