### PR TITLE
[9.x] Adds new nested validation rules syntax

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -47,12 +47,35 @@ class ValidationRuleParser
     {
         $this->implicitAttributes = [];
 
+        $rules = $this->explodeNestedAssociativeArrays($rules);
         $rules = $this->explodeRules($rules);
 
         return (object) [
             'rules' => $rules,
             'implicitAttributes' => $this->implicitAttributes,
         ];
+    }
+
+    /**
+     * Expands nested associative arrays into dot notation rules.
+     *
+     * @param  array  $rules
+     * @return array
+     */
+    public function explodeNestedAssociativeArrays($rules)
+    {
+        $exploded = [];
+
+        foreach ($rules as $key => $rule) {
+            if (is_array($rule) && Arr::isAssoc($rule)) {
+                $nestedRules = Arr::prependKeysWith($this->explodeNestedAssociativeArrays($rule), $key . '.');
+                $exploded = array_merge($exploded, [$key => 'array'], $nestedRules);
+            } else {
+                $exploded[$key] = $rule;
+            }
+        }
+
+        return $exploded;
     }
 
     /**

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -68,7 +68,7 @@ class ValidationRuleParser
 
         foreach ($rules as $key => $rule) {
             if (is_array($rule) && Arr::isAssoc($rule)) {
-                $nestedRules = Arr::prependKeysWith($this->explodeNestedAssociativeArrays($rule), $key . '.');
+                $nestedRules = Arr::prependKeysWith($this->explodeNestedAssociativeArrays($rule), $key.'.');
                 $exploded = array_merge($exploded, [$key => 'array'], $nestedRules);
             } else {
                 $exploded[$key] = $rule;

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -162,8 +162,8 @@ class ValidationRuleParserTest extends TestCase
                 'items' => [
                     '*' => [
                         'id' => 'numeric',
-                        'description' => 'string'
-                    ]
+                        'description' => 'string',
+                    ],
                 ],
             ],
         ];
@@ -182,8 +182,8 @@ class ValidationRuleParserTest extends TestCase
                 'items' => [
                     ['id' => 1, 'description' => 'foo'],
                     ['id' => 2, 'description' => 'bar'],
-                ]
-            ]
+                ],
+            ],
         ]));
 
         $exploded = $parser->explode($rules);

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -143,6 +143,67 @@ class ValidationRuleParserTest extends TestCase
         $this->assertSame('regex:/^(foo', $exploded->rules['items.0.type'][1]);
         $this->assertSame('bar)$/i', $exploded->rules['items.0.type'][2]);
     }
+    public function testExplodeAssociativeArraysOfRules()
+    {
+        $rules = [
+            'invoice' => [
+                'state' => ['string', Rule::in(['foo', 'bar'])],
+
+                'user' => [
+                    'name' => 'string',
+                    'email' => ['email'],
+                ],
+
+                'coupons' => [
+                    '*' => ['string'],
+                ],
+
+                'items' => [
+                    '*' => [
+                        'id' => 'numeric',
+                        'description' => 'string'
+                    ]
+                ],
+            ],
+        ];
+
+        $parser = (new ValidationRuleParser([
+            'invoice' => [
+                'state' => 'foo',
+
+                'user' => [
+                    'name' => 'Taylor Otwell',
+                    'email' => '',
+                ],
+
+                'coupons' => ['foo', 'bar'],
+
+                'items' => [
+                    ['id' => 1, 'description' => 'foo'],
+                    ['id' => 2, 'description' => 'bar'],
+                ]
+            ]
+        ]));
+
+        $exploded = $parser->explode($rules);
+
+        $this->assertSame(['array'], $exploded->rules['invoice']);
+        $this->assertSame(['string', 'in:"foo","bar"'], $exploded->rules['invoice.state']);
+
+        $this->assertSame(['string'], $exploded->rules['invoice.user.name']);
+        $this->assertSame(['email'], $exploded->rules['invoice.user.email']);
+
+        $this->assertSame(['string'], $exploded->rules['invoice.coupons.0']);
+        $this->assertSame(['string'], $exploded->rules['invoice.coupons.1']);
+
+        $this->assertSame(['array'], $exploded->rules['invoice.items.0']);
+        $this->assertSame(['numeric'], $exploded->rules['invoice.items.0.id']);
+        $this->assertSame(['string'], $exploded->rules['invoice.items.0.description']);
+
+        $this->assertSame(['array'], $exploded->rules['invoice.items.1']);
+        $this->assertSame(['numeric'], $exploded->rules['invoice.items.1.id']);
+        $this->assertSame(['string'], $exploded->rules['invoice.items.1.description']);
+    }
 
     public function testExplodeGeneratesNestedRules()
     {


### PR DESCRIPTION
Currently, Laravel validation rules can be defined with one of the following types:

- A string (Ex: `"array"`)
- A string of multiple rules, joined by pipes (Ex: `"required|array"`)
- A closure (Ex: `function($attribute, $value, $fail) { $fail('error message'); }`)
- A rule object (Ex: new `CustomRule()`)
- An **indexed array** of the types mentioned above. (Ex: `['required', Rule::in(['foo','bar'])]`)
  - Note: Associative arrays can also be used, but the keys are ignored and there is no benefit in using them.

The definition of nested array rules is achieved by using the format `'array.key' => 'rule'` or `'array.*.key' => 'rule'`.

Defining large or deeply nested array rules is cumbersome and verbose, looking like the following:

```php
[
    'authentication'=> 'array',
    'authentication.type' => 'string|in:password,oauth',

    // Simple dictionary
    'authentication.oauth' => 'array',
    'authentication.oauth.client_id' => 'string',
    'authentication.oauth.client_secret' => 'string',

    // Array of strings
    'authentication.secrets' => 'array',
    'authentication.secrets.*' => 'string',

    // Array of dictionaries
    'authentication.certificates' => 'array',
    'authentication.certificates.*.value' => 'string',
];
```

As the number of rules increases, the readability of the code is heavily impacted.

One could argue that complex rules should be moved to a custom rule, but this is not always possible or desired. Custom rules dont exclude unvalidated array keys as currently implemented in Laravel 9 by the method `validated`.

Other option would be to prepend the rules using `Arr::prependKeysWith`. This is a simple option, but there is room for improvement.

This PR adds a new type of validation rule, an **associative arrays of rules**, which makes easier to define nested rules.

To generate the authentication rules described above, people could use a more readable format:

```php
// This rules definition:
$rules = [
    'authentication' => [
        'type' => 'string|in:password,oauth',
        'test' => ['string', Rule::in(['password', 'oauth'])],

        'oauth' => [
            'client_id' => 'string',
            'client_secret' => 'string',
        ],

        'secrets' => [
            '*' => 'string',
        ],

        'certificates' => [
            '*' => [
                'uuid' => 'string',
                'value' => 'string'
            ]
        ],
    ],
];

// Is internally converted into this:
[
    "authentication" => "array",
    "authentication.type" => "string|in:password,oauth",
    "authentication.test" => ["string", Rule::in('...')]],

    "authentication.oauth" => "array",
    "authentication.oauth.client_id" => "string",
    "authentication.oauth.client_secret" => "string",

    "authentication.secrets" => "array",
    "authentication.secrets.*" => ["string"],

    "authentication.certificates" => "array",
    "authentication.certificates.*.uuid" => "string",
    "authentication.certificates.*.value" => "string",
];
```

This could be a breaking change only for people already using associative arrays to define validation rules. Since this usage is not documented and using associative arrays bring no benefits in the current implementation, its fair to expect that no one is actually using it.
