### PR TITLE
[9.x] Fix console help output consistency

### DIFF
--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -146,7 +146,7 @@ class ObserverMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observer applies to.'],
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observer applies to'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -99,8 +99,8 @@ class RuleMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['implicit', 'i', InputOption::VALUE_NONE, 'Generate an implicit rule.'],
-            ['invokable', null, InputOption::VALUE_NONE, 'Generate a single method, invokable rule class.'],
+            ['implicit', 'i', InputOption::VALUE_NONE, 'Generate an implicit rule'],
+            ['invokable', null, InputOption::VALUE_NONE, 'Generate a single method, invokable rule class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -115,8 +115,8 @@ class TestMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['unit', 'u', InputOption::VALUE_NONE, 'Create a unit test.'],
-            ['pest', 'p', InputOption::VALUE_NONE, 'Create a Pest test.'],
+            ['unit', 'u', InputOption::VALUE_NONE, 'Create a unit test'],
+            ['pest', 'p', InputOption::VALUE_NONE, 'Create a Pest test'],
         ];
     }
 }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -277,14 +277,14 @@ class ControllerMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['api', null, InputOption::VALUE_NONE, 'Exclude the create and edit methods from the controller.'],
-            ['type', null, InputOption::VALUE_REQUIRED, 'Manually specify the controller stub file to use.'],
+            ['api', null, InputOption::VALUE_NONE, 'Exclude the create and edit methods from the controller'],
+            ['type', null, InputOption::VALUE_REQUIRED, 'Manually specify the controller stub file to use'],
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the controller already exists'],
-            ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable controller class.'],
-            ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
-            ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
-            ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
-            ['requests', 'R', InputOption::VALUE_NONE, 'Generate FormRequest classes for store and update.'],
+            ['invokable', 'i', InputOption::VALUE_NONE, 'Generate a single method, invokable controller class'],
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model'],
+            ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class'],
+            ['requests', 'R', InputOption::VALUE_NONE, 'Generate FormRequest classes for store and update'],
         ];
     }
 }


### PR DESCRIPTION
This removes a full stop from the end of some options for four different console commands:

- `php artisan help make:observer`
- `php artisan help make:rule`
- `php artisan help make:test`
- `php artisan help make:controller`

Every other console commands help options does not terminate with a full stop, so this essentially just sets consistency across the board of commands.