### PR TITLE
[10.x] Fix timestamp change after model setter in a different timezone

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1291,7 +1291,7 @@ trait HasAttributes
         // Carbon instances from that format. Again, this provides for simple date
         // fields on the database, while still supporting Carbonized conversion.
         if ($this->isStandardDateFormat($value)) {
-            return Date::instance(Carbon::createFromFormat('Y-m-d', $value)->startOfDay());
+            return Date::instance(Carbon::createFromFormat('Y-m-d', $value, 'UTC')->startOfDay());
         }
 
         $format = $this->getDateFormat();
@@ -1300,12 +1300,12 @@ trait HasAttributes
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
         try {
-            $date = Date::createFromFormat($format, $value);
-        } catch (InvalidArgumentException $e) {
+            $date = Date::createFromFormat($format, $value, 'UTC')->setTimezone(date_default_timezone_get());
+        } catch (InvalidArgumentException) {
             $date = false;
         }
 
-        return $date ?: Date::parse($value);
+        return $date ?: Date::parse($value, 'UTC')->setTimezone(date_default_timezone_get());
     }
 
     /**
@@ -1327,7 +1327,7 @@ trait HasAttributes
      */
     public function fromDateTime($value)
     {
-        return empty($value) ? $value : $this->asDateTime($value)->setTimezone(date_default_timezone_get())->format(
+        return empty($value) ? $value : $this->asDateTime($value)->setTimezone('UTC')->format(
             $this->getDateFormat()
         );
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1327,7 +1327,7 @@ trait HasAttributes
      */
     public function fromDateTime($value)
     {
-        return empty($value) ? $value : $this->asDateTime($value)->format(
+        return empty($value) ? $value : $this->asDateTime($value)->setTimezone(date_default_timezone_get())->format(
             $this->getDateFormat()
         );
     }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -64,6 +64,9 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
 
         $this->assertEquals((new Carbon($model->getAttributes()['format_datetime']))->timestamp, $date->timestamp);
         $this->assertEquals((new Carbon($model->getAttributes()['basic_datetime']))->timestamp, $date->timestamp);
+
+        // Make sure the date was not mutated
+        $this->assertEquals('+09:00', $date->getOffsetString());
     }
 
     public function testDatesArePreservedInGetter()

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -53,35 +53,20 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertSame(['2019-10-01', '2019-10-01 10:15:20', '2019-10-01', '2019-10-01 10:15'], $bindings);
     }
 
-    public function testDatesArePreservedInSetter()
+    public function testDatesArePreservedInSetterGetter()
     {
         $date = Carbon::make('2022-08-28T12:52:02+09:00');
 
-        $model = new TestModel1();
+        $model = new TestModel1([
+            'format_datetime' => $date,
+            'basic_datetime' => $date,
+        ]);
 
-        $model->setAttribute('basic_datetime', $date);
-        $model->setAttribute('format_datetime', $date);
-
-        $this->assertEquals((new Carbon($model->getAttributes()['format_datetime']))->timestamp, $date->timestamp);
-        $this->assertEquals((new Carbon($model->getAttributes()['basic_datetime']))->timestamp, $date->timestamp);
+        $this->assertEquals($model->format_datetime, $date);
+        $this->assertEquals($model->basic_datetime, $date);
 
         // Make sure the date was not mutated
         $this->assertEquals('+09:00', $date->getOffsetString());
-    }
-
-    public function testDatesArePreservedInGetter()
-    {
-        $date = Carbon::make('2022-08-28T12:52:02+09:00');
-
-        $model = new TestModel1();
-
-        $model->setRawAttributes([
-            'basic_datetime' => $date,
-            'format_datetime' => $date,
-        ]);
-
-        $this->assertEquals((new Carbon($model->getAttribute('format_datetime')))->timestamp, $date->timestamp);
-        $this->assertEquals((new Carbon($model->getAttribute('basic_datetime')))->timestamp, $date->timestamp);
     }
 
     public function testDatesFormattedArrayAndJson()

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -53,6 +53,34 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertSame(['2019-10-01', '2019-10-01 10:15:20', '2019-10-01', '2019-10-01 10:15'], $bindings);
     }
 
+    public function testDatesArePreservedInSetter()
+    {
+        $date = Carbon::make('2022-08-28T12:52:02+09:00');
+
+        $model = new TestModel1();
+
+        $model->setAttribute('basic_datetime', $date);
+        $model->setAttribute('format_datetime', $date);
+
+        $this->assertEquals((new Carbon($model->getAttributes()['format_datetime']))->timestamp, $date->timestamp);
+        $this->assertEquals((new Carbon($model->getAttributes()['basic_datetime']))->timestamp, $date->timestamp);
+    }
+
+    public function testDatesArePreservedInGetter()
+    {
+        $date = Carbon::make('2022-08-28T12:52:02+09:00');
+
+        $model = new TestModel1();
+
+        $model->setRawAttributes([
+            'basic_datetime' => $date,
+            'format_datetime' => $date,
+        ]);
+
+        $this->assertEquals((new Carbon($model->getAttribute('format_datetime')))->timestamp, $date->timestamp);
+        $this->assertEquals((new Carbon($model->getAttribute('basic_datetime')))->timestamp, $date->timestamp);
+    }
+
     public function testDatesFormattedArrayAndJson()
     {
         $user = TestModel1::create([
@@ -126,5 +154,8 @@ class TestModel1 extends Model
         'datetime_field' => 'datetime:Y-m H:i',
         'immutable_date_field' => 'date:Y-m',
         'immutable_datetime_field' => 'datetime:Y-m H:i',
+        'basic_datetime' => 'datetime',
+        // Even though they should be the same, there is a functional difference
+        'format_datetime' => 'datetime:Y-m-d H:i:s',
     ];
 }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/42993, https://github.com/laravel/framework/issues/33604, https://github.com/laravel/framework/issues/33592

Currently when setting a date on a model the timestamp of the date that we just set on it doesn't match if it was in a different timezone than the application timezone, this issue is only present with the `datetime` cast and not the `datetime:Y-m-d H:i:s` cast