### PR TITLE
[10.x] Fix race condition in locks issued by the file cache driver

### DIFF
--- a/src/Illuminate/Cache/CacheLock.php
+++ b/src/Illuminate/Cache/CacheLock.php
@@ -14,7 +14,7 @@ class CacheLock extends Lock
     /**
      * Create a new lock instance.
      *
-     * @param  \Illuminate\Contracts\Cache\Store  $store
+     * @param  \Illuminate\Contracts\Cache\Store  $store  The store must contain an add method that atomically stores an item in the cache if it does not already exist. See CacheLock's acquire method for details.
      * @param  string  $name
      * @param  int  $seconds
      * @param  string|null  $owner
@@ -34,19 +34,9 @@ class CacheLock extends Lock
      */
     public function acquire()
     {
-        if (method_exists($this->store, 'add') && $this->seconds > 0) {
-            return $this->store->add(
-                $this->name, $this->owner, $this->seconds
-            );
-        }
-
-        if (! is_null($this->store->get($this->name))) {
-            return false;
-        }
-
-        return ($this->seconds > 0)
-                ? $this->store->put($this->name, $this->owner, $this->seconds)
-                : $this->store->forever($this->name, $this->owner);
+        return $this->store->add(
+            $this->name, $this->owner, $this->seconds
+        );
     }
 
     /**


### PR DESCRIPTION
This PR fixes issue https://github.com/laravel/framework/issues/43627.
I previously submitted similar changes to branch 9.x in PR https://github.com/laravel/framework/pull/43661.

#### TLDR:
Atomic locks issued by [FileStore](https://github.com/laravel/framework/blob/09d50b70557cd061ced973efcd06713a0bf803c4/src/Illuminate/Cache/FileStore.php) or other stores that use the [HasCacheLock](https://github.com/laravel/framework/blob/09d50b70557cd061ced973efcd06713a0bf803c4/src/Illuminate/Cache/HasCacheLock.php) trait have a [race condition](https://github.com/laravel/framework/blob/09d50b70557cd061ced973efcd06713a0bf803c4/src/Illuminate/Cache/CacheLock.php#L43-L49) when the lock timeout is zero (the default). This can cause multiple processes to concurrently enter a critical section protected by the lock.

#### The fix:
The [old lock implementation](https://github.com/laravel/framework/blob/09d50b70557cd061ced973efcd06713a0bf803c4/src/Illuminate/Cache/CacheLock.php#L30-L50) would do a non-atomic `get` and `put` when the lock timeout is less than or equal to zero and an atomic `add` otherwise. The [new implementation](https://github.com/hbgl/framework/blob/c93e7f13e5a35b18153fec34cce0d6d4b3a5df0b/src/Illuminate/Cache/CacheLock.php#L30-L43) always does an atomic `add`. This change only breaks code that incorrectly implemented their cache store, i.e. their `add` method cannot handle lock timeouts less than or equal to zero.