### PR TITLE
[9.x] Flush stale cache data

### DIFF
--- a/src/Illuminate/Cache/Console/FlushStaleCommand.php
+++ b/src/Illuminate/Cache/Console/FlushStaleCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Illuminate\Cache\Console;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+
+#[AsCommand(name: 'cache:flush-stale')]
+class FlushStaleCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'cache:flush-stale {store? : The store to clean up}';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'cache:flush-stale';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Flushes any stale data from the cache';
+
+    /**
+     * The cache manager instance.
+     *
+     * @var \Illuminate\Cache\CacheManager
+     */
+    protected $cache;
+
+    /**
+     * Create a new cache clear command instance.
+     *
+     * @param  \Illuminate\Cache\CacheManager  $cache
+     * @return void
+     */
+    public function __construct(CacheManager $cache)
+    {
+        parent::__construct();
+
+        $this->cache = $cache;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->laravel['events']->dispatch(
+            'cache:flushing-stale', [$this->argument('store')]
+        );
+
+        $repository = $this->cache->store($this->argument('store'));
+
+        // Adding a flushStale() empty method into Store contract would be a breaking change,
+        // so instead we're just checking whether it implements the method directly.
+        if (!$repository->supportsFlushingStale()) {
+            return $this->warn('Given store does not support flushing stale data. Make sure the correct store name was given.');
+        }
+
+        $repository->flushStale();
+
+        $this->laravel['events']->dispatch(
+            'cache:flushed-stale', [$this->argument('store')]
+        );
+
+        $this->info('Flushed stale cache data successfully.');
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['store', InputArgument::OPTIONAL, 'The name of the store you would like to clear'],
+        ];
+    }
+}

--- a/src/Illuminate/Cache/LuaScripts.php
+++ b/src/Illuminate/Cache/LuaScripts.php
@@ -22,4 +22,59 @@ else
 end
 LUA;
     }
+
+    /**
+     * Get the Lua script to delete stale tag members and tags themselves that don't have any members left.
+     *
+     * KEYS[1] - Connection cache prefix
+     * ARGV[1] - Application cache prefix
+     * ARGV[2] - Standard reference key const
+     * ARGV[3] - Forever reference key const
+     *
+     * @return string
+     */
+    public static function flushStaleTags(): string
+    {
+        return <<<'LUA'
+local deadKeys = {}
+
+for _, tagKey in ipairs(redis.call('keys', KEYS[1] .. ARGV[1] .. 'tag:*')) do
+    -- So Laravel PHP serializes values before they go into the cache, but not always.
+    -- If a value is a numeric (e.g. "6307238514508800660377"), it's written as is,
+    -- but all other values (including plain string, e.g. "63072380e1b1c629296883") are serialized.
+    -- Unfortunately, this means we have to attempt to support both cases here.
+    local tagValue = string.gsub(redis.call('get', tagKey), 's:%d+:"(%w+)";', '%1')
+
+    local referenceKeyPrefix = KEYS[1] .. ARGV[1] .. tagValue .. ':'
+
+    if redis.call('exists', referenceKeyPrefix .. ARGV[2]) > 0 then
+        local referenceMembers = redis.call('smembers', referenceKeyPrefix .. ARGV[2])
+		local deadMembers = {}
+
+		for _, key in pairs(referenceMembers) do
+			if(redis.call('exists', KEYS[1] .. key) == 0) then
+				table.insert(deadMembers, key)
+			end
+		end
+
+		if #deadMembers > 0 then
+			redis.call('srem', referenceKeyPrefix .. ARGV[2], unpack(deadMembers))
+		end
+
+		if #deadMembers == #referenceMembers then
+		    redis.call('del', referenceKeyPrefix .. ARGV[2])
+		end
+    end
+
+    if redis.call('exists', referenceKeyPrefix .. ARGV[2]) == 0 and redis.call('exists', referenceKeyPrefix .. ARGV[3]) then
+        table.insert(deadKeys, tagKey)
+    end
+end
+
+if(#deadKeys > 0) then
+    redis.call('del', unpack(deadKeys))
+end
+LUA;
+
+    }
 }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -236,6 +236,23 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Clean up any tag members that don't refer to an existing key anymore and empty tags themselves.
