### PR TITLE
[9.x] Add middleware condition for routes

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -392,13 +392,20 @@ class Gate implements GateContract
     public function inspect($ability, $arguments = [])
     {
         try {
-            $result = $this->raw($ability, $arguments);
+            $abilities = explode("|", $ability);
+            foreach($abilities as $ability) {
+                $result = $this->raw($ability, $arguments);
 
-            if ($result instanceof Response) {
-                return $result;
+                if ($result instanceof Response) {
+                    return $result;
+                }
+
+                if($result) {
+                    return Response::allow();
+                }
             }
 
-            return $result ? Response::allow() : Response::deny();
+            return Response::deny();
         } catch (AuthorizationException $e) {
             return $e->toResponse();
         }

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -392,15 +392,15 @@ class Gate implements GateContract
     public function inspect($ability, $arguments = [])
     {
         try {
-            $abilities = explode("|", $ability);
-            foreach($abilities as $ability) {
+            $abilities = explode('|', $ability);
+            foreach ($abilities as $ability) {
                 $result = $this->raw($ability, $arguments);
 
                 if ($result instanceof Response) {
                     return $result;
                 }
 
-                if($result) {
+                if ($result) {
                     return Response::allow();
                 }
             }


### PR DESCRIPTION
this commit will enable the can middleware to parse multiple policies using the "|" character

Sample Code

`Route::get('permissions', [FetchController::class, 'permissions'])->can("attach|detach",Permission::class);`

Since this is my first contribution I didn't know if I place it in the proper location, I do hope that this will be implemented.