### PR TITLE
[9.x] Add Eloquent mode to prevent silently discarding fills for attributes not in `$fillable`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -18,7 +18,6 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
@@ -466,7 +465,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             // the model, and all others will just get ignored for security reasons.
             if ($this->isFillable($key)) {
                 $this->setAttribute($key, $value);
-            } elseif($totallyGuarded || static::preventsGuardedAttributeFills()) {
+            } elseif ($totallyGuarded || static::preventsGuardedAttributeFills()) {
                 if (isset(static::$massAssignmentViolationCallback)) {
                     return call_user_func(static::$massAssignmentViolationCallback, $this, $key, $value);
                 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -429,7 +429,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             // the model, and all others will just get ignored for security reasons.
             if ($this->isFillable($key)) {
                 $this->setAttribute($key, $value);
-            } elseif ($totallyGuarded) {
+            } elseif ($totallyGuarded || app()->environment('local')) {
                 throw new MassAssignmentException(sprintf(
                     'Add [%s] to fillable property to allow mass assignment on [%s].',
                     $key, get_class($this)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -418,7 +418,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Register a callback that is responsible for handling lazy loading violations.
+     * Register a callback that is responsible for handling mass assignment violations.
      *
      * @param  callable|null  $callback
      * @return void

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1283,22 +1283,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $handledMassAssignmentExceptions = 0;
 
-        Model::preventDiscardingGuardedAttributeFills();
-
-        Model::handleMassAssignmentViolationUsing(function (Model $model, string $key, mixed $value) use (&$handledMassAssignmentExceptions) {
-            $handledMassAssignmentExceptions++;
-        });
-
-        $model = new EloquentModelStub;
-        $model->guard(['name', 'age']);
-        $model->fill(['Foo' => 'bar']);
-        $model->fill(['name' => 'Taylor']);
-        $model->mergeFillable(['name']);
-        $model->fill(['name' => 'Taylor']);
-
-        $this->assertSame(2, $handledMassAssignmentExceptions);
-
-        Model::handleMassAssignmentViolationUsing(null);
+        Model::preventSilentlyDiscardingAttributes();
 
         $this->expectException(MassAssignmentException::class);
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1280,6 +1280,31 @@ class DatabaseEloquentModelTest extends TestCase
         $model->guard(['name', 'age']);
         $model->fill(['Foo' => 'bar']);
         $this->assertFalse(isset($model->Foo));
+
+
+        $handledMassAssignmentExceptions = 0;
+
+        Model::preventDiscardingGuardedAttributeFills();
+
+        Model::handleMassAssignmentViolationUsing(function(Model $model, string $key, mixed $value) use (&$handledMassAssignmentExceptions) {
+            $handledMassAssignmentExceptions++;
+        });
+
+        $model = new EloquentModelStub;
+        $model->guard(['name', 'age']);
+        $model->fill(['Foo' => 'bar']);
+        $model->fill(['name' => 'Taylor']);
+        $model->mergeFillable(['name']);
+        $model->fill(['name' => 'Taylor']);
+
+        $this->assertSame(2, $handledMassAssignmentExceptions);
+
+        Model::handleMassAssignmentViolationUsing(null);
+
+        $this->expectException(MassAssignmentException::class);
+        $model = new EloquentModelStub;
+        $model->guard(['name', 'age']);
+        $model->fill(['Foo' => 'bar']);
     }
 
     public function testFillableOverridesGuarded()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1281,12 +1281,11 @@ class DatabaseEloquentModelTest extends TestCase
         $model->fill(['Foo' => 'bar']);
         $this->assertFalse(isset($model->Foo));
 
-
         $handledMassAssignmentExceptions = 0;
 
         Model::preventDiscardingGuardedAttributeFills();
 
-        Model::handleMassAssignmentViolationUsing(function(Model $model, string $key, mixed $value) use (&$handledMassAssignmentExceptions) {
+        Model::handleMassAssignmentViolationUsing(function (Model $model, string $key, mixed $value) use (&$handledMassAssignmentExceptions) {
             $handledMassAssignmentExceptions++;
         });
 

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -1,6 +1,10 @@
 <?php
 
+use Illuminate\Database\Eloquent\Model;
+
 use function PHPStan\Testing\assertType;
 
 $factory = User::factory();
 assertType('Illuminate\Database\Eloquent\Factories\Factory<User>', $factory);
+
+Model::preventLazyLoading();

--- a/types/Database/Eloquent/Model.php
+++ b/types/Database/Eloquent/Model.php
@@ -1,10 +1,6 @@
 <?php
 
-use Illuminate\Database\Eloquent\Model;
-
 use function PHPStan\Testing\assertType;
 
 $factory = User::factory();
 assertType('Illuminate\Database\Eloquent\Factories\Factory<User>', $factory);
-
-Model::preventLazyLoading();


### PR DESCRIPTION
One very irritating thing for me is to forget adding a new property to the `$fillable` array (because it's not my default way of working) and later discover that fills have been silently discarded, thus causing bugs.

Personally I always unguard my models using `$guarded = []`, because I know from myself that I never do anything like `$model->update($request->all())`. However, sometimes you join a new project where it's the convention to always use the `$fillable` array.

Currently Eloquent only throws an exception when the model is "totally guarded". This PR adds a method that is similar to the `Model::preventLazyLoading()` to also throw exceptions when a model change was discarded:

```php
Model::preventDiscardingGuardedAttributeFills();
```

It also works with a boolean:
```php
Model::preventDiscardingGuardedAttributeFills(! app()->isProduction());
```

_Naming ideas are appreciated. I tried to come up with a shorter name, but I couldn't yet think of a name that could convey the behaviour in a better and shorter way._

People can also add a callback to handle the exception. The callback receives the model, the key and the value of the attribute:

```php
Model::handleMassAssignmentViolationUsing(function(Model $model, string $key, mixed $value) {
    //
});
```

I think this would be very useful to prevent bugs on local environments when the developer forgets to add an attribute to `$fillable`. Thanks!