### PR TITLE
[9.x] Allow invokable rules to specify custom messsages

### DIFF
--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -114,7 +114,7 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     }
 
     /**
-     * Get the invokable
+     * Get the invokable.
      *
      * @return \Illuminate\Contracts\Validation\InvokableRule
      */

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -104,6 +104,16 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     }
 
     /**
+     * Get the underlying invokable rule.
+     *
+     * @return \Illuminate\Contracts\Validation\InvokableRule
+     */
+    public function invokable()
+    {
+        return $this->invokable;
+    }
+
+    /**
      * Get the validation error messages.
      *
      * @return array
@@ -111,16 +121,6 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     public function message()
     {
         return $this->messages;
-    }
-
-    /**
-     * Get the invokable.
-     *
-     * @return \Illuminate\Contracts\Validation\InvokableRule
-     */
-    public function invokable()
-    {
-        return $this->invokable;
     }
 
     /**

--- a/src/Illuminate/Validation/InvokableValidationRule.php
+++ b/src/Illuminate/Validation/InvokableValidationRule.php
@@ -114,6 +114,16 @@ class InvokableValidationRule implements Rule, ValidatorAwareRule
     }
 
     /**
+     * Get the invokable
+     *
+     * @return \Illuminate\Contracts\Validation\InvokableRule
+     */
+    public function invokable()
+    {
+        return $this->invokable;
+    }
+
+    /**
      * Set the data under validation.
      *
      * @param  array  $data

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -810,17 +810,21 @@ class Validator implements ValidatorContract
         }
 
         if (! $rule->passes($attribute, $value)) {
-            $this->failedRules[$attribute][get_class($rule)] = [];
+            $ruleClass = $rule instanceof InvokableValidationRule ?
+                get_class($rule->invokable()) :
+                get_class($rule);
 
-            $messages = $this->getFromLocalArray($attribute, get_class($rule)) ?? $rule->message();
+            $this->failedRules[$attribute][$ruleClass] = [];
 
-            $messages = $messages ? (array) $messages : [get_class($rule)];
+            $messages = $this->getFromLocalArray($attribute, $ruleClass) ?? $rule->message();
+
+            $messages = $messages ? (array) $messages : [$ruleClass];
 
             foreach ($messages as $key => $message) {
                 $key = is_string($key) ? $key : $attribute;
 
                 $this->messages->add($key, $this->makeReplacements(
-                    $message, $key, get_class($rule), []
+                    $message, $key, $ruleClass, []
                 ));
             }
         }

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -347,7 +347,7 @@ class ValidationInvokableRuleTest extends TestCase
             }
         };
 
-        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule], [$rule::class => ':attribute custom.',]);
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule], [$rule::class => ':attribute custom.']);
 
         $this->assertFalse($validator->passes());
         $this->assertSame([
@@ -356,7 +356,7 @@ class ValidationInvokableRuleTest extends TestCase
             ],
         ], $validator->messages()->messages());
 
-        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule], ['foo.'.$rule::class => ':attribute custom with key.',]);
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule], ['foo.'.$rule::class => ':attribute custom with key.']);
 
         $this->assertFalse($validator->passes());
         $this->assertSame([

--- a/tests/Validation/ValidationInvokableRuleTest.php
+++ b/tests/Validation/ValidationInvokableRuleTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
+use Illuminate\Validation\InvokableValidationRule;
 use Illuminate\Validation\Validator;
 use PHPUnit\Framework\TestCase;
 
@@ -331,6 +332,85 @@ class ValidationInvokableRuleTest extends TestCase
                 'There are many errors.',
             ],
         ], $validator->messages()->messages());
+    }
+
+    public function testExplicitRuleCanUseInlineValidationMessages()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class() implements InvokableRule
+        {
+            public $implicit = false;
+
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('xxxx');
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule], [$rule::class => ':attribute custom.',]);
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame([
+            'foo' => [
+                'foo custom.',
+            ],
+        ], $validator->messages()->messages());
+
+        $validator = new Validator($trans, ['foo' => 'bar'], ['foo' => $rule], ['foo.'.$rule::class => ':attribute custom with key.',]);
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame([
+            'foo' => [
+                'foo custom with key.',
+            ],
+        ], $validator->messages()->messages());
+    }
+
+    public function testImplicitRuleCanUseInlineValidationMessages()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rule = new class() implements InvokableRule
+        {
+            public $implicit = true;
+
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('xxxx');
+            }
+        };
+
+        $validator = new Validator($trans, ['foo' => ''], ['foo' => $rule], [$rule::class => ':attribute custom.']);
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame([
+            'foo' => [
+                'foo custom.',
+            ],
+        ], $validator->messages()->messages());
+
+        $validator = new Validator($trans, ['foo' => ''], ['foo' => $rule], ['foo.'.$rule::class => ':attribute custom with key.']);
+
+        $this->assertFalse($validator->passes());
+        $this->assertSame([
+            'foo' => [
+                'foo custom with key.',
+            ],
+        ], $validator->messages()->messages());
+    }
+
+    public function testItCanReturnInvokableRule()
+    {
+        $rule = new class() implements InvokableRule
+        {
+            public function __invoke($attribute, $value, $fail)
+            {
+                $fail('xxxx');
+            }
+        };
+
+        $invokableValidationRule = InvokableValidationRule::make($rule);
+
+        $this->assertSame($rule, $invokableValidationRule->invokable());
     }
 
     private function getIlluminateArrayTranslator()


### PR DESCRIPTION
From Laravel 9.2 we have a simple way to specify a custom message when validating with a rule object. #41145
But it doesn't seem to work with invokable rules.
This PR makes invokable rules to work with #41145.