### PR TITLE
Add getter and setter for connection in the `DatabaseBatchRepository` class

### DIFF
--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -341,4 +341,25 @@ class DatabaseBatchRepository implements PrunableBatchRepository
             $batch->finished_at ? CarbonImmutable::createFromTimestamp($batch->finished_at) : $batch->finished_at
         );
     }
+
+    /**
+     * Set the desired connection for the batch.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function setConnection(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Get the underlying database connection.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
 }

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -343,17 +343,6 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     }
 
     /**
-     * Set the desired connection for the batch.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @return void
-     */
-    public function setConnection(Connection $connection)
-    {
-        $this->connection = $connection;
-    }
-
-    /**
      * Get the underlying database connection.
      *
      * @return \Illuminate\Database\Connection
@@ -361,5 +350,16 @@ class DatabaseBatchRepository implements PrunableBatchRepository
     public function getConnection()
     {
         return $this->connection;
+    }
+
+    /**
+     * Set the underlying database connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function setConnection(Connection $connection)
+    {
+        $this->connection = $connection;
     }
 }


### PR DESCRIPTION
This simple PR adds `setConnection` and `getConnection` methods in the `DatabaseBatchRepository` class.

### Why
In the [tenancy package](https://github.com/archtechx/tenancy), We are adding support for Laravel job batches which required temporarily replacing the BatchRepository connection with the correct tenant connection and then reverting it back when exiting the tenant context.

The [current implementation](https://github.com/archtechx/tenancy/pull/874/files#diff-2febc26a1c30671271be5f0e3de46057738d82d0c89f7b7708dadb195b50f155R29) uses the PHP Reflection class. It would be nice to have these methods in the framework to get rid of the Reflection boilerplate and modify the connection easily.  

**Wondering how our code would look:** 

Before 
```
$batchRepositoryReflection = new ReflectionClass($batchRepository);
$connectionProperty        = $batchRepositoryReflection->getProperty('connection');
$connectionProperty->setAccessible(true);
$connection = $connectionProperty->getValue($batchRepository);

$this->previousConnection = $connection;

$connectionProperty->setValue($batchRepository, DB::connection('tenant'));
```

After
```
$this->previousConnection = $batchRepository->getConnection();
$batchRepository->setConnection(DB::connection('tenant'));
```

### Tests
I haven't added tests because, as I said, these are simple changes, not a feature. I'm not sure if we need tests for getters and setters. If still wants me to add tests, please comment, and I'll add them. 