### PR TITLE
[9.x] Fixed expectsOutputToContain & doesntExpectOutputToContain of PendingAction

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -182,7 +182,7 @@ class PendingCommand
      */
     public function doesntExpectOutputToContain($string)
     {
-        $this->test->unexpectedOutputSubstrings[$string] = false;
+        $this->test->unexpectedOutputSubstrings[] = $string;
 
         return $this;
     }
@@ -356,7 +356,7 @@ class PendingCommand
             }
         }
 
-        foreach ($this->test->unexpectedOutput as $text) {
+        foreach ($this->test->unexpectedOutputSubstrings as $text) {
             if (str_contains($allOutputStr, $text)) {
                 $this->test->fail('Output "'.$text.'" was printed.');
             }

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -34,7 +34,9 @@ class ArtisanCommandTest extends TestCase
         });
 
         Artisan::command('contains', function () {
+            $this->line('Hello everyone!');
             $this->line('My name is Taylor Otwell');
+            $this->line('I bet you can assert this line');
         });
     }
 
@@ -128,6 +130,8 @@ class ArtisanCommandTest extends TestCase
     {
         $this->artisan('contains')
              ->expectsOutputToContain('Taylor Otwell')
+             ->expectsOutputToContain('I bet you can assert this line')
+             ->expectsOutputToContain('I bet you can assert this line')
              ->assertExitCode(0);
     }
 


### PR DESCRIPTION
All the details go here #43896

Basically `expectsOutputToContain` and `doesntExpectOutputToContain` didn't assert against **all output** . 

So if you write an output that contains a lot of info, you can't assert it multiple times for the same output.


### Partial content from #43896

When I tried to use the `expectsOutputToContain`, assuming it would validate **all output** against the string, but it didn't

The printed result of my command:
```php
@property int $id
@property string $first_name
```

Test result: 
```php
$command->artisan(...)
    ->expectsOutputToContain('@property int $id') // ok
    ->expectsOutputToContain('@property string $first_name') // expected to work, but got "Output does not contain ..."
    ->execute();
```

Then I have to do the ugly way like this in order to assert the outputs:

https://github.com/sethsandaru/eloquent-docs/blob/main/src/Commands/EloquentDocsGeneratorCommand.php#L54-L57

```php
$lines = explode("\n", $generatedDocs);
foreach ($lines as $line) {
    $this->info($line);
} // after this => expectsOutputToContain works fine
```
