### PR TITLE
[9.x] Support Enumerable in Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -218,12 +218,16 @@ class Str
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param  string|string[]|Enumerable<array-key, string>  $needles
      * @param  bool  $ignoreCase
      * @return bool
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
+        if ($needles instanceof Enumerable) {
+            $needles = $needles->toArray();
+        }
+
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', (array) $needles);
@@ -242,12 +246,16 @@ class Str
      * Determine if a given string contains all array values.
      *
      * @param  string  $haystack
-     * @param  string[]  $needles
+     * @param  string[]|Enumerable<array-key, string>  $needles
      * @param  bool  $ignoreCase
      * @return bool
      */
-    public static function containsAll($haystack, array $needles, $ignoreCase = false)
+    public static function containsAll($haystack, $needles, $ignoreCase = false)
     {
+        if ($needles instanceof Enumerable) {
+            $needles = $needles->toArray();
+        }
+
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
             $needles = array_map('mb_strtolower', $needles);
@@ -266,7 +274,7 @@ class Str
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param  string|string[]|Enumerable<array-key, string>  $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
@@ -781,12 +789,16 @@ class Str
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  array<int|string, string>  $replace
+     * @param  string[]|Enumerable<array-key, string>  $replace
      * @param  string  $subject
      * @return string
      */
-    public static function replaceArray($search, array $replace, $subject)
+    public static function replaceArray($search, $replace, $subject)
     {
+        if ($replace instanceof Enumerable) {
+            $replace = $replace->toArray();
+        }
+
         $segments = explode($search, $subject);
 
         $result = array_shift($segments);
@@ -801,13 +813,25 @@ class Str
     /**
      * Replace the given value in the given string.
      *
-     * @param  string|string[]  $search
-     * @param  string|string[]  $replace
-     * @param  string|string[]  $subject
+     * @param  string|string[]|Enumerable<array-key, string>  $search
+     * @param  string|string[]|Enumerable<array-key, string>  $replace
+     * @param  string|string[]|Enumerable<array-key, string>  $subject
      * @return string
      */
     public static function replace($search, $replace, $subject)
     {
+        if ($search instanceof Enumerable) {
+            $search = $search->toArray();
+        }
+
+        if ($replace instanceof Enumerable) {
+            $replace = $replace->toArray();
+        }
+
+        if ($subject instanceof Enumerable) {
+            $subject = $subject->toArray();
+        }
+
         return str_replace($search, $replace, $subject);
     }
 
@@ -862,13 +886,17 @@ class Str
     /**
      * Remove any occurrence of the given string in the subject.
      *
-     * @param  string|array<string>  $search
+     * @param  string|string[]|Enumerable<array-key, string>  $search
      * @param  string  $subject
      * @param  bool  $caseSensitive
      * @return string
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
+        if ($search instanceof Enumerable) {
+            $search = $search->toArray();
+        }
+
         $subject = $caseSensitive
                     ? str_replace($search, '', $subject)
                     : str_ireplace($search, '', $subject);
@@ -1021,7 +1049,7 @@ class Str
      * Determine if a given string starts with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|string[]  $needles
+     * @param  string|string[]|Enumerable<array-key, string>  $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -576,12 +576,20 @@ class Stringable implements JsonSerializable
     /**
      * Replace the given value in the given string.
      *
-     * @param  string|string[]  $search
-     * @param  string|string[]  $replace
+     * @param  string|string[]|Enumerable<array-key, string>  $search
+     * @param  string|string[]|Enumerable<array-key, string>  $replace
      * @return static
      */
     public function replace($search, $replace)
     {
+        if ($search instanceof Enumerable) {
+            $search = $search->toArray();
+        }
+
+        if ($replace instanceof Enumerable) {
+            $replace = $replace->toArray();
+        }
+
         return new static(str_replace($search, $replace, $this->value));
     }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -524,6 +524,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('foo bar baz 8.x', Str::replace('?', '8.x', 'foo bar baz ?'));
         $this->assertSame('foo/bar/baz', Str::replace(' ', '/', 'foo bar baz'));
         $this->assertSame('foo bar baz', Str::replace(['?1', '?2', '?3'], ['foo', 'bar', 'baz'], '?1 ?2 ?3'));
+        $this->assertSame(['foo', 'bar', 'baz'], Str::replace(collect(['?1', '?2', '?3']), collect(['foo', 'bar', 'baz']), collect(['?1', '?2', '?3'])));
     }
 
     public function testReplaceArray()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -766,6 +766,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('bar/bar', (string) $this->stringable('?/?')->replace('?', 'bar'));
         $this->assertSame('?/?/?', (string) $this->stringable('? ? ?')->replace(' ', '/'));
         $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(['?1', '?2', '?3', '?4'], ['foo', 'bar', 'baz', 'bam']));
+        $this->assertSame('foo/bar/baz/bam', (string) $this->stringable('?1/?2/?3/?4')->replace(collect(['?1', '?2', '?3', '?4']), collect(['foo', 'bar', 'baz', 'bam'])));
     }
 
     public function testReplaceArray()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds simple quality of life improvement which allows us to pass `Enumerable` objects such as `Collection` to the `Stringable` helper functions that already accept `array` as a parameter.

For example, in a project I'm working on, we're doing the following:

```php
/** @var Collection<array-key, string> $months */
$months = months();

Str::remove($months->toArray(), $someString);
```

With this PR we can skip the `->toArray` call.

```php
/** @var Collection<array-key, string> $months */
$months = months();

Str::remove($months, $someString);
```