### PR TITLE
[9.x] Do not trim the request URL in testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -559,7 +559,7 @@ trait MakesHttpRequests
             $uri = substr($uri, 1);
         }
 
-        return trim(url($uri), '/');
+        return url($uri);
     }
 
     /**


### PR DESCRIPTION
URLs with and without a trailing slash are technically different routes according to the browser, so we should not be auto trimming the trailing slash here.

I've recently been trying to setup a middleware to redirect all non-root URLs that end in a trailing slash to be redirected to their non-trailing-slash counterpart. While trying to setup feature test for this behavior, I discovered this was impossible due to the fact all test URLs are having their trailing slashes trimmed automatically.

Looking back through the history of this line of code, it appears the `trim()` has been there since the beginning, so it's difficult to discern the reasoning behind having the `trim()`.

I'm not sure how other people feel if this is a breaking change or not, but it's currently targeting 9.x, so let me know if that's not correct.