### PR TITLE
[9.x] Added assertMiddleware to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -544,7 +544,10 @@ trait MakesHttpRequests
             $response = $this->followRedirects($response);
         }
 
-        return $this->createTestResponse($response);
+        $testResponse = $this->createTestResponse($response);
+        $testResponse->setRequestRoute($request->route());
+
+        return $testResponse;
     }
 
     /**

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -20,6 +20,7 @@ use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
 use LogicException;
+use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -1469,7 +1470,9 @@ EOF;
 
         $notFoundMiddleware = array_diff((array) $middleware, $requestRouteMiddleware);
 
-        PHPUnit::assertTrue(count($notFoundMiddleware) == 0, 'Middleware '. Arr::join($notFoundMiddleware, ', ', 'and') .' not found');
+        if(count($notFoundMiddleware) != 0){
+            throw new AssertionFailedError('Middleware '. Arr::join($notFoundMiddleware, ', ', 'and') .' not found');
+        }
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1459,7 +1459,7 @@ EOF;
      */
     public function assertMiddleware($middleware)
     {
-        if($this->requestRoute === null) {
+        if ($this->requestRoute === null) {
             PHPUnit::fail('Can not assert middleware because route does not exists (http error 404)');
 
             return $this;
@@ -1470,8 +1470,8 @@ EOF;
 
         $notFoundMiddleware = array_diff((array) $middleware, $requestRouteMiddleware);
 
-        if(count($notFoundMiddleware) != 0){
-            throw new AssertionFailedError('Middleware '. Arr::join($notFoundMiddleware, ', ', 'and') .' not found');
+        if (count($notFoundMiddleware) != 0) {
+            throw new AssertionFailedError('Middleware '.Arr::join($notFoundMiddleware, ', ', 'and').' not found');
         }
 
         return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2003,7 +2003,7 @@ class TestResponseTest extends TestCase
     public function testAssertMiddlewareThrowsErrorIfRouteNotFound()
     {
         $response = TestResponse::fromBaseResponse(new Response());
-        
+
         $this->expectException(AssertionFailedError::class);
         $response->assertMiddleware('foo');
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -9,11 +9,14 @@ use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Session\ArraySessionHandler;
 use Illuminate\Session\Store;
@@ -1965,6 +1968,33 @@ class TestResponseTest extends TestCase
         $this->assertInstanceOf(Cookie::class, $cookie);
         $this->assertEquals($cookieName, $cookie->getName());
         $this->assertEquals($cookieValue, $cookie->getValue());
+    }
+
+    public function testAssertMiddleware()
+    {
+        $container = new Container();
+        $router = new Router(new Dispatcher(), $container);
+        $router->middlewareGroup('MiddlewareGroup', [
+            'GroupedMiddlewareClass',
+        ]);
+
+        app()->instance('router', $router);
+
+        $route = new Route('get', '/', function () {
+        });
+        $route->middleware('MiddlewareGroup');
+        $route->middleware('MiddlewareClass');
+        $route->setContainer($container);
+
+        $response = TestResponse::fromBaseResponse(new Response());
+        $response->setRequestRoute($route);
+
+        $response->assertMiddleware('MiddlewareClass');
+        $response->assertMiddleware('MiddlewareGroup');
+        $response->assertMiddleware('GroupedMiddlewareClass');
+
+        $this->expectException(AssertionFailedError::class);
+        $response->assertMiddleware('foo');
     }
 
     private function makeMockResponse($content)

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1995,6 +1995,17 @@ class TestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
         $response->assertMiddleware('foo');
+
+        $response->setRequestRoute(null);
+        $response->assertMiddleware('MiddlewareClass');
+    }
+
+    public function testAssertMiddlewareThrowsErrorIfRouteNotFound()
+    {
+        $response = TestResponse::fromBaseResponse(new Response());
+        
+        $this->expectException(AssertionFailedError::class);
+        $response->assertMiddleware('foo');
     }
 
     private function makeMockResponse($content)


### PR DESCRIPTION
This PR adds assertMiddleware to the TestResponse. An easy way to check if the requested route has the middleware you expect it to have.

It works with full class names, aliases and middleware groups.

```php
$response = $this->get('/');
$response->assertMiddleware(\App\Http\Middleware\Authenticate::class);
$response->assertMiddleware('guest');
$response->assertMiddleware('web');
```

If the route doesn't exists an AssertionFailedError is thrown.
