### PR TITLE
[9.x] Automatically convert field's values to json string when using Model::upsert

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1022,7 +1022,6 @@ class Builder implements BuilderContract
             $update = array_keys(reset($values));
         }
 
-
         $modifiedUpdateValues = $this->addTimestampsToUpsertValues($values);
         $modifiedUpdateValues = $this->convertArrayObjectToJsonString($modifiedUpdateValues, $update);
 
@@ -1168,12 +1167,11 @@ class Builder implements BuilderContract
         return $update;
     }
 
-
     /**
-     * Convert array or object field to json string if the field is defined in model's casts
+     * Convert array or object field to json string if the field is defined in model's casts.
      *
-     * @param array $values
-     * @param array $update
+     * @param  array  $values
+     * @param @param  array  $update
      * @return array
      */
     protected function convertArrayObjectToJsonString(array $values, array $update)
@@ -1184,7 +1182,7 @@ class Builder implements BuilderContract
                 'object',
                 'array',
                 \Illuminate\Database\Eloquent\Casts\AsArrayObject::class,
-                \Illuminate\Database\Eloquent\Casts\AsCollection::class
+                \Illuminate\Database\Eloquent\Casts\AsCollection::class,
             ]);
         })->keys();
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2118,7 +2118,6 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(2, $result);
     }
 
-
     public function upsertWithJsonCastsModelProvider()
     {
         return [

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2125,7 +2125,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             [EloquentBuilderTestStubFieldCastAsArray::class],
             [EloquentBuilderTestStubFieldCastAsObject::class],
             [EloquentBuilderTestStubFieldCastAsCollection::class],
-            [EloquentBuilderTestStubFieldCastAsArrayObject::class]
+            [EloquentBuilderTestStubFieldCastAsArrayObject::class],
         ];
     }
 
@@ -2455,7 +2455,7 @@ class EloquentBuilderTestStubFieldCastAsArray extends Model
     protected $table = 'foo_table';
 
     protected $casts = [
-        'array_bars' => 'array'
+        'array_bars' => 'array',
     ];
 }
 
@@ -2466,7 +2466,7 @@ class EloquentBuilderTestStubFieldCastAsObject extends Model
     protected $table = 'foo_table';
 
     protected $casts = [
-        'array_bars' => 'object'
+        'array_bars' => 'object',
     ];
 }
 
@@ -2477,7 +2477,7 @@ class EloquentBuilderTestStubFieldCastAsCollection extends Model
     protected $table = 'foo_table';
 
     protected $casts = [
-        'array_bars' => \Illuminate\Database\Eloquent\Casts\AsCollection::class
+        'array_bars' => \Illuminate\Database\Eloquent\Casts\AsCollection::class,
     ];
 }
 class EloquentBuilderTestStubFieldCastAsArrayObject extends Model
@@ -2487,6 +2487,6 @@ class EloquentBuilderTestStubFieldCastAsArrayObject extends Model
     protected $table = 'foo_table';
 
     protected $casts = [
-        'array_bars' => \Illuminate\Database\Eloquent\Casts\AsArrayObject::class
+        'array_bars' => \Illuminate\Database\Eloquent\Casts\AsArrayObject::class,
     ];
 }


### PR DESCRIPTION
This PR adds a feature to automatically **json_encode** array/object value when using **Model::upsert** method. 

If we have a JSON column in the database, when we want to do batch inserting/updating using the **Model::upsert method** we have to manually json_encode it's value. i think we can handle that in the upsert method automatically based on **$casts** property that defined in the Model's class.

usually we will do this to do upsert query to a table with JSON field : 
```php
$values = [
    [
        'name' => 'J.K. Rowling',
        'books' => [
            [
                'title' => "Harry Potter and the Philosopher's Stone",
                "year" => "1997"
            ],
            ....
        ]
    ],
    [
        'name' => 'J. R. R. Tolkien',
        'books' => [
            [
                'title' => "The Lord of the Rings",
                "year" => "1954"
            ],
            ...
        ]
    ],
];

$values = collect($values)->map(function ($item) {
    return [
        'name' => $item['name'],
        'books' => json_encode($item['books'])
    ];
})->toArray();

Author::query()
    ->upsert($values, ['name']);
```

with this PR, if in the model we **cast** the field to one of these : 
- `object`, 
- `array`, 
- `\Illuminate\Database\Eloquent\Casts\AsArrayObject::class`, or 
- `\Illuminate\Database\Eloquent\Casts\AsCollection::class` 

those fields values would be converted to JSON string automatically without the needs to do json_encode manually again in the user's codebase
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
