### PR TITLE
[9.x] Add if locale directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -382,4 +382,36 @@ trait CompilesConditionals
     {
         return '<?php $__env->stopPush(); endif; ?>';
     }
+
+    /**
+     * Compile the if-locale statements into valid PHP.
+     *
+     * @param  string  $locale
+     * @return string
+     */
+    protected function compileLocale($locale)
+    {
+        return "<?php if(app()->getLocale() === $locale): ?>";
+    }
+
+    /**
+     * Compile the else-locale statements into valid PHP.
+     *
+     * @param  string  $locale
+     * @return string
+     */
+    protected function compileElseLocale($locale)
+    {
+        return "<?php elseif(app()->getLocale() === $locale): ?>";
+    }
+
+    /**
+     * Compile the end-locale statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndLocale()
+    {
+        return '<?php endif; ?>';
+    }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -391,7 +391,11 @@ trait CompilesConditionals
      */
     protected function compileLocale($locale)
     {
-        return "<?php if(app()->getLocale() === $locale): ?>";
+        $condition = str_contains($locale, ',')
+                    ? "in_array(app()->getLocale(), $locale)"
+                    : "app()->getLocale() === $locale";
+
+        return "<?php if(${condition}): ?>";
     }
 
     /**
@@ -402,7 +406,11 @@ trait CompilesConditionals
      */
     protected function compileElseLocale($locale)
     {
-        return "<?php elseif(app()->getLocale() === $locale): ?>";
+        $condition = str_contains($locale, ',')
+            ? "in_array(app()->getLocale(), $locale)"
+            : "app()->getLocale() === $locale";
+
+        return "<?php elseif(${condition}): ?>";
     }
 
     /**

--- a/tests/View/Blade/BladeIfLocaleStatementsTest.php
+++ b/tests/View/Blade/BladeIfLocaleStatementsTest.php
@@ -19,4 +19,20 @@ baz
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testIfLocaleStatementsWithArrayPassedAreCompiled()
+    {
+        $string = '@locale ([foo, bar])
+foo or bar
+@elselocale ([baz,qux])
+baz or qux
+@endlocale';
+
+        $expected = '<?php if(in_array(app()->getLocale(), ([foo, bar]))): ?>
+foo or bar
+<?php elseif(in_array(app()->getLocale(), ([baz,qux]))): ?>
+baz or qux
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeIfLocaleStatementsTest.php
+++ b/tests/View/Blade/BladeIfLocaleStatementsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfLocaleStatementsTest extends AbstractBladeTestCase
+{
+    public function testIfLocaleStatementsAreCompiled()
+    {
+        $string = '@locale (name(foo(bar)))
+bar
+@elselocale (name(foo(baz)))
+baz
+@endlocale';
+
+        $expected = '<?php if(app()->getLocale() === (name(foo(bar)))): ?>
+bar
+<?php elseif(app()->getLocale() === (name(foo(baz)))): ?>
+baz
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR provides an easy and straightforward way to check the current application locale through a shorthand syntax via a Blade directive. Helping developers to write clean and readable code. Sometimes developers need to load specific resources or toggle HTML tags/attributes depending on the current app locale, especially when supporting two or more languages that some work with `LTR` and other/s with `RTL`.

For example:
```php
// Old way
<body @if(app()->getLocale() === 'en' or app()->getLocale() === 'es') dir="ltr" @elseif(app()->getLocale() === 'ar') dir="rtl" @endif>

// New way
<body @locale(['en', 'es']) dir="ltr" @elselocale('ar') dir="rtl" @endlocale>
```
Another example:
```php
@locale('ar')
    <link href="{{ asset('css/style.rtl.css') }}">
@else
    <link href="{{ asset('css/style.ltr.css') }}">
@endlocale
```
