### PR TITLE
[9.x] Conditionally escape the PHP binary path

### DIFF
--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -68,7 +68,7 @@ class Composer
     public function findComposer()
     {
         if ($this->files->exists($this->workingPath.'/composer.phar')) {
-            return [$this->phpBinary(), 'composer.phar'];
+            return [$this->phpBinary(false), 'composer.phar'];
         }
 
         return ['composer'];
@@ -77,11 +77,18 @@ class Composer
     /**
      * Get the PHP binary.
      *
+     * @param  bool  $escape
      * @return string
      */
-    protected function phpBinary()
+    protected function phpBinary($escape = true)
     {
-        return ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
+        $binary = (new PhpExecutableFinder)->find(false);
+
+        if (! $escape) {
+            return $binary;
+        }
+
+        return ProcessUtils::escapeArgument($binary);
     }
 
     /**

--- a/src/Illuminate/Support/Composer.php
+++ b/src/Illuminate/Support/Composer.php
@@ -85,6 +85,10 @@ class Composer
         $binary = (new PhpExecutableFinder)->find(false);
 
         if (! $escape) {
+            if (! windows_os()) {
+                return preg_replace('/\s/', '\\ ', $binary);
+            }
+
             return $binary;
         }
 

--- a/tests/Support/SupportComposerTest.php
+++ b/tests/Support/SupportComposerTest.php
@@ -24,9 +24,7 @@ class SupportComposerTest extends TestCase
 
     public function testDumpAutoloadRunsTheCorrectCommandWhenCustomComposerPharIsPresent()
     {
-        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
-
-        $expectedProcessArguments = [$escape.PHP_BINARY.$escape,  'composer.phar', 'dump-autoload'];
+        $expectedProcessArguments = [PHP_BINARY,  'composer.phar', 'dump-autoload'];
         $customComposerPhar = true;
 
         $composer = $this->mockComposer($expectedProcessArguments, $customComposerPhar);


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/43878

It appears that escaping the full PHP path (for example; `'/opt/homebrew/Cellar/php/8.1.9/bin/php' composer.phar -V --no-ansi`) when running the Composer PHAR seems to break.