### PR TITLE
[9.x] Always use the write PDO connection to read the just stored pending batch

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -78,7 +78,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     {
         $batch = $this->connection->table($this->table)
                             ->where('id', $batchId)
-                            ->when($useWritePdo, fn($query) => $query->useWritePdo())
+                            ->when($useWritePdo, fn ($query) => $query->useWritePdo())
                             ->first();
 
         if ($batch) {

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -71,12 +71,14 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      * Retrieve information about an existing batch.
      *
      * @param  string  $batchId
+     * @param  bool  $useWritePdo
      * @return \Illuminate\Bus\Batch|null
      */
-    public function find(string $batchId)
+    public function find(string $batchId, bool $useWritePdo = false)
     {
         $batch = $this->connection->table($this->table)
                             ->where('id', $batchId)
+                            ->when($useWritePdo, fn($query) => $query->useWritePdo())
                             ->first();
 
         if ($batch) {
@@ -107,7 +109,8 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             'finished_at' => null,
         ]);
 
-        return $this->find($id);
+        // Use write PDO to prevent reading from a replicated DB immediately after writing
+        return $this->find($id, useWritePdo: true);
     }
 
     /**

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -71,14 +71,13 @@ class DatabaseBatchRepository implements PrunableBatchRepository
      * Retrieve information about an existing batch.
      *
      * @param  string  $batchId
-     * @param  bool  $useWritePdo
      * @return \Illuminate\Bus\Batch|null
      */
-    public function find(string $batchId, bool $useWritePdo = false)
+    public function find(string $batchId)
     {
         $batch = $this->connection->table($this->table)
+                            ->useWritePdo()
                             ->where('id', $batchId)
-                            ->when($useWritePdo, fn ($query) => $query->useWritePdo())
                             ->first();
 
         if ($batch) {
@@ -109,8 +108,7 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             'finished_at' => null,
         ]);
 
-        // Use write PDO to prevent reading from a replicated DB immediately after writing
-        return $this->find($id, useWritePdo: true);
+        return $this->find($id);
     }
 
     /**

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -397,9 +397,8 @@ class BusBatchTest extends TestCase
         $builder = m::spy(Builder::class);
 
         $connection->shouldReceive('table')->andReturn($builder);
-        $builder->shouldReceive('where')->andReturnSelf()
-            ->shouldReceive('when')->passthru()
-            ->shouldReceive('useWritePdo')->andReturnSelf();
+        $builder->shouldReceive('useWritePdo')->andReturnSelf();
+        $builder->shouldReceive('where')->andReturnSelf();
 
         $repository = new DatabaseBatchRepository(
             new BatchFactory(m::mock(Factory::class)), $connection, 'job_batches'
@@ -424,7 +423,7 @@ class BusBatchTest extends TestCase
 
         $connection = m::spy(PostgresConnection::class);
 
-        $connection->shouldReceive('table->where->when->first')
+        $connection->shouldReceive('table->useWritePdo->where->first')
             ->andReturn($m = (object) [
                 'id' => '',
                 'name' => '',

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -396,6 +396,7 @@ class BusBatchTest extends TestCase
 
         $connection->shouldReceive('table')->andReturnSelf()
             ->shouldReceive('where')->andReturnSelf()
+            ->shouldReceive('when')->passthru()
             ->shouldReceive('useWritePdo')->andReturnSelf();
 
         $repository = new DatabaseBatchRepository(

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -395,7 +395,8 @@ class BusBatchTest extends TestCase
         $connection = m::spy(PostgresConnection::class);
 
         $connection->shouldReceive('table')->andReturnSelf()
-            ->shouldReceive('where')->andReturnSelf();
+            ->shouldReceive('where')->andReturnSelf()
+            ->shouldReceive('useWritePdo')->andReturnSelf();
 
         $repository = new DatabaseBatchRepository(
             new BatchFactory(m::mock(Factory::class)), $connection, 'job_batches'
@@ -407,6 +408,8 @@ class BusBatchTest extends TestCase
             ->withArgs(function ($argument) use ($pendingBatch) {
                 return unserialize(base64_decode($argument['options'])) === $pendingBatch->options;
             });
+
+        $connection->shouldHaveReceived('first');
     }
 
     /**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -585,7 +585,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
-        $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.02);
+        $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.05);
     }
 
     public function testRetryWithPassingSleepCallback()
@@ -608,7 +608,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(3, $attempts);
 
         // Make sure we waited 300ms for the first two attempts
-        $this->assertEqualsWithDelta(0.3, microtime(true) - $startTime, 0.02);
+        $this->assertEqualsWithDelta(0.3, microtime(true) - $startTime, 0.05);
     }
 
     public function testRetryWithPassingWhenCallback()
@@ -629,7 +629,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
-        $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.02);
+        $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.05);
     }
 
     public function testRetryWithFailingWhenCallback()
@@ -661,7 +661,7 @@ class SupportHelpersTest extends TestCase
         // Make sure we made four attempts
         $this->assertEquals(4, $attempts);
 
-        $this->assertEqualsWithDelta(0.05 + 0.1 + 0.2, microtime(true) - $startTime, 0.02);
+        $this->assertEqualsWithDelta(0.05 + 0.1 + 0.2, microtime(true) - $startTime, 0.05);
     }
 
     public function testTransform()


### PR DESCRIPTION
Setting the `sticky` option to `false` for a database connection with separate read/write database nodes, results in problems with finding a batchable job right after creation. 

This can happen because the read query is executed on a replicated read-only node directly after writing to the write node. If the select query is executed faster than the database replication takes place, then no batch is found. In that case an exception is thrown because jobs are added to a `null` batch.

This PR fixes this problem by always using the write PDO connection for finding the just created batchable job in the `store()` method in `DatabaseBatchRepository.php`.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
