### PR TITLE
[9.x] Added `flatGet` to Collection

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -397,10 +397,10 @@ trait EnumeratesValues
     /**
      * flatten the collection by the given key.
      *
-     * @param  string  $key
+     * @param  \Illuminate\Support\Enumerable<array-key, TKey>|array<array-key, TKey>|string  $key
      * @return static
      */
-    public function flatGet(string $key)
+    public function flatGet($key)
     {
         return $this->only($key)->collapse();
     }

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -395,6 +395,17 @@ trait EnumeratesValues
     }
 
     /**
+     * flatten the collection by the given key.
+     *
+     * @param  string  $key
+     * @return static
+     */
+    public function flatGet(string $key)
+    {
+        return $this->only($key)->collapse();
+    }
+
+    /**
      * Map the values into a new class.
      *
      * @template TMapIntoValue

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1201,6 +1201,16 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('foo', $c->value('pivot.value'));
         $this->assertEquals('bar', $c->where('id', 2)->value('pivot.value'));
     }
+    
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFlatGet($collection)
+    {
+        $c = new $collection([['data' => [1, 2, 3]]]);
+
+        $this->assertEquals([1, 2, 3], $c->flatGet('data')->all());
+    }
 
     /**
      * @dataProvider collectionClassProvider

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1207,7 +1207,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testFlatGet($collection)
     {
-        $c = new $collection([['data' => [1, 2, 3]]]);
+        $c = new $collection(['data' => [1, 2, 3]]);
 
         $this->assertEquals([1, 2, 3], $c->flatGet('data')->all());
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1211,7 +1211,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals([1, 2, 3], $c->flatGet('data')->all());
     }
-
+    
     /**
      * @dataProvider collectionClassProvider
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1201,7 +1201,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('foo', $c->value('pivot.value'));
         $this->assertEquals('bar', $c->where('id', 2)->value('pivot.value'));
     }
-    
+
     /**
      * @dataProvider collectionClassProvider
      */
@@ -1211,7 +1211,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals([1, 2, 3], $c->flatGet('data')->all());
     }
-    
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
It is often when you get data as a collection from external api and you want to only get data from a nested key like so:

```php
//Before

$data = Http::get($url)->collect();

$data->only('data')->collapse();
```

```php
//After

$data = Http::get($url)->collect();

$data->flatGet('data');
```

I'm not quite sure about the name feel free to change if you want to merge the PR.