### PR TITLE
[9.x] Add Str::freezeUuidsFor method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1294,6 +1294,21 @@ class Str
     }
 
     /**
+     * Always return the same UUID when generating new UUIDs during the given callback's execution.
+     *
+     * @param  \Closure  $callback
+     * @return \Ramsey\Uuid\UuidInterface
+     */
+    public static function freezeUuidsFor(Closure $callback)
+    {
+        try {
+            return static::freezeUuids($callback);
+        } finally {
+            Str::createUuidsNormally();
+        }
+    }
+
+    /**
      * Indicate that UUIDs should be created normally and not using a custom factory.
      *
      * @return void

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -991,6 +991,19 @@ class SupportStrTest extends TestCase
         Str::createUuidsNormally();
     }
 
+    public function testItCreatesUuidsNormallyAfterFailureWithinFreezeFor()
+    {
+        try {
+            Str::freezeUuidsFor(function () {
+                Str::createUuidsUsing(fn () => Str::of('1234'));
+                $this->assertSame('1234', Str::uuid()->toString());
+                throw new \Exception('Something failed.');
+            });
+        } catch (\Exception $e) {
+            $this->assertNotSame('1234', Str::uuid()->toString());
+        }
+    }
+
     public function testItCanSpecifyASequenceOfUuidsToUtilise()
     {
         Str::createUuidsUsingSequence([


### PR DESCRIPTION
See https://github.com/laravel/framework/pull/44018 for alternate implementation using existing method.

**https://github.com/laravel/framework/pull/44018 should be closed if this is merged.**

---

Recently I ran into an issue using the new `createUuidsUsing` method introduced in https://github.com/laravel/framework/pull/42619.

The issue caused most of my test suite to fail due to one test failing.

This is because I use `Str::uuid()` to generate UUIDs for my models and I was getting a heap of duplicates. The underlying cause being that when my initial test failed, `Str::createUuidsNormally()` was never being called to essentially *clean up* from an exception/failed assertion that I was not expecting to be thrown.

Then when running the test in isolation, it works fine. I don't think failures in previous tests should cause all of your test suite to fail.

So as an example, both tests below would fail;
```php
class UuidTest extends FeatureTestCase
{
    /** @test */
    public function it_sets_uuid()
    {
        Str::createUuidsUsing(fn () => Str::of('1234'));

        // It was actually a Storage::assertExists() failure in my case.
        throw new Exception('Test failed.');

        Str::createUuidsNormally();
    }

    /** @test */
    public function it_creates_uuids_normally_after_previous_failed_tests()
    {
        $this->assertFalse(Str::orderedUuid()->toString() === '1234'); 
        // FAIL as it's still using '1234' from above
    }
}
```

This then caused hundreds of tests to fail. With this new PR, when considering the following example, the first test will fail (as expected) however the second test will pass.
```php
class UuidTest extends FeatureTestCase
{
    /** @test */
    public function it_sets_uuid()
    {
        Str::freezeUuidsFor(function () {
            Str::createUuidsUsing(fn () => Str::of('1234'));

            throw new Exception('Test failed.');
        });
    }

    /** @test */
    public function it_creates_uuids_normally_after_previous_failed_tests()
    {
        $this->assertFalse(Str::orderedUuid()->toString() === '1234');
        // PASS as `Str::createUuidsNormally();` will always be called after the callback
        // in `freezeUuidsFor`
    }
}
```

I believe similar logic would already apply to methods like `Event::fakeFor()` where failures within that closure would not affect additional tests.

I know that `freezeUuids` returns a UUID itself however instead of introducing new methods for each of the new string helpers for testing, I figured it's fine to simply continue using `freezeUuids` within `freezeUuidsFor` and just set the UUID generation method within the closure itself.

I also considered just adding this functionality to the initial `freezeUuids` method but wasn't sure if that would be breaking considering perhaps this is expected behaviour? So I just added the new method.

Also not 100% on the test I wrote but I believe it covers the use case. It's the only way I could think of testing it within a single test.