### PR TITLE
[9.x] Compressed JSON Response

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -91,13 +91,12 @@ class ResponseFactory implements FactoryContract
     /**
      * Create a new compressed JSON response instance. Requires php-zip extension.
      *
-     * @param array|string $data
-     * @param $status
-     * @param array $headers
-     * @param $options
+     * @param  array|string $data
+     * @param  $status
+     * @param  array $headers
      * @return Response
      */
-    public function compressedJson(array|string $data = [], $status = 200, array $headers = [], $options = 0)
+    public function compressedJson(array|string $data = [], $status = 200, array $headers = [])
     {
         if (! extension_loaded('zip')) {
             throw new RuntimeException('Gzip extension is not available.');

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -91,9 +91,9 @@ class ResponseFactory implements FactoryContract
     /**
      * Create a new compressed JSON response instance. Requires php-zip extension.
      *
-     * @param  array|string $data
-     * @param  $status
-     * @param  array $headers
+     * @param  array|string  $data
+     * @param  int  $status
+     * @param  array  $headers
      * @return Response
      */
     public function compressedJson(array|string $data = [], $status = 200, array $headers = [])

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -995,6 +995,18 @@ EOF;
     }
 
     /**
+     * Decode compressed response content.
+     *
+     * @return $this
+     */
+    public function decodeGzip(): self
+    {
+        $this->setContent(gzdecode($this->getContent()));
+
+        return $this;
+    }
+
+    /**
      * Validate and return the decoded response JSON.
      *
      * @param  string|null  $key

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -37,7 +37,7 @@ class ResponseTest extends TestCase
 
         $response = ['foo' => 'bar'];
 
-        $handler = fn() => response()->compressedJson($response);
+        $handler = fn () => response()->compressedJson($response);
 
         Route::get('/compressed-json', $handler);
 

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -28,4 +28,22 @@ class ResponseTest extends TestCase
 
         $this->get('/response');
     }
+
+    public function testCompressedJsonResponse()
+    {
+        if (! extension_loaded('zip')) {
+            $this->markTestSkipped('Zip extension is not loaded');
+        }
+
+        $response = ['foo' => 'bar'];
+
+        $handler = fn() => response()->compressedJson($response);
+
+        Route::get('/compressed-json', $handler);
+
+        $this->getJson('/compressed-json')->assertSuccessful()
+            ->assertSee(gzencode(json_encode($response), 9))
+            ->decodeGzip()
+            ->assertJson(['foo' => 'bar']);
+    }
 }


### PR DESCRIPTION
Following up on Taylor's tweet (https://twitter.com/taylorotwell/status/1562195841062154240), I decided to open up this PR to address a small papercut I have to implement more than once on a few projects.

This is particularly useful for projects running inside AWS Lambda. When an HTTP Response is bigger than 1MB, it causes AWS Lambda internal runtime to crash with a 502 which is hard to track down. The most convenient way to overcome that limitation is to gzip the response, which is widely supported by browsers and make the whole process transparent while still providing AWS with a smaller response size.