### PR TITLE
[9.x] Enhance column modifying

### DIFF
--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -41,12 +41,6 @@ class TimestampType extends Type implements PhpDateTimeMappingType
             $columnType = 'TIMESTAMP('.$fieldDeclaration['precision'].')';
         }
 
-        $notNull = $fieldDeclaration['notnull'] ?? false;
-
-        if (! $notNull) {
-            return $columnType.' NULL';
-        }
-
         return $columnType;
     }
 

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -41,6 +41,12 @@ class TimestampType extends Type implements PhpDateTimeMappingType
             $columnType = 'TIMESTAMP('.$fieldDeclaration['precision'].')';
         }
 
+        $notNull = $fieldDeclaration['notnull'] ?? false;
+
+        if (! $notNull) {
+            return $columnType.' NULL';
+        }
+
         return $columnType;
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -125,10 +125,6 @@ class ChangeColumn
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }
 
-        if ($fluent['type'] === 'binary') {
-            $options['length'] = 65535;
-        }
-
         if ($fluent['type'] === 'char') {
             $options['fixed'] = true;
         }

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -121,8 +121,12 @@ class ChangeColumn
     {
         $options = ['type' => static::getDoctrineColumnType($fluent['type'])];
 
-        if (in_array($fluent['type'], ['text', 'mediumText', 'longText'])) {
+        if (in_array($fluent['type'], ['tinyText', 'text', 'mediumText', 'longText'])) {
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
+        }
+
+        if ($fluent['type'] === 'binary') {
+            $options['length'] = 65535;
         }
 
         if ($fluent['type'] === 'char') {
@@ -152,10 +156,11 @@ class ChangeColumn
         return Type::getType(match ($type) {
             'biginteger' => 'bigint',
             'smallinteger' => 'smallint',
-            'mediumtext', 'longtext' => 'text',
+            'tinytext', 'mediumtext', 'longtext' => 'text',
             'binary' => 'blob',
             'uuid' => 'guid',
             'char' => 'string',
+            'double' => 'float',
             default => $type,
         });
     }
@@ -169,6 +174,7 @@ class ChangeColumn
     protected static function calculateDoctrineTextLength($type)
     {
         return match ($type) {
+            'tinyText' => 1,
             'mediumText' => 65535 + 1,
             'longText' => 16777215 + 1,
             default => 255 + 1,
@@ -197,6 +203,7 @@ class ChangeColumn
             'mediumInteger',
             'smallInteger',
             'time',
+            'timestamp',
             'tinyInteger',
         ]);
     }

--- a/tests/Integration/Database/DBAL/TimestampTypeTest.php
+++ b/tests/Integration/Database/DBAL/TimestampTypeTest.php
@@ -59,4 +59,25 @@ class TimestampTypeTest extends DatabaseTestCase
             ? $this->assertSame('timestamp', Schema::getColumnType('test', 'timestamp_to_datetime'))
             : $this->assertSame('datetime', Schema::getColumnType('test', 'timestamp_to_datetime'));
     }
+
+    public function testChangeStringColumnToTimestampColumn()
+    {
+        if ($this->driver !== 'mysql') {
+            $this->markTestSkipped('Test requires a MySQL connection.');
+        }
+
+        Schema::create('test', function (Blueprint $table) {
+            $table->string('string_to_timestamp');
+        });
+
+        $blueprint = new Blueprint('test', function ($table) {
+            $table->timestamp('string_to_timestamp')->nullable(true)->change();
+        });
+
+        $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
+
+        $expected = ['ALTER TABLE test CHANGE string_to_timestamp string_to_timestamp TIMESTAMP DEFAULT NULL'];
+
+        $this->assertEquals($expected, $queries);
+    }
 }

--- a/tests/Integration/Database/DBAL/TimestampTypeTest.php
+++ b/tests/Integration/Database/DBAL/TimestampTypeTest.php
@@ -76,7 +76,7 @@ class TimestampTypeTest extends DatabaseTestCase
 
         $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
 
-        $expected = ['ALTER TABLE test CHANGE string_to_timestamp string_to_timestamp TIMESTAMP DEFAULT NULL'];
+        $expected = ['ALTER TABLE test CHANGE string_to_timestamp string_to_timestamp TIMESTAMP NULL DEFAULT NULL'];
 
         $this->assertEquals($expected, $queries);
     }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -88,27 +88,6 @@ class SchemaBuilderTest extends DatabaseTestCase
         $this->assertSame('tinyinteger', Schema::getColumnType('test', 'test_column'));
     }
 
-    public function testChangeToBinaryColumn()
-    {
-        if ($this->driver !== 'mysql') {
-            $this->markTestSkipped('Test requires a MySQL connection.');
-        }
-
-        Schema::create('test', function (Blueprint $table) {
-            $table->integer('test_column');
-        });
-
-        $blueprint = new Blueprint('test', function ($table) {
-            $table->binary('test_column')->change();
-        });
-
-        $queries = $blueprint->toSql($this->getConnection(), $this->getConnection()->getSchemaGrammar());
-
-        $expected = ['ALTER TABLE test CHANGE test_column test_column BLOB NOT NULL'];
-
-        $this->assertEquals($expected, $queries);
-    }
-
     public function testChangeToTextColumn()
     {
         if ($this->driver !== 'mysql') {


### PR DESCRIPTION
This PR does:
- Add support for changing column type to `double`
- Add support for changing column type to `tinyText`.
- Fix a issue when changing column type to `timestamp`:
  * The SQL contained charset/collate: `TIMESTAMP SET utf8mb4 COLLATE utf8mb4_unicode_ci`
- ~~Fix a issue when changing column type to `binary`:~~
  * ~~on MySQL, the type was `LONGBLOB` instead of expected `BLOB`~~

PS: I added tests for all adds and changes.
PS: changes to `binary` reverted.