### PR TITLE
[9.x] Re-enable Memcached store tests

### DIFF
--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -71,9 +71,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testIncrementMethodProperlyCallsMemcache()
     {
-        /** @link https://github.com/php-memcached-dev/php-memcached/pull/468 */
-        $this->markTestSkipped('Test broken due to parse error in PHP Memcached.');
-
         $memcached = m::mock(Memcached::class);
         $memcached->shouldReceive('increment')->with('foo', 5)->once()->andReturn(5);
 
@@ -83,9 +80,6 @@ class CacheMemcachedStoreTest extends TestCase
 
     public function testDecrementMethodProperlyCallsMemcache()
     {
-        /** @link https://github.com/php-memcached-dev/php-memcached/pull/468 */
-        $this->markTestSkipped('Test broken due to parse error in PHP Memcached.');
-
         $memcached = m::mock(Memcached::class);
         $memcached->shouldReceive('decrement')->with('foo', 5)->once()->andReturn(0);
 


### PR DESCRIPTION
Fixes for this have been rolled out by now. 

https://github.com/laravel/framework/pull/43876