### PR TITLE
Added Authentication keyword for ODBC driver

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -160,6 +160,10 @@ class SqlServerConnector extends Connector implements ConnectorInterface
             $arguments['LoginTimeout'] = $config['login_timeout'];
         }
 
+        if (isset($config['authentication'])) {
+            $arguments['Authentication'] = $config['authentication'];
+        }
+
         return $this->buildConnectString('sqlsrv', $arguments);
     }
 


### PR DESCRIPTION
Existing functionality does not allow the Authentication keyword to be passed into the DSN when connecting to a SQL Server instance. This prevents developers connecting to a SQL Server instance using Azure AD.

Setting the authentication keyword is done by adding the authentication option to the DSN string. Example: "sqlsrv:Server=server;Database=dbname;Authentication=ActiveDirectoryPassword"

References:
[Microsoft Guide - Connect via Azure AD Auth](https://docs.microsoft.com/en-us/sql/connect/php/azure-active-directory?view=sql-server-ver16)
[Microsoft connection options documentation](https://docs.microsoft.com/en-us/sql/connect/php/connection-options?view=sql-server-ver16)