### PR TITLE
FIX Resource class name was not derived correctly from the Collection…

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -52,8 +52,8 @@ trait CollectsResources
         if ($this->collects) {
             $collects = $this->collects;
         } elseif (str_ends_with(class_basename($this), 'Collection') &&
-            (class_exists($class = Str::replaceLast('Collection', '', get_class($this))) ||
-             class_exists($class = Str::replaceLast('Collection', 'Resource', get_class($this))))) {
+            (@class_exists($class = Str::replaceLast('Collection', '', get_class($this))) ||
+             @class_exists($class = Str::replaceLast('Collection', 'Resource', get_class($this))))) {
             $collects = $class;
         }
 


### PR DESCRIPTION
… name

this only worked if the Resource class did not have a Resource suffix (like in the first class_exists check) However the code clearly intends to support the Resource suffix aswell


does not break existing usage! fixes expected functionality