### PR TITLE
[9.x] Add opt-in support for an identity map to Eloquent

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -30,6 +30,8 @@ class DatabaseServiceProvider extends ServiceProvider
         Model::setConnectionResolver($this->app['db']);
 
         Model::setEventDispatcher($this->app['events']);
+
+        Model::setIdentityManager($this->app->make(IdentityManager::class));
     }
 
     /**

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -6,6 +6,7 @@ use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
 use Illuminate\Contracts\Queue\EntityResolver;
 use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Database\Eloquent\IdentityManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\QueueEntityResolver;
 use Illuminate\Support\ServiceProvider;
@@ -43,6 +44,7 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->registerConnectionServices();
         $this->registerEloquentFactory();
         $this->registerQueueableEntityResolver();
+        $this->registerEloquentIdentityManager();
     }
 
     /**
@@ -96,6 +98,18 @@ class DatabaseServiceProvider extends ServiceProvider
             static::$fakers[$locale]->unique(true);
 
             return static::$fakers[$locale];
+        });
+    }
+
+    /**
+     * Register the Eloquent identity map instance in the container.
+     *
+     * @return void
+     */
+    private function registerEloquentIdentityManager()
+    {
+        $this->app->singleton(IdentityManager::class, function ($app) {
+            return new IdentityManager();
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -160,11 +160,13 @@ class Builder implements BuilderContract
      * Create a new Eloquent query builder instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\IdentityManager|null $identityManager
      * @return void
      */
-    public function __construct(QueryBuilder $query)
+    public function __construct(QueryBuilder $query, IdentityManager $identityManager = null)
     {
         $this->query = $query;
+        $this->identityManager = $identityManager;
     }
 
     /**
@@ -597,11 +599,20 @@ class Builder implements BuilderContract
      */
     public function getIdentityManager()
     {
-        if (! isset($this->identityManager)) {
-            $this->identityManager = app(IdentityManager::class);
-        }
-
         return $this->identityManager;
+    }
+
+    /**
+     * Set the underlying query builder instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\IdentityManager  $identityManager
+     * @return $this
+     */
+    public function setIdentityManager($identityManager)
+    {
+        $this->identityManager = $identityManager;
+
+        return $this;
     }
 
     /**
@@ -635,6 +646,7 @@ class Builder implements BuilderContract
     protected function shouldUseIdentityMap()
     {
         return $this->identityIsMapped
+            && isset($this->identityManager)
             && ! $this->refreshIdentityMap
             && empty($this->query->bindings['where'] ?? [])
             && empty($this->query->bindings['join'] ?? [])

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -483,7 +483,7 @@ class Builder implements BuilderContract
             $newIds = [];
 
             foreach ($ids as $id) {
-                $models[$id] = $this->identityModel($id);
+                $models[$id] = $this->identifyModel($id);
 
                 if ($models[$id] === null) {
                     $newIds[] = $id;
@@ -608,10 +608,9 @@ class Builder implements BuilderContract
      * Get a model by its identity, if it is mapped.
      *
      * @param $id
-     *
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    protected function identityModel($id)
+    protected function identifyModel($id)
     {
         if (! $this->shouldUseIdentityMap()) {
             return null;
@@ -944,7 +943,7 @@ class Builder implements BuilderContract
 
             if ($key !== null) {
                 if ($relation->getRelated()->isIdentifiableModel()) {
-                    $loadedModel = $this->identityModel($key);
+                    $loadedModel = $this->identifyModel($key);
 
                     if ($loadedModel !== null) {
                         $loadedModels[] = $loadedModel;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -617,7 +617,7 @@ class Builder implements BuilderContract
         }
 
         $identifier = $this->newModelInstance([
-            $this->getModel()->getKeyName() => $id
+            $this->getModel()->getKeyName() => $id,
         ])->getModelIdentifier();
 
         if ($this->getIdentityManager()->hasModel($identifier)) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -160,7 +160,7 @@ class Builder implements BuilderContract
      * Create a new Eloquent query builder instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\IdentityManager|null $identityManager
+     * @param  \Illuminate\Database\Eloquent\IdentityManager|null  $identityManager
      * @return void
      */
     public function __construct(QueryBuilder $query, IdentityManager $identityManager = null)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -899,10 +899,6 @@ class Builder implements BuilderContract
             $eagerModels = $relation->getEager()->merge($loadedModels);
         }
 
-        $relation->addEagerConstraints($models);
-
-        $constraints($relation);
-
         // Once we have the results, we just match those back up to their parent models
         // using the relationship instance. Then we just return the finished arrays
         // of models which have been eagerly hydrated and are readied for return.

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -43,13 +43,6 @@ class Builder implements BuilderContract
     protected $query;
 
     /**
-     * The identity manager.
-     *
-     * @var \Illuminate\Database\Eloquent\IdentityManager
-     */
-    protected $identityManager;
-
-    /**
      * The model being queried.
      *
      * @var \Illuminate\Database\Eloquent\Model
@@ -160,13 +153,11 @@ class Builder implements BuilderContract
      * Create a new Eloquent query builder instance.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\IdentityManager|null  $identityManager
      * @return void
      */
-    public function __construct(QueryBuilder $query, IdentityManager $identityManager = null)
+    public function __construct(QueryBuilder $query)
     {
         $this->query = $query;
-        $this->identityManager = $identityManager;
     }
 
     /**
@@ -599,20 +590,7 @@ class Builder implements BuilderContract
      */
     public function getIdentityManager()
     {
-        return $this->identityManager;
-    }
-
-    /**
-     * Set the underlying query builder instance.
-     *
-     * @param  \Illuminate\Database\Eloquent\IdentityManager  $identityManager
-     * @return $this
-     */
-    public function setIdentityManager($identityManager)
-    {
-        $this->identityManager = $identityManager;
-
-        return $this;
+        return $this->getModel()::getIdentityManager();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Eloquent\Concerns\QueriesRelationships;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\RecordsNotFoundException;
@@ -881,7 +882,7 @@ class Builder implements BuilderContract
         $newModels = $models;
 
         if ($this->eagerLoadHasNoConstraints($name) && $this->shouldUseIdentityMap()) {
-            if ($relation instanceof BelongsToMany) {
+            if ($relation instanceof MorphTo) {
                 // This is intentionally empty so that the relation doesn't get
                 // caught in the belongs to block below it.
             } else if ($relation instanceof BelongsTo) {
@@ -896,7 +897,15 @@ class Builder implements BuilderContract
 
             $constraints($relation);
 
-            $eagerModels = $relation->getEager()->merge($loadedModels);
+            $eagerModels = $relation->getEager();
+
+            if (! empty($loadedModels)) {
+                if ($eagerModels instanceof \Illuminate\Support\Collection) {
+                    $eagerModels = $eagerModels->merge($loadedModels);
+                } else {
+                    $eagerModels = array_merge($eagerModels, $loadedModels);
+                }
+            }
         }
 
         // Once we have the results, we just match those back up to their parent models

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -892,19 +892,19 @@ class Builder implements BuilderContract
 
         if (empty($newModels)) {
             $eagerModels = $relation->getRelated()->newCollection($loadedModels);
+
+            $newModels = $relation->initRelation($newModels, $name);
         } else {
             $relation->addEagerConstraints($newModels);
 
             $constraints($relation);
 
+            $newModels = $relation->initRelation($newModels, $name);
+
             $eagerModels = $relation->getEager();
 
             if (! empty($loadedModels)) {
-                if ($eagerModels instanceof \Illuminate\Support\Collection) {
-                    $eagerModels = $eagerModels->merge($loadedModels);
-                } else {
-                    $eagerModels = array_merge($eagerModels, $loadedModels);
-                }
+                $eagerModels = $eagerModels->merge($loadedModels);
             }
         }
 
@@ -912,8 +912,7 @@ class Builder implements BuilderContract
         // using the relationship instance. Then we just return the finished arrays
         // of models which have been eagerly hydrated and are readied for return.
         return $relation->match(
-            $relation->initRelation($models, $name),
-            $eagerModels, $name
+            $newModels, $eagerModels, $name
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -586,8 +586,6 @@ class Builder implements BuilderContract
             return $this->findMany($id, $columns);
         }
 
-        $model = $this->identifyModel($id);
-
         return $this->identifyModel($id) ?? $this->whereKey($id)->first($columns);
     }
 
@@ -614,7 +612,7 @@ class Builder implements BuilderContract
      */
     protected function identityModel($id)
     {
-        if (! $this->identityIsMapped || ! $this->shouldUseIdentityMap()) {
+        if (! $this->shouldUseIdentityMap()) {
             return null;
         }
 
@@ -636,7 +634,8 @@ class Builder implements BuilderContract
      */
     protected function shouldUseIdentityMap()
     {
-        return ! $this->refreshIdentityMap
+        return $this->identityIsMapped
+            && ! $this->refreshIdentityMap
             && empty($this->query->bindings['where'] ?? [])
             && empty($this->query->bindings['join'] ?? [])
             && empty($this->query->bindings['having'] ?? []);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -491,7 +491,7 @@ class Builder implements BuilderContract
             }
 
             $newModels = $this->whereKey($newIds)->get($columns);
-            $newModels->each(function (Model $model) use(&$models) {
+            $newModels->each(function (Model $model) use (&$models) {
                 $models[$model->getKey()] = $model;
             });
 
@@ -885,7 +885,7 @@ class Builder implements BuilderContract
             if ($relation instanceof MorphTo) {
                 // This is intentionally empty so that the relation doesn't get
                 // caught in the belongs to block below it.
-            } else if ($relation instanceof BelongsTo) {
+            } elseif ($relation instanceof BelongsTo) {
                 $loadedModels = $this->eagerLoadBelongsToIdentities($relation, $newModels);
             }
         }
@@ -917,10 +917,9 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Determine if the eager loadaed relationship has no constraints.
+     * Determine if the eager loaded relationship has no constraints.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return bool
      */
     protected function eagerLoadHasNoConstraints(string $name): bool
@@ -931,14 +930,13 @@ class Builder implements BuilderContract
     /**
      * Find identity stored models for an eager loaded belongs to relationship.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\BelongsTo $relation
-     * @param array                                             $models
-     *
+     * @param  \Illuminate\Database\Eloquent\Relations\BelongsTo  $relation
+     * @param  array  $models
      * @return array
      */
     protected function eagerLoadBelongsToIdentities(BelongsTo $relation, array &$models): array
     {
-        $newModels    = [];
+        $newModels = [];
         $loadedModels = [];
 
         foreach ($models as $i => $model) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Database\Eloquent\IdentityManager;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelIdentityException;
+use Illuminate\Support\Facades\Date;
+
+trait HandlesModelIdentities
+{
+    /**
+     * Indicates whether this model should be stored by identity.
+     *
+     * @var bool
+     */
+    protected $identifiable = false;
+
+    /**
+     * @var IdentityManager|null
+     */
+    private $identityManager;
+
+    /**
+     * Boot the trait.
+     *
+     * @return void
+     */
+    public static function bootHandlesModelIdentities()
+    {
+        static::deleted(function (Model $model) {
+            $model->forgetModelIdentity();
+        });
+
+        static::created(function (Model $model) {
+            $model->storeModelIdentity();
+        });
+    }
+
+    /**
+     * Get the identifier for the model.
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelIdentityException
+     *
+     * @return string
+     */
+    public function getModelIdentifier()
+    {
+        if (! $this->isIdentifiableModel()) {
+            throw ModelIdentityException::forModel($this);
+        }
+
+        return implode(':', [
+            $this->getConnection()->getName(),
+            static::class,
+            $this->getKey()
+        ]);
+    }
+
+    /**
+     * Determine if this model is identifiable.
+     *
+     * @return bool
+     */
+    public function isIdentifiableModel()
+    {
+        return $this->identifiable;
+    }
+
+    /**
+     * Store this model in the identity manager.
+     *
+     * @return void
+     */
+    public function storeModelIdentity()
+    {
+        $this->getIdentityManager()->storeModel($this);
+    }
+
+    /**
+     * Forget this models identity.
+     *
+     * @return void
+     */
+    public function forgetModelIdentity()
+    {
+        $this->getIdentityManager()->forgetModel($this);
+    }
+
+    /**
+     * Get the identity manager.
+     *
+     * @return \Illuminate\Database\Eloquent\IdentityManager
+     */
+    private function getIdentityManager()
+    {
+        if (! isset($this->identityManager)) {
+            $this->identityManager = app(IdentityManager::class);
+        }
+
+        return $this->identityManager;
+    }
+
+    /**
+     * Determine whether the provided attributes are newer than the provided models attributes.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param array                               $attributes
+     *
+     * @return bool
+     */
+    protected function areAttributesMoreRecent(Model $model, array $attributes)
+    {
+        if (! $this->exists || ! $this->usesTimestamps()) {
+            return true;
+        }
+
+        $updatedAt = $attributes[$this->getUpdatedAtColumn()] ?? null;
+
+        if ($updatedAt !== null) {
+            $format = $this->getDateFormat();
+
+            if (is_numeric($updatedAt)) {
+                $updatedAt = Date::createFromTimestamp($updatedAt);
+            } else if (Date::hasFormat($updatedAt, $format)) {
+                $updatedAt = Date::createFromFormat($format, $updatedAt);
+            }
+        }
+
+        $modelUpdatedAt = $model->getAttribute($this->getUpdatedAtColumn());
+
+        return $modelUpdatedAt === null || $updatedAt === null || $modelUpdatedAt->isBefore($updatedAt);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -31,11 +31,15 @@ trait HandlesModelIdentities
     public static function bootHandlesModelIdentities()
     {
         static::deleted(function (Model $model) {
-            $model->forgetModelIdentity();
+            if ($model->isIdentifiableModel()) {
+                $model->forgetModelIdentity();
+            }
         });
 
         static::created(function (Model $model) {
-            $model->storeModelIdentity();
+            if ($model->isIdentifiableModel()) {
+                $model->storeModelIdentity();
+            }
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -24,26 +24,6 @@ trait HandlesModelIdentities
     private $identityManager;
 
     /**
-     * Boot the trait.
-     *
-     * @return void
-     */
-    public static function bootHandlesModelIdentities()
-    {
-        static::deleted(function (Model $model) {
-            if ($model->isIdentifiableModel()) {
-                $model->forgetModelIdentity();
-            }
-        });
-
-        static::created(function (Model $model) {
-            if ($model->isIdentifiableModel()) {
-                $model->storeModelIdentity();
-            }
-        });
-    }
-
-    /**
      * Get the identifier for the model.
      *
      * @throws \Illuminate\Database\Eloquent\ModelIdentityException

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -21,7 +21,7 @@ trait HandlesModelIdentities
     /**
      * @var IdentityManager|null
      */
-    private $identityManager;
+    protected $identityManager;
 
     /**
      * Get the identifier for the model.

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -39,7 +39,7 @@ trait HandlesModelIdentities
         return implode(':', [
             $this->getConnection()->getName(),
             static::class,
-            $this->getKey()
+            $this->getKey(),
         ]);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -27,7 +27,6 @@ trait HandlesModelIdentities
      * Set the identity manager instance.
      *
      * @param  \Illuminate\Database\Eloquent\IdentityManager  $identityManager
-     * @return static
      */
     public static function setIdentityManager(IdentityManager $identityManager)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -26,8 +26,7 @@ trait HandlesModelIdentities
     /**
      * Set the identity manager instance.
      *
-     * @param \Illuminate\Database\Eloquent\IdentityManager $identityManager
-     *
+     * @param  \Illuminate\Database\Eloquent\IdentityManager  $identityManager
      * @return static
      */
     public static function setIdentityManager(IdentityManager $identityManager)

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -26,9 +26,9 @@ trait HandlesModelIdentities
     /**
      * Get the identifier for the model.
      *
-     * @throws \Illuminate\Database\Eloquent\ModelIdentityException
-     *
      * @return string
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelIdentityException
      */
     public function getModelIdentifier()
     {
@@ -90,9 +90,8 @@ trait HandlesModelIdentities
     /**
      * Determine whether the provided attributes are newer than the provided models attributes.
      *
-     * @param \Illuminate\Database\Eloquent\Model $model
-     * @param array                               $attributes
-     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  array  $attributes
      * @return bool
      */
     protected function areAttributesMoreRecent(Model $model, array $attributes)
@@ -108,7 +107,7 @@ trait HandlesModelIdentities
 
             if (is_numeric($updatedAt)) {
                 $updatedAt = Date::createFromTimestamp($updatedAt);
-            } else if (Date::hasFormat($updatedAt, $format)) {
+            } elseif (Date::hasFormat($updatedAt, $format)) {
                 $updatedAt = Date::createFromFormat($format, $updatedAt);
             }
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -21,7 +21,19 @@ trait HandlesModelIdentities
     /**
      * @var IdentityManager|null
      */
-    protected $identityManager;
+    protected static $identityManager;
+
+    /**
+     * Set the identity manager instance.
+     *
+     * @param \Illuminate\Database\Eloquent\IdentityManager $identityManager
+     *
+     * @return static
+     */
+    public static function setIdentityManager(IdentityManager $identityManager)
+    {
+        static::$identityManager = $identityManager;
+    }
 
     /**
      * Get the identifier for the model.
@@ -50,7 +62,7 @@ trait HandlesModelIdentities
      */
     public function isIdentifiableModel()
     {
-        return $this->identifiable;
+        return static::$identityManager !== null && $this->identifiable;
     }
 
     /**
@@ -60,7 +72,11 @@ trait HandlesModelIdentities
      */
     public function storeModelIdentity()
     {
-        $this->getIdentityManager()->storeModel($this);
+        if (! isset(static::$identityManager)) {
+            return;
+        }
+
+        static::$identityManager->storeModel($this);
     }
 
     /**
@@ -70,21 +86,11 @@ trait HandlesModelIdentities
      */
     public function forgetModelIdentity()
     {
-        $this->getIdentityManager()->forgetModel($this);
-    }
-
-    /**
-     * Get the identity manager.
-     *
-     * @return \Illuminate\Database\Eloquent\IdentityManager
-     */
-    private function getIdentityManager()
-    {
-        if (! isset($this->identityManager)) {
-            $this->identityManager = app(IdentityManager::class);
+        if (! isset(static::$identityManager)) {
+            return;
         }
 
-        return $this->identityManager;
+        static::$identityManager->forgetModel($this);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HandlesModelIdentities.php
@@ -34,6 +34,16 @@ trait HandlesModelIdentities
     }
 
     /**
+     * Get the identity manager instance.
+     *
+     * @return \Illuminate\Database\Eloquent\IdentityManager|null
+     */
+    public static function getIdentityManager()
+    {
+        return self::$identityManager;
+    }
+
+    /**
      * Get the identifier for the model.
      *
      * @return string

--- a/src/Illuminate/Database/Eloquent/IdentityManager.php
+++ b/src/Illuminate/Database/Eloquent/IdentityManager.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Database\Eloquent;
+
+class IdentityManager
+{
+    /**
+     * @var \Illuminate\Support\Collection<string, \Illuminate\Database\Eloquent\Model>
+     */
+    private $models;
+
+    /**
+     * Create a new identity map instance.
+     *
+     * @param \Illuminate\Database\Eloquent\Collection|null $collection
+     */
+    public function __construct(\Illuminate\Support\Collection $collection = null)
+    {
+        $this->models = $collection ?? new \Illuminate\Support\Collection;
+    }
+
+    /**
+     * Get the model identifier from a model or return the provided string.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|string $identifier
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelIdentityException
+     *
+     * @return string
+     */
+    private function getIdentifier(Model|string $identifier)
+    {
+        return $identifier instanceof Model ? $identifier->getModelIdentifier() : $identifier;
+    }
+
+    /**
+     * Determine whether a model is stored for an identifier.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|string $identifier
+     *
+     * @return bool
+     */
+    public function hasModel(Model|string $identifier)
+    {
+        return $this->models->has($this->getIdentifier($identifier));
+    }
+
+    /**
+     * Get a model for the given identifier.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|string $identifier
+     *
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function getModel(Model|string $identifier)
+    {
+        return $this->models->get($identifier);
+    }
+
+    /**
+     * Store the provided model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return static
+     */
+    public function storeModel(Model $model)
+    {
+        $this->models->put($this->getIdentifier($model), $model);
+
+        return $this;
+    }
+
+    /**
+     * Forget the provided model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|string $identifier
+     *
+     * @return static
+     */
+    public function forgetModel(Model|string $identifier)
+    {
+        if ($this->hasModel($identifier)) {
+            $this->models->forget($this->getIdentifier($identifier));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Flush all models from the identity map.
+     *
+     * @return static
+     */
+    public function flushModels()
+    {
+        $this->models = new \Illuminate\Support\Collection;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/IdentityManager.php
+++ b/src/Illuminate/Database/Eloquent/IdentityManager.php
@@ -82,9 +82,7 @@ class IdentityManager
      */
     public function forgetModel(Model|string $identifier)
     {
-        if ($this->hasModel($identifier)) {
-            $this->models->forget($this->getIdentifier($identifier));
-        }
+        $this->models->forget($this->getIdentifier($identifier));
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/IdentityManager.php
+++ b/src/Illuminate/Database/Eloquent/IdentityManager.php
@@ -14,7 +14,7 @@ class IdentityManager
     /**
      * Create a new identity map instance.
      *
-     * @param \Illuminate\Database\Eloquent\Collection|null $collection
+     * @param  \Illuminate\Database\Eloquent\Collection|null  $collection
      */
     public function __construct(\Illuminate\Support\Collection $collection = null)
     {
@@ -24,11 +24,10 @@ class IdentityManager
     /**
      * Get the model identifier from a model or return the provided string.
      *
-     * @param \Illuminate\Database\Eloquent\Model|string $identifier
+     * @param  \Illuminate\Database\Eloquent\Model|string  $identifier
+     * @return string
      *
      * @throws \Illuminate\Database\Eloquent\ModelIdentityException
-     *
-     * @return string
      */
     private function getIdentifier(Model|string $identifier)
     {
@@ -38,8 +37,7 @@ class IdentityManager
     /**
      * Determine whether a model is stored for an identifier.
      *
-     * @param \Illuminate\Database\Eloquent\Model|string $identifier
-     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $identifier
      * @return bool
      */
     public function hasModel(Model|string $identifier)
@@ -50,8 +48,7 @@ class IdentityManager
     /**
      * Get a model for the given identifier.
      *
-     * @param \Illuminate\Database\Eloquent\Model|string $identifier
-     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $identifier
      * @return \Illuminate\Database\Eloquent\Model|null
      */
     public function getModel(Model|string $identifier)
@@ -62,8 +59,7 @@ class IdentityManager
     /**
      * Store the provided model.
      *
-     * @param \Illuminate\Database\Eloquent\Model $model
-     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return static
      */
     public function storeModel(Model $model)
@@ -76,8 +72,7 @@ class IdentityManager
     /**
      * Forget the provided model.
      *
-     * @param \Illuminate\Database\Eloquent\Model|string $identifier
-     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $identifier
      * @return static
      */
     public function forgetModel(Model|string $identifier)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1605,6 +1605,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->setRawAttributes(
             $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
+                ->refreshIdentityMap()
                 ->useWritePdo()
                 ->firstOrFail()
                 ->attributes

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -524,7 +524,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $model->setConnection($connection ?: $this->getConnectionName());
 
-        if ($this->getIdentityManager()->hasModel($model)) {
+        if ($this->isIdentifiableModel() && $this->getIdentityManager()->hasModel($model)) {
             $model = $this->getIdentityManager()->getModel($model);
 
             if ($this->areAttributesMoreRecent($model, $attributes)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2262,7 +2262,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->classCastCache = [];
         $this->attributeCastCache = [];
 
-        return array_keys(get_object_vars($this));
+        return array_keys(Arr::except(get_object_vars($this), 'identityManager'));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1213,6 +1213,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->wasRecentlyCreated = true;
 
+        if ($this->isIdentifiableModel()) {
+            $this->storeModelIdentity();
+        }
+
         $this->fireModelEvent('created', false);
 
         return true;
@@ -1302,6 +1306,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         $this->touchOwners();
 
         $this->performDeleteOnModel();
+
+        if ($this->isIdentifiableModel()) {
+            $this->forgetModelIdentity();
+        }
 
         // Once the model has been deleted, we will fire off the deleted event so that
         // the developers may hook into post-delete operations. We will then return

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -524,8 +524,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $model->setConnection($connection ?: $this->getConnectionName());
 
-        if ($this->isIdentifiableModel() && $this->getIdentityManager()->hasModel($model)) {
-            $model = $this->getIdentityManager()->getModel($model);
+        if ($this->isIdentifiableModel() && static::$identityManager->hasModel($model)) {
+            $model = static::$identityManager->getModel($model);
 
             if ($this->areAttributesMoreRecent($model, $attributes)) {
                 $dirtyAttributes = $model->getDirty();
@@ -1472,7 +1472,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newEloquentBuilder($query)
     {
-        return new Builder($query);
+        return new Builder($query, static::$identityManager);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/ModelIdentityException.php
+++ b/src/Illuminate/Database/Eloquent/ModelIdentityException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class ModelIdentityException extends RuntimeException
+{
+    /**
+     * Create a new model identity exception for the model.
+     *
+     * @param  mixed  $model
+     *
+     * @return static
+     */
+    public static function forModel($model)
+    {
+        return new static('Model ['.get_class($model).'] is not identifiable');
+    }
+}

--- a/src/Illuminate/Database/Eloquent/ModelIdentityException.php
+++ b/src/Illuminate/Database/Eloquent/ModelIdentityException.php
@@ -12,7 +12,6 @@ class ModelIdentityException extends RuntimeException
      * Create a new model identity exception for the model.
      *
      * @param  mixed  $model
-     *
      * @return static
      */
     public static function forModel($model)

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2183,6 +2183,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model->shouldReceive('getKeyName')->andReturn('foo');
         $model->shouldReceive('getTable')->andReturn('foo_table');
         $model->shouldReceive('getQualifiedKeyName')->andReturn('foo_table.foo');
+        $model->shouldReceive('isIdentifiableModel')->andReturn(false);
 
         return $model;
     }


### PR DESCRIPTION
This PR adds identity map support to Eloquent as an opt-in feature controlled by `Model::$identifiable`.

## Summary
Models that are marked as identifiable will have an identity, provided by `Model::getModelIdentifier()`, which by default will use the following format:

```
connectionName:className:key
```

When an instance of the model is created, it is stored in the `IdentityManager`. Every attempt thereafter to retrieve the same model from the database will give the same object.

This means that in the following example, all 3 variables contain the same instance.

```php
$user1 = auth()->user();
$user2 = User::find(auth()->id());
$user3 = User::find(auth()->id());
```

## Usage
### Finding
Any calls to `find()`, `findOrFail()` or `findOrNew()` on a model that is identifiable, will skip the query
if a model has already been created using the provided id.

Calls to `findMany()` will skip any ids that have already been used, only querying ones that are not present in the cache.

The query is skipped if there are no where clauses, joins or having statements.

If you wish to force the query, you can call `refreshIdentityMap()` on the query builder instance. If you wish to skip
the query on a builder instance where `refreshIdentityMap()` has been called, you can call `useIdentityMap()`.

### Hydrating
When the query builder attempts to create a new instance of an identifiable, with a key that matches an already 
existing instance of the model, the existing instance will be used.

If the model is using timestamps, and the returned attributes are newer, the attributes on the existing instance will be
updated, but will retain any changes you'd previously made.

### BelongsTo
If a belongs to relationship is loaded (not belongs to many) without constraints and without `refreshIdentityMap()` being 
called, the query will skip any model instances that already exist.

### Flushing
If you wish to flush the cached models, call `flushModels()` on an instance of `IdentityManager`, or on the `Identity`
facade.

## How
The `IdentityManager` stores an array containing all existing model instances keyed by their identity.

## Why
It's very easy to end up with multiple versions of the same model, meaning that updates on one aren't persisted
to others.

This aims to reduce the number of models created, help limit unnecessary queries, and allow for consistent model interaction. It doesn't matter where in your code you're dealing with user 1, any changes made during a request
will persist across all instances.