### PR TITLE
[9.x] Add previous exception

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -536,7 +536,7 @@ class Handler implements ExceptionHandlerContract
         }
 
         if (! $this->isHttpException($e)) {
-            $e = new HttpException(500, $e->getMessage());
+            $e = new HttpException(500, $e->getMessage(), $e);
         }
 
         return $this->toIlluminateResponse(


### PR DESCRIPTION
This PR ensures that the original (or previous) exception is not lost, when the exception handler wraps the exception into a `HttpException` in `prepareResonse`.

Knowing the original exception is helpful (or even mandatory) if the exception shall be handled in a special way in `renderHttpRepsonse` later down in the call stack. Moreover it is best practice to keep the chain of exception intact.

Note, this also does not introduce any security risk as it is the responsibility of `renderHttpRepsonse` anyway to only include information into the final HTML response which are deemed safe.