### PR TITLE
[9.x] Always return slash at the start of route prefix name.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -803,7 +803,7 @@ class Route
      */
     protected function updatePrefixOnAction($prefix)
     {
-        if (! empty($newPrefix = trim(rtrim($prefix, '/').'/'.ltrim($this->action['prefix'] ?? '', '/'), '/'))) {
+        if (! empty($newPrefix = rtrim(rtrim($prefix, '/').'/'.ltrim($this->action['prefix'] ?? '', '/'), '/'))) {
             $this->action['prefix'] = $newPrefix;
         }
     }

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -66,9 +66,9 @@ class RouteGroup
         $old = $old['prefix'] ?? '';
 
         if ($prependExistingPrefix) {
-            return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
+            return isset($new['prefix']) ? rtrim($old, '/').'/'.trim($new['prefix'], '/') : $old;
         } else {
-            return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
+            return isset($new['prefix']) ? rtrim($new['prefix'], '/').'/'.trim($old, '/') : $old;
         }
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### This PR solves issue #43882 
The main problem was that the behavior of `Route::current->getPrefix()` was different for cached / not cached routes.
Not Cached
`Route::current()->getPrefix()` returns `"/testPrefix"`;

Cached
`Route::current()->getPrefix()` returns `"testPrefix"`;
```php
// getPrefix() returns -> NOT CACHED: "/test" | CACHED: "test"
Route::prefix("/test")->group(function () {
    Route::view("/", "pages.test")->name("test");
});

// getPrefix() returns -> NOT CACHED: "/test" | CACHED: "test"
Route::group(["prefix" => "/test"], function () {
    Route::view("/", "pages.test")->name("test");
});

// getPrefix() returns -> NOT CACHED: "/test" | CACHED: "test"
Route::controller(TestController::class)->prefix("/test")->group(function () {
    Route::view("/", "pages.test")->name("test");
});
```

### Solution
I unified how the route prefix names are returned. Either cached or not cached.
Route prefix is now always returned with slash at the start -> `/test`, `/test/test`.

It was tested for all these routes.
```php
Route::group(["prefix" => "test"], function() {
    Route::view("/", "page.test"); // getPrefix() returns -> /test
});

Route::group(["prefix" => "/testSlash"], function() {
    Route::view("/", "page.test"); // getPrefix() returns -> /testSlash
});

Route::prefix("noSlash")->group(function() {
    Route::view("/", "page.test"); // getPrefix() returns -> /noSlash
});

Route::prefix("/slash")->group(function() {
    Route::view("/", "page.test"); // getPrefix() returns -> /slash
});

Route::group(["prefix" => "test"], function() {
    Route::group(["prefix" => "test"], function() {
        Route::view("/", "page.test"); // getPrefix() returns -> /test/test
    });
});

Route::group(["prefix" => "testSlash"], function() {
    Route::group(["prefix" => "testSlash"], function() {
        Route::view("/", "page.test"); // getPrefix() returns -> /testSlash/testSlash
    });
});

Route::controller(TestController::class)->prefix("/testController")->group(function () {
    Route::view("/", "pages.test")->name("test"); // getPrefix() returns -> /testController
});
```