+     *
+     * @return void
+     */
+    public function flushStale(): void
+    {
+        $this->connection()->eval(
+            LuaScripts::flushStaleTags(),
+            1,
+            '',
+            $this->prefix,
+            RedisTaggedCache::REFERENCE_KEY_STANDARD,
+            RedisTaggedCache::REFERENCE_KEY_FOREVER,
+        );
+    }
+
+    /**
      * Begin executing a new tags operation.
      *
      * @param  array|mixed  $names

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -543,6 +543,16 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Determine if the current store flushing stale data.
+     *
+     * @return bool
+     */
+    public function supportsFlushingStale()
+    {
+        return method_exists($this->store, 'flushStale');
+    }
+
+    /**
      * Get the default cache time.
      *
      * @return int|null

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
+use Illuminate\Cache\Console\FlushStaleCommand as CacheFlushStaleCommand;
 use Illuminate\Console\Scheduling\ScheduleClearCacheCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
@@ -100,6 +101,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'About' => AboutCommand::class,
         'CacheClear' => CacheClearCommand::class,
         'CacheForget' => CacheForgetCommand::class,
+        'CacheFlushStale' => CacheFlushStaleCommand::class,
         'ClearCompiled' => ClearCompiledCommand::class,
         'ClearResets' => ClearResetsCommand::class,
         'ConfigCache' => ConfigCacheCommand::class,
@@ -252,6 +254,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton(CacheForgetCommand::class, function ($app) {
             return new CacheForgetCommand($app['cache']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerCacheFlushStaleCommand()
+    {
+        $this->app->singleton(CacheFlushStaleCommand::class, function ($app) {
+            return new CacheFlushStaleCommand($app['cache']);
         });
     }
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -428,6 +428,22 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($nonTaggableRepo->supportsTags());
     }
 
+    public function testStaleFlushableRepositoriesSupportFlushingStale()
+    {
+        $taggable = m::mock(RedisStore::class);
+        $taggableRepo = new Repository($taggable);
+
+        $this->assertTrue($taggableRepo->supportsFlushingStale());
+    }
+
+    public function testNonStaleFlushableRepositoriesDoNotSupportFlushingStale()
+    {
+        $nonTaggable = m::mock(FileStore::class);
+        $nonTaggableRepo = new Repository($nonTaggable);
+
+        $this->assertFalse($nonTaggableRepo->supportsFlushingStale());
+    }
+
     protected function getRepository()
     {
         $dispatcher = new Dispatcher(m::mock(Container::class));

--- a/tests/Cache/FlushStaleCommandTest.php
+++ b/tests/Cache/FlushStaleCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Console\FlushStaleCommand;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Foundation\Application;
+use InvalidArgumentException;
+use Mockery as m;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class FlushStaleCommandTest extends TestCase
+{
+    /**
+     * @var FlushStaleCommand
+     */
+    private $command;
+
+    /**
+     * @var CacheManager|MockInterface
+     */
+    private $cacheManager;
+
+    /**
+     * @var Repository|MockInterface
+     */
+    private $cacheRepository;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cacheManager = m::mock(CacheManager::class);
+        $this->cacheRepository = m::mock(Repository::class);
+        $this->command = new FlushStaleCommand($this->cacheManager);
+
+        $app = new Application;
+        $app['path.storage'] = __DIR__;
+        $this->command->setLaravel($app);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testFlushWithNoStoreArgument()
+    {
+        $this->cacheManager->shouldReceive('store')->once()->with(null)->andReturn($this->cacheRepository);
+        $this->cacheRepository->shouldReceive('supportsFlushingStale')->once()->andReturnTrue();
+        $this->cacheRepository->shouldReceive('flushStale')->once();
+
+        $this->runCommand($this->command);
+    }
+
+    public function testFlushWithStoreArgument()
+    {
+        $this->cacheManager->shouldReceive('store')->once()->with('foo')->andReturn($this->cacheRepository);
+        $this->cacheRepository->shouldReceive('supportsFlushingStale')->once()->andReturnTrue();
+        $this->cacheRepository->shouldReceive('flushStale')->once();
+
+        $this->runCommand($this->command, ['store' => 'foo']);
+    }
+
+    public function testFlushWithNonFlushableStore()
+    {
+        $this->cacheManager->shouldReceive('store')->once()->with(null)->andReturn($this->cacheRepository);
+        $this->cacheRepository->shouldReceive('supportsFlushingStale')->once()->andReturnFalse();
+        $this->cacheRepository->shouldReceive('flushStale')->never();
+
+        $this->runCommand($this->command);
+    }
+
+    public function testClearWithInvalidStoreArgument()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->cacheManager->shouldReceive('store')->once()->with('bar')->andThrow(InvalidArgumentException::class);
+        $this->cacheRepository->shouldReceive('flushStale')->never();
+
+        $this->runCommand($this->command, ['store' => 'bar']);
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Cache;
 
+use Carbon\CarbonInterval;
+use Illuminate\Cache\RedisTaggedCache;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
@@ -10,11 +13,16 @@ class RedisStoreTest extends TestCase
 {
     use InteractsWithRedis;
 
+    private Repository $redisRepository;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->setUpRedis();
+
+        $this->redisRepository = Cache::store('redis');
+        $this->redisRepository->clear();
     }
 
     protected function tearDown(): void
