### PR TITLE
[9.x] Ensure freezeUuids always resets UUID creation after exception in callback

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1294,6 +1294,21 @@ class Str
     }
 
     /**
+     * Always return the same UUID when generating new UUIDs during the given callback's execution.
+     *
+     * @param  \Closure  $callback
+     * @return \Ramsey\Uuid\UuidInterface
+     */
+    public static function freezeUuidsFor(Closure $callback)
+    {
+        try {
+            return static::freezeUuids($callback);
+        } finally {
+            Str::createUuidsNormally();
+        }
+    }
+
+    /**
      * Indicate that UUIDs should be created normally and not using a custom factory.
      *
      * @return void

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1285,27 +1285,14 @@ class Str
         Str::createUuidsUsing(fn () => $uuid);
 
         if ($callback !== null) {
-            $callback($uuid);
-
-            Str::createUuidsNormally();
+            try {
+                $callback($uuid);
+            } finally {
+                Str::createUuidsNormally();
+            }
         }
 
         return $uuid;
-    }
-
-    /**
-     * Always return the same UUID when generating new UUIDs during the given callback's execution.
-     *
-     * @param  \Closure  $callback
-     * @return \Ramsey\Uuid\UuidInterface
-     */
-    public static function freezeUuidsFor(Closure $callback)
-    {
-        try {
-            return static::freezeUuids($callback);
-        } finally {
-            Str::createUuidsNormally();
-        }
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -991,6 +991,19 @@ class SupportStrTest extends TestCase
         Str::createUuidsNormally();
     }
 
+    public function testItCreatesUuidsNormallyAfterFailureWithinFreezeFor()
+    {
+        try {
+            Str::freezeUuidsFor(function () {
+                Str::createUuidsUsing(fn () => Str::of('1234'));
+                $this->assertSame('1234', Str::uuid()->toString());
+                throw new \Exception('Something failed.');
+            });
+        } catch (\Exception $e) {
+            $this->assertNotSame('1234', Str::uuid()->toString());
+        }
+    }
+
     public function testItCanSpecifyASequenceOfUuidsToUtilise()
     {
         Str::createUuidsUsingSequence([

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -991,10 +991,10 @@ class SupportStrTest extends TestCase
         Str::createUuidsNormally();
     }
 
-    public function testItCreatesUuidsNormallyAfterFailureWithinFreezeFor()
+    public function testItCreatesUuidsNormallyAfterFailureWithinFreezeMethod()
     {
         try {
-            Str::freezeUuidsFor(function () {
+            Str::freezeUuids(function () {
                 Str::createUuidsUsing(fn () => Str::of('1234'));
                 $this->assertSame('1234', Str::uuid()->toString());
                 throw new \Exception('Something failed.');


### PR DESCRIPTION
**If merged, https://github.com/laravel/framework/pull/44013 should be closed.**

Please see https://github.com/laravel/framework/pull/44013 for details on the problem this PR is solving.

This PR is a slightly different implementation of https://github.com/laravel/framework/pull/44013 using the existing method as per the recommendation from @timacdonald https://github.com/laravel/framework/pull/44013#issuecomment-1237528959.

Instead of messy commits I thought 2 separate PRs would be cleaner.

Only one of them should be merged.

---

Recently I ran into an issue using the new `createUuidsUsing` method introduced in https://github.com/laravel/framework/pull/42619.

The issue caused most of my test suite to fail due to one test failing.

This is because I use `Str::uuid()` to generate UUIDs for my models and I was getting a heap of duplicates. The underlying cause being that when my initial test failed, `Str::createUuidsNormally()` was never being called to essentially *clean up* from an exception/failed assertion that I was not expecting to be thrown.

Then when running the test in isolation, it works fine. I don't think failures in previous tests should cause all of your test suite to fail.

So as an example, both tests below would fail;
```php
class UuidTest extends FeatureTestCase
{
    /** @test */
    public function it_sets_uuid()
    {
        Str::createUuidsUsing(fn () => Str::of('1234'));

        // It was actually a Storage::assertExists() failure in my case.
        throw new Exception('Test failed.');

        Str::createUuidsNormally();
    }

    /** @test */
    public function it_creates_uuids_normally_after_previous_failed_tests()
    {
        $this->assertFalse(Str::orderedUuid()->toString() === '1234'); 
        // FAIL as it's still using '1234' from above
    }
}
```

This then caused hundreds of tests to fail. With this new PR, when considering the following example, the first test will fail (as expected) however the second test will pass.
```php
class UuidTest extends FeatureTestCase
{
    /** @test */
    public function it_sets_uuid()
    {
        Str::freezeUuids(function () {
            Str::createUuidsUsing(fn () => Str::of('1234'));

            throw new Exception('Test failed.');
        });
    }

    /** @test */
    public function it_creates_uuids_normally_after_previous_failed_tests()
    {
        $this->assertFalse(Str::orderedUuid()->toString() === '1234');
        // PASS as `Str::createUuidsNormally();` will always be called after the callback
        // in `freezeUuids`
    }
}
```

I believe similar logic would already apply to methods like `Event::fakeFor()` where failures within that closure would not affect additional tests.