### PR TITLE
[9.x] Job batching added delay support same as in jobs

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -172,10 +172,11 @@ class Batch implements Arrayable, JsonSerializable
                     return $chain->first()
                             ->allOnQueue($this->options['queue'] ?? null)
                             ->allOnConnection($this->options['connection'] ?? null)
+                            ->delay($this->options['delay'] ?? null)
                             ->chain($chain->slice(1)->values()->all());
                 });
             } else {
-                $job->withBatchId($this->id);
+                $job->withBatchId($this->id)->delay($this->options['delay'] ?? null);
 
                 $count++;
             }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -229,6 +229,19 @@ class PendingBatch
     }
 
     /**
+     * Set the desired delay in seconds for the pending batch.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @return $this
+     */
+    public function delay($delay)
+    {
+        $this->options['delay'] = $delay;
+
+        return $this;
+    }
+
+    /**
      * Add additional data into the batch's options array.
      *
      * @param  string  $key

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -87,12 +87,12 @@ class BusBatchTest extends TestCase
 
         $job = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
 
         $secondJob = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
 
         $thirdJob = function () {
@@ -125,14 +125,14 @@ class BusBatchTest extends TestCase
 
         $job = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
         $batch->add([$job]);
         $this->assertCount(1, $batch->jobs);
 
         $secondJob = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
 
             public $anotherProperty;
         };
@@ -150,7 +150,7 @@ class BusBatchTest extends TestCase
             for ($i = 0; $i < $jobsCount; $i++) {
                 yield new class
                 {
-                    use Batchable;
+                    use Batchable, Queueable;
                 };
             }
         };
@@ -180,12 +180,12 @@ class BusBatchTest extends TestCase
 
         $job = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
 
         $secondJob = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
 
         $queue->shouldReceive('connection')->once()
@@ -218,12 +218,12 @@ class BusBatchTest extends TestCase
 
         $job = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
 
         $secondJob = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
 
         $queue->shouldReceive('connection')->once()
@@ -259,12 +259,12 @@ class BusBatchTest extends TestCase
 
         $job = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
 
         $secondJob = new class
         {
-            use Batchable;
+            use Batchable, Queueable;
         };
 
         $queue->shouldReceive('connection')->once()


### PR DESCRIPTION
Added `Bus::batch()->delay()` support same as in jobs. I believe that this functionality will be useful to those who regularly work with jobs in Laravel. Because `delay()` is often used in jobs, but did not exist before in batches.