### PR TITLE
[9.x] Fixed `RoueGroup::merge` to format merged prefixes correctly

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -66,9 +66,9 @@ class RouteGroup
         $old = $old['prefix'] ?? '';
 
         if ($prependExistingPrefix) {
-            return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
+            return trim(isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old, '/');
         } else {
-            return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
+            return trim(isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old, '/');
         }
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1190,7 +1190,7 @@ class RoutingRouteTest extends TestCase
          */
         $router = $this->getRouter();
         $router->group(['as' => 'Foo::'], function () use ($router) {
-            $router->group(['prefix' => 'bar'], function () use($router) {
+            $router->group(['prefix' => 'bar'], function () use ($router) {
                 $router->get('baz', ['as' => 'baz', function () {
                     return 'hello';
                 }]);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1040,6 +1040,9 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(['prefix' => null, 'namespace' => null, 'where' => [
             'var1' => 'foo', 'var2' => 'bar',
         ]], RouteGroup::merge(['where' => ['var1' => 'foo', 'var2' => 'bar']], $old));
+
+        $old = [];
+        $this->assertEquals(['prefix' => 'foo', 'namespace' => null, 'where' => []], RouteGroup::merge(['prefix' => 'foo'], $old));
     }
 
     public function testRouteGrouping()
@@ -1168,6 +1171,34 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::baz');
         $this->assertSame('bar/foo', $route->getAction('prefix'));
+
+        /*
+         * nested with first layer skipped (prefix prepended)
+         */
+        $router = $this->getRouter();
+        $router->group(['as' => 'Foo::'], function () use ($router) {
+            $router->prefix('bar')->get('baz', ['as' => 'baz', function () {
+                return 'hello';
+            }]);
+        });
+        $routes = $router->getRoutes();
+        $route = $routes->getByName('Foo::baz');
+        $this->assertSame('bar', $route->getAction('prefix'));
+
+        /*
+         * nested with first layer skipped (prefix appended)
+         */
+        $router = $this->getRouter();
+        $router->group(['as' => 'Foo::'], function () use ($router) {
+            $router->group(['prefix' => 'bar'], function () use($router) {
+                $router->get('baz', ['as' => 'baz', function () {
+                    return 'hello';
+                }]);
+            });
+        });
+        $routes = $router->getRoutes();
+        $route = $routes->getByName('Foo::baz');
+        $this->assertSame('bar', $route->getAction('prefix'));
     }
 
     public function testRouteMiddlewareMergeWithMiddlewareAttributesAsStrings()


### PR DESCRIPTION

This PR fixes issue described in #43997 
## Problem this PR fixes
If route has parent RouteGroup with its prefix not set. FormatPrefix adds slash to either start or end of the actual prefix depending on the situtation.
This problem affects the whole `web.php` file, because the routes inside are loaded using group with empty $attributes array (so its prefix is empty).
```php
Route::middleware('web')
                ->group(base_path('routes/web.php'));
```

## Examples of the problem
**Appending prefix**
```php
Route::middleware("auth")->group(function () { // parent RouteGroup prefix is empty
    Route::view("/", "page.test");

    Route::prefix("dashboard")->group(function () { // we add another group with its own prefix
        Route::view("/settings", "page.test");
    });
});
```
### Expected behavior:
When user visits */dashboard/settings the `Route->current()->getPrefix()` should return `dashboard`

### Actual behavior:
The route prefix is returned with slash at the start -> `/dashboard`

**Prepending prefix**
```php
Route::middleware("web")->group(function () { // parent RouteGroup prefix is empty
    Route::prefix("dashboard")->get("/settings", TestController::class); // add route with its own prefix
});
```
### Expected behavior:
When user visits */dashboard/settings the `Route->current()->getPrefix()` should return `dashboard`

### Actual behavior:
The route prefix is returned with slash at the end -> `dashboard/`

**Quick side note:** I don't even know if this syntax is allowed. I didn't found any mentions about prepending route prefixes in the routing documentation, yet there is a test for this exact behavior.
https://github.com/laravel/framework/blob/7fa4beb386a139cabb730a7e3b9571ba8ea2a181/tests/Routing/RoutingRouteTest.php#L1159-L1170
Here the `bar` prefix is before the group `foo` prefix. Event tho its defined inside the group.

## Source of the problem
If i understood the problem correctly i think the issue is in the `RouteGroup::formatPrefix` method.
https://github.com/laravel/framework/blob/7fa4beb386a139cabb730a7e3b9571ba8ea2a181/src/Illuminate/Routing/RouteGroup.php#L64-L73
Here the `$old` variable  is set to empty string, when the parent  RouteGroup prefix is empty / not set.
And now when the old prefix is empty and new prefix is set. 
**Appending prefix**
This is what happens in the code on line 69  -> `"" . "/" . "newPrefix"`
There is **slash** added to the start of the new prefix.
**Prepending prefix**
This is what happens in the code on line 71  -> `"newPrefix" . "/" . ""`
There is **slash** added to the end of the new prefix.

## My solution
I managed to fix this issue by wrapping the return from `formatPrefix` in trim.
Reference:
https://github.com/laravel/framework/blob/7fa4beb386a139cabb730a7e3b9571ba8ea2a181/src/Illuminate/Routing/RouteGroup.php#L64-L73
My fix:
```php
if ($prependExistingPrefix) {
    return trim(isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old, '/');
} else {
    return trim(isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old, '/');
}
```
This should guarantee the prefix is always returned without slash at the start or end as expected.
I also tried running all the tests in the Routing folder after this fix and all of them have passed.

I hope my understanding of the problem is correct and the explanation was clear enough. :)

