### PR TITLE
[9.x] Improve test for macroable trait

### DIFF
--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -101,6 +101,23 @@ class SupportMacroableTest extends TestCase
 
         $instance->flushMethod();
     }
+
+    public function testFlushMacrosStatic()
+    {
+        TestMacroable::macro('flushMethod', function () {
+            return 'flushMethod';
+        });
+
+        $instance = new TestMacroable;
+
+        $this->assertSame('flushMethod', $instance::flushMethod());
+
+        TestMacroable::flushMacros();
+
+        $this->expectException(BadMethodCallException::class);
+
+        $instance::flushMethod();
+    }
 }
 
 class EmptyMacroable


### PR DESCRIPTION
add test for exception in __callstatic

