### PR TITLE
[9.x] Support a global deny http status for Gates / Policies

### DIFF
--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -23,6 +23,7 @@ use Illuminate\Contracts\Auth\Access\Gate as GateContract;
  * @method static bool has(string $ability)
  * @method static mixed getPolicyFor(object|string $class)
  * @method static mixed raw(string $ability, array|mixed $arguments = [])
+ * @method static \Illuminate\Auth\Access\Gate useDefaultDenyStatus(int $status)
  *
  * @see \Illuminate\Contracts\Auth\Access\Gate
  */


### PR DESCRIPTION
We currently have the ability to set the HTTP response status code for individual gate / policy functions. I believe it would be useful and good idea for many applications to default to a `404` deny status, and then on a case by case basis opt into the `403` status. 

Making it more "secure by default" than "opt-in".

```php
// service provider...

public function boot()
{
    Gate::useDefaultDenyStatus(404);

    // ...
}


// Use the default behaviour...

Gate::define('defaultStatus', fn () => Response::deny());

// Override the default status...

Gate::define('customStatus', fn () => Response::denyWithStatus(403));
```

Alternatively, you could also set this in a middleware to limit to specific routes / users:

```php
class Middleware
{
    public function handle($request, $next)
    {
        if ($request->user()->isNotAdmin()) {
            Gate::useDefaultDenyStatus(404);
        }
        
        return $next($request);
    }
}
```

You should ensure that this middleware runs before the authorization middleware.

## Form requests

This status does not apply to FormRequests. I'm sure I can make it so that it does, but I was not sure if it made sense, as the Form Request mechanism doesn't interact with gates at all.

Would love to know your thoughts on if this default status should be propagated to form request's "deny" functionality.

Documentation: https://github.com/laravel/docs/pull/8169