### PR TITLE
[9.x] Support objects like GMP for custom Model casts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis-phpredis/phpredis@5.3.5, igbinary, msgpack, lzf, zstd, lz4, memcached
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, redis-phpredis/phpredis@5.3.5, igbinary, msgpack, lzf, zstd, lz4, memcached, gmp
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
@@ -122,7 +122,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp, redis, memcached, gmp
           tools: composer:v2
           coverage: none
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -930,7 +930,7 @@ trait HasAttributes
         // If an attribute is listed as a "date", we'll convert it from a DateTime
         // instance into a form proper for storage on the database tables using
         // the connection grammar's date format. We will auto set the values.
-        elseif ($value && $this->isDateAttribute($key)) {
+        elseif (isset($value) && $this->isDateAttribute($key)) {
             $value = $this->fromDateTime($value);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -930,7 +930,7 @@ trait HasAttributes
         // If an attribute is listed as a "date", we'll convert it from a DateTime
         // instance into a form proper for storage on the database tables using
         // the connection grammar's date format. We will auto set the values.
-        elseif (isset($value) && $this->isDateAttribute($key)) {
+        elseif (! is_null($value) && $this->isDateAttribute($key)) {
             $value = $this->fromDateTime($value);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -289,11 +289,11 @@ trait HasAttributes
             // If the attribute cast was a date or a datetime, we will serialize the date as
             // a string. This allows the developers to customize how dates are serialized
             // into an array without affecting how they are persisted into the storage.
-            if ($attributes[$key] && in_array($value, ['date', 'datetime', 'immutable_date', 'immutable_datetime'])) {
+            if (isset($attributes[$key]) && in_array($value, ['date', 'datetime', 'immutable_date', 'immutable_datetime'])) {
                 $attributes[$key] = $this->serializeDate($attributes[$key]);
             }
 
-            if ($attributes[$key] && ($this->isCustomDateTimeCast($value) ||
+            if (isset($attributes[$key]) && ($this->isCustomDateTimeCast($value) ||
                 $this->isImmutableCustomDateTimeCast($value))) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
@@ -303,7 +303,7 @@ trait HasAttributes
                 $attributes[$key] = $this->serializeDate($attributes[$key]);
             }
 
-            if ($attributes[$key] && $this->isClassSerializable($key)) {
+            if (isset($attributes[$key]) && $this->isClassSerializable($key)) {
                 $attributes[$key] = $this->serializeClassCastableAttribute($key, $attributes[$key]);
             }
 

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -249,6 +249,15 @@ class GMPCast implements CastsAttributes, SerializesCastableAttributes
         return gmp_strval($value, 10);
     }
 
+    /**
+     * Serialize the attribute when converting the model to an array.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
     public function serialize($model, string $key, $value, array $attributes)
     {
         return gmp_strval($value, 10);

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -2,11 +2,15 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use GMP;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Schema\Blueprint;
 use InvalidArgumentException;
+use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -40,6 +44,7 @@ class EloquentModelCustomCastingTest extends TestCase
             $table->increments('id');
             $table->string('address_line_one');
             $table->string('address_line_two');
+            $table->integer('amount');
             $table->string('string_field');
             $table->timestamps();
         });
@@ -63,6 +68,7 @@ class EloquentModelCustomCastingTest extends TestCase
         /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
         $model = CustomCasts::create([
             'address' => new AddressModel('address_line_one_value', 'address_line_two_value'),
+            'amount' => gmp_init('1000', 10),
             'string_field' => null,
         ]);
 
@@ -72,6 +78,8 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->assertSame('address_line_two_value', $model->getOriginal('address_line_two'));
         $this->assertSame('address_line_two_value', $model->getAttribute('address_line_two'));
 
+        $this->assertSame('1000', $model->getRawOriginal('amount'));
+
         $this->assertNull($model->getOriginal('string_field'));
         $this->assertNull($model->getAttribute('string_field'));
         $this->assertSame('', $model->getRawOriginal('string_field'));
@@ -80,6 +88,7 @@ class EloquentModelCustomCastingTest extends TestCase
         $another_model = CustomCasts::create([
             'address_line_one' => 'address_line_one_value',
             'address_line_two' => 'address_line_two_value',
+            'amount' => gmp_init('500', 10),
             'string_field' => 'string_value',
         ]);
 
@@ -87,6 +96,7 @@ class EloquentModelCustomCastingTest extends TestCase
 
         $this->assertSame('address_line_one_value', $model->address->lineOne);
         $this->assertSame('address_line_two_value', $model->address->lineTwo);
+        $this->assertInstanceOf(GMP::class, $model->amount);
     }
 
     public function testInvalidArgumentExceptionOnInvalidValue()
@@ -94,6 +104,7 @@ class EloquentModelCustomCastingTest extends TestCase
         /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
         $model = CustomCasts::create([
             'address' => new AddressModel('address_line_one_value', 'address_line_two_value'),
+            'amount' => gmp_init('1000', 10),
             'string_field' => 'string_value',
         ]);
 
@@ -111,6 +122,7 @@ class EloquentModelCustomCastingTest extends TestCase
         /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
         $model = CustomCasts::create([
             'address' => new AddressModel('address_line_one_value', 'address_line_two_value'),
+            'amount' => gmp_init('1000', 10),
             'string_field' => 'string_value',
         ]);
 
@@ -121,6 +133,27 @@ class EloquentModelCustomCastingTest extends TestCase
         // Ensure model values remain unchanged
         $this->assertSame('address_line_one_value', $model->address->lineOne);
         $this->assertSame('address_line_two_value', $model->address->lineTwo);
+    }
+
+    public function testModelsWithCustomCastsCanBeConvertedToArrays()
+    {
+        /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
+        $model = CustomCasts::create([
+            'address' => new AddressModel('address_line_one_value', 'address_line_two_value'),
+            'amount' => gmp_init('1000', 10),
+            'string_field' => 'string_value',
+        ]);
+
+        // Ensure model values remain unchanged
+        $this->assertSame([
+            'address_line_one' => 'address_line_one_value',
+            'address_line_two' => 'address_line_two_value',
+            'amount' => '1000',
+            'string_field' => 'string_value',
+            'updated_at' => $model->updated_at->toJSON(),
+            'created_at' => $model->created_at->toJSON(),
+            'id' => 1,
+        ], $model->toArray());
     }
 
     /**
@@ -188,6 +221,42 @@ class AddressCast implements CastsAttributes
     }
 }
 
+class GMPCast implements CastsAttributes, SerializesCastableAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  string  $value
+     * @param  array  $attributes
+     * @return string|null
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return gmp_init($value, 10);
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  string|null  $value
+     * @param  array  $attributes
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return gmp_strval($value, 10);
+    }
+
+    public function serialize($model, string $key, $value, array $attributes)
+    {
+        return gmp_strval($value, 10);
+    }
+}
+
 class NonNullableString implements CastsAttributes
 {
     /**
@@ -239,6 +308,7 @@ class CustomCasts extends Eloquent
      */
     protected $casts = [
         'address' => AddressCast::class,
+        'amount' => GMPCast::class,
         'string_field' => NonNullableString::class,
     ];
 }

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -5,12 +5,10 @@ namespace Illuminate\Tests\Integration\Database;
 use GMP;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Schema\Blueprint;
 use InvalidArgumentException;
-use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 
 /**


### PR DESCRIPTION
This PR fixes an issue where some objects like GMP objects couldn't be used as custom casts. The reason is that these objects cannot be converted to booleans so an `if ($attribute[$key])` check will hard-fail. By using `isset` we can just check if the attribute is present and has a value.

Fixes https://github.com/laravel/framework/issues/43870