### PR TITLE
[9.x] Add read-only filesystem adapter decoration as a config option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,7 @@
         "laravel/tinker": "Required to use the tinker console command (^2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.0).",
         "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.0).",
+        "league/flysystem-read-only": "Required to use read-only disks (^3.3)",
         "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.0).",
         "mockery/mockery": "Required to use mocking (^1.4.4).",
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "league/flysystem-aws-s3-v3": "^3.0",
         "league/flysystem-ftp": "^3.0",
+        "league/flysystem-read-only": "^3.3",
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.4.4",
         "orchestra/testbench-core": "^7.1",

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -16,6 +16,7 @@ use League\Flysystem\Ftp\FtpConnectionOptions;
 use League\Flysystem\Local\LocalFilesystemAdapter as LocalAdapter;
 use League\Flysystem\PhpseclibV3\SftpAdapter;
 use League\Flysystem\PhpseclibV3\SftpConnectionProvider;
+use League\Flysystem\ReadOnly\ReadOnlyFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\Visibility;
 
@@ -275,6 +276,10 @@ class FilesystemManager implements FactoryContract
      */
     protected function createFlysystem(FlysystemAdapter $adapter, array $config)
     {
+        if ($config['read-only'] ?? false === true) {
+            $adapter = new ReadOnlyFilesystemAdapter($adapter);
+        }
+
         return new Flysystem($adapter, Arr::only($config, [
             'directory_visibility',
             'disable_asserts',

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -2,16 +2,11 @@
 
 namespace Illuminate\Tests\Filesystem;
 
-use function fclose;
-use function file_put_contents;
-use function fopen;
-use function fwrite;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use function unlink;
 
 class FilesystemManagerTest extends TestCase
 {

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -2,16 +2,15 @@
 
 namespace Illuminate\Tests\Filesystem;
 
+use function fclose;
+use function file_put_contents;
+use function fopen;
+use function fwrite;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-
-use function fclose;
-use function file_put_contents;
-use function fopen;
-use function fwrite;
 use function unlink;
 
 class FilesystemManagerTest extends TestCase


### PR DESCRIPTION
This PR adds the ability to configure a disk to operate in `read-only` mode. When this option is set to `true`, the underlying adapter is decorated with an implementation that ensures no write operation is possible on the disk. This is useful when you're receiving files through a shared storage, but you shouldn't manipulate any of the files stored.

If interested, I can also add a PR to include a path prefixing decorator: https://flysystem.thephpleague.com/docs/adapter/path-prefixing/