### PR TITLE
Added support for `"true"` and `"false"` text values to the Boolean validation rule for compatibility with FormData

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -435,7 +435,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 'true', 'false', 0, 1, '0', '1'];
 
         return in_array($value, $acceptable, true);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2221,10 +2221,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
@@ -2246,6 +2246,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 0], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'Boolean']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => []], ['foo' => 'Boolean']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => new NonEloquentModel()], ['foo' => 'Boolean']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateBool()
@@ -2258,10 +2267,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());
@@ -2283,6 +2292,15 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => 0], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'Bool']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => []], ['foo' => 'Bool']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => new NonEloquentModel()], ['foo' => 'Bool']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateNumeric()


### PR DESCRIPTION
Very often, data is sent from the web interface along with the file.

Unfortunately, you can only send a file through JS using [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append), and it has its own characteristics and limitations. For example, it can only transfer strings:

```javascript
formData.append('name', "John");   // "John"
formData.append('age', 72);        // "72"
formData.append('is_admin', true); // "true"
formData.append('avatar', (binary));
```

At this point, we are faced with another problem - the validation of a boolean value:

```php
public function rules(): array
{
    return [
        // ...
        'is_admin' => ['required', 'bool']
    ];
}
```

Because "true" and "false" are strings of 4 and 5 characters respectively, not booleans.

For this reason, in the above request, the validator will return the message:

```
The :attribute field must be true or false.
```

Of course, you can use the [`filter_var`](https://www.php.net/manual/en/function.filter-var) function when checking, but then another problem arises - it defines `null` values as `false`:

```php
filter_var(true, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);    // true
filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);   // false
filter_var('true', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);  // true
filter_var('false', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE); // false
filter_var('yes', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);   // true
filter_var('no', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);    // false
filter_var(null, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);    // false
filter_var($obj, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);    // null
filter_var([], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);      // null
```

Therefore, it is better not to use it, because. often it is necessary to catch exactly `null` value.

That is why I propose to extend the existing variable definition method by adding string values for `true` and `false` to it.

Since defining string values changes behavior, I consider these changes to be backwards incompatible.

At the moment, you have to insert a crutch in the form of a custom rule. In my opinion, this is wrong, given the presence of the rule in the "box".

```php
class BooleanRule implements Rule
{
    public function passes($attribute, $value): bool
    {
        $acceptable = [true, false, 'true', 'false', 0, 1, '0', '1'];

        return in_array($value, $acceptable, true);
    }

    public function message()
    {
        return trans('validation.boolean');
    }
}

class CustomRequest
{
    public function rules(): array
    {
        // ...
        'is_admin' => ['required', new BooleanRule()]
    }
}
```
