### PR TITLE
[9.x] Add missing /DateInterval typehint to `expireAfter`

### DIFF
--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -105,7 +105,7 @@ class WithoutOverlapping
     /**
      * Set the maximum number of seconds that can elapse before the lock is released.
      *
-     * @param  \DateTimeInterface|int  $expiresAfter
+     * @param  \DateTimeInterface|\DateInterval|int  $expiresAfter
      * @return $this
      */
     public function expireAfter($expiresAfter)


### PR DESCRIPTION
![Screen Shot 2022-09-02 at 9 28 30 AM](https://user-images.githubusercontent.com/611784/188156262-e3243ea5-6b9d-4ccf-9a6d-0a9032782478.png)

Saw this warning, but `expireAfter` calls `secondsUntil` which takes - `@param  \DateTimeInterface|\DateInterval|int  $delay` which allows it work from the Interval. So a simple update to docblock.