### PR TITLE
[9.x] Add strict mode for when() conditionals

### DIFF
--- a/src/Illuminate/Conditionable/Traits/Conditionable.php
+++ b/src/Illuminate/Conditionable/Traits/Conditionable.php
@@ -8,7 +8,7 @@ use Illuminate\Support\HigherOrderWhenProxy;
 trait Conditionable
 {
     /**
-     * Apply the callback if the given "value" is (or resolves to) truthy.
+     * Apply the callback if the given "value" is (or resolves to) truthy or true with strict mode.
      *
      * @template TWhenParameter
      * @template TWhenReturnType
@@ -16,9 +16,10 @@ trait Conditionable
      * @param  (\Closure($this): TWhenParameter)|TWhenParameter|null $value
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $callback
      * @param  (callable($this, TWhenParameter): TWhenReturnType)|null  $default
+     * @param  bool|null  $strict
      * @return $this|TWhenReturnType
      */
-    public function when($value = null, callable $callback = null, callable $default = null)
+    public function when($value = null, callable $callback = null, callable $default = null, ?bool $strict = false)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
@@ -30,7 +31,7 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition($value);
         }
 
-        if ($value) {
+        if ($strict === true ? $value === true : $value) {
             return $callback($this, $value) ?? $this;
         } elseif ($default) {
             return $default($this, $value) ?? $this;
@@ -40,7 +41,7 @@ trait Conditionable
     }
 
     /**
-     * Apply the callback if the given "value" is (or resolves to) falsy.
+     * Apply the callback if the given "value" is (or resolves to) falsy or false with strict mode.
      *
      * @template TUnlessParameter
      * @template TUnlessReturnType
@@ -48,9 +49,10 @@ trait Conditionable
      * @param  (\Closure($this): TUnlessParameter)|TUnlessParameter|null  $value
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $callback
      * @param  (callable($this, TUnlessParameter): TUnlessReturnType)|null  $default
+     * @param  bool|null  $strict
      * @return $this|TUnlessReturnType
      */
-    public function unless($value = null, callable $callback = null, callable $default = null)
+    public function unless($value = null, callable $callback = null, callable $default = null, bool $strict = false)
     {
         $value = $value instanceof Closure ? $value($this) : $value;
 
@@ -62,7 +64,7 @@ trait Conditionable
             return (new HigherOrderWhenProxy($this))->condition(! $value);
         }
 
-        if (! $value) {
+        if ($strict === true ? $value === false : ! $value) {
             return $callback($this, $value) ?? $this;
         } elseif ($default) {
             return $default($this, $value) ?? $this;


### PR DESCRIPTION
Recently I and @michalmyskow found out that `when()` conditional method is resolving parameters to "trurthy" and "falsy" accordingly to the documentation. For example you cannot find any user with `"0"` phrase, because `when()` converts string zero to boolean false:

```php
$search = $request->get("search"); // "0"

User::query()
    ->when($search, function(Builder $query) => $query->where("name", "LIKE", "%$search%"))
    ->toSql();
// "SELECT * FROM users;"
```

This change adds non-breaking change of parameters of `when()` and `unless()` methods. With this:

```php
$search = $request->get("search"); // "0"

User::query()
    ->when($search, function(Builder $query) => $query->where("name", "LIKE", "%$search%"), strict: true)
    ->toSql();
// "SELECT * FROM users WHERE name LIKE '%0%';"
```