### PR TITLE
[9.x]  Added whenHasValue method to the request object

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -134,6 +134,28 @@ trait InteractsWithInput
     }
 
     /**
+     * Apply the callback if the request contains the given input with the given value.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenHasValue($key, $value, callable $callback, callable $default = null)
+    {
+        if ($this->input($key) == $value) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the request contains a non-empty value for an input item.
      *
      * @param  string|array  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -384,6 +384,26 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($bar);
     }
 
+    public function testWhenHasValueMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'framework' => 'Laravel']);
+
+        $name = $framework = 'Test';
+
+        $request->whenHasValue('name', 'Taylor' , function ($value) use (&$name) {
+            $name = $value;
+        });
+
+        $request->whenHasValue('framework', 'Django', function () use (&$framework) {
+            $framework = true;
+        }, function () use (&$framework) {
+            $framework = false;
+        });
+
+        $this->assertSame('Taylor', $name);
+        $this->assertFalse($framework);
+    }
+
     public function testWhenFilledMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);


### PR DESCRIPTION
Sometimes we need to evaluate the value of a input and execute one thing or another, we can achieve this by using a simple if or with the whenHas method.
```php
$request->whenHas('input', $closure)..
```
The thing with this is that even we know that the input is present, if we need to evaluate the value of the input we have to add an extra if inside the closure.

```php
$request->whenHas('input', function($value) {
    if($value == 'Hello') {

    } else {

    }
})..
```

I think we be really cool if we can pass an extra param to evaluate the value of the input, think is cleaner this way.
The method take 2 closures one of the input has the value (if), and the other closure when this input doesn't match with the value we passed as parameter (else).

```php
$request->whenHasValue('input', 'Hello', function($value) {
    // the input has the value of hello
}, function() {
    // the input does not have the value of hello
})..
```