### PR TITLE
[9.x] Support preloading assets with Vite

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -360,7 +360,7 @@ class Vite implements Htmlable
     }
 
     /**
-     * Make preload tag for the given chunk.
+     * Make a preload tag for the given chunk.
      *
      * @param  string  $src
      * @param  string  $url

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -63,11 +63,35 @@ class Vite implements Htmlable
     protected $styleTagAttributesResolvers = [];
 
     /**
+     * The preload tag attributes resolvers.
+     *
+     * @var array
+     */
+    protected $preloadTagAttributesResolvers = [];
+
+    /**
+     * The preloaded assets.
+     *
+     * @var array
+     */
+    protected $preloadedAssets = [];
+
+    /**
      * The cached manifest files.
      *
      * @var array
      */
     protected static $manifests = [];
+
+    /**
+     * Get the preloaded assets.
+     *
+     * @var array
+     */
+    public function preloadedAssets()
+    {
+        return $this->preloadedAssets;
+    }
 
     /**
      * Get the Content Security Policy nonce applied to all generated tags.
@@ -187,6 +211,23 @@ class Vite implements Htmlable
     }
 
     /**
+     * Use the given callback to resolve attributes for preload tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return $this
+     */
+    public function usePreloadTagAttributes($attributes)
+    {
+        if (! is_callable($attributes)) {
+            $attributes = fn () => $attributes;
+        }
+
+        $this->preloadTagAttributesResolvers[] = $attributes;
+
+        return $this;
+    }
+
+    /**
      * Generate Vite tags for an entrypoint.
      *
      * @param  string|string[]  $entrypoints
@@ -212,13 +253,35 @@ class Vite implements Htmlable
         $manifest = $this->manifest($buildDirectory);
 
         $tags = collect();
+        $preloads = collect();
 
         foreach ($entrypoints as $entrypoint) {
             $chunk = $this->chunk($manifest, $entrypoint);
 
+            $preloads->push($this->makePreloadTagForChunk(
+                $chunk['src'],
+                $this->assetPath("{$buildDirectory}/{$chunk['file']}"),
+                $chunk,
+                $manifest
+            ));
+
             foreach ($chunk['imports'] ?? [] as $import) {
+                $preloads->push($this->makePreloadTagForChunk(
+                    $import,
+                    $this->assetPath("{$buildDirectory}/{$manifest[$import]['file']}"),
+                    $manifest[$import],
+                    $manifest
+                ));
+
                 foreach ($manifest[$import]['css'] ?? [] as $css) {
                     $partialManifest = Collection::make($manifest)->where('file', $css);
+
+                    $preloads->push($this->makePreloadTagForChunk(
+                        $partialManifest->keys()->first(),
+                        $this->assetPath("{$buildDirectory}/{$css}"),
+                        $partialManifest->first(),
+                        $manifest
+                    ));
 
                     $tags->push($this->makeTagForChunk(
                         $partialManifest->keys()->first(),
@@ -239,6 +302,13 @@ class Vite implements Htmlable
             foreach ($chunk['css'] ?? [] as $css) {
                 $partialManifest = Collection::make($manifest)->where('file', $css);
 
+                $preloads->push($this->makePreloadTagForChunk(
+                    $partialManifest->keys()->first(),
+                    $this->assetPath("{$buildDirectory}/{$css}"),
+                    $partialManifest->first(),
+                    $manifest
+                ));
+
                 $tags->push($this->makeTagForChunk(
                     $partialManifest->keys()->first(),
                     $this->assetPath("{$buildDirectory}/{$css}"),
@@ -250,7 +320,9 @@ class Vite implements Htmlable
 
         [$stylesheets, $scripts] = $tags->partition(fn ($tag) => str_starts_with($tag, '<link'));
 
-        return new HtmlString($stylesheets->join('').$scripts->join(''));
+        $preloads = $preloads->sortByDesc(fn ($link) => str_contains($link, 'rel="preload"'));
+
+        return new HtmlString($preloads->join('').$stylesheets->join('').$scripts->join(''));
     }
 
     /**
@@ -284,6 +356,26 @@ class Vite implements Htmlable
             $url,
             $this->resolveScriptTagAttributes($src, $url, $chunk, $manifest)
         );
+    }
+
+    /**
+     * Make preload tag for the given chunk.
+     *
+     * @param  string  $src
+     * @param  string  $url
+     * @param  array  $chunk
+     * @param  array  $manifest
+     * @return string|null
+     */
+    protected function makePreloadTagForChunk($src, $url, $chunk, $manifest)
+    {
+        $attributes = $this->resolvePreloadTagAttributes($src, $url, $chunk, $manifest);
+
+        $this->preloadedAssets[$url] = $this->parseAttributes(
+            Collection::make($attributes)->forget('href')->all()
+        );
+
+        return '<link '.implode(' ', $this->parseAttributes($attributes)).' />';
     }
 
     /**
@@ -324,6 +416,37 @@ class Vite implements Htmlable
             : [];
 
         foreach ($this->styleTagAttributesResolvers as $resolver) {
+            $attributes = array_merge($attributes, $resolver($src, $url, $chunk, $manifest));
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Resolve the attributes for the chunks generated preload tag.
+     *
+     * @param  string  $src
+     * @param  string  $url
+     * @param  array  $chunk
+     * @param  array  $manifest
+     * @return array
+     */
+    protected function resolvePreloadTagAttributes($src, $url, $chunk, $manifest)
+    {
+        $attributes = $this->isCssPath($url) ? [
+            'rel' => 'preload',
+            'as' => 'style',
+            'href' => $url,
+        ] : [
+            'rel' => 'modulepreload',
+            'href' => $url,
+        ];
+
+        $attributes = $this->integrityKey !== false
+            ? array_merge($attributes, ['integrity' => $chunk[$this->integrityKey] ?? false])
+            : $attributes;
+
+        foreach ($this->preloadTagAttributesResolvers as $resolver) {
             $attributes = array_merge($attributes, $resolver($src, $url, $chunk, $manifest));
         }
 

--- a/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
+++ b/src/Illuminate/Http/Middleware/AddLinkHeadersForPreloadedAssets.php
@@ -5,7 +5,7 @@ namespace Illuminate\Http\Middleware;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Vite;
 
-class VitePreloading
+class AddLinkHeadersForPreloadedAssets
 {
     /**
      * Handle the incoming request.

--- a/src/Illuminate/Http/Middleware/VitePreloading.php
+++ b/src/Illuminate/Http/Middleware/VitePreloading.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Http\Middleware;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Vite;
+
+class VitePreloading
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Illuminate\Http\Response
+     */
+    public function handle($request, $next)
+    {
+        return tap($next($request), function ($response) {
+            if (Vite::preloadedAssets() !== []) {
+                $response->header('Link', Collection::make(Vite::preloadedAssets())
+                    ->map(fn ($attributes, $url) => "<{$url}>; ".implode('; ', $attributes))
+                    ->sortByDesc(fn ($link) => str_contains($link, 'rel="preload"'))
+                    ->join(', '));
+            }
+        });
+    }
+}

--- a/src/Illuminate/Http/Middleware/VitePreloading.php
+++ b/src/Illuminate/Http/Middleware/VitePreloading.php
@@ -20,7 +20,6 @@ class VitePreloading
             if (Vite::preloadedAssets() !== []) {
                 $response->header('Link', Collection::make(Vite::preloadedAssets())
                     ->map(fn ($attributes, $url) => "<{$url}>; ".implode('; ', $attributes))
-                    ->sortByDesc(fn ($link) => str_contains($link, 'rel="preload"'))
                     ->join(', '));
             }
         });

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -680,15 +680,15 @@ class FoundationViteTest extends TestCase
             .'<script type="module" src="https://example.com/'.$buildDir.'/assets/Login.8c52c4a3.js"></script>', $result->toHtml()
         );
         $this->assertSame([
+            'https://example.com/'.$buildDir.'/assets/app.9842b564.css' => [
+                'rel="preload"',
+                'as="style"',
+            ],
             'https://example.com/'.$buildDir.'/assets/Login.8c52c4a3.js' => [
                 'rel="modulepreload"',
             ],
             'https://example.com/'.$buildDir.'/assets/app.a26d8e4d.js' => [
                 'rel="modulepreload"',
-            ],
-            'https://example.com/'.$buildDir.'/assets/app.9842b564.css' => [
-                'rel="preload"',
-                'as="style"',
             ],
             'https://example.com/'.$buildDir.'/assets/AuthenticationCard.47ef70cc.js' => [
                 'rel="modulepreload"',
@@ -813,6 +813,16 @@ class FoundationViteTest extends TestCase
         $result->toHtml());
 
         $this->assertSame([
+            "https://example.com/$buildDir/assets/app.versioned.css" => [
+                'rel="preload"',
+                'as="style"',
+                'general="attribute"',
+                'crossorigin',
+                'data-persistent-across-pages="YES"',
+                'keep-me',
+                'empty-string=""',
+                'zero="0"',
+            ],
             "https://example.com/$buildDir/assets/app.versioned.js" => [
                 'rel="modulepreload"',
                 'general="attribute"',
@@ -824,16 +834,6 @@ class FoundationViteTest extends TestCase
             ],
             "https://example.com/$buildDir/assets/import.versioned.js" => [
                 'rel="modulepreload"',
-                'general="attribute"',
-                'crossorigin',
-                'data-persistent-across-pages="YES"',
-                'keep-me',
-                'empty-string=""',
-                'zero="0"',
-            ],
-            "https://example.com/$buildDir/assets/app.versioned.css" => [
-                'rel="preload"',
-                'as="style"',
                 'general="attribute"',
                 'crossorigin',
                 'data-persistent-across-pages="YES"',

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -29,7 +29,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)('resources/js/app.js');
 
-        $this->assertSame('<script type="module" src="https://example.com/build/assets/app.versioned.js"></script>', $result->toHtml());
+        $this->assertStringEndsWith('<script type="module" src="https://example.com/build/assets/app.versioned.js"></script>', $result->toHtml());
     }
 
     public function testViteWithCssAndJs()
@@ -38,7 +38,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" />'
             .'<script type="module" src="https://example.com/build/assets/app.versioned.js"></script>',
             $result->toHtml()
@@ -51,7 +51,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)('resources/js/app-with-css-import.js');
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/build/assets/imported-css.versioned.css" />'
             .'<script type="module" src="https://example.com/build/assets/app-with-css-import.versioned.js"></script>',
             $result->toHtml()
@@ -64,7 +64,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)(['resources/js/app-with-shared-css.js']);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/build/assets/shared-css.versioned.css" />'
             .'<script type="module" src="https://example.com/build/assets/app-with-shared-css.versioned.js"></script>',
             $result->toHtml()
@@ -128,7 +128,7 @@ class FoundationViteTest extends TestCase
 
         $this->assertSame('random-string-with-length:40', $nonce);
         $this->assertSame('random-string-with-length:40', ViteFacade::cspNonce());
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" nonce="random-string-with-length:40" />'
             .'<script type="module" src="https://example.com/build/assets/app.versioned.js" nonce="random-string-with-length:40"></script>',
             $result->toHtml()
@@ -163,7 +163,7 @@ class FoundationViteTest extends TestCase
 
         $this->assertSame('expected-nonce', $nonce);
         $this->assertSame('expected-nonce', ViteFacade::cspNonce());
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" nonce="expected-nonce" />'
             .'<script type="module" src="https://example.com/build/assets/app.versioned.js" nonce="expected-nonce"></script>',
             $result->toHtml()
@@ -175,10 +175,12 @@ class FoundationViteTest extends TestCase
         $buildDir = Str::random();
         $this->makeViteManifest([
             'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
                 'file' => 'assets/app.versioned.js',
                 'integrity' => 'expected-app.js-integrity',
             ],
             'resources/css/app.css' => [
+                'src' => 'resources/css/app.css',
                 'file' => 'assets/app.versioned.css',
                 'integrity' => 'expected-app.css-integrity',
             ],
@@ -186,7 +188,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js'], $buildDir);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/app.versioned.css" integrity="expected-app.css-integrity" />'
             .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js" integrity="expected-app.js-integrity"></script>',
             $result->toHtml()
@@ -200,6 +202,7 @@ class FoundationViteTest extends TestCase
         $buildDir = Str::random();
         $this->makeViteManifest([
             'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
                 'file' => 'assets/app.versioned.js',
                 'css' => [
                     'assets/direct-css-dependency.aabbcc.css',
@@ -221,7 +224,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)('resources/js/app.js', $buildDir);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/direct-css-dependency.aabbcc.css" integrity="expected-imported-css.css-integrity" />'
             .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js" integrity="expected-app.js-integrity"></script>',
             $result->toHtml()
@@ -235,6 +238,7 @@ class FoundationViteTest extends TestCase
         $buildDir = Str::random();
         $this->makeViteManifest([
             'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
                 'file' => 'assets/app.versioned.js',
                 'imports' => [
                     '_import.versioned.js',
@@ -256,7 +260,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)('resources/js/app.js', $buildDir);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/imported-css.versioned.css" integrity="expected-imported-css.css-integrity" />'
             .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js" integrity="expected-app.js-integrity"></script>',
             $result->toHtml()
@@ -270,10 +274,12 @@ class FoundationViteTest extends TestCase
         $buildDir = Str::random();
         $this->makeViteManifest([
             'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
                 'file' => 'assets/app.versioned.js',
                 'different-integrity-key' => 'expected-app.js-integrity',
             ],
             'resources/css/app.css' => [
+                'src' => 'resources/css/app.css',
                 'file' => 'assets/app.versioned.css',
                 'different-integrity-key' => 'expected-app.css-integrity',
             ],
@@ -282,7 +288,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js'], $buildDir);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/app.versioned.css" integrity="expected-app.css-integrity" />'
             .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js" integrity="expected-app.js-integrity"></script>',
             $result->toHtml()
@@ -300,12 +306,17 @@ class FoundationViteTest extends TestCase
         ViteFacade::useScriptTagAttributes(function ($src, $url, $chunk, $manifest) {
             $this->assertSame('resources/js/app.js', $src);
             $this->assertSame('https://example.com/build/assets/app.versioned.js', $url);
-            $this->assertSame(['file' => 'assets/app.versioned.js'], $chunk);
+            $this->assertSame([
+                'src' => 'resources/js/app.js',
+                'file' => 'assets/app.versioned.js',
+            ], $chunk);
             $this->assertSame([
                 'resources/js/app.js' => [
+                    'src' => 'resources/js/app.js',
                     'file' => 'assets/app.versioned.js',
                 ],
                 'resources/js/app-with-css-import.js' => [
+                    'src' => 'resources/js/app-with-css-import.js',
                     'file' => 'assets/app-with-css-import.versioned.js',
                     'css' => [
                         'assets/imported-css.versioned.css',
@@ -315,20 +326,24 @@ class FoundationViteTest extends TestCase
                     'file' => 'assets/imported-css.versioned.css',
                 ],
                 'resources/js/app-with-shared-css.js' => [
+                    'src' => 'resources/js/app-with-shared-css.js',
                     'file' => 'assets/app-with-shared-css.versioned.js',
                     'imports' => [
                         '_someFile.js',
                     ],
                 ],
                 'resources/css/app.css' => [
+                    'src' => 'resources/css/app.css',
                     'file' => 'assets/app.versioned.css',
                 ],
                 '_someFile.js' => [
+                    'file' => 'assets/someFile.versioned.js',
                     'css' => [
                         'assets/shared-css.versioned.css',
                     ],
                 ],
                 'resources/css/shared-css' => [
+                    'src' => 'resources/css/shared-css',
                     'file' => 'assets/shared-css.versioned.css',
                 ],
             ], $manifest);
@@ -346,7 +361,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" />'
             .'<script type="module" src="https://example.com/build/assets/app.versioned.js" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me empty-string="" zero="0"></script>',
             $result->toHtml()
@@ -362,12 +377,17 @@ class FoundationViteTest extends TestCase
         ViteFacade::useStyleTagAttributes(function ($src, $url, $chunk, $manifest) {
             $this->assertSame('resources/css/app.css', $src);
             $this->assertSame('https://example.com/build/assets/app.versioned.css', $url);
-            $this->assertSame(['file' => 'assets/app.versioned.css'], $chunk);
+            $this->assertSame([
+                'src' => 'resources/css/app.css',
+                'file' => 'assets/app.versioned.css',
+            ], $chunk);
             $this->assertSame([
                 'resources/js/app.js' => [
+                    'src' => 'resources/js/app.js',
                     'file' => 'assets/app.versioned.js',
                 ],
                 'resources/js/app-with-css-import.js' => [
+                    'src' => 'resources/js/app-with-css-import.js',
                     'file' => 'assets/app-with-css-import.versioned.js',
                     'css' => [
                         'assets/imported-css.versioned.css',
@@ -377,20 +397,24 @@ class FoundationViteTest extends TestCase
                     'file' => 'assets/imported-css.versioned.css',
                 ],
                 'resources/js/app-with-shared-css.js' => [
+                    'src' => 'resources/js/app-with-shared-css.js',
                     'file' => 'assets/app-with-shared-css.versioned.js',
                     'imports' => [
                         '_someFile.js',
                     ],
                 ],
                 'resources/css/app.css' => [
+                    'src' => 'resources/css/app.css',
                     'file' => 'assets/app.versioned.css',
                 ],
                 '_someFile.js' => [
+                    'file' => 'assets/someFile.versioned.js',
                     'css' => [
                         'assets/shared-css.versioned.css',
                     ],
                 ],
                 'resources/css/shared-css' => [
+                    'src' => 'resources/css/shared-css',
                     'file' => 'assets/shared-css.versioned.css',
                 ],
             ], $manifest);
@@ -405,7 +429,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="stylesheet" href="https://example.com/build/assets/app.versioned.css" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me />'
             .'<script type="module" src="https://example.com/build/assets/app.versioned.js"></script>',
             $result->toHtml()
@@ -492,7 +516,7 @@ class FoundationViteTest extends TestCase
 
         $result = app(Vite::class)(['resources/css/app.css', 'resources/js/app.js']);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<link rel="expected-rel" href="expected-href" />'
             .'<script type="expected-type" src="expected-src"></script>',
             $result->toHtml()
@@ -575,7 +599,7 @@ class FoundationViteTest extends TestCase
 
         $vite->withEntryPoints(['resources/js/app.js']);
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<script type="module" src="https://example.com/build/assets/app.versioned.js"></script>',
             $vite->toHtml()
         );
@@ -589,7 +613,7 @@ class FoundationViteTest extends TestCase
 
         $vite->withEntryPoints(['resources/js/app.js'])->useBuildDirectory('custom-build');
 
-        $this->assertSame(
+        $this->assertStringEndsWith(
             '<script type="module" src="https://example.com/custom-build/assets/app.versioned.js"></script>',
             $vite->toHtml()
         );
@@ -633,6 +657,195 @@ class FoundationViteTest extends TestCase
         $this->cleanViteManifest($buildDir);
     }
 
+    public function testItGeneratesPreloadDirectivesForJsAndCssImports()
+    {
+        $manifest = json_decode(file_get_contents(__DIR__.'/fixtures/jetstream-manifest.json'));
+        $buildDir = Str::random();
+        $this->makeViteManifest($manifest, $buildDir);
+
+        $result = app(Vite::class)(['resources/js/Pages/Auth/Login.vue'], $buildDir);
+
+        $this->assertSame(
+            '<link rel="preload" as="style" href="https://example.com/'.$buildDir.'/assets/app.9842b564.css" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/Login.8c52c4a3.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/app.a26d8e4d.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/AuthenticationCard.47ef70cc.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/AuthenticationCardLogo.9999a373.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/Checkbox.33ba23f3.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/TextInput.e2f0248c.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/InputLabel.d245ec4e.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/PrimaryButton.931d2859.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/_plugin-vue_export-helper.cdc0426e.js" />'
+            .'<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/app.9842b564.css" />'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/Login.8c52c4a3.js"></script>', $result->toHtml()
+        );
+        $this->assertSame([
+            'https://example.com/'.$buildDir.'/assets/Login.8c52c4a3.js' => [
+                'rel="modulepreload"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/app.a26d8e4d.js' => [
+                'rel="modulepreload"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/app.9842b564.css' => [
+                'rel="preload"',
+                'as="style"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/AuthenticationCard.47ef70cc.js' => [
+                'rel="modulepreload"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/AuthenticationCardLogo.9999a373.js' => [
+                'rel="modulepreload"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/Checkbox.33ba23f3.js' => [
+                'rel="modulepreload"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/TextInput.e2f0248c.js' => [
+                'rel="modulepreload"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/InputLabel.d245ec4e.js' => [
+                'rel="modulepreload"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/PrimaryButton.931d2859.js' => [
+                'rel="modulepreload"',
+            ],
+            'https://example.com/'.$buildDir.'/assets/_plugin-vue_export-helper.cdc0426e.js' => [
+                'rel="modulepreload"',
+            ],
+        ], ViteFacade::preloadedAssets());
+
+        $this->cleanViteManifest($buildDir);
+    }
+
+    public function testItCanSpecifyAttributesForPreloadedAssets()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest([
+            'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
+                'file' => 'assets/app.versioned.js',
+                'imports' => [
+                    'import.js',
+                ],
+                'css' => [
+                    'assets/app.versioned.css',
+                ],
+            ],
+            'import.js' => [
+                'file' => 'assets/import.versioned.js',
+            ],
+            'resources/css/app.css' => [
+                'src' => 'resources/css/app.css',
+                'file' => 'assets/app.versioned.css',
+            ],
+        ], $buildDir);
+        ViteFacade::usePreloadTagAttributes([
+            'general' => 'attribute',
+        ]);
+        ViteFacade::usePreloadTagAttributes(function ($src, $url, $chunk, $manifest) use ($buildDir) {
+            $this->assertSame([
+                'resources/js/app.js' => [
+                    'src' => 'resources/js/app.js',
+                    'file' => 'assets/app.versioned.js',
+                    'imports' => [
+                        'import.js',
+                    ],
+                    'css' => [
+                        'assets/app.versioned.css',
+                    ],
+                ],
+                'import.js' => [
+                    'file' => 'assets/import.versioned.js',
+                ],
+                'resources/css/app.css' => [
+                    'src' => 'resources/css/app.css',
+                    'file' => 'assets/app.versioned.css',
+                ],
+            ], $manifest);
+
+            (match ($src) {
+                'resources/js/app.js' => function () use ($url, $chunk, $buildDir) {
+                    $this->assertSame("https://example.com/{$buildDir}/assets/app.versioned.js", $url);
+                    $this->assertSame([
+                        'src' => 'resources/js/app.js',
+                        'file' => 'assets/app.versioned.js',
+                        'imports' => [
+                            'import.js',
+                        ],
+                        'css' => [
+                            'assets/app.versioned.css',
+                        ],
+                    ], $chunk);
+                },
+                'import.js' => function () use ($url, $chunk, $buildDir) {
+                    $this->assertSame("https://example.com/{$buildDir}/assets/import.versioned.js", $url);
+                    $this->assertSame([
+                        'file' => 'assets/import.versioned.js',
+                    ], $chunk);
+                },
+                'resources/css/app.css' => function () use ($url, $chunk, $buildDir) {
+                    $this->assertSame("https://example.com/{$buildDir}/assets/app.versioned.css", $url);
+                    $this->assertSame([
+                        'src' => 'resources/css/app.css',
+                        'file' => 'assets/app.versioned.css',
+                    ], $chunk);
+                },
+            })();
+
+            return [
+                'crossorigin',
+                'data-persistent-across-pages' => 'YES',
+                'remove-me' => false,
+                'keep-me' => true,
+                'null' => null,
+                'empty-string' => '',
+                'zero' => 0,
+            ];
+        });
+
+        $result = app(Vite::class)(['resources/js/app.js'], $buildDir);
+
+        $this->assertSame(
+            '<link rel="preload" as="style" href="https://example.com/'.$buildDir.'/assets/app.versioned.css" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me empty-string="" zero="0" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/app.versioned.js" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me empty-string="" zero="0" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/import.versioned.js" general="attribute" crossorigin data-persistent-across-pages="YES" keep-me empty-string="" zero="0" />'
+            .'<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/app.versioned.css" />'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app.versioned.js"></script>',
+        $result->toHtml());
+
+        $this->assertSame([
+            "https://example.com/$buildDir/assets/app.versioned.js" => [
+                'rel="modulepreload"',
+                'general="attribute"',
+                'crossorigin',
+                'data-persistent-across-pages="YES"',
+                'keep-me',
+                'empty-string=""',
+                'zero="0"',
+            ],
+            "https://example.com/$buildDir/assets/import.versioned.js" => [
+                'rel="modulepreload"',
+                'general="attribute"',
+                'crossorigin',
+                'data-persistent-across-pages="YES"',
+                'keep-me',
+                'empty-string=""',
+                'zero="0"',
+            ],
+            "https://example.com/$buildDir/assets/app.versioned.css" => [
+                'rel="preload"',
+                'as="style"',
+                'general="attribute"',
+                'crossorigin',
+                'data-persistent-across-pages="YES"',
+                'keep-me',
+                'empty-string=""',
+                'zero="0"',
+            ],
+        ], ViteFacade::preloadedAssets());
+
+        $this->cleanViteManifest($buildDir);
+    }
+
     protected function makeViteManifest($contents = null, $path = 'build')
     {
         app()->singleton('path.public', fn () => __DIR__);
@@ -643,32 +856,39 @@ class FoundationViteTest extends TestCase
 
         $manifest = json_encode($contents ?? [
             'resources/js/app.js' => [
+                'src' => 'resources/js/app.js',
                 'file' => 'assets/app.versioned.js',
             ],
             'resources/js/app-with-css-import.js' => [
+                'src' => 'resources/js/app-with-css-import.js',
                 'file' => 'assets/app-with-css-import.versioned.js',
                 'css' => [
                     'assets/imported-css.versioned.css',
                 ],
             ],
             'resources/css/imported-css.css' => [
+                // 'src' => 'resources/css/imported-css.css',
                 'file' => 'assets/imported-css.versioned.css',
             ],
             'resources/js/app-with-shared-css.js' => [
+                'src' => 'resources/js/app-with-shared-css.js',
                 'file' => 'assets/app-with-shared-css.versioned.js',
                 'imports' => [
                     '_someFile.js',
                 ],
             ],
             'resources/css/app.css' => [
+                'src' => 'resources/css/app.css',
                 'file' => 'assets/app.versioned.css',
             ],
             '_someFile.js' => [
+                'file' => 'assets/someFile.versioned.js',
                 'css' => [
                     'assets/shared-css.versioned.css',
                 ],
             ],
             'resources/css/shared-css' => [
+                'src' => 'resources/css/shared-css',
                 'file' => 'assets/shared-css.versioned.css',
             ],
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/tests/Foundation/fixtures/jetstream-manifest.json
+++ b/tests/Foundation/fixtures/jetstream-manifest.json
@@ -1,0 +1,406 @@
+{
+  "resources/js/app.js": {
+    "file": "assets/app.a26d8e4d.js",
+    "src": "resources/js/app.js",
+    "isEntry": true,
+    "dynamicImports": [
+      "resources/js/Pages/API/Index.vue",
+      "resources/js/Pages/API/Partials/ApiTokenManager.vue",
+      "resources/js/Pages/Auth/ConfirmPassword.vue",
+      "resources/js/Pages/Auth/ForgotPassword.vue",
+      "resources/js/Pages/Auth/Login.vue",
+      "resources/js/Pages/Auth/Register.vue",
+      "resources/js/Pages/Auth/ResetPassword.vue",
+      "resources/js/Pages/Auth/TwoFactorChallenge.vue",
+      "resources/js/Pages/Auth/VerifyEmail.vue",
+      "resources/js/Pages/Dashboard.vue",
+      "resources/js/Pages/PrivacyPolicy.vue",
+      "resources/js/Pages/Profile/Partials/DeleteUserForm.vue",
+      "resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue",
+      "resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue",
+      "resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue",
+      "resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue",
+      "resources/js/Pages/Profile/Show.vue",
+      "resources/js/Pages/TermsOfService.vue",
+      "resources/js/Pages/Welcome.vue"
+    ],
+    "css": [
+      "assets/app.9842b564.css"
+    ]
+  },
+  "resources/js/Pages/API/Index.vue": {
+    "file": "assets/Index.58f39f21.js",
+    "src": "resources/js/Pages/API/Index.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/Pages/API/Partials/ApiTokenManager.vue",
+      "_AppLayout.e6a6a429.js",
+      "resources/js/app.js",
+      "_ActionMessage.f06648ac.js",
+      "_DialogModal.957bf006.js",
+      "_SectionTitle.060e9618.js",
+      "__plugin-vue_export-helper.cdc0426e.js",
+      "_Checkbox.33ba23f3.js",
+      "_DangerButton.12acbcf1.js",
+      "_FormSection.64ccd4c1.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "_SecondaryButton.0f3618fc.js",
+      "_SectionBorder.b8ebe4c3.js"
+    ]
+  },
+  "resources/js/Pages/API/Partials/ApiTokenManager.vue": {
+    "file": "assets/ApiTokenManager.b6097283.js",
+    "src": "resources/js/Pages/API/Partials/ApiTokenManager.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_ActionMessage.f06648ac.js",
+      "_DialogModal.957bf006.js",
+      "_Checkbox.33ba23f3.js",
+      "_DangerButton.12acbcf1.js",
+      "_FormSection.64ccd4c1.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "_SecondaryButton.0f3618fc.js",
+      "_SectionBorder.b8ebe4c3.js",
+      "_SectionTitle.060e9618.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "_AppLayout.e6a6a429.js": {
+    "file": "assets/AppLayout.e6a6a429.js",
+    "imports": [
+      "resources/js/app.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "_ActionMessage.f06648ac.js": {
+    "file": "assets/ActionMessage.f06648ac.js",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "_DialogModal.957bf006.js": {
+    "file": "assets/DialogModal.957bf006.js",
+    "imports": [
+      "_SectionTitle.060e9618.js",
+      "resources/js/app.js"
+    ]
+  },
+  "_Checkbox.33ba23f3.js": {
+    "file": "assets/Checkbox.33ba23f3.js",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "_DangerButton.12acbcf1.js": {
+    "file": "assets/DangerButton.12acbcf1.js",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "_FormSection.64ccd4c1.js": {
+    "file": "assets/FormSection.64ccd4c1.js",
+    "imports": [
+      "resources/js/app.js",
+      "_SectionTitle.060e9618.js"
+    ]
+  },
+  "_TextInput.e2f0248c.js": {
+    "file": "assets/TextInput.e2f0248c.js",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "_InputLabel.d245ec4e.js": {
+    "file": "assets/InputLabel.d245ec4e.js",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "_PrimaryButton.931d2859.js": {
+    "file": "assets/PrimaryButton.931d2859.js",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "_SecondaryButton.0f3618fc.js": {
+    "file": "assets/SecondaryButton.0f3618fc.js",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "_SectionBorder.b8ebe4c3.js": {
+    "file": "assets/SectionBorder.b8ebe4c3.js",
+    "imports": [
+      "__plugin-vue_export-helper.cdc0426e.js",
+      "resources/js/app.js"
+    ]
+  },
+  "_SectionTitle.060e9618.js": {
+    "file": "assets/SectionTitle.060e9618.js",
+    "imports": [
+      "__plugin-vue_export-helper.cdc0426e.js",
+      "resources/js/app.js"
+    ]
+  },
+  "__plugin-vue_export-helper.cdc0426e.js": {
+    "file": "assets/_plugin-vue_export-helper.cdc0426e.js"
+  },
+  "resources/js/Pages/Auth/ConfirmPassword.vue": {
+    "file": "assets/ConfirmPassword.0f0db8fa.js",
+    "src": "resources/js/Pages/Auth/ConfirmPassword.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCard.47ef70cc.js",
+      "_AuthenticationCardLogo.9999a373.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "_AuthenticationCard.47ef70cc.js": {
+    "file": "assets/AuthenticationCard.47ef70cc.js",
+    "imports": [
+      "__plugin-vue_export-helper.cdc0426e.js",
+      "resources/js/app.js"
+    ]
+  },
+  "_AuthenticationCardLogo.9999a373.js": {
+    "file": "assets/AuthenticationCardLogo.9999a373.js",
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "resources/js/Pages/Auth/ForgotPassword.vue": {
+    "file": "assets/ForgotPassword.5e46b816.js",
+    "src": "resources/js/Pages/Auth/ForgotPassword.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCard.47ef70cc.js",
+      "_AuthenticationCardLogo.9999a373.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Auth/Login.vue": {
+    "file": "assets/Login.8c52c4a3.js",
+    "src": "resources/js/Pages/Auth/Login.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCard.47ef70cc.js",
+      "_AuthenticationCardLogo.9999a373.js",
+      "_Checkbox.33ba23f3.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Auth/Register.vue": {
+    "file": "assets/Register.f69e0819.js",
+    "src": "resources/js/Pages/Auth/Register.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCard.47ef70cc.js",
+      "_AuthenticationCardLogo.9999a373.js",
+      "_Checkbox.33ba23f3.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Auth/ResetPassword.vue": {
+    "file": "assets/ResetPassword.507eb03d.js",
+    "src": "resources/js/Pages/Auth/ResetPassword.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCard.47ef70cc.js",
+      "_AuthenticationCardLogo.9999a373.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Auth/TwoFactorChallenge.vue": {
+    "file": "assets/TwoFactorChallenge.60db078c.js",
+    "src": "resources/js/Pages/Auth/TwoFactorChallenge.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCard.47ef70cc.js",
+      "_AuthenticationCardLogo.9999a373.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Auth/VerifyEmail.vue": {
+    "file": "assets/VerifyEmail.fc56de65.js",
+    "src": "resources/js/Pages/Auth/VerifyEmail.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCard.47ef70cc.js",
+      "_AuthenticationCardLogo.9999a373.js",
+      "_PrimaryButton.931d2859.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Dashboard.vue": {
+    "file": "assets/Dashboard.50e1603d.js",
+    "src": "resources/js/Pages/Dashboard.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "_AppLayout.e6a6a429.js",
+      "__plugin-vue_export-helper.cdc0426e.js",
+      "resources/js/app.js"
+    ]
+  },
+  "resources/js/Pages/PrivacyPolicy.vue": {
+    "file": "assets/PrivacyPolicy.c2abeb25.js",
+    "src": "resources/js/Pages/PrivacyPolicy.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCardLogo.9999a373.js"
+    ]
+  },
+  "resources/js/Pages/Profile/Partials/DeleteUserForm.vue": {
+    "file": "assets/DeleteUserForm.9a6b1c68.js",
+    "src": "resources/js/Pages/Profile/Partials/DeleteUserForm.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_DialogModal.957bf006.js",
+      "_DangerButton.12acbcf1.js",
+      "_TextInput.e2f0248c.js",
+      "_SecondaryButton.0f3618fc.js",
+      "_SectionTitle.060e9618.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue": {
+    "file": "assets/LogoutOtherBrowserSessionsForm.6fa01927.js",
+    "src": "resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_ActionMessage.f06648ac.js",
+      "_DialogModal.957bf006.js",
+      "_TextInput.e2f0248c.js",
+      "_PrimaryButton.931d2859.js",
+      "_SecondaryButton.0f3618fc.js",
+      "_SectionTitle.060e9618.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue": {
+    "file": "assets/TwoFactorAuthenticationForm.494ff4de.js",
+    "src": "resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_DialogModal.957bf006.js",
+      "_TextInput.e2f0248c.js",
+      "_PrimaryButton.931d2859.js",
+      "_SecondaryButton.0f3618fc.js",
+      "_DangerButton.12acbcf1.js",
+      "_InputLabel.d245ec4e.js",
+      "_SectionTitle.060e9618.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue": {
+    "file": "assets/UpdatePasswordForm.a8718b3a.js",
+    "src": "resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_ActionMessage.f06648ac.js",
+      "_FormSection.64ccd4c1.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "_SectionTitle.060e9618.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue": {
+    "file": "assets/UpdateProfileInformationForm.dc291001.js",
+    "src": "resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_ActionMessage.f06648ac.js",
+      "_FormSection.64ccd4c1.js",
+      "_TextInput.e2f0248c.js",
+      "_InputLabel.d245ec4e.js",
+      "_PrimaryButton.931d2859.js",
+      "_SecondaryButton.0f3618fc.js",
+      "_SectionTitle.060e9618.js",
+      "__plugin-vue_export-helper.cdc0426e.js"
+    ]
+  },
+  "resources/js/Pages/Profile/Show.vue": {
+    "file": "assets/Show.836f42f9.js",
+    "src": "resources/js/Pages/Profile/Show.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "_AppLayout.e6a6a429.js",
+      "resources/js/Pages/Profile/Partials/DeleteUserForm.vue",
+      "resources/js/Pages/Profile/Partials/LogoutOtherBrowserSessionsForm.vue",
+      "_SectionBorder.b8ebe4c3.js",
+      "resources/js/Pages/Profile/Partials/TwoFactorAuthenticationForm.vue",
+      "resources/js/Pages/Profile/Partials/UpdatePasswordForm.vue",
+      "resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue",
+      "resources/js/app.js",
+      "__plugin-vue_export-helper.cdc0426e.js",
+      "_DialogModal.957bf006.js",
+      "_SectionTitle.060e9618.js",
+      "_DangerButton.12acbcf1.js",
+      "_TextInput.e2f0248c.js",
+      "_SecondaryButton.0f3618fc.js",
+      "_ActionMessage.f06648ac.js",
+      "_PrimaryButton.931d2859.js",
+      "_InputLabel.d245ec4e.js",
+      "_FormSection.64ccd4c1.js"
+    ]
+  },
+  "resources/js/Pages/TermsOfService.vue": {
+    "file": "assets/TermsOfService.a0750aab.js",
+    "src": "resources/js/Pages/TermsOfService.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js",
+      "_AuthenticationCardLogo.9999a373.js"
+    ]
+  },
+  "resources/js/Pages/Welcome.vue": {
+    "file": "assets/Welcome.78edc4a1.js",
+    "src": "resources/js/Pages/Welcome.vue",
+    "isDynamicEntry": true,
+    "imports": [
+      "resources/js/app.js"
+    ]
+  },
+  "resources/js/app.css": {
+    "file": "assets/app.9842b564.css",
+    "src": "resources/js/app.css"
+  }
+}
+

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -4,7 +4,7 @@ namespace Illuminate\Tests\Http\Middleware;
 
 use Illuminate\Container\Container;
 use Illuminate\Foundation\Vite;
-use Illuminate\Http\Middleware\VitePreloading;
+use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Facade;
@@ -21,13 +21,12 @@ class VitePreloadingTest extends TestCase
     public function testItDoesNotSetLinkTagWhenNoTagsHaveBeenPreloaded()
     {
         $app = new Container();
-        $app->instance(Vite::class, new class extends Vite
-        {
+        $app->instance(Vite::class, new class extends Vite {
             protected $preloadedAssets = [];
         });
         Facade::setFacadeApplication($app);
 
-        $response = (new VitePreloading)->handle(new Request, function () {
+        $response = (new AddLinkHeadersForPreloadedAssets)->handle(new Request, function () {
             return new Response('Hello Laravel');
         });
 
@@ -37,8 +36,7 @@ class VitePreloadingTest extends TestCase
     public function testItAddsPreloadLinkHeader()
     {
         $app = new Container();
-        $app->instance(Vite::class, new class extends Vite
-        {
+        $app->instance(Vite::class, new class extends Vite {
             protected $preloadedAssets = [
                 'https://laravel.com/app.js' => [
                     'rel="modulepreload"',
@@ -48,7 +46,7 @@ class VitePreloadingTest extends TestCase
         });
         Facade::setFacadeApplication($app);
 
-        $response = (new VitePreloading)->handle(new Request, function () {
+        $response = (new AddLinkHeadersForPreloadedAssets)->handle(new Request, function () {
             return new Response('Hello Laravel');
         });
 

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -57,32 +57,4 @@ class VitePreloadingTest extends TestCase
             '<https://laravel.com/app.js>; rel="modulepreload"; foo="bar"'
         );
     }
-
-    public function testItPrioritizesCss()
-    {
-        $app = new Container();
-        $app->instance(Vite::class, new class extends Vite
-        {
-            protected $preloadedAssets = [
-                'https://laravel.com/app.js' => [
-                    'rel="modulepreload"',
-                    'foo="bar"',
-                ],
-                'https://laravel.com/app.css' => [
-                    'rel="preload"',
-                    'bar="baz"',
-                ],
-            ];
-        });
-        Facade::setFacadeApplication($app);
-
-        $response = (new VitePreloading)->handle(new Request, function () {
-            return new Response('Hello Laravel');
-        });
-
-        $this->assertSame(
-            $response->headers->get('Link'),
-            '<https://laravel.com/app.css>; rel="preload"; bar="baz", <https://laravel.com/app.js>; rel="modulepreload"; foo="bar"'
-        );
-    }
 }

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Http\Middleware;
+
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Vite;
+use Illuminate\Http\Middleware\VitePreloading;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\TestCase;
+
+class VitePreloadingTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Facade::setFacadeApplication(null);
+        Facade::clearResolvedInstances();
+    }
+
+    public function testItDoesNotSetLinkTagWhenNoTagsHaveBeenPreloaded()
+    {
+        $app = new Container();
+        $app->instance(Vite::class, new class extends Vite
+        {
+            protected $preloadedAssets = [];
+        });
+        Facade::setFacadeApplication($app);
+
+        $response = (new VitePreloading)->handle(new Request, function () {
+            return new Response('Hello Laravel');
+        });
+
+        $this->assertNull($response->headers->get('Link'));
+    }
+
+    public function testItAddsPreloadLinkHeader()
+    {
+        $app = new Container();
+        $app->instance(Vite::class, new class extends Vite
+        {
+            protected $preloadedAssets = [
+                'https://laravel.com/app.js' => [
+                    'rel="modulepreload"',
+                    'foo="bar"',
+                ],
+            ];
+        });
+        Facade::setFacadeApplication($app);
+
+        $response = (new VitePreloading)->handle(new Request, function () {
+            return new Response('Hello Laravel');
+        });
+
+        $this->assertSame(
+            $response->headers->get('Link'),
+            '<https://laravel.com/app.js>; rel="modulepreload"; foo="bar"'
+        );
+    }
+
+    public function testItPrioritizesCss()
+    {
+        $app = new Container();
+        $app->instance(Vite::class, new class extends Vite
+        {
+            protected $preloadedAssets = [
+                'https://laravel.com/app.js' => [
+                    'rel="modulepreload"',
+                    'foo="bar"',
+                ],
+                'https://laravel.com/app.css' => [
+                    'rel="preload"',
+                    'bar="baz"',
+                ],
+            ];
+        });
+        Facade::setFacadeApplication($app);
+
+        $response = (new VitePreloading)->handle(new Request, function () {
+            return new Response('Hello Laravel');
+        });
+
+        $this->assertSame(
+            $response->headers->get('Link'),
+            '<https://laravel.com/app.css>; rel="preload"; bar="baz", <https://laravel.com/app.js>; rel="modulepreload"; foo="bar"'
+        );
+    }
+}


### PR DESCRIPTION
Preloading is a mechanism that informs the browser which assets are required for the current page load. You can read more about [preloading on web.dev](https://web.dev/preload-critical-assets/).

Using this PR on a real-world application increased the Lighthouse score from `59` to `90`. These were the average results from a controlled environment. Your mileage may vary, but this PR should generally work for the 95% usecase (IMO).

Preloading is not something to opt into. With this PR it becomes the default behaviour for applications using Vite, however the middleware does need to be applied manually if you want to have the preloading headers sent with the initial Laravel HTTP response.

I'll outline the problem we are looking to solve: for SPA applications building with Vite, or any modern build tool using code splitting, the resulting assets look similar to the following:

- `app.123.js`
- `Welcome.123.js`
- `Login.123.js`
- `Register.123.js`
- ...

Each of these top-level "pages" will often have imports:

- `Login.123.js`
  - `TextInput.123.js`
  - `InputLabel.123.js`
  - `PrimaryButton.123.js`

"Code splitting" like this is a performance optimisation so you load only the JavaScript required for the current page, which makes the initial page load faster.

Currently in Laravel, when loading the very first page of an application, we specify the following entry point:

```blade
@vite(['resources/js/app.js'])
```

This results in the following _waterfall_ of requests:

1. `/login.html`...
2. `app.js`...
3. `Login.js`, `TextInput.js`, `InputLabel.js`, `PrimaryButton.js`...

This waterfall of requests is, of course, less than ideal. Working through this waterfall:

1. The browser must first download the HTML and parse it to know what CSS and JavaScript the document has specified. Our document has specified "app.js", so the browser proceeds to fetch it.
2. Once `app.js` js fetched and parsed, the JavaScript kicks in an informs the browser that it should be loading the `Login.js` file and it's imports.
3. The browser begins fetching, parsing, and executing the required imports.

Possible solutions are:

1. Bundle everything into a single `app.js` with "eager globing"
4. Preloading

Before I dig into these solutions, let me post the results of my Lighthouse performance testing against a real-world application. These tests were run against "mobile".

I acknowledge that this is a single application and need further verification.

| With Preloading | Configuration | Lighthouse score |
|-----------------|---------------|------------------|
| YES | Code split + vendor split | 90 |
| YES | Code split | 90 |
| NO | Code split + vendor split | 85 |
| NO | Code split | 85 |
| YES | Eager glob + vendor split | 65 |
| NO | Eager glob + vendor split | 63 |
| YES | Eager glob | 61 |
| NO | Eager glob | 59 |

We can see in all instances, preloading had a positive impact on the Lighthouse scores.

<details>

<summary>Lighthouse screenshots</summary>

Although all these screenshots are of the same page, I found similar results across other pages with the application.

## Preloading w/ Code split + vendor split

![1  Code split + vendor split w: Preloading](https://user-images.githubusercontent.com/24803032/190065517-a0c49745-09b7-4e5e-a602-f8796849aac0.png)

## Preloading w/ Code split

![2  Code split w: Preloading](https://user-images.githubusercontent.com/24803032/190065547-73d84406-348c-4c58-a1a4-5dca53116740.png)

## Not Preloading w/ Code split + vendor split

![3  Code split + vendor split](https://user-images.githubusercontent.com/24803032/190065600-29e5e176-e3a1-4175-85e0-798752a670b4.png)

## Not Preloading w/ Code split

![4  Code split](https://user-images.githubusercontent.com/24803032/190065622-4ba61f7c-25fe-4c42-a37a-003ca156b272.png)

## Preloading w/ Eager glob + vendor split

![5  Eager glob + vendor split w: Preloading](https://user-images.githubusercontent.com/24803032/190065759-34e9ad43-e0d3-41da-a9ce-739a726a9af3.png)

## Preloading w/ Eager

![6  Eager glob w: Preloading](https://user-images.githubusercontent.com/24803032/190065789-01e9a985-a602-48b5-8ea8-c3d835c81a9d.png)

## Not preloading w/ Eager glob + vendor split

![7  Eager glob + vendor split](https://user-images.githubusercontent.com/24803032/190065842-de009d78-88c4-40c0-9a8d-6fb0e73fdfc8.png)

## Not preloading w/ Eager glob

![8  Eager glob](https://user-images.githubusercontent.com/24803032/190065870-e268c73f-5d92-4a5a-a0e6-9535c36fcdfd.png)

</details>

Although eager globing does solve the waterfall issue, I believe that the Vite setup for Laravel should also support code splitting the best it can. Preloading is utilised by Vite itself when doing things "the Vite way". This is the mechanism that all code splitting usually works. Additionally, if you utilise vendor splitting with eager globing, you are back to the original waterfall problem, as the `app.js` has to be fetched and parsed before `vendor.js` is requested and parsed.

With this PR in place, we are able to, at best, remove the waterfall entirely for all configurations:

1. `/login.html`, `app.js`, `Login.js`, `TextInput.js`, `InputLabel.js`, `PrimaryButton.js`...

and at worst, the non-SPA waterfall:

1. `/login.html`
2. `app.js`, `Login.js`, `TextInput.js`, `InputLabel.js`, `PrimaryButton.js`...

This PR works by adding "preload" `<link` tags into the HTML for any asset required by the current page and if used the middleware will send preload `Link: ` headers to the browser.

Preload tags are generated for the JavaScript and CSS entry points and their imports.

To take full advantage of this, applications do need to specify the page / chunk they are currently trying to load in the Vite tag:

```blade
@vite(["resources/js/Pages/{$page['component']}.vue"])
```

Applications do not have to update the Vite directive may still find this PR beneficial, as it can send the headers with the document instructing the browser to start fetching the `app.js` and any additional CSS it imports.

With that in mind, preloading is beneficial to all configurations: eager glob, vendor split, code split, etc.

> **Note** Applications that are vendor splitting will still need to add the `app.js` into the Vite directive:

```blade
@vite([
    'resources/js/app.js',
    "resources/js/Pages/{$page['component']}.vue",
])
```

## Browser support

For CSS files, we have [great browser support](https://caniuse.com/link-rel-preload).

For JavaScript "Module preloading" unfortunately out of the main browsers Firefox and Safari do not currently support this feature. According to [caniuse](https://caniuse.com/link-rel-modulepreload) 73% of browsers in use globally support this feature. Their stats are provided by [statscounter](https://gs.statcounter.com/).

A lot of JavaScript eco-system is relying on this feature and we are _all_ waiting for Firefox and Safari to roll the feature out.

The good news is that this feature has no negative impacts on un-supprted browsers. They simply ignore the tag and move on with their existing behaviour.

However, because CSS preloading is supported, applications will still likely get a boost in Firefox and Safari.