### PR TITLE
[9.x] New `env:encrypt` and `env:decrypt` commands

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -78,7 +78,7 @@ class EnvironmentDecryptCommand extends Command
             return Command::FAILURE;
         }
 
-        $cipher = $this->option('cipher') ?: 'aes-128-cbc';
+        $cipher = $this->option('cipher') ?: 'AES-256-CBC';
 
         $key = $this->parseKey($key);
 

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -106,6 +106,10 @@ class EnvironmentDecryptCommand extends Command
         }
 
         $this->components->info('Environment successfully decrypted.');
+        $this->components->bulletList([
+            "File: {$filename}",
+        ]);
+        $this->newLine();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -23,7 +23,7 @@ class EnvironmentDecryptCommand extends Command
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be decrypted}
                     {--force : Overwrite existing environment file}
-                    {--filename : Filename to which to write the decrypted contents}';
+                    {--filename= : Filename to which to write the decrypted contents}';
 
     /**
      * The name of the console command.

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -40,7 +40,7 @@ class EnvironmentDecryptCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Decrypt the given environment file';
+    protected $description = 'Decrypt an environment file';
 
     /**
      * The filesystem instance.

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -22,8 +22,8 @@ class EnvironmentDecryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be decrypted}
-                    {--force : Overwrite existing environment file}
-                    {--filename= : Filename to which to write the decrypted contents}';
+                    {--force : Overwrite the existing environment file}
+                    {--filename= : Where to write the decrypted file contents}';
 
     /**
      * The name of the console command.
@@ -50,6 +50,12 @@ class EnvironmentDecryptCommand extends Command
      */
     protected $files;
 
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
     public function __construct(Filesystem $files)
     {
         parent::__construct();
@@ -73,12 +79,18 @@ class EnvironmentDecryptCommand extends Command
         }
 
         $cipher = $this->option('cipher') ?: 'aes-128-cbc';
+
         $key = $this->parseKey($key);
+
         $environmentFile = $this->option('env')
-                            ? base_path('.env').'.'.$this->option('env')
-                            : $this->laravel->environmentFilePath();
+                    ? base_path('.env').'.'.$this->option('env')
+                    : $this->laravel->environmentFilePath();
+
         $encryptedFile = $environmentFile.'.encrypted';
