### PR TITLE
Fix race condition in locks issued by the file cache driver

### DIFF
--- a/src/Illuminate/Cache/CacheLock.php
+++ b/src/Illuminate/Cache/CacheLock.php
@@ -34,19 +34,12 @@ class CacheLock extends Lock
      */
     public function acquire()
     {
-        if (method_exists($this->store, 'add') && $this->seconds > 0) {
-            return $this->store->add(
-                $this->name, $this->owner, $this->seconds
-            );
-        }
-
-        if (! is_null($this->store->get($this->name))) {
-            return false;
-        }
-
-        return ($this->seconds > 0)
-                ? $this->store->put($this->name, $this->owner, $this->seconds)
-                : $this->store->forever($this->name, $this->owner);
+        // Cache stores that return this lock type must ensure that they
+        // contain a compatible add method that atomically stores an item
+        // in the cache if does not already exist.
+        return $this->store->add(
+            $this->name, $this->owner, $this->seconds
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request fixes issue https://github.com/laravel/framework/issues/43627.

TLDR:
Atomic locks issued by [FileStore](https://github.com/laravel/framework/blob/09d50b70557cd061ced973efcd06713a0bf803c4/src/Illuminate/Cache/FileStore.php) or other stores that use the [HasCacheLock](https://github.com/laravel/framework/blob/09d50b70557cd061ced973efcd06713a0bf803c4/src/Illuminate/Cache/HasCacheLock.php) trait have a [race condition](https://github.com/laravel/framework/blob/09d50b70557cd061ced973efcd06713a0bf803c4/src/Illuminate/Cache/CacheLock.php#L43-L49) when the lock timeout is zero (the default). This can cause multiple processes to concurrently enter a critical section protected by the lock.

The [old lock implementation](https://github.com/laravel/framework/blob/09d50b70557cd061ced973efcd06713a0bf803c4/src/Illuminate/Cache/CacheLock.php#L30-L50) would do a non-atomic `get` and `put` when the lock timeout is less than or equal to zero and an atomic `add` otherwise. The [new implementation](https://github.com/hbgl/framework/blob/c93e7f13e5a35b18153fec34cce0d6d4b3a5df0b/src/Illuminate/Cache/CacheLock.php#L30-L43) always does an atomic `add`. This change only breaks code that incorrectly implemented their cache store, i.e. their `add` method cannot handle lock timeouts less or equal to zero.