### PR TITLE
[9.x] Render Blade Component instance when returned from route action

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -19,9 +19,11 @@ use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Events\Routing;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\View\Component;
 use JsonSerializable;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use ReflectionClass;
@@ -813,6 +815,10 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         if ($response instanceof Responsable) {
             $response = $response->toResponse($request);
+        }
+
+        if ($response instanceof Component) {
+            $response = Blade::renderComponent($response);
         }
 
         if ($response instanceof PsrResponseInterface) {

--- a/tests/Integration/Routing/ComponentTest.php
+++ b/tests/Integration/Routing/ComponentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\View\Component;
+use Orchestra\Testbench\TestCase;
+
+class ComponentTest extends TestCase
+{
+    public function testComponentsAreRendered()
+    {
+        Route::get('/component', function () {
+            return new TestComponent('Taylor');
+        });
+
+        $response = $this->get('/component');
+
+        $this->assertEquals(200, $response->status());
+        $this->assertSame('Hello Taylor', $response->getContent());
+    }
+}
+
+class TestComponent extends Component
+{
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function render()
+    {
+        return 'Hello {{ $name }}';
+    }
+}


### PR DESCRIPTION
This PR builds on #40745 by automatically calling `Blade::renderComponent()` on a component instance returned from a route action, removing the need for the user to do it manually.

## Example

```php
class HelloComponent extends Component
{
    public $name;

    public function __construct(string $name)
    {
        $this->name = $name;
    }

    public function render()
    {
        return 'Hello, {{ $name }}';
    }
}

// Before
Route::get('/component', function () {
    return Blade::renderComponent(new HelloComponent('Taylor'));
});

// After
Route::get('/component', function () {
    return new HelloComponent('Taylor');
});

// GET /component outputs: Hello, Taylor
```

## Rationale

Traditionally in Laravel, views are returned from route/controller actions, and components are used within views using the `<x-component>` syntax. I believe this is just how the framework has evolved – views were the original concept, and then components were invented to solve the specific problem of reusable bits of UI.

However, when compared to frontend frameworks like React/Vue where *everything* is a component, this distinction now seems a bit odd. Traditional views have a major downside – they do not have strict data dependencies, so you have to go into the `.blade.php` file to see what data it consumes. Components on the other hand allow data dependencies to be typed in the constructor.

For those who wish to adopt the "everything is a component" philosophy in their app, and take advantage of components' strict data dependencies, this PR makes it extremely ergonomic to do so.