-        $filename = $this->option('filename') ? base_path($this->option('filename')) : $environmentFile;
+
+        $filename = $this->option('filename')
+                    ? base_path($this->option('filename'))
+                    : $environmentFile;
 
         if (Str::endsWith($filename, '.encrypted')) {
             $this->components->error('Invalid filename.');

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -80,6 +80,12 @@ class EnvironmentDecryptCommand extends Command
         $encryptedFile = $environmentFile.'.encrypted';
         $filename = $this->option('filename') ? base_path($this->option('filename')) : $environmentFile;
 
+        if (Str::endsWith($filename, '.encrypted')) {
+            $this->components->error('Invalid filename.');
+
+            return Command::FAILURE;
+        }
+
         if (! $this->files->exists($encryptedFile)) {
             $this->components->error('Encrypted environment file not found.');
 

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -112,9 +112,9 @@ class EnvironmentDecryptCommand extends Command
         }
 
         $this->components->info('Environment successfully decrypted.');
-        $this->components->bulletList([
-            "File: {$filename}",
-        ]);
+
+        $this->components->twoColumnDetail('Decrypted file', $filename);
+
         $this->newLine();
     }
 

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -22,7 +22,8 @@ class EnvironmentDecryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be decrypted}
-                    {--force : Overwrite existing environment file}';
+                    {--force : Overwrite existing environment file}
+                    {--filename : Filename to which to write the decrypted contents}';
 
     /**
      * The name of the console command.
@@ -77,6 +78,7 @@ class EnvironmentDecryptCommand extends Command
                             ? base_path('.env').'.'.$this->option('env')
                             : $this->laravel->environmentFilePath();
         $encryptedFile = $environmentFile.'.encrypted';
+        $filename = $this->option('filename') ? base_path($this->option('filename')) : $environmentFile;
 
         if (! $this->files->exists($encryptedFile)) {
             $this->components->error('Encrypted environment file not found.');
@@ -94,7 +96,7 @@ class EnvironmentDecryptCommand extends Command
             $encrypter = new Encrypter($key, $cipher);
 
             $this->files->put(
-                $environmentFile,
+                $filename,
                 $encrypter->decrypt($this->files->get($encryptedFile))
             );
         } catch (Exception $e) {

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -6,7 +6,6 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Env;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'env:encrypt')]
@@ -63,7 +62,8 @@ class EnvironmentEncryptCommand extends Command
     public function handle()
     {
         $cipher = $this->option('cipher') ?: 'aes-128-cbc';
-        $key = $keyPassed = $this->option('key') ?: Env::get('ENVIRONMENT_ENCRYPTION_KEY');
+        $key = $this->option('key');
+        $keyPassed = $key !== null;
         $environmentFile = $this->option('env')
                             ? base_path('.env').'.'.$this->option('env')
                             : $this->laravel->environmentFilePath();

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -67,7 +67,7 @@ class EnvironmentEncryptCommand extends Command
      */
     public function handle()
     {
-        $cipher = $this->option('cipher') ?: 'aes-128-cbc';
+        $cipher = $this->option('cipher') ?: 'AES-256-CBC';
 
         $key = $this->option('key');
 

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'env:encrypt')]
+class EnvironmentEncryptCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'env:encrypt
+                    {--key= : The encryption key}
+                    {--cipher= : The encryption cipher}
+                    {--file= : The environment file to be decrypted}
+                    {--force : Overwrite any existing files}';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'env:encrypt';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Encrypt the given environment file';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $key = $this->option('key') ?: Str::random(16);
+        $cipher = $this->option('cipher') ?: 'aes-128-cbc';
+        $environment = $this->option('file') ?: $this->laravel->environmentFilePath();
+        $encrypted = $environment.'.encrypted';
+
+        if (! $this->files->exists($environment)) {
+            return $this->components->error("The environment file {$environment} does not exist.");
+        }
+
+        if ($this->files->exists($encrypted) && ! $this->option('force')) {
+            return $this->components->error("The encrypted environment file {$encrypted} already exists.");
+        }
+
+        $encrypter = new Encrypter($key, $cipher);
+
+        $this->files->put($encrypted, $encrypter->encrypt($this->files->get($environment)));
+
+        $this->components->info("The environment file {$environment} has been encrypted using they key {$key}.");
+    }
+}

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -99,11 +99,11 @@ class EnvironmentEncryptCommand extends Command
         }
 
         $this->components->info('Environment successfully encrypted.');
-        $this->components->bulletList([
-            'Key: '.($keyPassed ? $key : 'base64:'.base64_encode($key)),
-            "Cipher: {$cipher}",
-            "File: {$encryptedFile}",
-        ]);
+
+        $this->components->twoColumnDetail('Key', ($keyPassed ? $key : 'base64:'.base64_encode($key)));
+        $this->components->twoColumnDetail('Cipher', $cipher);
+        $this->components->twoColumnDetail('Encrypted file', $encryptedFile);
+
         $this->newLine();
     }
 }

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -39,7 +39,7 @@ class EnvironmentEncryptCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Encrypt the given environment file';
+    protected $description = 'Encrypt an environment file';
 
     /**
      * The filesystem instance.

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -20,7 +20,7 @@ class EnvironmentEncryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
-                    {--force : Overwrite existing encrypted environment file}';
+                    {--force : Overwrite the existing encrypted environment file}';
 
     /**
      * The name of the console command.
@@ -47,6 +47,12 @@ class EnvironmentEncryptCommand extends Command
      */
     protected $files;
 
