### PR TITLE
[10.x] Optimize eager loading when no keys to be loaded

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -113,7 +113,7 @@ class BelongsTo extends Relation
 
         $whereIn = $this->whereInMethod($this->related, $this->ownerKey);
 
-        $this->query->{$whereIn}($key, $this->getEagerModelKeys($models));
+        $this->whereInEager($whereIn, $key, $this->getEagerModelKeys($models));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -242,7 +242,8 @@ class BelongsToMany extends Relation
     {
         $whereIn = $this->whereInMethod($this->parent, $this->parentKey);
 
-        $this->whereInEager($whereIn,
+        $this->whereInEager(
+            $whereIn,
             $this->getQualifiedForeignPivotKeyName(),
             $this->getKeys($models, $this->parentKey)
         );

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -242,7 +242,7 @@ class BelongsToMany extends Relation
     {
         $whereIn = $this->whereInMethod($this->parent, $this->parentKey);
 
-        $this->query->{$whereIn}(
+        $this->whereInEager($whereIn,
             $this->getQualifiedForeignPivotKeyName(),
             $this->getKeys($models, $this->parentKey)
         );

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -160,7 +160,7 @@ class HasManyThrough extends Relation
     {
         $whereIn = $this->whereInMethod($this->farParent, $this->localKey);
 
-        $this->query->{$whereIn}(
+        $this->whereInEager($whereIn,
             $this->getQualifiedFirstKeyName(), $this->getKeys($models, $this->localKey)
         );
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -160,8 +160,10 @@ class HasManyThrough extends Relation
     {
         $whereIn = $this->whereInMethod($this->farParent, $this->localKey);
 
-        $this->whereInEager($whereIn,
-            $this->getQualifiedFirstKeyName(), $this->getKeys($models, $this->localKey)
+        $this->whereInEager(
+            $whereIn,
+            $this->getQualifiedFirstKeyName(),
+            $this->getKeys($models, $this->localKey)
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -98,8 +98,10 @@ abstract class HasOneOrMany extends Relation
     {
         $whereIn = $this->whereInMethod($this->parent, $this->localKey);
 
-        $this->whereInEager($whereIn,
-            $this->foreignKey, $this->getKeys($models, $this->localKey),
+        $this->whereInEager(
+            $whereIn,
+            $this->foreignKey,
+            $this->getKeys($models, $this->localKey),
             $this->getRelationQuery()
         );
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -98,8 +98,9 @@ abstract class HasOneOrMany extends Relation
     {
         $whereIn = $this->whereInMethod($this->parent, $this->localKey);
 
-        $this->getRelationQuery()->{$whereIn}(
-            $this->foreignKey, $this->getKeys($models, $this->localKey)
+        $this->whereInEager($whereIn,
+            $this->foreignKey, $this->getKeys($models, $this->localKey),
+            $this->getRelationQuery()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -41,6 +41,13 @@ abstract class Relation implements BuilderContract
     protected $related;
 
     /**
+     * Indicates whether the eagerly loaded relation should implicitly return an empty collection.
+     *
+     * @var bool
+     */
+    protected $eagerImplicitlyEmpty = false;
+
+    /**
      * Indicates if the relation is adding constraints.
      *
      * @var bool

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -161,7 +161,7 @@ abstract class Relation implements BuilderContract
      */
     public function getEager()
     {
-        if ($this->eagerImplicitlyEmpty ?? false) {
+        if ($this->eagerImplicitlyEmpty) {
             return $this->query->getModel()->newCollection();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -45,7 +45,7 @@ abstract class Relation implements BuilderContract
      *
      * @var bool
      */
-    protected $eagerImplicitlyEmpty = false;
+    protected $eagerKeysWereEmpty = false;
 
     /**
      * Indicates if the relation is adding constraints.
@@ -161,11 +161,9 @@ abstract class Relation implements BuilderContract
      */
     public function getEager()
     {
-        if ($this->eagerImplicitlyEmpty) {
-            return $this->query->getModel()->newCollection();
-        }
-
-        return $this->get();
+        return $this->eagerKeysWereEmpty
+                    ? $this->query->getModel()->newCollection()
+                    : $this->get();
     }
 
     /**
@@ -389,6 +387,24 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Add a whereIn eager constraint for the given set of model keys to be loaded.
+     *
+     * @param  string  $whereIn
+     * @param  string  $key
+     * @param  array  $modelKeys
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    protected function whereInEager(string $whereIn, string $key, array $modelKeys, $query = null)
+    {
+        ($query ?? $this->query)->{$whereIn}($key, $modelKeys);
+
+        if ($modelKeys === []) {
+            $this->eagerKeysWereEmpty = true;
+        }
+    }
+
+    /**
      * Get the name of the "where in" method for eager loading.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -401,24 +417,6 @@ abstract class Relation implements BuilderContract
                     && in_array($model->getKeyType(), ['int', 'integer'])
                         ? 'whereIntegerInRaw'
                         : 'whereIn';
-    }
-
-    /**
-     * Add a whereIn eager constraint for the given set of model keys to be loaded.
-     *
-     * @param  string  $whereIn
-     * @param  string  $key
-     * @param  array  $modelKeys
-     * @param  Builder  $query
-     * @return void
-     */
-    protected function whereInEager(string $whereIn, $key, array $modelKeys, $query = null)
-    {
-        ($query ?? $this->query)->{$whereIn}($key, $modelKeys);
-
-        if ($modelKeys === []) {
-            $this->eagerImplicitlyEmpty = true;
-        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -154,6 +154,10 @@ abstract class Relation implements BuilderContract
      */
     public function getEager()
     {
+        if ($this->eagerImplicitlyEmpty ?? false) {
+            return $this->query->getModel()->newCollection();
+        }
+
         return $this->get();
     }
 
@@ -390,6 +394,24 @@ abstract class Relation implements BuilderContract
                     && in_array($model->getKeyType(), ['int', 'integer'])
                         ? 'whereIntegerInRaw'
                         : 'whereIn';
+    }
+
+    /**
+     * Add a whereIn eager constraint for the given set of model keys to be loaded.
+     *
+     * @param  string  $whereIn
+     * @param  string  $key
+     * @param  array  $modelKeys
+     * @param  Builder  $query
+     * @return void
+     */
+    protected function whereInEager(string $whereIn, $key, array $modelKeys, $query = null)
+    {
+        ($query ?? $this->query)->{$whereIn}($key, $modelKeys);
+
+        if ($modelKeys === []) {
+            $this->eagerImplicitlyEmpty = true;
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -767,6 +767,29 @@ class DatabaseEloquentBuilderTest extends TestCase
         unset($_SERVER['__eloquent.constrain']);
     }
 
+    public function testRelationshipEagerLoadProcessForImplicitlyEmpty()
+    {
+        $queryBuilder = $this->getMockQueryBuilder();
+        $builder = m::mock(Builder::class.'[getRelation]', [$queryBuilder]);
+        $builder->setEagerLoads(['parentFoo' => function ($query) {
+            $_SERVER['__eloquent.constrain'] = $query;
+        }]);
+        $model = new EloquentBuilderTestModelSelfRelatedStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+
+        $models = [
+            new EloquentBuilderTestModelSelfRelatedStub,
+            new EloquentBuilderTestModelSelfRelatedStub,
+        ];
+        $relation = m::mock($model->parentFoo());
+
+        $builder->shouldReceive('getRelation')->once()->with('parentFoo')->andReturn($relation);
+
+        $results = $builder->eagerLoadRelations($models);
+
+        unset($_SERVER['__eloquent.constrain']);
+    }
+
     public function testGetRelationProperlySetsNestedRelationships()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Sending this again. @taylorotwell please could you provide suggestions on what I can do to get this merged?

Currently when eager loading relations it causes many impossible wheres to be executed, slowing down application load time. The reason for that is mentioned in the [original PR](https://github.com/laravel/framework/pull/43689) - Laravel will add an impossible where `0 = 1` which would never return a result for an eagerly loaded relation. This PR fixes those eager loading scenarios, which are very common with `NULL` column values.

If you could provide alternative suggestions on how to get this merged that would be great.

![image](https://user-images.githubusercontent.com/1702638/184921022-03c6b137-1149-4048-b597-d70abdc55afc.png)