### PR TITLE
added support for self-closing x-slot tags in blade components.

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -466,6 +466,7 @@ class ComponentTagCompiler
                     \s*
                 )
                 (?<![\/=\-])
+                (?<selfClosing>\s*\/\s*)?
             >
         /x";
 
@@ -484,7 +485,9 @@ class ComponentTagCompiler
 
             $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
 
-            return " @slot({$name}, null, [".$this->attributesToString($attributes).']) ';
+            $maybeClose = isset($matches['selfClosing']) ? '@endslot' : '';
+
+            return " @slot({$name}, null, [".$this->attributesToString($attributes).']) '.$maybeClose;
         }, $value);
 
         return preg_replace('/<\/\s*x[\-\:]slot[^>]*>/', ' @endslot', $value);

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -84,6 +84,44 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("@slot('foo', null, ['class' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\Illuminate\Support\Arr::toCssClasses(\$classes))]) \n".' @endslot', trim($result));
     }
 
+    public function testSelfClosingSlotsCanBeCompiled()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot name="foo"/>');
+
+        $this->assertSame("@slot('foo', null, []) @endslot", trim($result));
+
+        $result = $this->compiler()->compileSlots('<x-slot name="foo" />');
+
+        $this->assertSame("@slot('foo', null, []) @endslot", trim($result));
+
+        $result = $this->compiler()->compileSlots('<x-slot name="foo"/ >');
+
+        $this->assertSame("@slot('foo', null, []) @endslot", trim($result));
+
+        $result = $this->compiler()->compileSlots('<x-slot name="foo" / >');
+
+        $this->assertSame("@slot('foo', null, []) @endslot", trim($result));
+    }
+
+    public function testSlefClosingInlineSlotsCanBeCompiled()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot:foo/>');
+
+        $this->assertSame("@slot('foo', null, []) @endslot", trim($result));
+
+        $result = $this->compiler()->compileSlots('<x-slot:foo />');
+
+        $this->assertSame("@slot('foo', null, []) @endslot", trim($result));
+
+        $result = $this->compiler()->compileSlots('<x-slot:foo/ >');
+
+        $this->assertSame("@slot('foo', null, []) @endslot", trim($result));
+
+        $result = $this->compiler()->compileSlots('<x-slot:foo / >');
+
+        $this->assertSame("@slot('foo', null, []) @endslot", trim($result));
+    }
+
     public function testBasicComponentParsing()
     {
         $this->mockViewFactory();


### PR DESCRIPTION
As per discussion #43765, I've added support for self-closing `<x-slot />` tags in blade components.
Why should this be accepted? Because I think it is a good quality of life enhancement, it is not a breaking change.
Complete with tests.