### PR TITLE
[10.x] Return exit status instead of booleans from `GeneratorCommand::handle()`

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
@@ -258,14 +259,16 @@ abstract class GeneratorCommand extends Command
     /**
      * Get the destination class path.
      *
-     * @param  string  $name
+     * @param string $name
+     *
      * @return string
+     * @throws BindingResolutionException
      */
     protected function getPath($name)
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->make('path').'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**
@@ -392,10 +395,11 @@ abstract class GeneratorCommand extends Command
      * Get the model for the default guard's user provider.
      *
      * @return string|null
+     * @throws BindingResolutionException
      */
     protected function userProviderModel()
     {
-        $config = $this->laravel['config'];
+        $config = $this->laravel->make('config');
 
         $provider = $config->get('auth.guards.'.$config->get('auth.defaults.guard').'.provider');
 

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -137,7 +137,7 @@ abstract class GeneratorCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return bool|null
+     * @return int|void
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
@@ -149,7 +149,7 @@ abstract class GeneratorCommand extends Command
         if ($this->isReservedName($this->getNameInput())) {
             $this->components->error('The name "'.$this->getNameInput().'" is reserved by PHP.');
 
-            return false;
+            return self::FAILURE;
         }
 
         $name = $this->qualifyClass($this->getNameInput());
@@ -164,7 +164,7 @@ abstract class GeneratorCommand extends Command
              $this->alreadyExists($this->getNameInput())) {
             $this->components->error($this->type.' already exists.');
 
-            return false;
+            return self::FAILURE;
         }
 
         // Next, we will generate the path to the location where this class' file should get
@@ -183,6 +183,8 @@ abstract class GeneratorCommand extends Command
         }
 
         $this->components->info($info.' created successfully.');
+
+        return self::SUCCESS;
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -259,9 +259,9 @@ abstract class GeneratorCommand extends Command
     /**
      * Get the destination class path.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return string
+     *
      * @throws BindingResolutionException
      */
     protected function getPath($name)
@@ -395,6 +395,7 @@ abstract class GeneratorCommand extends Command
      * Get the model for the default guard's user provider.
      *
      * @return string|null
+     *
      * @throws BindingResolutionException
      */
     protected function userProviderModel()

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
@@ -261,8 +260,6 @@ abstract class GeneratorCommand extends Command
      *
      * @param  string  $name
      * @return string
