### PR TITLE
[9.x] Add DeferrableValidation interface to FormRequest

### DIFF
--- a/src/Illuminate/Contracts/Validation/DeferrableValidation.php
+++ b/src/Illuminate/Contracts/Validation/DeferrableValidation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface DeferrableValidation
+{
+    /**
+     * Determine if validated data is valid.
+     *
+     * @return bool
+     */
+    public function isValid(): bool;
+}


### PR DESCRIPTION
## Motivation

Sometimes there is a need to perform custom logic in the controller when the form request validation fails. I want to have an easy way to save the validation rules in the FormRequest's child class, but I decide what I want to do with the results in the controller.

## Solution

We can introduce the `DeferrableValidation` interface that will change the behavior of the `FormRequest`. The validation will be done on resolve (like it's doing right now), but exceptions wouldn't be thrown unless you are decide to do it.

## Example

`ExampleRequest` with the new `DeferrableValidation` trait:
```php
<?php

namespace App\Http\Web;

use Illuminate\Contracts\Validation\DeferrableValidation;
use Illuminate\Foundation\Http\FormRequest;

class ExampleRequest extends FormRequest implements DeferrableValidation
{
    public function rules(): array
    {
        return [
            'user_id' => [
                'required',
                'integer',
            ],
        ];
    }
}
```

`ExampleRequest` with the new `DeferrableValidation` trait:
```php
<?php

namespace App\Http\Web;

class ExampleController
{
    public function __invoke(ExampleRequest $request)
    {
        if (!$request->isValid()) {
            // Handle failed validation here

            throw $request->validationException; // optional
        }

        // Handle happy path
    }
}
```