### PR TITLE
[9.x] Fix unique lock release for broadcast events

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -169,14 +169,18 @@ class BroadcastManager implements FactoryContract
         }
 
         $broadcastEvent = new BroadcastEvent(clone $event);
+
         if ($event instanceof ShouldBeUnique) {
             $broadcastEvent = new UniqueBroadcastEvent(clone $event);
+
             if ($this->mustBeUniqueAndCannotAcquireLock($broadcastEvent)) {
                 return;
             }
         }
 
-        $this->app->make('queue')->connection($event->connection ?? null)->pushOn($queue, $broadcastEvent);
+        $this->app->make('queue')
+            ->connection($event->connection ?? null)
+            ->pushOn($queue, $broadcastEvent);
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -168,13 +168,15 @@ class BroadcastManager implements FactoryContract
             $queue = $event->queue;
         }
 
-        if ($this->mustBeUniqueAndCannotAcquireLock($event)) {
-            return;
+        $broadcastEvent = new BroadcastEvent(clone $event);
+        if($event instanceof ShouldBeUnique) {
+            $broadcastEvent = new UniqueBroadcastEvent(clone $event);
+            if ($this->mustBeUniqueAndCannotAcquireLock($broadcastEvent)) {
+                return;
+            }
         }
 
-        $this->app->make('queue')
-                ->connection($event->connection ?? null)
-                ->pushOn($queue, new BroadcastEvent(clone $event));
+        $this->app->make('queue')->connection($event->connection ?? null)->pushOn($queue, $broadcastEvent);
     }
 
     /**
@@ -185,10 +187,6 @@ class BroadcastManager implements FactoryContract
      */
     protected function mustBeUniqueAndCannotAcquireLock($event)
     {
-        if (! $event instanceof ShouldBeUnique) {
-            return false;
-        }
-
         return ! (new UniqueLock(
             method_exists($event, 'uniqueVia')
                 ? $event->uniqueVia()

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -169,7 +169,7 @@ class BroadcastManager implements FactoryContract
         }
 
         $broadcastEvent = new BroadcastEvent(clone $event);
-        if($event instanceof ShouldBeUnique) {
+        if ($event instanceof ShouldBeUnique) {
             $broadcastEvent = new UniqueBroadcastEvent(clone $event);
             if ($this->mustBeUniqueAndCannotAcquireLock($broadcastEvent)) {
                 return;

--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Broadcasting;
 
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 
 class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
@@ -19,13 +20,6 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
      * @var int
      */
     public $uniqueFor;
-
-    /**
-     * The cache repository implementation that should be used to obtain unique locks.
-     *
-     * @var \Illuminate\Contracts\Cache\Repository
-     */
-    public $uniqueVia;
 
     /**
      * Create a new job handler instance.
@@ -49,12 +43,15 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
             $this->uniqueFor = $event->uniqueFor;
         }
 
-        if (method_exists($event, 'uniqueVia')) {
-            $this->uniqueVia = $event->uniqueVia();
-        } elseif (property_exists($event, 'uniqueVia')) {
-            $this->uniqueVia = $event->uniqueVia;
+        parent::__construct($event);
+    }
+
+    public function uniqueVia()
+    {
+        if (method_exists($this->event, 'uniqueVia')) {
+            return $this->event->uniqueVia();
         }
 
-        parent::__construct($event);
+        return app(Repository::class);
     }
 }

--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Broadcasting;
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
+{
+    /**
+     * The unique lock identifier.
+     *
+     * @var mixed
+     */
+    public $uniqueId;
+
+    /**
+     * The number of seconds the unique lock should be maintained.
+     *
+     * @var int
+     */
+    public $uniqueFor;
+
+    /**
+     * The cache repository implementation that should be used to obtain unique locks.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    public $uniqueVia;
+
+    /**
+     * Create a new job handler instance.
+     *
+     * @param  mixed  $event
+     * @return void
+     */
+    public function __construct($event)
+    {
+        $this->uniqueId = get_class($event);
+
+        if (method_exists($event, 'uniqueId')) {
+            $this->uniqueId .= $event->uniqueId();
+        } elseif (property_exists($event, 'uniqueId')) {
+            $this->uniqueId .= $event->uniqueId;
+        }
+
+        if (method_exists($event, 'uniqueFor')) {
+            $this->uniqueFor = $event->uniqueFor();
+        } elseif (property_exists($event, 'uniqueFor')) {
+            $this->uniqueFor = $event->uniqueFor;
+        }
+
+        if (method_exists($event, 'uniqueVia')) {
+            $this->uniqueVia = $event->uniqueVia();
+        } elseif (property_exists($event, 'uniqueVia')) {
+            $this->uniqueVia = $event->uniqueVia;
+        }
+
+        parent::__construct($event);
+    }
+}

--- a/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/UniqueBroadcastEvent.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Broadcasting;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 
@@ -22,7 +23,7 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
     public $uniqueFor;
 
     /**
-     * Create a new job handler instance.
+     * Create a new event instance.
      *
      * @param  mixed  $event
      * @return void
@@ -46,12 +47,15 @@ class UniqueBroadcastEvent extends BroadcastEvent implements ShouldBeUnique
         parent::__construct($event);
     }
 
+    /**
+     * Resolve the cache implementation that should manage the event's uniqueness.
+     *
+     * @return \Illuminate\Contracts\Cache\Repository
+     */
     public function uniqueVia()
     {
-        if (method_exists($this->event, 'uniqueVia')) {
-            return $this->event->uniqueVia();
-        }
-
-        return app(Repository::class);
+        return method_exists($this->event, 'uniqueVia')
+                ? $this->event->uniqueVia()
+                : Container::getInstance()->make(Repository::class);
     }
 }

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -19,6 +19,7 @@
         "psr/log": "^1.0|^2.0|^3.0",
         "illuminate/bus": "^9.0",
         "illuminate/collections": "^9.0",
+        "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/queue": "^9.0",
         "illuminate/support": "^9.0"

--- a/tests/Integration/Broadcasting/BroadcastManagerTest.php
+++ b/tests/Integration/Broadcasting/BroadcastManagerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Broadcasting;
 
 use Illuminate\Broadcasting\BroadcastEvent;
+use Illuminate\Broadcasting\UniqueBroadcastEvent;
 use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
@@ -43,10 +44,10 @@ class BroadcastManagerTest extends TestCase
 
         Broadcast::queue(new TestEventUnique);
 
-        Bus::assertNotDispatched(BroadcastEvent::class);
-        Queue::assertPushed(BroadcastEvent::class);
+        Bus::assertNotDispatched(UniqueBroadcastEvent::class);
+        Queue::assertPushed(UniqueBroadcastEvent::class);
 
-        $lockKey = 'laravel_unique_job:'.TestEventUnique::class;
+        $lockKey = 'laravel_unique_job:'.UniqueBroadcastEvent::class.TestEventUnique::class;
         $this->assertFalse($this->app->get(Cache::class)->lock($lockKey, 10)->get());
     }
 }


### PR DESCRIPTION
This fix fixes not triggered lock release of #43416, #43516. It added back the UniqueBroadcastEvent class created by @DougSisk but now the uniqueId will always include the original event class. 

The regular BroadcastEvent does not implement the 'Queue' ShouldBeUnique and wasn't removing the lock. Now it is possible to dispatch the same event and id after the previous has been processed. 