### PR TITLE
[9.x] Fix Stringable typehints with Enumerable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -218,22 +218,21 @@ class Str
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack
-     * @param  string|string[]|Enumerable<array-key, string>  $needles
+     * @param  string|iterable<string>  $needles
      * @param  bool  $ignoreCase
      * @return bool
      */
     public static function contains($haystack, $needles, $ignoreCase = false)
     {
-        if ($needles instanceof Enumerable) {
-            $needles = $needles->toArray();
-        }
-
         if ($ignoreCase) {
             $haystack = mb_strtolower($haystack);
-            $needles = array_map('mb_strtolower', (array) $needles);
         }
 
         foreach ((array) $needles as $needle) {
+            if ($ignoreCase) {
+                $needle = mb_strtolower($needle);
+            }
+
             if ($needle !== '' && str_contains($haystack, $needle)) {
                 return true;
             }
@@ -246,23 +245,14 @@ class Str
      * Determine if a given string contains all array values.
      *
      * @param  string  $haystack
-     * @param  string[]|Enumerable<array-key, string>  $needles
+     * @param  iterable<string>  $needles
      * @param  bool  $ignoreCase
      * @return bool
      */
     public static function containsAll($haystack, $needles, $ignoreCase = false)
     {
-        if ($needles instanceof Enumerable) {
-            $needles = $needles->toArray();
-        }
-
-        if ($ignoreCase) {
-            $haystack = mb_strtolower($haystack);
-            $needles = array_map('mb_strtolower', $needles);
-        }
-
         foreach ($needles as $needle) {
-            if (! static::contains($haystack, $needle)) {
+            if (! static::contains($haystack, $needle, $ignoreCase)) {
                 return false;
             }
         }
@@ -274,7 +264,7 @@ class Str
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|string[]|Enumerable<array-key, string>  $needles
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
@@ -341,21 +331,15 @@ class Str
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string|array  $pattern
+     * @param  string|iterable<string>  $pattern
      * @param  string  $value
      * @return bool
      */
     public static function is($pattern, $value)
     {
-        $patterns = Arr::wrap($pattern);
-
         $value = (string) $value;
 
-        if (empty($patterns)) {
-            return false;
-        }
-
-        foreach ($patterns as $pattern) {
+        foreach ((array) $pattern as $pattern) {
             $pattern = (string) $pattern;
 
             // If the given value is an exact match we can of course return true right
@@ -789,7 +773,7 @@ class Str
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  string[]|Enumerable<array-key, string>  $replace
+     * @param  array<string>|Enumerable<array-key, string>  $replace
      * @param  string  $subject
      * @return string
      */
@@ -813,9 +797,9 @@ class Str
     /**
      * Replace the given value in the given string.
      *
-     * @param  string|string[]|Enumerable<array-key, string>  $search
-     * @param  string|string[]|Enumerable<array-key, string>  $replace
-     * @param  string|string[]|Enumerable<array-key, string>  $subject
+     * @param  string|array<string>|Enumerable<array-key, string>  $search
+     * @param  string|array<string>|Enumerable<array-key, string>  $replace
+     * @param  string|array<string>|Enumerable<array-key, string>  $subject
      * @return string
      */
     public static function replace($search, $replace, $subject)
@@ -886,7 +870,7 @@ class Str
     /**
      * Remove any occurrence of the given string in the subject.
      *
-     * @param  string|string[]|Enumerable<array-key, string>  $search
+     * @param  string|array<string>|Enumerable<array-key, string>  $search
      * @param  string  $subject
      * @param  bool  $caseSensitive
      * @return string
@@ -1049,7 +1033,7 @@ class Str
      * Determine if a given string starts with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|string[]|Enumerable<array-key, string>  $needles
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)
@@ -1118,11 +1102,11 @@ class Str
     /**
      * Replace text within a portion of a string.
      *
-     * @param  string|array  $string
-     * @param  string|array  $replace
-     * @param  array|int  $offset
-     * @param  array|int|null  $length
-     * @return string|array
+     * @param  string|string[]  $string
+     * @param  string|string[]  $replace
+     * @param  int|int[]  $offset
+     * @param  int|int[]|null  $length
+     * @return string|string[]
      */
     public static function substrReplace($string, $replace, $offset = 0, $length = null)
     {
@@ -1171,7 +1155,7 @@ class Str
      * Split a string into pieces by uppercase characters.
      *
      * @param  string  $string
-     * @return array
+     * @return string[]
      */
     public static function ucsplit($string)
     {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -14,6 +14,7 @@ use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
+use Traversable;
 use voku\helper\ASCII;
 
 class Str
@@ -228,7 +229,11 @@ class Str
             $haystack = mb_strtolower($haystack);
         }
 
-        foreach ((array) $needles as $needle) {
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
+        }
+
+        foreach ($needles as $needle) {
             if ($ignoreCase) {
                 $needle = mb_strtolower($needle);
             }
@@ -269,7 +274,11 @@ class Str
      */
     public static function endsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
+        }
+
+        foreach ($needles as $needle) {
             if ((string) $needle !== '' && str_ends_with($haystack, $needle)) {
                 return true;
             }
@@ -339,7 +348,11 @@ class Str
     {
         $value = (string) $value;
 
-        foreach ((array) $pattern as $pattern) {
+        if (! is_iterable($pattern)) {
+            $pattern = [$pattern];
+        }
+
+        foreach ($pattern as $pattern) {
             $pattern = (string) $pattern;
 
             // If the given value is an exact match we can of course return true right
@@ -773,14 +786,14 @@ class Str
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  array<string>|Enumerable<array-key, string>  $replace
+     * @param  iterable<string>  $replace
      * @param  string  $subject
      * @return string
      */
     public static function replaceArray($search, $replace, $subject)
     {
-        if ($replace instanceof Enumerable) {
-            $replace = $replace->toArray();
+        if ($replace instanceof Traversable) {
+            $replace = collect($replace)->all();
         }
 
         $segments = explode($search, $subject);
@@ -797,23 +810,23 @@ class Str
     /**
      * Replace the given value in the given string.
      *
-     * @param  string|array<string>|Enumerable<array-key, string>  $search
-     * @param  string|array<string>|Enumerable<array-key, string>  $replace
-     * @param  string|array<string>|Enumerable<array-key, string>  $subject
+     * @param  string|iterable<string>  $search
+     * @param  string|iterable<string>  $replace
+     * @param  string|iterable<string>  $subject
      * @return string
      */
     public static function replace($search, $replace, $subject)
     {
-        if ($search instanceof Enumerable) {
-            $search = $search->toArray();
+        if ($search instanceof Traversable) {
+            $search = collect($search)->all();
         }
 
-        if ($replace instanceof Enumerable) {
-            $replace = $replace->toArray();
+        if ($replace instanceof Traversable) {
+            $replace = collect($replace)->all();
         }
 
-        if ($subject instanceof Enumerable) {
-            $subject = $subject->toArray();
+        if ($subject instanceof Traversable) {
+            $subject = collect($subject)->all();
         }
 
         return str_replace($search, $replace, $subject);
@@ -870,15 +883,15 @@ class Str
     /**
      * Remove any occurrence of the given string in the subject.
      *
-     * @param  string|array<string>|Enumerable<array-key, string>  $search
+     * @param  string|iterable<string>  $search
      * @param  string  $subject
      * @param  bool  $caseSensitive
      * @return string
      */
     public static function remove($search, $subject, $caseSensitive = true)
     {
-        if ($search instanceof Enumerable) {
-            $search = $search->toArray();
+        if ($search instanceof Traversable) {
+            $search = collect($search)->all();
         }
 
         $subject = $caseSensitive
@@ -1038,7 +1051,11 @@ class Str
      */
     public static function startsWith($haystack, $needles)
     {
-        foreach ((array) $needles as $needle) {
+        if (! is_iterable($needles)) {
+            $needles = [$needles];
+        }
+
+        foreach ($needles as $needle) {
             if ((string) $needle !== '' && str_starts_with($haystack, $needle)) {
                 return true;
             }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -180,7 +180,7 @@ class Stringable implements JsonSerializable
      * @param  iterable<string>  $needles
      * @return bool
      */
-    public function containsAll(array $needles)
+    public function containsAll($needles)
     {
         return Str::containsAll($this->value, $needles);
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -576,31 +576,23 @@ class Stringable implements JsonSerializable
     /**
      * Replace the given value in the given string.
      *
-     * @param  string|array<string>|Enumerable<array-key, string>  $search
-     * @param  string|array<string>|Enumerable<array-key, string>  $replace
+     * @param  string|iterable<string>  $search
+     * @param  string|iterable<string>  $replace
      * @return static
      */
     public function replace($search, $replace)
     {
-        if ($search instanceof Enumerable) {
-            $search = $search->toArray();
-        }
-
-        if ($replace instanceof Enumerable) {
-            $replace = $replace->toArray();
-        }
-
-        return new static(str_replace($search, $replace, $this->value));
+        return new static(Str::replace($search, $replace, $this->value));
     }
 
     /**
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  array<string>|Enumerable<array-key, string>  $replace
+     * @param  iterable<string>  $replace
      * @return static
      */
-    public function replaceArray($search, array $replace)
+    public function replaceArray($search, $replace)
     {
         return new static(Str::replaceArray($search, $replace, $this->value));
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -166,7 +166,7 @@ class Stringable implements JsonSerializable
     /**
      * Determine if a given string contains a given substring.
      *
-     * @param  string|string[]  $needles
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public function contains($needles)
@@ -177,7 +177,7 @@ class Stringable implements JsonSerializable
     /**
      * Determine if a given string contains all array values.
      *
-     * @param  array  $needles
+     * @param  iterable<string>  $needles
      * @return bool
      */
     public function containsAll(array $needles)
@@ -199,7 +199,7 @@ class Stringable implements JsonSerializable
     /**
      * Determine if a given string ends with a given substring.
      *
-     * @param  string|string[]  $needles
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public function endsWith($needles)
@@ -279,7 +279,7 @@ class Stringable implements JsonSerializable
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string|array  $pattern
+     * @param  string|iterable<string>  $pattern
      * @return bool
      */
     public function is($pattern)
@@ -576,8 +576,8 @@ class Stringable implements JsonSerializable
     /**
      * Replace the given value in the given string.
      *
-     * @param  string|string[]|Enumerable<array-key, string>  $search
-     * @param  string|string[]|Enumerable<array-key, string>  $replace
+     * @param  string|array<string>|Enumerable<array-key, string>  $search
+     * @param  string|array<string>|Enumerable<array-key, string>  $replace
      * @return static
      */
     public function replace($search, $replace)
@@ -597,7 +597,7 @@ class Stringable implements JsonSerializable
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  array  $replace
+     * @param  array<string>|Enumerable<array-key, string>  $replace
      * @return static
      */
     public function replaceArray($search, array $replace)
@@ -755,7 +755,7 @@ class Stringable implements JsonSerializable
     /**
      * Determine if a given string starts with a given substring.
      *
-     * @param  string|string[]  $needles
+     * @param  string|iterable<string>  $needles
      * @return bool
      */
     public function startsWith($needles)
@@ -801,9 +801,9 @@ class Stringable implements JsonSerializable
     /**
      * Replace text within a portion of a string.
      *
-     * @param  string|array  $replace
-     * @param  array|int  $offset
-     * @param  array|int|null  $length
+     * @param  string|string[]  $replace
+     * @param  int|int[]  $offset
+     * @param  int|int[]|null  $length
      * @return static
      */
     public function substrReplace($replace, $offset = 0, $length = null)
@@ -888,7 +888,7 @@ class Stringable implements JsonSerializable
     /**
      * Execute the given callback if the string contains a given substring.
      *
-     * @param  string|string[]  $needles
+     * @param  string|iterable<string>  $needles
      * @param  callable  $callback
      * @param  callable|null  $default
      * @return static
@@ -901,7 +901,7 @@ class Stringable implements JsonSerializable
     /**
      * Execute the given callback if the string contains all array values.
      *
-     * @param  array  $needles
+     * @param  iterable<string>  $needles
      * @param  callable  $callback
      * @param  callable|null  $default
      * @return static
@@ -938,7 +938,7 @@ class Stringable implements JsonSerializable
     /**
      * Execute the given callback if the string ends with a given substring.
      *
-     * @param  string|string[]  $needles
+     * @param  string|iterable<string>  $needles
      * @param  callable  $callback
      * @param  callable|null  $default
      * @return static
@@ -977,7 +977,7 @@ class Stringable implements JsonSerializable
     /**
      * Execute the given callback if the string matches a given pattern.
      *
-     * @param  string|array  $pattern
+     * @param  string|iterable<string>  $pattern
      * @param  callable  $callback
      * @param  callable|null  $default
      * @return static
@@ -1014,7 +1014,7 @@ class Stringable implements JsonSerializable
     /**
      * Execute the given callback if the string starts with a given substring.
      *
-     * @param  string|string[]  $needles
+     * @param  string|iterable<string>  $needles
      * @param  callable  $callback
      * @param  callable|null  $default
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -92,6 +92,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::startsWith('jason', 'jason'));
         $this->assertTrue(Str::startsWith('jason', ['jas']));
         $this->assertTrue(Str::startsWith('jason', ['day', 'jas']));
+        $this->assertTrue(Str::startsWith('jason', collect(['day', 'jas'])));
         $this->assertFalse(Str::startsWith('jason', 'day'));
         $this->assertFalse(Str::startsWith('jason', ['day']));
         $this->assertFalse(Str::startsWith('jason', null));
@@ -125,6 +126,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::endsWith('jason', 'jason'));
         $this->assertTrue(Str::endsWith('jason', ['on']));
         $this->assertTrue(Str::endsWith('jason', ['no', 'on']));
+        $this->assertTrue(Str::endsWith('jason', collect(['no', 'on'])));
         $this->assertFalse(Str::endsWith('jason', 'no'));
         $this->assertFalse(Str::endsWith('jason', ['no']));
         $this->assertFalse(Str::endsWith('jason', ''));
@@ -876,6 +878,7 @@ class SupportStrTest extends TestCase
             ['Taylor', ['ylo'], true, true],
             ['Taylor', ['ylo'], true, false],
             ['Taylor', ['xxx', 'ylo'], true, true],
+            ['Taylor', collect(['xxx', 'ylo']), true, true],
             ['Taylor', ['xxx', 'ylo'], true, false],
             ['Taylor', 'xxx', false],
             ['Taylor', ['xxx'], false],

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -477,6 +477,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('jason')->startsWith('jason'));
         $this->assertTrue($this->stringable('jason')->startsWith(['jas']));
         $this->assertTrue($this->stringable('jason')->startsWith(['day', 'jas']));
+        $this->assertTrue($this->stringable('jason')->startsWith(collect(['day', 'jas'])));
         $this->assertFalse($this->stringable('jason')->startsWith('day'));
         $this->assertFalse($this->stringable('jason')->startsWith(['day']));
         $this->assertFalse($this->stringable('jason')->startsWith(null));
@@ -506,6 +507,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('jason')->endsWith('jason'));
         $this->assertTrue($this->stringable('jason')->endsWith(['on']));
         $this->assertTrue($this->stringable('jason')->endsWith(['no', 'on']));
+        $this->assertTrue($this->stringable('jason')->endsWith(collect(['no', 'on'])));
         $this->assertFalse($this->stringable('jason')->endsWith('no'));
         $this->assertFalse($this->stringable('jason')->endsWith(['no']));
         $this->assertFalse($this->stringable('jason')->endsWith(''));
@@ -619,6 +621,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('taylor')->contains('taylor'));
         $this->assertTrue($this->stringable('taylor')->contains(['ylo']));
         $this->assertTrue($this->stringable('taylor')->contains(['xxx', 'ylo']));
+        $this->assertTrue($this->stringable('taylor')->contains(collect(['xxx', 'ylo'])));
         $this->assertFalse($this->stringable('taylor')->contains('xxx'));
         $this->assertFalse($this->stringable('taylor')->contains(['xxx']));
         $this->assertFalse($this->stringable('taylor')->contains(''));
@@ -627,6 +630,7 @@ class SupportStringableTest extends TestCase
     public function testContainsAll()
     {
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor', 'otwell']));
+        $this->assertTrue($this->stringable('taylor otwell')->containsAll(collect(['taylor', 'otwell'])));
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor']));
         $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx']));
     }
@@ -778,6 +782,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo?/bar/baz', (string) $this->stringable('?/?/?')->replaceArray('?', ['foo?', 'bar', 'baz']));
         $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', [1 => 'foo', 2 => 'bar']));
         $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', ['x' => 'foo', 'y' => 'bar']));
+        $this->assertSame('foo/bar', (string) $this->stringable('?/?')->replaceArray('?', collect(['x' => 'foo', 'y' => 'bar'])));
     }
 
     public function testReplaceFirst()
@@ -813,6 +818,7 @@ class SupportStringableTest extends TestCase
         $this->assertSame('oobar', (string) $this->stringable('Foobar')->remove('f', false));
 
         $this->assertSame('Fbr', (string) $this->stringable('Foobar')->remove(['o', 'a']));
+        $this->assertSame('Fbr', (string) $this->stringable('Foobar')->remove(collect(['o', 'a'])));
         $this->assertSame('Fooar', (string) $this->stringable('Foobar')->remove(['f', 'b']));
         $this->assertSame('ooar', (string) $this->stringable('Foobar')->remove(['f', 'b'], false));
         $this->assertSame('Foobar', (string) $this->stringable('Foo|bar')->remove(['f', '|']));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fixes a bug with static analysis using PHPStan that was introduced in #44012. I've taken the liberty of making the `Str` and `Stringable` helpers work with iterators where possible, and broadened the types as well.

Below is an example of the errors and how they are fixed now.
https://phpstan.org/r/a8f703b0-5d8c-470e-8b7f-2ce3adbcdf1a