### PR TITLE
[9.x] Introduce `artisan warm`

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -320,6 +320,18 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Return a resolver for the application warmer.
+     *
+     * @return \Closure
+     */
+    public function warmResolver()
+    {
+        return method_exists($this, 'warm')
+            ? Closure::fromCallable([$this, 'warm'])
+            : fn () => null;
+    }
+
+    /**
      * Get the Artisan application instance.
      *
      * @return \Illuminate\Console\Application

--- a/src/Illuminate/Foundation/Console/WarmCommand.php
+++ b/src/Illuminate/Foundation/Console/WarmCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\WarmerCollection;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'warm')]
+class WarmCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'warm {--exclude= : The registered warmers to exclude} {--only= : Only run the specified registered warmers}';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'warm';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Warm the application.';
+
+    /**
+     * Execute the console command.
+     *
+     * @param  \Illuminate\Support\WarmerCollection  $warmers
+     * @param  \Illuminate\Contracts\Console\Kernel  $kernel
+     * @return int
+     */
+    public function handle(WarmerCollection $warmers, Kernel $kernel)
+    {
+        $warmers
+            ->forget($this->excluded())
+            ->only($this->only())
+            ->when(method_exists($kernel, 'warmResolver'))->merge([
+                'The application: '.config('app.name') => $kernel->warmResolver()
+            ])
+            ->each(fn ($callable, $name) => $this->warm($name, $callable));
+
+        $this->components->info('Your application has finished warming.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Run the wamer.
+     *
+     * @param  string  $name
+     * @param  callable  $callable
+     * @return void
+     */
+    protected function warm($name, $callable)
+    {
+        $this->components->task($name, fn () => $this->laravel->call($callable));
+    }
+
+    /**
+     * The registered warmers to exclude from running.
+     *
+     * @return array
+     */
+    protected function excluded()
+    {
+        return explode(',', $this->option('exclude') ?? '');
+    }
+
+    /**
+     * The registered warmers that should be run.
+     *
+     * @return null|array
+     */
+    protected function only()
+    {
+        if ($this->option('only') === null) {
+            return null;
+        }
+
+        return explode(',', $this->option('only'));
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -68,6 +68,7 @@ use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Foundation\Console\ViewCacheCommand;
 use Illuminate\Foundation\Console\ViewClearCommand;
+use Illuminate\Foundation\Console\WarmCommand;
 use Illuminate\Notifications\Console\NotificationTableCommand;
 use Illuminate\Queue\Console\BatchesTableCommand;
 use Illuminate\Queue\Console\ClearCommand as QueueClearCommand;
@@ -147,6 +148,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Up' => UpCommand::class,
         'ViewCache' => ViewCacheCommand::class,
         'ViewClear' => ViewClearCommand::class,
+        'Warm' => WarmCommand::class,
     ];
 
     /**
@@ -1151,6 +1153,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         $this->app->singleton(ViewClearCommand::class, function ($app) {
             return new ViewClearCommand($app['files']);
         });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerWarmCommand()
+    {
+        $this->app->singleton(WarmCommand::class);
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -391,6 +391,23 @@ abstract class ServiceProvider
     }
 
     /**
+     * Register an application warmer.
+     *
+     * @param  string  $key
+     * @param  callable  $callable
+     * @return $this
+     */
+    protected function registerWarmer($key, $callable)
+    {
+        $this->app->instance(
+            WarmerCollection::class,
+            $this->app[WarmerCollection::class]->put($key, $callable)
+        );
+
+        return $this;
+    }
+
+    /**
      * Register the package's custom Artisan commands.
      *
      * @param  array|mixed  $commands

--- a/src/Illuminate/Support/WarmerCollection.php
+++ b/src/Illuminate/Support/WarmerCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Support\Collection;
+
+class WarmerCollection extends Collection
+{
+    //
+}

--- a/tests/Integration/Console/WarmAppTest.php
+++ b/tests/Integration/Console/WarmAppTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Console\Kernel as KernelContract;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Foundation\Console\Kernel;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\WarmerCollection;
+use Orchestra\Testbench\TestCase;
+
+class WarmAppTest extends TestCase
+{
+    protected function resolveApplicationConsoleKernel($app)
+    {
+        $app->singleton(KernelContract::class, fn ($app) => new class ($app, $app->make(Dispatcher::class)) extends Kernel {
+            public function commands()
+            {
+                $this->command('warm.command', function () {
+                    Cache::put('warm.command', true, now()->addDay());
+                });
+            }
+
+            protected function warm(Repository $cache)
+            {
+                $cache->put('warm', true, now()->addDay());
+            }
+        });
+    }
+
+    public function testItCanWarmAppViaKernel()
+    {
+        $this->assertNull(Cache::get('warm'));
+
+        Artisan::call('warm');
+
+        $this->assertTrue(Cache::get('warm'));
+    }
+
+    public function testPackagesCanBindClosuresToWarm()
+    {
+        $this->app->register(new class($this->app) extends ServiceProvider {
+            public function register()
+            {
+                //
+            }
+
+            public function boot()
+            {
+                $this->registerWarmer('spatie/package', fn (Repository $cache) => $cache->put('warm.package', true, now()->addDay()));
+            }
+        });
+
+        $this->assertNull(Cache::get('warm.package'));
+
+        Artisan::call('warm');
+
+        $this->assertTrue(Cache::get('warm.package'));
+    }
+
+    public function testItCanRunArtisanCommandsInWarmer()
+    {
+        $this->app->register(new class($this->app) extends ServiceProvider {
+            public function register()
+            {
+                //
+            }
+
+            public function boot()
+            {
+                $this->registerWarmer('spatie/package', fn () => Artisan::call('warm.command'));
+            }
+        });
+
+        $this->assertNull(Cache::get('warm.command'));
+
+        Artisan::call('warm');
+
+        $this->assertTrue(Cache::get('warm.command'));
+    }
+
+    public function testItCanExcludeRegisteredWarmers()
+    {
+        $this->app->instance(WarmerCollection::class, new WarmerCollection([
+            'foo' => fn () => Cache::put('warm.foo', true, now()->addDay()),
+            'bar' => fn () => Cache::put('warm.bar', true, now()->addDay()),
+            'baz' => fn () => Cache::put('warm.baz', true, now()->addDay()),
+        ]));
+
+        $this->assertNull(Cache::get('warm.foo'));
+        $this->assertNull(Cache::get('warm.bar'));
+        $this->assertNull(Cache::get('warm.baz'));
+
+        Artisan::call('warm --exclude=bar,baz');
+
+        $this->assertTrue(Cache::get('warm.foo'));
+        $this->assertNull(Cache::get('warm.bar'));
+        $this->assertNull(Cache::get('warm.baz'));
+    }
+
+    public function testItCanRunSpecificWarmersOnly()
+    {
+        $this->app->instance(WarmerCollection::class, new WarmerCollection([
+            'foo' => fn () => Cache::put('warm.foo', true, now()->addDay()),
+            'bar' => fn () => Cache::put('warm.bar', true, now()->addDay()),
+            'baz' => fn () => Cache::put('warm.baz', true, now()->addDay()),
+        ]));
+
+        $this->assertNull(Cache::get('warm.foo'));
+        $this->assertNull(Cache::get('warm.bar'));
+        $this->assertNull(Cache::get('warm.baz'));
+
+        Artisan::call('warm --only=bar,baz');
+
+        $this->assertNull(Cache::get('warm.foo'));
+        $this->assertTrue(Cache::get('warm.bar'));
+        $this->assertTrue(Cache::get('warm.baz'));
+    }
+
+    public function testItCanRunNoRegisteredWarmers()
+    {
+        $this->app->instance(WarmerCollection::class, new WarmerCollection([
+            'foo' => fn () => Cache::put('warm.foo', true, now()->addDay()),
+            'bar' => fn () => Cache::put('warm.bar', true, now()->addDay()),
+            'baz' => fn () => Cache::put('warm.baz', true, now()->addDay()),
+        ]));
+
+        $this->assertNull(Cache::get('warm.foo'));
+        $this->assertNull(Cache::get('warm.bar'));
+        $this->assertNull(Cache::get('warm.baz'));
+
+        Artisan::call('warm --only=');
+
+        $this->assertNull(Cache::get('warm.foo'));
+        $this->assertNull(Cache::get('warm.bar'));
+        $this->assertNull(Cache::get('warm.baz'));
+    }
+
+    public function testMixOfIncludeExclude()
+    {
+        $this->app->instance(WarmerCollection::class, new WarmerCollection([
+            'foo' => fn () => Cache::put('warm.foo', true, now()->addDay()),
+            'bar' => fn () => Cache::put('warm.bar', true, now()->addDay()),
+            'baz' => fn () => Cache::put('warm.baz', true, now()->addDay()),
+        ]));
+
+        $this->assertNull(Cache::get('warm.foo'));
+        $this->assertNull(Cache::get('warm.bar'));
+        $this->assertNull(Cache::get('warm.baz'));
+
+        Artisan::call('warm --only=warm.foo --exclude=warm.foo');
+
+        $this->assertNull(Cache::get('warm.foo'));
+        $this->assertNull(Cache::get('warm.bar'));
+        $this->assertNull(Cache::get('warm.baz'));
+    }
+}


### PR DESCRIPTION
> **Note** This description is a WIP.

This PR introduces a new `artisan warm` command that allows applications to specify how their application should be "warmed" before deployment. It also allows packages to hook into the process.

This command would enable the Framework, 3rd party packages, and the application to all warm via a single command. This command would be called before or just after bringing the application out of maintenance mode (depending on the requirements):

```sh
php artisan down

# ...

php artisan migrate

php artisan warm

php artisan up
```

Warming an application is all about ensuring that users do not suffer a slow experience when any cache is stale. A "cache" in this context is any kind of cache, but it Redis or a file that is expected on disk, etc.

An application initially might cache things via the `Cache::remember()` function when the resource is first required for a user request - but this means that the user will be impacted by this stale cache.

Solutions to this might include keeping the cache warm on a schedule:

```php
class Kernel extends ConsoleKernel
{
    protected function schedule(Schedule $schedule)
    {
        $schedule->call(function () {
            Cache::put('forge.ips', Http::get('https://forge.laravel.com/ips-v4.txt'), now()->addHours(2));
        })->hourly();
    }
}
```

The user still pays the price for caching:

1. On the initial deploy.
2. When the cache is cleared.
3. When things go wrong and the downtime creates a stale entry.

This command could be used for application specific warming - or package specific warming. Given a package that gives you currency conversion rates, the package could register a warmer in their service provider that downloads and caches the initial rates.

```php
/**
 * Bootstrap any application services.
 *
 * @return void
 */
public function boot()
{
    $this->registerWarmer('currency/converter', fn () => UpdateRates::dispatchNow());
}
```

<img width="1136" alt="Screen Shot 2022-08-30 at 5 18 55 pm" src="https://user-images.githubusercontent.com/24803032/187374504-4dbe54f6-5e6d-45eb-87d3-cd5b56276d71.png">


An application may specify how it is warmed in the Kernel alongside the `schedule` method.

```php
class Kernel extends ConsoleKernel
{
    protected function schedule(Schedule $schedule)
    {
        $schedule->call(CacheForgeIPs::class)->hourly();
    }

    protected function warm()
    {
        CacheForgeIPs::dispatchNow();
    }
}
```
