### PR TITLE
[9.x] Fixes creation of deprecations channel

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -144,9 +144,11 @@ class HandleExceptions
 
             $this->ensureNullLogDriverIsConfigured();
 
-            $options = $config->get('logging.deprecations');
-
-            $driver = is_array($options) ? $options['channel'] : ($options ?? 'null');
+            if (is_array($options = $config->get('logging.deprecations'))) {
+                $driver = $options['channel'] ?? 'null';
+            } else {
+                $driver = $options ?? 'null';
+            }
 
             $config->set('logging.channels.deprecations', $config->get("logging.channels.{$driver}"));
         });


### PR DESCRIPTION
This pull request fixes a regression introduced https://github.com/laravel/framework/pull/42235 - that have being mentioned here https://github.com/laravel/laravel/pull/5974 - that causes deprecations logging a `Unable to create configured logger. Using emergency logger.` for each deprecation found.

It's a little bit odd that this issue was found only now, yet it can be explained by the fact that the issue only exists on new Laravel applications and most of code out there is ready for PHP 8.1.