### PR TITLE
[9.x] Mock dns check during tests

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -117,13 +117,28 @@ trait ValidatesAttributes
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
-                return count(dns_get_record($url.'.', DNS_A | DNS_AAAA)) > 0;
+                $records = $this->getDnsRecords($url.'.', DNS_A | DNS_AAAA);
+                if (is_array($records) && count($records) > 0) {
+                    return true;
+                }
             } catch (Exception $e) {
                 return false;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Overwritable dns check method. Can be mocked in tests to avoid actual calls.
+     *
+     * @param  string  $hostname
+     * @param  int  $type
+     * @return array|false
+     */
+    protected function getDnsRecords($hostname, $type)
+    {
+        return dns_get_record($hostname, $type);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -118,6 +118,7 @@ trait ValidatesAttributes
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
                 $records = $this->getDnsRecords($url.'.', DNS_A | DNS_AAAA);
+
                 if (is_array($records) && count($records) > 0) {
                     return true;
                 }
@@ -130,7 +131,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Overwritable dns check method. Can be mocked in tests to avoid actual calls.
+     * Get the DNS records for the given hostname.
      *
      * @param  string  $hostname
      * @param  int  $type

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -27,6 +27,7 @@ use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use InvalidArgumentException;
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
@@ -3533,23 +3534,50 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
-    public function testValidateActiveUrl()
+    /**
+     * @dataProvider activeUrlDataProvider
+     */
+    public function testValidateActiveUrl($data, $outcome)
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'active_url']);
-        $this->assertFalse($v->passes());
+        $v = m::mock(
+            new Validator($trans, $data, ['x' => 'active_url']),
+            function (MockInterface $mock) {
+                $mock
+                    ->shouldAllowMockingProtectedMethods()
+                    ->shouldReceive('getDnsRecords')
+                    ->withAnyArgs()
+                    ->zeroOrMoreTimes()
+                    ->andReturn(['hit']);
+            }
+        );
+        $this->assertEquals($outcome, $v->passes());
+    }
 
-        $v = new Validator($trans, ['x' => ['fdsfs', 'fdsfds']], ['x' => 'active_url']);
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'active_url']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['x' => 'http://www.google.com'], ['x' => 'active_url']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, ['x' => 'http://www.google.com/about'], ['x' => 'active_url']);
-        $this->assertTrue($v->passes());
+    public function activeUrlDataProvider()
+    {
+        return [
+            'Invalid Url' => [
+                ['x' => 'aslsdlks'],
+                false,
+            ],
+            'Invalid Urls' => [
+                ['x' => 'fdsfs', 'fdsfds'],
+                false,
+            ],
+            'Google Without Subdomain' => [
+                ['x' => 'http://google.com'],
+                true,
+            ],
+            'Google With Subdomain' => [
+                ['x' => 'http://www.google.com'],
+                true,
+            ],
+            'Google With Subdomain About Page' => [
+                ['x' => 'http://www.google.com/about'],
+                true,
+            ],
+        ];
     }
 
     public function testValidateImage()


### PR DESCRIPTION
I noticed that sometimes windows tests failed (https://github.com/laravel/framework/runs/7163912435?check_suite_focus=true), because the `active_url` validator test was doing real DNS lookups, which must be avoided during test runs as sometimes this times out or fails. This is now fixed by mocking the dns record fetching and in addition may be overwritten by a custom way of fetching dns records.

The added changes are:

- Mock actual DNS lookup calls (dns_get_record).