-     *
-     * @throws BindingResolutionException
      */
     protected function getPath($name)
     {
@@ -395,8 +392,6 @@ abstract class GeneratorCommand extends Command
      * Get the model for the default guard's user provider.
      *
      * @return string|null
-     *
-     * @throws BindingResolutionException
      */
     protected function userProviderModel()
     {

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -36,6 +37,7 @@ class ComponentMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
+     * @throws FileNotFoundException
      */
     public function handle()
     {
@@ -47,8 +49,8 @@ class ComponentMakeCommand extends GeneratorCommand
             return;
         }
 
-        if (parent::handle() === false && ! $this->option('force')) {
-            return false;
+        if (parent::handle() !== self::SUCCESS) {
+            return;
         }
 
         if (! $this->option('inline')) {

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -49,7 +49,7 @@ class ComponentMakeCommand extends GeneratorCommand
             return;
         }
 
-        if (parent::handle() !== self::SUCCESS) {
+        if ((parent::handle() !== self::SUCCESS) && ! $this->option('force')) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -37,6 +37,7 @@ class ComponentMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
+     *
      * @throws FileNotFoundException
      */
     public function handle()

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -37,8 +36,6 @@ class ComponentMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
-     *
-     * @throws FileNotFoundException
      */
     public function handle()
     {

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -39,8 +38,6 @@ class MailMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
-     *
-     * @throws FileNotFoundException
      */
     public function handle()
     {

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -43,7 +43,7 @@ class MailMakeCommand extends GeneratorCommand
      */
     public function handle()
     {
-        if (parent::handle() !== self::SUCCESS) {
+        if ((parent::handle() !== self::SUCCESS) && ! $this->option('force')) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -38,10 +39,11 @@ class MailMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
+     * @throws FileNotFoundException
      */
     public function handle()
     {
-        if (parent::handle() === false && ! $this->option('force')) {
+        if (parent::handle() !== self::SUCCESS) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -39,6 +39,7 @@ class MailMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
+     *
      * @throws FileNotFoundException
      */
     public function handle()

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -39,8 +38,6 @@ class ModelMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
-     *
-     * @throws FileNotFoundException
      */
     public function handle()
     {

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -39,6 +39,7 @@ class ModelMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
+     *
      * @throws FileNotFoundException
      */
     public function handle()

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -38,11 +39,12 @@ class ModelMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
+     * @throws FileNotFoundException
      */
     public function handle()
     {
-        if (parent::handle() === false && ! $this->option('force')) {
-            return false;
+        if (parent::handle() !== self::SUCCESS) {
+            return;
         }
 
         if ($this->option('all')) {

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -43,7 +43,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     public function handle()
     {
-        if (parent::handle() !== self::SUCCESS) {
+        if ((parent::handle() !== self::SUCCESS) && ! $this->option('force')) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -38,6 +38,7 @@ class NotificationMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
+     *
      * @throws FileNotFoundException
      */
     public function handle()

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -42,7 +42,7 @@ class NotificationMakeCommand extends GeneratorCommand
      */
     public function handle()
     {
-        if (parent::handle() !== self::SUCCESS) {
+        if ((parent::handle() !== self::SUCCESS) && ! $this->option('force')) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -38,8 +37,6 @@ class NotificationMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
-     *
-     * @throws FileNotFoundException
      */
     public function handle()
     {

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -37,10 +38,11 @@ class NotificationMakeCommand extends GeneratorCommand
      * Execute the console command.
      *
      * @return void
+     * @throws FileNotFoundException
      */
     public function handle()
     {
-        if (parent::handle() === false && ! $this->option('force')) {
+        if (parent::handle() !== self::SUCCESS) {
             return;
         }
 

--- a/tests/Console/GeneratorCommandTest.php
+++ b/tests/Console/GeneratorCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class GeneratorCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldThrowIfNameIsNotPassedAsArgument(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "name").');
+
+        $sut = $this->getMockForAbstractClass(
+            GeneratorCommand::class,
+            [new Filesystem()],
+            'FooMakeCommand'
+        );
+        $sut->setLaravel(app());
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput();
+
+        $sut->run($input, $output);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldFailIfNameArgumentIsReservedName(): void
+    {
+        $sut = $this->getMockForAbstractClass(
+            GeneratorCommand::class,
+            [new Filesystem()],
+            'FooMakeCommand'
+        );
+        $sut->setLaravel(app());
+
+        $input = new ArrayInput(['name' => 'class']);
+        $output = new NullOutput();
+
+        $this->assertSame(Command::FAILURE, $sut->run($input, $output));
+    }
+}

--- a/tests/Console/GeneratorCommandTest.php
+++ b/tests/Console/GeneratorCommandTest.php
@@ -6,7 +6,6 @@ use Illuminate\Config\Repository;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
 use PHPUnit\Framework\TestCase;
@@ -17,10 +16,7 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class GeneratorCommandTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itShouldThrowIfNameIsNotPassedAsArgument(): void
+    public function testItShouldThrowIfNameIsNotPassedAsArgument(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Not enough arguments (missing: "name").');
@@ -38,10 +34,7 @@ class GeneratorCommandTest extends TestCase
         $sut->run($input, $output);
     }
 
-    /**
-     * @test
-     */
-    public function itShouldFailIfNameArgumentIsReservedName(): void
+    public function testItShouldFailIfNameArgumentIsReservedName(): void
     {
         $sut = $this->getMockForAbstractClass(
             GeneratorCommand::class,
@@ -56,12 +49,7 @@ class GeneratorCommandTest extends TestCase
         $this->assertSame(Command::FAILURE, $sut->run($input, $output));
     }
 
-    /**
-     * @test
-     *
-     * @throws FileNotFoundException
-     */
-    public function itShouldGenerateTheRequestedClass(): void
+    public function testItShouldGenerateTheRequestedClass(): void
     {
         $appPath = '/path/to/app';
         $nameArgument = 'MyFoo';
@@ -103,7 +91,7 @@ class GeneratorCommandTest extends TestCase
 
         $sut->setLaravel($laravel);
 
-        $input = new ArrayInput(['name' => 'MyFoo']);
+        $input = new ArrayInput(['name' => $nameArgument]);
         $output = new NullOutput();
 
         $sut->run($input, $output);

--- a/tests/Console/GeneratorCommandTest.php
+++ b/tests/Console/GeneratorCommandTest.php
@@ -63,7 +63,7 @@ class GeneratorCommandTest extends TestCase
      */
     public function itShouldGenerateTheRequestedClass(): void
     {
-        $appPath = '/path/to/App';
+        $appPath = '/path/to/app';
         $nameArgument = 'MyFoo';
 
         $fileSystem = $this->createStub(Filesystem::class);

--- a/tests/Console/GeneratorCommandTest.php
+++ b/tests/Console/GeneratorCommandTest.php
@@ -58,6 +58,7 @@ class GeneratorCommandTest extends TestCase
 
     /**
      * @test
+     *
      * @throws FileNotFoundException
      */
     public function itShouldGenerateTheRequestedClass(): void
@@ -71,7 +72,7 @@ class GeneratorCommandTest extends TestCase
 
         // @phpstan-ignore-next-line
         $fileSystem->expects($this->once())->method('put')->with(
-            sprintf("%s//%s.php", $appPath, $nameArgument),
+            sprintf('%s//%s.php', $appPath, $nameArgument),
             '<?php namespace App; class MyFoo {}'
         )->willReturn(0);
 


### PR DESCRIPTION
This PR reopens #43915 and updates the commands that use the `handle()` method.

::: Note
A note should be added to the upgrade guide.