### PR TITLE
[10.x] Create `EmptyArgument` class

### DIFF
--- a/src/Illuminate/Support/EmptyArgument.php
+++ b/src/Illuminate/Support/EmptyArgument.php
@@ -2,4 +2,6 @@
 
 namespace Illuminate\Support;
 
-class EmptyArgument{}
+class EmptyArgument
+{
+}

--- a/src/Illuminate/Support/EmptyArgument.php
+++ b/src/Illuminate/Support/EmptyArgument.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Illuminate\Support;
+
+class EmptyArgument{}

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\EmptyArgument;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
@@ -48,13 +49,13 @@ class TestView
      * @param  mixed  $value
      * @return $this
      */
-    public function assertViewHas($key, $value = null)
+    public function assertViewHas($key, $value = new EmptyArgument)
     {
         if (is_array($key)) {
             return $this->assertViewHasAll($key);
         }
 
-        if (is_null($value)) {
+        if ($value instanceof EmptyArgument) {
             PHPUnit::assertTrue(Arr::has($this->view->gatherData(), $key));
         } elseif ($value instanceof Closure) {
             PHPUnit::assertTrue($value(Arr::get($this->view->gatherData(), $key)));


### PR DESCRIPTION
`null` can have different meanings when used in different contexts. in a lot of places in the framework, it is used to mean "ignore this parameter when no argument is passed, and execute different behavior than if a value had been passed". for the most part this is fine, but it limits us slightly by not be able to check for a desired `null` value. this new empty marker class allows us to specifically designate we wish to treat the method call as if the argument was not passed, without conflating the use of `null`.

this **must** go to `master` because it requires a new feature of PHP 8.1 (https://www.php.net/manual/en/functions.arguments.php)

credit to @jasonmccreary for sparking this idea in #43923

there are a lot of places in the framework this would be useful, but I limited this PR to just the one usage change. if this gets merged, I'd PR some more of those changes in.