### PR TITLE
[9.x] Make local test setup os and composer independent

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -18,33 +18,57 @@ if $down; then
     exit 0
 fi
 
-echo "Ensuring docker is running"
+echo "Checking whether docker is running"
 
 if ! docker info > /dev/null 2>&1; then
   echo "Please start docker first."
   exit 1
 fi
 
-echo "Ensuring services are running"
+echo "Ensuring services required by the tests are running"
 
 docker-compose up -d
 
-if docker run -it --rm "registry.gitlab.com/grahamcampbell/php:$php-base" -r "\$tries = 0; while (true) { try { \$tries++; if (\$tries > 30) { throw new RuntimeException('MySQL never became available'); } sleep(1); new PDO('mysql:host=docker.for.mac.localhost;dbname=forge', 'root', '', [PDO::ATTR_TIMEOUT => 3]); break; } catch (PDOException \$e) {} }"; then
-    echo "Running tests"
+echo "Waiting until database is available"
 
-    if docker run -it -w /data -v ${PWD}:/data:delegated \
-       --user "www-data" --entrypoint vendor/bin/phpunit \
-       --env CI=1 --env DB_HOST=docker.for.mac.localhost --env DB_USERNAME=root \
-       --env DB_HOST=docker.for.mac.localhost --env DB_PORT=3306 \
-       --env DYNAMODB_ENDPOINT=docker.for.mac.localhost:8000 --env DYNAMODB_CACHE_TABLE=cache --env AWS_ACCESS_KEY_ID=dummy --env AWS_SECRET_ACCESS_KEY=dummy \
-       --env REDIS_HOST=docker.for.mac.localhost --env REDIS_PORT=6379 \
-       --env MEMCACHED_HOST=docker.for.mac.localhost --env MEMCACHED_PORT=11211 \
-       --rm "registry.gitlab.com/grahamcampbell/php:$php-base" "$@"; then
-        exit 0
-    else
-        exit 1
-    fi
-else
-    docker-compose logs
+docker run -it \
+    --add-host=host.docker.internal:host-gateway \
+    --rm "registry.gitlab.com/grahamcampbell/php:$php-base" \
+    -r "\$tries = 0; while (true) { \$tries++; try { new PDO('mysql:host=host.docker.internal;dbname=forge', 'root', '', [PDO::ATTR_TIMEOUT => 3]); break; } catch (PDOException \$e) {} if (\$tries > 30) { throw new Exception(); } sleep(1); }"  > /dev/null 2>&1
+
+if [ "$?" -ne 0 ]; then
+    echo "MySQL never became available"
     exit 1
 fi
+
+echo "Running composer update"
+
+docker run -it -w /data -v ${PWD}:/data:delegated -u $(id -u ${USER}):$(id -g ${USER}) \
+    --entrypoint composer \
+    --add-host=host.docker.internal:host-gateway \
+    --rm "registry.gitlab.com/grahamcampbell/php:$php-base" \
+    update --no-cache --no-interaction
+
+if [ "$?" -ne 0 ]; then
+    echo "Failed to install packages"
+    exit 1
+fi
+
+echo "Running tests"
+
+docker run -it -w /data -v ${PWD}:/data:delegated -u $(id -u ${USER}):$(id -g ${USER}) \
+    --entrypoint vendor/bin/phpunit \
+    --add-host=host.docker.internal:host-gateway \
+    --env CI=1 \
+    --env DB_HOST=host.docker.internal \
+    --env DB_PORT=3306 \
+    --env DB_USERNAME=root \
+    --env DYNAMODB_ENDPOINT=host.docker.internal:8000 \
+    --env DYNAMODB_CACHE_TABLE=cache \
+    --env AWS_ACCESS_KEY_ID=dummy \
+    --env AWS_SECRET_ACCESS_KEY=dummy \
+    --env REDIS_HOST=host.docker.internal \
+    --env REDIS_PORT=6379 \
+    --env MEMCACHED_HOST=host.docker.internal \
+    --env MEMCACHED_PORT=11211 \
+    --rm "registry.gitlab.com/grahamcampbell/php:$php-base" "$@"


### PR DESCRIPTION
The current `./bin/test.sh` has multiple issue:

1. Specifically written for a MacOS environment only (does not run on linux).
2. Assumption that everyone has a www-data user locally to mount the filesystem with.
3. Composer and php is installed on the host machine.

This pull request solves all those issues so that the local test suite can be run on either mac or linux. It mounts the project with the same user as the currently logged in user on the host so that no file permission or missing user issues appear. Also the changes make sure that an os agnostic host is used for all the services instead of `docker.for.mac.localhost`. On top of that it is no longer required that the host has php or composer installed. The test suite can be fully run within the docker container, making sure that composer installs the latest packages within the composer.json constraints before running the tests.