### PR TITLE
[9.x] Support arrays on Enum validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -43,7 +43,7 @@ class Enum implements Rule
             foreach (Arr::wrap($value) as $item) {
                 if (is_null($this->type::tryFrom($item))) {
                     return false;
-                };
+                }
             }
 
             return true;

--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Arr;
 use TypeError;
 
 class Enum implements Rule
@@ -39,7 +40,13 @@ class Enum implements Rule
         }
 
         try {
-            return ! is_null($this->type::tryFrom($value));
+            foreach (Arr::wrap($value) as $item) {
+                if (is_null($this->type::tryFrom($item))) {
+                    return false;
+                };
+            }
+
+            return true;
         } catch (TypeError $e) {
             return false;
         }

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -147,6 +147,36 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
     }
 
+    public function testValidationPassesWhenUsingOnArray()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status_array' => ['pending', 'done']
+            ],
+            [
+                'status_array' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    public function testValidationPassesWhenProvidingArrayThatContainsNonExistingCases()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status_array' => ['pending', 'foo']
+            ],
+            [
+                'status_array' => new Enum(StringStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+    }
+
     protected function setUp(): void
     {
         $container = Container::getInstance();

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -152,7 +152,7 @@ class ValidationEnumRuleTest extends TestCase
         $v = new Validator(
             resolve('translator'),
             [
-                'status_array' => ['pending', 'done']
+                'status_array' => ['pending', 'done'],
             ],
             [
                 'status_array' => new Enum(StringStatus::class),
@@ -167,7 +167,7 @@ class ValidationEnumRuleTest extends TestCase
         $v = new Validator(
             resolve('translator'),
             [
-                'status_array' => ['pending', 'foo']
+                'status_array' => ['pending', 'foo'],
             ],
             [
                 'status_array' => new Enum(StringStatus::class),


### PR DESCRIPTION
The `in` and `exists` validation rules can be used to validate all values of an array, but the `Enum` rule does currently not support this. This PR fixes that.
```php
// Before
return [
    'enum_values_array' => [
        'required',
        'array',
        'min:1',
    ],
    'enum_values_array.*' => [
        'required',
        new Enum(SomeEnum::class),
    ]
]

// After
return [
    'enum_values_array' => [
        'required',
        'array',
        'min:1',
        new Enum(SomeEnum::class),
    ],
]
```
