### PR TITLE
[9.x] Request model helper

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Http\Concerns;
 
+use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
@@ -360,6 +361,24 @@ trait InteractsWithInput
         }
 
         return $enumClass::tryFrom($this->input($key));
+    }
+
+    /**
+     * Retrieve input from the request as a model.
+     *
+     * @param  string  $key
+     * @param  string  $modelClass
+     * @return Eloquent|null
+     */
+    public function model($key, $modelClass)
+    {
+        if ($this->isNotFilled($key) ||
+            ! class_exists($modelClass) ||
+            ! new $modelClass instanceof Eloquent) {
+            return null;
+        }
+
+        return $modelClass::find($this->input($key));
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR aims to do similar thing like `$request->enum()` helper only in this case we are binding an Eloquent model instance.
Eg:
```php
$post = $request->model('post_id', Post::class);
```
Just like `enum` helper, it returns `null` if the field is missing from the payload or if there's an invalid key provided in the input field itself.

If that's something worth having I'll provide tests to cover all the cases.