### PR TITLE
fix artisan serve command crash on windows

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -236,7 +236,7 @@ class ServeCommand extends Command
                 $requestPort = $this->getRequestPortFromLine($line);
                 $requestDate = $this->getDateFromLine($line);
 
-                if ( null !== $requestPort && null !== $requestDate) {
+                if (null !== $requestPort && null !== $requestDate) {
                     $this->requestsPool[$requestPort] = [
                         $requestDate,
                         false,
@@ -245,12 +245,12 @@ class ServeCommand extends Command
                 
             } elseif (str($line)->contains([' [200]: GET '])) {
                 $requestPort = $this->getRequestPortFromLine($line);
-                if ( null !== $requestPort) {
+                if (null !== $requestPort) {
                     $this->requestsPool[$requestPort][1] = trim(explode('[200]: GET', $line)[1]);
                 }
             } elseif (str($line)->contains(' Closing')) {
                 $requestPort = $this->getRequestPortFromLine($line);
-                if ( null !== $requestPort ) {
+                if (null !== $requestPort) {
                     $request = $this->requestsPool[$requestPort];
 
                     [$startDate, $file] = $request;

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -236,7 +236,7 @@ class ServeCommand extends Command
                 $requestPort = $this->getRequestPortFromLine($line);
                 $requestDate = $this->getDateFromLine($line);
                 
-                if( null !== $requestPort && null !== $requestDate){
+                if( null !== $requestPort && null !== $requestDate) {
                     $this->requestsPool[$requestPort] = [
                         $requestDate,
                         false,
@@ -245,12 +245,12 @@ class ServeCommand extends Command
                 
             } elseif (str($line)->contains([' [200]: GET '])) {
                 $requestPort = $this->getRequestPortFromLine($line);
-                if( null !== $requestPort){
+                if( null !== $requestPort) {
                     $this->requestsPool[$requestPort][1] = trim(explode('[200]: GET', $line)[1]);
                 }
             } elseif (str($line)->contains(' Closing')) {
                 $requestPort = $this->getRequestPortFromLine($line);
-                if( null !== $requestPort ){
+                if( null !== $requestPort ) {
                     $request = $this->requestsPool[$requestPort];
 
                     [$startDate, $file] = $request;
@@ -264,7 +264,7 @@ class ServeCommand extends Command
                     $this->output->write("  <fg=gray>$date</> $time");
 
                     $requestDate = $this->getDateFromLine($line);
-                    if(null !== $requestDate){
+                    if(null !== $requestDate) {
                         $runTime = $requestDate->diffInSeconds($startDate);
                     }else{
                         $runTime = 'unknown ';
@@ -298,7 +298,7 @@ class ServeCommand extends Command
     {
         preg_match('/^\[([^\]]+)\]/', $line, $matches);
 
-        if(isset($matches[1])){
+        if(isset($matches[1])) {
             return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);
         }
         return null;
@@ -314,7 +314,7 @@ class ServeCommand extends Command
     {
         preg_match('/:(\d+)\s(?:(?:\w+$)|(?:\[.*))/', $line, $matches);
 
-        if(isset($matches[1])){
+        if(isset($matches[1])) {
             return (int) $matches[1];
         }
         return null;

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -244,7 +244,7 @@ class ServeCommand extends Command
                 $this->requestsPool[$requestPort][1] = trim(explode('[200]: GET', $line)[1]);
             } elseif (str($line)->contains(' Closing') && null !== $requestPort && isset($this->requestsPool[$requestPort]) && count($this->requestsPool[$requestPort]) == 2) {
                 $request = $this->requestsPool[$requestPort];
-                
+
                 [$startDate, $file] = $request;
 
                 $formattedStartedAt = $startDate->format('Y-m-d H:i:s');

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -235,8 +235,8 @@ class ServeCommand extends Command
             } elseif (str($line)->contains(' Accepted')) {
                 $requestPort = $this->getRequestPortFromLine($line);
                 $requestDate = $this->getDateFromLine($line);
-                
-                if( null !== $requestPort && null !== $requestDate) {
+
+                if ( null !== $requestPort && null !== $requestDate) {
                     $this->requestsPool[$requestPort] = [
                         $requestDate,
                         false,
@@ -245,12 +245,12 @@ class ServeCommand extends Command
                 
             } elseif (str($line)->contains([' [200]: GET '])) {
                 $requestPort = $this->getRequestPortFromLine($line);
-                if( null !== $requestPort) {
+                if ( null !== $requestPort) {
                     $this->requestsPool[$requestPort][1] = trim(explode('[200]: GET', $line)[1]);
                 }
             } elseif (str($line)->contains(' Closing')) {
                 $requestPort = $this->getRequestPortFromLine($line);
-                if( null !== $requestPort ) {
+                if ( null !== $requestPort ) {
                     $request = $this->requestsPool[$requestPort];
 
                     [$startDate, $file] = $request;
@@ -264,9 +264,9 @@ class ServeCommand extends Command
                     $this->output->write("  <fg=gray>$date</> $time");
 
                     $requestDate = $this->getDateFromLine($line);
-                    if(null !== $requestDate) {
+                    if (null !== $requestDate) {
                         $runTime = $requestDate->diffInSeconds($startDate);
-                    }else{
+                    } else {
                         $runTime = 'unknown ';
                     }
 
@@ -298,9 +298,10 @@ class ServeCommand extends Command
     {
         preg_match('/^\[([^\]]+)\]/', $line, $matches);
 
-        if(isset($matches[1])) {
+        if (isset($matches[1])) {
             return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);
         }
+
         return null;
     }
 
@@ -314,9 +315,10 @@ class ServeCommand extends Command
     {
         preg_match('/:(\d+)\s(?:(?:\w+$)|(?:\[.*))/', $line, $matches);
 
-        if(isset($matches[1])) {
+        if (isset($matches[1])) {
             return (int) $matches[1];
         }
+
         return null;
     }
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -242,7 +242,6 @@ class ServeCommand extends Command
                         false,
                     ];
                 }
-                
             } elseif (str($line)->contains([' [200]: GET '])) {
                 $requestPort = $this->getRequestPortFromLine($line);
                 if (null !== $requestPort) {


### PR DESCRIPTION
I have tried a workaround to fix the artisan serve command crash issue on windows.
Issues : #43673, #43653

**Fix:** Implemented condition to check if the request has valid port no and date, or else ignore the request ( not add in **$requestpool** and hence request details will not be visible in console output).