### PR TITLE
[9.x] Improves `Cache/RateLimiting/Limit` key type

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -7,7 +7,7 @@ class Limit
     /**
      * The rate limit signature key.
      *
-     * @var mixed|string
+     * @var mixed
      */
     public $key;
 
@@ -35,7 +35,7 @@ class Limit
     /**
      * Create a new limit instance.
      *
-     * @param  mixed|string  $key
+     * @param  mixed  $key
      * @param  int  $maxAttempts
      * @param  int  $decayMinutes
      * @return void
@@ -107,7 +107,7 @@ class Limit
     /**
      * Set the key of the rate limit.
      *
-     * @param  string  $key
+     * @param  mixed  $key
      * @return $this
      */
     public function by($key)


### PR DESCRIPTION
This pull request makes the Laravel's skeleton have no errors on Larastan level `--max`, and it fixes the Limit::$key property, as indeed it can be a `mixed` type.