### PR TITLE
[9.x] Move unique lock release

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -44,7 +44,7 @@ class UniqueLock
     }
 
     /**
-     * Release lock for the given job.
+     * Release the lock for the given job.
      *
      * @param  mixed  $job
      * @return void
@@ -59,7 +59,7 @@ class UniqueLock
     }
 
     /**
-     * Generate lock key for the given job.
+     * Generate the lock key for the given job.
      *
      * @param  mixed  $job
      * @return string

--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -32,10 +32,6 @@ class UniqueLock
      */
     public function acquire($job)
     {
-        $uniqueId = method_exists($job, 'uniqueId')
-                    ? $job->uniqueId()
-                    : ($job->uniqueId ?? '');
-
         $uniqueFor = method_exists($job, 'uniqueFor')
                     ? $job->uniqueFor()
                     : ($job->uniqueFor ?? 0);
@@ -44,9 +40,36 @@ class UniqueLock
                     ? $job->uniqueVia()
                     : $this->cache;
 
-        return (bool) $cache->lock(
-            $key = 'laravel_unique_job:'.get_class($job).$uniqueId,
-            $uniqueFor
-        )->get();
+        return (bool) $cache->lock($this->getKey($job), $uniqueFor)->get();
+    }
+
+    /**
+     * Release lock for the given job.
+     *
+     * @param  mixed  $job
+     * @return void
+     */
+    public function release($job)
+    {
+        $cache = method_exists($job, 'uniqueVia')
+                    ? $job->uniqueVia()
+                    : $this->cache;
+
+        $cache->lock($this->getKey($job))->forceRelease();
+    }
+
+    /**
+     * Generate lock key for the given job.
+     *
+     * @param  mixed  $job
+     * @return string
+     */
+    protected function getKey($job)
+    {
+        $uniqueId = method_exists($job, 'uniqueId')
+                    ? $job->uniqueId()
+                    : ($job->uniqueId ?? '');
+
+        return 'laravel_unique_job:'.get_class($job).$uniqueId;
     }
 }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -201,11 +201,9 @@ class CallQueuedHandler
      */
     protected function ensureUniqueJobLockIsReleased($command)
     {
-        if (! $command instanceof ShouldBeUnique) {
-            return;
+        if ($command instanceof ShouldBeUnique) {
+            (new UniqueLock($this->container->make(Cache::class)))->release($command);
         }
-
-        (new UniqueLock($this->container->make(Cache::class)))->release($command);
     }
 
     /**

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Exception;
 use Illuminate\Bus\Batchable;
+use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Container\Container;
@@ -204,17 +205,7 @@ class CallQueuedHandler
             return;
         }
 
-        $uniqueId = method_exists($command, 'uniqueId')
-                    ? $command->uniqueId()
-                    : ($command->uniqueId ?? '');
-
-        $cache = method_exists($command, 'uniqueVia')
-                    ? $command->uniqueVia()
-                    : $this->container->make(Cache::class);
-
-        $cache->lock(
-            'laravel_unique_job:'.get_class($command).$uniqueId
-        )->forceRelease();
+        (new UniqueLock($this->container->make(Cache::class)))->release($command);
     }
 
     /**


### PR DESCRIPTION
Currently the unique queue job release is decoupled from the `UniqueLock` class which is used to acquire the lock. Should the logic change on how the key is generated, it would break the release potentially.

This moves the release into the same `UniqueLock` class and ensures both acquisition and release use the same key.