### PR TITLE
[9.x] Allow for int value parameters to whereMonth() and whereDay()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1386,7 +1386,7 @@ class Builder implements BuilderContract
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  \DateTimeInterface|string|null  $value
+     * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
      * @return $this
      */
@@ -1403,7 +1403,7 @@ class Builder implements BuilderContract
         }
 
         if (! $value instanceof Expression) {
-            $value = str_pad($value, 2, '0', STR_PAD_LEFT);
+            $value = sprintf('%02d', $value);
         }
 
         return $this->addDateBasedWhere('Day', $column, $operator, $value, $boolean);
@@ -1414,7 +1414,7 @@ class Builder implements BuilderContract
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  \DateTimeInterface|string|null  $value
+     * @param  \DateTimeInterface|string|int|null  $value
      * @return $this
      */
     public function orWhereDay($column, $operator, $value = null)
@@ -1431,7 +1431,7 @@ class Builder implements BuilderContract
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  \DateTimeInterface|string|null  $value
+     * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
      * @return $this
      */
@@ -1448,7 +1448,7 @@ class Builder implements BuilderContract
         }
 
         if (! $value instanceof Expression) {
-            $value = str_pad($value, 2, '0', STR_PAD_LEFT);
+            $value = sprintf('%02d', $value);
         }
 
         return $this->addDateBasedWhere('Month', $column, $operator, $value, $boolean);
@@ -1459,7 +1459,7 @@ class Builder implements BuilderContract
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  \DateTimeInterface|string|null  $value
+     * @param  \DateTimeInterface|string|int|null  $value
      * @return $this
      */
     public function orWhereMonth($column, $operator, $value = null)


### PR DESCRIPTION
When trying to pass an integer value to whereMonth() or whereDay(), e.g. 
```php
User::whereMonth('updated_at', '=', 4)->get();
```
PHPstan will report `Parameter #3 $value of method Illuminate\Database\Eloquent\Builder<App\Models\User>::whereMonth() expects DateTimeInterface|string|null, int given.` 

At the same time,
```php
User::whereYear('updated_at', '=', 2022)->get();
```
will accept integer values.

This PR suggests to make the type definitions for `whereYear()`, `whereMonth()` and `whereDay()` more consistent by adding the int type to the @param docblock for `$value`.

I am swapping out the usage of `str_pad()` with `sprintf()` because the latter will accept mixed arguments, whereas for `str_pad()`, we would have to convert int values to strings first (and it's more compact, too).