### PR TITLE
Fix param type for `hasAny()` in `Illuminate\Support\MessageBag`

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -139,7 +139,7 @@ class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, Mess
     /**
      * Determine if messages exist for any of the given keys.
      *
-     * @param  array|string  $keys
+     * @param  array|string|null  $keys
      * @return bool
      */
     public function hasAny($keys = [])

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -151,6 +151,14 @@ class SupportMessageBagTest extends TestCase
         $this->assertFalse($container->hasAny('baz', 'biz'));
     }
 
+    public function testHasAnyWithKeyNull()
+    {
+        $container = new MessageBag;
+        $container->setFormat(':message');
+        $container->add('foo', 'bar');
+        $this->assertTrue($container->hasAny(null));
+    }
+
     public function testHasIndicatesExistenceOfAllKeys()
     {
         $container = new MessageBag;


### PR DESCRIPTION
In the `Illuminate\Support\MessageBag` class the `hasAny()` function also takes a param type of null. I added a test as well.

For example:

```php
use Illuminate\Support\MessageBag;

$messageBag = new MessageBag(['message' => 'bag']);

$messageBag->has(null);

// true

$messageBag->hasAny(null);

// true