### PR TITLE
[9.x] Add ability to determine if attachments exist

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1029,25 +1029,13 @@ class Mailable implements MailableContract, Renderable
      * @param  array  $options
      * @return bool
      */
-    public function hasAttachedData($data, $name = null, ?array $options = null)
+    public function hasAttachedData($data, $name, array $options = [])
     {
-        return collect($this->rawAttachments)->filter(function ($attachment) use ($data, $name, $options) {
-            if (is_null($name)) {
-                $nameMatches = true;
-            } else {
-                $nameMatches = $attachment['name'] === $name;
-            }
-
-            if (is_null($options)) {
-                $optionsMatch = true;
-            } else {
-                $optionsMatch = $attachment['options'] === $options;
-            }
-
-            return $attachment['data'] === $data
-                && $nameMatches
-                && $optionsMatch;
-        })->isNotEmpty();
+        return collect($this->rawAttachments)->contains(
+            fn ($attachment) => $attachment['data'] === $data
+                && $attachment['name'] === $name
+                && array_filter($attachment['options']) === array_filter($options)
+        );
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -913,7 +913,7 @@ class Mailable implements MailableContract, Renderable
      * Determine if the mailable has the given attachment.
      *
      * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
-     * @param  array $options
+     * @param  array  $options
      * @return bool
      */
     public function hasAttachment($file, array $options = [])
@@ -984,7 +984,7 @@ class Mailable implements MailableContract, Renderable
      * @param  string  $disk
      * @param  string  $path
      * @param  string|null  $name
-     * @param  array $options
+     * @param  array  $options
      * @return bool
      */
     public function hasAttachmentFromStorageDisk($disk, $path, $name = null, array $options = [])

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -981,6 +981,19 @@ class Mailable implements MailableContract, Renderable
     /**
      * Determine if the mailable has the given attachment from storage.
      *
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return bool
+     */
+    public function hasAttachmentFromStorage($path, $name = null, array $options = [])
+    {
+        return $this->hasAttachmentFromStorageDisk(null, $path, $name, $options);
+    }
+
+    /**
+     * Determine if the mailable has the given attachment from storage disk.
+     *
      * @param  string  $disk
      * @param  string  $path
      * @param  string|null  $name
@@ -1056,6 +1069,78 @@ class Mailable implements MailableContract, Renderable
     public function metadata($key, $value)
     {
         $this->metadata[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Assert the mailable has the given attachment.
+     *
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
+     * @param  array  $options
+     * @return $this
+     */
+    public function assertHasAttachment($file, array $options = [])
+    {
+        PHPUnit::assertTrue(
+            $this->hasAttachment($file, $options),
+            'Did not find the expected attachment.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the mailable has the given data as an attachment.
+     *
+     * @param  string  $data
+     * @param  string  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function assertHasAttachedData($data, $name, array $options = [])
+    {
+        PHPUnit::assertTrue(
+            $this->hasAttachedData($data, $name, $options),
+            'Did not find the expected attachment.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the mailable has the given attachment from storage.
+     *
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function assertHasAttachmentFromStorage($path, $name = null, array $options = [])
+    {
+        PHPUnit::assertTrue(
+            $this->hasAttachmentFromStorage($path, $name, $options),
+            'Did not find the expected attachment.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the mailable has the given attachment from storage disk.
+     *
+     * @param  string  $disk
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function assertHasAttachmentFromStorageDisk($disk, $path, $name = null, array $options = [])
+    {
+        PHPUnit::assertTrue(
+            $this->hasAttachmentFromStorageDisk($disk, $path, $name, $options),
+            'Did not find the expected attachment.'
+        );
 
         return $this;
     }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -992,7 +992,7 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
-     * Determine if the mailable has the given attachment from storage disk.
+     * Determine if the mailable has the given attachment from a specific storage disk.
      *
      * @param  string  $disk
      * @param  string  $path
@@ -1069,86 +1069,6 @@ class Mailable implements MailableContract, Renderable
     public function metadata($key, $value)
     {
         $this->metadata[$key] = $value;
-
-        return $this;
-    }
-
-    /**
-     * Assert the mailable has the given attachment.
-     *
-     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
-     * @param  array  $options
-     * @return $this
-     */
-    public function assertHasAttachment($file, array $options = [])
-    {
-        $this->renderForAssertions();
-
-        PHPUnit::assertTrue(
-            $this->hasAttachment($file, $options),
-            'Did not find the expected attachment.'
-        );
-
-        return $this;
-    }
-
-    /**
-     * Assert the mailable has the given data as an attachment.
-     *
-     * @param  string  $data
-     * @param  string  $name
-     * @param  array  $options
-     * @return $this
-     */
-    public function assertHasAttachedData($data, $name, array $options = [])
-    {
-        $this->renderForAssertions();
-
-        PHPUnit::assertTrue(
-            $this->hasAttachedData($data, $name, $options),
-            'Did not find the expected attachment.'
-        );
-
-        return $this;
-    }
-
-    /**
-     * Assert the mailable has the given attachment from storage.
-     *
-     * @param  string  $path
-     * @param  string|null  $name
-     * @param  array  $options
-     * @return $this
-     */
-    public function assertHasAttachmentFromStorage($path, $name = null, array $options = [])
-    {
-        $this->renderForAssertions();
-
-        PHPUnit::assertTrue(
-            $this->hasAttachmentFromStorage($path, $name, $options),
-            'Did not find the expected attachment.'
-        );
-
-        return $this;
-    }
-
-    /**
-     * Assert the mailable has the given attachment from storage disk.
-     *
-     * @param  string  $disk
-     * @param  string  $path
-     * @param  string|null  $name
-     * @param  array  $options
-     * @return $this
-     */
-    public function assertHasAttachmentFromStorageDisk($disk, $path, $name = null, array $options = [])
-    {
-        $this->renderForAssertions();
-
-        PHPUnit::assertTrue(
-            $this->hasAttachmentFromStorageDisk($disk, $path, $name, $options),
-            'Did not find the expected attachment.'
-        );
 
         return $this;
     }
@@ -1251,6 +1171,86 @@ class Mailable implements MailableContract, Renderable
         [$html, $text] = $this->renderForAssertions();
 
         PHPUnit::assertThat($strings, new SeeInOrder($text));
+
+        return $this;
+    }
+
+    /**
+     * Assert the mailable has the given attachment.
+     *
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
+     * @param  array  $options
+     * @return $this
+     */
+    public function assertHasAttachment($file, array $options = [])
+    {
+        $this->renderForAssertions();
+
+        PHPUnit::assertTrue(
+            $this->hasAttachment($file, $options),
+            'Did not find the expected attachment.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the mailable has the given data as an attachment.
+     *
+     * @param  string  $data
+     * @param  string  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function assertHasAttachedData($data, $name, array $options = [])
+    {
+        $this->renderForAssertions();
+
+        PHPUnit::assertTrue(
+            $this->hasAttachedData($data, $name, $options),
+            'Did not find the expected attachment.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the mailable has the given attachment from storage.
+     *
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function assertHasAttachmentFromStorage($path, $name = null, array $options = [])
+    {
+        $this->renderForAssertions();
+
+        PHPUnit::assertTrue(
+            $this->hasAttachmentFromStorage($path, $name, $options),
+            'Did not find the expected attachment.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert the mailable has the given attachment from a specific storage disk.
+     *
+     * @param  string  $disk
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array  $options
+     * @return $this
+     */
+    public function assertHasAttachmentFromStorageDisk($disk, $path, $name = null, array $options = [])
+    {
+        $this->renderForAssertions();
+
+        PHPUnit::assertTrue(
+            $this->hasAttachmentFromStorageDisk($disk, $path, $name, $options),
+            'Did not find the expected attachment.'
+        );
 
         return $this;
     }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -980,26 +980,14 @@ class Mailable implements MailableContract, Renderable
      * @param  array $options
      * @return bool
      */
-    public function hasAttachmentFromStorageDisk($disk, $path, $name = null, ?array $options = null)
+    public function hasAttachmentFromStorageDisk($disk, $path, $name = null, array $options = [])
     {
-        return collect($this->diskAttachments)->filter(function ($diskAttachment) use ($disk, $path, $name, $options) {
-            if (is_null($name)) {
-                $nameMatches = true;
-            } else {
-                $nameMatches = $diskAttachment['name'] === $name;
-            }
-
-            if (is_null($options)) {
-                $optionsMatch = true;
-            } else {
-                $optionsMatch = $diskAttachment['options'] === $options;
-            }
-
-            return $diskAttachment['disk'] === $disk
-                && $diskAttachment['path'] === $path
-                && $nameMatches
-                && $optionsMatch;
-        })->isNotEmpty();
+        return collect($this->diskAttachments)->contains(
+            fn ($attachment) => $attachment['disk'] === $disk
+                && $attachment['path'] === $path
+                && $attachment['name'] === ($name ?? basename($path))
+                && $attachment['options'] === $options
+        );
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -910,6 +910,27 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Determine if the mailable has the given attachment.
+     *
+     * @param  string|\Illuminate\Contracts\Mail\Attachable|\Illuminate\Mail\Attachment  $file
+     * @param  array $options
+     * @return bool
+     */
+    public function hasAttachment($file, ?array $options = null)
+    {
+        return collect($this->attachments)->filter(function ($attachment) use ($file, $options) {
+            if (is_null($options)) {
+                $optionsMatch = true;
+            } else {
+                $optionsMatch = $attachment['options'] === $options;
+            }
+
+            return $attachment['file'] === $file
+                && $optionsMatch;
+        })->isNotEmpty();
+    }
+
+    /**
      * Attach a file to the message from storage.
      *
      * @param  string  $path
@@ -946,6 +967,37 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Determine if the mailable has the given attachment from storage.
+     *
+     * @param  string  $disk
+     * @param  string  $path
+     * @param  string|null  $name
+     * @param  array $options
+     * @return bool
+     */
+    public function hasAttachmentFromStorageDisk($disk, $path, $name = null, ?array $options = null)
+    {
+        return collect($this->diskAttachments)->filter(function ($diskAttachment) use ($disk, $path, $name, $options) {
+            if (is_null($name)) {
+                $nameMatches = true;
+            } else {
+                $nameMatches = $diskAttachment['name'] === $name;
+            }
+
+            if (is_null($options)) {
+                $optionsMatch = true;
+            } else {
+                $optionsMatch = $diskAttachment['options'] === $options;
+            }
+
+            return $diskAttachment['disk'] === $disk
+                && $diskAttachment['path'] === $path
+                && $nameMatches
+                && $optionsMatch;
+        })->isNotEmpty();
+    }
+
+    /**
      * Attach in-memory data as an attachment.
      *
      * @param  string  $data
@@ -962,6 +1014,35 @@ class Mailable implements MailableContract, Renderable
                 })->all();
 
         return $this;
+    }
+
+    /**
+     * Determine if the mailable has the given data as an attachment.
+     *
+     * @param  string  $data
+     * @param  string  $name
+     * @param  array  $options
+     * @return bool
+     */
+    public function hasAttachedData($data, $name = null, ?array $options = null)
+    {
+        return collect($this->rawAttachments)->filter(function ($attachment) use ($data, $name, $options) {
+            if (is_null($name)) {
+                $nameMatches = true;
+            } else {
+                $nameMatches = $attachment['name'] === $name;
+            }
+
+            if (is_null($options)) {
+                $optionsMatch = true;
+            } else {
+                $optionsMatch = $attachment['options'] === $options;
+            }
+
+            return $attachment['data'] === $data
+                && $nameMatches
+                && $optionsMatch;
+        })->isNotEmpty();
     }
 
     /**

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -923,11 +923,18 @@ class Mailable implements MailableContract, Renderable
         }
 
         if ($file instanceof Attachment) {
-            [$file, $options] = $file->attachWith(
+            $parts = $file->attachWith(
                 fn ($path) => [$path, ['as' => $file->as, 'mime' => $file->mime]],
-                // TODO: pass through to hasAttachedData.
-                fn () => [null, []]
+                fn ($data) => $this->hasAttachedData($data(), $file->as, ['mime' => $file->mime])
             );
+
+            if ($parts === true) {
+                return true;
+            }
+
+            [$file, $options] = $parts === false
+                ? [null, []]
+                : $parts;
         }
 
         return collect($this->attachments)->contains(

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1082,6 +1082,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasAttachment($file, array $options = [])
     {
+        $this->renderForAssertions();
+
         PHPUnit::assertTrue(
             $this->hasAttachment($file, $options),
             'Did not find the expected attachment.'
@@ -1100,6 +1102,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasAttachedData($data, $name, array $options = [])
     {
+        $this->renderForAssertions();
+
         PHPUnit::assertTrue(
             $this->hasAttachedData($data, $name, $options),
             'Did not find the expected attachment.'
@@ -1118,6 +1122,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasAttachmentFromStorage($path, $name = null, array $options = [])
     {
+        $this->renderForAssertions();
+
         PHPUnit::assertTrue(
             $this->hasAttachmentFromStorage($path, $name, $options),
             'Did not find the expected attachment.'
@@ -1137,6 +1143,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function assertHasAttachmentFromStorageDisk($disk, $path, $name = null, array $options = [])
     {
+        $this->renderForAssertions();
+
         PHPUnit::assertTrue(
             $this->hasAttachmentFromStorageDisk($disk, $path, $name, $options),
             'Did not find the expected attachment.'

--- a/tests/Integration/Mail/AttachingFromStorageTest.php
+++ b/tests/Integration/Mail/AttachingFromStorageTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Mail;
 
 use Illuminate\Mail\Attachment;
+use Illuminate\Mail\Mailable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\TestCase;
@@ -64,5 +65,14 @@ class AttachingFromStorageTest extends TestCase
         );
 
         $this->assertSame($message, $result);
+    }
+
+    public function testItCanCheckForStorageBasedAttachments()
+    {
+        Storage::disk()->put('/dir/foo.png', 'expected body contents');
+        $mailable = new Mailable();
+        $mailable->attach(Attachment::fromStorage('/dir/foo.png'));
+
+        $this->assertTrue($mailable->hasAttachment(Attachment::fromStorage('/dir/foo.png')));
     }
 }

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -744,14 +744,16 @@ class MailMailableTest extends TestCase
 
     public function testAssertHasAttachment()
     {
-        Container::getInstance()->instance('mailer', new class {
+        Container::getInstance()->instance('mailer', new class
+        {
             public function render()
             {
                 //
             }
         });
 
-        $mailable = new class () extends Mailable {
+        $mailable = new class() extends Mailable
+        {
             public function build()
             {
                 //
@@ -765,7 +767,8 @@ class MailMailableTest extends TestCase
             $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
         }
 
-        $mailable = new class () extends Mailable {
+        $mailable = new class() extends Mailable
+        {
             public function build()
             {
                 $this->attach('/path/to/foo.jpg');
@@ -777,14 +780,16 @@ class MailMailableTest extends TestCase
 
     public function testAssertHasAttachedData()
     {
-        Container::getInstance()->instance('mailer', new class {
+        Container::getInstance()->instance('mailer', new class
+        {
             public function render()
             {
                 //
             }
         });
 
-        $mailable = new class () extends Mailable {
+        $mailable = new class() extends Mailable
+        {
             public function build()
             {
                 //
@@ -798,7 +803,8 @@ class MailMailableTest extends TestCase
             $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
         }
 
-        $mailable = new class () extends Mailable {
+        $mailable = new class() extends Mailable
+        {
             public function build()
             {
                 $this->attachData('data', 'foo.jpg');
@@ -810,7 +816,8 @@ class MailMailableTest extends TestCase
 
     public function testAssertHasAttachmentFromStorage()
     {
-        $mailable = new class () extends Mailable {
+        $mailable = new class() extends Mailable
+        {
             public function build()
             {
                 //
@@ -824,7 +831,8 @@ class MailMailableTest extends TestCase
             $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
         }
 
-        $mailable = new class () extends Mailable {
+        $mailable = new class() extends Mailable
+        {
             public function build()
             {
                 $this->attachFromStorage('/path/to/foo.jpg');

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -579,7 +579,6 @@ class MailMailableTest extends TestCase
     public function testItCanCheckForPathBasedAttachments()
     {
         $mailable = new WelcomeMailableStub;
-
         $mailable->attach('foo.jpg');
 
         $this->assertTrue($mailable->hasAttachment('foo.jpg'));
@@ -594,6 +593,7 @@ class MailMailableTest extends TestCase
         $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('foo.jpg')->withMime('text/css')));
         $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg')->withMime('text/css'))));
 
+        $mailable = new WelcomeMailableStub;
         $mailable->attach('bar.jpg', ['mime' => 'text/css']);
 
         $this->assertTrue($mailable->hasAttachment('bar.jpg', ['mime' => 'text/css']));
@@ -612,7 +612,6 @@ class MailMailableTest extends TestCase
     public function testItCanCheckForAttachmentBasedAttachments()
     {
         $mailable = new WelcomeMailableStub;
-
         $mailable->attach(Attachment::fromPath('foo.jpg'));
 
         $this->assertTrue($mailable->hasAttachment('foo.jpg'));
@@ -627,6 +626,7 @@ class MailMailableTest extends TestCase
         $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('foo.jpg')->withMime('text/css')));
         $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg')->withMime('text/css'))));
 
+        $mailable = new WelcomeMailableStub;
         $mailable->attach(Attachment::fromPath('bar.jpg')->withMime('text/css'));
 
         $this->assertTrue($mailable->hasAttachment('bar.jpg', ['mime' => 'text/css']));
@@ -645,7 +645,6 @@ class MailMailableTest extends TestCase
     public function testItCanCheckForAttachableBasedAttachments()
     {
         $mailable = new WelcomeMailableStub;
-
         $mailable->attach(new MailTestAttachable(Attachment::fromPath('foo.jpg')));
 
         $this->assertTrue($mailable->hasAttachment('foo.jpg'));
@@ -660,6 +659,7 @@ class MailMailableTest extends TestCase
         $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('foo.jpg')->withMime('text/css')));
         $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg')->withMime('text/css'))));
 
+        $mailable = new WelcomeMailableStub;
         $mailable->attach(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/css')));
 
         $this->assertTrue($mailable->hasAttachment('bar.jpg', ['mime' => 'text/css']));
@@ -673,6 +673,41 @@ class MailMailableTest extends TestCase
         $this->assertFalse($mailable->hasAttachment('bar.jpg', ['mime' => 'text/html']));
         $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')->withMime('text/html')));
         $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/html'))));
+    }
+
+    public function testItCanCheckForDataBasedAttachments()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->attachData('data', 'foo.jpg');
+
+        $this->assertTrue($mailable->hasAttachedData('data', 'foo.jpg'));
+        $this->assertFalse($mailable->hasAttachedData('xxxx', 'foo.jpg'));
+        $this->assertFalse($mailable->hasAttachedData('data', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachedData('data', 'foo.jpg', ['mime' => 'text/css']));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->attachData('data', 'bar.jpg', ['mime' => 'text/css']);
+
+        $this->assertTrue($mailable->hasAttachedData('data', 'bar.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachedData('xxxx', 'bar.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachedData('data', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachedData('data', 'bar.jpg', ['mime' => 'text/html']));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->attach(Attachment::fromData(fn () => 'data', 'foo.jpg'));
+
+        $this->assertTrue($mailable->hasAttachedData('data', 'foo.jpg'));
+        $this->assertFalse($mailable->hasAttachedData('xxxx', 'foo.jpg'));
+        $this->assertFalse($mailable->hasAttachedData('data', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachedData('data', 'foo.jpg', ['mime' => 'text/css']));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->attach(Attachment::fromData(fn () => 'data', 'bar.jpg')->withMime('text/css'));
+
+        $this->assertTrue($mailable->hasAttachedData('data', 'bar.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachedData('xxxx', 'bar.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachedData('data', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachedData('data', 'bar.jpg', ['mime' => 'text/html']));
     }
 }
 

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -709,6 +709,36 @@ class MailMailableTest extends TestCase
         $this->assertFalse($mailable->hasAttachedData('data', 'bar.jpg'));
         $this->assertFalse($mailable->hasAttachedData('data', 'bar.jpg', ['mime' => 'text/html']));
     }
+
+    public function testItCanCheckForStorageBasedAttachments()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->attachFromStorageDisk('disk', '/path/to/foo.jpg');
+
+        $this->assertTrue($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg'));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('xxxx', '/path/to/foo.jpg'));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', null, ['mime' => 'text/css']));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->attachFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg');
+
+        $this->assertTrue($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('xxxx', '/path/to/foo.jpg', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', 'bar.jpg', 'bar.jpg'));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'foo.jpg'));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg', ['mime' => 'text/css']));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->attachFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg', ['mime' => 'text/css']);
+
+        $this->assertTrue($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('xxxx', '/path/to/foo.jpg', 'bar.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', 'bar.jpg', 'bar.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'foo.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg', ['mime' => 'text/html']));
+    }
 }
 
 class WelcomeMailableStub extends Mailable

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -575,6 +575,105 @@ class MailMailableTest extends TestCase
             ],
         ], $mailable->rawAttachments[0]);
     }
+
+    public function testItCanCheckForPathBasedAttachments()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach('foo.jpg');
+
+        $this->assertTrue($mailable->hasAttachment('foo.jpg'));
+        $this->assertTrue($mailable->hasAttachment(Attachment::fromPath('foo.jpg')));
+        $this->assertTrue($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg'));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('foo.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('foo.jpg')->withMime('text/css')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg')->withMime('text/css'))));
+
+        $mailable->attach('bar.jpg', ['mime' => 'text/css']);
+
+        $this->assertTrue($mailable->hasAttachment('bar.jpg', ['mime' => 'text/css']));
+        $this->assertTrue($mailable->hasAttachment(Attachment::fromPath('bar.jpg')->withMime('text/css')));
+        $this->assertTrue($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/css'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg'));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg', ['mime' => 'text/html']));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')->withMime('text/html')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/html'))));
+    }
+
+    public function testItCanCheckForAttachmentBasedAttachments()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach(Attachment::fromPath('foo.jpg'));
+
+        $this->assertTrue($mailable->hasAttachment('foo.jpg'));
+        $this->assertTrue($mailable->hasAttachment(Attachment::fromPath('foo.jpg')));
+        $this->assertTrue($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg'));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('foo.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('foo.jpg')->withMime('text/css')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg')->withMime('text/css'))));
+
+        $mailable->attach(Attachment::fromPath('bar.jpg')->withMime('text/css'));
+
+        $this->assertTrue($mailable->hasAttachment('bar.jpg', ['mime' => 'text/css']));
+        $this->assertTrue($mailable->hasAttachment(Attachment::fromPath('bar.jpg')->withMime('text/css')));
+        $this->assertTrue($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/css'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg'));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg', ['mime' => 'text/html']));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')->withMime('text/html')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/html'))));
+    }
+
+    public function testItCanCheckForAttachableBasedAttachments()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attach(new MailTestAttachable(Attachment::fromPath('foo.jpg')));
+
+        $this->assertTrue($mailable->hasAttachment('foo.jpg'));
+        $this->assertTrue($mailable->hasAttachment(Attachment::fromPath('foo.jpg')));
+        $this->assertTrue($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg'));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('foo.jpg', ['mime' => 'text/css']));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('foo.jpg')->withMime('text/css')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('foo.jpg')->withMime('text/css'))));
+
+        $mailable->attach(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/css')));
+
+        $this->assertTrue($mailable->hasAttachment('bar.jpg', ['mime' => 'text/css']));
+        $this->assertTrue($mailable->hasAttachment(Attachment::fromPath('bar.jpg')->withMime('text/css')));
+        $this->assertTrue($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/css'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg'));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg'))));
+
+        $this->assertFalse($mailable->hasAttachment('bar.jpg', ['mime' => 'text/html']));
+        $this->assertFalse($mailable->hasAttachment(Attachment::fromPath('bar.jpg')->withMime('text/html')));
+        $this->assertFalse($mailable->hasAttachment(new MailTestAttachable(Attachment::fromPath('bar.jpg')->withMime('text/html'))));
+    }
 }
 
 class WelcomeMailableStub extends Mailable
@@ -599,4 +698,17 @@ class MailableTestUserStub
 {
     public $name = 'Taylor Otwell';
     public $email = 'taylor@laravel.com';
+}
+
+class MailTestAttachable implements Attachable
+{
+    public function __construct(protected $attachment)
+    {
+        //
+    }
+
+    public function toMailAttachment()
+    {
+        return $this->attachment;
+    }
 }

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Attachment;
@@ -9,6 +10,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailer;
 use Illuminate\Mail\Transport\ArrayTransport;
 use Mockery as m;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 
 class MailMailableTest extends TestCase
@@ -738,6 +740,98 @@ class MailMailableTest extends TestCase
         $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', 'bar.jpg', 'bar.jpg', ['mime' => 'text/css']));
         $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'foo.jpg', ['mime' => 'text/css']));
         $this->assertFalse($mailable->hasAttachmentFromStorageDisk('disk', '/path/to/foo.jpg', 'bar.jpg', ['mime' => 'text/html']));
+    }
+
+    public function testAssertHasAttachment()
+    {
+        Container::getInstance()->instance('mailer', new class {
+            public function render()
+            {
+                //
+            }
+        });
+
+        $mailable = new class () extends Mailable {
+            public function build()
+            {
+                //
+            }
+        };
+
+        try {
+            $mailable->assertHasAttachment('/path/to/foo.jpg');
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
+        }
+
+        $mailable = new class () extends Mailable {
+            public function build()
+            {
+                $this->attach('/path/to/foo.jpg');
+            }
+        };
+
+        $mailable->assertHasAttachment('/path/to/foo.jpg');
+    }
+
+    public function testAssertHasAttachedData()
+    {
+        Container::getInstance()->instance('mailer', new class {
+            public function render()
+            {
+                //
+            }
+        });
+
+        $mailable = new class () extends Mailable {
+            public function build()
+            {
+                //
+            }
+        };
+
+        try {
+            $mailable->assertHasAttachedData('data', 'foo.jpg');
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
+        }
+
+        $mailable = new class () extends Mailable {
+            public function build()
+            {
+                $this->attachData('data', 'foo.jpg');
+            }
+        };
+
+        $mailable->assertHasAttachedData('data', 'foo.jpg');
+    }
+
+    public function testAssertHasAttachmentFromStorage()
+    {
+        $mailable = new class () extends Mailable {
+            public function build()
+            {
+                //
+            }
+        };
+
+        try {
+            $mailable->assertHasAttachmentFromStorage('/path/to/foo.jpg');
+            $this->fail();
+        } catch (AssertionFailedError $e) {
+            $this->assertSame("Did not find the expected attachment.\nFailed asserting that false is true.", $e->getMessage());
+        }
+
+        $mailable = new class () extends Mailable {
+            public function build()
+            {
+                $this->attachFromStorage('/path/to/foo.jpg');
+            }
+        };
+
+        $mailable->assertHasAttachmentFromStorage('/path/to/foo.jpg');
     }
 }
 


### PR DESCRIPTION
This adds the ability to determine if the given attachment(s) are included in the mailable, similar to the existing `$mail->hasTo()`, `$mail->hasSubject()`, etc. methods.

This is particularly useful in tests; example:

```php
use App\Mail\InvoicePaid;
use App\Models\User;
 
public function test_mailable_content()
{
    $user = User::factory()->create();
 
    $mailable = new InvoicePaid($user);
 
    $mailable->assertSeeInHtml($user->email);
    $mailable->assertSeeInHtml('Invoice Paid');
    $mailable->assertSeeInOrderInHtml(['Invoice Paid', 'Thanks']);
 
    $mailable->assertSeeInText($user->email);
    $mailable->assertSeeInOrderInText(['Invoice Paid', 'Thanks']);

    // Test normal attachment.
    $this->assertTrue(
        $mail->hasAttachment('Receipt.pdf')
    );

    // Test attachment from storage disk.
    $this->assertTrue(
        $mail->hasAttachmentFromStorageDisk('s3', 'invoices', $user->latest_invoice->name)
    );

    // Test raw attachment.
    $this->assertTrue(
        $mail->hasAttachedData('12345', 'confirmation.txt')
    );
}
```