### PR TITLE
[9.x] Fix Collection::random php-doc param

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -974,7 +974,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Get one or a specified number of items randomly from the collection.
      *
-     * @param  (callable(TValue): int)|int|null  $number
+     * @param  (callable(self<TKey, TValue>): int)|int|null  $number
      * @return static<int, TValue>|TValue
      *
      * @throws \InvalidArgumentException


### PR DESCRIPTION
When calling `Collection::random` with a closure, the current php-doc accept a callable with `callable(TValue): int` signature, as if the items of the collection are passed to the closure, whereas it's the collection itself which is passed to the closure:
```php
if (is_callable($number)) {
    return new static(Arr::random($this->items, $number($this)));
}
```

In addition, the [documentation](https://laravel.com/docs/9.x/collections#method-random) is right:
> The random method also accepts a closure, which will receive the current collection instance

