### PR TITLE
[9.x] Improve test failure output

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -64,6 +64,13 @@ trait MakesHttpRequests
     protected $withCredentials = false;
 
     /**
+     * The latest test response.
+     *
+     * @var TestResponse
+     */
+    protected $latestResponse;
+
+    /**
      * Define additional headers to be sent with the request.
      *
      * @param  array  $headers
@@ -544,7 +551,7 @@ trait MakesHttpRequests
             $response = $this->followRedirects($response);
         }
 
-        return $this->createTestResponse($response);
+        return $this->latestResponse = $this->createTestResponse($response);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -68,7 +68,7 @@ trait MakesHttpRequests
      *
      * @var TestResponse
      */
-    protected $latestResponse;
+    public $latestResponse;
 
     /**
      * Define additional headers to be sent with the request.

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -66,7 +66,7 @@ trait MakesHttpRequests
     /**
      * The latest test response.
      *
-     * @var TestResponse
+     * @var \Illuminate\Testing\TestResponse
      */
     public $latestResponse;
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -66,7 +66,7 @@ trait MakesHttpRequests
     /**
      * The latest test response.
      *
-     * @var \Illuminate\Testing\TestResponse
+     * @var \Illuminate\Testing\TestResponse|null
      */
     public $latestResponse;
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -271,7 +271,8 @@ abstract class TestCase extends BaseTestCase
     /**
      * This method is called when a test method did not execute successfully.
      *
-     * @throws Throwable
+     * @param  Throwable  $exception
+     * @return void
      */
     protected function onNotSuccessfulTest(Throwable $exception): void
     {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -6,14 +6,19 @@ use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Queue\Queue;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\ParallelTesting;
 use Illuminate\Support\Str;
+use Illuminate\Testing\AssertableJsonString;
 use Mockery;
 use Mockery\Exception\InvalidCountException;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use ReflectionProperty;
 use Throwable;
 
 abstract class TestCase extends BaseTestCase
@@ -261,5 +266,116 @@ abstract class TestCase extends BaseTestCase
                 }
             }
         }
