### PR TITLE
[9.x] Return exit status instead of booleans from `GeneratorCommand::handle()`

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
@@ -258,14 +259,16 @@ abstract class GeneratorCommand extends Command
     /**
      * Get the destination class path.
      *
-     * @param  string  $name
+     * @param string $name
+     *
      * @return string
+     * @throws BindingResolutionException
      */
     protected function getPath($name)
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->make('path').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**
@@ -392,10 +395,11 @@ abstract class GeneratorCommand extends Command
      * Get the model for the default guard's user provider.
      *
      * @return string|null
+     * @throws BindingResolutionException
      */
     protected function userProviderModel()
     {
-        $config = $this->laravel['config'];
+        $config = $this->laravel->make('config');
 
         $provider = $config->get('auth.guards.'.$config->get('auth.defaults.guard').'.provider');
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -137,7 +137,7 @@ abstract class GeneratorCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return bool|null
+     * @return int|void
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
@@ -149,7 +149,7 @@ abstract class GeneratorCommand extends Command
         if ($this->isReservedName($this->getNameInput())) {
             $this->components->error('The name "'.$this->getNameInput().'" is reserved by PHP.');
 
-            return false;
+            return self::FAILURE;
         }
 
         $name = $this->qualifyClass($this->getNameInput());
@@ -164,7 +164,7 @@ abstract class GeneratorCommand extends Command
              $this->alreadyExists($this->getNameInput())) {
             $this->components->error($this->type.' already exists.');
 
-            return false;
+            return self::FAILURE;
         }
 
         // Next, we will generate the path to the location where this class' file should get
@@ -183,6 +183,8 @@ abstract class GeneratorCommand extends Command
         }
 
         $this->components->info($info.' created successfully.');
+
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -259,9 +259,9 @@ abstract class GeneratorCommand extends Command
     /**
      * Get the destination class path.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return string
+     *
      * @throws BindingResolutionException
      */
     protected function getPath($name)
@@ -395,6 +395,7 @@ abstract class GeneratorCommand extends Command
      * Get the model for the default guard's user provider.
      *
      * @return string|null
+     *
      * @throws BindingResolutionException
      */
     protected function userProviderModel()

--- a/tests/Console/GeneratorCommandTest.php
+++ b/tests/Console/GeneratorCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class GeneratorCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldThrowIfNameIsNotPassedAsArgument(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
+
+        $sut = $this->getMockForAbstractClass(
+            GeneratorCommand::class,
+            [new Filesystem()],
+            'FooMakeCommand'
+        );
+        $sut->setLaravel(app());
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput();
+
+        $sut->run($input, $output);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldFailIfNameArgumentIsReservedName(): void
+    {
+        $sut = $this->getMockForAbstractClass(
+            GeneratorCommand::class,
+            [new Filesystem()],
+            'FooMakeCommand'
+        );
+        $sut->setLaravel(app());
+
+        $input = new ArrayInput(['name' => 'class']);
+        $output = new NullOutput();
+
+        $this->assertSame(Command::FAILURE, $sut->run($input, $output));
+    }
+}

--- a/tests/Console/GeneratorCommandTest.php
+++ b/tests/Console/GeneratorCommandTest.php
@@ -63,7 +63,7 @@ class GeneratorCommandTest extends TestCase
      */
     public function itShouldGenerateTheRequestedClass(): void
     {
-        $appPath = '/path/to/App';
+        $appPath = '/path/to/app';
         $nameArgument = 'MyFoo';
 
         $fileSystem = $this->createStub(Filesystem::class);

--- a/tests/Console/GeneratorCommandTest.php
+++ b/tests/Console/GeneratorCommandTest.php
@@ -58,6 +58,7 @@ class GeneratorCommandTest extends TestCase
 
     /**
      * @test
+     *
      * @throws FileNotFoundException
      */
     public function itShouldGenerateTheRequestedClass(): void
@@ -71,7 +72,7 @@ class GeneratorCommandTest extends TestCase
 
         // @phpstan-ignore-next-line
         $fileSystem->expects($this->once())->method('put')->with(
-            sprintf("%s//%s.php", $appPath, $nameArgument),
+            sprintf('%s//%s.php', $appPath, $nameArgument),
             '<?php namespace App; class MyFoo {}'
         )->willReturn(0);
 


### PR DESCRIPTION
This PR updates the `GenertorCommand::handle()` method to return exit code instead of boolean and adds 3 new tests. The unit tests help to understand why this update is needed. 

#43889 

Besides, it replaces a couple of calls to the application instance as an ArrayAccess with a `make()` method calls. This practice makes it easier to be tested. It does not change the behavior as the `\Illuminate\Container\Container::offsetGet()` uses the same logic.

https://github.com/laravel/framework/blob/45cd804928f4c1a42fafd2b78c7fa023a59c542a/src/Illuminate/Container/Container.php#L1413-L1416
