### PR TITLE
[9.x] Speed optimization syncWithoutDetaching

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -99,6 +99,7 @@ trait InteractsWithPivotTable
         // array of the new IDs given to the method which will complete the sync.
         if ($detaching) {
             $detach = array_diff($current, array_keys($records));
+
             if (count($detach) > 0) {
                 $this->detach($detach);
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -92,17 +92,18 @@ trait InteractsWithPivotTable
         $current = $this->getCurrentlyAttachedPivots()
                         ->pluck($this->relatedPivotKey)->all();
 
-        $detach = array_diff($current, array_keys(
-            $records = $this->formatRecordsList($this->parseIds($ids))
-        ));
+        $records = $this->formatRecordsList($this->parseIds($ids));
 
         // Next, we will take the differences of the currents and given IDs and detach
         // all of the entities that exist in the "current" array but are not in the
         // array of the new IDs given to the method which will complete the sync.
-        if ($detaching && count($detach) > 0) {
-            $this->detach($detach);
+        if ($detaching) {
+            $detach = array_diff($current, array_keys($records));
+            if (count($detach) > 0) {
+                $this->detach($detach);
 
-            $changes['detached'] = $this->castKeys($detach);
+                $changes['detached'] = $this->castKeys($detach);
+            }
         }
 
         // Now we are finally ready to attach the new records. Note that we'll disable


### PR DESCRIPTION
When using `syncWithoutDetaching` the `$detach` variable is created from an expensive array_diff even though it is not used anywhere because of the condition on `$detaching`

Here is a simplified benchmark to demonstrate the before and after
<details>
<summary>
https://3v4l.org/gZQIX
</summary>

```php
<?php

$detaching = false;
$ids = array_flip([3,4,5,6,11,13,15]);
$current = [1,2,3,4,5,6,7,8,9,10];

$prev = hrtime(true);
for($i = 0; $i < 10000; $i++) {
        // Next, we will take the differences of the currents and given IDs and detach
        // all of the entities that exist in the "current" array but are not in the
        // array of the new IDs given to the method which will complete the sync.
        if ($detaching) {
            $detach = array_diff($current, array_keys($ids));
            if (count($detach) > 0) {
                // 
            }
        }
}
echo hrtime(true) - $prev;
echo PHP_EOL;

$prev = hrtime(true);
for($i = 0; $i < 10000; $i++) {
        $detach = array_diff($current, array_keys($ids));

        // Next, we will take the differences of the currents and given IDs and detach
        // all of the entities that exist in the "current" array but are not in the
        // array of the new IDs given to the method which will complete the sync.
        if ($detaching && count($detach) > 0) {
            //
        }
}
echo hrtime(true) - $prev;
echo PHP_EOL;
```
</details>

Output for php 8.1.9
With improvement: 61817 nanoseconds
Without improvement: 3490783 nanoseconds

The performance gain is in a factor of 50 which is not negligible when working with large pivot datasets and multiple updates

This is not a breaking change as it just moves the code around in a more optimal manner