### PR TITLE
[9.x] Allow injecting tagged instances via attribute

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1006,6 +1006,19 @@ class Container implements ArrayAccess, ContainerContract
             return $parameter->getDefaultValue();
         }
 
+        $type = $parameter->getType();
+
+        if ($type instanceof \ReflectionNamedType && $type->getName() === 'iterable') {
+            $attribute = $parameter->getAttributes(Tagged::class)[0] ?? null;
+
+            if (null !== $attribute) {
+                /** @var Tagged|null $tagged */
+                $tagged = $attribute?->newInstance();
+
+                return $this->tagged($tagged->tag);
+            }
+        }
+
         $this->unresolvablePrimitive($parameter);
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1012,8 +1012,7 @@ class Container implements ArrayAccess, ContainerContract
             $attribute = $parameter->getAttributes(Tagged::class)[0] ?? null;
 
             if (null !== $attribute) {
-                /** @var Tagged|null $tagged */
-                $tagged = $attribute?->newInstance();
+                $tagged = $attribute->newInstance();
 
                 return $this->tagged($tagged->tag);
             }

--- a/src/Illuminate/Container/Tagged.php
+++ b/src/Illuminate/Container/Tagged.php
@@ -7,5 +7,6 @@ class Tagged
 {
     public function __construct(
         public string $tag
-    ) {}
+    ) {
+    }
 }

--- a/src/Illuminate/Container/Tagged.php
+++ b/src/Illuminate/Container/Tagged.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Container;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
+class Tagged
+{
+    public function __construct(
+        public string $tag
+    ) {}
+}

--- a/tests/Container/ContainerTaggingTest.php
+++ b/tests/Container/ContainerTaggingTest.php
@@ -115,6 +115,18 @@ class ContainerTaggingTest extends TestCase
         $this->assertContainsOnlyInstancesOf(IContainerTaggedContractStub::class, $instance->tagged);
         $this->assertInstanceOf(ContainerImplementationTaggedStub::class, $instance->stub);
     }
+
+    public function testAnEmptyArrayIsInjectedWhenProvidingAnInvalidTagToTheAttribute()
+    {
+        $container = new Container;
+        $container->tag(ContainerImplementationTaggedStub::class, ['bar']);
+        $container->tag(ContainerImplementationTaggedStubTwo::class, ['bar']);
+
+        $instance = $container->build(ContainerTaggedInjection::class);
+
+        $this->assertInstanceOf(ContainerTaggedInjection::class, $instance);
+        $this->assertEmpty($instance->tagged);
+    }
 }
 
 interface IContainerTaggedContractStub

--- a/tests/Container/ContainerTaggingTest.php
+++ b/tests/Container/ContainerTaggingTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Container;
 
 use Illuminate\Container\Container;
+use Illuminate\Container\Tagged;
 use PHPUnit\Framework\TestCase;
 
 class ContainerTaggingTest extends TestCase
@@ -87,6 +88,33 @@ class ContainerTaggingTest extends TestCase
         $this->assertInstanceOf(ContainerImplementationTaggedStub::class, $fooResults[0]);
         $this->assertInstanceOf(ContainerImplementationTaggedStubTwo::class, $fooResults[1]);
     }
+
+    public function testTaggedInstancesCanBeInjectedViaTheAttribute()
+    {
+        $container = new Container;
+        $container->tag(ContainerImplementationTaggedStub::class, ['foo']);
+        $container->tag(ContainerImplementationTaggedStubTwo::class, ['foo']);
+
+        $instance = $container->build(ContainerTaggedInjection::class);
+
+        $this->assertInstanceOf(ContainerTaggedInjection::class, $instance);
+        $this->assertCount(2, $instance->tagged);
+        $this->assertContainsOnlyInstancesOf(IContainerTaggedContractStub::class, $instance->tagged);
+    }
+
+    public function testTaggedAttributeCanBeUsedTogetherWithOtherParameters()
+    {
+        $container = new Container;
+        $container->tag(ContainerImplementationTaggedStub::class, ['foo']);
+        $container->tag(ContainerImplementationTaggedStubTwo::class, ['foo']);
+
+        $instance = $container->build(ContainerTaggedInjectionTwo::class);
+
+        $this->assertInstanceOf(ContainerTaggedInjectionTwo::class, $instance);
+        $this->assertCount(2, $instance->tagged);
+        $this->assertContainsOnlyInstancesOf(IContainerTaggedContractStub::class, $instance->tagged);
+        $this->assertInstanceOf(ContainerImplementationTaggedStub::class, $instance->stub);
+    }
 }
 
 interface IContainerTaggedContractStub
@@ -103,3 +131,18 @@ class ContainerImplementationTaggedStubTwo implements IContainerTaggedContractSt
 {
     //
 }
+
+class ContainerTaggedInjection {
+    public function __construct(
+        #[Tagged('foo')] public iterable $tagged,
+    ) {}
+}
+
+class ContainerTaggedInjectionTwo {
+    public function __construct(
+        #[Tagged('foo')] public iterable $tagged,
+        public ContainerImplementationTaggedStub $stub,
+    ) {}
+}
+
+

--- a/tests/Container/ContainerTaggingTest.php
+++ b/tests/Container/ContainerTaggingTest.php
@@ -132,17 +132,21 @@ class ContainerImplementationTaggedStubTwo implements IContainerTaggedContractSt
     //
 }
 
-class ContainerTaggedInjection {
+class ContainerTaggedInjection
+{
     public function __construct(
         #[Tagged('foo')] public iterable $tagged,
-    ) {}
+    ) {
+    }
 }
 
-class ContainerTaggedInjectionTwo {
+class ContainerTaggedInjectionTwo
+{
     public function __construct(
         #[Tagged('foo')] public iterable $tagged,
         public ContainerImplementationTaggedStub $stub,
-    ) {}
+    ) {
+    }
 }
 
 

--- a/tests/Container/ContainerTaggingTest.php
+++ b/tests/Container/ContainerTaggingTest.php
@@ -148,5 +148,3 @@ class ContainerTaggedInjectionTwo
     ) {
     }
 }
-
-


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR add the `Tagged` attribute which can be added to a constructor argument that is explicitly typehinted as `iterable`, this way tagged servives can be required without having to explicitly create a custom binding.
