### PR TITLE
[8.x] Avoid Passing null to parameter exception on PHP 8.1

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -846,8 +846,8 @@ class Builder
      */
     protected function invalidOperator($operator)
     {
-        return ! in_array(strtolower($operator), $this->operators, true) &&
-               ! in_array(strtolower($operator), $this->grammar->getOperators(), true);
+        return ! is_string($operator) || (! in_array(strtolower($operator), $this->operators, true) &&
+               ! in_array(strtolower($operator), $this->grammar->getOperators(), true));
     }
 
     /**


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/109558925/187706124-77ea7824-7ad3-4dcf-853d-682b491400f7.png)

This PR makes sure that the parameter is a string, same as `9.x` for `8.x`, please, really a small not breaking change
https://github.com/laravel/framework/blob/e07e00507e67c710798eb98cdb09845f65026429/src/Illuminate/Database/Query/Builder.php#L851-L855