### PR TITLE
[9.x] Prompt to create sqlite db when migrating

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Database\Connectors;
 
-use InvalidArgumentException;
+use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
 
 class SQLiteConnector extends Connector implements ConnectorInterface
 {
@@ -12,7 +12,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
      * @param  array  $config
      * @return \PDO
      *
-     * @throws \InvalidArgumentException
+     * @throws \Illuminate\Database\SQLiteDatabaseDoesNotExistException
      */
     public function connect(array $config)
     {
@@ -31,7 +31,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         // as the developer probably wants to know if the database exists and this
         // SQLite driver will not throw any exception if it does not by default.
         if ($path === false) {
-            throw new InvalidArgumentException("Database ({$config['database']}) does not exist.");
+            throw new SQLiteDatabaseDoesNotExistException($config['database']);
         }
 
         return $this->createConnection("sqlite:{$path}", $config, $options);

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\View\Components\Task;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\SchemaLoaded;
 use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
 use Illuminate\Database\SqlServerConnection;
 
 class MigrateCommand extends BaseCommand
@@ -108,7 +109,7 @@ class MigrateCommand extends BaseCommand
      */
     protected function prepareDatabase()
     {
-        if (! $this->migrator->repositoryExists()) {
+        if (! $this->repositoryExists()) {
             $this->components->info('Preparing database.');
 
             $this->components->task('Creating migration table', function () {
@@ -123,6 +124,36 @@ class MigrateCommand extends BaseCommand
         if (! $this->migrator->hasRunAnyMigrations() && ! $this->option('pretend')) {
             $this->loadSchemaState();
         }
+    }
+
+    /**
+     * Check if the migrator repository exists.
+     *
+     * @return bool
+     */
+    protected function repositoryExists()
+    {
+        return retry(2, fn () => $this->migrator->repositoryExists(), 0, function ($e) {
+            if (! $e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
+                return false;
+            }
+
+            if ($this->option('force')) {
+                return touch($e->getPrevious()->path);
+            }
+
+            if ($this->option('no-interaction')) {
+                return false;
+            }
+
+            $this->components->warn('The SQLite database does yet exist: '.$e->getPrevious()->path);
+
+            if (! $this->components->confirm('Would you like to attempt to create it?')) {
+                return false;
+            }
+
+            return touch($e->getPrevious()->path);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -127,7 +127,7 @@ class MigrateCommand extends BaseCommand
     }
 
     /**
-     * Check if the migrator repository exists.
+     * Determine if the migrator repository exists.
      *
      * @return bool
      */
@@ -146,9 +146,9 @@ class MigrateCommand extends BaseCommand
                 return false;
             }
 
-            $this->components->warn('The SQLite database does yet exist: '.$e->getPrevious()->path);
+            $this->components->warn('The SQLite database does not exist: '.$e->getPrevious()->path);
 
-            if (! $this->components->confirm('Would you like to attempt to create it?')) {
+            if (! $this->components->confirm('Would you like to create it?')) {
                 return false;
             }
 

--- a/src/Illuminate/Database/SQLiteDatabaseDoesNotExistException.php
+++ b/src/Illuminate/Database/SQLiteDatabaseDoesNotExistException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Database;
+
+use InvalidArgumentException;
+
+class SQLiteDatabaseDoesNotExistException extends InvalidArgumentException
+{
+    /**
+     * The path to the database.
+     *
+     * @var string
+     */
+    public $path;
+
+    /**
+     * Create a new instance.
+     *
+     * @param  string  $path
+     */
+    public function __construct($path)
+    {
+        parent::__construct("Database ({$path}) does not exist.");
+
+        $this->path = $path;
+    }
+}

--- a/src/Illuminate/Database/SQLiteDatabaseDoesNotExistException.php
+++ b/src/Illuminate/Database/SQLiteDatabaseDoesNotExistException.php
@@ -14,9 +14,10 @@ class SQLiteDatabaseDoesNotExistException extends InvalidArgumentException
     public $path;
 
     /**
-     * Create a new instance.
+     * Create a new exception instance.
      *
      * @param  string  $path
+     * @return void
      */
     public function __construct($path)
     {


### PR DESCRIPTION
Papercut: If you use the SQLite driver and run migrations, you are often greeted with the following wall of hell:

<img width="1288" alt="Screen Shot 2022-08-26 at 3 53 35 pm" src="https://user-images.githubusercontent.com/24803032/186831806-dcc59f3c-6db5-4d40-b8b6-46322658ae33.png">

So often I find myself then copying the path and:

```sh
touch <paste-path>
```

Band-Aid: With this PR, we automate this process away AND retry the original migration, so you don't need to re-run `php artisan migrate` again:

<img width="1253" alt="Screen Shot 2022-08-26 at 3 55 09 pm" src="https://user-images.githubusercontent.com/24803032/186832032-d12f952a-b158-4a25-ab72-576c6f697574.png">

> **Note**: The typo in this screen shot has been fixed.

If you select "no" or if the `touch` operation fails, you will still see the original exception message.

## Options

```
# No prompt, just attempts to create the file.
# If it fails the exception is shown.

php artisan migrate --force

# No prompt and the exception is shown.
# This is the same as the current behaviour.

php artisan migrate --force
```

