### PR TITLE
[9.x] RateLimiter Facade docblock type

### DIFF
--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -12,7 +12,7 @@ namespace Illuminate\Support\Facades;
  * @method static int retriesLeft($key, $maxAttempts)
  * @method static void clear($key)
  * @method static int availableIn($key)
- * @method static bool attempt($key, $maxAttempts, \Closure $callback, $decaySeconds = 60)
+ * @method static mixed attempt($key, $maxAttempts, \Closure $callback, $decaySeconds = 60)
  *
  * @see \Illuminate\Cache\RateLimiter
  */


### PR DESCRIPTION
The `attempt()` method returns a mixed type and not bool, since it returns the callback you pass to it. See

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Cache/RateLimiter.php#L63-L81