### PR TITLE
[9.x] Allow multiple Fields to be selected with insertGetId in pgsql

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -328,12 +328,20 @@ class PostgresGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
-     * @param  string  $sequence
+     * @param  string|array|null  $sequence
      * @return string
      */
     public function compileInsertGetId(Builder $query, $values, $sequence)
     {
-        return $this->compileInsert($query, $values).' returning '.$this->wrap($sequence ?: 'id');
+        if ($sequence === null) {
+            $fields = $this->wrap('id');
+        } elseif (is_array($sequence)) {
+            $fields = Arr::join(Arr::map($sequence, fn ($e) => $this->wrap($e)), ',');
+        } else {
+            $fields = $this->wrap($sequence);
+        }
+
+        return $this->compileInsert($query, $values).' returning '.$fields;
     }
 
     /**


### PR DESCRIPTION
# Overview

`Builder::insertGetId` with PostgreSQL works with the `RETURNING` clause. This enables arbitrary fields to be returned from the inserted rows and also works for multi-row inserts. Currently this cannot be utilized. This PR aims to change that.

# Changes to PostgresGrammar

`compileInsertGetId` now accepts an array as `$sequence`.
When given an array, it wraps all elements and joins them with `,` (comma) to produce the `RETURNING` clause.
When not given an array it behaves like previously.

# Changes to PostgresProcessor

`processInsertGetId` now also accepts an array as `$sequence`.

The behavior is as follows:
If multiple rows were inserted, an array of same length with the selected ids will be returned.
If only one column is selected, this column will be in the array.
If multiple columns were selected, the array contains associative arrays with `$fieldName => $fieldValue`.

If the returned array would only contain one item, the item is returned directly.
If no rows were inserted, null is returned. (Open to debate, if an empty array would be better).

Some examples:

1. One row inserted, one column (or defaulted) `$sequence` -> simple value returned
2. Multiple rows inserted, one column (or defaulted) `$sequence` -> array of simple values returned
3. One row inserted, multiple columns `$sequence` -> array of selected columns (Open to debate, if an array with one element  containing selected columns would be better)
4. Multiple rows inserted, multiple columns `$sequence` -> array of arrays of selected columns

Note on automatic tests: I would appreciate help on this topic, as I have not worked with mocks yet and don't know how I would write automatic tests for this.