### PR TITLE
[9.x] Fix documented return type of Database\Concerns\BuildsQueries::first()

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -289,7 +289,7 @@ trait BuildsQueries
      * Execute the query and get the first result.
      *
      * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     * @return mixed
      */
     public function first($columns = ['*'])
     {


### PR DESCRIPTION
This changes PhpDoc-documented return type of method `Database\Concerns\BuildsQueries::first()` to `mixed`. The reason is that `Database/Query/Builder::get()` calls a `Database\Query\Processors::processSelect()`, which may be extended to return anything. Therefore, `Database\Concerns\BuildsQueries::first()` may return anything as well.