### PR TITLE
[9.x] Fixes providesTemporaryUrls on AwsS3V3Adapter

### DIFF
--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -55,6 +55,18 @@ class AwsS3V3Adapter extends FilesystemAdapter
             $this->config['bucket'], $this->prefixer->prefixPath($path)
         );
     }
+    
+    /**
+     * Determine if temporary URLs can be generated.
+     *
+     * @return bool
+     */
+    public function providesTemporaryUrls()
+    {
+        // S3Adapter doesn't provide a getTemporaryUrl method, but this AwsS3V3Adapter provides temporary urls.
+
+        return true;
+    }
 
     /**
      * Get a temporary URL for the file at the given path.

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -55,7 +55,7 @@ class AwsS3V3Adapter extends FilesystemAdapter
             $this->config['bucket'], $this->prefixer->prefixPath($path)
         );
     }
-    
+
     /**
      * Determine if temporary URLs can be generated.
      *

--- a/src/Illuminate/Filesystem/AwsS3V3Adapter.php
+++ b/src/Illuminate/Filesystem/AwsS3V3Adapter.php
@@ -63,8 +63,6 @@ class AwsS3V3Adapter extends FilesystemAdapter
      */
     public function providesTemporaryUrls()
     {
-        // S3Adapter doesn't provide a getTemporaryUrl method, but this AwsS3V3Adapter provides temporary urls.
-
         return true;
     }
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -547,6 +547,17 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->providesTemporaryUrls());
     }
 
+    public function testProvidesTemporaryUrlsForS3Adapter()
+    {
+        $filesystem = new FilesystemManager(new Application);
+        $filesystemAdapter = $filesystem->createS3Driver([
+            'region' => 'us-west-1',
+            'bucket' => 'laravel',
+        ]);
+
+        $this->assertTrue($filesystemAdapter->providesTemporaryUrls());
+    }
+
     public function testProvidesTemporaryUrlsForAdapterWithoutTemporaryUrlSupport()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);


### PR DESCRIPTION
When using providesTemporaryUrls introduced in #43317 on a `s3` disk, providesTemporaryUrls() method always returns false 

```php
>>> Storage::disk('s3')->providesTemporaryUrls()
=> false // expected true
```

This is because providesTemporaryUrls implementation relies on adapter getTemporaryUrl method existence which doesn't exists on `League\Flysystem\AwsS3V3\AwsS3V3Adapter` 

Since `Illuminate\Filesystem\AwsS3V3Adapter` overrides `temporaryUrl`, and doesn't rely on adapter, we can also safely override providesTemporaryUrls method to always return true.