### PR TITLE
[9.x] Make Application macroable

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -30,6 +31,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class Application extends Container implements ApplicationContract, CachesConfiguration, CachesRoutes, HttpKernelInterface
 {
+    use Macroable;
+
     /**
      * The Laravel framework version.
      *

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -515,7 +515,7 @@ class FoundationApplicationTest extends TestCase
 
           $app['env'] = 'bar';
 
-        $this->assertFalse($app->foo());
+          $this->assertFalse($app->foo());
       }
 }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\RegisterFacades;
 use Illuminate\Foundation\Events\LocaleUpdated;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -499,6 +500,23 @@ class FoundationApplicationTest extends TestCase
             $_SERVER['APP_EVENTS_CACHE']
         );
     }
+
+     /** @test */
+      public function testMacroable(): void
+      {
+          $app = new Application;
+          $app['env'] = 'foo';
+
+          $app->macro('foo', function() {
+              return $this->environment('foo');
+          });
+
+          $this->assertTrue($app->foo());
+
+          $app['env'] = 'bar';
+
+        $this->assertFalse($app->foo());
+      }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider


### PR DESCRIPTION
This PR adds the macroable trait to the Application instance. This allows developers to add handy macros (e.g. environment) checks to the application instance.

For example:

```php
App::macro('runningDuskTests', function () {
    return $this->environment('dusk');
});
```

Thanks!