@@ -26,23 +34,64 @@ class RedisStoreTest extends TestCase
 
     public function testItCanStoreInfinite()
     {
-        Cache::store('redis')->clear();
-
-        $result = Cache::store('redis')->put('foo', INF);
+        $result = $this->redisRepository->put('foo', INF);
         $this->assertTrue($result);
-        $this->assertSame(INF, Cache::store('redis')->get('foo'));
+        $this->assertSame(INF, $this->redisRepository->get('foo'));
 
-        $result = Cache::store('redis')->put('bar', -INF);
+        $result = $this->redisRepository->put('bar', -INF);
         $this->assertTrue($result);
-        $this->assertSame(-INF, Cache::store('redis')->get('bar'));
+        $this->assertSame(-INF, $this->redisRepository->get('bar'));
     }
 
     public function testItCanStoreNan()
     {
-        Cache::store('redis')->clear();
-
-        $result = Cache::store('redis')->put('foo', NAN);
+        $result = $this->redisRepository->put('foo', NAN);
         $this->assertTrue($result);
-        $this->assertNan(Cache::store('redis')->get('foo'));
+        $this->assertNan($this->redisRepository->get('foo'));
+    }
+
+    public function testItFlushesStaleTags()
+    {
+        $this->redisRepository->put('forever-key', 'value1');
+        $this->redisRepository->tags('one')->put('one-forever-key', 'value2');
+        $this->redisRepository->tags('one')->put('one-expired-key', 'value3', CarbonInterval::second());
+        $this->redisRepository->tags('one', 'two')->put('one-two-valid-key', 'value4', CarbonInterval::hour());
+        $this->redisRepository->tags('three')->put('three-expired-key', 'value5', CarbonInterval::second());
+
+        $tagOneReferenceKey = $this->redisRepository->tags('one')->getTags()->getNamespace();
+        $tagTwoReferenceKey = $this->redisRepository->tags('two')->getTags()->getNamespace();
+        $oneForeverValueKey = $this->redisRepository->tags('one')->taggedItemKey('one-forever-key');
+        $oneTwoValidValueKey = $this->redisRepository->tags('one', 'two')->taggedItemKey('one-two-valid-key');
+
+        sleep(2);
+
+        $this->redisRepository->flushStale();
+
+        $this->assertEqualsCanonicalizing([
+            'laravel_database_laravel_cache_:forever-key',
+            "laravel_database_laravel_cache_:$oneForeverValueKey",
+            "laravel_database_laravel_cache_:$oneTwoValidValueKey",
+            'laravel_database_laravel_cache_:tag:one:key',
+            'laravel_database_laravel_cache_:tag:two:key',
+            "laravel_database_laravel_cache_:$tagOneReferenceKey:" . RedisTaggedCache::REFERENCE_KEY_FOREVER,
+            "laravel_database_laravel_cache_:$tagOneReferenceKey:" . RedisTaggedCache::REFERENCE_KEY_STANDARD,
+            "laravel_database_laravel_cache_:$tagTwoReferenceKey:" . RedisTaggedCache::REFERENCE_KEY_STANDARD,
+        ], $this->redisRepository->connection()->keys('*'));
+
+        $this->assertEqualsCanonicalizing([
+            "laravel_cache_:$oneForeverValueKey",
+        ], $this->redisRepository->connection()->smembers("laravel_cache_:$tagOneReferenceKey:" . RedisTaggedCache::REFERENCE_KEY_FOREVER));
+        $this->assertEqualsCanonicalizing([
+            "laravel_cache_:$oneTwoValidValueKey",
+        ], $this->redisRepository->connection()->smembers("laravel_cache_:$tagOneReferenceKey:" . RedisTaggedCache::REFERENCE_KEY_STANDARD));
+        $this->assertEqualsCanonicalizing([
+            "laravel_cache_:$oneTwoValidValueKey",
+        ], $this->redisRepository->connection()->smembers("laravel_cache_:$tagTwoReferenceKey:" . RedisTaggedCache::REFERENCE_KEY_STANDARD));
+
+        $this->assertSame('value1', $this->redisRepository->get('forever-key'));
+        $this->assertSame('value2', $this->redisRepository->tags(['one'])->get('one-forever-key'));
+        $this->assertNull($this->redisRepository->tags(['one'])->get('one-expired-key'));
+        $this->assertSame('value4', $this->redisRepository->tags(['one', 'two'])->get('one-two-valid-key'));
+        $this->assertNull($this->redisRepository->tags(['three'])->get('three-expired-key'));
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Resolves #43850

The "flush" naming was chosen over "clear" as this is the naming consistently used internally by Laravel (e.g. Cache::flush(), 
queue:flush), but I can change it to "clear" if that makes any difference.

Otherwise this should be a 100% backwards compatible.