### PR TITLE
Ensure correct 'integrity' value is used for css assets

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -159,10 +159,12 @@ class Vite
             ));
 
             foreach ($manifest[$entrypoint]['css'] ?? [] as $css) {
+                $partialManifest = Collection::make($manifest)->where('file', $css);
+
                 $tags->push($this->makeTagForChunk(
-                    $entrypoint,
+                    $partialManifest->keys()->first(),
                     asset("{$buildDirectory}/{$css}"),
-                    $manifest[$entrypoint],
+                    $partialManifest->first(),
                     $manifest
                 ));
             }


### PR DESCRIPTION
Like with a css resource that is a dependency of an import, a directly imported css file should also use its own manifest record to make sure the correct integrity value is applied.
Before this change, the `<link` would use the integrity key of the JS asset.