### PR TITLE
[9.x] Make `Vite::hotFile()` public

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -118,7 +118,7 @@ class Vite implements Htmlable
      *
      * @return string
      */
-    protected function hotFile()
+    public function hotFile()
     {
         return $this->hotFile ?? public_path('/hot');
     }

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -6,6 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
  * @method static string asset(string $asset, string|null $buildDirectory)
+ * @method static string hotFile()
  * @method static \Illuminate\Foundation\Vite useBuildDirectory(string $path)
  * @method static \Illuminate\Foundation\Vite useHotFile(string $path)
  * @method static \Illuminate\Foundation\Vite useIntegrityKey(string|false $key)


### PR DESCRIPTION
Hey!

I often encounter the Problem while developing that I run into an error and then I need to manually reload the page after correcting the error. Using ViteJS it is already possible to reload the page automatically on file save and I would love it, if there is a way for auto reloading the error page to check if the code is running correctly.

For that I added the ability to add custom HTML to the error page in https://github.com/spatie/ignition/pull/161

There is already a followup PR for adding the Vite Reload Script to the Error Page Head in https://github.com/spatie/laravel-ignition/pull/110

While doing the PR I saw, that the `hotFile` method is protected, which is needed for detecting the correct file path. (Otherwise only a fallback to the public path hot-file is possible)

This PR makes the `hotFile` method public.