### PR TITLE
[9.x] Direct stream download

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -167,7 +167,6 @@ class ResponseFactory implements FactoryContract
      *
      * @param  StreamInterface $stream
      * @param  string $name
-     *
      * @return  StreamedResponse
      */
     public function directStreamDownload(StreamInterface $stream, string $name)

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 use Illuminate\Routing\Exceptions\StreamedResponseException;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Throwable;
@@ -159,6 +160,21 @@ class ResponseFactory implements FactoryContract
         }
 
         return $response;
+    }
+
+    /**
+     * Directly output stream as an HTTP Response.
+     *
+     * @param  StreamInterface $stream
+     * @param  string $name
+     *
+     * @return  StreamedResponse
+     */
+    public function directStreamDownload(StreamInterface $stream, string $name)
+    {
+        return $this->streamDownload(function () use ($stream) {
+            echo $stream;
+        }, $name);
     }
 
     /**

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -165,9 +165,9 @@ class ResponseFactory implements FactoryContract
     /**
      * Directly output stream as an HTTP Response.
      *
-     * @param   StreamInterface $stream
-     * @param   string $name
-     * @return  StreamedResponse
+     * @param  StreamInterface  $stream
+     * @param  string  $name
+     * @return StreamedResponse
      */
     public function directStreamDownload(StreamInterface $stream, string $name)
     {

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -165,8 +165,8 @@ class ResponseFactory implements FactoryContract
     /**
      * Directly output stream as an HTTP Response.
      *
-     * @param  StreamInterface $stream
-     * @param  string $name
+     * @param   StreamInterface $stream
+     * @param   string $name
      * @return  StreamedResponse
      */
     public function directStreamDownload(StreamInterface $stream, string $name)

--- a/tests/Integration/Http/StreamResponseTest.php
+++ b/tests/Integration/Http/StreamResponseTest.php
@@ -10,6 +10,10 @@ class StreamResponseTest extends TestCase
 {
     public function testDirectStreamResponse()
     {
+        if (! class_exists(HttpFactory::class)) {
+            $this->markTestSkipped('GuzzleHttp is not installed.');
+        }
+
         Route::get('/stream-response', function () {
             $factory = new HttpFactory;
 

--- a/tests/Integration/Http/StreamResponseTest.php
+++ b/tests/Integration/Http/StreamResponseTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class StreamResponseTest extends TestCase
+{
+    public function testDirectStreamResponse()
+    {
+        Route::get('/stream-response', function () {
+            $factory = new HttpFactory;
+
+            $stream = $factory->createStream('Hello World');
+
+            return response()->directStreamDownload($stream, 'test.txt');
+        });
+
+        $response = $this->get('/stream-response')
+            ->assertSuccessful()
+            ->streamedContent();
+
+        $this->assertSame('Hello World', $response);
+    }
+}


### PR DESCRIPTION
Following up on Taylor's tweet (https://twitter.com/taylorotwell/status/1562195841062154240), I decided to open up this PR to address a small papercut I have to implement more than once on a few projects.

The fact that the `ResponseFactory` class only accepts a `callback` is slightly annoying as we have to manage the process of dumping the contents of the stream onto the response inside project code. This small change enhances Laravel to take on a PSR Stream object and directly output it as a download onto the browser.