### PR TITLE
[9.x] fix incorrect? phpdoc for Connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1258,7 +1258,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the database connection name.
      *
-     * @return string|null
+     * @return string
      */
     public function getName()
     {
@@ -1268,7 +1268,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the database connection full name.
      *
-     * @return string|null
+     * @return string
      */
     public function getNameWithReadWriteType()
     {


### PR DESCRIPTION
I noticed that phpdoc for `getName` says it returns `string|null` but I think this should return `string`.

By fixing this,  it will become consistent with places where this is actually used like [ConnectionEvent](https://github.com/laravel/framework/blob/0efbd7e6df26c48c3a2438fffefcdea932ec768f/src/Illuminate/Database/Events/ConnectionEvent.php#L7-L12) and [DatabaseTransactionRecord](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/DatabaseTransactionRecord.php#L7-L12).

In most cases, `getName()` will not return `null` since [ConnectionFactory will always set the name](https://github.com/laravel/framework/blob/0efbd7e6df26c48c3a2438fffefcdea932ec768f/src/Illuminate/Database/Connectors/ConnectionFactory.php#L62). 

The only way a `null` can slip in is if a user instantiates the `Connection` and not set `$config['name']`.

I also fixed the related, `getNameWithReadWriteType()`.