### PR TITLE
[10.x] Handle relative ASSET_URL

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -255,7 +255,7 @@ class UrlGenerator implements UrlGeneratorContract
         // for asset paths, but only for routes to endpoints in the application.
         $root = $this->assetRoot ?: $this->formatRoot($this->formatScheme($secure));
 
-        return $this->removeIndex($root).'/'.trim($path, '/');
+        return Str::finish($this->removeIndex($root), '/').trim($path, '/');
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -41,10 +41,10 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         $this->assertSame('https://www.foo.com/foo/bar', $url->to('foo/bar'));
+    }
 
-        /*
-         * Test asset URL generation...
-         */
+    public function testAssetGeneration()
+    {
         $url = new UrlGenerator(
             new RouteCollection,
             Request::create('http://www.foo.com/index.php/')
@@ -52,6 +52,15 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertSame('http://www.foo.com/foo/bar', $url->asset('foo/bar'));
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
+
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/index.php/'),
+            '/'
+        );
+
+        $this->assertSame('/foo/bar', $url->asset('foo/bar'));
+        $this->assertSame('/foo/bar', $url->asset('foo/bar', true));
     }
 
     public function testBasicGenerationWithHostFormatting()


### PR DESCRIPTION
Recently, I faced with a situation, where I had to set relative asset URLs everywhere in the application.

I was trying to set `ASSET_URL=/`, but as it turned out it generates double starting slashes at the beginning of the relative URL: `//path/to/file.jpg`. 

So as a workaround I found a solution, when the `ASSET_URL=/.`, and it generates `/./path/to/file.jpg`. It works, but feels a bit odd.

I think when the `ASSET_URL` is set to `/`, the asset URLs sould be relative and start with only one slash.

----

I found some related PRs: https://github.com/laravel/framework/pull/43556 and https://github.com/laravel/framework/pull/43555

----

I think this is not a BC, but I target the master branch, just to be sure.