### PR TITLE
Make the `model:prune` command easier to extend

### DIFF
--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -142,7 +142,7 @@ class PruneCommand extends Command
     /**
      * Get the default path where models are located.
      *
-     * @return string
+     * @return string|string[]
      */
     protected function getDefaultPath()
     {

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -80,7 +80,7 @@ class PruneCommand extends Command
     /**
      * Prune the given model.
      *
-     * @param string $model
+     * @param  string  $model
      * @return void
      */
     protected function pruneModel(string $model)

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -71,22 +71,33 @@ class PruneCommand extends Command
         });
 
         $models->each(function ($model) {
-            $instance = new $model;
-
-            $chunkSize = property_exists($instance, 'prunableChunkSize')
-                            ? $instance->prunableChunkSize
-                            : $this->option('chunk');
-
-            $total = $this->isPrunable($model)
-                        ? $instance->pruneAll($chunkSize)
-                        : 0;
-
-            if ($total == 0) {
-                $this->components->info("No prunable [$model] records found.");
-            }
+            $this->pruneModel($model);
         });
 
         $events->forget(ModelsPruned::class);
+    }
+
+    /**
+     * Prune the given model.
+     *
+     * @param string $model
+     * @return void
+     */
+    protected function pruneModel(string $model)
+    {
+        $instance = new $model;
+
+        $chunkSize = property_exists($instance, 'prunableChunkSize')
+            ? $instance->prunableChunkSize
+            : $this->option('chunk');
+
+        $total = $this->isPrunable($model)
+            ? $instance->pruneAll($chunkSize)
+            : 0;
+
+        if ($total == 0) {
+            $this->components->info("No prunable [$model] records found.");
+        }
     }
 
     /**


### PR DESCRIPTION
Today I was working on an application that needed some customisations on the `model:prune` artisan command. Because of multitenancy I needed to dynamically set the connection on a model and loop on it for multiple times. I also needed to update the paths that the command was searching for.

This PR makes it possible to re-use more code of the original command in my project. Instead of copying everything over.

One thing that I'm still looking for is how I can make it possible to also scan models that do not have the default application namespace (outside of the app folder). With the current logic, the namespace is not correctly namespaced.

Maybe there is a way to create a better model loader for this kind of stuff anyway (with support for _"outside-of-app"_ namespaces). Because we are using the same code in  `src/Illuminate/Foundation/Console/Kernel.php`. Anyway, that's something for an other PR.