### PR TITLE
[9.x] Primitive variadic class make

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1006,6 +1006,10 @@ class Container implements ArrayAccess, ContainerContract
             return $parameter->getDefaultValue();
         }
 
+        if ($parameter->isVariadic()) {
+            return [];
+        }
+
         $this->unresolvablePrimitive($parameter);
     }
 

--- a/tests/Container/ContainerResolveNonInstantiableTest.php
+++ b/tests/Container/ContainerResolveNonInstantiableTest.php
@@ -23,6 +23,14 @@ class ContainerResolveNonInstantiableTest extends TestCase
         $this->assertCount(0, $parent->child->objects);
         $this->assertSame(42, $parent->i);
     }
+
+    public function testResolveVariadicPrimitive()
+    {
+        $container = new Container;
+        $parent = $container->make(VariadicPrimitive::class);
+
+        $this->assertSame($parent->params, []);
+    }
 }
 
 interface TestInterface
@@ -71,5 +79,18 @@ class ChildClass
     public function __construct(TestInterface ...$objects)
     {
         $this->objects = $objects;
+    }
+}
+
+class VariadicPrimitive
+{
+    /**
+     * @var array
+     */
+    public $params;
+
+    public function __construct(...$params)
+    {
+        $this->params = $params;
     }
 }


### PR DESCRIPTION
Currently the following code

```php
class Test { 
    protected array $parameters = []; 
    public function __construct(...$parameters) { 
        $this->parameters = $parameters; 
    }
}
>>> app()->make(Test::class);
```
Will throw `Illuminate\Contracts\Container\BindingResolutionException with message 'Unresolvable dependency resolving [Parameter #0 [ <optional> ...$parameters ]] in class Test'`

Even though `Test` is a perfectly instantiable class without any parameters (eg: `new Test();`)

That is because php doesn't mark variadic parameters as having default values in Reflection (even though they technically do as they are always arrays) and laravel only checks for `$parameter->isDefaultValueAvailable()` instead of `$parameter->isOptional()` before throwing an exception

Because laravel uses make for almost any class we provide it, this makes us unable to use this kind of class definition

Fixes https://github.com/laravel/framework/issues/26950