### PR TITLE
[9.x] Fix ordering of stylesheets when using @vite

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -213,6 +213,19 @@ class Vite implements Htmlable
         foreach ($entrypoints as $entrypoint) {
             $chunk = $this->chunk($manifest, $entrypoint);
 
+            foreach ($chunk['imports'] ?? [] as $import) {
+                foreach ($manifest[$import]['css'] ?? [] as $css) {
+                    $partialManifest = Collection::make($manifest)->where('file', $css);
+
+                    $tags->push($this->makeTagForChunk(
+                        $partialManifest->keys()->first(),
+                        asset("{$buildDirectory}/{$css}"),
+                        $partialManifest->first(),
+                        $manifest
+                    ));
+                }
+            }
+
             $tags->push($this->makeTagForChunk(
                 $entrypoint,
                 asset("{$buildDirectory}/{$chunk['file']}"),
@@ -229,19 +242,6 @@ class Vite implements Htmlable
                     $partialManifest->first(),
                     $manifest
                 ));
-            }
-
-            foreach ($chunk['imports'] ?? [] as $import) {
-                foreach ($manifest[$import]['css'] ?? [] as $css) {
-                    $partialManifest = Collection::make($manifest)->where('file', $css);
-
-                    $tags->push($this->makeTagForChunk(
-                        $partialManifest->keys()->first(),
-                        asset("{$buildDirectory}/{$css}"),
-                        $partialManifest->first(),
-                        $manifest
-                    ));
-                }
             }
         }
 


### PR DESCRIPTION
First up: Thank you all so much for this awesome framework (and the great documentation). I'm using it for many years now and always enjoy working with it!

When I started a new project recently I however came across a problem: My stylesheets end up in the wrong order in the rendered HTML when using `@vite`. This prevented any CSS overrides from within my application's stylesheet to actually work.

This is the current order of the stylesheets:
```
<link rel="stylesheet" href="https://.../build/assets/app.0981a13d.css">
<link rel="stylesheet" href="https://.../build/assets/vendor.a8fc34b5.css">
```
when it should IMHO actually be the other way around.

This PR fixes this issue, although please forgive the very "quick-fix" nature of the PR. I'm not aware if my changes could break things elsewhere or if this actually touches intended behaviour.

<details>
  <summary>For anyone coming across this</summary>

For the time being, I solved this issue in my project by introducing a custom blade directive and extending from `\Illuminate\Foundation\Vite`. This allowed me to prevent any changes to `vendor` code while still being able to have my stylesheets rendered in the right order.

```php
// In app/Providers/AppServiceProvider.php
public function boot()
{
    ...
    Blade::directive('custom_vite', function ($arguments) {
        $arguments ??= '';
        $class = Vite::class;
        return "<?php echo app('$class')({$arguments}); ?>";
    });
}

// Created app\Facades\Vite.php
<?php

namespace App\Facades;

use Exception;
use Illuminate\Foundation\Vite as OriginalVite;
use Illuminate\Support\Collection;
use Illuminate\Support\HtmlString;

class Vite extends OriginalVite
{
    /**
     * Generate Vite tags for an entrypoint.
     *
     * @param  string|string[]  $entrypoints
     * @param  string|null  $buildDirectory
     * @return \Illuminate\Support\HtmlString
     *
     * @throws \Exception
     */
    public function __invoke($entrypoints, $buildDirectory = null)
    {
        $entrypoints = collect($entrypoints);
        $buildDirectory ??= $this->buildDirectory;

        if ($this->isRunningHot()) {
            return new HtmlString(
                $entrypoints
                    ->prepend('@vite/client')
                    ->map(fn ($entrypoint) => $this->makeTagForChunk($entrypoint, $this->hotAsset($entrypoint), null, null))
                    ->join('')
            );
        }

        $manifest = $this->manifest($buildDirectory);

        $tags = collect();

        foreach ($entrypoints as $entrypoint) {
            $chunk = $this->chunk($manifest, $entrypoint);

            foreach ($chunk['imports'] ?? [] as $import) {
                foreach ($manifest[$import]['css'] ?? [] as $css) {
                    $partialManifest = Collection::make($manifest)->where('file', $css);

                    $tags->push($this->makeTagForChunk(
                        $partialManifest->keys()->first(),
                        asset("{$buildDirectory}/{$css}"),
                        $partialManifest->first(),
                        $manifest
                    ));
                }
            }

            $tags->push($this->makeTagForChunk(
                $entrypoint,
                asset("{$buildDirectory}/{$chunk['file']}"),
                $chunk,
                $manifest
            ));

            foreach ($chunk['css'] ?? [] as $css) {
                $partialManifest = Collection::make($manifest)->where('file', $css);

                $tags->push($this->makeTagForChunk(
                    $partialManifest->keys()->first(),
                    asset("{$buildDirectory}/{$css}"),
                    $partialManifest->first(),
                    $manifest
                ));
            }
        }

        [$stylesheets, $scripts] = $tags->partition(fn ($tag) => str_starts_with($tag, '<link'));

        return new HtmlString($stylesheets->join('').$scripts->join(''));
    }
}
```

Afterwards just use `@vite_custom(...)` instead of `@vite(...)` in your blade templates :wink: 
</details>