### PR TITLE
[9.x] Fix HTTP client pool

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -1277,4 +1277,11 @@ class PendingRequest
     {
         return $this->options;
     }
+
+    public function __clone() : void
+    {
+        $this->beforeSendingCallbacks = new Collection($this->beforeSendingCallbacks->all());
+        $this->stubCallbacks = new Collection($this->stubCallbacks->all());
+        $this->middleware = new Collection($this->middleware->all());
+    }
 }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -43,7 +43,7 @@ class PendingRequest
     protected $client;
 
     /**
-     * The HTTP handler.
+     * The handler function for the Guzzle client.
      *
      * @var callable|null
      */

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -43,6 +43,13 @@ class PendingRequest
     protected $client;
 
     /**
+     * The HTTP handler.
+     *
+     * @var callable|null
+     */
+    protected $handler = null;
+
+    /**
      * The base URL for the request.
      *
      * @var string
@@ -966,29 +973,7 @@ class PendingRequest
      */
     public function buildClient()
     {
-        return $this->requestsReusableClient()
-               ? $this->getReusableClient()
-               : $this->createClient($this->buildHandlerStack());
-    }
-
-    /**
-     * Determine if a reusable client is required.
-     *
-     * @return bool
-     */
-    protected function requestsReusableClient()
-    {
-        return ! is_null($this->client) || $this->async;
-    }
-
-    /**
-     * Retrieve a reusable Guzzle client.
-     *
-     * @return \GuzzleHttp\Client
-     */
-    protected function getReusableClient()
-    {
-        return $this->client = $this->client ?: $this->createClient($this->buildHandlerStack());
+        return $this->client ?? $this->createClient($this->buildHandlerStack());
     }
 
     /**
@@ -1012,7 +997,7 @@ class PendingRequest
      */
     public function buildHandlerStack()
     {
-        return $this->pushHandlers(HandlerStack::create());
+        return $this->pushHandlers(HandlerStack::create($this->handler));
     }
 
     /**
@@ -1278,9 +1263,7 @@ class PendingRequest
      */
     public function setHandler($handler)
     {
-        $this->client = $this->createClient(
-            $this->pushHandlers(HandlerStack::create($handler))
-        );
+        $this->handler = $handler;
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -746,7 +746,7 @@ class PendingRequest
     {
         $results = [];
 
-        $requests = tap(new Pool($this->factory), $callback)->getRequests();
+        $requests = tap(new Pool($this), $callback)->getRequests();
 
         foreach ($requests as $key => $item) {
             $results[$key] = $item instanceof static ? $item->getPromise()->wait() : $item->wait();

--- a/src/Illuminate/Http/Client/Pool.php
+++ b/src/Illuminate/Http/Client/Pool.php
@@ -17,13 +17,6 @@ class Pool
     protected $factory;
 
     /**
-     * The handler function for the Guzzle client.
-     *
-     * @var callable
-     */
-    protected $handler;
-
-    /**
      * The pool of requests.
      *
      * @var array

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1139,6 +1139,31 @@ class HttpClientTest extends TestCase
         $this->assertSame(500, $responses['test500']->status());
     }
 
+    public function testMiddlewareRunsInPool()
+    {
+        $this->factory->fake(function (Request $request) {
+            return $this->factory->response('Fake');
+        });
+
+        $history = [];
+
+        $middleware = Middleware::history($history);
+
+        $responses = $this->factory->pool(fn (Pool $pool) => [
+            $pool->withMiddleware($middleware)->post('https://example.com', ['hyped-for' => 'laravel-movie'])
+        ]);
+
+        $response = $responses[0];
+
+        $this->assertSame('Fake', $response->body());
+
+        $this->assertCount(1, $history);
+
+        $this->assertSame('Fake', tap($history[0]['response']->getBody())->rewind()->getContents());
+
+        $this->assertSame(['hyped-for' => 'laravel-movie'], json_decode(tap($history[0]['request']->getBody())->rewind()->getContents(), true));
+    }
+
     public function testTheRequestSendingAndResponseReceivedEventsAreFiredWhenARequestIsSent()
     {
         $events = m::mock(Dispatcher::class);


### PR DESCRIPTION
This PR fixes 2 problems:

1. Middleware not being sent when registered inside the pool callback (1st commit):
```php
// The middleware is never being called
Http::pool(fn (Pool $pool) => [
    $pool->withMiddleware($middleware)->get('https://example.com'),
]);
```
This is because the Guzzle client is created in the `setHandler` method on `PendingRequest`. Because of this, middleware are never registered on the handler stack when calling `send` on the request since the Guzzle client is not re-created.

2. Initial setup ignored (2nd commit):
```php
// The token (or any other setup done on the pending request before the pool() method call) is
// not passed to the final requests in the callback
Http::withToken('secret-key')->pool(fn (Pool $pool) => [
    $pool->post('https://example.com/api', $payload_1),
    $pool->post('https://example.com/api', $payload_2),
]);
```

