### PR TITLE
Check if middleware is really set on the route

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -64,6 +64,13 @@ trait MakesHttpRequests
     protected $withCredentials = false;
 
     /**
+     * Automatically apply assertMiddleware to TestResponse
+     *
+     * @var array
+     */
+    protected $assertMiddleware = [];
+
+    /**
      * Define additional headers to be sent with the request.
      *
      * @param  array  $headers
@@ -161,6 +168,8 @@ trait MakesHttpRequests
                     return $next($request);
                 }
             });
+
+            $this->assertMiddleware[] = $abstract;
         }
 
         return $this;
@@ -544,7 +553,13 @@ trait MakesHttpRequests
             $response = $this->followRedirects($response);
         }
 
-        return $this->createTestResponse($response);
+        $testResponse = $this->createTestResponse($response);
+        $testResponse->setRequestRoute($request->route());
+        if(count($this->assertMiddleware) > 0) {
+            $testResponse->assertMiddleware($this->assertMiddleware);
+        }
+
+        return $testResponse;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -64,7 +64,7 @@ trait MakesHttpRequests
     protected $withCredentials = false;
 
     /**
-     * Automatically apply assertMiddleware to TestResponse
+     * Automatically apply assertMiddleware to TestResponse.
      *
      * @var array
      */
@@ -555,7 +555,7 @@ trait MakesHttpRequests
 
         $testResponse = $this->createTestResponse($response);
         $testResponse->setRequestRoute($request->route());
-        if(count($this->assertMiddleware) > 0) {
+        if (count($this->assertMiddleware) > 0) {
             $testResponse->assertMiddleware($this->assertMiddleware);
         }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1458,7 +1458,7 @@ EOF;
      */
     public function assertMiddleware($middleware)
     {
-        if($this->requestRoute === null) {
+        if ($this->requestRoute === null) {
             PHPUnit::fail('Can not assert middleware because route does not exists (http error 404)');
 
             return $this;
@@ -1469,7 +1469,7 @@ EOF;
 
         $notFoundMiddleware = array_diff((array) $middleware, $requestRouteMiddleware);
 
-        PHPUnit::assertTrue(count($notFoundMiddleware) == 0, 'Middleware '. Arr::join($notFoundMiddleware, ', ', 'and') .' not found');
+        PHPUnit::assertTrue(count($notFoundMiddleware) == 0, 'Middleware '.Arr::join($notFoundMiddleware, ', ', 'and').' not found');
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1980,7 +1980,7 @@ class TestResponseTest extends TestCase
 
         app()->instance('router', $router);
 
-        $route = new Route('get', '/', function() {
+        $route = new Route('get', '/', function () {
         });
         $route->middleware('MiddlewareGroup');
         $route->middleware('MiddlewareClass');

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Testing;
 
 use Exception;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -1981,8 +1980,7 @@ class TestResponseTest extends TestCase
 
         app()->instance('router', $router);
 
-        $route = new Route('get', '/', function(){
-
+        $route = new Route('get', '/', function() {
         });
         $route->middleware('MiddlewareGroup');
         $route->middleware('MiddlewareClass');


### PR DESCRIPTION
If you currently calling withoutMiddleware within your tests they will pass even if the skipped middleware is not on the route. This can lead to security issues because you are assuming that the middleware is set.

This PR will automaticly check if the skipped middleware is on the requested route. I also added the assertMiddleware check to the TestResponse object so you can check if middleware is present even if you have not skipped it.

This PR can be a breaking change to the test of current laravel projects because they fail now if there is middleware that is skipped that is not set. But I think that is a good thing. Because you are assuming it is set.