### PR TITLE
Adding support for non-backed enums

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -814,7 +814,11 @@ trait HasAttributes
             return $value;
         }
 
-        return $castType::from($value);
+        if (is_subclass_of($castType, \BackedEnum::class)) {
+            return $castType::from($value);
+        }
+
+        return constant($castType . '::' . $value);
     }
 
     /**
@@ -1110,7 +1114,7 @@ trait HasAttributes
      * Set the value of an enum castable attribute.
      *
      * @param  string  $key
-     * @param  \BackedEnum  $value
+     * @param  \UnitEnum  $value
      * @return void
      */
     protected function setEnumCastableAttribute($key, $value)
@@ -1119,10 +1123,18 @@ trait HasAttributes
 
         if (! isset($value)) {
             $this->attributes[$key] = null;
-        } elseif ($value instanceof $enumClass) {
-            $this->attributes[$key] = $value->value;
+        } else if (is_subclass_of($enumClass, \BackedEnum::class)) {
+            if ($value instanceof $enumClass) {
+                $this->attributes[$key] = $value->value;
+            } else {
+                $this->attributes[$key] = $enumClass::from($value)->value;
+            }
         } else {
-            $this->attributes[$key] = $enumClass::from($value)->value;
+            if ($value instanceof $enumClass) {
+                $this->attributes[$key] = $value->name;
+            } else {
+                $this->attributes[$key] = constant($enumClass .'::' . $value)->name;
+            }
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1114,7 +1114,7 @@ trait HasAttributes
      * Set the value of an enum castable attribute.
      *
      * @param  string  $key
-     * @param  \UnitEnum  $value
+     * @param  \UnitEnum|string|int  $value
      * @return void
      */
     protected function setEnumCastableAttribute($key, $value)


### PR DESCRIPTION
This PR adds support for non-backed enums when casting eloquent attributes. It works based on the fact that enum cases are glorified constants, so the `constant()` method will work for retrieving.

It also updates the `$value` param type for `Illuminate\Database\Eloquent\Concerns\HasAttributes::setEnumCastableAttribute` from `\BackedEnum` to `\UnitEnum|string|int`. It's worth noting that the original version should have technically been `\BackedEnum|string|int` because there are code paths for handling when it isn't an instance.