### PR TITLE
[10.x] Fix Session missing() logic.

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -265,7 +265,7 @@ class Store implements Session
      */
     public function missing($key)
     {
-        return ! $this->exists($key);
+        return ! $this->has($key);
     }
 
     /**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -499,9 +499,9 @@ class SessionStoreTest extends TestCase
         $session->put('baz', null);
         $session->put('hulk', ['one' => true]);
         $this->assertFalse($session->has('baz'));
-        $this->assertFalse($session->missing('baz'));
+        $this->assertTrue($session->missing('baz'));
         $this->assertTrue($session->missing('bogus'));
-        $this->assertFalse($session->missing(['foo', 'baz']));
+        $this->assertTrue($session->missing(['foo', 'baz']));
         $this->assertTrue($session->missing(['foo', 'baz', 'bogus']));
         $this->assertFalse($session->missing(['hulk.one']));
         $this->assertTrue($session->missing(['hulk.two']));


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In the documentation under Session > https://laravel.com/docs/master/session#determining-if-an-item-exists-in-the-session, the `missing()` method has the following description:

> To determine if an item is not present in the session, you may use the `missing` method. The `missing` method returns `true` if the item is `null` or if the item is not present:

However, it cannot be correct if the `missing()` method is the inverse of `exists()`, since `exists()` will also return `true` if the item is `null`.

The `missing()` method should be defined as the inverse of `has()` instead, since `has()` will only return `true` if the item is present AND is not `null`.

The test cases have also been fixed to match with the described behavior in the documentation.

Suggesting to merge into `master` branch due to potential breaking change.