### PR TITLE
[9.x] Fake Batches

### DIFF
--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -84,7 +84,9 @@ trait Batchable
                                   int $failedJobs = 0,
                                   array $failedJobIds = [],
                                   array $options = [],
-                                  CarbonImmutable $createdAt = null)
+                                  CarbonImmutable $createdAt = null,
+                                  ?CarbonImmutable $cancelledAt = null,
+                                  ?CarbonImmutable $finishedAt = null)
     {
         $this->fakeBatch = new BatchFake(
             empty($id) ? (string) Str::uuid() : $id,
@@ -94,7 +96,9 @@ trait Batchable
             $failedJobs,
             $failedJobIds,
             $options,
-            $createdAt ?? CarbonImmutable::now()
+            $createdAt ?? CarbonImmutable::now(),
+            $cancelledAt,
+            $finishedAt,
         );
 
         return $this->fakeBatch;

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -100,6 +100,6 @@ trait Batchable
             $finishedAt,
         );
 
-        return $this->fakeBatch;
+        return [$this, $this->fakeBatch];
     }
 }

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -4,7 +4,6 @@ namespace Illuminate\Bus;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Container\Container;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Support\Testing\Fakes\BatchFake;
 

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -2,7 +2,11 @@
 
 namespace Illuminate\Bus;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Container\Container;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Illuminate\Support\Testing\Fakes\BatchFake;
 
 trait Batchable
 {
@@ -14,12 +18,23 @@ trait Batchable
     public $batchId;
 
     /**
+     * The fake batch, if applicable.
+     *
+     * @var \Illuminate\Support\Testing\BatchFake
+     */
+    private $fakeBatch;
+
+    /**
      * Get the batch instance for the job, if applicable.
      *
      * @return \Illuminate\Bus\Batch|null
      */
     public function batch()
     {
+        if ($this->fakeBatch) {
+            return $this->fakeBatch;
+        }
+
         if ($this->batchId) {
             return Container::getInstance()->make(BatchRepository::class)->find($this->batchId);
         }
@@ -48,5 +63,40 @@ trait Batchable
         $this->batchId = $batchId;
 
         return $this;
+    }
+
+    /**
+     * Indicate that the job should use a fake batch.
+     *
+     * @param  string  $id
+     * @param  string  $name
+     * @param  int  $totalJobs
+     * @param  int  $pendingJobs
+     * @param  int  $failedJobs
+     * @param  array  $failedJobIds
+     * @param  array  $options
+     * @return \Illuminate\Support\Testing\BatchFake
+     */
+    public function withFakeBatch(string $id = '',
+                                  string $name = '',
+                                  int $totalJobs = 0,
+                                  int $pendingJobs = 0,
+                                  int $failedJobs = 0,
+                                  array $failedJobIds = [],
+                                  array $options = [],
+                                  CarbonImmutable $createdAt = null)
+    {
+        $this->fakeBatch = new BatchFake(
+            empty($id) ? (string) Str::uuid() : $id,
+            $name,
+            $totalJobs,
+            $pendingJobs,
+            $failedJobs,
+            $failedJobIds,
+            $options,
+            $createdAt ?? CarbonImmutable::now()
+        );
+
+        return $this->fakeBatch;
     }
 }

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -74,7 +74,7 @@ trait Batchable
      * @param  int  $failedJobs
      * @param  array  $failedJobIds
      * @param  array  $options
