### PR TITLE
[9.x] Fix middleware `SetCacheHeaders` with file responses

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Carbon;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class SetCacheHeaders
 {
@@ -21,7 +22,7 @@ class SetCacheHeaders
     {
         $response = $next($request);
 
-        if (! $request->isMethodCacheable() || ! $response->getContent()) {
+        if (! $request->isMethodCacheable() || (! $response->getContent() && ! $response instanceof BinaryFileResponse)) {
             return $response;
         }
 

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class CacheTest extends TestCase
 {
@@ -31,6 +32,16 @@ class CacheTest extends TestCase
 
         $this->assertNull($response->getMaxAge());
         $this->assertNull($response->getEtag());
+    }
+
+    public function testSetHeaderToFileEvenWithNoContent()
+    {
+        $response = (new Cache)->handle(new Request, function ()  {
+            $filePath = __DIR__.'/../fixtures/test.txt';
+            return new BinaryFileResponse($filePath);
+        }, 'max_age=120;s_maxage=60');
+
+        $this->assertNotNull($response->getMaxAge());
     }
 
     public function testAddHeaders()


### PR DESCRIPTION
The middleware "SetCacheHeaders" (cache.headers) doesn't work with file responses because in this case `! $response->getContent()` is empty: https://github.com/laravel/framework/blob/9.x/src/Illuminate/Http/Middleware/SetCacheHeaders.php#L24

@driesvints suggested to me me to submit a PR for that: https://github.com/laravel/framework/issues/44036