### PR TITLE
[9.x] Use new Ubuntu 22.04 image

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   mysql_57:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       mysql:
@@ -47,7 +47,7 @@ jobs:
           DB_USERNAME: root
 
   mysql_8:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       mysql:
@@ -90,7 +90,7 @@ jobs:
           DB_USERNAME: root
 
   mariadb:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       mysql:
@@ -133,7 +133,7 @@ jobs:
           DB_USERNAME: root
 
   pgsql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       postgresql:
@@ -177,7 +177,7 @@ jobs:
           DB_PASSWORD: password
 
   mssql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       sqlsrv:

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -201,7 +201,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc, pdo_odbc
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -177,7 +177,7 @@ jobs:
           DB_PASSWORD: password
 
   mssql:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     services:
       sqlsrv:

--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -201,7 +201,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlsrv, pdo, pdo_sqlsrv, odbc
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   src:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linux_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       memcached:


### PR DESCRIPTION
Only the SQL Server 2019 tests couldn't be updated because Ubuntu 22.04 apparently doesn't ships yet with the needed ODBC extension.