+    /**
+     * Create a new command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
     public function __construct(Filesystem $files)
     {
         parent::__construct();
@@ -62,11 +68,15 @@ class EnvironmentEncryptCommand extends Command
     public function handle()
     {
         $cipher = $this->option('cipher') ?: 'aes-128-cbc';
+
         $key = $this->option('key');
+
         $keyPassed = $key !== null;
+
         $environmentFile = $this->option('env')
                             ? base_path('.env').'.'.$this->option('env')
                             : $this->laravel->environmentFilePath();
+
         $encryptedFile = $environmentFile.'.encrypted';
 
         if (! $keyPassed) {

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -34,6 +34,7 @@ use Illuminate\Foundation\Console\ConsoleMakeCommand;
 use Illuminate\Foundation\Console\DocsCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
+use Illuminate\Foundation\Console\EnvironmentEncryptCommand;
 use Illuminate\Foundation\Console\EventCacheCommand;
 use Illuminate\Foundation\Console\EventClearCommand;
 use Illuminate\Foundation\Console\EventGenerateCommand;
@@ -112,6 +113,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'DbWipe' => WipeCommand::class,
         'Down' => DownCommand::class,
         'Environment' => EnvironmentCommand::class,
+        'EnvironmentEncrypt' => EnvironmentEncryptCommand::class,
         'EventCache' => EventCacheCommand::class,
         'EventClear' => EventClearCommand::class,
         'EventList' => EventListCommand::class,
@@ -505,6 +507,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerEnvironmentCommand()
     {
         $this->app->singleton(EnvironmentCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerEnvironmentEncryptCommand()
+    {
+        $this->app->singleton(EnvironmentEncryptCommand::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -34,6 +34,7 @@ use Illuminate\Foundation\Console\ConsoleMakeCommand;
 use Illuminate\Foundation\Console\DocsCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
+use Illuminate\Foundation\Console\EnvironmentDecryptCommand;
 use Illuminate\Foundation\Console\EnvironmentEncryptCommand;
 use Illuminate\Foundation\Console\EventCacheCommand;
 use Illuminate\Foundation\Console\EventClearCommand;
@@ -113,6 +114,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'DbWipe' => WipeCommand::class,
         'Down' => DownCommand::class,
         'Environment' => EnvironmentCommand::class,
+        'EnvironmentDecrypt' => EnvironmentDecryptCommand::class,
         'EnvironmentEncrypt' => EnvironmentEncryptCommand::class,
         'EventCache' => EventCacheCommand::class,
         'EventClear' => EventClearCommand::class,
@@ -507,6 +509,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerEnvironmentCommand()
     {
         $this->app->singleton(EnvironmentCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerEnvironmentDecryptCommand()
+    {
+        $this->app->singleton(EnvironmentDecryptCommand::class);
     }
 
     /**

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class EnvironmentDecryptCommandTest extends TestCase
+{
+    protected $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = m::spy(Filesystem::class);
+        $this->filesystem->shouldReceive('put')
+            ->andReturn(true);
+        File::swap($this->filesystem);
+    }
+
+    public function testItFailsWithInvalidCipherFails()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:decrypt', ['--cipher' => 'invalid', '--key' => 'abcdefghijklmnop'])
+            ->expectsOutputToContain('Unsupported cipher')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsUsingCipherWithInvalidKey()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:decrypt', ['--cipher' => 'aes-128-cbc', '--key' => 'invalid'])
+            ->expectsOutputToContain('incorrect key length')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsWhenEncyptionFileCannotBeFound()
+    {
+        $this->filesystem->shouldReceive('exists')->andReturn(true);
+
+        $this->artisan('env:decrypt', ['--key' => 'secret-key'])
+            ->expectsOutputToContain('Environment file already exists.')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsWhenEnvironmentFileExists()
+    {
+        $this->filesystem->shouldReceive('exists')->andReturn(false);
+
+        $this->artisan('env:decrypt', ['--key' => 'secret-key'])
+            ->expectsOutputToContain('Encrypted environment file not found.')
+            ->assertExitCode(1);
+    }
+
+    public function testItGeneratesTheEnvironmentFileWithGeneratedKey()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter($key = Encrypter::generateKey('aes-128-cbc'), 'aes-128-cbc'))
+                    ->encrypt('APP_NAME=Laravel')
+            );
+
+        $this->artisan('env:decrypt', ['--force' => true, '--key' => 'base64:'.base64_encode($key)])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env'), 'APP_NAME=Laravel');
+    }
+
+    public function testItGeneratesTheEnvironmentFileWithUserProvidedKey()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter('abcdefghijklmnop', 'aes-128-gcm'))
+                    ->encrypt('APP_NAME="Laravel Two"')
+            );
+
+        $this->artisan('env:decrypt', ['--cipher' => 'aes-128-gcm', '--key' => 'abcdefghijklmnop'])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env'), 'APP_NAME="Laravel Two"');
+    }
+
+    public function testItGeneratesTheEnvironmentFileWithKeyFromEnvironment()
+    {
+        putenv('LARAVEL_ENV_ENCRYPTION_KEY=ponmlkjihgfedcba');
+
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter('ponmlkjihgfedcba', 'aes-128-cbc'))
+                    ->encrypt('APP_NAME="Laravel Three"')
+            );
+
+        $this->artisan('env:decrypt')
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env'), 'APP_NAME="Laravel Three"');
+    }
+
+    public function testItGeneratesTheEnvironmentFileWhenForcing()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter('abcdefghijklmnop', 'aes-128-gcm'))
+                    ->encrypt('APP_NAME="Laravel Two"')
+            );
+
+        $this->artisan('env:decrypt', ['--force' => true, '--key' => 'abcdefghijklmnop', '--cipher' => 'aes-128-gcm'])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env'), 'APP_NAME="Laravel Two"');
+    }
+
+    public function testItDecryptsMultiLineEnvironmentCorrectly()
+    {
+        $contents = <<<'Text'
+        APP_NAME=Laravel
+        APP_ENV=local
+        APP_DEBUG=true
+        APP_URL=http://localhost
+
+        LOG_CHANNEL=stack
+        LOG_DEPRECATIONS_CHANNEL=null
+        LOG_LEVEL=debug
+
+        DB_CONNECTION=mysql
+        DB_HOST=127.0.0.1
+        DB_PORT=3306
+        DB_DATABASE=laravel
+        DB_USERNAME=root
+        DB_PASSWORD=
+        Text;
+
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter('abcdefghijklmnop', 'aes-128-gcm'))
+                    ->encrypt($contents)
+            );
+
+        $this->artisan('env:decrypt', ['--force' => true, '--key' => 'abcdefghijklmnop', '--cipher' => 'aes-128-gcm'])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env'), $contents);
+    }
+}

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -202,4 +202,27 @@ class EnvironmentDecryptCommandTest extends TestCase
         $this->filesystem->shouldHaveReceived('put')
             ->with(base_path('.env'), $contents);
     }
+
+    public function testItWritesTheEnvironmentFileCustomFilename()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter('abcdefghijklmnop'))
+                    ->encrypt('APP_NAME="Laravel Two"')
+            );
+
+        $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnop', '--filename' => '.env'])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env'), 'APP_NAME="Laravel Two"');
+    }
 }

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -225,4 +225,15 @@ class EnvironmentDecryptCommandTest extends TestCase
         $this->filesystem->shouldHaveReceived('put')
             ->with(base_path('.env'), 'APP_NAME="Laravel Two"');
     }
+
+    public function testItCannotOverwriteEncryptedFiles()
+    {
+        $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnop', '--filename' => '.env.production.encrypted'])
+            ->expectsOutputToContain('Invalid filename.')
+            ->assertExitCode(1);
+
+        $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnop', '--filename' => '.env.staging.encrypted'])
+            ->expectsOutputToContain('Invalid filename.')
+            ->assertExitCode(1);
+    }
 }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\File;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class EnvironmentEncryptCommandTest extends TestCase
+{
+    protected $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = m::spy(Filesystem::class);
+        $this->filesystem->shouldReceive('get')
+            ->andReturn(true)
+            ->shouldReceive('put')
+            ->andReturn('APP_NAME=Laravel');
+        File::swap($this->filesystem);
+    }
+
+    public function testItFailsWithInvalidCipherFails()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:encrypt', ['--cipher' => 'invalid'])
+            ->expectsOutputToContain('Unsupported cipher')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsUsingCipherWithInvalidKey()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:encrypt', ['--cipher' => 'aes-128-cbc', '--key' => 'invalid'])
+            ->expectsOutputToContain('incorrect key length')
+            ->assertExitCode(1);
+    }
+
+    public function testItGeneratesTheCorrectFileWhenUsingEnvironment()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:encrypt', ['--env' => 'production'])
+            ->expectsOutputToContain('.env.production.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env.production.encrypted'), m::any());
+    }
+
+    public function testItGeneratesTheCorrectFileWhenNotUsingEnvironment()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get');
+
+        $this->artisan('env:encrypt')
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env.encrypted'), m::any());
+    }
+
+    public function testItFailsWhenEnvironmentFileCannotBeFound()
+    {
+        $this->filesystem->shouldReceive('exists')->andReturn(false);
+
+        $this->artisan('env:encrypt')
+            ->expectsOutputToContain('Environment file not found.')
+            ->assertExitCode(1);
+    }
+
+    public function testItFailsWhenEncyptionFileExists()
+    {
+        $this->filesystem->shouldReceive('exists')->andReturn(true);
+
+        $this->artisan('env:encrypt')
+            ->expectsOutputToContain('Encrypted environment file already exists.')
+            ->assertExitCode(1);
+    }
+
+    public function testItGeneratesTheEncryptionFileWhenForcing()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(true);
+
+        $this->artisan('env:encrypt', ['--force' => true])
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env.encrypted'), m::any());
+    }
+}


### PR DESCRIPTION
This PR proposes two new Artisan commands; `env:encrypt` and `env:decrypt` which provide a mechanism for encrypting and decrypting .env files.

Inspiration for this was taken from Rails who have had similar functionality since Rails 5.1 released in 2017.

The biggest benefit of this is that the encrypted environment files can be committed to version control which opens up a number of possibilities.

1. Production and staging environment variables can be committed to version control and automatically decrypted as part of a deployment. This prevents the need to remember to add/update environment variables prior to/during a deployment.
2. Local environments can be shared between development teams. If a new environment variable is added as part of a pull request, there is no longer a need to communicate this information. Instead, simply ensure the environment is decrypted after pulling down the latest updates.
3. CI environments can be updated without manual intervention.
4. Environment files for all environments can be encrypted with different keys meaning all can reside in the project, but the relevant keys only need to be shared with those that require it.
5. The environment can become a living, breathing part of an application.

Real world examples where these commands can be used include ecosystem tools such as Forge, Vapor and Envoyer.

With Forge and Envoyer, it would be possible to decrypt the environment as part of the deployment script.
With Vapor, this would help solve an issue with the limit on the number of environment variables allowed by Lambda and the cost associated with decrypting secrets from KMS.

Decryption can be carried out either by passing a `--key` option to the command or by setting the `LARAVEL_ENV_ENCRYPTION_KEY` environment variable. The affordance of the environment variable means it would be use in conjunction with secrets in a service like GitHub Actions.
_____

### `env:encrypt`

Running `php artisan env:encrypt` will look for a `.env` file at the root of the project, grab the contents of the file, encrypt it with a new key and save it as `.env.encrypted`.

The decryption key is displayed in the output of the command along with the cipher used and the path of the encrypted file.

<img width="631" alt="image" src="https://user-images.githubusercontent.com/3438564/189882291-035f53e4-1b3d-4f5e-beee-e93e7980fe5e.png">

You may utilise your own key by using the `--key` option.

```bash
php artisan env:encrypt --key=h9kAPUmxdZ8ZbwT3
```

Similarly, you may specify any of the ciphers supported by Laravel’s [[Encrypter](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Encryption/Encrypter.php#L32-L37)](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Encryption/Encrypter.php#L32-L37) class using the `--cipher` option. If no key is passed when using this option, the command will generate a key of the correct length for the cipher.

```bash
php artisan env:encrypt --cipher=aes-256-cbc
```

You may also utilise the `--env` option to tell the command which environment you wish to encrypt.

```bash
php artisan env:encrypt --env=production
```

 The above command will look for an environment file called `.env.production`. If the file exists, the contents will be encrypted and stored in a file called `.env.production.encrypted`.

If an encrypted file already exists at the location where the command is attempting to store it, it will not be overwritten by default. Of course, you may choose to do so using the `--force` option.

```bash
php artisan env:encrypt --force
```
_____

### `env:decrypt`

The `env:decrypt` command decrypts the contents of the encrypted environment file and writes the output to the `.env` of the chosen environment.

A decryption key is required to run this command which can be obtained from one of two places.

1. Passing the `--key` options
2. The command will look for the presence of an environment variable called `LARAVEL_ENV_ENCRYPTION_KEY`

The `--key` option takes precedence over the environment variable. The purpose of the environment variable is to make the decryption process simple and secret during deployment/CI.

```bash
php artisan env:decrypt --key=h9kAPUmxdZ8ZbwT3
```

Like the encrypt command, you may also pass the cipher used to encrypt the file.

```bash
php artisan env:decrypt --key=h9kAPUmxdZ8ZbwT3 --cipher=aes-128-gcm
```

In the decrypt command, passing the `--env` option will result in the command looking for a file called `.env.[environment].encrypted` to decrypt which, if found and decrypted successfully, will be written to `.env.[environment]`. This format is already supported by Laravel.

<img width="448" alt="Screenshot 2022-09-06 at 15 03 26" src="https://user-images.githubusercontent.com/3438564/188880799-293a69b0-6063-4fe4-9c04-e375eb8b75a0.png">

If a file already exists where the command attempts to write the file to, it will not be overwritten. This behaviour can be forced with the `--force` option.

Sometimes, for example if you were running the command as part of a forge deployment, you may wish to decrypt the contents of file to a different filename. You may do this with the `--filename` option.

```bash
php artisan env:decrypt --key=h9kAPUmxdZ8ZbwT3 --env=production --filename=.env"
```

Running the command above would find the encrypted file `.env.production.encrypted` and write the decrypted contents to `.env`.