### PR TITLE
[9.x] Added return type declaration for stubs

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('{{ table }}', function (Blueprint $table) {
             $table->id();
@@ -24,7 +24,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('{{ table }}');
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         //
     }
@@ -21,7 +21,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         //
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
             //
@@ -23,7 +23,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
             //

--- a/src/Illuminate/Foundation/Console/stubs/channel.stub
+++ b/src/Illuminate/Foundation/Console/stubs/channel.stub
@@ -22,7 +22,7 @@ class {{ class }}
      * @param  \{{ namespacedUserModel }}  $user
      * @return array|bool
      */
-    public function join({{ userModel }} $user)
+    public function join({{ userModel }} $user): array|bool
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -25,7 +25,7 @@ class {{ class }} extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         return 0;
     }

--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -29,7 +29,7 @@ class {{ class }}
      *
      * @return \Illuminate\Broadcasting\Channel|array
      */
-    public function broadcastOn()
+    public function broadcastOn(): \Illuminate\Broadcasting\Channel|array
     {
         return new PrivateChannel('channel-name');
     }

--- a/src/Illuminate/Foundation/Console/stubs/exception-render-report.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-render-report.stub
@@ -22,7 +22,7 @@ class {{ class }} extends Exception
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function render($request)
+    public function render($request): \Illuminate\Http\Response
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/exception-render.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-render.stub
@@ -12,7 +12,7 @@ class {{ class }} extends Exception
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function render($request)
+    public function render($request): \Illuminate\Http\Response
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/exception-report.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-report.stub
@@ -11,7 +11,7 @@ class {{ class }} extends Exception
      *
      * @return bool|null
      */
-    public function report()
+    public function report(): bool|null
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/job.queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.queued.stub
@@ -28,7 +28,7 @@ class {{ class }} implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/job.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.stub
@@ -23,7 +23,7 @@ class {{ class }}
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/listener-duck.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-duck.stub
@@ -23,7 +23,7 @@ class {{ class }}
      * @param  object  $event
      * @return void
      */
-    public function handle($event)
+    public function handle($event): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued-duck.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued-duck.stub
@@ -25,7 +25,7 @@ class {{ class }} implements ShouldQueue
      * @param  object  $event
      * @return void
      */
-    public function handle($event)
+    public function handle($event): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
@@ -26,7 +26,7 @@ class {{ class }} implements ShouldQueue
      * @param  {{ eventNamespace }}  $event
      * @return void
      */
-    public function handle({{ event }} $event)
+    public function handle({{ event }} $event): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/listener.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.stub
@@ -24,7 +24,7 @@ class {{ class }}
      * @param  \{{ eventNamespace }}  $event
      * @return void
      */
-    public function handle({{ event }} $event)
+    public function handle({{ event }} $event): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/mail.stub
@@ -26,7 +26,7 @@ class {{ class }} extends Mailable
      *
      * @return $this
      */
-    public function build()
+    public function build(): static
     {
         return $this->view('view.name');
     }

--- a/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
@@ -26,7 +26,7 @@ class {{ class }} extends Mailable
      *
      * @return $this
      */
-    public function build()
+    public function build(): static
     {
         return $this->markdown('{{ view }}');
     }

--- a/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
@@ -27,7 +27,7 @@ class {{ class }} extends Notification
      * @param  mixed  $notifiable
      * @return array
      */
-    public function via($notifiable)
+    public function via($notifiable): array
     {
         return ['mail'];
     }
@@ -38,7 +38,7 @@ class {{ class }} extends Notification
      * @param  mixed  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
-    public function toMail($notifiable)
+    public function toMail($notifiable): \Illuminate\Notifications\Messages\MailMessage
     {
         return (new MailMessage)->markdown('{{ view }}');
     }
@@ -49,7 +49,7 @@ class {{ class }} extends Notification
      * @param  mixed  $notifiable
      * @return array
      */
-    public function toArray($notifiable)
+    public function toArray($notifiable): array
     {
         return [
             //

--- a/src/Illuminate/Foundation/Console/stubs/notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.stub
@@ -27,7 +27,7 @@ class {{ class }} extends Notification
      * @param  mixed  $notifiable
      * @return array
      */
-    public function via($notifiable)
+    public function via($notifiable): array
     {
         return ['mail'];
     }
@@ -38,7 +38,7 @@ class {{ class }} extends Notification
      * @param  mixed  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
-    public function toMail($notifiable)
+    public function toMail($notifiable): \Illuminate\Notifications\Messages\MailMessage
     {
         return (new MailMessage)
                     ->line('The introduction to the notification.')
@@ -52,7 +52,7 @@ class {{ class }} extends Notification
      * @param  mixed  $notifiable
      * @return array
      */
-    public function toArray($notifiable)
+    public function toArray($notifiable): array
     {
         return [
             //

--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -12,7 +12,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function created({{ model }} ${{ modelVariable }})
+    public function created({{ model }} ${{ modelVariable }}): void
     {
         //
     }
@@ -23,7 +23,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function updated({{ model }} ${{ modelVariable }})
+    public function updated({{ model }} ${{ modelVariable }}): void
     {
         //
     }
@@ -34,7 +34,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function deleted({{ model }} ${{ modelVariable }})
+    public function deleted({{ model }} ${{ modelVariable }}): void
     {
         //
     }
@@ -45,7 +45,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function restored({{ model }} ${{ modelVariable }})
+    public function restored({{ model }} ${{ modelVariable }}): void
     {
         //
     }
@@ -56,7 +56,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return void
      */
-    public function forceDeleted({{ model }} ${{ modelVariable }})
+    public function forceDeleted({{ model }} ${{ modelVariable }}): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -16,7 +16,7 @@ class {{ class }}
      * @param  \{{ namespacedUserModel }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function viewAny({{ user }} $user)
+    public function viewAny({{ user }} $user): \Illuminate\Auth\Access\Response|bool
     {
         //
     }
@@ -28,7 +28,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function view({{ user }} $user, {{ model }} ${{ modelVariable }})
+    public function view({{ user }} $user, {{ model }} ${{ modelVariable }}): \Illuminate\Auth\Access\Response|bool
     {
         //
     }
@@ -39,7 +39,7 @@ class {{ class }}
      * @param  \{{ namespacedUserModel }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function create({{ user }} $user)
+    public function create({{ user }} $user): \Illuminate\Auth\Access\Response|bool
     {
         //
     }
@@ -51,7 +51,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function update({{ user }} $user, {{ model }} ${{ modelVariable }})
+    public function update({{ user }} $user, {{ model }} ${{ modelVariable }}): \Illuminate\Auth\Access\Response|bool
     {
         //
     }
@@ -63,7 +63,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function delete({{ user }} $user, {{ model }} ${{ modelVariable }})
+    public function delete({{ user }} $user, {{ model }} ${{ modelVariable }}): \Illuminate\Auth\Access\Response|bool
     {
         //
     }
@@ -75,7 +75,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function restore({{ user }} $user, {{ model }} ${{ modelVariable }})
+    public function restore({{ user }} $user, {{ model }} ${{ modelVariable }}): \Illuminate\Auth\Access\Response|bool
     {
         //
     }
@@ -87,7 +87,7 @@ class {{ class }}
      * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }})
+    public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }}): \Illuminate\Auth\Access\Response|bool
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/provider.stub
+++ b/src/Illuminate/Foundation/Console/stubs/provider.stub
@@ -11,7 +11,7 @@ class {{ class }} extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         //
     }
