### PR TITLE
[9.x] Allow key as second argument for LazyCollection#filter

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -398,7 +398,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     /**
      * Run a filter over each of the items.
      *
-     * @param  (callable(TValue): bool)|null  $callback
+     * @param  (callable(TValue, TKey): bool)|null  $callback
      * @return static
      */
     public function filter(callable $callback = null)


### PR DESCRIPTION
Same as https://github.com/laravel/framework/pull/40627 but instead for LazyCollection.

> Currently, the key is not allowed in the PHPDoc as a second parameter. This makes PHPStan complain.
