### PR TITLE
Disallow PHP 8.1 support for 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^7.2.5|8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",


### PR DESCRIPTION
This fixes PHP constraint to `"8.0"` for 6.1 since PHP 8.1 gives this:

> During inheritance of ArrayAccess: Uncaught Return type of Illuminate\Container\Container::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Maybe it's worth to also port these changes to 7.x and 8.x
