### PR TITLE
[9.x] Update Model.php to assist in IDE detection of Builder methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -23,6 +23,9 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
 
+/**
+ * @mixin \Illuminate\Contracts\Database\Eloquent\Builder
+ */
 abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,


### PR DESCRIPTION
Adding the `@mixin` docblock helps various IDE:s automatically detect that `Builder` methods are permitted on Models.