### PR TITLE
[9.x] Fix empty collection class serialization

### DIFF
--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -35,19 +35,28 @@ class ModelIdentifier
     public $connection;
 
     /**
+     * The class name of the model collection.
+     *
+     * @var string|null
+     */
+    public $collectionClass;
+
+    /**
      * Create a new model identifier.
      *
      * @param  string  $class
      * @param  mixed  $id
      * @param  array  $relations
      * @param  mixed  $connection
+     * @param  string  $collectionClass
      * @return void
      */
-    public function __construct($class, $id, array $relations, $connection)
+    public function __construct($class, $id, array $relations, $connection, $collectionClass = null)
     {
         $this->id = $id;
         $this->class = $class;
         $this->relations = $relations;
         $this->connection = $connection;
+        $this->collectionClass = $collectionClass;
     }
 }

--- a/src/Illuminate/Contracts/Database/ModelIdentifier.php
+++ b/src/Illuminate/Contracts/Database/ModelIdentifier.php
@@ -48,15 +48,26 @@ class ModelIdentifier
      * @param  mixed  $id
      * @param  array  $relations
      * @param  mixed  $connection
-     * @param  string  $collectionClass
      * @return void
      */
-    public function __construct($class, $id, array $relations, $connection, $collectionClass = null)
+    public function __construct($class, $id, array $relations, $connection)
     {
         $this->id = $id;
         $this->class = $class;
         $this->relations = $relations;
         $this->connection = $connection;
+    }
+
+    /**
+     * Specify the collection class that should be used when serializing / restoring collections.
+     *
+     * @param  string|null  $collectionClass
+     * @return $this
+     */
+    public function useCollectionClass(?string $collectionClass)
+    {
         $this->collectionClass = $collectionClass;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -24,7 +24,8 @@ trait SerializesAndRestoresModelIdentifiers
                 $value->getQueueableClass(),
                 $value->getQueueableIds(),
                 $value->getQueueableRelations(),
-                $value->getQueueableConnection()
+                $value->getQueueableConnection(),
+                get_class($value)
             );
         }
 
@@ -66,7 +67,9 @@ trait SerializesAndRestoresModelIdentifiers
     protected function restoreCollection($value)
     {
         if (! $value->class || count($value->id) === 0) {
-            return new EloquentCollection;
+            return ! is_null($value->collectionClass ?? null)
+                ? new $value->collectionClass
+                : new EloquentCollection;
         }
 
         $collection = $this->getQueryForModelRestoration(

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -25,7 +25,9 @@ trait SerializesAndRestoresModelIdentifiers
                 $value->getQueueableIds(),
                 $value->getQueueableRelations(),
                 $value->getQueueableConnection(),
-                get_class($value)
+                ($collectionClass = get_class($value)) !== EloquentCollection::class
+                    ? $collectionClass
+                    : null
             );
         }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -20,11 +20,12 @@ trait SerializesAndRestoresModelIdentifiers
     protected function getSerializedPropertyValue($value)
     {
         if ($value instanceof QueueableCollection) {
-            return new ModelIdentifier(
+            return (new ModelIdentifier(
                 $value->getQueueableClass(),
                 $value->getQueueableIds(),
                 $value->getQueueableRelations(),
-                $value->getQueueableConnection(),
+                $value->getQueueableConnection()
+            ))->useCollectionClass(
                 ($collectionClass = get_class($value)) !== EloquentCollection::class
                     ? $collectionClass
                     : null

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -376,7 +376,6 @@ class ModelSerializationTypedCustomCollectionTestClass
     }
 }
 
-
 class ModelSerializationTestCustomUser extends Model
 {
     public $table = 'users';

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -314,8 +314,20 @@ class ModelSerializationTest extends TestCase
         $serialized = serialize(new ModelSerializationParentAccessibleTestClass($user, $user, $user));
 
         $this->assertSame(
-            'O:78:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationParentAccessibleTestClass":2:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";}s:8:"'."\0".'*'."\0".'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";}}', $serialized
+            'O:78:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationParentAccessibleTestClass":2:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":5:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}s:8:"'."\0".'*'."\0".'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":5:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:7:"testing";s:15:"collectionClass";N;}}', $serialized
         );
+    }
+
+    public function test_serialization_types_empty_custom_eloquent_collection()
+    {
+        $class = new ModelSerializationTypedCustomCollectionTestClass(
+            new ModelSerializationTestCustomUserCollection());
+
+        $serialized = serialize($class);
+
+        unserialize($serialized);
+
+        $this->assertTrue(true);
     }
 }
 
@@ -351,6 +363,19 @@ class ModelSerializationTestCustomUserCollection extends Collection
 {
     //
 }
+
+class ModelSerializationTypedCustomCollectionTestClass
+{
+    use SerializesModels;
+
+    public ModelSerializationTestCustomUserCollection $collection;
+
+    public function __construct(ModelSerializationTestCustomUserCollection $collection)
+    {
+        $this->collection = $collection;
+    }
+}
+
 
 class ModelSerializationTestCustomUser extends Model
 {


### PR DESCRIPTION
This fixes an issue where restoring a custom Eloquent collection wouldn't be of the same type. We should save the class type in the ModelIdentifier class to achieve this.

Fixes #43732
