### PR TITLE
[9.x] Translation of the default message of the validator

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -88,15 +88,15 @@ class ValidationException extends Exception
         $messages = $validator->errors()->all();
 
         if (! count($messages) || ! is_string($messages[0])) {
-            return 'The given data was invalid.';
+            return $validator->getTranslator()->get('The given data was invalid.');
         }
 
         $message = array_shift($messages);
 
-        if ($additional = count($messages)) {
-            $pluralized = $additional === 1 ? 'error' : 'errors';
+        if ($count = count($messages)) {
+            $pluralized = $count === 1 ? 'error' : 'errors';
 
-            $message .= " (and {$additional} more {$pluralized})";
+            $message .= ' '.$validator->getTranslator()->get("(and :count more $pluralized)", compact('count'));
         }
 
         return $message;


### PR DESCRIPTION
### Before:

```json
{
    "message": "The given data was invalid.",
    "errors": {
        "email": [
            "Taki adres e-mail już występuje."
        ]
    }
}

{
    "message": "Taki adres e-mail już występuje. (and 1 more error)",
    "errors": {
        "email": [
            "Taki adres e-mail już występuje."
        ],
        "name": [
            "Taki nazwa już występuje."
        ]
    }
}
```

### After

```json
{
    "message": "Podane dane były nieprawidłowe.",
    "errors": {
        "email": [
            "Taki adres e-mail już występuje."
        ]
    }
}

{
    "message": "Taki adres e-mail już występuje. (i jeszcze 1 błąd)",
    "errors": {
        "email": [
            "Taki adres e-mail już występuje."
        ],
        "name": [
            "Taki nazwa już występuje."
        ]
    }
}
```

On line 99, I deliberately put the space character outside the translation function, as it can be confusing for developers, namely, they can compose translations as `"(and :count more errors)"` instead of `" (and :count more errors)"` and will not understand why the translation does not work.