### PR TITLE
[9.x] Added support for notification based events

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -147,6 +147,10 @@ class NotificationSender
 
         $response = $this->manager->driver($channel)->send($notifiable, $notification);
 
+        if (method_exists($notification, 'onSent')) {
+            $notification->onSent($channel);
+        }
+
         $this->events->dispatch(
             new NotificationSent($notifiable, $notification, $channel, $response)
         );

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -171,6 +171,10 @@ class NotificationSender
             return false;
         }
 
+        if (method_exists($notification, 'onSending')) {
+            $notification->onSending($channel);
+        }
+
         return $this->events->until(
             new NotificationSending($notifiable, $notification, $channel)
         ) !== false;


### PR DESCRIPTION
This PR adds support for executing any kind of action while sending a notification or after a notification is sent. And those actions are defined in notifications.

This can be done already using notification events but those events are dispatched for all notifications in the project. With this PR it will be possible to execute any kind of action only for a specific notification.

1- Actions that need to be executed while sending a notification can be added in `onSending()` method of the notification.
```php
public function onSending($channel): void
{
    logger('The notification is being sent via '.$channel);
}
```

2- Actions that need to be executed after a notification is sent can be added in `onSent()` method of the notification.
```php
public function onSent($channel): void
{
    logger('The notification has been sent via '.$channel);
}
```

The final notification will be like following:
```php
class FooNotification extends Notification
{
    public function __construct()
    {
        //
    }

    public function via($notifiable): array
    {
        return ['database', 'mail'];
    }

    public function toMail(mixed $notifiable): MailMessage
    {
        return (new MailMessage)
            ->subject('foo')
            ->markdown('emails.foo_notification');
    }

    public function toDatabase(mixed $notifiable): array
    {
        return [
            'message' => 'Lorem ipsum dolor sit amet',
        ];
    }

    public function onSent($channel): void
    {
        logger($this::class.' has been sent via '.$channel);
    }

    public function onSending($channel): void
    {
        logger($this::class.' is being sent via '.$channel);
    }
}
```
