### PR TITLE
Add support for additional where* methods to route groups

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -29,6 +29,8 @@ use InvalidArgumentException;
  */
 class RouteRegistrar
 {
+    use CreatesRegularExpressionRouteConstraints;
+
     /**
      * The router instance.
      *

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1367,6 +1367,10 @@ class Router implements BindingRegistrar, RegistrarContract
             return (new RouteRegistrar($this))->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
         }
 
+        if ($method !== 'where' && Str::startsWith($method, 'where')) {
+            return (new RouteRegistrar($this))->{$method}(...$parameters);
+        }
+
         return (new RouteRegistrar($this))->attribute($method, array_key_exists(0, $parameters) ? $parameters[0] : true);
     }
 }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -864,6 +864,142 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testGroupWhereNumberRegistrationOnRouteRegistrar()
+    {
+        $wheres = ['foo' => '[0-9]+', 'bar' => '[0-9]+'];
+
+        $this->router->prefix('/{foo}/{bar}')->whereNumber(['foo', 'bar'])->group(function($router) {
+            $router->get('/');
+        });
+
+        $this->router->prefix('/api/{bar}/{foo}')->whereNumber(['bar', 'foo'])->group(function($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereAlphaRegistrationOnRouteRegistrar()
+    {
+        $wheres = ['foo' => '[a-zA-Z]+', 'bar' => '[a-zA-Z]+'];
+
+        $this->router->prefix('/{foo}/{bar}')->whereAlpha(['foo', 'bar'])->group(function($router) {
+            $router->get('/');
+        });
+
+        $this->router->prefix('/api/{bar}/{foo}')->whereAlpha(['bar', 'foo'])->group(function($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereAlphaNumericRegistrationOnRouteRegistrar()
+    {
+        $wheres = ['1a2b3c' => '[a-zA-Z0-9]+'];
+
+        $this->router->prefix('/{foo}')->whereAlphaNumeric(['1a2b3c'])->group(function($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereInRegistrationOnRouteRegistrar()
+    {
+        $wheres = ['foo' => 'one|two', 'bar' => 'one|two'];
+
+        $this->router->prefix('/{foo}/{bar}')->whereIn(['foo', 'bar'], ['one', 'two'])->group(function($router) {
+            $router->get('/');
+        });
+
+        $this->router->prefix('/api/{bar}/{foo}')->whereIn(['bar', 'foo'], ['one', 'two'])->group(function($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereNumberRegistrationOnRouter()
+    {
+        $wheres = ['foo' => '[0-9]+', 'bar' => '[0-9]+'];
+
+        $this->router->whereNumber(['foo', 'bar'])->prefix('/{foo}/{bar}')->group(function($router) {
+            $router->get('/');
+        });
+
+        $this->router->whereNumber(['bar', 'foo'])->prefix('/api/{bar}/{foo}')->group(function($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereAlphaRegistrationOnRouter()
+    {
+        $wheres = ['foo' => '[a-zA-Z]+', 'bar' => '[a-zA-Z]+'];
+
+        $this->router->whereAlpha(['foo', 'bar'])->prefix('/{foo}/{bar}')->group(function($router) {
+            $router->get('/');
+        });
+
+        $this->router->whereAlpha(['bar', 'foo'])->prefix('/api/{bar}/{foo}')->group(function($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereAlphaNumericRegistrationOnRouter()
+    {
+        $wheres = ['1a2b3c' => '[a-zA-Z0-9]+'];
+
+        $this->router->whereAlphaNumeric(['1a2b3c'])->prefix('/{foo}')->group(function($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testGroupWhereInRegistrationOnRouter()
+    {
+        $wheres = ['foo' => 'one|two', 'bar' => 'one|two'];
+
+        $this->router->whereIn(['foo', 'bar'], ['one', 'two'])->prefix('/{foo}/{bar}')->group(function($router) {
+            $router->get('/');
+        });
+
+        $this->router->whereIn(['bar', 'foo'], ['one', 'two'])->prefix('/api/{bar}/{foo}')->group(function($router) {
+            $router->get('/');
+        });
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -868,11 +868,11 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['foo' => '[0-9]+', 'bar' => '[0-9]+'];
 
-        $this->router->prefix('/{foo}/{bar}')->whereNumber(['foo', 'bar'])->group(function($router) {
+        $this->router->prefix('/{foo}/{bar}')->whereNumber(['foo', 'bar'])->group(function ($router) {
             $router->get('/');
         });
 
-        $this->router->prefix('/api/{bar}/{foo}')->whereNumber(['bar', 'foo'])->group(function($router) {
+        $this->router->prefix('/api/{bar}/{foo}')->whereNumber(['bar', 'foo'])->group(function ($router) {
             $router->get('/');
         });
 
@@ -886,11 +886,11 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['foo' => '[a-zA-Z]+', 'bar' => '[a-zA-Z]+'];
 
-        $this->router->prefix('/{foo}/{bar}')->whereAlpha(['foo', 'bar'])->group(function($router) {
+        $this->router->prefix('/{foo}/{bar}')->whereAlpha(['foo', 'bar'])->group(function ($router) {
             $router->get('/');
         });
 
-        $this->router->prefix('/api/{bar}/{foo}')->whereAlpha(['bar', 'foo'])->group(function($router) {
+        $this->router->prefix('/api/{bar}/{foo}')->whereAlpha(['bar', 'foo'])->group(function ($router) {
             $router->get('/');
         });
 
@@ -904,7 +904,7 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['1a2b3c' => '[a-zA-Z0-9]+'];
 
-        $this->router->prefix('/{foo}')->whereAlphaNumeric(['1a2b3c'])->group(function($router) {
+        $this->router->prefix('/{foo}')->whereAlphaNumeric(['1a2b3c'])->group(function ($router) {
             $router->get('/');
         });
 
@@ -918,11 +918,11 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['foo' => 'one|two', 'bar' => 'one|two'];
 
-        $this->router->prefix('/{foo}/{bar}')->whereIn(['foo', 'bar'], ['one', 'two'])->group(function($router) {
+        $this->router->prefix('/{foo}/{bar}')->whereIn(['foo', 'bar'], ['one', 'two'])->group(function ($router) {
             $router->get('/');
         });
 
-        $this->router->prefix('/api/{bar}/{foo}')->whereIn(['bar', 'foo'], ['one', 'two'])->group(function($router) {
+        $this->router->prefix('/api/{bar}/{foo}')->whereIn(['bar', 'foo'], ['one', 'two'])->group(function ($router) {
             $router->get('/');
         });
 
@@ -936,11 +936,11 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['foo' => '[0-9]+', 'bar' => '[0-9]+'];
 
-        $this->router->whereNumber(['foo', 'bar'])->prefix('/{foo}/{bar}')->group(function($router) {
+        $this->router->whereNumber(['foo', 'bar'])->prefix('/{foo}/{bar}')->group(function ($router) {
             $router->get('/');
         });
 
-        $this->router->whereNumber(['bar', 'foo'])->prefix('/api/{bar}/{foo}')->group(function($router) {
+        $this->router->whereNumber(['bar', 'foo'])->prefix('/api/{bar}/{foo}')->group(function ($router) {
             $router->get('/');
         });
 
@@ -954,11 +954,11 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['foo' => '[a-zA-Z]+', 'bar' => '[a-zA-Z]+'];
 
-        $this->router->whereAlpha(['foo', 'bar'])->prefix('/{foo}/{bar}')->group(function($router) {
+        $this->router->whereAlpha(['foo', 'bar'])->prefix('/{foo}/{bar}')->group(function ($router) {
             $router->get('/');
         });
 
-        $this->router->whereAlpha(['bar', 'foo'])->prefix('/api/{bar}/{foo}')->group(function($router) {
+        $this->router->whereAlpha(['bar', 'foo'])->prefix('/api/{bar}/{foo}')->group(function ($router) {
             $router->get('/');
         });
 
@@ -972,7 +972,7 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['1a2b3c' => '[a-zA-Z0-9]+'];
 
-        $this->router->whereAlphaNumeric(['1a2b3c'])->prefix('/{foo}')->group(function($router) {
+        $this->router->whereAlphaNumeric(['1a2b3c'])->prefix('/{foo}')->group(function ($router) {
             $router->get('/');
         });
 
@@ -986,11 +986,11 @@ class RouteRegistrarTest extends TestCase
     {
         $wheres = ['foo' => 'one|two', 'bar' => 'one|two'];
 
-        $this->router->whereIn(['foo', 'bar'], ['one', 'two'])->prefix('/{foo}/{bar}')->group(function($router) {
+        $this->router->whereIn(['foo', 'bar'], ['one', 'two'])->prefix('/{foo}/{bar}')->group(function ($router) {
             $router->get('/');
         });
 
-        $this->router->whereIn(['bar', 'foo'], ['one', 'two'])->prefix('/api/{bar}/{foo}')->group(function($router) {
+        $this->router->whereIn(['bar', 'foo'], ['one', 'two'])->prefix('/api/{bar}/{foo}')->group(function ($router) {
             $router->get('/');
         });
 


### PR DESCRIPTION
This PR addresses the change originally mentioned in #43509 and reverted in #43523.

Unlike the original PR, it adds support for all of the additional `where*` methods available on a route, to a route group, by adding the `CreatesRegularExpressionRouteConstraints` trait.

It works directly on the router, handled by `Router::__call` with an explicit check for beginning with `where`, that proxies to the method. There is no check to see if the method exists, because if it does not, it will be passed to the `RouteRegistrar::attributes` method automatically, so will achieve the same without the requirement for an additional condition.

```php
Route::whereIn(['foo', 'bar'], ['one', 'two'])->prefix('/{foo}/{bar}')->group(function () {});
```

And on a `RouteRegistrar`, using the trait.
```php
Route::prefix('/{foo}/{bar}')->whereIn(['foo', 'bar'], ['one', 'two'])->group(function () {});
```

This PR also adds 8 tests that test both of the approaches, as they are slightly different. No changes have been made to `RouteRegistrar::allowedAttributes` because the trait turns them into `where` attributes.