### PR TITLE
[9.x] Adds "PendingCommand::assertOk()"

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -250,6 +250,16 @@ class PendingCommand
     }
 
     /**
+     * Assert that the command has the success exit code.
+     *
+     * @return $this
+     */
+    public function assertOk()
+    {
+        return $this->assertSuccessful();
+    }
+
+    /**
      * Assert that the command does not have the success exit code.
      *
      * @return $this

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -33,12 +33,27 @@ class ArtisanCommandTest extends TestCase
             $this->line($this->ask('Huh?'));
         });
 
+        Artisan::command('exit {code}', fn () => (int) $this->argument('code'));
+
         Artisan::command('contains', function () {
             $this->line('My name is Taylor Otwell');
         });
     }
 
     public function test_console_command_that_passes()
+    {
+        $this->artisan('exit', ['code' => 0])->assertOk();
+    }
+
+    public function test_console_command_that_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Expected status code 0 but received 1.');
+
+        $this->artisan('exit', ['code' => 1])->assertOk();
+    }
+
+    public function test_console_command_that_passes_with_output()
     {
         $this->artisan('survey')
              ->expectsQuestion('What is your name?', 'Taylor Otwell')


### PR DESCRIPTION
While creating tests for Artisan commands, I've noticed that `assertSuccessful` is just too many characters for me. So, this pull request proposes an `assertOk()` method that is simply an alias of `assertExitCode(0)`:

```php
it('can run', function () {
    $this->artisan('inspire')->assertOk();
});
```

Note that, this combines well with the HTTP layer regarding testing, as we we already have an `assertOk()` there:

```php
$this->get('/')->assertOk();
```
