### PR TITLE
[9.x] Move `db` command to `db:cli`

### DIFF
--- a/src/Illuminate/Database/Console/CliCommand.php
+++ b/src/Illuminate/Database/Console/CliCommand.php
@@ -7,14 +7,14 @@ use Illuminate\Support\ConfigurationUrlParser;
 use Symfony\Component\Process\Process;
 use UnexpectedValueException;
 
-class DbCommand extends Command
+class CliCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'db {connection? : The database connection that should be used}
+    protected $signature = 'db:cli {connection? : The database connection that should be used}
                {--read : Connect to the read connection}
                {--write : Connect to the write connection}';
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -13,7 +13,7 @@ use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Console\Scheduling\ScheduleTestCommand;
 use Illuminate\Console\Scheduling\ScheduleWorkCommand;
 use Illuminate\Contracts\Support\DeferrableProvider;
-use Illuminate\Database\Console\DbCommand;
+use Illuminate\Database\Console\CliCommand as DatabaseCliCommand;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Database\Console\MonitorCommand as DatabaseMonitorCommand;
@@ -104,7 +104,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ClearResets' => ClearResetsCommand::class,
         'ConfigCache' => ConfigCacheCommand::class,
         'ConfigClear' => ConfigClearCommand::class,
-        'Db' => DbCommand::class,
+        'DbCli' => DatabaseCliCommand::class,
         'DbMonitor' => DatabaseMonitorCommand::class,
         'DbPrune' => PruneCommand::class,
         'DbShow' => ShowCommand::class,
@@ -376,9 +376,9 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      *
      * @return void
      */
-    protected function registerDbCommand()
+    protected function registerDbCliCommand()
     {
-        $this->app->singleton(DbCommand::class);
+        $this->app->singleton(DatabaseCliCommand::class);
     }
 
     /**


### PR DESCRIPTION
I suggest to move `db` command under `db` group like this:

<img width="977" alt="Schermata 2022-08-25 alle 14 28 10" src="https://user-images.githubusercontent.com/104917502/186667081-584b831a-5797-4582-a49e-fce8d127f754.png">

I propose to call it `db:cli`

