### PR TITLE
[9.x] Add ability to discard Eloquent Model changes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1885,6 +1885,19 @@ trait HasAttributes
     }
 
     /**
+     * Discard attribute(s) changes.
+     *
+     * @return $this
+     */
+    public function discardChanges()
+    {
+        $this->attributes = $this->original;
+        $this->changes = [];
+
+        return $this;
+    }
+
+    /**
      * Determine if the model or any of the given attribute(s) were changed when the model was last saved.
      *
      * @param  array|string|null  $attributes

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1885,14 +1885,13 @@ trait HasAttributes
     }
 
     /**
-     * Discard attribute(s) changes.
+     * Discard attribute changes and reset the attributes to their original state.
      *
      * @return $this
      */
     public function discardChanges()
     {
-        $this->attributes = $this->original;
-        $this->changes = [];
+        [$this->attributes, $this->changes] = [$this->original, []];
 
         return $this;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2414,6 +2414,23 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertNull($user->name);
     }
+
+    public function testDiscardChanges()
+    {
+        $user = new EloquentModelStub([
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $this->assertNotEmpty($user->isDirty());
+        $this->assertNull($user->getOriginal('name'));
+        $this->assertSame('Taylor Otwell', $user->getAttribute('name'));
+
+        $user->discardChanges();
+
+        $this->assertEmpty($user->isDirty());
+        $this->assertNull($user->getOriginal('name'));
+        $this->assertNull($user->getAttribute('name'));
+    }
 }
 
 class EloquentTestObserverStub

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -64,6 +64,36 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertTrue($user->wasChanged());
         $this->assertTrue($user->wasChanged('name'));
     }
+
+    public function testDiscardChanges()
+    {
+        $user = TestModel2::create([
+            'name' => $originalName = Str::random(), 'title' => Str::random(),
+        ]);
+
+        $this->assertEmpty($user->getDirty());
+        $this->assertEmpty($user->getChanges());
+        $this->assertFalse($user->isDirty());
+        $this->assertFalse($user->wasChanged());
+
+        $user->name = $overideName = Str::random();
+
+        $this->assertEquals(['name' => $overideName], $user->getDirty());
+        $this->assertEmpty($user->getChanges());
+        $this->assertTrue($user->isDirty());
+        $this->assertFalse($user->wasChanged());
+        $this->assertSame($originalName, $user->getOriginal('name'));
+        $this->assertSame($overideName, $user->getAttribute('name'));
+
+        $user->discardChanges();
+
+        $this->assertEmpty($user->getDirty());
+        $this->assertSame($originalName, $user->getOriginal('name'));
+        $this->assertSame($originalName, $user->getAttribute('name'));
+
+        $user->save();
+        $this->assertFalse($user->wasChanged());
+    }
 }
 
 class TestModel1 extends Model


### PR DESCRIPTION
```php
Project::updating(function (Project $model) {
    /*
     * The project update should be a change request
     */
    $changeRequest = new ProjectChangeRequest([
        'original' => array_intersect_key($model->getRawOriginal(), $model->getDirty()),
        'changes' => $model->getDirty(),
    ]);

    $changeRequest->source_model()->associate($model);
    $changeRequest->save();

    // Now we can simply ignore all attribute changes and only save `status="change_request"`
    $model->discardChanges();

    $model->status = 'change_request';
});
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

