### PR TITLE
Patch for timeless timing attack vulnerability in user login

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Auth;
 
 use Closure;
 use Illuminate\Contracts\Auth\Factory as FactoryContract;
+use Illuminate\Support\Timebox;
 use InvalidArgumentException;
 
 class AuthManager implements FactoryContract
@@ -122,7 +123,7 @@ class AuthManager implements FactoryContract
     {
         $provider = $this->createUserProvider($config['provider'] ?? null);
 
-        $guard = new SessionGuard($name, $provider, $this->app['session.store']);
+        $guard = new SessionGuard($name, $provider, $this->app['session.store'], null, new Timebox);
 
         // When using the remember me functionality of the authentication services we
         // will need to be set the encryption instance of the guard, which allows

--- a/src/Illuminate/Support/Facades/Timebox.php
+++ b/src/Illuminate/Support/Facades/Timebox.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+
+/**
+ * @method static \Illuminate\Support\Timebox make(callable $callback, int $microseconds): mixed
+ *
+ * @see \Illuminate\Support\Timebox
+ */
+class Timebox extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return \Illuminate\Support\Timebox::class;
+    }
+}

--- a/src/Illuminate/Support/Timebox.php
+++ b/src/Illuminate/Support/Timebox.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Timebox
+{
+    /**
+     * Is the timebox allowed to do an early return
+     *
+     * @var bool
+     */
+    public $earlyReturn = false;
+
+    /**
+     * @param  callable  $callback
+     * @param  int  $microseconds
+     * @return mixed
+     */
+    public function make(callable $callback, int $microseconds)
+    {
+        $start = microtime(true);
+
+        $result = $callback($this);
+
+        $remainder = $microseconds - ((microtime(true) - $start) * 1000000);
+
+        if (! $this->earlyReturn && $remainder > 0) {
+            $this->usleep($remainder);
+        }
+
+        return $result;
+    }
+
+    public function returnEarly(): self
+    {
+        $this->earlyReturn = true;
+
+        return $this;
+    }
+
+    public function dontReturnEarly(): self
+    {
+        $this->earlyReturn = false;
+
+        return $this;
+    }
+
+    /**
+     * @param  $microseconds
+     * @return void
+     */
+    protected function usleep($microseconds)
+    {
+        usleep($microseconds);
+    }
+}

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Cookie\CookieJar;
+use Illuminate\Support\Timebox;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -94,6 +95,10 @@ class AuthGuardTest extends TestCase
     {
         $guard = $this->getGuard();
         $guard->setDispatcher($events = m::mock(Dispatcher::class));
+        $timebox = $guard->getTimebox();
+        $timebox->shouldReceive('make')->once()->andReturnUsing(function ($callback) use ($timebox) {
+            return $callback($timebox);
+        });
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $events->shouldNotReceive('dispatch')->with(m::type(Validated::class));
@@ -103,9 +108,12 @@ class AuthGuardTest extends TestCase
 
     public function testAttemptReturnsUserInterface()
     {
-        [$session, $provider, $request, $cookie] = $this->getMocks();
-        $guard = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
+        $guard = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['login'])->setConstructorArgs(['default', $provider, $session, $request, $timebox])->getMock();
         $guard->setDispatcher($events = m::mock(Dispatcher::class));
+        $timebox->shouldReceive('make')->once()->andReturnUsing(function ($callback, $microseconds) use ($timebox) {
+            return $callback($timebox->shouldReceive('returnEarly')->once()->getMock());
+        });
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Validated::class));
         $user = $this->createMock(Authenticatable::class);
@@ -119,6 +127,10 @@ class AuthGuardTest extends TestCase
     {
         $mock = $this->getGuard();
         $mock->setDispatcher($events = m::mock(Dispatcher::class));
+        $timebox = $mock->getTimebox();
+        $timebox->shouldReceive('make')->once()->andReturnUsing(function ($callback, $microseconds) use ($timebox) {
+            return $callback($timebox);
+        });
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $events->shouldNotReceive('dispatch')->with(m::type(Validated::class));
@@ -128,9 +140,12 @@ class AuthGuardTest extends TestCase
 
     public function testAttemptAndWithCallbacks()
     {
-        [$session, $provider, $request, $cookie] = $this->getMocks();
-        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request])->getMock();
+        [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
+        $mock = $this->getMockBuilder(SessionGuard::class)->onlyMethods(['getName'])->setConstructorArgs(['default', $provider, $session, $request, $timebox])->getMock();
         $mock->setDispatcher($events = m::mock(Dispatcher::class));
+        $timebox->shouldReceive('make')->andReturnUsing(function ($callback) use ($timebox) {
+            return $callback($timebox->shouldReceive('returnEarly')->getMock());
+        });
         $user = m::mock(Authenticatable::class);
         $events->shouldReceive('dispatch')->times(3)->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Login::class));
