### PR TITLE
[9.x] Fixed expectsOutputToContain & doesntExpectOutputToContain of PendingAction

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -67,6 +67,13 @@ class PendingCommand
     protected $hasExecuted = false;
 
     /**
+     * All outputs that printed out by the command.
+     *
+     * @var array
+     */
+    protected $allOutputs = [];
+
+    /**
      * Create a new pending console command run.
      *
      * @param  \PHPUnit\Framework\TestCase  $test
@@ -175,7 +182,7 @@ class PendingCommand
      */
     public function doesntExpectOutputToContain($string)
     {
-        $this->test->unexpectedOutputSubstrings[$string] = false;
+        $this->test->unexpectedOutputSubstrings[] = $string;
 
         return $this;
     }
@@ -337,16 +344,22 @@ class PendingCommand
             $this->test->fail('Output "'.Arr::first($this->test->expectedOutput).'" was not printed.');
         }
 
-        if (count($this->test->expectedOutputSubstrings)) {
-            $this->test->fail('Output does not contain "'.Arr::first($this->test->expectedOutputSubstrings).'".');
-        }
-
         if ($output = array_search(true, $this->test->unexpectedOutput)) {
             $this->test->fail('Output "'.$output.'" was printed.');
         }
 
-        if ($output = array_search(true, $this->test->unexpectedOutputSubstrings)) {
-            $this->test->fail('Output "'.$output.'" was printed.');
+        $allOutputStr = implode("\n", $this->allOutputs);
+
+        foreach ($this->test->expectedOutputSubstrings as $text) {
+            if (! str_contains($allOutputStr, $text)) {
+                $this->test->fail('Output does not contain "'.$text.'".');
+            }
+        }
+
+        foreach ($this->test->unexpectedOutputSubstrings as $text) {
+            if (str_contains($allOutputStr, $text)) {
+                $this->test->fail('Output "'.$text.'" was printed.');
+            }
         }
     }
 
@@ -407,14 +420,6 @@ class PendingCommand
                 });
         }
 
-        foreach ($this->test->expectedOutputSubstrings as $i => $text) {
-            $mock->shouldReceive('doWrite')
-                ->withArgs(fn ($output) => str_contains($output, $text))
-                ->andReturnUsing(function () use ($i) {
-                    unset($this->test->expectedOutputSubstrings[$i]);
-                });
-        }
-
         foreach ($this->test->unexpectedOutput as $output => $displayed) {
             $mock->shouldReceive('doWrite')
                 ->ordered()
@@ -424,13 +429,10 @@ class PendingCommand
                 });
         }
 
-        foreach ($this->test->unexpectedOutputSubstrings as $text => $displayed) {
-            $mock->shouldReceive('doWrite')
-                 ->withArgs(fn ($output) => str_contains($output, $text))
-                 ->andReturnUsing(function () use ($text) {
-                     $this->test->unexpectedOutputSubstrings[$text] = true;
-                 });
-        }
+        $this->allOutputs = [];
+
+        $mock->shouldReceive('doWrite')
+            ->withArgs(fn ($output) => $this->allOutputs[] = $output);
 
         return $mock;
     }

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -36,6 +36,11 @@ class ArtisanCommandTest extends TestCase
         Artisan::command('contains', function () {
             $this->line('My name is Taylor Otwell');
         });
+
+        Artisan::command('containsMultipleLines', function () {
+            $this->line('First line
+Second line');
+        });
     }
 
     public function test_console_command_that_passes()
@@ -141,6 +146,16 @@ class ArtisanCommandTest extends TestCase
                  ->expectsOutputToContain('Otwell Taylor')
                  ->assertExitCode(0);
         });
+    }
+
+    public function test_console_command_can_assert_multiple_lines_contain()
+    {
+        $this->artisan('containsMultipleLines')
+            ->expectsOutputToContain('First line')
+            ->expectsOutputToContain('Second line')
+            ->expectsOutputToContain('First line
+Second line')
+            ->assertExitCode(0);
     }
 
     /**


### PR DESCRIPTION
All the details go here #43896 and resends #43916

Basically `expectsOutputToContain` and `doesntExpectOutputToContain` didn't assert against **all output** . 

So if you write an output that contains a lot of info, you can't assert it multiple times for the same output.


### Partial content from #43896

When I tried to use the `expectsOutputToContain`, assuming it would validate **all output** against the string, but it didn't

The printed result of my command:
```php
@property int $id
@property string $first_name
```

Test result: 
```php
$command->artisan(...)
    ->expectsOutputToContain('@property int $id') // ok
    ->expectsOutputToContain('@property string $first_name') // expected to work, but got "Output does not contain ..."
    ->execute();
```

Then I have to do the ugly way like this in order to assert the outputs:

https://github.com/sethsandaru/eloquent-docs/blob/main/src/Commands/EloquentDocsGeneratorCommand.php#L54-L57

```php
$lines = explode("\n", $generatedDocs);
foreach ($lines as $line) {
    $this->info($line);
} // after this => expectsOutputToContain works fine
```
