### PR TITLE
[9.x] Adds interval casting

### DIFF
--- a/src/Illuminate/Support/CarbonInterval.php
+++ b/src/Illuminate/Support/CarbonInterval.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Carbon\CarbonInterval as BaseCarbonInterval;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Traits\Conditionable;
+
+class CarbonInterval extends BaseCarbonInterval implements Arrayable
+{
+    use Conditionable;
+
+    /**
+     * @inheritDoc
+     */
+    public function toArray()
+    {
+        return $this->__toString();
+    }
+}


### PR DESCRIPTION
## What?

Allows a model cast to support datetime intervals through the [`CarbonInterval`](https://carbon.nesbot.com/docs/#api-interval).

```php
class Subscription extends Model
{
   protected $casts = ['period' => 'interval'];
}

$subscription = Subscription::create(['period' => '1 month 1 hour']);

DB::table('subscriptions')->value('period'); // "P1MT1H"
```

A Carbon Interval can be used to manipulate Carbon instances and calculate periods of time, and the cast allows to safely store that interval. I usually use this for subscriptions, to extend a subscription cycle.

## The standard way

The cast is handled by `Illuminate\Support\CarbonInterval` instead of the base class because it needs to be `Arrayable` and override the `toArray()` to return a string on array serialization (overridable by the user).

The cast will create an interval from a human period like `1 month` or `yesterday, next friday`, spec periods like `P1MT1H`, and `DateInterval`, `CarbonInterval` or `Closure` instances. This is all handled internally by `CarbonInterval`.

The cast, as you expect, will be persisted using the ISO 8601 spec (format with designators). Since is a string, it can be safely stored as an string column.

## Caveats

- The object is not immutable, as PHP doesn't have an immutable version for intervals.
- Builder methods helpers no included, so nothing like `$builder->whereInterval('period', $interval)`.  Comparisons in SQL are tricky for intervals and are out of the scope for this PR.