### PR TITLE
[9.x] Fix `is()` related model check

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php
@@ -64,7 +64,10 @@ trait ComparesRelatedModels
      */
     protected function compareKeys($parentKey, $relatedKey)
     {
-        if (empty($parentKey) || empty($relatedKey)) {
+        if ($parentKey === null
+            || $parentKey === ''
+            || $relatedKey === null
+            || $relatedKey === '') {
             return false;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php
@@ -64,10 +64,7 @@ trait ComparesRelatedModels
      */
     protected function compareKeys($parentKey, $relatedKey)
     {
-        if ($parentKey === null
-            || $parentKey === ''
-            || $relatedKey === null
-            || $relatedKey === '') {
+        if (blank($parentKey) || blank($relatedKey)) {
             return false;
         }
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -284,6 +284,69 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertTrue($relation->is($model));
     }
 
+    public function testIsModelWithZeroParentKey()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return an integer
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(0);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('0');
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithZeroRelatedKey()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return a string
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('0');
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(0);
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithZeroKeys()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return an integer
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(0);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(0);
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
     public function testIsNotModelWithNullParentKey()
     {
         $parent = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -246,6 +246,21 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->assertTrue($relation->is($model));
     }
 
+    public function testIsModelZeroRelatedKey()
+    {
+        $relation = $this->getRelation();
+
+        $this->related->shouldReceive('getTable')->once()->andReturn('table');
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(0);
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $this->assertTrue($relation->is($model));
+    }
+
     public function testIsModelWithStringRelatedKey()
     {
         $relation = $this->getRelation();

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -248,7 +248,7 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     public function testIsModelZeroRelatedKey()
     {
-        $relation = $this->getRelation();
+        $relation = $this->getRelationZero();
 
         $this->related->shouldReceive('getTable')->once()->andReturn('table');
         $this->related->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -345,6 +345,23 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $this->parent = m::mock(Model::class);
         $this->parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $this->parent->shouldReceive('getAttribute')->with('username')->andReturn('taylor');
+        $this->parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+        $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $this->parent->shouldReceive('newQueryWithoutScopes')->andReturn($this->builder);
+
+        return new HasOne($this->builder, $this->parent, 'table.foreign_key', 'id');
+    }
+
+    protected function getRelationZero()
+    {
+        $this->builder = m::mock(Builder::class);
+        $this->builder->shouldReceive('whereNotNull')->with('table.foreign_key');
+        $this->builder->shouldReceive('where')->with('table.foreign_key', '=', 0);
+        $this->related = m::mock(Model::class);
+        $this->builder->shouldReceive('getModel')->andReturn($this->related);
+        $this->parent = m::mock(Model::class);
+        $this->parent->shouldReceive('getAttribute')->with('id')->andReturn(0);
         $this->parent->shouldReceive('getAttribute')->with('username')->andReturn('taylor');
         $this->parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -293,6 +293,36 @@ class DatabaseEloquentMorphTest extends TestCase
         $this->assertTrue($relation->is($model));
     }
 
+    public function testIsModelWithZeroRelatedKey()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->once()->andReturn('table');
+        $relation->getRelated()->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('morph_id')->andReturn(0);
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithZeroStringRelatedKey()
+    {
+        $relation = $this->getOneRelation();
+
+        $relation->getRelated()->shouldReceive('getTable')->once()->andReturn('table');
+        $relation->getRelated()->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('morph_id')->andReturn('0');
+        $model->shouldReceive('getTable')->once()->andReturn('table');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $this->assertTrue($relation->is($model));
+    }
+
     public function testIsNotModelWithNullRelatedKey()
     {
         $relation = $this->getOneRelation();

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -295,7 +295,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
     public function testIsModelWithZeroRelatedKey()
     {
-        $relation = $this->getOneRelation();
+        $relation = $this->getOneRelationZero();
 
         $relation->getRelated()->shouldReceive('getTable')->once()->andReturn('table');
         $relation->getRelated()->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -310,7 +310,7 @@ class DatabaseEloquentMorphTest extends TestCase
 
     public function testIsModelWithZeroStringRelatedKey()
     {
-        $relation = $this->getOneRelation();
+        $relation = $this->getOneRelationZero();
 
         $relation->getRelated()->shouldReceive('getTable')->once()->andReturn('table');
         $relation->getRelated()->shouldReceive('getConnectionName')->once()->andReturn('connection');
@@ -392,6 +392,21 @@ class DatabaseEloquentMorphTest extends TestCase
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+        $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
+
+        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+    }
+
+    protected function getOneRelationZero()
+    {
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 0);
+        $related = m::mock(Model::class);
+        $builder->shouldReceive('getModel')->andReturn($related);
+        $parent = m::mock(Model::class);
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(0);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -286,6 +286,67 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->assertTrue($relation->is($model));
     }
 
+    public function testIsModelWithZeroParentKey()
+    {
+        $parent = m::mock(Model::class);
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return an integer
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(0);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn('0');
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithZeroRelatedKey()
+    {
+        $parent = m::mock(Model::class);
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return a string
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('0');
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(0);
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
+    public function testIsModelWithZeroKeys()
+    {
+        $parent = m::mock(Model::class);
+
+        // when addConstraints is called we need to return the foreign value
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        // when getParentKey is called we want to return an integer
+        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn(0);
+
+        $relation = $this->getRelation($parent);
+
+        $this->related->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $model = m::mock(Model::class);
+        $model->shouldReceive('getAttribute')->once()->with('id')->andReturn(0);
+        $model->shouldReceive('getTable')->once()->andReturn('relation');
+        $model->shouldReceive('getConnectionName')->once()->andReturn('relation');
+
+        $this->assertTrue($relation->is($model));
+    }
+
     public function testIsNotModelWithNullParentKey()
     {
         $parent = m::mock(Model::class);


### PR DESCRIPTION
https://github.com/laravel/framework/blob/d23de5f9af1bd253a9d8b823cec9bf37987facf2/src/Illuminate/Database/Eloquent/Relations/Concerns/ComparesRelatedModels.php#L16-L19
In this part if the `id` of the model is `0`, then `compareKeys()` will return `false` even if the key matches.

```php
    /**
     * Compare the parent key with the related key.
     *
     * @param  mixed  $parentKey
     * @param  mixed  $relatedKey
     * @return bool
     */
    protected function compareKeys($parentKey, $relatedKey)
    {
        if (empty($parentKey) || empty($relatedKey)) {
            return false;
        }

        if (is_int($parentKey) || is_int($relatedKey)) {
            return (int) $parentKey === (int) $relatedKey;
        }

        return $parentKey === $relatedKey;
    }
```

This is because `empty(0)` is `true`. In this specific case, this is not the expected behavior.
This pull request simply replace the `empty($var)` check by ~~`$var === null || $var === ''`~~ `blank($var)`, cornering the two edge cases while leaving 0 as a valid id.

[Phpstan strict rules](https://github.com/phpstan/phpstan-strict-rules), while opinionated, discourage the use of `empty()`. :)

-----
### Rationale for this fix:
I am currently working on upgrading [Lychee](https://github.com/LycheeOrg/Lychee) to Laravel 9 and migrating from [Larapass](https://github.com/DarkGhostHunter/Larapass) to [WebAuthn](https://github.com/Laragear/WebAuthn). The later makes use of the `isNot()` function. In Lychee, currently user with id = `0` is the Admin, hence how I ended up finding this bug.
