### PR TITLE
[9.x] Load relationships using LazyCollection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
+use Illuminate\Support\LazyCollection;
 
 class BelongsTo extends Relation
 {
@@ -160,11 +161,11 @@ class BelongsTo extends Relation
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         $foreign = $this->foreignKey;
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -161,11 +161,11 @@ class BelongsTo extends Relation
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         $foreign = $this->foreignKey;
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -269,11 +269,11 @@ class BelongsToMany extends Relation
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         $dictionary = $this->buildDictionary($results);
 
@@ -296,10 +296,10 @@ class BelongsToMany extends Relation
     /**
      * Build model dictionary keyed by the relation's foreign key.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @return array
      */
-    protected function buildDictionary(Collection $results)
+    protected function buildDictionary(Collection|LazyCollection $results)
     {
         // First we'll build a dictionary of child models keyed by the foreign key
         // of the relation so that we will easily and quickly match them to the

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithPivotTable;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -268,11 +269,11 @@ class BelongsToMany extends Relation
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         $dictionary = $this->buildDictionary($results);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\LazyCollection;
 
 class HasMany extends HasOneOrMany
 {
@@ -38,11 +39,11 @@ class HasMany extends HasOneOrMany
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         return $this->matchMany($models, $results, $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -39,11 +39,11 @@ class HasMany extends HasOneOrMany
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         return $this->matchMany($models, $results, $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -186,11 +186,11 @@ class HasManyThrough extends Relation
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         $dictionary = $this->buildDictionary($results);
 
@@ -211,10 +211,10 @@ class HasManyThrough extends Relation
     /**
      * Build model dictionary keyed by the relation's foreign key.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @return array
      */
-    protected function buildDictionary(Collection $results)
+    protected function buildDictionary(Collection|LazyCollection $results)
     {
         $dictionary = [];
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\LazyCollection;
 
 class HasManyThrough extends Relation
 {
@@ -185,11 +186,11 @@ class HasManyThrough extends Relation
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         $dictionary = $this->buildDictionary($results);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -50,11 +50,11 @@ class HasOne extends HasOneOrMany implements SupportsPartialRelations
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         return $this->matchOne($models, $results, $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\CanBeOneOfMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\LazyCollection;
 
 class HasOne extends HasOneOrMany implements SupportsPartialRelations
 {
@@ -49,11 +50,11 @@ class HasOne extends HasOneOrMany implements SupportsPartialRelations
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         return $this->matchOne($models, $results, $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -108,11 +108,11 @@ abstract class HasOneOrMany extends Relation
      * Match the eagerly loaded results to their single parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function matchOne(array $models, Collection $results, $relation)
+    public function matchOne(array $models, Collection|LazyCollection $results, $relation)
     {
         return $this->matchOneOrMany($models, $results, $relation, 'one');
     }
@@ -121,11 +121,11 @@ abstract class HasOneOrMany extends Relation
      * Match the eagerly loaded results to their many parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function matchMany(array $models, Collection | LazyCollection $results, $relation)
+    public function matchMany(array $models, Collection|LazyCollection $results, $relation)
     {
         return $this->matchOneOrMany($models, $results, $relation, 'many');
     }
@@ -134,12 +134,12 @@ abstract class HasOneOrMany extends Relation
      * Match the eagerly loaded results to their many parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @param  string  $type
      * @return array
      */
-    protected function matchOneOrMany(array $models, Collection | LazyCollection $results, $relation, $type)
+    protected function matchOneOrMany(array $models, Collection|LazyCollection $results, $relation, $type)
     {
         $dictionary = $this->buildDictionary($results);
 
@@ -175,10 +175,10 @@ abstract class HasOneOrMany extends Relation
     /**
      * Build model dictionary keyed by the relation's foreign key.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @return array
      */
-    protected function buildDictionary(Collection $results)
+    protected function buildDictionary(Collection|LazyCollection $results)
     {
         $foreign = $this->getForeignKeyName();
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Support\LazyCollection;
 
 abstract class HasOneOrMany extends Relation
 {
@@ -124,7 +125,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $relation
      * @return array
      */
-    public function matchMany(array $models, Collection $results, $relation)
+    public function matchMany(array $models, Collection | LazyCollection $results, $relation)
     {
         return $this->matchOneOrMany($models, $results, $relation, 'many');
     }
@@ -138,7 +139,7 @@ abstract class HasOneOrMany extends Relation
      * @param  string  $type
      * @return array
      */
-    protected function matchOneOrMany(array $models, Collection $results, $relation, $type)
+    protected function matchOneOrMany(array $models, Collection | LazyCollection $results, $relation, $type)
     {
         $dictionary = $this->buildDictionary($results);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
+use Illuminate\Support\LazyCollection;
 
 class HasOneThrough extends HasManyThrough
 {
@@ -41,11 +42,11 @@ class HasOneThrough extends HasManyThrough
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         $dictionary = $this->buildDictionary($results);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -42,11 +42,11 @@ class HasOneThrough extends HasManyThrough
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         $dictionary = $this->buildDictionary($results);
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -39,11 +39,11 @@ class MorphMany extends MorphOneOrMany
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         return $this->matchMany($models, $results, $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\LazyCollection;
 
 class MorphMany extends MorphOneOrMany
 {
@@ -38,11 +39,11 @@ class MorphMany extends MorphOneOrMany
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         return $this->matchMany($models, $results, $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\CanBeOneOfMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\ComparesRelatedModels;
 use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\LazyCollection;
 
 class MorphOne extends MorphOneOrMany implements SupportsPartialRelations
 {
@@ -49,11 +50,11 @@ class MorphOne extends MorphOneOrMany implements SupportsPartialRelations
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         return $this->matchOne($models, $results, $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -50,11 +50,11 @@ class MorphOne extends MorphOneOrMany implements SupportsPartialRelations
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         return $this->matchOne($models, $results, $relation);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Concerns\InteractsWithDictionary;
+use Illuminate\Support\LazyCollection;
 
 class MorphTo extends BelongsTo
 {
@@ -194,11 +195,11 @@ class MorphTo extends BelongsTo
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection | LazyCollection $results, $relation)
     {
         return $models;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -195,11 +195,11 @@ class MorphTo extends BelongsTo
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    public function match(array $models, Collection | LazyCollection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         return $models;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -164,9 +164,9 @@ abstract class Relation implements BuilderContract
     public function getEager()
     {
         // check if lazy loading is enabled
-        return $this->lazy_chunkSize
+        return $this->lazyChunkSize
             // load relation as lazy collection
-            ? $this->lazy($this->lazy_chunkSize)
+            ? $this->lazy($this->lazyChunkSize)
             // load relation as normal collection
             : $this->get();
     }
@@ -180,7 +180,7 @@ abstract class Relation implements BuilderContract
     public function asLazy(false|int $chunkSize = 1000): self
     {
         // store the chunk size for lazy collection
-        $this->lazy_chunkSize = $chunkSize;
+        $this->lazyChunkSize = $chunkSize;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -71,11 +71,11 @@ abstract class Relation implements BuilderContract
     protected static $selfJoinCount = 0;
 
     /**
-     * Flag to enable loading this relation as a LazyCollection
+     * Flag to enable loading this relation as a LazyCollection.
      *
-     * @var false | int Chunk size for the lazy collection, false to load relation as normal collection
+     * @var false|int Chunk size for the lazy collection, false to load relation as normal collection
      */
-    private false | int $lazy_chunkSize = false;
+    private false|int $lazy_chunkSize = false;
 
     /**
      * Create a new relation instance.
@@ -143,11 +143,11 @@ abstract class Relation implements BuilderContract
      * Match the eagerly loaded results to their parents.
      *
      * @param  array  $models
-     * @param  \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection  $results
+     * @param  \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection  $results
      * @param  string  $relation
      * @return array
      */
-    abstract public function match(array $models, Collection | LazyCollection $results, $relation);
+    abstract public function match(array $models, Collection|LazyCollection $results, $relation);
 
     /**
      * Get the results of the relationship.
@@ -159,26 +159,26 @@ abstract class Relation implements BuilderContract
     /**
      * Get the relationship for eager loading.
      *
-     * @return \Illuminate\Database\Eloquent\Collection | \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Support\LazyCollection
      */
     public function getEager()
     {
         // check if lazy loading is enabled
         return $this->lazy_chunkSize
             // load relation as lazy collection
-            ? $this->lazy( $this->lazy_chunkSize )
+            ? $this->lazy($this->lazy_chunkSize)
             // load relation as normal collection
             : $this->get();
     }
 
     /**
-     * Enable lazy loading for this relation
+     * Enable lazy loading for this relation.
      *
-     * @param false | int $chunkSize
-     *
+     * @param  false|int  $chunkSize
      * @return $this
      */
-    public function asLazy(false | int $chunkSize = 1000): self {
+    public function asLazy(false|int $chunkSize = 1000): self
+    {
         // store the chunk size for lazy collection
         $this->lazy_chunkSize = $chunkSize;
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -75,7 +75,7 @@ abstract class Relation implements BuilderContract
      *
      * @var false|int Chunk size for the lazy collection, false to load relation as normal collection
      */
-    private false|int $lazy_chunkSize = false;
+    private false|int $lazyChunkSize = false;
 
     /**
      * Create a new relation instance.

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\LazyCollection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -307,7 +308,7 @@ class EloquentRelationStub extends Relation
         //
     }
 
-    public function match(array $models, Collection $results, $relation)
+    public function match(array $models, Collection|LazyCollection $results, $relation)
     {
         //
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello everyone,
This will be my first contribution to the Laravel Framework.

This PR adds the ability to enable loading a relation using LazyCollection, why?

## Motivation
I'm working on a project that has a lot of data, our database has data since 1970.

On the table where we are fetching the main info has almost 300k records, over that we can load using the standard `lazy()` method of the model, but when we add the lazy loading of relations through `with(...)` we were facing memory issues, because we are loading relations up to 3 levels depth. For example, the first relation has between 130 and 150 records per parent, below that we have the second relation that has 25-50 records.

On some processes that runs once per month, we process a bit chunk of data from the database for reporting and other stuff. We tried to optimize the loading times using LazyCollection on the referenced relations. We see that loading a big resultset of data takes more time than loading in chunks (it's not much, but the CPU is happy that can wait waiting for next chunk 😄). Also as mentioned, we were getting memory.

## Examples
Instead of changing the core functionality of [Relation](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Relations/Relation.php#L158), I added a modifier to enable lazy on a single relation on demand:
```php
// get all Lands that where sold in the last month
$lands = SoldLand::with([
    // load all installments that were pay
    'installments' => fn($installment) => $installment->isPay()->with([
        // load payments of installments (load relation using LazyCollection)
        'payments' => fn($payment) => $payment->asLazy(),
    ]),
])->soldInLastMonth()->lazy();
```

## Breaking changes
This PR will break libraries that extends functionality over Illuminate/Database.