### PR TITLE
[9.x] Adds closure support to dispatch conditionals.

### DIFF
--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Bus;
 
+use Closure;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Fluent;
 
@@ -26,7 +27,15 @@ trait Dispatchable
      */
     public static function dispatchIf($boolean, ...$arguments)
     {
-        return value($boolean, ...$arguments)
+        if ($boolean instanceof Closure) {
+            $dispatchable = new static(...$arguments);
+
+            return value($boolean, $dispatchable)
+                ? new PendingDispatch($dispatchable)
+                : new Fluent;
+        }
+
+        return value($boolean)
             ? new PendingDispatch(new static(...$arguments))
             : new Fluent;
     }
@@ -40,7 +49,15 @@ trait Dispatchable
      */
     public static function dispatchUnless($boolean, ...$arguments)
     {
-        return ! value($boolean, ...$arguments)
+        if ($boolean instanceof Closure) {
+            $dispatchable = new static(...$arguments);
+
+            return ! value($boolean, $dispatchable)
+                ? new PendingDispatch($dispatchable)
+                : new Fluent;
+        }
+
+        return ! value($boolean)
             ? new PendingDispatch(new static(...$arguments))
             : new Fluent;
     }

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -20,13 +20,13 @@ trait Dispatchable
     /**
      * Dispatch the job with the given arguments if the given truth test passes.
      *
-     * @param  bool  $boolean
+     * @param  bool|\Closure  $boolean
      * @param  mixed  ...$arguments
      * @return \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent
      */
     public static function dispatchIf($boolean, ...$arguments)
     {
-        return $boolean
+        return value($boolean, ...$arguments)
             ? new PendingDispatch(new static(...$arguments))
             : new Fluent;
     }
@@ -34,13 +34,13 @@ trait Dispatchable
     /**
      * Dispatch the job with the given arguments unless the given truth test passes.
      *
-     * @param  bool  $boolean
+     * @param  bool|\Closure  $boolean
      * @param  mixed  ...$arguments
      * @return \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent
      */
     public static function dispatchUnless($boolean, ...$arguments)
     {
-        return ! $boolean
+        return ! value($boolean, ...$arguments)
             ? new PendingDispatch(new static(...$arguments))
             : new Fluent;
     }

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -38,15 +38,13 @@ class JobDispatchingTest extends TestCase
 
     public function testDispatchesConditionallyWithClosure()
     {
-        Job::dispatchIf(fn ($string) => $string === 'test' ? 0 : 1, 'test')->replaceValue('new-test');
+        Job::dispatchIf(fn ($job) => $job instanceof Job ? 0 : 1, 'test')->replaceValue('new-test');
 
         $this->assertFalse(Job::$ran);
-        $this->assertNull(Job::$value);
 
-        Job::dispatchIf(fn ($string) => $string === 'test' ? 1 : 0, 'test')->replaceValue('new-test');
+        Job::dispatchIf(fn ($job) => $job instanceof Job ? 1 : 0, 'test')->replaceValue('new-test');
 
         $this->assertTrue(Job::$ran);
-        $this->assertSame('new-test', Job::$value);
     }
 
     public function testDoesNotDispatchesConditionallyWithBoolean()
@@ -64,15 +62,13 @@ class JobDispatchingTest extends TestCase
 
     public function testDoesNotDispatchesConditionallyWithClosure()
     {
-        Job::dispatchUnless(fn ($string) => $string === 'test' ? 1 : 0, 'test')->replaceValue('new-test');
+        Job::dispatchUnless(fn ($job) => $job instanceof Job ? 1 : 0, 'test')->replaceValue('new-test');
 
         $this->assertFalse(Job::$ran);
-        $this->assertNull(Job::$value);
 
-        Job::dispatchUnless(fn ($string) => $string === 'test' ? 0 : 1, 'test')->replaceValue('new-test');
+        Job::dispatchUnless(fn ($job) => $job instanceof Job ? 0 : 1, 'test')->replaceValue('new-test');
 
         $this->assertTrue(Job::$ran);
-        $this->assertSame('new-test', Job::$value);
     }
 }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -38,12 +38,12 @@ class JobDispatchingTest extends TestCase
 
     public function testDispatchesConditionallyWithClosure()
     {
-        Job::dispatchIf(fn($string) => $string === 'test' ? 0 : 1, 'test')->replaceValue('new-test');
+        Job::dispatchIf(fn ($string) => $string === 'test' ? 0 : 1, 'test')->replaceValue('new-test');
 
         $this->assertFalse(Job::$ran);
         $this->assertNull(Job::$value);
 
-        Job::dispatchIf(fn($string) => $string === 'test' ? 1 : 0, 'test')->replaceValue('new-test');
+        Job::dispatchIf(fn ($string) => $string === 'test' ? 1 : 0, 'test')->replaceValue('new-test');
 
         $this->assertTrue(Job::$ran);
         $this->assertSame('new-test', Job::$value);
@@ -64,12 +64,12 @@ class JobDispatchingTest extends TestCase
 
     public function testDoesNotDispatchesConditionallyWithClosure()
     {
-        Job::dispatchUnless(fn($string) => $string === 'test' ? 1 : 0, 'test')->replaceValue('new-test');
+        Job::dispatchUnless(fn ($string) => $string === 'test' ? 1 : 0, 'test')->replaceValue('new-test');
 
         $this->assertFalse(Job::$ran);
         $this->assertNull(Job::$value);
 
-        Job::dispatchUnless(fn($string) => $string === 'test' ? 0 : 1, 'test')->replaceValue('new-test');
+        Job::dispatchUnless(fn ($string) => $string === 'test' ? 0 : 1, 'test')->replaceValue('new-test');
 
         $this->assertTrue(Job::$ran);
         $this->assertSame('new-test', Job::$value);


### PR DESCRIPTION
## What?

Enables usage of closures to dispatch a job conditionally. The closure will receive the job arguments.

```php
MyQueuableJob::dispatchIf(Something::check(...), $name);
```

Also adds tests both `dispatchIf` and `dispatchUnless`.