### PR TITLE
[9.x] Improve @return value for `Illuminate\Database\Query\Builder::get()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2610,7 +2610,7 @@ class Builder implements BuilderContract
      * Execute the query as a "select" statement.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection
      */
     public function get($columns = ['*'])
     {


### PR DESCRIPTION
## Change

`Illuminate\Database\Query\Builder::get()` should return a `\Illuminate\Database\Eloquent\Collection` instance.

## Motivation

I have a class property with the type `Illuminate\Database\Eloquent\Collection`.

In the constructor, I populate it with `Book::all()`, and works as expected.

Recently I had to add one condition to my query, so I replaced `Book::all()` to `Book::whereNull('column')->get()` and I get the following complain from PHPStorm:

![image](https://user-images.githubusercontent.com/21138205/186421958-723ff836-7e1d-4cd7-8737-53ab1aad0f16.png)

Both statements return objects of `Illuminate\Database\Eloquent\Collection`.

## Any considerations? 

- Should I completely drop `\Illuminate\Support\Collection` or the Union is actually fine?


