### PR TITLE
[9.x] Vite asset url helper

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -10,13 +10,6 @@ use Illuminate\Support\Str;
 class Vite
 {
     /**
-     * The cached manifest files.
-     *
-     * @var array
-     */
-    protected static $manifests = [];
-
-    /**
      * The Content Security Policy nonce to apply to all generated tags.
      *
      * @var string|null
@@ -43,6 +36,13 @@ class Vite
      * @var array
      */
     protected $styleTagAttributesResolvers = [];
+
+    /**
+     * The cached manifest files.
+     *
+     * @var array
+     */
+    protected static $manifests = [];
 
     /**
      * Get the Content Security Policy nonce applied to all generated tags.
@@ -390,6 +390,16 @@ class Vite
     }
 
     /**
+     * Get the path to a given asset when running in HMR mode.
+     *
+     * @return string
+     */
+    protected function hotAsset($asset)
+    {
+        return rtrim(file_get_contents(public_path('/hot'))).'/'.$asset;
+    }
+
+    /**
      * Get the URL for an asset.
      *
      * @param  string  $asset
@@ -408,7 +418,7 @@ class Vite
     }
 
     /**
-     * Get the the manifest file in the build directory.
+     * Get the the manifest file for the given build directory.
      *
      * @param  string  $buildDirectory
      * @return array
@@ -456,15 +466,5 @@ class Vite
     protected function isRunningHot()
     {
         return is_file(public_path('/hot'));
-    }
-
-    /**
-     * The path for assets during HMR mode.
-     *
-     * @return string
-     */
-    protected function hotAsset($asset)
-    {
-        return rtrim(file_get_contents(public_path('/hot'))).'/'.$asset;
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -124,6 +124,7 @@ class Vite
     public function __invoke($entrypoints, $buildDirectory = 'build')
     {
         $entrypoints = collect($entrypoints);
+        $buildDirectory = Str::start($buildDirectory, '/');
 
         if ($this->isRunningHot()) {
             return new HtmlString(

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -405,9 +405,9 @@ class Vite
 
         $manifest = $this->manifest($buildDirectory);
 
-        $this->findChunk($manifest, $asset);
+        $chunk = $this->findChunk($manifest, $asset);
 
-        return asset($buildDirectory.'/'.$manifest[$asset]['file']);
+        return asset($buildDirectory.'/'$chunk['file']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -407,7 +407,7 @@ class Vite
 
         $chunk = $this->findChunk($manifest, $asset);
 
-        return asset($buildDirectory.'/'$chunk['file']);
+        return asset($buildDirectory.'/'.$chunk['file']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -397,6 +397,10 @@ class Vite
      */
     public function asset($asset, $buildDirectory = null)
     {
+        if ($this->isRunningHot()) {
+            return $this->hotAsset($asset);
+        }
+
         $buildDirectory = func_get_args()[1] ?? $this->buildDirectory ?? 'build';
 
         $manifest = $this->manifest($buildDirectory);

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -442,7 +442,7 @@ class Vite
      *
      * @throws \Exception
      */
-    public function findChunk($manifest, $file)
+    protected function findChunk($manifest, $file)
     {
         if (! isset($manifest[$file])) {
             throw new Exception("Unable to locate file in Vite manifest: {$file}.");

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -124,7 +124,6 @@ class Vite
     public function __invoke($entrypoints, $buildDirectory = 'build')
     {
         $entrypoints = collect($entrypoints);
-        $buildDirectory = Str::start($buildDirectory, '/');
 
         if (is_file(public_path('/hot'))) {
             $url = rtrim(file_get_contents(public_path('/hot')));

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -125,13 +125,11 @@ class Vite
     {
         $entrypoints = collect($entrypoints);
 
-        if ($this->isRunningHMR()) {
-            $url = rtrim(file_get_contents(public_path('/hot')));
-
+        if ($this->isRunningHot()) {
             return new HtmlString(
                 $entrypoints
                     ->prepend('@vite/client')
-                    ->map(fn ($entrypoint) => $this->makeTagForChunk($entrypoint, "{$url}/{$entrypoint}", null, null))
+                    ->map(fn ($entrypoint) => $this->makeTagForChunk($entrypoint, "{$this->hotAssetUrl()}/{$entrypoint}", null, null))
                     ->join('')
             );
         }
@@ -370,11 +368,9 @@ class Vite
      */
     public function reactRefresh()
     {
-        if (! $this->isRunningHMR()) {
+        if (! $this->isRunningHot()) {
             return;
         }
-
-        $url = rtrim(file_get_contents(public_path('/hot')));
 
         return new HtmlString(
             sprintf(
@@ -387,7 +383,7 @@ class Vite
                     window.__vite_plugin_react_preamble_installed__ = true
                 </script>
                 HTML,
-                $url
+                $this->hotAssetUrl()
             )
         );
     }
@@ -456,8 +452,18 @@ class Vite
      *
      * @return bool
      */
-    protected function isRunningHMR()
+    protected function isRunningHot()
     {
         return is_file(public_path('/hot'));
+    }
+
+    /**
+     * The path for assets during HMR mode.
+     *
+     * @return string
+     */
+    protected function hotAssetUrl()
+    {
+        return rtrim(file_get_contents(public_path('/hot')));
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -129,7 +129,7 @@ class Vite
             return new HtmlString(
                 $entrypoints
                     ->prepend('@vite/client')
-                    ->map(fn ($entrypoint) => $this->makeTagForChunk($entrypoint, "{$this->hotAssetUrl()}/{$entrypoint}", null, null))
+                    ->map(fn ($entrypoint) => $this->makeTagForChunk($entrypoint, $this->hotAsset($entrypoint), null, null))
                     ->join('')
             );
         }
@@ -376,14 +376,14 @@ class Vite
             sprintf(
                 <<<'HTML'
                 <script type="module">
-                    import RefreshRuntime from '%s/@react-refresh'
+                    import RefreshRuntime from '%s'
                     RefreshRuntime.injectIntoGlobalHook(window)
                     window.$RefreshReg$ = () => {}
                     window.$RefreshSig$ = () => (type) => type
                     window.__vite_plugin_react_preamble_installed__ = true
                 </script>
                 HTML,
-                $this->hotAssetUrl()
+                $this->hotAsset('@react-refresh')
             )
         );
     }
@@ -462,8 +462,8 @@ class Vite
      *
      * @return string
      */
-    protected function hotAssetUrl()
+    protected function hotAsset($asset)
     {
-        return rtrim(file_get_contents(public_path('/hot')));
+        return rtrim(file_get_contents(public_path('/hot'))).'/'.$asset;
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -415,6 +415,8 @@ class Vite
      *
      * @param  string  $buildDirectory
      * @return array
+     *
+     * @throws \Exception
      */
     protected function manifest($buildDirectory)
     {

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -125,7 +125,7 @@ class Vite
     {
         $entrypoints = collect($entrypoints);
 
-        if (is_file(public_path('/hot'))) {
+        if ($this->isRunningHMR()) {
             $url = rtrim(file_get_contents(public_path('/hot')));
 
             return new HtmlString(
@@ -370,7 +370,7 @@ class Vite
      */
     public function reactRefresh()
     {
-        if (! is_file(public_path('/hot'))) {
+        if (! $this->isRunningHMR()) {
             return;
         }
 
@@ -449,5 +449,15 @@ class Vite
         }
 
         return $manifest[$file];
+    }
+
+    /**
+     * Determine if the HMR server is running.
+     *
+     * @return bool
+     */
+    protected function isRunningHMR()
+    {
+        return is_file(public_path('/hot'));
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -403,9 +403,7 @@ class Vite
 
         $buildDirectory = $buildDirectory ?? $this->buildDirectory ?? 'build';
 
-        $manifest = $this->manifest($buildDirectory);
-
-        $chunk = $this->findChunk($manifest, $asset);
+        $chunk = $this->findChunk($this->manifest($buildDirectory), $asset);
 
         return asset($buildDirectory.'/'.$chunk['file']);
     }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -394,6 +394,24 @@ class Vite
     }
 
     /**
+     * Get the URL for an asset.
+     *
+     * @param  string  $asset
+     * @param  string|null  $buildDirectory
+     * @return string
+     */
+    public function asset($asset, $buildDirectory = null)
+    {
+        $buildDirectory = func_get_args()[1] ?? $this->buildDirectory ?? 'build';
+
+        $manifest = $this->manifest($buildDirectory);
+
+        $this->findChunk($manifest, $asset);
+
+        return asset($buildDirectory.'/'.$manifest[$asset]['file']);
+    }
+
+    /**
      * Get the the manifest file in the build directory.
      *
      * @param  string  $buildDirectory

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -142,18 +142,16 @@ class Vite
         $tags = collect();
 
         foreach ($entrypoints as $entrypoint) {
-            if (! isset($manifest[$entrypoint])) {
-                throw new Exception("Unable to locate file in Vite manifest: {$entrypoint}.");
-            }
+            $chunk = $this->findChunk($manifest, $entrypoint);
 
             $tags->push($this->makeTagForChunk(
                 $entrypoint,
-                asset("{$buildDirectory}/{$manifest[$entrypoint]['file']}"),
-                $manifest[$entrypoint],
+                asset("{$buildDirectory}/{$chunk['file']}"),
+                $chunk,
                 $manifest
             ));
 
-            foreach ($manifest[$entrypoint]['css'] ?? [] as $css) {
+            foreach ($chunk['css'] ?? [] as $css) {
                 $partialManifest = Collection::make($manifest)->where('file', $css);
 
                 $tags->push($this->makeTagForChunk(
@@ -164,7 +162,7 @@ class Vite
                 ));
             }
 
-            foreach ($manifest[$entrypoint]['imports'] ?? [] as $import) {
+            foreach ($chunk['imports'] ?? [] as $import) {
                 foreach ($manifest[$import]['css'] ?? [] as $css) {
                     $partialManifest = Collection::make($manifest)->where('file', $css);
 
@@ -414,5 +412,23 @@ class Vite
         }
 
         return static::$manifests[$path];
+    }
+
+    /**
+     * Find the chunk for the given entry point / asset.
+     *
+     * @param  array  $manifest
+     * @param  string  $file
+     * @return array
+     *
+     * @throws \Exception
+     */
+    public function findChunk($manifest, $file)
+    {
+        if (! isset($manifest[$file])) {
+            throw new Exception("Unable to locate file in Vite manifest: {$file}.");
+        }
+
+        return $manifest[$file];
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -401,7 +401,7 @@ class Vite
             return $this->hotAsset($asset);
         }
 
-        $buildDirectory = func_get_args()[1] ?? $this->buildDirectory ?? 'build';
+        $buildDirectory = $buildDirectory ?? $this->buildDirectory ?? 'build';
 
         $manifest = $this->manifest($buildDirectory);
 

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -395,13 +395,11 @@ class Vite
      * @param  string|null  $buildDirectory
      * @return string
      */
-    public function asset($asset, $buildDirectory = null)
+    public function asset($asset, $buildDirectory = 'build')
     {
         if ($this->isRunningHot()) {
             return $this->hotAsset($asset);
         }
-
-        $buildDirectory = $buildDirectory ?? $this->buildDirectory ?? 'build';
 
         $chunk = $this->findChunk($this->manifest($buildDirectory), $asset);
 

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -139,7 +139,7 @@ class Vite
         $tags = collect();
 
         foreach ($entrypoints as $entrypoint) {
-            $chunk = $this->findChunk($manifest, $entrypoint);
+            $chunk = $this->chunk($manifest, $entrypoint);
 
             $tags->push($this->makeTagForChunk(
                 $entrypoint,
@@ -401,7 +401,7 @@ class Vite
             return $this->hotAsset($asset);
         }
 
-        $chunk = $this->findChunk($this->manifest($buildDirectory), $asset);
+        $chunk = $this->chunk($this->manifest($buildDirectory), $asset);
 
         return asset($buildDirectory.'/'.$chunk['file']);
     }
@@ -430,7 +430,7 @@ class Vite
     }
 
     /**
-     * Find the chunk for the given entry point / asset.
+     * Get the chunk for the given entry point / asset.
      *
      * @param  array  $manifest
      * @param  string  $file
@@ -438,7 +438,7 @@ class Vite
      *
      * @throws \Exception
      */
-    protected function findChunk($manifest, $file)
+    protected function chunk($manifest, $file)
     {
         if (! isset($manifest[$file])) {
             throw new Exception("Unable to locate file in Vite manifest: {$file}.");

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
+ * @method static string asset(string $asset, string|null $buildDirectory)
  * @method static \Illuminte\Foundation\Vite useIntegrityKey(string|false $key)
  * @method static \Illuminte\Foundation\Vite useScriptTagAttributes(callable|array $callback)
  * @method static \Illuminte\Foundation\Vite useStyleTagAttributes(callable|array $callback)

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -3,11 +3,8 @@
 namespace Illuminate\Tests\Foundation;
 
 use Illuminate\Foundation\Vite;
-use Illuminate\Routing\UrlGenerator;
-use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Vite as ViteFacade;
 use Illuminate\Support\Str;
-use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
 class FoundationViteTest extends TestCase

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -514,6 +514,15 @@ class FoundationViteTest extends TestCase
         $this->assertSame('https://example.com/build/assets/app.versioned.js', $url);
     }
 
+    public function testItCanGenerateIndividualAssetUrlInHotMode()
+    {
+        $this->makeViteHotFile();
+
+        $url = ViteFacade::asset('resources/js/app.js');
+
+        $this->assertSame('http://localhost:3000/resources/js/app.js', $url);
+    }
+
     protected function makeViteManifest($contents = null, $path = 'build')
     {
         app()->singleton('path.public', fn () => __DIR__);

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Exception;
 use Illuminate\Foundation\Vite;
 use Illuminate\Support\Facades\Vite as ViteFacade;
 use Illuminate\Support\Str;
@@ -518,6 +519,24 @@ class FoundationViteTest extends TestCase
         $url = ViteFacade::asset('resources/js/app.js');
 
         $this->assertSame('http://localhost:3000/resources/js/app.js', $url);
+    }
+
+    public function testItThrowsWhenUnableToFindAssetManifestInBuildMode()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Vite manifest not found at: '.public_path('build/manifest.json'));
+
+        ViteFacade::asset('resources/js/app.js');
+    }
+
+    public function testItThrowsWhenUnableToFindAssetChunkInBuildMode()
+    {
+        $this->makeViteManifest();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unable to locate file in Vite manifest: resources/js/missing.js');
+
+        ViteFacade::asset('resources/js/missing.js');
     }
 
     protected function makeViteManifest($contents = null, $path = 'build')

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -513,6 +513,15 @@ class FoundationViteTest extends TestCase
         );
     }
 
+    public function testItCanGenerateIndividualAssetUrlInBuildMode()
+    {
+        $this->makeViteManifest();
+
+        $url = ViteFacade::asset('resources/js/app.js');
+
+        $this->assertSame('https://example.com/build/assets/app.versioned.js', $url);
+    }
+
     protected function makeViteManifest($contents = null, $path = 'build')
     {
         app()->singleton('path.public', fn () => __DIR__);

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -8,29 +8,21 @@ use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Vite as ViteFacade;
 use Illuminate\Support\Str;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 
 class FoundationViteTest extends TestCase
 {
     protected function setUp(): void
     {
-        app()->instance('url', tap(
-            m::mock(UrlGenerator::class),
-            fn ($url) => $url
-                ->shouldReceive('asset')
-                ->andReturnUsing(fn ($value) => "https://example.com{$value}")
-        ));
+        parent::setUp();
 
-        app()->singleton(Vite::class);
-        Facade::setFacadeApplication(app());
+        app('config')->set('app.asset_url', 'https://example.com');
     }
 
     protected function tearDown(): void
     {
         $this->cleanViteManifest();
         $this->cleanViteHotFile();
-        Facade::clearResolvedInstances();
-        m::close();
     }
 
     public function testViteWithJsOnly()


### PR DESCRIPTION
When using plain Blade as your templating platform, it can be useful to still process images that are not referenced in your JS with Vite - it may even be the case that you don't have any JS and still want to minify your projects' images.

This PR introduces a `Vite::asset()` helper, which can be used in Blade templates to generate the URLs to your projects build assets.

With the following manifest:

```json
{
  "resources/images/logo.jpeg": {
    "file": "assets/logo.1ddf943b.jpeg",
    "src": "resources/images/logo.jpeg"
  },
  "resources/js/app.js": {
    "file": "assets/app.e5198d1b.js",
    "src": "resources/js/app.js",
    "isEntry": true
  }
}
```

You can now generate a URL to the profile image in Blade with the following:

```blade
<img src="{{ Vite::asset('resources/images/logo.jpeg') }}">
```

Which would result in the following HTML:

```html
<img src="http://asset-url.com/build/assets/logo.1ddf943b.jpeg">
```

In build mode, this will generate a URL to the dev server, resulting in the following HTML:

```html
<img src="http://[::1]:5173/resources/images/logo.jpeg">
```

For more information on including static assets in your applications build, see https://github.com/laravel/docs/pull/8124