### PR TITLE
Add ListCommand with an option to hide vendor commands

### DIFF
--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -79,4 +79,14 @@ class ClosureCommand extends Command
 
         return $this;
     }
+
+    /**
+     * Get the command callback.
+     *
+     * @return Closure
+     */
+    public function getCallback()
+    {
+        return $this->callback;
+    }
 }

--- a/src/Illuminate/Foundation/Console/ListCommand.php
+++ b/src/Illuminate/Foundation/Console/ListCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+
+class ListCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'list
+                    {namespace? : The namespace name}
+                    {--format=txt : The output format (txt, xml, json, or md)}
+                    {--raw : To output raw command list}
+                    {--short : To skip describing commands\' arguments}
+                    {--no-vendor : To skip commands defined by vendor dependencies}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List commands';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $helper = new DescriptorHelper();
+
+        if($this->option('no-vendor')) {
+            $helper->register('txt', new NoVendorTextDescriptor());
+        }
+
+        $helper->describe($this->output, $this->getApplication(), [
+            'format' => $this->option('format'),
+            'raw_text' => $this->option('raw'),
+            'namespace' => $this->argument('namespace'),
+            'short' => $this->option('short'),
+        ]);
+    }
+}

--- a/src/Illuminate/Foundation/Console/NoVendorTextDescriptor.php
+++ b/src/Illuminate/Foundation/Console/NoVendorTextDescriptor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Support\Str;
+use ReflectionClass;
+use ReflectionFunction;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Descriptor\ApplicationDescription;
+use Symfony\Component\Console\Descriptor\TextDescriptor;
+
+class NoVendorTextDescriptor extends TextDescriptor
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function describeApplication(Application $application, array $options = [])
+    {
+        $description = new ApplicationDescription($application, $options['namespace'] ?? null);
+
+        foreach ($description->getCommands() as $command) {
+            if ($command instanceof ClosureCommand) {
+                $fileName = (new ReflectionFunction($command->getCallback()))->getFileName();
+            } else {
+                $fileName = (new ReflectionClass($command))->getFileName();
+            }
+
+            if ($fileName && str_starts_with($fileName, base_path('vendor'))) {
+                $command->setHidden(true);
+            }
+        }
+
+        parent::describeApplication($application, $options);
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -42,6 +42,7 @@ use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
+use Illuminate\Foundation\Console\ListCommand;
 use Illuminate\Foundation\Console\ListenerMakeCommand;
 use Illuminate\Foundation\Console\MailMakeCommand;
 use Illuminate\Foundation\Console\ModelMakeCommand;
@@ -116,6 +117,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'EventClear' => EventClearCommand::class,
         'EventList' => EventListCommand::class,
         'KeyGenerate' => KeyGenerateCommand::class,
+        'List' => ListCommand::class,
         'Optimize' => OptimizeCommand::class,
         'OptimizeClear' => OptimizeClearCommand::class,
         'PackageDiscover' => PackageDiscoverCommand::class,
@@ -559,6 +561,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerKeyGenerateCommand()
     {
         $this->app->singleton(KeyGenerateCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerListCommand()
+    {
+        $this->app->singleton(ListCommand::class);
     }
 
     /**

--- a/tests/Integration/Foundation/ListCommand/ListCommandTest.php
+++ b/tests/Integration/Foundation/ListCommand/ListCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\ListCommand;
+
+use Illuminate\Console\Application as ConsoleApplication;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Foundation\Application as FoundationApplication;
+use Illuminate\Foundation\Console\ListCommand;
+use Illuminate\Tests\Integration\Foundation\ListCommand\fixtures\app\AppCommand;
+use Illuminate\Tests\Integration\Foundation\ListCommand\fixtures\vendor\VendorCommand;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ListCommandTest extends TestCase
+{
+    public function testVendorCommandsCanBeHidden()
+    {
+        $output = $this->runCommand(['--no-vendor' => true]);
+
+        $this->assertStringContainsString('app-command', $output);
+        $this->assertStringNotContainsString('vendor-command', $output);
+    }
+
+    public function testVendorCommandsAreVisibleByDefault()
+    {
+        $output = $this->runCommand([]);
+
+        $this->assertStringContainsString('app-command', $output);
+        $this->assertStringContainsString('vendor-command', $output);
+    }
+
+    protected function runCommand($parameters)
+    {
+        $output = new BufferedOutput();
+
+        $app = new FoundationApplication();
+        $app->setBasePath(__DIR__ . DIRECTORY_SEPARATOR . 'fixtures');
+
+        $artisan = new ConsoleApplication(
+            $app,
+            m::mock(Dispatcher::class, ['dispatch' => null, 'fire' => null]),
+            'testing'
+        );
+        $artisan->add(new AppCommand());
+        $artisan->add(new VendorCommand());
+
+        $command = new ListCommand();
+        $command->setLaravel($app);
+        $command->setApplication($artisan);
+        $command->run(new ArrayInput($parameters), $output);
+
+        return $output->fetch();
+    }
+}

--- a/tests/Integration/Foundation/ListCommand/fixtures/app/AppCommand.php
+++ b/tests/Integration/Foundation/ListCommand/fixtures/app/AppCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\ListCommand\fixtures\app;
+
+use Illuminate\Console\Command;
+
+class AppCommand extends Command
+{
+    protected $signature = 'app-command';
+
+    public function handle() {}
+}

--- a/tests/Integration/Foundation/ListCommand/fixtures/vendor/VendorCommand.php
+++ b/tests/Integration/Foundation/ListCommand/fixtures/vendor/VendorCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\ListCommand\fixtures\vendor;
+
+use Illuminate\Console\Command;
+
+class VendorCommand extends Command
+{
+    protected $signature = 'vendor-command';
+
+    public function handle() {}
+}


### PR DESCRIPTION
Currently there's no way to hide vendor commands in `php artisan list` output.
When the application's commands aren't namespaced, it's difficult to see exactly what custom commands are available.
When the application's commands are however namespaced it's easy to forget about the namespace and adding the namespace every time one runs it gets annoying.

This aims to fix that by adding a `--no-vendor` option to the `php artisan list` command.

Output without `--no-vendor` option:
```
Available commands:
  about                  Display basic information about your application
  clear-compiled         Remove the compiled class file
  completion             Dump the shell completion script
  db                     Start a new database CLI session
  docs                   Access the Laravel documentation
  down                   Put the application into maintenance / demo mode
  env                    Display the current framework environment
  generate-some-report   Generate some report
  help                   Display help for a command
  list                   List commands
  migrate                Run the database migrations
  optimize               Cache the framework bootstrap files
  quick-command          Closure command defined in routes/console.php
  serve                  Serve the application on the PHP development server
  sync-some-data         Sync some data
  test                   Run the application tests
  tinker                 Interact with your application
  up                     Bring the application out of maintenance mode
 auth
  auth:clear-resets      Flush expired password reset tokens
...
```

Output with `--no-vendor` option:
```
Available commands:
  generate-some-report  Generate some report
  quick-command         Closure command defined in routes/console.php
  sync-some-data        Sync some data
```

As seen above this also correctly recognizes Closure Commands created in routes/console.php by checking the file where the Closure on which the command is based has been defined.