### PR TITLE
Add identifier to schedule event

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Reflector;
+use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\ReflectsClosures;
@@ -43,6 +44,13 @@ class Event
      * @var \DateTimeZone|string
      */
     public $timezone;
+
+    /**
+     * The UUID to track the event.
+     *
+     * @var string
+     */
+    public $uuid;
 
     /**
      * The user the command should run as.
@@ -169,6 +177,7 @@ class Event
         $this->mutex = $mutex;
         $this->command = $command;
         $this->timezone = $timezone;
+        $this->uuid = (string) Str::uuid();
 
         $this->output = $this->getDefaultOutput();
     }


### PR DESCRIPTION
**Problem**
Currently, it's not possible to track schedule events. This makes it hard for package creators to build something like Laravel Horizon for schedule tasks. Most packages out there, add a dynamic property (UUID, microtime, etc) to handle that case.

**Solution**
This PR adds an UUID to the schedule event.

**Example**
```php
// -> not needed anymore
// $this->app->resolving(Schedule::class, function (Schedule $schedule) {
//     foreach ($schedule->events() as $event) {
//         $event->taskIdentifier = Str::uuid();
//     }
// });

Event::listen(ScheduledTaskStarting::class, function ($event) {
    $event->task->uuid; // trackable
});
```