### PR TITLE
Option to move null values at the end for Ascending Sort/Order

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1411,6 +1411,23 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Sort the collection in ascending order using the given callback with the option to move null values at the end.
+     *
+     * @param array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
+     * @param int $options
+     * @return static
+     */
+    public function sortByAsc($callback, $options = SORT_REGULAR)
+    {
+        define("SORT_ASC_NULLS_LAST", 6);
+
+        return $this->sortBy($options == SORT_ASC_NULLS_LAST
+            ? fn($items) => $items->{$callback} ?: PHP_INT_MAX
+            : $callback,
+            $options);
+    }
+
+    /**
      * Sort the collection keys.
      *
      * @param  int  $options

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1418,7 +1418,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function sortByAsc($callback)
     {
-        return $this->sortBy(fn($items) => $items->{$callback} ?: PHP_INT_MAX);
+        return $this->sortBy(fn ($items) => $items->{$callback} ?: PHP_INT_MAX);
     }
 
     /**

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1414,15 +1414,15 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Sort the collection in ascending order using the given callback with the option to move null values at the end.
      *
      * @param array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
-     * @param int $options
+     * @param  int  $options
      * @return static
      */
     public function sortByAsc($callback, $options = SORT_REGULAR)
     {
-        define("SORT_ASC_NULLS_LAST", 6);
+        define('SORT_ASC_NULLS_LAST', 6);
 
         return $this->sortBy($options == SORT_ASC_NULLS_LAST
-            ? fn($items) => $items->{$callback} ?: PHP_INT_MAX
+            ? fn ($items) => $items->{$callback} ?: PHP_INT_MAX
             : $callback,
             $options);
     }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1414,17 +1414,11 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Sort the collection in ascending order using the given callback with the option to move null values at the end.
      *
      * @param array<array-key, (callable(TValue, TKey): mixed)|array<array-key, string>|(callable(TValue, TKey): mixed)|string  $callback
-     * @param  int  $options
      * @return static
      */
-    public function sortByAsc($callback, $options = SORT_REGULAR)
+    public function sortByAsc($callback)
     {
-        define('SORT_ASC_NULLS_LAST', 6);
-
-        return $this->sortBy($options == SORT_ASC_NULLS_LAST
-            ? fn ($items) => $items->{$callback} ?: PHP_INT_MAX
-            : $callback,
-            $options);
+        return $this->sortBy(fn($items) => $items->{$callback} ?: PHP_INT_MAX);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2246,13 +2246,11 @@ class Builder implements BuilderContract
      * Add an ascending "order by" clause to the query with the option to move the null values at the end.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
-     * @param  bool  $nullsLast
      * @return $this
      */
-    public function orderByAsc($column, $nullsLast = false)
+    public function orderByAsc($column)
     {
-        return $this->when($nullsLast, fn ($query) => $query->orderByRaw('ISNULL('.$column.')'))
-            ->orderBy($column, 'asc');
+        return $this->orderByRaw('ISNULL('.$column.')')->orderBy($column, 'asc');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2246,13 +2246,13 @@ class Builder implements BuilderContract
      * Add an ascending "order by" clause to the query with the option to move the null values at the end.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
-     * @param  Boolean  $nullsLast
+     * @param  bool  $nullsLast
      * @return $this
      */
     public function orderByAsc($column, $nullsLast = false)
     {
-        return $this->when($nullsLast, fn($query) => $query->orderByRaw($column . ' is null'))
-            ->orderBy($column, 'asc');
+        return $this->when($nullsLast, fn ($query) => $query->orderByRaw('ISNULL('.$column.')'))
+            ->orderBy($column);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2243,6 +2243,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Add an ascending "order by" clause to the query with the option to move the null values at the end.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
+     * @param  Boolean  $nullsLast
+     * @return $this
+     */
+    public function orderByAsc($column, $nullsLast = false)
+    {
+        return $this->when($nullsLast, fn($query) => $query->orderByRaw($column . ' is null'))
+            ->orderBy($column, 'asc');
+    }
+
+    /**
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2251,8 +2251,8 @@ class Builder implements BuilderContract
      */
     public function orderByAsc($column, $nullsLast = false)
     {
-        return $this->when($nullsLast, fn($query) => $query->orderByRaw($column . ' is null'))
-            ->orderBy($column, 'asc');
+        return $this->when($nullsLast, fn($query) => $query->orderByRaw('ISNULL('.$column.')'))
+            ->orderBy($column);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2246,13 +2246,13 @@ class Builder implements BuilderContract
      * Add an ascending "order by" clause to the query with the option to move the null values at the end.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
-     * @param  Boolean  $nullsLast
+     * @param  bool  $nullsLast
      * @return $this
      */
     public function orderByAsc($column, $nullsLast = false)
     {
-        return $this->when($nullsLast, fn($query) => $query->orderByRaw('ISNULL('.$column.')'))
-            ->orderBy($column);
+        return $this->when($nullsLast, fn ($query) => $query->orderByRaw('ISNULL('.$column.')'))
+            ->orderBy($column, 'asc');
     }
 
     /**


### PR DESCRIPTION
I've faced cases when I wanted to sort/order values ascendingly, but I didn't want null values at the start.

When I googled I noticed that many users face the same issue so I decided to make it somewhat easier for everyone to sort ascendingly but move null values at the end of the results