### PR TITLE
[9.x] Passing event into `viaQueue` and `viaConnection` of Queued Listener

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -579,11 +579,11 @@ class Dispatcher implements DispatcherContract
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
         $connection = $this->resolveQueue()->connection(method_exists($listener, 'viaConnection')
-                    ? $listener->viaConnection()
+                    ? $listener->viaConnection($arguments[0])
                     : $listener->connection ?? null);
 
         $queue = method_exists($listener, 'viaQueue')
-                    ? $listener->viaQueue()
+                    ? $listener->viaQueue($arguments[0])
                     : $listener->queue ?? null;
 
         isset($listener->delay)

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -123,7 +123,7 @@ class QueuedEventsTest extends TestCase
         $d->listen('some.event', TestDispatcherGetConnectionDynamically::class.'@handle');
         $d->dispatch('some.event', [
             ['shouldUseRedisConnection' => true],
-            'bar'
+            'bar',
         ]);
     }
 

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -82,6 +83,48 @@ class QueuedEventsTest extends TestCase
 
         $d->listen('some.event', TestDispatcherGetConnection::class.'@handle');
         $d->dispatch('some.event', ['foo', 'bar']);
+    }
+
+    public function testQueueIsSetByGetQueueDynamically()
+    {
+        $d = new Dispatcher;
+
+        $fakeQueue = new QueueFake(new Container);
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherGetQueueDynamically::class.'@handle');
+        $d->dispatch('some.event', [['useHighPriorityQueue' => true], 'bar']);
+
+        $fakeQueue->assertPushedOn('p0', CallQueuedListener::class);
+    }
+
+    public function testQueueIsSetByGetConnectionDynamically()
+    {
+        $d = new Dispatcher;
+        $queueManager = $this->createMock(QueueManager::class);
+        $queue = $this->createMock(Queue::class);
+
+        $queueManager->expects($this->once())
+            ->method('connection')
+            ->with('redis')
+            ->willReturn($queue);
+
+        $queue->expects($this->once())
+            ->method('pushOn')
+            ->with(null, $this->isInstanceOf(CallQueuedListener::class));
+
+        $d->setQueueResolver(function () use ($queueManager) {
+            return $queueManager;
+        });
+
+        $d->listen('some.event', TestDispatcherGetConnectionDynamically::class.'@handle');
+        $d->dispatch('some.event', [
+            ['shouldUseRedisConnection' => true],
+            'bar'
+        ]);
     }
 
     public function testQueuePropagateRetryUntilAndMaxExceptions()
@@ -218,5 +261,41 @@ class TestMiddleware
     public function handle($job, $next)
     {
         $next($job);
+    }
+}
+
+class TestDispatcherGetConnectionDynamically implements ShouldQueue
+{
+    public function handle()
+    {
+        //
+    }
+
+    public function viaConnection($event)
+    {
+        if ($event['shouldUseRedisConnection']) {
+            return 'redis';
+        }
+
+        return 'sqs';
+    }
+}
+
+class TestDispatcherGetQueueDynamically implements ShouldQueue
+{
+    public $queue = 'my_queue';
+
+    public function handle()
+    {
+        //
+    }
+
+    public function viaQueue($event)
+    {
+        if ($event['useHighPriorityQueue']) {
+            return 'p0';
+        }
+
+        return 'p99';
     }
 }


### PR DESCRIPTION
Proposal this (if got approved & merged, I'll submit a doc PR)

For our project, we have a lot of Queued Listeners. At the moment, for some critical endpoints (that need to respond as fast as they can), we need to push it to a `redis` connection instead of `sqs` based on the events's data (which is impossible at the moment)

At my first try (which didn't work), I used the `shouldQueue($event)` to set the `$connection` dynamically.

After spending a bit of time reading the logic. I see that before Laravel invoking the `shouldQueue`, it will create a new concrete listener class to and use it to check. 

And before the queue push happen, Laravel create another new concrete listener class via Reflector.  Thus my `$connection` will never be there.

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Events/Dispatcher.php#L560

With this patch, we would be able to do something like this:

```php
public function viaConnection($event): string
{
    if ($event->useRedisQueue) {
        return 'redis';
    } 

    return config('queue.default');
}
```


Code & unit testing added, no breaking changes! 