### PR TITLE
[9.x] Allow using a model instance in place of nested model factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -62,13 +62,13 @@ class BelongsToManyRelationship
     /**
      * Specify the model instances to always use when creating relationships.
      *
-     * @param  \Illuminate\Support\Collection  $using
+     * @param  \Illuminate\Support\Collection  $recycle
      * @return $this
      */
-    public function using($using)
+    public function recycle($recycle)
     {
         if ($this->factory instanceof Factory) {
-            $this->factory = $this->factory->using($using);
+            $this->factory = $this->factory->recycle($recycle);
         }
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -43,15 +43,6 @@ class BelongsToManyRelationship
         $this->relationship = $relationship;
     }
 
-    public function using($using)
-    {
-        if ($this->factory instanceof Factory) {
-            $this->factory = $this->factory->using($using);
-        }
-
-        return $this;
-    }
-
     /**
      * Create the attached relationship for the given model.
      *
@@ -66,5 +57,20 @@ class BelongsToManyRelationship
                 is_callable($this->pivot) ? call_user_func($this->pivot, $model) : $this->pivot
             );
         });
+    }
+
+    /**
+     * Specify the model instances to always use when creating relationships.
+     *
+     * @param  \Illuminate\Support\Collection  $using
+     * @return $this
+     */
+    public function using($using)
+    {
+        if ($this->factory instanceof Factory) {
+            $this->factory = $this->factory->using($using);
+        }
+
+        return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -43,6 +43,15 @@ class BelongsToManyRelationship
         $this->relationship = $relationship;
     }
 
+    public function using($using)
+    {
+        if ($this->factory instanceof Factory) {
+            $this->factory = $this->factory->using($using);
+        }
+
+        return $this;
+    }
+
     /**
      * Create the attached relationship for the given model.
      *

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -41,15 +41,6 @@ class BelongsToRelationship
         $this->relationship = $relationship;
     }
 
-    public function using($using)
-    {
-        if ($this->factory instanceof Factory) {
-            $this->factory = $this->factory->using($using);
-        }
-
-        return $this;
-    }
-
     /**
      * Get the parent model attributes and resolvers for the given child model.
      *
@@ -85,5 +76,20 @@ class BelongsToRelationship
 
             return $this->resolved;
         };
+    }
+
+    /**
+     * Specify the model instances to always use when creating relationships.
+     *
+     * @param  \Illuminate\Support\Collection  $using
+     * @return $this
+     */
+    public function using($using)
+    {
+        if ($this->factory instanceof Factory) {
+            $this->factory = $this->factory->using($using);
+        }
+
+        return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -41,6 +41,15 @@ class BelongsToRelationship
         $this->relationship = $relationship;
     }
 
+    public function using($using)
+    {
+        if ($this->factory instanceof Factory) {
+            $this->factory = $this->factory->using($using);
+        }
+
+        return $this;
+    }
+
     /**
      * Get the parent model attributes and resolvers for the given child model.
      *

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -81,13 +81,13 @@ class BelongsToRelationship
     /**
      * Specify the model instances to always use when creating relationships.
      *
-     * @param  \Illuminate\Support\Collection  $using
+     * @param  \Illuminate\Support\Collection  $recycle
      * @return $this
      */
-    public function using($using)
+    public function recycle($recycle)
     {
         if ($this->factory instanceof Factory) {
-            $this->factory = $this->factory->using($using);
+            $this->factory = $this->factory->recycle($recycle);
         }
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -66,7 +66,7 @@ abstract class Factory
     /**
      * The model instances to always use when creating relationships.
      *
-     * @var  \Illuminate\Support\Collection
+     * @var \Illuminate\Support\Collection
      */
     protected $using;
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -68,7 +68,7 @@ abstract class Factory
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $using;
+    protected $recycle;
 
     /**
      * The "after making" callbacks that will be applied to the model.
@@ -129,7 +129,7 @@ abstract class Factory
      * @param  \Illuminate\Support\Collection|null  $afterMaking
      * @param  \Illuminate\Support\Collection|null  $afterCreating
      * @param  string|null  $connection
-     * @param  \Illuminate\Support\Collection|null  $using
+     * @param  \Illuminate\Support\Collection|null  $recycle
      * @return void
      */
     public function __construct($count = null,
@@ -139,7 +139,7 @@ abstract class Factory
                                 ?Collection $afterMaking = null,
                                 ?Collection $afterCreating = null,
                                 $connection = null,
-                                ?Collection $using = null)
+                                ?Collection $recycle = null)
     {
         $this->count = $count;
         $this->states = $states ?? new Collection;
@@ -148,7 +148,7 @@ abstract class Factory
         $this->afterMaking = $afterMaking ?? new Collection;
         $this->afterCreating = $afterCreating ?? new Collection;
         $this->connection = $connection;
-        $this->using = $using ?? new Collection;
+        $this->recycle = $recycle ?? new Collection;
         $this->faker = $this->withFaker();
     }
 
