### PR TITLE
[9.x] Add Vite asset path generation method

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -219,7 +219,7 @@ class Vite implements Htmlable
 
                     $tags->push($this->makeTagForChunk(
                         $partialManifest->keys()->first(),
-                        asset("{$buildDirectory}/{$css}"),
+                        $this->assetPath("{$buildDirectory}/{$css}"),
                         $partialManifest->first(),
                         $manifest
                     ));
@@ -228,7 +228,7 @@ class Vite implements Htmlable
 
             $tags->push($this->makeTagForChunk(
                 $entrypoint,
-                asset("{$buildDirectory}/{$chunk['file']}"),
+                $this->assetPath("{$buildDirectory}/{$chunk['file']}"),
                 $chunk,
                 $manifest
             ));
@@ -238,7 +238,7 @@ class Vite implements Htmlable
 
                 $tags->push($this->makeTagForChunk(
                     $partialManifest->keys()->first(),
-                    asset("{$buildDirectory}/{$css}"),
+                    $this->assetPath("{$buildDirectory}/{$css}"),
                     $partialManifest->first(),
                     $manifest
                 ));
@@ -487,7 +487,19 @@ class Vite implements Htmlable
 
         $chunk = $this->chunk($this->manifest($buildDirectory), $asset);
 
-        return asset($buildDirectory.'/'.$chunk['file']);
+        return $this->assetPath($buildDirectory.'/'.$chunk['file']);
+    }
+
+    /**
+     * Generate an asset path for the application.
+     *
+     * @param  string  $path
+     * @param  bool|null  $secure
+     * @return string
+     */
+    protected function assetPath($path, $secure = null)
+    {
+        return asset($path, $secure);
     }
 
     /**


### PR DESCRIPTION
This PR adds a method to the `Vite` class so the the way the asset URLs are generated can be separated from the main class.

This would make it so Teams/Projects that have their own way of loading assets can extend the functionality of the `Vite` class and add their own method of loading assets. 

This would ease the path of migrations from Laravel-Mix to Vite for those teams.

The `assetPath()` method has the same signature as the global `asset()` helper