### PR TITLE
Optimize eager loading when no keys to be loaded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -113,7 +113,7 @@ class BelongsTo extends Relation
 
         $whereIn = $this->whereInMethod($this->related, $this->ownerKey);
 
-        $this->query->{$whereIn}($key, $this->getEagerModelKeys($models));
+        $this->whereInEager($whereIn, $key, $this->getEagerModelKeys($models));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -242,7 +242,7 @@ class BelongsToMany extends Relation
     {
         $whereIn = $this->whereInMethod($this->parent, $this->parentKey);
 
-        $this->query->{$whereIn}(
+        $this->whereInEager($whereIn,
             $this->getQualifiedForeignPivotKeyName(),
             $this->getKeys($models, $this->parentKey)
         );

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -160,7 +160,7 @@ class HasManyThrough extends Relation
     {
         $whereIn = $this->whereInMethod($this->farParent, $this->localKey);
 
-        $this->query->{$whereIn}(
+        $this->whereInEager($whereIn,
             $this->getQualifiedFirstKeyName(), $this->getKeys($models, $this->localKey)
         );
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -98,8 +98,9 @@ abstract class HasOneOrMany extends Relation
     {
         $whereIn = $this->whereInMethod($this->parent, $this->localKey);
 
-        $this->getRelationQuery()->{$whereIn}(
-            $this->foreignKey, $this->getKeys($models, $this->localKey)
+        $this->whereInEager($whereIn,
+            $this->foreignKey, $this->getKeys($models, $this->localKey),
+            $this->getRelationQuery()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -154,6 +154,10 @@ abstract class Relation implements BuilderContract
      */
     public function getEager()
     {
+        if ($this->eagerImplicitlyEmpty ?? false) {
+            return $this->query->getModel()->newCollection();
+        }
+
         return $this->get();
     }
 
@@ -390,6 +394,24 @@ abstract class Relation implements BuilderContract
                     && in_array($model->getKeyType(), ['int', 'integer'])
                         ? 'whereIntegerInRaw'
                         : 'whereIn';
+    }
+
+    /**
+     * Add a whereIn eager constraint for the given set of model keys to be loaded.
+     *
+     * @param  string  $whereIn
+     * @param  string  $key
+     * @param  array  $modelKeys
+     * @param  Builder  $query
+     * @return void
+     */
+    protected function whereInEager(string $whereIn, $key, array $modelKeys, $query = null)
+    {
+        ($query ?? $this->query)->{$whereIn}($key, $modelKeys);
+
+        if ($modelKeys === []) {
+            $this->eagerImplicitlyEmpty = true;
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -767,6 +767,29 @@ class DatabaseEloquentBuilderTest extends TestCase
         unset($_SERVER['__eloquent.constrain']);
     }
 
+    public function testRelationshipEagerLoadProcessForImplicitlyEmpty()
+    {
+        $queryBuilder = $this->getMockQueryBuilder();
+        $builder = m::mock(Builder::class.'[getRelation]', [$queryBuilder]);
+        $builder->setEagerLoads(['parentFoo' => function ($query) {
+            $_SERVER['__eloquent.constrain'] = $query;
+        }]);
+        $model = new EloquentBuilderTestModelSelfRelatedStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $models = [
+            new EloquentBuilderTestModelSelfRelatedStub,
+            new EloquentBuilderTestModelSelfRelatedStub,
+        ];
+        $relation = m::mock($model->parentFoo());
+
+        $builder->shouldReceive('getRelation')->once()->with('parentFoo')->andReturn($relation);
+
+        $results = $builder->eagerLoadRelations($models);
+
+        unset($_SERVER['__eloquent.constrain']);
+    }
+
     public function testGetRelationProperlySetsNestedRelationships()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Currently when eager loading relations that don't have any keys to be loaded Laravel will still execute the query:

**Example:**

```php
class User {
   public function picture()
   {
      return $this->belongsTo(Picture::class);
   }
}

User::create(['picture_id' => null]),
User::create(['picture_id' => null])
$users = User::all()->load(['picture']);
```

The eager load will trigger a select on the database even though there is no model keys to be loaded.

It does this by replacing replacing the empty `where in (...)` with [`where 0 = 1`](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Query/Grammars/Grammar.php#L292):

```sql
select * from `pictures` where 0 = 1
```

This PR checks to see if there are not any model keys that can be loaded, and if so will implicitly return an empty collection - this prevents the unnecessary database query.