### PR TITLE
[9.x] Added replaceInsensitive to Str and Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -796,7 +796,7 @@ class Str
      * @param  string|string[]  $subject
      * @return string
      */
-    public function replaceInsensitive($search, $replace, $subject)
+    public static function replaceInsensitive($search, $replace, $subject)
     {
         return str_ireplace($search, $replace, $subject);
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -789,6 +789,19 @@ class Str
     }
 
     /**
+     * Replace the given case-insensitive value in the given string.
+     *
+     * @param  string|string[]  $search
+     * @param  string|string[]  $replace
+     * @param  string|string[]  $subject
+     * @return string
+     */
+    public function replaceInsensitive($search, $replace, $subject)
+    {
+        return str_ireplace($search, $replace, $subject);
+    }
+
+    /**
      * Replace the given value in the given string.
      *
      * @param  string|string[]  $search

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -586,6 +586,18 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Replace the given case-insensitive value in the given string.
+     *
+     * @param  string|string[]  $search
+     * @param  string|string[]  $replace
+     * @return static
+     */
+    public function replaceInsensitive($search, $replace)
+    {
+        return new static(str_ireplace($search, $replace, $this->value));
+    }
+
+    /**
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -518,6 +518,14 @@ class SupportStrTest extends TestCase
         }
     }
 
+    public function testReplaceInsensitive()
+    {
+        $this->assertSame('foo bar laravel', Str::replaceInsensitive('Baz', 'laravel', 'foo bar baz'));
+        $this->assertSame('foo bar baz 8.x', Str::replaceInsensitive('?', '8.x', 'foo bar baz ?'));
+        $this->assertSame('foo/bar/baz', Str::replaceInsensitive(' ', '/', 'foo bar baz'));
+        $this->assertSame('foo bar baz', Str::replaceInsensitive(['?1', '?2', '?3'], ['foo', 'bar', 'baz'], '?1 ?2 ?3'));
+    }
+
     public function testReplace()
     {
         $this->assertSame('foo bar laravel', Str::replace('baz', 'laravel', 'foo bar baz'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -745,6 +745,15 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(['?1', '?2', '?3', '?4'], ['foo', 'bar', 'baz', 'bam']));
     }
 
+    public function testReplaceInsensitive()
+    {
+        $this->assertSame('foo/foo/foo', (string) $this->stringable('?/?/?')->replace('?', 'foo'));
+        $this->assertSame('foo/foo/foo', (string) $this->stringable('a/a/a')->replace('A', 'foo'));
+        $this->assertSame('bar/bar', (string) $this->stringable('?/?')->replace('?', 'bar'));
+        $this->assertSame('?/?/?', (string) $this->stringable('? ? ?')->replace(' ', '/'));
+        $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(['?1', '?2', '?3', '?4'], ['foo', 'bar', 'baz', 'bam']));
+    }
+
     public function testReplaceArray()
     {
         $this->assertSame('foo/bar/baz', (string) $this->stringable('?/?/?')->replaceArray('?', ['foo', 'bar', 'baz']));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -747,11 +747,11 @@ class SupportStringableTest extends TestCase
 
     public function testReplaceInsensitive()
     {
-        $this->assertSame('foo/foo/foo', (string) $this->stringable('?/?/?')->replace('?', 'foo'));
-        $this->assertSame('foo/foo/foo', (string) $this->stringable('a/a/a')->replace('A', 'foo'));
-        $this->assertSame('bar/bar', (string) $this->stringable('?/?')->replace('?', 'bar'));
-        $this->assertSame('?/?/?', (string) $this->stringable('? ? ?')->replace(' ', '/'));
-        $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(['?1', '?2', '?3', '?4'], ['foo', 'bar', 'baz', 'bam']));
+        $this->assertSame('foo/foo/foo', (string) $this->stringable('?/?/?')->replaceInsensitive('?', 'foo'));
+        $this->assertSame('foo/foo/foo', (string) $this->stringable('a/a/a')->replaceInsensitive('A', 'foo'));
+        $this->assertSame('bar/bar', (string) $this->stringable('?/?')->replaceInsensitive('?', 'bar'));
+        $this->assertSame('?/?/?', (string) $this->stringable('? ? ?')->replaceInsensitive(' ', '/'));
+        $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replaceInsensitive(['?1', '?2', '?3', '?4'], ['foo', 'bar', 'baz', 'bam']));
     }
 
     public function testReplaceArray()


### PR DESCRIPTION
Added in the ability to call `Str::of('Abc')->replaceInsensitive('abc', 'Foo')` or `Str::replaceInsensitive('abc', 'Foo', 'AbC')`