### PR TITLE
[9.x] Restores original table name guessing for Morph Pivot model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use function class_basename;
 use Illuminate\Support\Str;
 
 class MorphPivot extends Pivot

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -2,9 +2,8 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Support\Str;
 use function class_basename;
-use function str_replace;
+use Illuminate\Support\Str;
 
 class MorphPivot extends Pivot
 {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -2,6 +2,10 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Support\Str;
+use function class_basename;
+use function str_replace;
+
 class MorphPivot extends Pivot
 {
     /**
@@ -106,6 +110,16 @@ class MorphPivot extends Pivot
         $this->morphClass = $morphClass;
 
         return $this;
+    }
+
+    /**
+     * Get the table associated with the model.
+     *
+     * @return string
+     */
+    public function getTable()
+    {
+        return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentPivotTestModelPluralDummies.php
+++ b/tests/Database/DatabaseEloquentPivotTestModelPluralDummies.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Mockery as m;
@@ -139,6 +140,18 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertSame('pivot', $pivot->getTable());
     }
 
+    public function testPivotModelTableNameIsSingularSnake()
+    {
+        $pivot = new DummyPivotModelPluralDummies;
+        $this->assertSame('dummy_pivot_model_plural_dummy', $pivot->getTable());
+    }
+
+    public function testMorphPivotModelTableNameIsPlural()
+    {
+        $pivot = new DummyMorphPivot;
+        $this->assertSame('dummy_morph_pivots', $pivot->getTable());
+    }
+
     public function testPivotModelWithParentReturnsParentsTimestampColumns()
     {
         $parent = m::mock(Model::class);
@@ -223,4 +236,14 @@ class DatabaseEloquentPivotTestJsonCastStub extends Pivot
 class DummyModel extends Model
 {
     //
+}
+
+class DummyPivotModelPluralDummies extends Pivot
+{
+
+}
+
+class DummyMorphPivot extends MorphPivot
+{
+
 }


### PR DESCRIPTION
## What?

When calling a many-to-many relations using morph pivot model, the table that Laravel guesses is snake singular from the pivot model name. For example, "Taggable" will point to `taggable` instead of `taggables`.

```php
use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\Relations\MorphPivot;

class Post extends Model
{
    public function tags()
    {
        return $this->morphToMany(Tag::class, 'taggable', Taggable::class);
    }
}

class Tag extends Model
{
    // ...
}

class Taggable extends MorphPivot
{
    // ...
}

Post::find(1)->tags()->dd();

// "select * from "tags" 
//    inner join "taggable" on "tags"."id" = "taggable"."tag_id" 
//    where 
//        "taggable"."taggable_id" = ? 
//    and 
//        "taggable"."taggable_type" = ?
```

This patch adds back the plural table name guesser to `MorphPivot`, which will point to the plural name of the model rather than a the singular snake (which doesn't make sense). It will also avoid the developer to set the table manually when is the plural of the model name.

> **Note** I decided against removing the method from the `AsPivot` trait because it would break something, but it could be done for 10.x I supposse.

This doesn't affect monomorphic Pivot, as is inferred the developer is using the convention `{Bar}_{Foo}`, which if not it should point the table name manually.