### PR TITLE
[9.x] Improve Artisan Commands Readability

### DIFF
--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -16,6 +16,13 @@ class Task extends Component
     private static $counter = 0;
 
     /**
+     * The list of separators
+     *
+     * @var array $separators
+     */
+    private $separators = ['.', '-'];
+
+    /**
      * Renders the component using the given arguments.
      *
      * @param  string  $description
@@ -53,7 +60,7 @@ class Task extends Component
             $dots = max($width - $descriptionWidth - $runTimeWidth - 10, 0);
 
             self::$counter++;
-            $separator = (self::$counter % 2) ? '.' : '-' ;
+            $separator = $this->separators[(self::$counter % 2)];
 
             $this->output->write(str_repeat("<fg=gray>$separator</>", $dots), false, $verbosity);
             $this->output->write("<fg=gray>$runTime</>", false, $verbosity);

--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -9,16 +9,16 @@ use Throwable;
 class Task extends Component
 {
     /**
-     * The counter of class instances
+     * The counter of class instances.
      *
-     * @var int $counter
+     * @var int
      */
     private static $counter = 0;
 
     /**
-     * The list of separators
+     * The list of separators.
      *
-     * @var array $separators
+     * @var array
      */
     private $separators = ['.', '-'];
 

--- a/src/Illuminate/Console/View/Components/Task.php
+++ b/src/Illuminate/Console/View/Components/Task.php
@@ -9,6 +9,13 @@ use Throwable;
 class Task extends Component
 {
     /**
+     * The counter of class instances
+     *
+     * @var int $counter
+     */
+    private static $counter = 0;
+
+    /**
      * Renders the component using the given arguments.
      *
      * @param  string  $description
@@ -45,7 +52,10 @@ class Task extends Component
             $width = min(terminal()->width(), 150);
             $dots = max($width - $descriptionWidth - $runTimeWidth - 10, 0);
 
-            $this->output->write(str_repeat('<fg=gray>.</>', $dots), false, $verbosity);
+            self::$counter++;
+            $separator = (self::$counter % 2) ? '.' : '-' ;
+
+            $this->output->write(str_repeat("<fg=gray>$separator</>", $dots), false, $verbosity);
             $this->output->write("<fg=gray>$runTime</>", false, $verbosity);
 
             $this->output->writeln(

--- a/src/Illuminate/Console/View/Components/TwoColumnDetail.php
+++ b/src/Illuminate/Console/View/Components/TwoColumnDetail.php
@@ -14,6 +14,14 @@ class TwoColumnDetail extends Component
     private static $counter = 0;
 
     /**
+     * The list of separators
+     *
+     * @var array $separators
+     */
+    private $separators = ['.', '-'];
+
+
+    /**
      * Renders the component using the given arguments.
      *
      * @param  string  $first
@@ -36,7 +44,7 @@ class TwoColumnDetail extends Component
         ]);
 
         self::$counter++;
-        $separator = (self::$counter % 2) ? '.' : '-' ;
+        $separator = $this->separators[(self::$counter % 2)];
 
         $this->renderView('two-column-detail', [
             'first' => $first,

--- a/src/Illuminate/Console/View/Components/TwoColumnDetail.php
+++ b/src/Illuminate/Console/View/Components/TwoColumnDetail.php
@@ -7,6 +7,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class TwoColumnDetail extends Component
 {
     /**
+     * The counter of class instances
+     *
+     * @var int $counter
+     */
+    private static $counter = 0;
+
+    /**
      * Renders the component using the given arguments.
      *
      * @param  string  $first
@@ -28,9 +35,13 @@ class TwoColumnDetail extends Component
             Mutators\EnsureRelativePaths::class,
         ]);
 
+        self::$counter++;
+        $separator = (self::$counter % 2) ? '.' : '-' ;
+
         $this->renderView('two-column-detail', [
             'first' => $first,
             'second' => $second,
+            'separator' => $separator,
         ], $verbosity);
     }
 }

--- a/src/Illuminate/Console/View/Components/TwoColumnDetail.php
+++ b/src/Illuminate/Console/View/Components/TwoColumnDetail.php
@@ -7,19 +7,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 class TwoColumnDetail extends Component
 {
     /**
-     * The counter of class instances
+     * The counter of class instances.
      *
-     * @var int $counter
+     * @var int
      */
     private static $counter = 0;
 
     /**
-     * The list of separators
+     * The list of separators.
      *
-     * @var array $separators
+     * @var array
      */
     private $separators = ['.', '-'];
-
 
     /**
      * Renders the component using the given arguments.

--- a/src/Illuminate/Console/resources/views/components/two-column-detail.php
+++ b/src/Illuminate/Console/resources/views/components/two-column-detail.php
@@ -2,7 +2,7 @@
     <span>
         <?php echo htmlspecialchars($first) ?>
     </span>
-    <span class="flex-1 content-repeat-[.] text-gray ml-1"></span>
+    <span class="flex-1 content-repeat-[<?php echo $separator ?>] text-gray ml-1"></span>
     <?php if ($second !== '') { ?>
         <span class="ml-1">
             <?php echo htmlspecialchars($second) ?>

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -131,9 +131,9 @@ class MigratorTest extends TestCase
 
     protected function expectTask($description, $result): void
     {
-        // Ignore dots...
+        // Ignore dots and dashes...
         $this->output->shouldReceive('write')->with(m::on(
-            fn ($argument) => str($argument)->contains(['<fg=gray></>', '<fg=gray>.</>']),
+            fn ($argument) => str($argument)->contains(['<fg=gray></>', '<fg=gray>.</>', '<fg=gray>-</>']),
         ), m::any(), m::any());
 
         // Ignore duration...


### PR DESCRIPTION
Hi developers

I also love the new artisan look like you (Special Thanks @nunomaduro ), but I was having readability issues, I have to track the dots from one end to another, This PR will improve a little bit by shuffling between dots and dashes. here is an example of `about` command 

### Before

![before](https://user-images.githubusercontent.com/53037997/189636532-622dcc7a-aec8-44e2-a9ec-92f110e4dc50.png)

### After

![after](https://user-images.githubusercontent.com/53037997/189637121-2e683495-ae8a-416a-a110-17926cc30072.png)

I tried to use different symbols and also more than two symbols, but they reduce the beauty instead of increasing readability 😉