### PR TITLE
[9.x] Added scoped filesystem driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "league/flysystem-aws-s3-v3": "^3.0",
         "league/flysystem-ftp": "^3.0",
+        "league/flysystem-path-prefixing": "^3.3",
         "league/flysystem-read-only": "^3.3",
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.4.4",

--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,7 @@
         "laravel/tinker": "Required to use the tinker console command (^2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^3.0).",
         "league/flysystem-ftp": "Required to use the Flysystem FTP driver (^3.0).",
+        "league/flysystem-path-prefixing": "Required to use the scoped driver (^3.3).",
         "league/flysystem-read-only": "Required to use read-only disks (^3.3)",
         "league/flysystem-sftp-v3": "Required to use the Flysystem SFTP driver (^3.0).",
         "mockery/mockery": "Required to use mocking (^1.4.4).",

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -92,10 +92,13 @@ class FilesystemAdapter implements CloudFilesystemContract
         $this->driver = $driver;
         $this->adapter = $adapter;
         $this->config = $config;
+        $separator = $config['directory_separator'] ?? DIRECTORY_SEPARATOR;
 
-        $this->prefixer = new PathPrefixer(
-            $config['root'] ?? '', $config['directory_separator'] ?? DIRECTORY_SEPARATOR
-        );
+        $this->prefixer = new PathPrefixer($config['root'] ?? '', $separator);
+
+        if (isset($config['prefix'])) {
+            $this->prefixer = new PathPrefixer($this->prefixer->prefixPath($config['prefix']), $separator);
+        }
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -204,26 +204,6 @@ class FilesystemManager implements FactoryContract
     }
 
     /**
-     * @param  array  $config
-     * @return \Illuminate\Contracts\Filesystem\Filesystem
-     */
-    public function createScopedDriver(array $config)
-    {
-        if (empty($config['disk'])) {
-            throw new InvalidArgumentException('Missing disk for scoped driver.');
-        }
-
-        if (empty($config['prefix'])) {
-            throw new InvalidArgumentException('Prefix is missing for scoped driver.');
-        }
-
-        $diskConfig = $this->getConfig($config['disk']);
-        $diskConfig['prefix'] = $config['prefix'];
-
-        return $this->build($diskConfig);
-    }
-
-    /**
      * Create an instance of the sftp driver.
      *
      * @param  array  $config
@@ -286,6 +266,26 @@ class FilesystemManager implements FactoryContract
         }
 
         return $config;
+    }
+
+    /**
+     * Create a scoped driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    public function createScopedDriver(array $config)
+    {
+        if (empty($config['disk'])) {
+            throw new InvalidArgumentException('Scoped disk is missing "disk" configuration option.');
+        } elseif (empty($config['prefix'])) {
+            throw new InvalidArgumentException('Scoped disk is missing "prefix" configuration option.');
+        }
+
+        return $this->build(tap(
+            $this->getConfig($config['disk']),
+            fn (&$parent) => $parent['prefix'] = $config['prefix']
+        ));
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -204,17 +204,17 @@ class FilesystemManager implements FactoryContract
     }
 
     /**
-     * @param array $config
+     * @param  array  $config
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public function createScopedDriver(array $config)
     {
         if (empty($config['disk'])) {
-            throw new InvalidArgumentException("Missing disk for scoped driver.");
+            throw new InvalidArgumentException('Missing disk for scoped driver.');
         }
 
         if (empty($config['prefix'])) {
-            throw new InvalidArgumentException("Prefix is missing for scoped driver.");
+            throw new InvalidArgumentException('Prefix is missing for scoped driver.');
         }
 
         $diskConfig = $this->getConfig($config['disk']);

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -73,26 +73,29 @@ class FilesystemManagerTest extends TestCase
 
     public function testCanBuildScopedDisks()
     {
-        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
-            $app['config'] = [
-                'filesystems.disks.local' => [
-                    'driver' => 'local',
-                    'root' => 'to-be-scoped',
-                ],
-            ];
-        }));
+        try {
+            $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+                $app['config'] = [
+                    'filesystems.disks.local' => [
+                        'driver' => 'local',
+                        'root' => 'to-be-scoped',
+                    ],
+                ];
+            }));
 
-        $local = $filesystem->disk('local');
-        $scoped = $filesystem->build([
-            'driver' => 'scoped',
-            'disk' => 'local',
-            'prefix' => 'path-prefix',
-        ]);
+            $local = $filesystem->disk('local');
+            $scoped = $filesystem->build([
+                'driver' => 'scoped',
+                'disk' => 'local',
+                'prefix' => 'path-prefix',
+            ]);
 
-        $scoped->put('dirname/filename.txt', 'file content');
-        $this->assertEquals('file content', $local->get('path-prefix/dirname/filename.txt'));
-        $local->deleteDirectory('path-prefix');
+            $scoped->put('dirname/filename.txt', 'file content');
+            $this->assertEquals('file content', $local->get('path-prefix/dirname/filename.txt'));
+            $local->deleteDirectory('path-prefix');
+        } finally {
+            rmdir(__DIR__.'/../../to-be-scoped');
+        }
 
-        rmdir(__DIR__.'/../../to-be-scoped');
     }
 }

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -70,4 +70,29 @@ class FilesystemManagerTest extends TestCase
         unlink(__DIR__.'/../../my-custom-path/path.txt');
         rmdir(__DIR__.'/../../my-custom-path');
     }
+
+    public function testCanBuildScopedDisks()
+    {
+        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+            $app['config'] = [
+                'filesystems.disks.local' => [
+                    'driver' => 'local',
+                    'root' => 'to-be-scoped',
+                ],
+            ];
+        }));
+
+        $local = $filesystem->disk('local');
+        $scoped = $filesystem->build([
+            'driver' => 'scoped',
+            'disk' => 'local',
+            'prefix' => 'path-prefix',
+        ]);
+
+        $scoped->put('dirname/filename.txt', 'file content');
+        $this->assertEquals('file content', $local->get('path-prefix/dirname/filename.txt'));
+        $local->deleteDirectory('path-prefix');
+
+        rmdir(__DIR__.'/../../to-be-scoped');
+    }
 }


### PR DESCRIPTION
Often, files are placed on a single filesystem (like S3) but at different paths. This base path needs to be kept in sync all across the codebase. The scoped driver makes it easy to re-use disk configurations, and decorated the internal adapter.

Consider the following situation, when I have an existing `s3` disk:

```php
        's3' => [
            'driver' => 's3',
            'key' => env('AWS_ACCESS_KEY_ID'),
            'secret' => env('AWS_SECRET_ACCESS_KEY'),
            'region' => env('AWS_DEFAULT_REGION'),
            'bucket' => env('AWS_BUCKET'),
            'url' => env('AWS_URL'),
            'endpoint' => env('AWS_ENDPOINT'),
            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
            'throw' => false,
        ],
```

Using the new `scoped` driver, I can create a version of the existing `s3` driver with a deeper base path:

```php
        's3_videos' => [
            'driver' => 'scoped',
            'prefix' => 'path/for/videos',
            'disk' => 's3',
        ],
```

---

Possible optimisation, since this is a decorated adapter, we could re-use the inner adapter. I didn't find an elegant way to do so, but I'm open to suggestions.