### PR TITLE
[9.x] Don't use locks for queue job popping for PlanetScale's MySQL-compatible Vitess engine

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -261,7 +261,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         if (Str::of($databaseVersion)->contains('MariaDB')) {
             $databaseEngine = 'mariadb';
             $databaseVersion = Str::before(Str::after($databaseVersion, '5.5.5-'), '-');
-        } else if (Str::of($databaseVersion)->contains('vitess')) {
+        } elseif (Str::of($databaseVersion)->contains('vitess')) {
             $databaseEngine = 'vitess';
             $databaseVersion = Str::before($databaseVersion, '-');
         }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -261,6 +261,9 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         if (Str::of($databaseVersion)->contains('MariaDB')) {
             $databaseEngine = 'mariadb';
             $databaseVersion = Str::before(Str::after($databaseVersion, '5.5.5-'), '-');
+        } else if (Str::of($databaseVersion)->contains('vitess')) {
+            $databaseEngine = 'vitess';
+            $databaseVersion = Str::before($databaseVersion, '-');
         }
 
         if (($databaseEngine === 'mysql' && version_compare($databaseVersion, '8.0.1', '>=')) ||


### PR DESCRIPTION
PlanetScale provides great serverless MySQL-compatible database and guide on how to integrate it in Laravel (https://planetscale.com/docs/tutorials/connect-laravel-app) but under hood uses Vitess.

However it looks that Vitess doesn't support "skip" queries:
```SQLSTATE[HY000]: General error: 1105 syntax error at position 185 near 'SKIP' (SQL: select * from `jobs` where `queue` = default and ((`reserved_at` is null and `available_at` <= 1662479913) or (`reserved_at` <= 1662479823)) order by `id` asc limit 1 FOR UPDATE SKIP LOCKED)```

Following https://github.com/laravel/framework/issues/31536 I've added a check for Vitess engine/version parsing so it wouldn't use locks for popping:

```
>>> DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME)
=> "mysql"

>>> DB::connection()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION)
=> "8.0.23-vitess"
```