### PR TITLE
[10.x] Do not trim the request URL

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -566,7 +566,7 @@ trait MakesHttpRequests
             $uri = substr($uri, 1);
         }
 
-        return trim(url($uri), '/');
+        return url($uri);
     }
 
     /**


### PR DESCRIPTION
this is a resubmission of #44041 to the master branch.

URLs with and without a trailing slash are technically different routes according to the browser, so we should not be auto trimming the trailing slash here.

the `url()` function also does its own trimming, so this commit doesn't actually solve the problem, but it does get rid of the duplicate trimming. changing `url()` has wider reaching effects, so will have to look closer into that change.
