### PR TITLE
[9.x] Call `prepare()` on `HttpException` responses

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -530,7 +530,7 @@ class Handler implements ExceptionHandlerContract
     protected function prepareResponse($request, Throwable $e)
     {
         if (! $this->isHttpException($e) && config('app.debug')) {
-            return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
+            return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e)->prepare($request);
         }
 
         if (! $this->isHttpException($e)) {
@@ -539,7 +539,7 @@ class Handler implements ExceptionHandlerContract
 
         return $this->toIlluminateResponse(
             $this->renderHttpException($e), $e
-        );
+        )->prepare($request);
     }
 
     /**


### PR DESCRIPTION
When the `AbstractRouteCollection::handleMatchedRoute()` throws a `NotFoundHttpException`, the generated response is never passed through `Router::toResponse()` which calls the `Response::prepare()` method.

The end result of this is that the when a non-existing route is called the response doesn't contain the `Content-Type: text/html` header and the response may not be rendered correctly, depending on whether the web server will "intelligently" add the `Content-Type` header.

I ran into this when running Octane using my own AWS Lambda handler that doesn't correct this, like `vapor-core` does.