### PR TITLE
Improve display of failures for assertDatabaseHas

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -81,14 +81,14 @@ class HasInDatabase extends Constraint
         $similarResults = $query->where(
             array_key_first($this->data),
             $this->data[array_key_first($this->data)]
-        )->limit($this->show)->get();
+        )->select(array_keys($this->data))->limit($this->show)->get();
 
         if ($similarResults->isNotEmpty()) {
             $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
         } else {
             $query = $this->database->table($table);
 
-            $results = $query->limit($this->show)->get();
+            $results = $query->select(array_keys($this->data))->limit($this->show)->get();
 
             if ($results->isEmpty()) {
                 return 'The table is empty';

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -321,6 +321,8 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $builder->shouldReceive('where')->with($key, $value)->andReturnSelf();
 
+        $builder->shouldReceive('select')->with(array_keys($this->data))->andReturnSelf();
+
         $builder->shouldReceive('limit')->andReturnSelf();
 
         $builder->shouldReceive('where')->with($this->data)->andReturnSelf();


### PR DESCRIPTION
This PR attempts to improve the developer experience when debugging `assertDatabaseHas` test failures.

Currently, when a `assertDatabaseHas` assertion has failed, similar results may be displayed. The current functionality for `assertDatabaseHas` is helpful in many scenarios but in others, it can make it difficult to track down the cause the failure. 

For example, consider the following test assertion:
```
// test code that updates some database table

$this-assertDatabaseHas('some_table',  [
    'column_a' => 'expected_column_a_value',
    'column_e' => 'expected_column_e_value',
    'column_h' => 'expected_column_h_value',
]);
```

When a test failure occurs and similar results are displayed with the failure message, all of the table columns are shown even though, in this case, we were concerned with 3 columns. For example:

```
Failed asserting that a row in the [some_table] matches the attributes {
    'column_a': 'expected_column_a_value',
    'column_h': 'expected_column_h_value',
    'column_e': 'expected_column_e_value',
}

Found similar results: [
    {
        'column_a': 'column_a_value',
        'column_b': 'column_b_value',
        'column_c': 'column_c_value',
        'column_d': 'column_d_value',
        'column_e': 'column_e_value',
        'column_f': 'column_f_value',
        'column_g': 'column_g_value',
        'column_h': 'column_h_value',
        'column_i': 'column_i_value',
        'column_j': 'column_j_value',
        'column_k': 'column_k_value',
        ...
    }
]
```

It can be time consuming to locate each column and compare it to the expectation. Also, when the assertion columns/values are in a different order than the table schema (like in the example above), it makes it that much more complex to find the cause of the failure. The more columns a table has, the more complex it is to track down failures and the less likely a developer is going to pass columns in to their assertions in the same order as the table schema.

The PR includes updates the "similar results" functionality so that only the columns that are being asserted on get displayed back as well as displaying them in the exact order they have been asserted on.

Using the example from above, but including with the changes in this PR make the comparison much simpilar:
```
Failed asserting that a row in the [some_table] matches the attributes {
    'column_a': 'expected_column_a_value',
    'column_h': 'expected_column_h_value',
    'column_e': 'expected_column_e_value',
}

Found similar results: [
    {
        'column_a': 'column_a_value',
        'column_h': 'column_h_value',
        'column_e': 'column_e_value',
    }
]
```