@@ -212,6 +227,10 @@ class AuthGuardTest extends TestCase
     {
         $guard = $this->getGuard();
         $guard->setDispatcher($events = m::mock(Dispatcher::class));
+        $timebox = $guard->getTimebox();
+        $timebox->shouldReceive('make')->once()->andReturnUsing(function ($callback, $microseconds) use ($timebox) {
+            return $callback($timebox);
+        });
         $events->shouldReceive('dispatch')->once()->with(m::type(Attempting::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(Failed::class));
         $events->shouldNotReceive('dispatch')->with(m::type(Validated::class));
@@ -544,9 +563,12 @@ class AuthGuardTest extends TestCase
 
     public function testLoginOnceSetsUser()
     {
-        [$session, $provider, $request, $cookie] = $this->getMocks();
-        $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
+        [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
+        $guard = m::mock(SessionGuard::class, ['default', $provider, $session, $request, $timebox])->makePartial();
         $user = m::mock(Authenticatable::class);
+        $timebox->shouldReceive('make')->once()->andReturnUsing(function ($callback) use ($timebox) {
+            return $callback($timebox->shouldReceive('returnEarly')->once()->getMock());
+        });
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(true);
         $guard->shouldReceive('setUser')->once()->with($user);
@@ -555,9 +577,12 @@ class AuthGuardTest extends TestCase
 
     public function testLoginOnceFailure()
     {
-        [$session, $provider, $request, $cookie] = $this->getMocks();
-        $guard = m::mock(SessionGuard::class, ['default', $provider, $session])->makePartial();
+        [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
+        $guard = m::mock(SessionGuard::class, ['default', $provider, $session, $request, $timebox])->makePartial();
         $user = m::mock(Authenticatable::class);
+        $timebox->shouldReceive('make')->once()->andReturnUsing(function ($callback) use ($timebox) {
+            return $callback($timebox);
+        });
         $guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user);
         $guard->getProvider()->shouldReceive('validateCredentials')->once()->with($user, ['foo'])->andReturn(false);
         $this->assertFalse($guard->once(['foo']));
@@ -565,9 +590,9 @@ class AuthGuardTest extends TestCase
 
     protected function getGuard()
     {
-        [$session, $provider, $request, $cookie] = $this->getMocks();
+        [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();
 
-        return new SessionGuard('default', $provider, $session, $request);
+        return new SessionGuard('default', $provider, $session, $request, $timebox);
     }
 
     protected function getMocks()
@@ -577,6 +602,7 @@ class AuthGuardTest extends TestCase
             m::mock(UserProvider::class),
             Request::create('/', 'GET'),
             m::mock(CookieJar::class),
+            m::mock(Timebox::class),
         ];
     }
 

--- a/tests/Support/SupportTimeboxTest.php
+++ b/tests/Support/SupportTimeboxTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Timebox;
+use PHPUnit\Framework\TestCase;
+use Mockery as m;
+
+class SupportTimeboxTest extends TestCase
+{
+    public function testMakeExecutesCallback()
+    {
+        $callback = function () {
+            $this->assertTrue(true);
+        };
+
+        (new Timebox)->make($callback, 0);
+    }
+
+    public function testMakeWaitsForMicroseconds()
+    {
+        $mock = m::spy(Timebox::class)->shouldAllowMockingProtectedMethods()->makePartial();
+        $mock->shouldReceive('usleep')->once();
+
+        $mock->make(function () {}, 10000);
+
+        $mock->shouldHaveReceived('usleep')->once();
+    }
+
+    public function testMakeShouldNotSleepWhenEarlyReturnHasBeenFlagged()
+    {
+        $mock = m::spy(Timebox::class)->shouldAllowMockingProtectedMethods()->makePartial();
+        $mock->make(function ($timebox) {
+            $timebox->returnEarly();
+        }, 10000);
+
+        $mock->shouldNotHaveReceived('usleep');
+    }
+
+    public function testMakeShouldSleepWhenDontEarlyReturnHasBeenFlagged()
+    {
+        $mock = m::spy(Timebox::class)->shouldAllowMockingProtectedMethods()->makePartial();
+        $mock->shouldReceive('usleep')->once();
+
+        $mock->make(function ($timebox) {
+            $timebox->returnEarly();
+            $timebox->dontReturnEarly();
+        }, 10000);
+
+        $mock->shouldHaveReceived('usleep')->once();
+    }
+}


### PR DESCRIPTION
## Timebox class
This new Timebox class makes a callable execute for at least the supplied amount of time.

This helps us guard against timing attacks at the application.

## Timeless timing attacks

The authentication method is currently vulnerable to user enumeration via timeless timing attacks.
This is caused by the early return inside the `hasValidCredentials` method in the `Illuminate\Auth\SessionGuard` class.

If the user does not exist most of the code in that method will not be called and thus the execution time will be a tiny bit shorter.

With traditional timing attacks this would not be practical to utilize because of the large sample sizes needed, but [timeless timing attacks](https://tom.vg/papers/timeless-timing-attack_usenix2020.pdf) which uses the HTTP/2 multiplexing protocol can with high accuracy measure timing differences between two calls to a remote server on 20 microseconds with a sample size of only 6 request pairs.

This means that most throttling/max attempts/DoS attack protection etc will not be triggered, and it is suddently very practical to harvest existing emails for a site (user enumeration).

User enumeration in itself is a security problem for some sites (where users dont want others to know they are using that site), but in general user enumeration can be used in tandem with other attacks (e.g. brute-forcing passwords or using previously leaked passwords).

## The patch

That is why the new Timebox class is also implemented inside the `hasValidCredentials` method in this PR.

A demo script that can be used to exploit the user enumeration can be [found here](https://github.com/ephort/laravel-user-enumeration-demo).

The changes in this PR add a minimum execution time for the `hasValidCredentials` method of 200 milliseconds.
But if the credentials are correct the timebox will be escaped and the user would not have to wait.

So this change only affects users typing the wrong credentials.

This pull request is opened with permission from Taylor via e-mail.

More in depth explanation of timeless timing attacks [can be found here](https://ephort.dk/blog/laravel-timing-attack-vulnerability/).