### PR TITLE
[9.x] Introduces `expectsAllOutputToContain` and `doesntExpectAllOutputToContain` for PendingCommand

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -16,6 +16,13 @@ trait InteractsWithConsole
     public $mockConsoleOutput = true;
 
     /**
+     * All of the output that printed out by the command
+     *
+     * @var array
+     */
+    public $allOutputs = [];
+
+    /**
      * All of the expected output lines.
      *
      * @var array
@@ -30,6 +37,13 @@ trait InteractsWithConsole
     public $expectedOutputSubstrings = [];
 
     /**
+     * All of the expected text to be present in the all the outputs.
+     *
+     * @var array
+     */
+    public $expectedAllOutputSubstrings = [];
+
+    /**
      * All of the output lines that aren't expected to be displayed.
      *
      * @var array
@@ -42,6 +56,13 @@ trait InteractsWithConsole
      * @var array
      */
     public $unexpectedOutputSubstrings = [];
+
+    /**
+     * All of the text that is not expected to be present in all the output.
+     *
+     * @var array
+     */
+    public $unexpectedAllOutputSubstrings = [];
 
     /**
      * All of the expected output tables.

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -16,7 +16,7 @@ trait InteractsWithConsole
     public $mockConsoleOutput = true;
 
     /**
-     * All of the output that printed out by the command
+     * All of the output that printed out by the command.
      *
      * @var array
      */

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -380,7 +380,7 @@ class PendingCommand
             $allOutputStr = implode("\n", $this->test->allOutputs);
 
             foreach ($this->test->expectedAllOutputSubstrings as $text) {
-                if (!str_contains($allOutputStr, $text)) {
+                if (! str_contains($allOutputStr, $text)) {
                     $this->test->fail('Output does not contain "'.$text.'".');
                 }
             }

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -386,7 +386,7 @@ class PendingCommand
             }
 
             foreach ($this->test->unexpectedAllOutputSubstrings as $text) {
-                if (!str_contains($allOutputStr, $text)) {
+                if (str_contains($allOutputStr, $text)) {
                     $this->test->fail('Output "'.$text.'" was printed.');
                 }
             }

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -193,7 +193,6 @@ class PendingCommand
         return $this;
     }
 
-
     /**
      * Specify that the given string shouldn't be contained in the command output.
      *


### PR DESCRIPTION
## What

`expectsOutputToContain` and `doesntExpectOutputToContain` have their limitations. Real case scenario below:

I have a command that write a multiple lines in 1 go `$this->info($strContainsMultileLines)`. 

When I tried to use the `expectsOutputToContain`, assuming it would validate **all output** against the string, but it didn't

The printed result of my command:
```php
@property int $id
@property string $first_name
```

Test result: 
```php
$command->artisan(...)
    ->expectsOutputToContain('@property int $id') // ok
    ->expectsOutputToContain('@property string $first_name') // expected to work, but got "Output does not contain ..."
    ->execute();
```

Then I have to do the ugly way like this in order to assert the outputs:

https://github.com/sethsandaru/eloquent-docs/blob/main/src/Commands/EloquentDocsGeneratorCommand.php#L54-L57

```php
$lines = explode("\n", $generatedDocs);
foreach ($lines as $line) {
    $this->info($line);
} // after this => expectsOutputToContain works fine
```

## Solution

Introducing `expectsAllOutputToContain` and `doesntExpectAllOutputToContain` for `PendingCommand`, which gonna help us to assert **all outputs** of the command, which gonna help for:

- Assert the string on all the outputs
- Doesn't really care about the order, I just wanna to validate the inner texts after the command ran, whether it's from the start, middle or end.


## Breaking change?

No