### PR TITLE
[9.x] Adds builder `countDistinct()`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3013,11 +3013,11 @@ class Builder implements BuilderContract
      * Retrieve the "count" result of the query for distinct column values.
      *
      * @param  string  $columns
-     * @return void
+     * @return int
      */
     public function countDistinct($columns)
     {
-        return $this->distinct()->count($columns)
+        return $this->distinct()->count($columns);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3010,6 +3010,17 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Retrieve the "count" result of the query for distinct column values.
+     *
+     * @param  string  $columns
+     * @return void
+     */
+    public function countDistinct($columns)
+    {
+        return $this->distinct()->count($columns)
+    }
+
+    /**
      * Retrieve the minimum value of a given column.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2259,6 +2259,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $results);
     }
 
+    public function testCountDistinct()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select count(distinct "country") as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
+            return $results;
+        });
+        $results = $builder->from('users')->countDistinct('country');
+        $this->assertEquals(1, $results);
+    }
+
     public function testSqlServerExists()
     {
         $builder = $this->getSqlServerBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2268,6 +2268,14 @@ class DatabaseQueryBuilderTest extends TestCase
         });
         $results = $builder->from('users')->countDistinct('country');
         $this->assertEquals(1, $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select count(distinct "country", "favorite_color") as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) {
+            return $results;
+        });
+        $results = $builder->select('name')->distinct()->from('users')->countDistinct(['country', 'favorite_color']);
+        $this->assertEquals(1, $results);
     }
 
     public function testSqlServerExists()


### PR DESCRIPTION
## What?

Sugar syntax to counting distinct values from the database, making more lexically clear.

```php
// Before
DB::table('students')->distinct()->count();
DB::table('students')->distinct('country')->count();

// After
DB::table('students')->countDistinct();
DB::table('students')->countDistinct('country');
```