### PR TITLE
[9.x] Fixes `Http::fake()` return type

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -154,7 +154,7 @@ class Factory
     /**
      * Register a stub callable that will intercept requests and be able to return stub responses.
      *
-     * @param  callable|array  $callback
+     * @param  callable|array|null  $callback
      * @return $this
      */
     public function fake($callback = null)


### PR DESCRIPTION
This pull request fixes `Http::fake()` return type, as it may be used without any arguments.