### PR TITLE
[9.x] New flag: artisan make:test --model=XXXXX

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.model.stub
@@ -1,0 +1,80 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class {{ class }} extends TestCase
+{
+    // use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->followingRedirects();
+    }
+
+    public function test_{{ route }}_index()
+    {
+        $response = $this->get('{{ route }}');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_{{ route }}_create()
+    {
+        $response = $this->get('{{ route }}/create');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_{{ route }}_store()
+    {
+        $new{{ model }} = {{ model }}::factory()->make();
+
+        $response = $this->post('{{ route }}', $new{{ model }}->toArray());
+
+        $response->assertStatus(200);
+    }
+
+    public function test_{{ route }}_show()
+    {
+        $new{{ model }} = {{ model }}::factory()->create();
+
+        $response = $this->get('{{ route }}/' . $new{{ model }}->getKey());
+
+        $response->assertStatus(200);
+    }
+
+    public function test_{{ route }}_edit()
+    {
+        $new{{ model }} = {{ model }}::factory()->create();
+
+        $response = $this->get('{{ route }}/' . $new{{ model }}->getKey() . '/edit');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_{{ route }}_update()
+    {
+        $new{{ model }} = {{ model }}::factory()->create();
+        $updated{{ model }} = {{ model }}::factory()->make();
+
+        $response = $this->put('{{ route }}/' . $new{{ model }}->getKey(), $updated{{ model }}->toArray());
+
+        $response->assertStatus(200);
+    }
+
+    public function test_{{ route }}_destroy()
+    {
+        $new{{ model }} = {{ model }}::factory()->create();
+
+        $response = $this->delete('{{ route }}/' . $new{{ model }}->getKey());
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
I want to help newcomers to testing and generate sample "smoke tests" for them, to test the typical resource controller routes.

The basic "version 1" idea is in this PR: new flag `php artisan make:test UserTest --model=User` would generate the feature UserTest from a specific stub, containing 7 methods, corresponding to exactly the methods of resource controllers: https://laravel.com/docs/9.x/controllers#resource-controllers

So, if the controller methods are implemented, the only thing to change in the generated test would be to enable `RefreshDatabase` after making sure you're working on the testing dababase and not on the production one.

Loom video with a 30-second demo: https://www.loom.com/share/d25be7d688eb44898cdabe40ba7c9d28

Now, of course, the Feature Test content is a little opinionated and assumes a few things:

- Factories are created
- All 7 resourceful controller methods exist and return the things they are typically supposed to return (status 200 or redirect)


But I still think it can be a massive helper to __newcomers__ to testing, to give them an example test, which they would then modify as they want, if some method doesn't pass initially.

If you don't think this should be a part of the core, no problem, I would create a separate package, with potentially more customizations.

- - - - - 

Open questions for discussions:

1. If I get a green light with this, I will also make a PEST implementation, with `php artisan make:test UserTest --pest --model=User`
2. Should RefreshDatabase be enabled by default, or it is too risky?
3. The test creates a `setUp()` method with `$this->followingRedirects()` to match two cases in post/put/delete requests: that those controllers return 2xx code, or that they redirect to success/index page. Not sure if it's the most elegant solution.
4. I wanted to extend that into `php artisan make:model --test` and `php artisan make:controller --test` but apparently those flags already exist there, just generate **empty** tests. If you give me green light, I could override those empty tests with the model-stub ones? Or should I create different flags for those like "--route-test" or "--resource-test" or something.

Any other suggestions or feedback are welcome. Thanks!