### PR TITLE
Prunable contracts

### DIFF
--- a/src/Illuminate/Contracts/Eloquent/MassPrunable.php
+++ b/src/Illuminate/Contracts/Eloquent/MassPrunable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Contracts\Eloquent;
+
+interface MassPrunable
+{
+    /**
+     * Prune all prunable models in the database.
+     *
+     * @param  int  $chunkSize
+     * @return int
+     */
+    public function pruneAll(int $chunkSize = 1000);
+
+    /**
+     * Get the prunable model query.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function prunable();
+}

--- a/src/Illuminate/Contracts/Eloquent/Prunable.php
+++ b/src/Illuminate/Contracts/Eloquent/Prunable.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Contracts\Eloquent;
+
+interface Prunable
+{
+    /**
+     * Prune all prunable models in the database.
+     *
+     * @param  int  $chunkSize
+     * @return int
+     */
+    public function pruneAll(int $chunkSize = 1000);
+
+    /**
+     * Get the prunable model query.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function prunable();
+
+    /**
+     * Prune the model in the database.
+     *
+     * @return bool|null
+     */
+    public function prune();
+}

--- a/src/Illuminate/Database/Console/PruneCommand.php
+++ b/src/Illuminate/Database/Console/PruneCommand.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Eloquent\MassPrunable as MassPrunableContract;
+use Illuminate\Contracts\Eloquent\Prunable as PrunableContract;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Prunable;
@@ -157,6 +159,10 @@ class PruneCommand extends Command
      */
     protected function isPrunable($model)
     {
+        if ($model instanceof PrunableContract || $model instanceof MassPrunableContract) {
+            return true;
+        }
+
         $uses = class_uses_recursive($model);
 
         return in_array(Prunable::class, $uses) || in_array(MassPrunable::class, $uses);

--- a/tests/Database/PruneCommandTest.php
+++ b/tests/Database/PruneCommandTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Eloquent\MassPrunable as MassPrunableContract;
+use Illuminate\Contracts\Eloquent\Prunable as PrunableContract;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Console\PruneCommand;
@@ -212,14 +214,14 @@ class PruneCommandTest extends TestCase
     }
 }
 
-class PrunableTestModelWithPrunableRecords extends Model
+class PrunableTestModelWithPrunableRecords extends Model implements MassPrunableContract
 {
     use MassPrunable;
 
     protected $table = 'prunables';
     protected $connection = 'default';
 
-    public function pruneAll()
+    public function pruneAll(int $chunkSize = 1000)
     {
         event(new ModelsPruned(static::class, 10));
         event(new ModelsPruned(static::class, 20));
@@ -233,7 +235,7 @@ class PrunableTestModelWithPrunableRecords extends Model
     }
 }
 
-class PrunableTestSoftDeletedModelWithPrunableRecords extends Model
+class PrunableTestSoftDeletedModelWithPrunableRecords extends Model implements MassPrunableContract
 {
     use MassPrunable, SoftDeletes;
 
@@ -246,11 +248,11 @@ class PrunableTestSoftDeletedModelWithPrunableRecords extends Model
     }
 }
 
-class PrunableTestModelWithoutPrunableRecords extends Model
+class PrunableTestModelWithoutPrunableRecords extends Model implements PrunableContract
 {
     use Prunable;
 
-    public function pruneAll()
+    public function pruneAll(int $chunkSize = 1000)
     {
         return 0;
     }


### PR DESCRIPTION
**What**
I added 2 contracts to improve the typehinting and static analysis experience for prunable model.

In my previous  PR regarding pruning, I did an update to the PruneCommand to make it better extendible. Now, I'm getting phpstan errors when trying to call `pruneAll()` manually. Since traits are not type-hintable, I've decided to add 2 interfaces for this.

**Why**
I figured this change is welcome because we also use it on the `Authenticatable` trait. Type hinting is used more frequently on that interface ofcourse, but I figured we should give the developer the choice here. If this is not the way to go I could always just suppress the code style warning.

**No breaking changes**
I purposefully kept the support for using the trait without the interface to prevent breaking changes.