### PR TITLE
[9.x] Add ability to resolve a parser 

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -565,7 +565,7 @@ class Validator implements ValidatorContract
     {
         $this->currentRule = $rule;
 
-        [$rule, $parameters] = ValidationRuleParser::parse($rule);
+        [$rule, $parameters] = $this->parser()::parse($rule);
 
         if ($rule === '') {
             return;
@@ -1025,7 +1025,7 @@ class Validator implements ValidatorContract
         $rules = (array) $rules;
 
         foreach ($this->rules[$attribute] as $rule) {
-            [$rule, $parameters] = ValidationRuleParser::parse($rule);
+            [$rule, $parameters] = $this->parser()::parse($rule);
 
             if (in_array($rule, $rules)) {
                 return [$rule, $parameters];
@@ -1121,8 +1121,7 @@ class Validator implements ValidatorContract
         // The primary purpose of this parser is to expand any "*" rules to the all
         // of the explicit rules needed for the given data. For example the rule
         // names.* would get expanded to names.0, names.1, etc. for this data.
-        $response = (new ValidationRuleParser($this->data))
-                            ->explode(ValidationRuleParser::filterConditionalRules($rules, $this->data));
+        $response = $this->parser()->explode($this->parser()::filterConditionalRules($rules, $this->data));
 
         $this->rules = array_merge_recursive(
             $this->rules, $response->rules
@@ -1146,7 +1145,7 @@ class Validator implements ValidatorContract
         $payload = new Fluent($this->data);
 
         foreach ((array) $attribute as $key) {
-            $response = (new ValidationRuleParser($this->data))->explode([$key => $rules]);
+            $response = $this->parser()->explode([$key => $rules]);
 
             $this->implicitAttributes = array_merge($response->implicitAttributes, $this->implicitAttributes);
 
@@ -1534,5 +1533,15 @@ class Validator implements ValidatorContract
         throw new BadMethodCallException(sprintf(
             'Method %s::%s does not exist.', static::class, $method
         ));
+    }
+
+    /**
+     * The rule parser.
+     *
+     * @return \Illuminate\Validation\ValidationRuleParser
+     */
+    protected function parser()
+    {
+        return new ValidationRuleParser($this->data);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is an attempt at solving the issues outlined in #43192 where validating field names or values that contain a pipe no longer work in Laravel 9.

There's more detail in the issue but, as a simple summary, in Laravel 8 it was possible to perform validation on fields/values that used a pipe character when you opted to use the array syntax of defining validation rules rather than the string-based rules that use a pipe delimiter.

As an example, the below **would not** work in Laravel 8

```
Validator::make(
    [
        '|field' => 'somevalue|foo'
    ], 
    [
        '|field' => 'ends_with:|foo,|bar'
    ]
)->passes() // BadMethodCallException with message 'Method Illuminate\Validation\Validator::validateFoo, does not exist.'
```

But the below **would** work in Laravel 8

```
Validator::make(
    [
        '|field' => 'somevalue|foo'
    ], 
    [
        '|field' => [
            'ends_with:|foo,|bar'
        ]
    ]
)->passes() // true
```

In Laravel 9,  `Rule::forEach` was added and to support its functionality the rules need to be flattened so that it can be detected whether a rule is an instance of NestedRules.
This is done inside of the `explodeWildcardRules` method where this is the behaviour in Laravel 9

```
foreach (Arr::flatten((array) $rules) as $rule) {
    // ...
}
```

Whereas in Laravel 8 it was 

```
foreach ((array) $rules as $rule) {
    // ...
}
```

The result of this change is that when you're working with an array of validation rules, they're now parsed one-by-one rather than as an array of rules that they were passed through as.

Considering that these are string rules, they then inevitably enter the string check inside of the `explodeExplicitRule` method:

```
if (is_string($rule)) {
    [$name] = static::parseStringRule($rule);

    return static::ruleIsRegex($name) ? [$rule] : explode('|', $rule);
}
```

And as such are unintentionally being split on the pipe now. As is evident in the code block above, and detailed more in #40924, this issue also affected regex rules but a workaround was added to address that specific rule.

I explored a few different options to add this support, but they all had drawbacks, assumptions, or breaking changes, and so I've opted for a solution that doesn't really alter any framework code, but allows the flexibility for someone inside their project to override how this works in any way that they want.

By moving the resolution of the `ValidationRuleParser` to a method, we can extend the `Validator` class and override the `parser` method to return a different, extended instance of the `ValidationRuleParser` that allows a developer to change any functionality they like; including changing how string rules are split if you _need_ to work with fields/values that use pipes in them.

This solution offers the ability to specify at a _per validator_ level, custom resolution logic (or not) such that you can isolate your behaviour to single instances of the validator rather than overriding how it works globally in your app.
Of course, you could still extend the `Validator` and update the two methods that new up the `ValidationRuleParser` but this means you need to override and maintain that entire method just to use an extended `ValidationRuleParser` - using the proposed solution you can just change it in one place and it's used everywhere a `ValidationRuleParser` is required.

An alternative solution could use statics or container bindings to resolve/override a custom delimiting function to offer similar control to the developer to change how rules are split but suffers from the fact that this is a global change and as such could have unintended side-effects if you were performing multiple levels of validation (although I'm unsure how common this would actually be).