### PR TITLE
[9.x] Add default to request enum

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -350,16 +350,16 @@ trait InteractsWithInput
      * @param  string  $enumClass
      * @return mixed|null
      */
-    public function enum($key, $enumClass)
+    public function enum($key, $enumClass, $default = null)
     {
         if ($this->isNotFilled($key) ||
             ! function_exists('enum_exists') ||
             ! enum_exists($enumClass) ||
             ! method_exists($enumClass, 'tryFrom')) {
-            return null;
+            return $default;
         }
 
-        return $enumClass::tryFrom($this->input($key));
+        return $enumClass::tryFrom($this->input($key)) ?: $default;
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -359,7 +359,7 @@ trait InteractsWithInput
             return $default;
         }
 
-        return $enumClass::tryFrom($this->input($key)) ?: $default;
+        return $enumClass::tryFrom($this->input($key));
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -640,10 +640,9 @@ class HttpRequestTest extends TestCase
         ]);
 
         $this->assertNull($request->enum('doesnt_exists', TestEnum::class));
+        $this->assertEquals(TestEnum::test, $request->enum('doesnt_exists', TestEnum::class, TestEnum::test));
 
         $this->assertEquals(TestEnum::test, $request->enum('valid_enum_value', TestEnum::class));
-
-        $this->assertEquals(TestEnum::test, $request->enum('invalid_enum_value', TestEnum::class, TestEnum::test));
 
         $this->assertNull($request->enum('invalid_enum_value', TestEnum::class));
     }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -643,6 +643,8 @@ class HttpRequestTest extends TestCase
 
         $this->assertEquals(TestEnum::test, $request->enum('valid_enum_value', TestEnum::class));
 
+        $this->assertEquals(TestEnum::test, $request->enum('invalid_enum_value', TestEnum::class, TestEnum::test));
+
         $this->assertNull($request->enum('invalid_enum_value', TestEnum::class));
     }
 


### PR DESCRIPTION
This PR adds support to the `enum` method on the request for setting a default value, similar to the `input` method.

```php
$enum = $request->enum('value', Enum::class, Enum::Value);
```

I could add a check that the default enum value matches the enum class, but I thought I would keep it simple for now.