### PR TITLE
[9.x] Improve testability of batched jobs

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -14,6 +14,13 @@ use Illuminate\Support\Str;
 class BatchRepositoryFake implements BatchRepository
 {
     /**
+     * The batches stored in the repository.
+     *
+     * @var \Illuminate\Bus\Batch[]
+     */
+    protected $batches = [];
+
+    /**
      * Retrieve a list of batches.
      *
      * @param  int  $limit
@@ -22,7 +29,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function get($limit, $before)
     {
-        return [];
+        return $this->batches;
     }
 
     /**
@@ -33,7 +40,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function find(string $batchId)
     {
-        //
+        return $this->batches[$batchId] ?? null;
     }
 
     /**
@@ -44,10 +51,12 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function store(PendingBatch $batch)
     {
-        return new Batch(
+        $id = (string) Str::orderedUuid();
+
+        $this->batches[$id] = new Batch(
             new QueueFake(Facade::getFacadeApplication()),
             $this,
-            (string) Str::orderedUuid(),
+            $id,
             $batch->name,
             count($batch->jobs),
             count($batch->jobs),
@@ -58,6 +67,8 @@ class BatchRepositoryFake implements BatchRepository
             null,
             null
         );
+
+        return $this->batches[$id];
     }
 
     /**
@@ -104,7 +115,9 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function markAsFinished(string $batchId)
     {
-        //
+        if (isset($this->batches[$batchId])) {
+            $this->batches[$batchId]->finishedAt = now();
+        }
     }
 
     /**
@@ -115,7 +128,9 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function cancel(string $batchId)
     {
-        //
+        if (isset($this->batches[$batchId])) {
+            $this->batches[$batchId]->cancelledAt = now();
+        }
     }
 
     /**
@@ -126,7 +141,7 @@ class BatchRepositoryFake implements BatchRepository
      */
     public function delete(string $batchId)
     {
-        //
+        unset($this->batches[$batchId]);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -658,6 +658,16 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
+     * Create a new, empty batch for testing.
+     *
+     * @return \Illuminate\Bus\Batch
+     */
+    public function fakeBatch()
+    {
+        return $this->batch([])->dispatch();
+    }
+
+    /**
      * Record the fake pending batch dispatch.
      *
      * @param  \Illuminate\Bus\PendingBatch  $pendingBatch

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -29,6 +29,13 @@ class BusFake implements QueueingDispatcher
     protected $jobsToFake;
 
     /**
+     * The fake repository to track batched jobs.
+     *
+     * @var \Illuminate\Bus\BatchRepository
+     */
+    protected $batchRepository;
+
+    /**
      * The commands that have been dispatched.
      *
      * @var array
@@ -68,6 +75,8 @@ class BusFake implements QueueingDispatcher
         $this->dispatcher = $dispatcher;
 
         $this->jobsToFake = Arr::wrap($jobsToFake);
+
+        $this->batchRepository = new BatchRepositoryFake();
     }
 
     /**
@@ -634,7 +643,7 @@ class BusFake implements QueueingDispatcher
      */
     public function findBatch(string $batchId)
     {
-        //
+        return $this->batchRepository->find($batchId);
     }
 
     /**
@@ -658,7 +667,7 @@ class BusFake implements QueueingDispatcher
     {
         $this->batches[] = $pendingBatch;
 
-        return (new BatchRepositoryFake)->store($pendingBatch);
+        return $this->batchRepository->store($pendingBatch);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -656,16 +656,6 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
-     * Create a new, empty batch for testing.
-     *
-     * @return \Illuminate\Bus\Batch
-     */
-    public function fakeBatch()
-    {
-        return $this->batch([])->dispatch();
-    }
-
-    /**
      * Record the fake pending batch dispatch.
      *
      * @param  \Illuminate\Bus\PendingBatch  $pendingBatch

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -73,10 +73,8 @@ class BusFake implements QueueingDispatcher
     public function __construct(QueueingDispatcher $dispatcher, $jobsToFake = [])
     {
         $this->dispatcher = $dispatcher;
-
         $this->jobsToFake = Arr::wrap($jobsToFake);
-
-        $this->batchRepository = new BatchRepositoryFake();
+        $this->batchRepository = new BatchRepositoryFake;
     }
 
     /**

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -468,6 +468,26 @@ class SupportTestingBusFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('Batched jobs were dispatched unexpectedly.'));
         }
     }
+
+    public function testFindBatch()
+    {
+        $this->assertNull($this->fake->findBatch('non-existent-batch'));
+
+        $batch = $this->fake->batch([])->dispatch();
+
+        $this->assertSame($batch, $this->fake->findBatch($batch->id));
+    }
+
+    public function testBatchesCanBeCancelled()
+    {
+        $batch = $this->fake->batch([])->dispatch();
+
+        $this->assertFalse($batch->cancelled());
+
+        $batch->cancel();
+
+        $this->assertTrue($batch->cancelled());
+    }
 }
 
 class BusJobStub

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -488,6 +488,15 @@ class SupportTestingBusFakeTest extends TestCase
 
         $this->assertTrue($batch->cancelled());
     }
+
+    public function testFakeBatch()
+    {
+        $batch = $this->fake->fakeBatch();
+
+        $this->assertInstanceOf(\Illuminate\Bus\Batch::class, $batch);
+        $this->assertSame($batch, $this->fake->findBatch($batch->id));
+        $this->assertSame(0, $batch->totalJobs);
+    }
 }
 
 class BusJobStub

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -488,15 +488,6 @@ class SupportTestingBusFakeTest extends TestCase
 
         $this->assertTrue($batch->cancelled());
     }
-
-    public function testFakeBatch()
-    {
-        $batch = $this->fake->fakeBatch();
-
-        $this->assertInstanceOf(\Illuminate\Bus\Batch::class, $batch);
-        $this->assertSame($batch, $this->fake->findBatch($batch->id));
-        $this->assertSame(0, $batch->totalJobs);
-    }
 }
 
 class BusJobStub


### PR DESCRIPTION
This implements a number of empty interface methods relating to batched jobs making it easier to test batched jobs were dispatched, cancelled, or deleted.

Before this PR, it was not possible to test that a batched job was cancelled. For example:

```php
Bus::fake();

$batch = Bus::batch([])->dispatch();
Cache::put('batched-automation', $batch->id);

Shift::runAutomation('v9.29.0'); // cancels previous batched job

Bus::assertDispatched(UpdateRepositories::class);
$this->assertTrue($batch->cancelled());
```

After this PR, the test above would pass.

---

Submitted from 37,000ft over the Gulf of Mexico.
