### PR TITLE
[9.x] Resolve query builders out of the container

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Doctrine\DBAL\Connection as DoctrineConnection;
 use Doctrine\DBAL\Types\Type;
 use Exception;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\StatementPrepared;
@@ -332,9 +333,11 @@ class Connection implements ConnectionInterface
      */
     public function query()
     {
-        return new QueryBuilder(
-            $this, $this->getQueryGrammar(), $this->getPostProcessor()
-        );
+        return Container::getInstance()->make(QueryBuilder::class, [
+            'connection' => $this,
+            'grammar' => $this->getQueryGrammar(),
+            'processor' => $this->getPostProcessor(),
+        ]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\HasBroadcastChannel;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -1450,7 +1451,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newEloquentBuilder($query)
     {
-        return new Builder($query);
+        return Container::getInstance()->make(Builder::class, ['query' => $query]);
     }
 
     /**


### PR DESCRIPTION
Resolving these two classes out of the container makes package developers able to swap them at run-time without touching the models like adding a trait on all the models or changing the parent Model class. (For example creating a driver for neo4j or something.)
### Why
My particular need for this came while I was developing the[ eloquent-mockery ](https://github.com/imanghafoori1/eloquent-mockery) package. If developers want to use my package, `they have to put a dev-only trait on all their models`, which is kinda painful since it will be pushed into production for no reason.
I think with this change packages like neo-eloquent will be able to create a configurable driver for eloquent without changing the parent class of all the model classes.

### Compatibility:
- It is not a breaking change unless the `QueryBuilder::class` is already bound to something else on the container which is extremely unlikely.
- Let me note that the `illuminate/container` is a dependency of the `illuminate/database` and we can use it there.