+    }
+
+    /**
+     * This method is called when a test method did not execute successfully.
+     *
+     * @throws Throwable
+     */
+    protected function onNotSuccessfulTest(Throwable $exception): void
+    {
+        if (! $exception instanceof ExpectationFailedException || ! $this->latestResponse) {
+            parent::onNotSuccessfulTest($exception);
+        }
+
+        if ($lastException = $this->latestResponse->exceptions->last()) {
+            parent::onNotSuccessfulTest($this->appendExceptionToException($lastException, $exception));
+
+            return;
+        }
+
+        if ($this->latestResponse->baseResponse instanceof RedirectResponse) {
+            $session = $this->latestResponse->baseResponse->getSession();
+
+            if (! is_null($session) && $session->has('errors')) {
+                parent::onNotSuccessfulTest($this->appendErrorsToException($session->get('errors')->all(), $exception));
+
+                return;
+            }
+        }
+
+        if ($this->latestResponse->baseResponse->headers->get('Content-Type') === 'application/json') {
+            $testJson = new AssertableJsonString($this->latestResponse->getContent());
+
+            if (isset($testJson['errors'])) {
+                parent::onNotSuccessfulTest($this->appendErrorsToException($testJson->json(), $exception, true));
+
+                return;
+            }
+        }
+
+        parent::onNotSuccessfulTest($exception);
+    }
+
+    /**
+     * Append an exception to the message of another exception.
+     *
+     * @param  Throwable  $exceptionToAppend
+     * @param  Throwable  $exception
+     * @return Throwable
+     */
+    protected function appendExceptionToException($exceptionToAppend, $exception)
+    {
+        $exceptionMessage = $exceptionToAppend->getMessage();
+        $exceptionToAppend = (string) $exceptionToAppend;
+        $message = <<<"EOF"
+            The following exception occurred during the last request:
+
+            $exceptionToAppend
+
+            ----------------------------------------------------------------------------------
+
+            $exceptionMessage
+            EOF;
+
+        return $this->appendMessageToException($message, $exception);
+    }
+
+    /**
+     * Append errors to an exception message.
+     *
+     * @param  array  $errors
+     * @param  Throwable  $exception
+     * @param  bool  $json
+     * @return Throwable
+     */
+    protected function appendErrorsToException($errors, $exception, $json = false)
+    {
+        $errors = $json
+            ? json_encode($errors, JSON_PRETTY_PRINT)
+            : implode(PHP_EOL, Arr::flatten($errors));
+
+        // JSON error messages may already contain the errors, so we shouldn't duplicate them.
+        if (str_contains($exception->getMessage(), $errors)) {
+            return $exception;
+        }
+
+        $message = <<<"EOF"
+            The following errors occurred during the last request:
+
+            $errors
+            EOF;
+
+        return $this->appendMessageToException($message, $exception);
+    }
+
+    /**
+     * Append a message to an exception.
+     *
+     * @param  string  $message
+     * @param  Throwable  $exception
+     * @return Throwable
+     */
+    protected function appendMessageToException($message, $exception)
+    {
+        $property = new ReflectionProperty($exception, 'message');
+        $property->setAccessible(true);
+        $property->setValue(
+            $exception,
+            $exception->getMessage().PHP_EOL.PHP_EOL.$message.PHP_EOL
+        );
+
+        return $exception;
     }
 }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -278,7 +278,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function onNotSuccessfulTest(Throwable $exception): void
     {
-        if (! $exception instanceof ExpectationFailedException || ! $this->latestResponse) {
+        if (! $exception instanceof ExpectationFailedException || is_null($this->latestResponse)) {
             parent::onNotSuccessfulTest($exception);
         }
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -271,7 +271,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * This method is called when a test method did not execute successfully.
      *
-     * @param  Throwable  $exception
+     * @param  \Throwable  $exception
      * @return void
      */
     protected function onNotSuccessfulTest(Throwable $exception): void
@@ -312,9 +312,9 @@ abstract class TestCase extends BaseTestCase
     /**
      * Append an exception to the message of another exception.
      *
-     * @param  Throwable  $exceptionToAppend
-     * @param  Throwable  $exception
-     * @return Throwable
+     * @param  \Throwable  $exceptionToAppend
+     * @param  \Throwable  $exception
+     * @return \Throwable
      */
     protected function appendExceptionToException($exceptionToAppend, $exception)
     {
@@ -337,9 +337,9 @@ abstract class TestCase extends BaseTestCase
      * Append errors to an exception message.
      *
      * @param  array  $errors
-     * @param  Throwable  $exception
+     * @param  \Throwable  $exception
      * @param  bool  $json
-     * @return Throwable
+     * @return \Throwable
      */
     protected function appendErrorsToException($errors, $exception, $json = false)
     {
@@ -365,8 +365,8 @@ abstract class TestCase extends BaseTestCase
      * Append a message to an exception.
      *
      * @param  string  $message
-     * @param  Throwable  $exception
-     * @return Throwable
+     * @param  \Throwable  $exception
+     * @return \Throwable
      */
     protected function appendMessageToException($message, $exception)
     {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -321,7 +321,9 @@ abstract class TestCase extends BaseTestCase
     protected function appendExceptionToException($exceptionToAppend, $exception)
     {
         $exceptionMessage = $exceptionToAppend->getMessage();
+
         $exceptionToAppend = (string) $exceptionToAppend;
+
         $message = <<<"EOF"
             The following exception occurred during the last request:
 
@@ -349,7 +351,7 @@ abstract class TestCase extends BaseTestCase
             ? json_encode($errors, JSON_PRETTY_PRINT)
             : implode(PHP_EOL, Arr::flatten($errors));
 
-        // JSON error messages may already contain the errors, so we shouldn't duplicate them.
+        // JSON error messages may already contain the errors, so we shouldn't duplicate them...
         if (str_contains($exception->getMessage(), $errors)) {
             return $exception;
         }
@@ -373,7 +375,9 @@ abstract class TestCase extends BaseTestCase
     protected function appendMessageToException($message, $exception)
     {
         $property = new ReflectionProperty($exception, 'message');
+
         $property->setAccessible(true);
+
         $property->setValue(
             $exception,
             $exception->getMessage().PHP_EOL.PHP_EOL.$message.PHP_EOL

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -86,6 +86,8 @@ abstract class TestCase extends BaseTestCase
      */
     protected function setUp(): void
     {
+        $this->latestResponse = null;
+
         Facade::clearResolvedInstances();
 
         if (! $this->app) {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -44,7 +43,7 @@ class TestResponse implements ArrayAccess
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $exceptions;
+    public $exceptions;
 
     /**
      * The streamed content of the response.
@@ -190,81 +189,7 @@ class TestResponse implements ArrayAccess
      */
     protected function statusMessageWithDetails($expected, $actual)
     {
-        $lastException = $this->exceptions->last();
-
-        if ($lastException) {
-            return $this->statusMessageWithException($expected, $actual, $lastException);
-        }
-
-        if ($this->baseResponse instanceof RedirectResponse) {
-            $session = $this->baseResponse->getSession();
-
-            if (! is_null($session) && $session->has('errors')) {
-                return $this->statusMessageWithErrors($expected, $actual, $session->get('errors')->all());
-            }
-        }
-
-        if ($this->baseResponse->headers->get('Content-Type') === 'application/json') {
-            $testJson = new AssertableJsonString($this->getContent());
-
-            if (isset($testJson['errors'])) {
-                return $this->statusMessageWithErrors($expected, $actual, $testJson->json());
-            }
-        }
-
         return "Expected response status code [{$expected}] but received {$actual}.";
-    }
-
-    /**
-     * Get an assertion message for a status assertion that has an unexpected exception.
-     *
-     * @param  string|int  $expected
-     * @param  string|int  $actual
-     * @param  \Throwable  $exception
-     * @return string
-     */
-    protected function statusMessageWithException($expected, $actual, $exception)
-    {
-        $message = $exception->getMessage();
-
-        $exception = (string) $exception;
-
-        return <<<EOF
-Expected response status code [$expected] but received $actual.
-
-The following exception occurred during the request:
-
-$exception
-
-----------------------------------------------------------------------------------
-
-$message
-
-EOF;
-    }
-
-    /**
-     * Get an assertion message for a status assertion that contained errors.
-     *
-     * @param  string|int  $expected
-     * @param  string|int  $actual
-     * @param  array  $errors
-     * @return string
-     */
-    protected function statusMessageWithErrors($expected, $actual, $errors)
-    {
-        $errors = $this->baseResponse->headers->get('Content-Type') === 'application/json'
-            ? json_encode($errors, JSON_PRETTY_PRINT)
-            : implode(PHP_EOL, Arr::flatten($errors));
-
-        return <<<EOF
-Expected response status code [$expected] but received $actual.
-
-The following errors occurred during the request:
-
-$errors
-
-EOF;
     }
 
     /**

--- a/tests/Foundation/Testing/TestCaseTest.php
+++ b/tests/Foundation/Testing/TestCaseTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Foundation\Testing;
+
+use Exception;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
+use Illuminate\Session\NullSessionHandler;
+use Illuminate\Session\Store;
+use Illuminate\Testing\TestResponse;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCaseTest extends BaseTestCase
+{
+    public function test_it_includes_response_exceptions_on_test_failures()
+    {
+        $testCase = new ExampleTestCase();
+        $testCase->latestResponse = TestResponse::fromBaseResponse(new Response())
+            ->withExceptions(collect([new Exception('Unexpected exception.')]));
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Assertion message.*Unexpected exception/s');
+
+        $testCase->onNotSuccessfulTest(new ExpectationFailedException('Assertion message.'));
+    }
+
+    public function test_it_includes_validation_errors_on_test_failures()
+    {
+        $testCase = new ExampleTestCase();
+        $testCase->latestResponse = TestResponse::fromBaseResponse(
+            tap(new RedirectResponse('/'))
+                ->setSession(new Store('test-session', new NullSessionHandler()))
+                ->withErrors([
+                    'first_name' => 'The first name field is required.',
+                ])
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Assertion message.*The first name field is required/s');
+        $testCase->onNotSuccessfulTest(new ExpectationFailedException('Assertion message.'));
+    }
+
+    public function test_it_includes_json_validation_errors_on_test_failures()
+    {
+        $testCase = new ExampleTestCase();
+        $testCase->latestResponse = TestResponse::fromBaseResponse(
+            new Response(['errors' => ['first_name' => 'The first name field is required.']])
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Assertion message.*The first name field is required/s');
+        $testCase->onNotSuccessfulTest(new ExpectationFailedException('Assertion message.'));
+    }
+
+    public function test_it_doesnt_fail_with_false_json()
+    {
+        $testCase = new ExampleTestCase();
+        $testCase->latestResponse = TestResponse::fromBaseResponse(
+            new Response(false, 200, ['Content-Type' => 'application/json'])
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Assertion message/s');
+        $testCase->onNotSuccessfulTest(new ExpectationFailedException('Assertion message.'));
+    }
+
+    public function test_it_doesnt_fail_with_encoded_json()
+    {
+        $testCase = new ExampleTestCase();
+        $testCase->latestResponse = TestResponse::fromBaseResponse(
+            tap(new Response, function ($response) {
+                $response->header('Content-Type', 'application/json');
+                $response->header('Content-Encoding', 'gzip');
+                $response->setContent('b"x£½V*.I,)-V▓R╩¤V¬\x05\x00+ü\x059"');
+            })
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/Assertion message/s');
+        $testCase->onNotSuccessfulTest(new ExpectationFailedException('Assertion message.'));
+    }
+}
+
+class ExampleTestCase extends TestCase
+{
+    public function createApplication()
+    {
+        //
+    }
+}

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Testing;
 
-use Exception;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
@@ -621,90 +620,6 @@ class TestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse($baseResponse);
         $response->assertStatus($expectedStatusCode);
-    }
-
-    public function testAssertStatusShowsExceptionOnUnexpected500()
-    {
-        $statusCode = 500;
-        $expectedStatusCode = 200;
-
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('Test exception message');
-
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
-            $response->setStatusCode($statusCode);
-        });
-        $exceptions = collect([new Exception('Test exception message')]);
-
-        $response = TestResponse::fromBaseResponse($baseResponse)
-            ->withExceptions($exceptions);
-        $response->assertStatus($expectedStatusCode);
-    }
-
-    public function testAssertStatusShowsErrorsOnUnexpectedErrorRedirect()
-    {
-        $statusCode = 302;
-        $expectedStatusCode = 200;
-
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('The first name field is required.');
-
-        $baseResponse = tap(new RedirectResponse('/', $statusCode), function ($response) {
-            $response->setSession(new Store('test-session', new ArraySessionHandler(1)));
-            $response->withErrors([
-                'first_name' => 'The first name field is required.',
-                'last_name' => 'The last name field is required.',
-            ]);
-        });
-
-        $response = TestResponse::fromBaseResponse($baseResponse);
-        $response->assertStatus($expectedStatusCode);
-    }
-
-    public function testAssertStatusShowsJsonErrorsOnUnexpected422()
-    {
-        $statusCode = 422;
-        $expectedStatusCode = 200;
-
-        $this->expectException(AssertionFailedError::class);
-
-        $this->expectExceptionMessage('"The first name field is required."');
-
-        $baseResponse = new Response(
-            [
-                'message' => 'The given data was invalid.',
-                'errors' => [
-                    'first_name' => 'The first name field is required.',
-                    'last_name' => 'The last name field is required.',
-                ],
-            ],
-            $statusCode
-        );
-
-        $response = TestResponse::fromBaseResponse($baseResponse);
-        $response->assertStatus($expectedStatusCode);
-    }
-
-    public function testAssertStatusWhenJsonIsFalse()
-    {
-        $baseResponse = new Response('false', 200, ['Content-Type' => 'application/json']);
-
-        $response = TestResponse::fromBaseResponse($baseResponse);
-        $response->assertStatus(200);
-    }
-
-    public function testAssertStatusWhenJsonIsEncoded()
-    {
-        $baseResponse = tap(new Response, function ($response) {
-            $response->header('Content-Type', 'application/json');
-            $response->header('Content-Encoding', 'gzip');
-            $response->setContent('b"x£½V*.I,)-V▓R╩¤V¬\x05\x00+ü\x059"');
-        });
-
-        $response = TestResponse::fromBaseResponse($baseResponse);
-        $response->assertStatus(200);
     }
 
     public function testAssertHeader()


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/38025 and https://github.com/laravel/framework/pull/38046, we improved the test output for the `assertStatus` methods to display any exceptions or errors that may have caused the status assertion to fail.

These improvements almost removed the need to call `withoutExceptionHandling`. Almost...

This PR expands on the previous work to display exceptions or errors on *any* failed assertion, not just status assertions, and not even just `TestResponse` assertions.

A common example is when asserting Inertia redirects, and an unexpected validation error occurs. The current output doesn't give any clues that the redirect assertion failure was due to a validation error:

![image](https://user-images.githubusercontent.com/4977161/187591134-f2a7880f-b3ab-4641-8a13-15d4c4a231e2.png)

Under the hood, this calls `assertStatus` and `assertLocation`, but it's only the `assertLocation` that fails, which doesn't currently display exceptions or errors.

With the changes in this PR, the error now looks like this:

![image](https://user-images.githubusercontent.com/4977161/187591543-5bac4ee9-ad3e-49e7-be5e-f084e7a8e379.png)

> **Note** Unfortunately, it doesn't seem possible to inject the exception/error *after* the ComparisonFailure diff, so the output is not 100% what I'd want.

The existing `assertStatus` behaviour is now handled by this new logic, so there's no duplication of code. There is a minor change in output because the extra content is now appended _after_ PHPUnit's raw assertion error instead of before it:

**Before:**
![image](https://user-images.githubusercontent.com/4977161/187590627-3cb41ecc-bcc7-4cc1-b5d1-b20e42b4bff4.png)

**After:**
![image](https://user-images.githubusercontent.com/4977161/187592394-0d0f04e1-ebf2-4d70-8dd5-9da30d066897.png)

We'll now also see this extra context even if we don't assert against the TestResponse. For example, imagine this test where we expect a user record to be created:

```php
$this->post('/users', []);

$this->assertSame(1, User::count());
```

If a validation error or exception occurred during the last request, we'll get the extra context on PHPUnit's built-in assertions like `assertSame`:

![image](https://user-images.githubusercontent.com/4977161/188358546-496659d9-206e-4b6c-b0c9-519f1d7dd3ff.png)

The only scenario I can think of where this feature is undesirable is the `assertJson` assertion. If a validation error occurs, the `assertJson` assertion will already show the full response body. To prevent duplicate output, I've ensured that we don't append the JSON error response if the existing message already includes it.

If the user makes multiple requests in one test, only errors/exceptions from the latest request will be displayed, hopefully preventing red herrings.

The extra context will only be displayed when an assertion fails, so you won't see any output if you expect an error or exception as long as your assertions pass.

Developers may opt-out of this feature by overriding the `onNotSuccessfulTest` method in their base test case to throw the given exception like PHPUnit does by default.