### PR TITLE
[10.x] remove mail fake failures method

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -394,16 +394,6 @@ class MailFake implements Factory, Mailer, MailQueue
     }
 
     /**
-     * Get the array of failed recipients.
-     *
-     * @return array
-     */
-    public function failures()
-    {
-        return [];
-    }
-
-    /**
      * Infer mailable class using reflection if a typehinted closure is passed to assertion.
      *
      * @param  string|\Closure  $mailable


### PR DESCRIPTION
Mail::failures does not exists anymore, so should also be removed from the MailFake.