### PR TITLE
[9.x] Feature whereLike added to Mathcing trait of AssertableJson + tests

### DIFF
--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -5,6 +5,7 @@ namespace Illuminate\Testing\Fluent\Concerns;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 trait Matching
@@ -42,6 +43,28 @@ trait Matching
             $expected,
             $actual,
             sprintf('Property [%s] does not match the expected value.', $this->dotPath($key))
+        );
+
+        return $this;
+    }
+
+
+    /**
+     * Asserts that the property matches the expected pattern.
+     *
+     * @param  string  $key
+     * @param  string  $expected
+     * @return $this
+     */
+    public function whereLike(string $key, $expected): self
+    {
+        $this->has($key);
+
+        $actual = $this->prop($key);
+
+        PHPUnit::assertTrue(
+            Str::is($expected, $actual),
+            sprintf('Property [%s] does not match the expected pattern.', $this->dotPath($key))
         );
 
         return $this;

--- a/src/Illuminate/Testing/Fluent/Concerns/Matching.php
+++ b/src/Illuminate/Testing/Fluent/Concerns/Matching.php
@@ -48,7 +48,6 @@ trait Matching
         return $this;
     }
 
-
     /**
      * Asserts that the property matches the expected pattern.
      *

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -528,7 +528,7 @@ class AssertTest extends TestCase
 
         $assert->whereLike('baz', 'invalid');
     }
-    
+
     public function testAssertWhereContainsFailsWithEmptyValue()
     {
         $assert = AssertableJson::fromArray([]);

--- a/tests/Testing/Fluent/AssertTest.php
+++ b/tests/Testing/Fluent/AssertTest.php
@@ -496,6 +496,39 @@ class AssertTest extends TestCase
             ]);
     }
 
+    public function testAssertWhereLikeMatchesValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value is here',
+        ]);
+
+        $assert->whereLike('bar', 'value * here');
+    }
+
+    public function testAssertWhereLikeFailsWhenDoesNotMatchValue()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value is somewhere else...',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [bar] does not match the expected pattern.');
+
+        $assert->whereLike('bar', 'value * here');
+    }
+
+    public function testAssertWhereLikeFailsWhenMissing()
+    {
+        $assert = AssertableJson::fromArray([
+            'bar' => 'value',
+        ]);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Property [baz] does not exist.');
+
+        $assert->whereLike('baz', 'invalid');
+    }
+    
     public function testAssertWhereContainsFailsWithEmptyValue()
     {
         $assert = AssertableJson::fromArray([]);


### PR DESCRIPTION
### Description 
The PR implements `$assertableJson->whereLike()` method for `Illuminate\Testing\Fluent\Concerns\Matching` trait, which gets the `key` and `expected` pattern and returns a boolean representing matched or not...

### Problem
In most of cases we need to check a particular pattern on a json response and we have to check it in callbacks maybe. This PR simply added a dedicated method for this purpose.
#### Sample usage
```php
$this->post('test-uri', [])->assertStatus(429)->assertJson(fn(AssertableJson $json) =>
    $json->whereLike('message', 'Try again * seconds later!')
        ->missing('data')
        ->etc();
);
```

Let me know your comments! 

Thanks <3
 
