### PR TITLE
[9.x] Fix withoutVite

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -141,17 +141,17 @@ trait InteractsWithContainer
                 return $this;
             }
 
-            public function useBuildDirectory($path)
+            public function useBuildDirectory()
             {
                 return $this;
             }
 
-            public function useHotFile($path)
+            public function useHotFile()
             {
                 return $this;
             }
 
-            public function withEntryPoints($entryPoints)
+            public function withEntryPoints()
             {
                 return $this;
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -121,6 +121,11 @@ trait InteractsWithContainer
                 return '';
             }
 
+            public function __toString()
+            {
+                return '';
+            }
+
             public function useIntegrityKey()
             {
                 return $this;
@@ -132,6 +137,21 @@ trait InteractsWithContainer
             }
 
             public function useStyleTagAttributes()
+            {
+                return $this;
+            }
+
+            public function useBuildDirectory($path)
+            {
+                return $this;
+            }
+
+            public function useHotFile($path)
+            {
+                return $this;
+            }
+
+            public function withEntryPoints($entryPoints)
             {
                 return $this;
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -131,16 +131,6 @@ trait InteractsWithContainer
                 return $this;
             }
 
-            public function useScriptTagAttributes()
-            {
-                return $this;
-            }
-
-            public function useStyleTagAttributes()
-            {
-                return $this;
-            }
-
             public function useBuildDirectory()
             {
                 return $this;
@@ -152,6 +142,16 @@ trait InteractsWithContainer
             }
 
             public function withEntryPoints()
+            {
+                return $this;
+            }
+
+            public function useScriptTagAttributes()
+            {
+                return $this;
+            }
+
+            public function useStyleTagAttributes()
             {
                 return $this;
             }

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -25,6 +25,14 @@ class InteractsWithContainerTest extends TestCase
         $this->assertSame($this, $instance);
     }
 
+    public function testWithoutViteHandlesAsset()
+    {
+        $instance = $this->withoutVite();
+
+        $this->assertSame('', app(Vite::class)->asset('path/to/asset.png'));
+        $this->assertSame($this, $instance);
+    }
+
     public function testWithViteRestoresOriginalHandlerAndReturnsInstance()
     {
         $handler = new stdClass;


### PR DESCRIPTION
This PR fixes the `withoutVite` method.

-----

With the latest release some `Vite` methods were added, however currently they are not compatible with the `withoutVite` testing method. 

For example in an app.blade.php:

```blade
    {{
        Vite::withEntryPoints('resources/js/app.js')
            ->useBuildDirectory('vendor/package-name/build')
            ->useHotFile(public_path('vendor/package-name/hot'))
    }}
```

The following error is coming up: 

```
Error: Call to a member function useBuildDirectory() on string in ...
```

The methods that are returning other value type than a string for example `$this` must be defined. Also, the `__toString` is added to the anonymus class to make sure blade can render it.

------

I was not sure how to test it since no other tests were added to the similar fake methods.
