### PR TITLE
[9.x] Add `makeOr` method to `Container`

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -702,7 +702,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function makeOr($abstract, $parameters = [], $callback = null)
+    public function makeOr($abstract, $parameters = [], Closure $callback = null)
     {
         try {
             if ($parameters instanceof Closure) {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -696,23 +696,22 @@ class Container implements ArrayAccess, ContainerContract
      * Resolve the given type from the container or execute the callback.
      *
      * @param  string  $abstract
+     * @param  mixed|array  $parameters
      * @param  Closure|array  $callback
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function makeOr($abstract, $callback = null)
+    public function makeOr($abstract, $parameters = [], $callback = null)
     {
         try {
-            if (func_num_args() <= 2) {
+            if ($parameters instanceof Closure) {
+                $callback = $parameters;
+
                 return $this->make($abstract);
             }
 
-            $args = func_get_args();
-
-            $callback = $args[2];
-
-            return $this->make(...$args);
+            return $this->make($abstract, $parameters);
         } catch (BindingResolutionException $e) {
             return $callback instanceof Closure ? $callback($this) : throw $e;
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -696,23 +696,23 @@ class Container implements ArrayAccess, ContainerContract
      * Resolve the given type from the container or execute the callback.
      *
      * @param  string  $abstract
-     * @param  Closure|array|null  $callback
+     * @param  Closure|array  $callback
      * @return mixed
      */
     public function makeOr($abstract, $callback = null)
     {
         try {
-            if (func_num_args() > 2) {
-                $args = func_get_args();
-
-                $callback = $args[2];
-
-                return $this->make(...$args);
+            if (func_num_args() <= 2) {
+                return $this->make($abstract);
             }
 
-            return $this->make($abstract);
+            $args = func_get_args();
+
+            $callback = $args[2];
+
+            return $this->make(...$args);
         } catch (BindingResolutionException) {
-            return $callback();
+            return $callback instanceof Closure ? $callback() : null;
         }
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -702,15 +702,15 @@ class Container implements ArrayAccess, ContainerContract
     public function makeOr($abstract, $callback = null)
     {
         try {
-            if (func_num_args() <= 2) {
-                return $this->make($abstract);
+            if (func_num_args() > 2) {
+                $args = func_get_args();
+
+                $callback = $args[2];
+
+                return $this->make(...$args);
             }
 
-            $args = func_get_args();
-
-            $callback = $args[2];
-
-            return $this->make(...$args);
+            return $this->make($abstract);
         } catch (BindingResolutionException) {
             return $callback instanceof Closure ? $callback($this) : null;
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -712,7 +712,7 @@ class Container implements ArrayAccess, ContainerContract
 
             return $this->make(...$args);
         } catch (BindingResolutionException) {
-            return $callback instanceof Closure ? $callback() : null;
+            return $callback instanceof Closure ? $callback($this) : null;
         }
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -704,15 +704,15 @@ class Container implements ArrayAccess, ContainerContract
     public function makeOr($abstract, $callback = null)
     {
         try {
-            if (func_num_args() > 2) {
-                $args = func_get_args();
-
-                $callback = $args[2];
-
-                return $this->make(...$args);
+            if (func_num_args() <= 2) {
+                return $this->make($abstract);
             }
 
-            return $this->make($abstract);
+            $args = func_get_args();
+
+            $callback = $args[2];
+
+            return $this->make(...$args);
         } catch (BindingResolutionException $e) {
             return $callback instanceof Closure ? $callback($this) : throw $e;
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -679,20 +679,6 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Resolve the given type from the container.
-     *
-     * @param  string|callable  $abstract
-     * @param  array  $parameters
-     * @return mixed
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
-     */
-    public function make($abstract, array $parameters = [])
-    {
-        return $this->resolve($abstract, $parameters);
-    }
-
-    /**
      * Resolve the given type from the container or execute the callback.
      *
      * @param  string  $abstract
@@ -715,6 +701,20 @@ class Container implements ArrayAccess, ContainerContract
         } catch (BindingResolutionException $e) {
             return $callback instanceof Closure ? $callback($this) : throw $e;
         }
+    }
+
+    /**
+     * Resolve the given type from the container.
+     *
+     * @param  string|callable  $abstract
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function make($abstract, array $parameters = [])
+    {
+        return $this->resolve($abstract, $parameters);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -698,6 +698,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @param  Closure|array  $callback
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function makeOr($abstract, $callback = null)
     {
@@ -711,8 +713,8 @@ class Container implements ArrayAccess, ContainerContract
             }
 
             return $this->make($abstract);
-        } catch (BindingResolutionException) {
-            return $callback instanceof Closure ? $callback($this) : null;
+        } catch (BindingResolutionException $e) {
+            return $callback instanceof Closure ? $callback($this) : throw $e;
         }
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -693,6 +693,26 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Resolve the given type from the container or execute the callback.
+     *
+     * @param  string|array  $abstract
+     * @param  Closure|null  $callback
+     * @return mixed
+     */
+    public function makeOr($abstract, Closure $callback = null)
+    {
+        try {
+            if (! is_array($abstract)) {
+                return $this->make($abstract);
+            }
+
+            return $this->make($abstract[0], $abstract[1]);
+        } catch (BindingResolutionException) {
+            return $callback();
+        }
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return mixed

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -695,18 +695,22 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Resolve the given type from the container or execute the callback.
      *
-     * @param  string|array  $abstract
-     * @param  Closure|null  $callback
+     * @param  string  $abstract
+     * @param  Closure|array|null  $callback
      * @return mixed
      */
-    public function makeOr($abstract, Closure $callback = null)
+    public function makeOr($abstract, $callback = null)
     {
         try {
-            if (! is_array($abstract)) {
-                return $this->make($abstract);
+            if (func_num_args() > 2) {
+                $args = func_get_args();
+
+                $callback = $args[2];
+
+                return $this->make(...$args);
             }
 
-            return $this->make($abstract[0], $abstract[1]);
+            return $this->make($abstract);
         } catch (BindingResolutionException) {
             return $callback();
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -697,7 +697,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string  $abstract
      * @param  mixed|array  $parameters
-     * @param  Closure|array  $callback
+     * @param  \Closure|null  $callback
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -163,8 +163,8 @@ class ContainerTest extends TestCase
     public function testMakeOr()
     {
         $container = new Container;
-        $callback = function () use ($container) {
-            $container->bind('test', fn () => true);
+        $callback = function ($app) {
+            $app->bind('test', fn () => true);
 
             return false;
         };
@@ -179,8 +179,8 @@ class ContainerTest extends TestCase
     public function testParametrizedMakeOr()
     {
         $container = new Container;
-        $callback = function () use ($container) {
-            $container->bind('test', fn () => true);
+        $callback = function ($app) {
+            $app->bind('test', fn () => true);
 
             return false;
         };

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -195,7 +195,8 @@ class ContainerTest extends TestCase
     public function testMakeOrResolutionWithoutCallback()
     {
         $container = new Container;
-        $container->makeOr(ContainerInjectVariableStub::class, ['something' => 'laravel']);
+        $var = $container->makeOr(ContainerInjectVariableStub::class, ['something' => 'laravel']);
+        $this->assertSame('laravel', $var->something);
     }
 
     public function testMakeOrThrowsExceptionWhenCannotResolveAbstractOrExecuteCallback()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -160,6 +160,41 @@ class ContainerTest extends TestCase
         $this->assertSame($var1, $var2);
     }
 
+    public function testMakeOr()
+    {
+        $container = new Container;
+        $callback = function () use ($container) {
+            $container->bind('test', fn () => true);
+
+            return false;
+        };
+
+        $var1 = $container->makeOr('test', $callback);
+        $this->assertFalse($var1);
+
+        $var2 = $container->makeOr('test', $callback);
+        $this->assertTrue($var2);
+    }
+
+    public function testParametrizedMakeOr()
+    {
+        $container = new Container;
+        $callback = function () use ($container) {
+            $container->bind('test', fn () => true);
+
+            return false;
+        };
+
+        $var1 = $container->makeOr(ContainerInjectVariableStub::class, $callback);
+        $this->assertFalse($var1);
+
+        $var2 = $container->makeOr([
+            ContainerInjectVariableStub::class,
+            ['something' => 'laravel'],
+        ], $callback);
+        $this->assertSame('laravel', $var2->something);
+    }
+
     public function testScopedConcreteResolutionResets()
     {
         $container = new Container;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -192,6 +192,13 @@ class ContainerTest extends TestCase
         $this->assertSame('laravel', $var2->something);
     }
 
+    public function testMakeOrNullable()
+    {
+        $container = new Container;
+        $var = $container->makeOr(ContainerInjectVariableStub::class);
+        $this->assertNull($var);
+    }
+
     public function testScopedConcreteResolutionResets()
     {
         $container = new Container;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -176,7 +176,7 @@ class ContainerTest extends TestCase
         $this->assertTrue($var2);
     }
 
-    public function testParametrizedMakeOr()
+    public function testMakeOrParametrized()
     {
         $container = new Container;
         $callback = function ($app) {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -192,11 +192,17 @@ class ContainerTest extends TestCase
         $this->assertSame('laravel', $var2->something);
     }
 
-    public function testMakeOrThrowsExceptionIfNoCallbackPassed()
+    public function testMakeOrResolutionWithoutCallback()
+    {
+        $container = new Container;
+        $container->makeOr(ContainerInjectVariableStub::class, ['something' => 'laravel']);
+    }
+
+    public function testMakeOrThrowsExceptionWhenCannotResolveAbstractOrExecuteCallback()
     {
         $this->expectException(BindingResolutionException::class);
         $container = new Container;
-        $container->makeOr(ContainerInjectVariableStub::class, ['something' => 'laravel']);
+        $container->makeOr(ContainerInjectVariableStub::class);
     }
 
     public function testScopedConcreteResolutionResets()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -188,10 +188,7 @@ class ContainerTest extends TestCase
         $var1 = $container->makeOr(ContainerInjectVariableStub::class, $callback);
         $this->assertFalse($var1);
 
-        $var2 = $container->makeOr([
-            ContainerInjectVariableStub::class,
-            ['something' => 'laravel'],
-        ], $callback);
+        $var2 = $container->makeOr(ContainerInjectVariableStub::class, ['something' => 'laravel'], $callback);
         $this->assertSame('laravel', $var2->something);
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -192,11 +192,11 @@ class ContainerTest extends TestCase
         $this->assertSame('laravel', $var2->something);
     }
 
-    public function testMakeOrNullable()
+    public function testMakeOrThrowsExceptionIfNoCallbackPassed()
     {
+        $this->expectException(BindingResolutionException::class);
         $container = new Container;
-        $var = $container->makeOr(ContainerInjectVariableStub::class);
-        $this->assertNull($var);
+        $container->makeOr(ContainerInjectVariableStub::class, ['something' => 'laravel']);
     }
 
     public function testScopedConcreteResolutionResets()


### PR DESCRIPTION
## About
This method will help us ensure our code will be executed if container resolution fails. This way we can bind stuff to the container "on-the-fly" even if it wasn't bound previously, or do something else.

For example:
```php
app()->makeOr('company', function ($app) {
    $company = Company::firstWhere('uuid', request()->segment(1));

    $app->scoped('company', fn () => $company);

    return $company;
});
```

If we're resolving the service with parameters, we can do this:
```php
app()->makeOr(Service::class, ['dependency' => $dependency], function ($app) {
    //
});
```

There are a lot more use cases though. Optionally, it would have been binding results of executed queries to the container to avoid query duplication in the scope of the request lifecycle, if someone doesn't want to deal with the cache/invalidation issues, etc.

---