### PR TITLE
[9.x] Add `acceptedIf` and `declinedIf` validation methods

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,6 +4,8 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\AcceptedIf;
+use Illuminate\Validation\Rules\DeclinedIf;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
@@ -114,6 +116,28 @@ class Rule
     public static function excludeIf($callback)
     {
         return new ExcludeIf($callback);
+    }
+
+    /**
+     * Get a accepted_if constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\AcceptedIf
+     */
+    public static function acceptedIf($callback)
+    {
+        return new AcceptedIf($callback);
+    }
+
+    /**
+     * Get a declined_if constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\DeclinedIf
+     */
+    public static function declinedIf($callback)
+    {
+        return new DeclinedIf($callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/AcceptedIf.php
+++ b/src/Illuminate/Validation/Rules/AcceptedIf.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use InvalidArgumentException;
+
+class AcceptedIf
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new required validation rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($condition)
+    {
+        if (! is_string($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'accepted' : '';
+        }
+
+        return $this->condition ? 'accepted' : '';
+    }
+}

--- a/src/Illuminate/Validation/Rules/DeclinedIf.php
+++ b/src/Illuminate/Validation/Rules/DeclinedIf.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use InvalidArgumentException;
+
+class DeclinedIf
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new required validation rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($condition)
+    {
+        if (! is_string($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'declined' : '';
+        }
+
+        return $this->condition ? 'declined' : '';
+    }
+}

--- a/tests/Validation/ValidationAcceptedIfTest.php
+++ b/tests/Validation/ValidationAcceptedIfTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Validation;
 
 use Exception;
 use Illuminate\Validation\Rules\AcceptedIf;
-use Illuminate\Validation\Rules\RequiredIf;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Validation/ValidationAcceptedIfTest.php
+++ b/tests/Validation/ValidationAcceptedIfTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Validation\Rules\AcceptedIf;
+use Illuminate\Validation\Rules\RequiredIf;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ValidationAcceptedIfTest extends TestCase
+{
+    public function testItClosureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new AcceptedIf(function () {
+            return true;
+        });
+
+        $this->assertSame('accepted', (string) $rule);
+
+        $rule = new AcceptedIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new AcceptedIf(true);
+
+        $this->assertSame('accepted', (string) $rule);
+
+        $rule = new AcceptedIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new AcceptedIf(false);
+
+        $rule = new AcceptedIf(true);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $rule = new AcceptedIf('phpinfo');
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new AcceptedIf(function () {
+            return true;
+        }));
+    }
+}

--- a/tests/Validation/ValidationDeclinedIfTest.php
+++ b/tests/Validation/ValidationDeclinedIfTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Validation\Rules\AcceptedIf;
+use Illuminate\Validation\Rules\DeclinedIf;
+use Illuminate\Validation\Rules\RequiredIf;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ValidationDeclinedIfTest extends TestCase
+{
+    public function testItClosureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new DeclinedIf(function () {
+            return true;
+        });
+
+        $this->assertSame('declined', (string) $rule);
+
+        $rule = new DeclinedIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new DeclinedIf(true);
+
+        $this->assertSame('declined', (string) $rule);
+
+        $rule = new DeclinedIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testItOnlyCallableAndBooleanAreAcceptableArgumentsOfTheRule()
+    {
+        $rule = new DeclinedIf(false);
+
+        $rule = new DeclinedIf(true);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $rule = new DeclinedIf('phpinfo');
+    }
+
+    public function testItReturnedRuleIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new DeclinedIf(function () {
+            return true;
+        }));
+    }
+}

--- a/tests/Validation/ValidationDeclinedIfTest.php
+++ b/tests/Validation/ValidationDeclinedIfTest.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Tests\Validation;
 
 use Exception;
-use Illuminate\Validation\Rules\AcceptedIf;
 use Illuminate\Validation\Rules\DeclinedIf;
-use Illuminate\Validation\Rules\RequiredIf;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
This PR adds methods `acceptedIf` and `declinedIf` for the current `accepted_if` and `declined_if` validations respectively.

The reason I made this PR is I am used to using the `requiredIf` method and just *assumed* that other methods for `*_if` validations would exist. 

A recent PR adding similar rules for `*_unless` methods was not merged https://github.com/laravel/framework/pull/43293 however I believe as we already have rules for `requiredIf`, `excludeIf` and `prohibitedIf`, it is confusing to only include some `*_if` validation methods, and not others (as opposed to adding a full set of `*_unless` methods). This PR would mean all `*_if` validations would be available as a method.

This PR adds only 2 very simple classes with almost identical tests as the existing `requiredIf` method and would remove confusion for developers wondering if a validation method for an `*_if` rule exists or not.