### PR TITLE
Make string padding UTF-8 safe (bugfix)

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -608,7 +608,13 @@ class Str
      */
     public static function padBoth($value, $length, $pad = ' ')
     {
-        return str_pad($value, strlen($value) - mb_strlen($value) + $length, $pad, STR_PAD_BOTH);
+        $short = max(0, $length - mb_strlen($value));
+        $short_left = floor($short / 2);
+        $short_right = ceil($short / 2);
+        return
+            mb_substr(str_repeat($pad, $short_left), 0, $short_left) .
+            $value .
+            mb_substr(str_repeat($pad, $short_right), 0, $short_right);
     }
 
     /**
@@ -621,7 +627,8 @@ class Str
      */
     public static function padLeft($value, $length, $pad = ' ')
     {
-        return str_pad($value, strlen($value) - mb_strlen($value) + $length, $pad, STR_PAD_LEFT);
+        $short = max(0, $length - mb_strlen($value));
+        return mb_substr(str_repeat($pad, $short), 0, $short) . $value;
     }
 
     /**
@@ -634,7 +641,8 @@ class Str
      */
     public static function padRight($value, $length, $pad = ' ')
     {
-        return str_pad($value, strlen($value) - mb_strlen($value) + $length, $pad, STR_PAD_RIGHT);
+        $short = max(0, $length - mb_strlen($value));
+        return $value . mb_substr(str_repeat($pad, $short), 0, $short);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -612,8 +612,8 @@ class Str
         $short_left = floor($short / 2);
         $short_right = ceil($short / 2);
         return
-            mb_substr(str_repeat($pad, $short_left), 0, $short_left) .
-            $value .
+            mb_substr(str_repeat($pad, $short_left), 0, $short_left).
+            $value.
             mb_substr(str_repeat($pad, $short_right), 0, $short_right);
     }
 
@@ -628,7 +628,7 @@ class Str
     public static function padLeft($value, $length, $pad = ' ')
     {
         $short = max(0, $length - mb_strlen($value));
-        return mb_substr(str_repeat($pad, $short), 0, $short) . $value;
+        return mb_substr(str_repeat($pad, $short), 0, $short).$value;
     }
 
     /**
@@ -642,7 +642,7 @@ class Str
     public static function padRight($value, $length, $pad = ' ')
     {
         $short = max(0, $length - mb_strlen($value));
-        return $value . mb_substr(str_repeat($pad, $short), 0, $short);
+        return $value.mb_substr(str_repeat($pad, $short), 0, $short);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -781,6 +781,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('__Alien___', Str::padBoth('Alien', 10, '_'));
         $this->assertSame('  Alien   ', Str::padBoth('Alien', 10));
         $this->assertSame('  ❤MultiByte☆   ', Str::padBoth('❤MultiByte☆', 16));
+        $this->assertSame('❤☆❤MultiByte☆❤☆❤', Str::padBoth('❤MultiByte☆', 16, '❤☆'));
     }
 
     public function testPadLeft()
@@ -788,13 +789,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('-=-=-Alien', Str::padLeft('Alien', 10, '-='));
         $this->assertSame('     Alien', Str::padLeft('Alien', 10));
         $this->assertSame('     ❤MultiByte☆', Str::padLeft('❤MultiByte☆', 16));
+        $this->assertSame('❤☆❤☆❤❤MultiByte☆', Str::padLeft('❤MultiByte☆', 16, '❤☆'));
     }
 
     public function testPadRight()
     {
-        $this->assertSame('Alien-----', Str::padRight('Alien', 10, '-'));
+        $this->assertSame('Alien-=-=-', Str::padRight('Alien', 10, '-='));
         $this->assertSame('Alien     ', Str::padRight('Alien', 10));
         $this->assertSame('❤MultiByte☆     ', Str::padRight('❤MultiByte☆', 16));
+        $this->assertSame('❤MultiByte☆❤☆❤☆❤', Str::padRight('❤MultiByte☆', 16, '❤☆'));
     }
 
     public function testSwapKeywords(): void


### PR DESCRIPTION
# The issue

In the `Str::pad*` functions, the pad string could be truncated in the middle of a unicode code point. E.g. (in Tinker):
```
for ($i = 3; $i < 7; $i++) echo Str::padRight('abc', $i, '❤'), PHP_EOL;
```
results in:
```
abc
abc<E2>
abc<E2><9D>
abc❤
```
This PR aims to fix this for the `padRight`, `padLeft` and `padBoth` functions.

# Tests

As the unit test does not yet test for these cases (UTF-8 characters in the `$pad` string), this PR also adds assert tests for this.

# Notes

As [noted](https://www.php.net/manual/en/function.str-pad.php#116164) on the PHP documentation "User Contributed Notes":

> since the default pad_type is STR_PAD_RIGHT. using STR_PAD_BOTH were always favor in the right pad if the required number of padding characters can't be evenly divided.

This PR takes this behavior into account.

# Impact

This PR should not impact code using the `Str::pad*` functions with a single-byte-coded pad-string (or the default string).
Users who used a UTF-8 code point in the pad string, should have encountered an issue and either avoided it or repaired it themselves in their own project.
