### PR TITLE
[9.x] Fix QueryBuilder whereNot with array conditions 

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -800,7 +800,7 @@ class Builder implements BuilderContract
                 if (is_numeric($key) && is_array($value)) {
                     $query->{$method}(...array_values($value));
                 } else {
-                    $query->$method($key, '=', $value, $boolean);
+                    $query->{$method}($key, '=', $value, $boolean);
                 }
             }
         }, $boolean);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -894,7 +894,7 @@ class Builder implements BuilderContract
      */
     public function whereNot($column, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->whereNested(function($query) use ($column, $operator, $value, $boolean) {
+        return $this->whereNested(function ($query) use ($column, $operator, $value, $boolean) {
             $query->where($column, $operator, $value, $boolean);
         }, $boolean.' not');
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -894,9 +894,13 @@ class Builder implements BuilderContract
      */
     public function whereNot($column, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->whereNested(function ($query) use ($column, $operator, $value, $boolean) {
-            $query->where($column, $operator, $value, $boolean);
-        }, $boolean.' not');
+        if (is_array($column)) {
+            return $this->whereNested(function ($query) use ($column, $operator, $value, $boolean) {
+                $query->where($column, $operator, $value, $boolean);
+            }, $boolean.' not');
+        }
+
+        return $this->where($column, $operator, $value, $boolean.' not');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -894,7 +894,9 @@ class Builder implements BuilderContract
      */
     public function whereNot($column, $operator = null, $value = null, $boolean = 'and')
     {
-        return $this->where($column, $operator, $value, $boolean.' not');
+        return $this->whereNested(function($query) use ($column, $operator, $value, $boolean) {
+            $query->where($column, $operator, $value, $boolean);
+        }, $boolean.' not');
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -306,7 +306,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNot('name', 'foo')->whereNot('name', '<>', 'bar');
-        $this->assertSame('select * from "users" where not "name" = ? and not "name" <> ?', $builder->toSql());
+        $this->assertSame('select * from "users" where not ("name" = ?) and not ("name" <> ?)', $builder->toSql());
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
@@ -728,7 +728,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orWhereNot('name', 'foo')->orWhereNot('name', '<>', 'bar');
-        $this->assertSame('select * from "users" where not "name" = ? or not "name" <> ?', $builder->toSql());
+        $this->assertSame('select * from "users" where not ("name" = ?) or not ("name" <> ?)', $builder->toSql());
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
@@ -1728,21 +1728,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereNot(function ($q) {
             $q->where('email', '=', 'foo');
         });
-        $this->assertSame('select * from "users" where not ("email" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where not (("email" = ?))', $builder->toSql());
         $this->assertEquals([0 => 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'bar')->whereNot(function ($q) {
             $q->where('email', '=', 'foo');
         });
-        $this->assertSame('select * from "users" where "name" = ? and not ("email" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "name" = ? and not (("email" = ?))', $builder->toSql());
         $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'bar')->orWhereNot(function ($q) {
             $q->where('email', '=', 'foo');
         });
-        $this->assertSame('select * from "users" where "name" = ? or not ("email" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "name" = ? or not (("email" = ?))', $builder->toSql());
         $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1746,6 +1746,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testWhereNotWithArrayConditions()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot([['foo', 1], ['bar', 2]]);
+        $this->assertSame('select * from "users" where not (("foo" = ? and "bar" = ?))', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot(['foo' => 1, 'bar' => 2]);
+        $this->assertSame('select * from "users" where not (("foo" = ? and "bar" = ?))', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNot([['foo', 1], ['bar', '<', 2]]);
+        $this->assertSame('select * from "users" where not (("foo" = ? and "bar" < ?))', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+    }
+
     public function testFullSubSelects()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -306,7 +306,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNot('name', 'foo')->whereNot('name', '<>', 'bar');
-        $this->assertSame('select * from "users" where not ("name" = ?) and not ("name" <> ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where not "name" = ? and not "name" <> ?', $builder->toSql());
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
@@ -728,7 +728,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orWhereNot('name', 'foo')->orWhereNot('name', '<>', 'bar');
-        $this->assertSame('select * from "users" where not ("name" = ?) or not ("name" <> ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where not "name" = ? or not "name" <> ?', $builder->toSql());
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
@@ -1728,21 +1728,21 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereNot(function ($q) {
             $q->where('email', '=', 'foo');
         });
-        $this->assertSame('select * from "users" where not (("email" = ?))', $builder->toSql());
+        $this->assertSame('select * from "users" where not ("email" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'bar')->whereNot(function ($q) {
             $q->where('email', '=', 'foo');
         });
-        $this->assertSame('select * from "users" where "name" = ? and not (("email" = ?))', $builder->toSql());
+        $this->assertSame('select * from "users" where "name" = ? and not ("email" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'bar')->orWhereNot(function ($q) {
             $q->where('email', '=', 'foo');
         });
-        $this->assertSame('select * from "users" where "name" = ? or not (("email" = ?))', $builder->toSql());
+        $this->assertSame('select * from "users" where "name" = ? or not ("email" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
     }
 


### PR DESCRIPTION
```php
$query->whereNot([
    'foo' => 1, 
    'bar' => 2
]);
```

currently yields `not ( not foo = 1 and not bar = 2 )`
while I would expect this to implictly become a nested clause `not ( foo = 1 and bar = 2 )`.

The commits in this PR are deliberately threefold:

1. the actual bugfix + tests
2. the consequence of reusing `whereNested`: aesthetically superfluous parentheses (but sql doesn't care).
3. a missing variable interpolation I encountered on the go

---
Note: the PR only tackles `Query\Builder`. The same principle probably applies for `Eloquent\Builder`
