### PR TITLE
[9.x] Add missing method tag and common assertion

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static void assertDispatched(string|\Closure $command, callable|int $callback = null)
  * @method static void assertDispatchedTimes(string $command, int $times = 1)
  * @method static void assertNotDispatched(string|\Closure $command, callable|int $callback = null)
+ * @method static void assertNothingDispatched()
  * @method static void assertDispatchedAfterResponse(string|\Closure $command, callable|int $callback = null)
  * @method static void assertDispatchedAfterResponseTimes(string $command, int $times = 1)
  * @method static void assertNotDispatchedAfterResponse(string|\Closure $command, callable $callback = null)

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static void assertNotDispatchedAfterResponse(string|\Closure $command, callable $callback = null)
  * @method static void assertBatched(callable $callback)
  * @method static void assertBatchCount(int $count)
+ * @method static void assertNothingBatched()
  * @method static void assertChained(array $expectedChain)
  * @method static void assertDispatchedSync(string|\Closure $command, callable $callback = null)
  * @method static void assertDispatchedSyncTimes(string $command, int $times = 1)

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -423,6 +423,16 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
+     * Assert that no batched jobs were dispatched.
+     *
+     * @return void
+     */
+    public function assertNothingBatched()
+    {
+        PHPUnit::assertEmpty($this->batches, 'Batched jobs were dispatched unexpectedly.');
+    }
+
+    /**
      * Get all of the jobs matching a truth-test callback.
      *
      * @param  string  $command

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -454,6 +454,20 @@ class SupportTestingBusFakeTest extends TestCase
             return $job->id === 1;
         });
     }
+
+    public function testAssertNothingBatched()
+    {
+        $this->fake->assertNothingBatched();
+
+        $this->fake->batch([])->dispatch();
+
+        try {
+            $this->fake->assertNothingBatched();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('Batched jobs were dispatched unexpectedly.'));
+        }
+    }
 }
 
 class BusJobStub


### PR DESCRIPTION
Simple changes as I dive into the `BusFake` to add assertions around cancelled batched jobs.