### PR TITLE
Prevent workflows from running twice

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -1,6 +1,10 @@
 name: databases
 
-on: [push, pull_request]
+on:
+  push:
+    - master
+    - '*.x'
+  pull_request:
 
 jobs:
   mysql_57:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,6 +2,8 @@ name: static analysis
 
 on:
   push:
+    - master
+    - '*.x'
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: tests
 
 on:
   push:
+    - master
+    - '*.x'
   pull_request:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
### Explanation

When creating a PR from a branch within the same repo (i.e. not a fork), the current run-test workflows get triggered twice - for both push and pull_request:

![Screenshot 2022-09-08 at 18 08 50](https://user-images.githubusercontent.com/15707543/189171800-6496cab2-535b-4334-9e3e-9b30571abaab.png)

This PR adds constrains so that the workflow only runs once.
(Push Event will only be triggered on the `master` and `*.x` branch)

### Sources

Idea and Changes are taken from https://github.com/spatie/package-skeleton-laravel/pull/119
Thanks and Credits to @jessarcher 

Branch names can use patterns for Pull Requests:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

### Side note
I think it would be good to change the default branch to main per
https://github.com/github/renaming#new-repositories-use-main-as-the-default-branch-name