### PR TITLE
[9.x] Add $instance->withoutTimestamps()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -170,6 +170,10 @@ trait HasTimestamps
 
         $this->timestamps = false;
 
-        return tap($callback($this), fn () => $this->timestamps = true);
+        try {
+            return $callback($this);
+        } finally {
+            $this->timestamps = true;
+        }
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -155,4 +155,21 @@ trait HasTimestamps
     {
         return $this->qualifyColumn($this->getUpdatedAtColumn());
     }
+
+    /**
+     * Run the given callable without timestamping the model.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function withoutTimestamps(callable $callback)
+    {
+        if (! $this->usesTimestamps()) {
+            return $callback();
+        }
+
+        $this->timestamps = false;
+
+        return tap($callback(), fn () => $this->timestamps = true);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -165,11 +165,11 @@ trait HasTimestamps
     public function withoutTimestamps(callable $callback)
     {
         if (! $this->usesTimestamps()) {
-            return $callback();
+            return $callback($this);
         }
 
         $this->timestamps = false;
 
-        return tap($callback(), fn () => $this->timestamps = true);
+        return tap($callback($this), fn () => $this->timestamps = true);
     }
 }

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class EloquentModelTest extends DatabaseTestCase
 {
@@ -101,6 +102,21 @@ class EloquentModelTest extends DatabaseTestCase
 
         $this->assertFalse($user->timestamps);
         $this->assertTrue($now->equalTo($user->updated_at));
+    }
+
+    public function testWithoutTimestampRestoresWhenClosureThrowsException()
+    {
+        $user = TestModel3::create(['name' => 'foo']);
+        $user->timestamps = true;
+
+        try {
+            $user->withoutTimestamps(fn () => throw new RuntimeException());
+            $this->fail();
+        } catch (RuntimeException) {
+            //
+        }
+
+        $this->assertTrue($user->timestamps);
     }
 }
 


### PR DESCRIPTION
This feature has been PR'd before, but I hoping this simplified version may be more palatable for core. This PR adds the ability to turn off timestamps of a single model for the duration of a given callback.

```php
$user = User::first();


// `updated_at` is not changed...

$user->withoutTimestamps(
    fn () => $user->update(['reserved_at' => now()])
);
```

A lot of these `without*` helpers are global / static to the Model, but this is on an instance by instance basis.


This, for example, is **not** how you use this helper...

```php
$users = User::get();

$user[0]->withoutTimestamps(function () use ($users) {

    // timestamp is not updated...

    $users[0]->update(['reserved_at' => now()]);

    // timestamp is updated because `withoutTimestamps` was called on $users[0]...

    $users[1]->update(['reserved_at' => now()]);
});
```

Instead you would do the following for a collection of models...


```php
User::get()->each->withoutTimestamps(
    fn ($user) => $user->update(['reserved_at' => now()])
);
```