-     * @return \Illuminate\Support\Testing\BatchFake
+     * @return array{0: $this, 1: \Illuminate\Support\Testing\BatchFake}
      */
     public function withFakeBatch(string $id = '',
                                   string $name = '',

--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Bus\Batch;
+use Illuminate\Support\Carbon;
+
+class BatchFake extends Batch
+{
+    /**
+     * The jobs that have been added to the batch.
+     *
+     * @var array
+     */
+    public $added = [];
+
+    /**
+     * Indicates if the batch has been deleted.
+     *
+     * @var bool
+     */
+    public $deleted = false;
+
+    /**
+     * Create a new batch instance.
+     *
+     * @param  string  $id
+     * @param  string  $name
+     * @param  int  $totalJobs
+     * @param  int  $pendingJobs
+     * @param  int  $failedJobs
+     * @param  array  $failedJobIds
+     * @param  array  $options
+     * @param  \Carbon\CarbonImmutable  $createdAt
+     * @param  \Carbon\CarbonImmutable|null  $cancelledAt
+     * @param  \Carbon\CarbonImmutable|null  $finishedAt
+     * @return void
+     */
+    public function __construct(string $id,
+                                string $name,
+                                int $totalJobs,
+                                int $pendingJobs,
+                                int $failedJobs,
+                                array $failedJobIds,
+                                array $options,
+                                CarbonImmutable $createdAt,
+                                ?CarbonImmutable $cancelledAt = null,
+                                ?CarbonImmutable $finishedAt = null)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->totalJobs = $totalJobs;
+        $this->pendingJobs = $pendingJobs;
+        $this->failedJobs = $failedJobs;
+        $this->failedJobIds = $failedJobIds;
+        $this->options = $options;
+        $this->createdAt = $createdAt;
+        $this->cancelledAt = $cancelledAt;
+        $this->finishedAt = $finishedAt;
+    }
+
+    /**
+     * Get a fresh instance of the batch represented by this ID.
+     *
+     * @return self
+     */
+    public function fresh()
+    {
+        return $this;
+    }
+
+    /**
+     * Add additional jobs to the batch.
+     *
+     * @param  \Illuminate\Support\Enumerable|object|array  $jobs
+     * @return self
+     */
+    public function add($jobs)
+    {
+        $this->added[] = array_merge($this->added, $jobs);
+
+        return $this;
+    }
+
+    /**
+     * Record that a job within the batch finished successfully, executing any callbacks if necessary.
+     *
+     * @param  string  $jobId
+     * @return void
+     */
+    public function recordSuccessfulJob(string $jobId)
+    {
+        //
+    }
+
+    /**
+     * Decrement the pending jobs for the batch.
+     *
+     * @param  string  $jobId
+     * @return \Illuminate\Bus\UpdatedBatchJobCounts
+     */
+    public function decrementPendingJobs(string $jobId)
+    {
+        //
+    }
+
+    /**
+     * Record that a job within the batch failed to finish successfully, executing any callbacks if necessary.
+     *
+     * @param  string  $jobId
+     * @param  \Throwable  $e
+     * @return void
+     */
+    public function recordFailedJob(string $jobId, $e)
+    {
+        //
+    }
+
+    /**
+     * Increment the failed jobs for the batch.
+     *
+     * @param  string  $jobId
+     * @return \Illuminate\Bus\UpdatedBatchJobCounts
+     */
+    public function incrementFailedJobs(string $jobId)
+    {
+        return new UpdatedBatchJobCounts;
+    }
+
+    /**
+     * Cancel the batch.
+     *
+     * @return void
+     */
+    public function cancel()
+    {
+        $this->cancelledAt = Carbon::now();
+    }
+
+    /**
+     * Delete the batch from storage.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->deleted = true;
+    }
+}

--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -147,4 +147,14 @@ class BatchFake extends Batch
     {
         $this->deleted = true;
     }
+
+    /**
+     * Determine if the batch has been deleted.
+     *
+     * @return bool
+     */
+    public function deleted()
+    {
+        return $this->deleted;
+    }
 }


### PR DESCRIPTION
It's currently hard to test things like if a batch was cancelled by a job or if a job added additional jobs to a batch. You have to create a FakeBatch manually and override the cancel / add methods, etc.

This solves that.

```php
[$job, $batch] = (new TestJob)->withFakeBatch();

$job->handle();

$this->assertTrue($batch->cancelled());
$this->assertNotEmpty($batch->added);
```