### PR TITLE
[9.x] Add getIntendedUrl method to redirector

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -114,29 +114,6 @@ class Redirector
     }
 
     /**
-     * Set the intended url.
-     *
-     * @param  string  $url
-     * @return $this
-     */
-    public function setIntendedUrl($url)
-    {
-        $this->session->put('url.intended', $url);
-
-        return $this;
-    }
-
-    /**
-     * Get the intended url.
-     *
-     * @return string|null
-     */
-    public function getIntendedUrl()
-    {
-        return $this->session->get('url.intended');
-    }
-
-    /**
      * Create a new redirect response to the given path.
      *
      * @param  string  $path
@@ -272,5 +249,28 @@ class Redirector
     public function setSession(SessionStore $session)
     {
         $this->session = $session;
+    }
+
+    /**
+     * Get the "intended" URL from the session.
+     *
+     * @return string|null
+     */
+    public function getIntendedUrl()
+    {
+        return $this->session->get('url.intended');
+    }
+
+    /**
+     * Set the "intended" URL in the session.
+     *
+     * @param  string  $url
+     * @return $this
+     */
+    public function setIntendedUrl($url)
+    {
+        $this->session->put('url.intended', $url);
+
+        return $this;
     }
 }

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -127,6 +127,16 @@ class Redirector
     }
 
     /**
+     * Get the intended url.
+     *
+     * @return string|null
+     */
+    public function getIntendedUrl()
+    {
+        return $this->session->get('url.intended');
+    }
+
+    /**
      * Create a new redirect response to the given path.
      *
      * @param  string  $path

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -178,11 +178,14 @@ class RoutingRedirectorTest extends TestCase
         $this->assertSame('http://foo.com/bar?signature=secret', $response->getTargetUrl());
     }
 
-    public function testItSetsValidIntendedUrl()
+    public function testItSetsAndGetsValidIntendedUrl()
     {
         $this->session->shouldReceive('put')->once()->with('url.intended', 'http://foo.com/bar');
+        $this->session->shouldReceive('get')->andReturn('http://foo.com/bar');
 
         $result = $this->redirect->setIntendedUrl('http://foo.com/bar');
         $this->assertInstanceOf(Redirector::class, $result);
+
+        $this->assertSame('http://foo.com/bar', $this->redirect->getIntendedUrl());
     }
 }


### PR DESCRIPTION
This PR adds the `getIntendedUrl` method the `Redirector` class. It feels more comfortable, than checking out the session directly.