### PR TITLE
[9.x] Avoid matching 'use' in custom Stub templates

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -355,7 +355,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function sortImports($stub)
     {
-        if (preg_match('/(?P<imports>(?:use [^;{]+;$\n?)+)/m', $stub, $match)) {
+        if (preg_match('/(?P<imports>(?:^use [^;{]+;$\n?)+)/m', $stub, $match)) {
             $imports = explode("\n", trim($match['imports']));
 
             sort($imports);


### PR DESCRIPTION
When using custom stubs the word 'use' is also matched outside of the import statement. With this change only the lines starting with use are taken into consideration.

Use Case:
We added an Apache License Header to the module stub and the word 'use' (L4) is used inside the license text.
```
<?php
/**
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at:
 *
 * http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

namespace {{ namespace }};
[...]
```

output of the $imports variable:
```
array:13 [
  0 => "use this file except in compliance with the License."
  1 => " * You may obtain a copy of the License at:"
  2 => " *"
  3 => " * http://www.apache.org/licenses/LICENSE-2.0"
  4 => " *"
  5 => " * Unless required by applicable law or agreed to in writing, software"
  6 => " * distributed under the License is distributed on an "AS IS" BASIS,"
  7 => " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied."
  8 => " * See the License for the specific language governing permissions and"
  9 => " * limitations under the License."
  10 => " */"
  11 => ""
  12 => "namespace App;"
]
```
