### PR TITLE
[10.x] Added `Rule::boolean()` method and improved handling of `boolean` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -435,7 +435,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 'true', 'false', 1, 0, '1', '0'];
 
         return in_array($value, $acceptable, true);
     }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,6 +4,7 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\Boolean;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
@@ -137,5 +138,15 @@ class Rule
     public static function unique($table, $column = 'NULL')
     {
         return new Unique($table, $column);
+    }
+
+    /**
+     * Get a boolean constraint builder instance.
+     *
+     * @return \Illuminate\Validation\Rules\Boolean
+     */
+    public static function boolean()
+    {
+        return new Boolean();
     }
 }

--- a/src/Illuminate/Validation/Rules/Boolean.php
+++ b/src/Illuminate/Validation/Rules/Boolean.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class Boolean implements Rule
+{
+    /**
+     * The name of the rule.
+     */
+    protected string $rule = 'boolean';
+
+    /**
+     * The values to check.
+     *
+     * @var array
+     */
+    protected array $acceptable = [true, false, 'true', 'false', 1, 0, '1', '0'];
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        return in_array($value, $this->acceptable, true);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message(): string
+    {
+        return trans('validation.boolean');
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->rule;
+    }
+}

--- a/src/Illuminate/Validation/Rules/Boolean.php
+++ b/src/Illuminate/Validation/Rules/Boolean.php
@@ -21,9 +21,8 @@ class Boolean implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed $value
-     *
+     * @param  string  $attribute
+     * @param  mixed  $value
      * @return bool
      */
     public function passes($attribute, $value): bool

--- a/tests/Validation/ValidationBooleanRuleTest.php
+++ b/tests/Validation/ValidationBooleanRuleTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationBooleanRuleTest extends TestCase
+{
+    public function testCorrectValues()
+    {
+        $this->passes(true);
+        $this->passes(false);
+
+        $this->passes('true');
+        $this->passes('false');
+
+        $this->passes(1);
+        $this->passes(0);
+
+        $this->passes('1');
+        $this->passes('0');
+
+        $this->passes('');
+    }
+
+    public function testIncorrectValues()
+    {
+        $this->fails('True');
+        $this->fails('False');
+
+        $this->fails('on');
+        $this->fails('off');
+
+        $this->fails('On');
+        $this->fails('Off');
+
+        $this->fails('yes');
+        $this->fails('no');
+
+        $this->fails('Yes');
+        $this->fails('No');
+
+        $this->fails(null);
+
+        $this->fails(12);
+        $this->fails('12');
+
+        $this->fails('custom');
+
+        $this->fails([]);
+
+        $this->fails(new Foo());
+        $this->fails(Foo::class);
+    }
+
+    protected function fails($value)
+    {
+        $this->assertValidationRules($value, false, ['value' => ['validation.boolean']]);
+    }
+
+    protected function passes($value)
+    {
+        $this->assertValidationRules($value, true, []);
+    }
+
+    protected function assertValidationRules($value, $result, $message)
+    {
+        $v = new Validator(
+            resolve('translator'),
+            ['value' => $value],
+            ['value' => Rule::boolean()]
+        );
+
+        $this->assertSame($result, $v->passes());
+        $this->assertSame($message, $v->messages()->toArray());
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader, 'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+    }
+}
+
+class Foo
+{
+}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2252,10 +2252,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
@@ -2289,10 +2289,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
The main problem with the "boolean" string validation rule is that it ignores the textual representation of the `"true"` and `"false"` boolean values sent via [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append) JS.

My PR https://github.com/laravel/framework/pull/43955 was closed, but in return, @taylorotwell offered to move the functionality into a separate method.

In the course of development, I found out that the scheme [`proposed`](https://github.com/laravel/framework/pull/43955#issuecomment-1234411787) by Taylor will mislead developers because by writing, for example, `Rule::boolean(['foo', 'bar'])` we will get `true` for the `foo` value from the request, which is wrong.

Therefore, this method does not take external arguments, checking the field itself against certain values passed to the `in_array` function.

This is a breaking change because the values `"true"` and `"false"` are now "boolean".