### PR TITLE
[9.x] feature: `min_digits` and `max_digits` validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -127,6 +127,20 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the min digits rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceMinDigits($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':min', $parameters[0], $message);
+    }
+
+    /**
      * Replace all place-holders for the max rule.
      *
      * @param  string  $message
@@ -136,6 +150,20 @@ trait ReplacesAttributes
      * @return string
      */
     protected function replaceMax($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':max', $parameters[0], $message);
+    }
+
+    /**
+     * Replace all place-holders for the max digits rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceMaxDigits($message, $attribute, $rule, $parameters)
     {
         return str_replace(':max', $parameters[0], $message);
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1326,6 +1326,23 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute has a maximum number of digits.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMaxDigits($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'max');
+
+        $length = strlen((string) $value);
+
+        return ! preg_match('/[^0-9]/', $value) && $length <= $parameters[0];
+    }
+
+    /**
      * Validate the guessed extension of a file upload is in a set of file extensions.
      *
      * @param  string  $attribute
@@ -1408,6 +1425,23 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'min');
 
         return $this->getSize($attribute, $value) >= $parameters[0];
+    }
+
+    /**
+     * Validate that an attribute has a minimum number of digits.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateMinDigits($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'min');
+
+        $length = strlen((string) $value);
+
+        return ! preg_match('/[^0-9]/', $value) && $length >= $parameters[0];
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2381,7 +2381,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'max_digits:10']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'max_digits:5']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'max_digits:3']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'max_digits:6']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2360,6 +2360,32 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'digits_between:1,6']);
         $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'min_digits:1']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'min_digits:1']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'min_digits:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'min_digits:1']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => '12345'], ['foo' => 'max_digits:6']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'max_digits:10']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'max_digits:5']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'max_digits:6']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateSize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2381,7 +2381,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'max_digits:10']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'max_digits:3']);
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'max_digits:2']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => '+12.3'], ['foo' => 'max_digits:6']);


### PR DESCRIPTION
As per the [`size` rule](https://laravel.com/docs/9.x/validation#rule-size), the number of digits in numeric input cannot be validated traditionally using `min` and `max`.

Currently, we have, `digits` to validate the exact length of a number, and `digits_between` to validate the length within two boundaries.

However, as far as I can see there is not yet a way to validate that a number has a minimum OR maximum number of digits, just both.

This PR introduces two validation rules - `min_digits` and `max_digits` for this use:

```php
Validator::validate([
    'number' => 1000,
], [
    'number' => [
        'min_digits:3', 'max_digits:5', // Passes as `1000` has 4 digits
        'min:3', 'max:5', // Fails as `1000` is greater than 5
    ],
])
```