### PR TITLE
Fix for potential bug with non-backed enums

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1129,7 +1129,6 @@ trait HasAttributes
     /**
      * @param  string  $enumClass
      * @param  string|int  $value
-     *
      * @return \UnitEnum|\BackedEnum
      */
     protected function getEnumCaseFromValue($enumClass, $value)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1119,7 +1119,7 @@ trait HasAttributes
 
         if (! isset($value)) {
             $this->attributes[$key] = null;
-        } else if (is_object($value)) {
+        } elseif (is_object($value)) {
             $this->attributes[$key] = $this->getCastableAttributeFromEnum($value);
         } else {
             $this->attributes[$key] = $this->getCastableAttributeFromEnum($this->getEnumCaseFromValue($enumClass, $value));

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1149,7 +1149,7 @@ trait HasAttributes
      */
     protected function getCastableAttributeFromEnum($value)
     {
-        if ($value instanceof \BackedEnum::class) {
+        if ($value instanceof \BackedEnum) {
             return $value->value;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithDictionary.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
 use BackedEnum;
 use Doctrine\Instantiator\Exception\InvalidArgumentException;
+use UnitEnum;
 
 trait InteractsWithDictionary
 {
@@ -23,8 +24,8 @@ trait InteractsWithDictionary
             }
 
             if (function_exists('enum_exists') &&
-                $attribute instanceof BackedEnum) {
-                return $attribute->value;
+                $attribute instanceof UnitEnum) {
+                return $attribute instanceof BackedEnum ? $attribute->value : $attribute->name;
             }
 
             throw new InvalidArgumentException('Model attribute value is an object but does not have a __toString method.');


### PR DESCRIPTION
This PR abstracts out the collection of an enum case and enum value to their own methods to simplify and fixes a potential bug with `addCastAttributesToArray` where it always assumes a backed enum.

It also fixes something left over from the last PR, where relation dictionaries didn't support non-backed enums.