### PR TITLE
[9.x] Add UUID support to native castables

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1459,7 +1459,7 @@ trait HasAttributes
     }
 
     /**
-     * Return a UUID.
+     * Convert the given value into a UUID instance.
      *
      * @param  mixed  $value
      * @return \Ramsey\Uuid\UuidInterface
@@ -1470,7 +1470,7 @@ trait HasAttributes
     }
 
     /**
-     * Converts a UUID into a string.
+     * Convert a UUID into a string.
      *
      * @param  mixed  $value
      * @return mixed
@@ -1481,7 +1481,7 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the given attribute is a UUID.
+     * Determine if the given attribute has a UUID cast assigned to it.
      *
      * @param  string  $key
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -28,7 +28,6 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
 use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
+use Ramsey\Uuid\Uuid;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -755,6 +756,8 @@ trait HasAttributes
                 return $this->asDateTime($value)->toImmutable();
             case 'timestamp':
                 return $this->asTimestamp($value);
+            case 'uuid':
+                return $this->asUuid($value);
         }
 
         if ($this->isEnumCastable($key)) {
@@ -1446,6 +1449,17 @@ trait HasAttributes
         $this->dateFormat = $format;
 
         return $this;
+    }
+
+    /**
+     * Return a UUID.
+     *
+     * @param  mixed  $value
+     * @return \Ramsey\Uuid\UuidInterface
+     */
+    protected function asUuid($value)
+    {
+        return Uuid::fromString($value);
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelUuidCastingTest.php
+++ b/tests/Integration/Database/EloquentModelUuidCastingTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelUuidCastingTest;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+class EloquentModelUuidCastingTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('test_model1', function (Blueprint $table) {
+            $table->increments('id');
+            $table->uuid();
+        });
+    }
+
+    public function testUuidsAreCustomCastable()
+    {
+        $user = TestModel1::create([
+            'uuid' => '41828d7a-997c-4190-976a-ff2cf61f0b52',
+        ]);
+
+        $this->assertSame('41828d7a-997c-4190-976a-ff2cf61f0b52', $user->toArray()['uuid']);
+        $this->assertInstanceOf(UuidInterface::class, $user->uuid);
+    }
+
+    public function testUuidsArrayAndJson()
+    {
+        $user = TestModel1::create([
+            'uuid' => '41828d7a-997c-4190-976a-ff2cf61f0b52',
+        ]);
+
+        $expected = [
+            'uuid' => '41828d7a-997c-4190-976a-ff2cf61f0b52',
+            'id' => 1,
+        ];
+
+        $this->assertSame($expected, $user->toArray());
+        $this->assertSame(json_encode($expected), $user->toJson());
+    }
+
+    public function testCustomUuidCastsAreComparedAsUuidsForUuidInstances()
+    {
+        $user = TestModel1::create([
+            'uuid' => '41828d7a-997c-4190-976a-ff2cf61f0b52',
+        ]);
+
+        $user->uuid = Uuid::fromString('41828d7a-997c-4190-976a-ff2cf61f0b52');
+
+        $this->assertArrayNotHasKey('uuid', $user->getDirty());
+    }
+
+    public function testCustomUuidCastsAreComparedAsUuidsForStringValues()
+    {
+        $user = TestModel1::create([
+            'uuid' => '41828d7a-997c-4190-976a-ff2cf61f0b52',
+        ]);
+
+        $user->uuid = '41828d7a-997c-4190-976a-ff2cf61f0b52';
+
+        $this->assertArrayNotHasKey('uuid', $user->getDirty());
+    }
+}
+
+class TestModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public $casts = [
+        'uuid' => 'uuid',
+    ];
+}

--- a/tests/Integration/Database/EloquentModelUuidCastingTest.php
+++ b/tests/Integration/Database/EloquentModelUuidCastingTest.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentModelUuidCastingTest;
 
-use Carbon\Carbon;
-use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;


### PR DESCRIPTION
This is a small PR which adds support for the castable type `uuid`. Since we have a `uuid` option for migrations, it only makes sense that we also support adding it as a castable type.

I appreciate that it does couple models with the `ramsey\uuid` package, but that is included in the framework, and has been for some time.
