### PR TITLE
[9.x] Added new method in Attribute Cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -33,6 +33,13 @@ class Attribute
     public $withObjectCaching = true;
 
     /**
+     * Indicates if need to add this attribute in append.
+     *
+     * @var bool
+     */
+    public $withAppend = false;
+
+    /**
      * Create a new attribute accessor / mutator.
      *
      * @param  callable|null  $get
@@ -99,6 +106,18 @@ class Attribute
     public function shouldCache()
     {
         $this->withCaching = true;
+
+        return $this;
+    }
+
+    /**
+     * Enable append for the attribute.
+     *
+     * @return static
+     */
+    public function withAppend()
+    {
+        $this->withAppend = true;
 
         return $this;
     }

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -18,6 +18,11 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
             $table->increments('id');
             $table->timestamps();
         });
+
+        Schema::create('test_eloquent_model_with_appends', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
     }
 
     public function testBasicCustomCasting()
@@ -331,6 +336,19 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
             $this->assertNotSame($previous, $previous = $model->virtualDateTimeWithoutCachingFluent);
         }
     }
+
+    public function testEloquentModelWithAppend()
+    {
+        $model = new TestEloquentModelWithAppend;
+
+        $this->assertTrue(isset($model->name));
+        $this->assertSame('Michael', $model->name);
+        $this->assertTrue($model->hasAppended('name'));
+
+        $this->assertTrue(isset($model->firstName));
+        $this->assertSame('Nabil', $model->firstName);
+        $this->assertFalse($model->hasAppended('firstName'));
+    }
 }
 
 class TestEloquentModelWithAttributeCast extends Model
@@ -518,5 +536,22 @@ class AttributeCastAddress
     {
         $this->lineOne = $lineOne;
         $this->lineTwo = $lineTwo;
+    }
+}
+
+class TestEloquentModelWithAppend extends Model
+{
+    protected function name(): Attribute
+    {
+        return Attribute::get(function () {
+            return 'Michael';
+        })->withAppend();
+    }
+
+    protected function firstName(): Attribute
+    {
+        return Attribute::get(function () {
+            return 'Nabil';
+        });
     }
 }


### PR DESCRIPTION
This pull request adds a new method to attribute Cast `withAppend()`.

Before:
```php
class Employee extends Model
{
    /**
     * The accessors to append to the model's array form.
     *
     * @var array
     */
    protected $appends = [
        'total_time',
    ];

    /**
     * Get the timeEntry's total time.
     *
     * @return \Illuminate\Database\Eloquent\Casts\Attribute
     */
    protected function totalTime(): Attribute
    {
        return Attribute::get(function () {
            return $this->time_end?->diff($this->time_start)->format('%H:%I:%S');
        });
    }
}
```

After:
```php
class Employee extends Model
{
    /**
     * Get the timeEntry's total time.
     *
     * @return \Illuminate\Database\Eloquent\Casts\Attribute
     */
    protected function totalTime(): Attribute
    {
        return Attribute::get(function () {
            return $this->time_end?->diff($this->time_start)->format('%H:%I:%S');
        })->withAppend();
    }
}
```

It needs some modifications, but I don't know what to do