### PR TITLE
Cache - support for dependencies between cached items

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -119,6 +119,20 @@ class ApcStore extends TaggableStore
     }
 
     /**
+     * Begin executing a new dependency operation.
+     *
+     * @param  array|mixed  $dependencies
+     * @return \Illuminate\Cache\DependencyCache
+     */
+    public function dependencies($dependencies)
+    {
+        return new DependencyCache(
+            $this,
+            is_array($dependencies) ? $dependencies : func_get_args(),
+        );
+    }
+
+    /**
      * Get the cache key prefix.
      *
      * @return string

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -160,6 +160,20 @@ class ArrayStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Begin executing a new dependency operation.
+     *
+     * @param  array|mixed  $dependencies
+     * @return \Illuminate\Cache\DependencyCache
+     */
+    public function dependencies($dependencies)
+    {
+        return new DependencyCache(
+            $this,
+            is_array($dependencies) ? $dependencies : func_get_args(),
+        );
+    }
+
+    /**
      * Get the cache key prefix.
      *
      * @return string

--- a/src/Illuminate/Cache/DependencyCache.php
+++ b/src/Illuminate/Cache/DependencyCache.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Contracts\Cache\Store;
+use Psr\SimpleCache\InvalidArgumentException;
+
+class DependencyCache extends Repository {
+    private const DEPENDENCY_CACHE_KEY_PREFIX = 'cache_dependency';
+
+    /**
+     * Built dependencies names
+     * @var array
+     */
+    private array $dependenciesNames;
+
+    /**
+     * Create a new DependencyCache instance
+     *
+     * @param Store $store
+     * @param array $dependenciesList
+     * @param TagSet|null $tags
+     */
+    public function __construct(Store $store, array $dependenciesList, protected ?TagSet $tags = NULL)
+    {
+        parent::__construct($store);
+
+        $this->dependenciesNames = self::buildDependenciesNames($dependenciesList);
+    }
+
+    /**
+     * Store an item in the cache and create its dependencies.
+     *
+     * @param array|string $key
+     * @param mixed $value
+     * @param \DateTimeInterface|\DateInterval|int|null $ttl
+     * @return bool
+     */
+    public function set($key, $value, $ttl = NULL): bool
+    {
+        $result = parent::set($key, $value, $ttl);
+
+        if ($result) {
+            $this->createDependency($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Store an item in the cache and create its dependencies.
+     *
+     * @param array|string $key
+     * @param mixed $value
+     * @param \DateTimeInterface|\DateInterval|int|null $ttl
+     * @return bool
+     */
+    public function put($key, $value, $ttl = NULL): bool
+    {
+        $result = parent::put($key, $value, $ttl);
+
+        if ($result) {
+            $this->createDependency($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Store multiple items in the cache for a given number of seconds and create its dependencies.
+     *
+     * @param array $values
+     * @param \DateTimeInterface|\DateInterval|int|null $ttl
+     * @return bool
+     */
+    public function putMany(array $values, $ttl = NULL): bool
+    {
+        $result = parent::putMany($values, $ttl);
+
+        foreach ($values as $key => $value) {
+            $this->createDependency($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Store multiple items in the cache indefinitely and create its dependencies.
+     *
+     * @param array $values
+     * @return bool
+     */
+    public function putManyForever(array $values): bool
+    {
+        $result = parent::putManyForever($values);
+
+        foreach ($values as $key => $value) {
+            $this->createDependency($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Store an item in the cache if the key does not exist and create its dependencies.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param \DateTimeInterface|\DateInterval|int|null $ttl
+     * @return bool
+     */
+    public function add($key, $value, $ttl = NULL): bool
+    {
+        $result = parent::add($key, $value, $ttl);
+
+        if ($result) {
+            $this->createDependency($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Store an item in the cache indefinitely and create its dependencies.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return bool
+     */
+    public function forever($key, $value): bool
+    {
+        $result = parent::forever($key, $value);
+
+        if ($result) {
+            $this->createDependency($key);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Removes all items stored in cache assigned to dependencies
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public function invalidate(): void
+    {
+        foreach ($this->dependenciesNames as $dependencyName) {
+            $dependencyNameCacheKey = self::getCacheKeyForDependencyName($dependencyName);
+            // Check, if cache key for dependency name exists
+            if ($this->has($dependencyNameCacheKey)) {
+                $dependencyCacheItems = $this->get($dependencyNameCacheKey);
+
+                foreach ($dependencyCacheItems as $cachedItemKey => $cacheItem) {
+                    // Removes cached items in taggable cache
+                    foreach ($cacheItem['tags'] as $tagGroup) {
+                        $this->tags(explode('|', $tagGroup))->delete($cachedItemKey);
+                    }
+
+                    // Removes cached item, which is not tagged by any tag
+                    if ($cacheItem['rnt']) {
+                        $this->delete($cachedItemKey);
+                    }
+                }
+
+                // After invalidation, we remove dependency cache record
+                $this->forget($dependencyNameCacheKey);
+            }
+        }
+    }
+
+    /**
+     * Check if dependencies exists in cache store.
+     *
+     * @return bool
+     */
+    public function exists(): bool
+    {
+        foreach ($this->dependenciesNames as $dependencyName) {
+            if (!$this->has(self::getCacheKeyForDependencyName($dependencyName))) {
+                return FALSE;
+            }
+        }
+
+        return TRUE;
+    }
+
+    /**
+     * Store a dependency item in the cache with related cache item data
+     *
+     * @param $key
+     * @return void
+     */
+    private function createDependency($key): void
+    {
+        foreach ($this->dependenciesNames as $dependencyName) {
+            $dependencyNameCacheKey = self::getCacheKeyForDependencyName($dependencyName);
+
+            if ($this->has($dependencyNameCacheKey)) {
+                $dependencies = $this->get($dependencyNameCacheKey);
+            }
+
+            // rnt - shortcut for "remove non tagged" item. It means, if we want to remove cached item which is not assigned to any tag
+            // tags - include existing tag groups assigned to cached item
+            $dependencies[$key] = [
+                'rnt' => empty($this->tags) ? TRUE : ($dependencies[$key]['rnt'] ?? FALSE),
+                'tags' => $dependencies[$key]['tags'] ?? [],
+            ];
+
+            // Save cache tags if provided
+            if ($this->tags?->getNames()) {
+                $tags = implode('|', $this->tags->getNames());
+                if (!empty($tags) && !in_array($tags, $dependencies[$key]['tags'])) {
+                    $dependencies[$key]['tags'][] = $tags;
+                }
+            }
+
+            parent::forever($dependencyNameCacheKey, $dependencies);
+        }
+    }
+
+    /**
+     * Dependencies names builder
+     *
+     * @param $dependencies
+     * @return array
+     */
+    private static function buildDependenciesNames($dependencies): array
+    {
+        $builtDependenciesNames = [];
+
+        foreach ($dependencies as $dependencyKey => $dependencyValues) {
+            if (!is_array($dependencyValues)) {
+                $builtDependenciesNames[] = $dependencyValues;
+
+                continue;
+            }
+
+            foreach ($dependencyValues as $dependencyValue) {
+                $builtDependenciesNames[] = implode('_', [$dependencyKey, $dependencyValue]);
+            }
+        }
+
+        return $builtDependenciesNames;
+    }
+
+    /**
+     * Generate cache key for dependency name
+     *
+     * @param $dependencyName
+     * @return string
+     */
+    private static function getCacheKeyForDependencyName($dependencyName): string
+    {
+        return sha1(self::DEPENDENCY_CACHE_KEY_PREFIX) . ':' . $dependencyName;
+    }
+}

--- a/src/Illuminate/Cache/DependencyCache.php
+++ b/src/Illuminate/Cache/DependencyCache.php
@@ -3,25 +3,26 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Contracts\Cache\Store;
-use Psr\SimpleCache\InvalidArgumentException;
 
-class DependencyCache extends Repository {
+class DependencyCache extends Repository
+{
     private const DEPENDENCY_CACHE_KEY_PREFIX = 'cache_dependency';
 
     /**
-     * Built dependencies names
+     * Built dependencies names.
+     *
      * @var array
      */
     private array $dependenciesNames;
 
     /**
-     * Create a new DependencyCache instance
+     * Create a new DependencyCache instance.
      *
-     * @param Store $store
-     * @param array $dependenciesList
-     * @param TagSet|null $tags
+     * @param  Store  $store
+     * @param  array  $dependenciesList
+     * @param  TagSet|null  $tags
      */
-    public function __construct(Store $store, array $dependenciesList, protected ?TagSet $tags = NULL)
+    public function __construct(Store $store, array $dependenciesList, protected ?TagSet $tags = null)
     {
         parent::__construct($store);
 
@@ -31,12 +32,12 @@ class DependencyCache extends Repository {
     /**
      * Store an item in the cache and create its dependencies.
      *
-     * @param array|string $key
-     * @param mixed $value
-     * @param \DateTimeInterface|\DateInterval|int|null $ttl
+     * @param  array|string  $key
+     * @param  mixed  $value
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
-    public function set($key, $value, $ttl = NULL): bool
+    public function set($key, $value, $ttl = null): bool
     {
         $result = parent::set($key, $value, $ttl);
 
@@ -50,12 +51,12 @@ class DependencyCache extends Repository {
     /**
      * Store an item in the cache and create its dependencies.
      *
-     * @param array|string $key
-     * @param mixed $value
-     * @param \DateTimeInterface|\DateInterval|int|null $ttl
+     * @param  array|string  $key
+     * @param  mixed  $value
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
-    public function put($key, $value, $ttl = NULL): bool
+    public function put($key, $value, $ttl = null): bool
     {
         $result = parent::put($key, $value, $ttl);
 
@@ -69,11 +70,11 @@ class DependencyCache extends Repository {
     /**
      * Store multiple items in the cache for a given number of seconds and create its dependencies.
      *
-     * @param array $values
-     * @param \DateTimeInterface|\DateInterval|int|null $ttl
+     * @param  array  $values
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
-    public function putMany(array $values, $ttl = NULL): bool
+    public function putMany(array $values, $ttl = null): bool
     {
         $result = parent::putMany($values, $ttl);
 
@@ -87,7 +88,7 @@ class DependencyCache extends Repository {
     /**
      * Store multiple items in the cache indefinitely and create its dependencies.
      *
-     * @param array $values
+     * @param  array  $values
      * @return bool
      */
     public function putManyForever(array $values): bool
@@ -104,12 +105,12 @@ class DependencyCache extends Repository {
     /**
      * Store an item in the cache if the key does not exist and create its dependencies.
      *
-     * @param string $key
-     * @param mixed $value
-     * @param \DateTimeInterface|\DateInterval|int|null $ttl
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
      * @return bool
      */
-    public function add($key, $value, $ttl = NULL): bool
+    public function add($key, $value, $ttl = null): bool
     {
         $result = parent::add($key, $value, $ttl);
 
@@ -123,8 +124,8 @@ class DependencyCache extends Repository {
     /**
      * Store an item in the cache indefinitely and create its dependencies.
      *
-     * @param string $key
-     * @param mixed $value
+     * @param  string  $key
+     * @param  mixed  $value
      * @return bool
      */
     public function forever($key, $value): bool
@@ -139,10 +140,9 @@ class DependencyCache extends Repository {
     }
 
     /**
-     * Removes all items stored in cache assigned to dependencies
+     * Removes all items stored in cache assigned to dependencies.
      *
      * @return void
-     * @throws InvalidArgumentException
      */
     public function invalidate(): void
     {
@@ -178,16 +178,16 @@ class DependencyCache extends Repository {
     public function exists(): bool
     {
         foreach ($this->dependenciesNames as $dependencyName) {
-            if (!$this->has(self::getCacheKeyForDependencyName($dependencyName))) {
-                return FALSE;
+            if (! $this->has(self::getCacheKeyForDependencyName($dependencyName))) {
+                return false;
             }
         }
 
-        return TRUE;
+        return true;
     }
 
     /**
-     * Store a dependency item in the cache with related cache item data
+     * Store a dependency item in the cache with related cache item data.
      *
      * @param $key
      * @return void
@@ -204,14 +204,14 @@ class DependencyCache extends Repository {
             // rnt - shortcut for "remove non tagged" item. It means, if we want to remove cached item which is not assigned to any tag
             // tags - include existing tag groups assigned to cached item
             $dependencies[$key] = [
-                'rnt' => empty($this->tags) ? TRUE : ($dependencies[$key]['rnt'] ?? FALSE),
+                'rnt' => empty($this->tags) ? true : ($dependencies[$key]['rnt'] ?? false),
                 'tags' => $dependencies[$key]['tags'] ?? [],
             ];
 
             // Save cache tags if provided
             if ($this->tags?->getNames()) {
                 $tags = implode('|', $this->tags->getNames());
-                if (!empty($tags) && !in_array($tags, $dependencies[$key]['tags'])) {
+                if (! empty($tags) && ! in_array($tags, $dependencies[$key]['tags'])) {
                     $dependencies[$key]['tags'][] = $tags;
                 }
             }
@@ -221,7 +221,7 @@ class DependencyCache extends Repository {
     }
 
     /**
-     * Dependencies names builder
+     * Dependencies names builder.
      *
      * @param $dependencies
      * @return array
@@ -231,7 +231,7 @@ class DependencyCache extends Repository {
         $builtDependenciesNames = [];
 
         foreach ($dependencies as $dependencyKey => $dependencyValues) {
-            if (!is_array($dependencyValues)) {
+            if (! is_array($dependencyValues)) {
                 $builtDependenciesNames[] = $dependencyValues;
 
                 continue;
@@ -246,13 +246,13 @@ class DependencyCache extends Repository {
     }
 
     /**
-     * Generate cache key for dependency name
+     * Generate cache key for dependency name.
      *
      * @param $dependencyName
      * @return string
      */
     private static function getCacheKeyForDependencyName($dependencyName): string
     {
-        return sha1(self::DEPENDENCY_CACHE_KEY_PREFIX) . ':' . $dependencyName;
+        return sha1(self::DEPENDENCY_CACHE_KEY_PREFIX).':'.$dependencyName;
     }
 }

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -452,6 +452,20 @@ class DynamoDbStore implements LockProvider, Store
     }
 
     /**
+     * Begin executing a new dependency operation.
+     *
+     * @param  array|mixed  $dependencies
+     * @return \Illuminate\Cache\DependencyCache
+     */
+    public function dependencies($dependencies)
+    {
+        return new DependencyCache(
+            $this,
+            is_array($dependencies) ? $dependencies : func_get_args(),
+        );
+    }
+
+    /**
      * Get the UNIX timestamp for the given number of seconds.
      *
      * @param  int  $seconds

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -238,6 +238,20 @@ class FileStore implements Store, LockProvider
     }
 
     /**
+     * Begin executing a new dependency operation.
+     *
+     * @param  array|mixed  $dependencies
+     * @return \Illuminate\Cache\DependencyCache
+     */
+    public function dependencies($dependencies)
+    {
+        return new DependencyCache(
+            $this,
+            is_array($dependencies) ? $dependencies : func_get_args(),
+        );
+    }
+
+    /**
      * Retrieve an item and expiry time from the cache by key.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -225,6 +225,20 @@ class MemcachedStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Begin executing a new dependency operation.
+     *
+     * @param  array|mixed  $dependencies
+     * @return \Illuminate\Cache\DependencyCache
+     */
+    public function dependencies($dependencies)
+    {
+        return new DependencyCache(
+            $this,
+            is_array($dependencies) ? $dependencies : func_get_args(),
+        );
+    }
+
+    /**
      * Get the expiration time of the key.
      *
      * @param  int  $seconds

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -115,6 +115,20 @@ class NullStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Begin executing a new dependency operation.
+     *
+     * @param  array|mixed  $dependencies
+     * @return \Illuminate\Cache\DependencyCache
+     */
+    public function dependencies($dependencies)
+    {
+        return new DependencyCache(
+            $this,
+            is_array($dependencies) ? $dependencies : func_get_args(),
+        );
+    }
+
+    /**
      * Get the cache key prefix.
      *
      * @return string

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -236,6 +236,20 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Begin executing a new dependency operation.
+     *
+     * @param  array|mixed  $dependencies
+     * @return \Illuminate\Cache\DependencyCache
+     */
+    public function dependencies($dependencies)
+    {
+        return new DependencyCache(
+            $this,
+            is_array($dependencies) ? $dependencies : func_get_args(),
+        );
+    }
+
+    /**
      * Begin executing a new tags operation.
      *
      * @param  array|mixed  $names

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -505,6 +505,21 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Begin executing a new dependency operation.
+     *
+     * @param  array|mixed  $dependencies
+     * @return \Illuminate\Cache\DependencyCache
+     */
+    public function dependencies($dependencies)
+    {
+        return new DependencyCache(
+            $this->store,
+            is_array($dependencies) ? $dependencies : func_get_args(),
+            $this->supportsTags() ? ($this->tags ?? NULL) : NULL
+        );
+    }
+
+    /**
      * Format the key for a cache item.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -515,7 +515,7 @@ class Repository implements ArrayAccess, CacheContract
         return new DependencyCache(
             $this->store,
             is_array($dependencies) ? $dependencies : func_get_args(),
-            $this->supportsTags() ? ($this->tags ?? NULL) : NULL
+            $this->supportsTags() ? ($this->tags ?? null) : null
         );
     }
 

--- a/tests/Cache/CacheDependencyCacheTest.php
+++ b/tests/Cache/CacheDependencyCacheTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\FileStore;
+use Illuminate\Cache\NullStore;
+use Illuminate\Filesystem\Filesystem;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class CacheDependencyCacheTest extends TestCase {
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testCacheDependencySetBasicItem()
+    {
+        $store = new ArrayStore;
+        $dependencies = 'dependencies_group';
+
+        $store->dependencies($dependencies)->put('foo', 'bar', 10);
+
+        $this->assertTrue($store->dependencies($dependencies)->exists());
+    }
+
+    public function testCacheDependencyInvalidateBasicItem()
+    {
+        $store = new ArrayStore;
+        $dependencies = 'dependencies_group';
+
+        $store->dependencies($dependencies)->put('foo', 'bar', 10);
+        $store->dependencies($dependencies)->invalidate();
+
+        $this->assertNull($store->get('foo'));
+    }
+
+    public function testFileStoreDependencyInvalidateBasicItem()
+    {
+        $files = $this->mockFilesystem();
+
+        $store = new FileStore($files, __DIR__);
+        $dependencies = 'dependencies_group';
+
+        $store->dependencies($dependencies)->put('foo', 'bar', 10);
+        $store->dependencies($dependencies)->invalidate();
+
+        $this->assertNull($store->get('foo'));
+    }
+
+    public function testNullStoreDependencyInvalidateBasicItem()
+    {
+        $store = new NullStore();
+        $dependencies = 'dependencies_group';
+
+        $store->dependencies($dependencies)->put('foo', 'bar', 10);
+        $store->dependencies($dependencies)->invalidate();
+
+        $this->assertFalse($store->dependencies($dependencies)->exists());
+    }
+
+    public function testCacheDependencyInvalidateOnTaggableStore()
+    {
+        $store = new ArrayStore;
+        $dependencies = 'dependencies_group';
+        $tags = ['test_tag'];
+
+        $store->tags($tags)->dependencies($dependencies)->put('foo', 'bar', 10);
+        $store->dependencies($dependencies)->invalidate();
+
+        $this->assertNull($store->tags($tags)->get('foo'));
+    }
+
+    public function testCacheDependencyInvalidateOnTaggableStoreAndCheckIfSameKeyExistsWithoutDependency()
+    {
+        $store = new ArrayStore;
+        $dependencies = 'dependencies_group';
+        $tags = ['test_tag'];
+
+        $store->tags($tags)->dependencies($dependencies)->put('foo', 'bar', 10);
+        $store->put('foo', 'bar', 10);
+        $store->dependencies($dependencies)->invalidate();
+
+        $this->assertNull($store->tags($tags)->get('foo'));
+        $this->assertEquals('bar', $store->get('foo'));
+    }
+
+    public function testCacheDependencyInvalidateOnTaggedAndNotTaggedItem()
+    {
+        $store = new ArrayStore;
+        $dependencies = 'dependencies_group';
+        $tags = ['test_tag'];
+
+        $store->tags($tags)->dependencies($dependencies)->put('foo', 'bar', 10);
+        $store->dependencies($dependencies)->put('foo2', 'bar', 10);
+        $store->dependencies($dependencies)->invalidate();
+
+        $this->assertNull($store->tags($tags)->get('foo'));
+        $this->assertNull($store->get('foo2'));
+    }
+
+    protected function mockFilesystem()
+    {
+        return $this->createMock(Filesystem::class);
+    }
+}

--- a/tests/Cache/CacheDependencyCacheTest.php
+++ b/tests/Cache/CacheDependencyCacheTest.php
@@ -9,7 +9,8 @@ use Illuminate\Filesystem\Filesystem;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
-class CacheDependencyCacheTest extends TestCase {
+class CacheDependencyCacheTest extends TestCase
+{
     protected function tearDown(): void
     {
         m::close();


### PR DESCRIPTION
In this PR request I would like to introduce cache dependencies. The main purpose of cache dependencies is to create connection of various cache items with each other by specific identifiers. This functionality is intended to help with simple work with the invalidation of cache records that chain each other. The programmer does not have to remember all the names of the cache keys or the exact sequence of cache tags from which he wants to delete cached items. You just have to set dependencies and invalidate them. Cache dependencies are not supported in database cache store.

Cache dependencies usage example:

When storing records in the cache, you can set the dependencies like:

```
 Cache::dependencies('my_cache_dependency')->set('test_item', 1); 
Cache::tags(['taggroup_1', 'taggroup_2'])->dependencies('my_cache_dependency')->set('test_item', 1);
```

Also setting more dependencies for cached item is supported as well, you just have to set them as an array: 

```
Cache::dependencies(['my_cache_dependency', 'another_cache_dependency'])->set('test_item', 1);
```

Or you can set dependencies as key, value pair: (this is useful if you want to make cache dependency by specific identifier/s from database etc.) 

```
Cache::dependencies(['product' => [1]])->set('test_item', 1); 
Cache::dependencies(['product' => [1, 2, 3, ..etc]])->set('test_item2’, 1);
```

If you want to invalidate (remove) all the records from the cache that have set specific dependency or dependencies, you can use one of the following codes: 

```
Cache::dependencies('my_cache_dependency')->invalidate();
Cache::dependencies(['my_cache_dependency', 'another_cache_dependency'])->invalidate();
Cache::dependencies(['product' => [1]])->invalidate();
```

If you have any questions or suggestions, let me ask. Thank you!