### PR TITLE
adding Arr::match() method

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -494,6 +494,21 @@ class Arr
     }
 
     /**
+     * Match array keys with given keys set
+     *
+     * @param  array  $array
+     * @param  array|string  $keys
+     * @return array
+     */
+    public static function match($array, $keys)
+    {
+        foreach ((array) $keys as $key) {
+            $array[$key] = $array[$key] ?? null;
+        }
+        return static::only($array, $keys);
+    }
+
+    /**
      * Pluck an array of values from an array.
      *
      * @param  iterable  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -497,6 +497,13 @@ class SupportArrTest extends TestCase
         $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
     }
 
+    public function testMatch()
+    {
+        $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];
+        $array = Arr::match($array, ['name', 'price', 'color']);
+        $this->assertEquals(['name' => 'Desk', 'price' => 100, 'color' => null], $array);
+    }
+
     public function testPluck()
     {
         $data = [


### PR DESCRIPTION
#### description

Arr::match() method return an array with values from the given array where their keys match the given set of keys, it keeps **only** the keys that exist in the list and **adds** the missing keys with a null value 

#### usage
formatting arrays with a standard set of keys

#### example 

```PHP
$array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];
$array = Arr::match($array, ['name', 'price', 'color']);
```

#### output
```PHP
[ 
   'name' => 'Desk', 
   'price' => 100, 
   'color' => null
]

```