### PR TITLE
[9.x] Add DeferrableValidation interface to FormRequest

### DIFF
--- a/src/Illuminate/Contracts/Validation/DeferrableValidation.php
+++ b/src/Illuminate/Contracts/Validation/DeferrableValidation.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Contracts\Validation;
 
+use Illuminate\Validation\ValidationException;
+
 interface DeferrableValidation
 {
     /**
@@ -10,4 +12,11 @@ interface DeferrableValidation
      * @return bool
      */
     public function isValid(): bool;
+
+    /**
+     * Get deferred validation exception.
+     *
+     * @return \Illuminate\Validation\ValidationException
+     */
+    public function getValidationException(): ?ValidationException;
 }

--- a/src/Illuminate/Contracts/Validation/DeferrableValidation.php
+++ b/src/Illuminate/Contracts/Validation/DeferrableValidation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Validation;
+
+interface DeferrableValidation
+{
+    /**
+     * Determine if validated data is valid.
+     *
+     * @return bool
+     */
+    public function isValid(): bool;
+}

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -260,6 +260,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Get deferred validation exception.
+     *
+     * @return \Illuminate\Validation\ValidationException
+     */
+    public function getValidationException(): ?ValidationException
+    {
+        return $this->validationException;
+    }
+
+    /**
      * Set the Validator instance.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -77,9 +77,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * The validation exception.
      *
-     * @var \Illuminate\Validation\ValidationException
+     * @var \Illuminate\Validation\ValidationException|null
      */
-    protected ?ValidationException $validationException;
+    protected $validationException;
 
     /**
      * Get the validator instance for the request.

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -137,7 +137,7 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
 
         $this->assertFalse($request->isValid());
-        $this->assertInstanceOf(ValidationException::class, $request->validationException);
+        $this->assertInstanceOf(ValidationException::class, $request->getValidationException());
         $this->assertEquals([], $request->validated());
     }
 
@@ -148,7 +148,7 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
 
         $this->assertTrue($request->isValid());
-        $this->assertNull($request->validationException);
+        $this->assertNull($request->getValidationException());
         $this->assertEquals('Anton', $request->validated('name'));
     }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -137,6 +137,7 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
 
         $this->assertFalse($request->isValid());
+        $this->assertInstanceOf(ValidationException::class, $request->validationException);
         $this->assertEquals([], $request->validated());
     }
 
@@ -147,6 +148,7 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
 
         $this->assertTrue($request->isValid());
+        $this->assertNull($request->validationException);
         $this->assertEquals('Anton', $request->validated('name'));
     }
 


### PR DESCRIPTION
## Motivation

Sometimes there is a need to perform custom logic in the controller when the form request validation fails. I want to have an easy way to keep the validation rules in the FormRequest's child class, but decide what to do with the validation results in the controller.

**Use cases:**
1. API has RPC API routes which should return 200 OK on validation error and REST API routes which returns 422 Unprocessable Entity.
2. Some of the routes has custom validation errors processing

## Solution

We can introduce the `DeferrableValidation` interface that will change the behavior of the `FormRequest`. The validation will be done on resolve (like it's doing right now), but exceptions wouldn't be thrown unless you are decide to do it.

## Usage example

```php
<?php

namespace App\Http\Web;

use Illuminate\Contracts\Validation\DeferrableValidation;
use Illuminate\Foundation\Http\FormRequest;

class ExampleRequest extends FormRequest implements DeferrableValidation
{
    public function rules(): array
    {
        return [
            'user_id' => [
                'required',
                'integer',
            ],
        ];
    }
}
```

```php
<?php

namespace App\Http\Web;

class ExampleController
{
    public function __invoke(ExampleRequest $request)
    {
        if (!$request->isValid()) {
            // Handle failed validation here

            // We can get validation errors in controller
            $errors = $request->getValidationException()->errors();

            // We can change redirect URL
            $request->getValidationException()->redirectTo($newUrl);

            // We can change HTTP status code
            $request->getValidationException()->status(200);

            // We can throw an exception
            throw $request->getValidationException();
        }

        // Handle happy path
    }
}
```

## Things to consider

- This change only affects the validation of the request, the authorization of the request still throws an exception.

## Naming

Alternative names for `$request->isValid()` method:
- `$request->validationPassed()`
- `$request->passedValidation()`
- `$request->validationFailed()`
- `$request->failedValidation()`