@@ -21,7 +21,7 @@ class {{ class }} extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -11,7 +11,7 @@ class {{ class }} extends FormRequest
      *
      * @return bool
      */
-    public function authorize()
+    public function authorize(): bool
     {
         return false;
     }
@@ -21,7 +21,7 @@ class {{ class }} extends FormRequest
      *
      * @return array<string, mixed>
      */
-    public function rules()
+    public function rules(): array
     {
         return [
             //

--- a/src/Illuminate/Foundation/Console/stubs/resource-collection.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource-collection.stub
@@ -12,7 +12,7 @@ class {{ class }} extends ResourceCollection
      * @param  \Illuminate\Http\Request  $request
      * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
      */
-    public function toArray($request)
+    public function toArray($request): array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
     {
         return parent::toArray($request);
     }

--- a/src/Illuminate/Foundation/Console/stubs/resource.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource.stub
@@ -12,7 +12,7 @@ class {{ class }} extends JsonResource
      * @param  \Illuminate\Http\Request  $request
      * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
      */
-    public function toArray($request)
+    public function toArray($request): array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
     {
         return parent::toArray($request);
     }

--- a/src/Illuminate/Foundation/Console/stubs/rule.invokable.implicit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.invokable.implicit.stub
@@ -21,7 +21,7 @@ class {{ class }} implements InvokableRule
      * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      * @return void
      */
-    public function __invoke($attribute, $value, $fail)
+    public function __invoke($attribute, $value, $fail): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/rule.invokable.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.invokable.stub
@@ -14,7 +14,7 @@ class {{ class }} implements InvokableRule
      * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      * @return void
      */
-    public function __invoke($attribute, $value, $fail)
+    public function __invoke($attribute, $value, $fail): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -23,7 +23,7 @@ class {{ class }} implements {{ ruleType }}
      * @param  mixed  $value
      * @return bool
      */
-    public function passes($attribute, $value)
+    public function passes($attribute, $value): bool
     {
         //
     }
@@ -33,7 +33,7 @@ class {{ class }} implements {{ ruleType }}
      *
      * @return string
      */
-    public function message()
+    public function message(): string
     {
         return 'The validation error message.';
     }

--- a/src/Illuminate/Foundation/Console/stubs/scope.stub
+++ b/src/Illuminate/Foundation/Console/stubs/scope.stub
@@ -15,7 +15,7 @@ class {{ class }} implements Scope
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void
      */
-    public function apply(Builder $builder, Model $model)
+    public function apply(Builder $builder, Model $model): void
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -13,7 +13,7 @@ class {{ class }} extends TestCase
      *
      * @return void
      */
-    public function test_example()
+    public function test_example(): void
     {
         $response = $this->get('/');
 

--- a/src/Illuminate/Foundation/Console/stubs/test.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.unit.stub
@@ -11,7 +11,7 @@ class {{ class }} extends TestCase
      *
      * @return void
      */
-    public function test_example()
+    public function test_example(): void
     {
         $this->assertTrue(true);
     }

--- a/src/Illuminate/Foundation/Console/stubs/view-component.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view-component.stub
@@ -21,7 +21,7 @@ class {{ class }} extends Component
      *
      * @return \Illuminate\Contracts\View\View|\Closure|string
      */
-    public function render()
+    public function render(): \Illuminate\Contracts\View\View|\Closure|string
     {
         return {{ view }};
     }

--- a/src/Illuminate/Foundation/stubs/facade.stub
+++ b/src/Illuminate/Foundation/stubs/facade.stub
@@ -14,7 +14,7 @@ class DummyClass extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'DummyTarget';
     }

--- a/src/Illuminate/Routing/Console/stubs/middleware.stub
+++ b/src/Illuminate/Routing/Console/stubs/middleware.stub
@@ -14,7 +14,7 @@ class {{ class }}
      * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
     {
         return $next($request);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Added return type declaration. Each time after class creation from artisan command requires manually add return type for each method.