@@ -342,7 +342,7 @@ abstract class Factory
     {
         Model::unguarded(function () use ($model) {
             $this->has->each(function ($has) use ($model) {
-                $has->using($this->using)->createFor($model);
+                $has->recycle($this->recycle)->createFor($model);
             });
         });
     }
@@ -449,7 +449,7 @@ abstract class Factory
         $model = $this->newModel();
 
         return $this->for->map(function (BelongsToRelationship $for) use ($model) {
-            return $for->using($this->using)->attributesFor($model);
+            return $for->recycle($this->recycle)->attributesFor($model);
         })->collapse()->all();
     }
 
@@ -464,9 +464,9 @@ abstract class Factory
         return collect($definition)
             ->map($evaluateRelations = function ($attribute) {
                 if ($attribute instanceof self) {
-                    $attribute = $this->using->has($attribute->modelName())
-                            ? $this->using->get($attribute->modelName())
-                            : $attribute->using($this->using)->create()->getKey();
+                    $attribute = $this->recycle->has($attribute->modelName())
+                            ? $this->recycle->get($attribute->modelName())
+                            : $attribute->recycle($this->recycle)->create()->getKey();
                 } elseif ($attribute instanceof Model) {
                     $attribute = $attribute->getKey();
                 }
@@ -624,10 +624,10 @@ abstract class Factory
      * @param  \Illuminate\Eloquent\Model|\Illuminate\Support\Collection|array  $model
      * @return static
      */
-    public function using($model)
+    public function recycle($model)
     {
         return $this->newInstance([
-            'using' => $this->using->merge(
+            'recycle' => $this->recycle->merge(
                 Collection::wrap($model instanceof Model ? func_get_args() : $model)
                     ->keyBy(fn ($model) => get_class($model))
             ),
@@ -725,7 +725,7 @@ abstract class Factory
             'afterMaking' => $this->afterMaking,
             'afterCreating' => $this->afterCreating,
             'connection' => $this->connection,
-            'using' => $this->using,
+            'recycle' => $this->recycle,
         ], $arguments)));
     }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -64,9 +64,9 @@ abstract class Factory
     protected $for;
 
     /**
-     * The model instances to use instead of any nested factories.
+     * The model instances to always use when creating relationships.
      *
-     * @var \Illuminate\Support\Collection
+     * @var  \Illuminate\Support\Collection
      */
     protected $using;
 
@@ -129,6 +129,7 @@ abstract class Factory
      * @param  \Illuminate\Support\Collection|null  $afterMaking
      * @param  \Illuminate\Support\Collection|null  $afterCreating
      * @param  string|null  $connection
+     * @param  \Illuminate\Support\Collection|null  $using
      * @return void
      */
     public function __construct($count = null,
@@ -463,11 +464,9 @@ abstract class Factory
         return collect($definition)
             ->map($evaluateRelations = function ($attribute) {
                 if ($attribute instanceof self) {
-                    if ($this->using->has($attribute->modelName())) {
-                        $attribute = $this->using->get($attribute->modelName());
-                    } else {
-                        $attribute = $attribute->using($this->using)->create()->getKey();
-                    }
+                    $attribute = $this->using->has($attribute->modelName())
+                            ? $this->using->get($attribute->modelName())
+                            : $attribute->using($this->using)->create()->getKey();
                 } elseif ($attribute instanceof Model) {
                     $attribute = $attribute->getKey();
                 }
@@ -620,7 +619,7 @@ abstract class Factory
     }
 
     /**
-     * Provide a model instance to use instead of any nested factory calls.
+     * Provide a model instance to use instead of any nested factory calls when creating relationships.
      *
      * @param  \Illuminate\Eloquent\Model|\Illuminate\Support\Collection|array  $model
      * @return static

--- a/src/Illuminate/Database/Eloquent/Factories/Relationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Relationship.php
@@ -36,13 +36,6 @@ class Relationship
         $this->relationship = $relationship;
     }
 
-    public function using($using)
-    {
-        $this->factory = $this->factory->using($using);
-
-        return $this;
-    }
-
     /**
      * Create the child relationship for the given parent model.
      *
@@ -65,5 +58,18 @@ class Relationship
         } elseif ($relationship instanceof BelongsToMany) {
             $relationship->attach($this->factory->create([], $parent));
         }
+    }
+
+    /**
+     * Specify the model instances to always use when creating relationships.
+     *
+     * @param  \Illuminate\Support\Collection  $using
+     * @return $this
+     */
+    public function using($using)
+    {
+        $this->factory = $this->factory->using($using);
+
+        return $this;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factories/Relationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Relationship.php
@@ -63,12 +63,12 @@ class Relationship
     /**
      * Specify the model instances to always use when creating relationships.
      *
-     * @param  \Illuminate\Support\Collection  $using
+     * @param  \Illuminate\Support\Collection  $recycle
      * @return $this
      */
-    public function using($using)
+    public function recycle($recycle)
     {
-        $this->factory = $this->factory->using($using);
+        $this->factory = $this->factory->recycle($recycle);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Factories/Relationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Relationship.php
@@ -36,6 +36,13 @@ class Relationship
         $this->relationship = $relationship;
     }
 
+    public function using($using)
+    {
+        $this->factory = $this->factory->using($using);
+
+        return $this;
+    }
+
     /**
      * Create the child relationship for the given parent model.
      *

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -70,6 +70,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             $table->increments('id');
             $table->foreignId('commentable_id');
             $table->string('commentable_type');
+            $table->foreignId('user_id');
             $table->string('body');
             $table->softDeletes();
             $table->timestamps();
@@ -651,6 +652,24 @@ class DatabaseEloquentFactoryTest extends TestCase
         FactoryTestUserFactory::new()->trashed()->create();
     }
 
+    public function test_model_instances_can_be_used_in_place_of_nested_factories()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $user = FactoryTestUserFactory::new()->create();
+        $post = FactoryTestPostFactory::new()
+            ->using($user)
+            ->hasComments(2)
+            ->create();
+
+        $this->assertSame(1, FactoryTestUser::count());
+        $this->assertEquals($user->id, $post->user_id);
+        $this->assertEquals($user->id, $post->comments[0]->user_id);
+        $this->assertEquals($user->id, $post->comments[1]->user_id);
+    }
+
     /**
      * Get a database connection instance.
      *
@@ -756,6 +775,7 @@ class FactoryTestCommentFactory extends Factory
         return [
             'commentable_id' => FactoryTestPostFactory::new(),
             'commentable_type' => FactoryTestPost::class,
+            'user_id' => FactoryTestUserFactory::new(),
             'body' => $this->faker->name,
         ];
     }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -660,7 +660,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $user = FactoryTestUserFactory::new()->create();
         $post = FactoryTestPostFactory::new()
-            ->using($user)
+            ->recycle($user)
             ->hasComments(2)
             ->create();
 


### PR DESCRIPTION
For applications with nested model factories, tests and seeders can get a little overwhelming when you want the nested models to all be related to a specific model.

For example, imagine you have `User`, `Team`, and `Post` models where posts belong to a user and a team, and the team also belongs to a user.

The following factory call would create two user records. One for the post itself, and one for the team that the post factory created.

```php
$post = Post::factory()->create();
```

To get around this, you might write something like the following:

```php
$user = User::factory()->create();
$post = Post::factory()
    ->for($user)
    ->for(Team::factory()->for($user))
    ->create();
```

That's still pretty nice! But maybe your posts have images that also belong to a team and/or a user. It can get out of control pretty quickly, and this is far from the most complex nesting I've seen.

This PR introduces a new `using` method for factories that allows you to provide one or more model instances to be used in place of any nested factories for the given models. What's more, it works recursively, automatically passing the model instances to any nested factories.

For our example above, your code would now look something like this:

```php
$user = User::factory()->create();
$post = Post::factory()
    ->using($user)
    ->create();
```

In this example, the post _and_ the nested team would all be owned by the provided user instance, with no additional records created. Depending on your application, this will either tidy up your factory calls, or it will prevent superfluous models from being created.

Of course, to take advantage of this feature, your factories must specify other factory instances in their definitions. If your factory definition calls the `create` method on any nested factories, then the created model will be used instead of anything passed to the `using` method.