### PR TITLE
[9.x] Allow registering instances of commands

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -273,6 +273,10 @@ class Application extends SymfonyApplication implements ApplicationContract
             return null;
         }
 
+        if ($command instanceof Command) {
+            return $this->add($command);
+        }
+
         return $this->add($this->laravel->make($command));
     }
 

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -262,7 +262,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Add a command, resolving through the application.
      *
-     * @param  string  $command
+     * @param  \Illuminate\Console\Command|string  $command
      * @return \Symfony\Component\Console\Command\Command|null
      */
     public function resolve($command)


### PR DESCRIPTION
Right now, you can only pass class names (or an array of class names) to [`resolveCommands`](https://github.com/laravel/framework/blob/7fa4beb386a139cabb730a7e3b9571ba8ea2a181/src/Illuminate/Console/Application.php#L285). With the change in this PR, you can also pass instances of commands.

This change is needed power [this upcoming feature](https://twitter.com/freekmurze/status/1565779627758567429) in [laravel-package-tools](https://github.com/spatie/laravel-package-tools). Under the hood this works by [instantiating a command](https://github.com/spatie/laravel-package-tools/blob/cebb33bfa174e7645c4be7d08c097d448ec94564/src/Package.php#L60), [dynamically setting its signature](https://github.com/spatie/laravel-package-tools/blob/cebb33bfa174e7645c4be7d08c097d448ec94564/src/Commands/InstallCommand.php#L22), and registering the instantiated command ([here](https://github.com/spatie/laravel-package-tools/blob/cebb33bfa174e7645c4be7d08c097d448ec94564/src/Package.php#L64), and [here](https://github.com/spatie/laravel-package-tools/blob/09f80fa240d44fafb1c70657c74ee44ffa929357/src/PackageServiceProvider.php#L104)).

I didn't find any relevant tests around this, so I added none. Happy to add a test if you point me in the right direction. I did manually test it in a fresh Laravel app though.

