### PR TITLE
[9.x] Add validatedExcept method to FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationException;
 
@@ -213,6 +214,23 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function validated($key = null, $default = null)
     {
         return data_get($this->validator->validated(), $key, $default);
+    }
+
+    /**
+     * Get the validated data from the request except for a specified array of items.
+     *
+     * @param  array|mixed  $keys
+     * @return array
+     */
+    public function validatedExcept($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $results = $this->validator->validated();
+
+        Arr::forget($results, $keys);
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -219,7 +219,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the validated data from the request except for a specified array of items.
      *
-     * @param  array|mixed  $keys
+     * @param  mixed  $keys
      * @return array
      */
     public function validatedExcept($keys)

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -29,6 +29,18 @@ class FoundationFormRequestTest extends TestCase
         $this->mocks = [];
     }
 
+    public function testValidatedExceptMethodReturnsTheValidatedDataExceptForASpecifiedArrayOfItems()
+    {
+        $payload = ['name' => 'Taylor', 'age' => 25, 'with' => 'extras'];
+
+        $request = $this->createRequest($payload, FoundationTestFormRequestExceptStub::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['name' => 'Taylor'], $request->validatedExcept('age'));
+        $this->assertEquals([], $request->validatedExcept('age', 'name'));
+    }
+
     public function testValidatedMethodReturnsTheValidatedData()
     {
         $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
@@ -257,6 +269,19 @@ class FoundationTestFormRequestStub extends FormRequest
     public function rules()
     {
         return ['name' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestExceptStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['name' => 'required', 'age' => 'required'];
     }
 
     public function authorize()


### PR DESCRIPTION
This PR adds validatedExcept method to FormRequest to get the validated data from the request except for a specified array of items.
