### PR TITLE
[9.x] Fix incorrect unit of measurement

### DIFF
--- a/src/Illuminate/Database/Console/ShowCommand.php
+++ b/src/Illuminate/Database/Console/ShowCommand.php
@@ -148,13 +148,13 @@ class ShowCommand extends DatabaseInspectionCommand
         $this->components->twoColumnDetail('Tables', $tables->count());
 
         if ($tableSizeSum = $tables->sum('size')) {
-            $this->components->twoColumnDetail('Total Size', number_format($tableSizeSum / 1024 / 1024, 2).'Mb');
+            $this->components->twoColumnDetail('Total Size', number_format($tableSizeSum / 1024 / 1024, 2).'MiB');
         }
 
         $this->newLine();
 
         if ($tables->isNotEmpty()) {
-            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (Mb)'.($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>Rows</>' : ''));
+            $this->components->twoColumnDetail('<fg=green;options=bold>Table</>', 'Size (MiB)'.($this->option('counts') ? ' <fg=gray;options=bold>/</> <fg=yellow;options=bold>Rows</>' : ''));
 
             $tables->each(function ($table) {
                 if ($tableSize = $table['size']) {

--- a/src/Illuminate/Database/Console/TableCommand.php
+++ b/src/Illuminate/Database/Console/TableCommand.php
@@ -195,7 +195,7 @@ class TableCommand extends DatabaseInspectionCommand
         $this->components->twoColumnDetail('Columns', $table['columns']);
 
         if ($size = $table['size']) {
-            $this->components->twoColumnDetail('Size', number_format($size / 1024 / 1024, 2).'Mb');
+            $this->components->twoColumnDetail('Size', number_format($size / 1024 / 1024, 2).'MiB');
         }
 
         $this->newLine();


### PR DESCRIPTION
This pull request fixes an incorrect unit of measurement in `db:show` and `db:table` commands.

Currently, both commands use `Mb` which stands for [`Megabit`](https://en.wikipedia.org/wiki/Megabit):

![image](https://user-images.githubusercontent.com/98191/184226010-f42da70d-70a0-4e59-8454-bef012911af3.png)

This PR changes the unit to `MiB`.

- https://en.wikipedia.org/wiki/Binary_prefix