### PR TITLE
[9.x] Formatting

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -170,7 +170,7 @@ class ServeCommand extends Command
      */
     protected function host()
     {
-        [$host, ] = $this->getHostAndPort();
+        [$host] = $this->getHostAndPort();
 
         return $host;
     }


### PR DESCRIPTION
PHP-CS-Fixer released a new rule [no_trailing_comma_in_singleline](https://cs.symfony.com/doc/rules/basic/no_trailing_comma_in_singleline.html) which replaced some deprecated rules and enforces the new style by default.
Pint already has received the update https://github.com/laravel/pint/pull/109 but it seems like StyleCI has not been updated to reflect the new rule (with the option `array_destructering` which is enabled by default by PHP-CS-Fixer)

I maintain the Repo https://github.com/Jubeki/laravel-code-style which executes daily tests and formatting based on the framework. Since StyleCI doesn't enforce the rule yet, the tests fail and I would like to fix that.