### PR TITLE
[9.x] Fix registering event listeners with array callback

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -40,7 +40,7 @@ class EventServiceProvider extends ServiceProvider
             $events = $this->getEvents();
 
             foreach ($events as $event => $listeners) {
-                foreach (array_unique($listeners) as $listener) {
+                foreach (array_unique($listeners, SORT_REGULAR) as $listener) {
                     Event::listen($event, $listener);
                 }
             }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
* Laravel Version: 9.26
* PHP Version: 8.1.1
 
 
 ### Description:
 
In Laravel 9.x according to the [docs](https://laravel.com/docs/9.x/events#manually-registering-events), you could register listeners with in EventServiceProvider with the array syntax. I.E
```php
class EventServiceProvider extends ServiceProvider { 
  /**
   * The event listener mappings for the application.
   *
   * @var array
   */
  protected $listen = [
      OrderShipped::class => [
          [SendShipmentNotification::class, 'handle'],
      ],
  ];
}
```
However, if you register multiple listeners with the array syntax, then you get an array to string conversion error
 ### Steps To Reproduce:
 
 ```php
class EventServiceProvider extends ServiceProvider { 
  /**
   * The event listener mappings for the application.
   *
   * @var array
   */
  protected $listen = [
      OrderShipped::class => [
          [SendShipmentNotification::class, 'handle'],
          [SendShipmentNotification::class, 'handle2'],
      ],
  ];
}
 ```
 ### Fix:
 The EventServiceProvider uses `array_unique` to get unique listeners, however the [default behavior is to compare items as strings](https://www.php.net/manual/en/function.array-unique.php). Giving the flag `SORT_REGULAR` fixes the issue.
 
