### PR TITLE
[9.x] Adds `Arr::move()`

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -566,6 +566,20 @@ class Arr
     }
 
     /**
+     * Moves a key value to another key.
+     *
+     * @param  array  $array
+     * @param  string  $origin
+     * @param  string  $destination
+     * @param  mixed  $default
+     * @return array
+     */
+    public static function move(&$array, $origin, $destination, $default = null)
+    {
+        return static::set($array, $destination, static::pull($array, $origin, $default));
+    }
+
+    /**
      * Push an item onto the beginning of an array.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -641,6 +641,27 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['first' => 'taylor', 'last' => 'otwell'], $data);
     }
 
+    public function testMove()
+    {
+        $data = ['first' => 'taylor', 'last' => 'otwell'];
+        $moved = Arr::move($data, 'first', 'last');
+
+        $this->assertEquals(['last' => 'taylor'], $data);
+        $this->assertSame($data, $moved);
+
+        $data = ['first' => 'taylor', 'sports' => ['football' => 'richmond']];
+        $moved = Arr::move($data, 'sports.football', 'first');
+
+        $this->assertEquals(['first' => 'richmond', 'sports' => []]);
+        $this->assertSame($data, $moved);
+
+        $data = ['first' => 'taylor', 'last' => 'otwell'];
+        $moved = Arr::move($data, 'second', 'last', 'default');
+
+        $this->assertEquals(['last' => 'default'], $data);
+        $this->assertSame($data, $moved);
+    }
+
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -652,7 +652,7 @@ class SupportArrTest extends TestCase
         $data = ['first' => 'taylor', 'sports' => ['football' => 'richmond']];
         $moved = Arr::move($data, 'sports.football', 'first');
 
-        $this->assertEquals(['first' => 'richmond', 'sports' => []]);
+        $this->assertEquals(['first' => 'richmond', 'sports' => []], $data);
         $this->assertSame($data, $moved);
 
         $data = ['first' => 'taylor', 'last' => 'otwell'];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -658,7 +658,7 @@ class SupportArrTest extends TestCase
         $data = ['first' => 'taylor', 'last' => 'otwell'];
         $moved = Arr::move($data, 'second', 'last', 'default');
 
-        $this->assertEquals(['last' => 'default'], $data);
+        $this->assertEquals(['first' => 'taylor', 'last' => 'default'], $data);
         $this->assertSame($data, $moved);
     }
 


### PR DESCRIPTION
## What?

The `Arr::move()` allows to move one value key to another in one line, deleting the source key.

```php
$array = ['count' => 100, 'real_count' => 200];

// Before
Arr::set($array, 'real_count', Arr::pull($array, 'count', 0);

// After
Arr::move($array, 'real_count', 'count', 0);
```

The key to move in the value will be created if it doesn't exists.