### PR TITLE
[10.x] Support calling whereExists with another builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1607,19 +1607,24 @@ class Builder implements BuilderContract
     /**
      * Add an exists clause to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
      */
-    public function whereExists(Closure $callback, $boolean = 'and', $not = false)
+    public function whereExists($query, $boolean = 'and', $not = false)
     {
-        $query = $this->forSubQuery();
+        if ($query instanceof Closure) {
+            $callback = $query;
+            $query = $this->forSubQuery();
 
-        // Similar to the sub-select clause, we will create a new query instance so
-        // the developer may cleanly specify the entire exists query and we will
-        // compile the whole thing in the grammar and insert it into the SQL.
-        $callback($query);
+            // Similar to the sub-select clause, we will create a new query instance so
+            // the developer may cleanly specify the entire exists query and we will
+            // compile the whole thing in the grammar and insert it into the SQL.
+            $callback($query);
+        } elseif ($query instanceof EloquentBuilder) {
+            $query = $query->toBase();
+        }
 
         return $this->addWhereExistsQuery($query, $boolean, $not);
     }
@@ -1627,36 +1632,36 @@ class Builder implements BuilderContract
     /**
      * Add an or exists clause to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
      * @param  bool  $not
      * @return $this
      */
-    public function orWhereExists(Closure $callback, $not = false)
+    public function orWhereExists($query, $not = false)
     {
-        return $this->whereExists($callback, 'or', $not);
+        return $this->whereExists($query, 'or', $not);
     }
 
     /**
      * Add a where not exists clause to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
      * @param  string  $boolean
      * @return $this
      */
-    public function whereNotExists(Closure $callback, $boolean = 'and')
+    public function whereNotExists($query, $boolean = 'and')
     {
-        return $this->whereExists($callback, $boolean, true);
+        return $this->whereExists($query, $boolean, true);
     }
 
     /**
      * Add a where not exists clause to the query.
      *
-     * @param  \Closure  $callback
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
      * @return $this
      */
-    public function orWhereNotExists(Closure $callback)
+    public function orWhereNotExists($query)
     {
-        return $this->orWhereExists($callback, true);
+        return $this->orWhereExists($query, true);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1769,6 +1769,42 @@ class DatabaseQueryBuilderTest extends TestCase
             $q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
         });
         $this->assertSame('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->whereExists($this->getBuilder()->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"')));
+        $this->assertSame('select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->whereNotExists($this->getBuilder()->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"')));
+        $this->assertSame('select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereExists($this->getBuilder()->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"')));
+        $this->assertSame('select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereNotExists($this->getBuilder()->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"')));
+        $this->assertSame('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $eloquentBuilder = new EloquentBuilder($this->getBuilder()->from('products'));
+        $builder->select('*')->from('orders')->whereExists($eloquentBuilder->where('products.id', '=', new Raw('"orders"."id"')));
+        $this->assertSame('select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $eloquentBuilder = new EloquentBuilder($this->getBuilder()->from('products'));
+        $builder->select('*')->from('orders')->whereNotExists($eloquentBuilder->where('products.id', '=', new Raw('"orders"."id"')));
+        $this->assertSame('select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $eloquentBuilder = new EloquentBuilder($this->getBuilder()->from('products'));
+        $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereExists($eloquentBuilder->where('products.id', '=', new Raw('"orders"."id"')));
+        $this->assertSame('select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $eloquentBuilder = new EloquentBuilder($this->getBuilder()->from('products'));
+        $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereNotExists($eloquentBuilder->where('products.id', '=', new Raw('"orders"."id"')));
+        $this->assertSame('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
     }
 
     public function testBasicJoins()


### PR DESCRIPTION
Eloquent provides multiple ways to deal with subqueries. Most methods that deal with subqueries support passing one through a `Closure`, an eloquent builder or a (base) query builder. `whereExists()` has always seemed like an odd duck to me because it forces the developer to work with a closure. I couldn't find any reason why this works the way it does, so I decided to try and remove this limitation.

This would open Eloquent up to syntax like:

```php
SomeModel::where(...)->whereExists(OtherModel::where(...));
```

PS. This PR is breaking because it alters 4 method signatures