### PR TITLE
Adds `fallbackView` method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -238,6 +238,23 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Register a new Fallback that returns a view.
+     *
+     * @param  string  $view
+     * @return \Illuminate\Routing\Route
+     */
+    public function fallbackView($view)
+    {
+        $placeholder = 'fallbackPlaceholder';
+
+        return $this->addRoute(
+            'GET',
+            "{{$placeholder}}",
+            fn () => view($view)
+        )->where($placeholder, '.*')->fallback();
+    }
+
+    /**
      * Create a redirect from one URI to another.
      *
      * @param  string  $uri


### PR DESCRIPTION
This PR adds a new router method which helps us to improve the readability of our code and makes it easier

## In the old versions

```PHP
Route::fallback(function () {
    return view('welcome');
});
```

## After this PR gets merged

```PHP
Route::fallbackView('welcome');
```