### PR TITLE
Bug fix Paginator hasMorePages()

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -65,9 +65,17 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     protected function setItems($items)
     {
-        $this->items = $items instanceof Collection ? $items : Collection::make($items);
+        if ($items instanceof Collection) {
+            $this->items = $items;
 
-        $this->hasMore = $this->items->count() > $this->perPage;
+            $this->hasMore = $this->items->count() > $this->perPage;
+        } else {
+            $this->items = Collection::make($items);
+
+            $lastPage = ceil($this->items->count() / $this->perPage);
+
+            $this->hasMore = $this->currentPage < $lastPage;
+        }
 
         $this->items = $this->items->slice(0, $this->perPage);
     }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -13,14 +13,15 @@ class PaginatorTest extends TestCase
 
         $this->assertEquals(2, $p->currentPage());
         $this->assertTrue($p->hasPages());
-        $this->assertTrue($p->hasMorePages());
+        $this->assertFalse($p->hasMorePages()); // Because: there are 3 items, 2 items per page = there are 2 pages. And we are on page 2 = we are on the last page.
         $this->assertEquals(['item3', 'item4'], $p->items());
 
         $pageInfo = [
             'per_page' => 2,
             'current_page' => 2,
             'first_page_url' => '/?page=1',
-            'next_page_url' => '/?page=3',
+            //'next_page_url' => '/?page=3',
+            'next_page_url' => '', // Because: hasMorePages() is false.
             'prev_page_url' => '/?page=1',
             'from' => 3,
             'to' => 4,
@@ -29,6 +30,24 @@ class PaginatorTest extends TestCase
         ];
 
         $this->assertEquals($pageInfo, $p->toArray());
+    }
+
+    /**
+     * @author Stephen Damian
+     */
+    public function testPaginatorisOnFirstAndLastPage()
+    {
+        $p = new Paginator($array = ['1', '2', '3', '4', '5'], 2, 1);
+
+        $this->assertTrue($p->onFirstPage());
+        $this->assertFalse($p->onLastPage());
+        $this->assertTrue($p->hasMorePages());
+
+        $p = new Paginator($array = ['1', '2', '3', '4', '5'], 2, 3);
+
+        $this->assertFalse($p->onFirstPage());
+        $this->assertTrue($p->onLastPage());
+        $this->assertFalse($p->hasMorePages());
     }
 
     public function testPaginatorRemovesTrailingSlashes()

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -20,7 +20,6 @@ class PaginatorTest extends TestCase
             'per_page' => 2,
             'current_page' => 2,
             'first_page_url' => '/?page=1',
-            //'next_page_url' => '/?page=3',
             'next_page_url' => '', // Because: hasMorePages() is false.
             'prev_page_url' => '/?page=1',
             'from' => 3,


### PR DESCRIPTION
Bug fix for **hasMorePages()** of Paginator for simplePaginate() if items are not a Collection.

**Bug fix:**
(This bug exists when items are not a Collection)
There was a bug in **testSimplePaginatorReturnsRelevantContextInformation()** of **PaginatorTest**.
Because in this test we simulate: there are 3 items, 2 items per page = there are 2 pages. And we are on page 2 = we are on the last page.
I fixed this bug. And I added the test "testPaginatorisOnFirstAndLastPage()" in order to better perpetuate it.
