### PR TITLE
[9.x] Change `@param` to `@var` on `Signals` Class

### DIFF
--- a/src/Illuminate/Console/Signals.php
+++ b/src/Illuminate/Console/Signals.php
@@ -17,14 +17,14 @@ class Signals
     /**
      * The signal registry's previous list of handlers.
      *
-     * @param array<int, array<int, callable>>|null
+     * @var array<int, array<int, callable>>|null
      */
     protected $previousHandlers;
 
     /**
      * The current availability resolver, if any.
      *
-     * @param (callable(): bool)|null
+     * @var (callable(): bool)|null
      */
     protected static $availabilityResolver;
 


### PR DESCRIPTION
This PR fixes the annotations that should be `@var` and not `@param`.