### PR TITLE
Explicitly add column name to SQLite query

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -149,7 +149,7 @@ abstract class DatabaseInspectionCommand extends Command
      */
     protected function getSqliteTableSize(ConnectionInterface $connection, string $table)
     {
-        $result = $connection->selectOne('SELECT SUM(pgsize) FROM dbstat WHERE name=?', [
+        $result = $connection->selectOne('SELECT SUM(pgsize) AS size FROM dbstat WHERE name=?', [
             $table,
         ]);
 


### PR DESCRIPTION
Running the new `db:show` and `db:table` on a SQLite database connection throws an error.

```shell
php artisan db:table users

   ErrorException 

  Undefined array key "size"

...
```
This Pull request fixes it.