### PR TITLE
[9.x] Add support for `USING` clause in query join condition

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -194,7 +194,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile a join clause's USING (...) subclause.
      *
-     * @param  \Illuminate\Database\Query\JoinClause $query
+     * @param  \Illuminate\Database\Query\JoinClause  $query
      * @return string
      */
     protected function compileJoinUsingClause(JoinClause $query)

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -203,7 +203,7 @@ class Grammar extends BaseGrammar
             ->map(fn ($column) => $this->wrap($column))
             ->implode(',');
 
-        return "using ($columns)";
+        return 'using ('.$columns.')';
     }
 
     /**

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -21,6 +21,13 @@ class JoinClause extends Builder
     public $table;
 
     /**
+     * The columns to use in the "USING" subclause.
+     *
+     * @var string[]|null
+     */
+    public ?array $using = null;
+
+    /**
      * The connection of the parent query builder.
      *
      * @var \Illuminate\Database\ConnectionInterface
@@ -120,6 +127,19 @@ class JoinClause extends Builder
     public function newQuery()
     {
         return new static($this->newParentQuery(), $this->type, $this->table);
+    }
+
+    /**
+     * Set the columns for the "USING" subclause
+     *
+     * @param  string|string[] $columns
+     * @return $this
+     */
+    public function using($columns)
+    {
+        $this->using = is_array($columns) ? $columns : func_get_args();
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -130,9 +130,9 @@ class JoinClause extends Builder
     }
 
     /**
-     * Set the columns for the "USING" subclause
+     * Set the columns for the "USING" subclause.
      *
-     * @param  string|string[] $columns
+     * @param  string|string[]  $columns
      * @return $this
      */
     public function using($columns)

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2110,6 +2110,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->rightJoinSub(['foo'], 'sub', 'users.id', '=', 'sub.id');
     }
 
+    public function testJoinWithUsing()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->join('contacts', function ($join) {
+            $join->using('name');
+        });
+        $this->assertSame('select * from "users" inner join "contacts" using ("name")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->join('contacts', function ($join) {
+            $join->using('name', 'email');
+        });
+        $this->assertSame('select * from "users" inner join "contacts" using ("name","email")', $builder->toSql());
+    }
+
     public function testRawExpressionsInSelect()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Currently, it is not trivial to make a join clause use a `USING` clause instead of an `ON` clause in its join condition.

While `ON` is generally more versatile, there are cases where `USING` is more useful. For example, when joining tables on columns that share the same name across the two tables. Additionally, it removes the need to fully qualify the joining columns. More information from this answer on stackoverflow: https://stackoverflow.com/a/11367066.

This PR seeks to add support for the `USING` clause in join conditions.

It may be set on the `JoinClause` builder object via a new `using` method. Multiple columns may be set as multiple arguments `$join->using('first, 'second')`, or by passing an array as the first argument `$join->using(['first', 'second'])`.

Since `USING` and `ON` cannot be used simultaneously, we will compile a `USING` clause if `$joinClause->using` is set, or otherwise continue with normal `ON` compilation.

Not needing to fully qualify columns allows us to join rows to an existing query without having to change the columns in any existing where conditions. This is not possible using only an `ON` clause, as we would get query exceptions like `ERROR 1052 (23000): Column 'xyz' in where clause is ambiguous`:

```php
use Illuminate\Database\Query\JoinClause;

$query = DB::table('users')->whereEmail('foo@bar.com');

$query
    ->rightJoin(
        'clients',
        fn (JoinClause $join) => $join->using('email')
    )
    ->toSql();
````

```SQL
SELECT * FROM `users`
RIGHT JOIN `clients` USING (`email`)
WHERE `email` = ?
```

The `USING` clause is valid syntax in MySql, PostgreSql and SQLite. It is not supported in SQL Server (thanks for clarifying @rodrigopedra). For SQL Server, we could convert the `USING` clause to a comparable `ON` clause (https://github.com/laravel/framework/pull/43898#issuecomment-1229539022), or throw an exception. I have left out this part of the PR, pending comment from the maintainers.

Also, this change does not break any existing features, as `USING` will only be compiled if it's been explicitly set via the `using` method on the `JoinClause` object.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
