### PR TITLE
[9.x] Null value for auto-cast field caused deprication warning in php 8.1

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1200,7 +1200,7 @@ trait HasAttributes
      */
     public function fromJson($value, $asObject = false)
     {
-        return json_decode($value, ! $asObject);
+        return json_decode($value ?? '', ! $asObject);
     }
 
     /**


### PR DESCRIPTION
Problem:
- PHP 8.1 no longer supports null for json_decode, and throws a deprication warning
https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
Changed in https://github.com/php/php-src/commit/b10416a652d26577a22fe0b183b2258b20c8bb86#diff-a39ce231303cec12a6d347165931a7f2209ee7dce5989f2e06f8c04143ec7032

However, thr RFC says that `null` is a valid JSON value:
https://datatracker.ietf.org/doc/rfc8259/
```
A JSON value MUST be an object, array, number, or string, or one of
the following three literal names:

    false null true

 The literal names MUST be lowercase.  No other literal names are
 allowed.
```
Thus, auto cast should accept `null` as a valid JSON and not result in a deprecation warning..

also see issue #43705