### PR TITLE
[9.x] Adds query `countGroupsBy()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3017,11 +3017,14 @@ class Builder implements BuilderContract
      */
     public function countGroupsBy($columns)
     {
-        return $this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
+        return $this->cloneWithout($this->unions || $this->havings || $this->groupBy ? [] : ['columns'])
                     ->cloneWithoutBindings($this->unions || $this->havings ? [] : ['select'])
                     ->setAggregate($function, $columns)
                     ->get($columns)
-                    ->map('array_change_key_case');
+                    ->each(function (array $results) {
+                        $results['count'] = $results['aggregate'];
+                        unset ($results['aggregate'])
+                    });
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3010,6 +3010,21 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Retrieve the "count" of each group of results from the query.
+     *
+     * @param  string  $columns
+     * @return \Illuminate\Support\Collection<int, int>
+     */
+    public function countGroupsBy($columns)
+    {
+        return $this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
+                    ->cloneWithoutBindings($this->unions || $this->havings ? [] : ['select'])
+                    ->setAggregate($function, $columns)
+                    ->get($columns)
+                    ->map('array_change_key_case');
+    }
+
+    /**
      * Retrieve the minimum value of a given column.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3013,7 +3013,7 @@ class Builder implements BuilderContract
      * Retrieve the "count" of each group of results from the query.
      *
      * @param  string  $columns
-     * @return \Illuminate\Support\Collection<int, int>
+     * @return \Illuminate\Support\Collection
      */
     public function countGroupsBy($columns)
     {
@@ -3021,9 +3021,10 @@ class Builder implements BuilderContract
                     ->cloneWithoutBindings($this->unions || $this->havings ? [] : ['select'])
                     ->setAggregate($function, $columns)
                     ->get($columns)
-                    ->each(function (array $results) {
-                        $results['count'] = $results['aggregate'];
-                        unset ($results['aggregate'])
+                    ->map(function (array $results) {
+                        $results = array_change_key_case($results);
+
+                        return Arr::set($results, 'count', (int) Arr::pull($results, 'aggregate', 0));
                     });
     }
 


### PR DESCRIPTION
## What?

This is mostly a response to multiple PR trying (and failing miserably) to count groups using the Query Builder: #44081, #28931, #1693 ...

The `countGroupsBy()` explicitly returns a `Collection` of results of arrays with the columns selected and the aggregate count of the group members.

```php
DB::table('students')->countGroupsBy('assignments', 'country');

// [
//     [
//         'assignments' => 5,
//         'country' => 'italy',
//         'count' => 10,
//     ],
//     [
//         'assignments' => 5,
//         'country' => 'france',
//         'count' => 78,
//     ],
//     // ...
// ]
```

The `countGroupsBy()` calls `groupBy()` and `select()` behind the scenes to coordinate the count of the resulting groups. The keys are normalized lowercase to retrieve the aggregate.