### PR TITLE
[10.x] Support for BackedEnum in value helper

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -184,6 +184,10 @@ if (! function_exists('value')) {
      */
     function value($value, ...$args)
     {
+        if ($value instanceof \BackedEnum) {
+            return $value->value;
+        }
+        
         return $value instanceof Closure ? $value(...$args) : $value;
     }
 }

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -187,7 +187,7 @@ if (! function_exists('value')) {
         if ($value instanceof \BackedEnum) {
             return $value->value;
         }
-        
+
         return $value instanceof Closure ? $value(...$args) : $value;
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -41,6 +41,7 @@ class SupportHelpersTest extends TestCase
 
     public function testValue()
     {
+        $this->assertSame(10, value(BackedEnumValeTest::English));
         $this->assertSame('foo', value('foo'));
         $this->assertSame('foo', value(function () {
             return 'foo';
@@ -881,4 +882,9 @@ class SupportTestArrayIterable implements IteratorAggregate
     {
         return new ArrayIterator($this->items);
     }
+}
+
+enum BackedEnumValeTest: int
+{
+    case English = 10;
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -41,7 +41,7 @@ class SupportHelpersTest extends TestCase
 
     public function testValue()
     {
-        $this->assertSame(10, value(BackedEnumValeTest::English));
+        $this->assertSame(10, value(BackedEnumValueTest::English));
         $this->assertSame('foo', value('foo'));
         $this->assertSame('foo', value(function () {
             return 'foo';
@@ -884,7 +884,7 @@ class SupportTestArrayIterable implements IteratorAggregate
     }
 }
 
-enum BackedEnumValeTest: int
+enum BackedEnumValueTest: int
 {
     case English = 10;
 }


### PR DESCRIPTION
when we use `value()` function we excepted this function return the 'value' of the argument we pass, so i think it make sense it return the value of BackedEnum instead of enum itself
