### PR TITLE
[9.x] Add getContainer method to the Route class

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1267,6 +1267,16 @@ class Route
     }
 
     /**
+     * Get the container instance.
+     *
+     * @return \Illuminate\Container\Container|null
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
      * Prepare the route instance for serialization.
      *
      * @return void


### PR DESCRIPTION
This PR allows to have access to the previously set container instance on a route. It can be useful when doing some custom route model binding for example.

```php
App::make('router')->bind('post', function ($value, $route) {
    if ($route->getContainer()->make(CustomValueBinder::class)->passes($route, $value)) {
        // doing some custom resolution...
    }

    return (new Post())->resolveRouteBinding($value);
});
```