### PR TITLE
[9.x] Allow any kind of whitespace in cron expressions

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -546,7 +546,7 @@ trait ManagesFrequencies
      */
     protected function spliceIntoPosition($position, $value)
     {
-        $segments = explode(' ', $this->expression);
+        $segments = preg_split("/\s+/", $this->expression);
 
         $segments[$position - 1] = $value;
 

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -159,7 +159,7 @@ class ScheduleListCommand extends Command
      */
     private function formatCronExpression($expression, $spacing)
     {
-        $expressions = explode(' ', $expression);
+        $expressions = preg_split("/\s+/", $expression);
 
         return collect($spacing)
             ->map(fn ($length, $index) => str_pad($expressions[$index], $length))

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -145,7 +145,7 @@ class ScheduleListCommand extends Command
      */
     private function getCronExpressionSpacing($events)
     {
-        $rows = $events->map(fn ($event) => array_map('mb_strlen', explode(' ', $event->expression)));
+        $rows = $events->map(fn ($event) => array_map('mb_strlen', preg_split("/\s+/", $event->expression)));
 
         return collect($rows[0] ?? [])->keys()->map(fn ($key) => $rows->max($key));
     }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -47,7 +47,7 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
-            ->expectsOutput('  0 9,17  * *      *  php artisan inspire ........ Next Due: 9 hours from now')
+            ->expectsOutput('  0 9,17  * *      *  php artisan inspire ......... Next Due: 9 hours from now')
             ->expectsOutput('  0 10    * *      *  php artisan inspire ........ Next Due: 10 hours from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -34,6 +34,8 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->command('inspire')->twiceDaily(14, 18);
         $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
         $this->schedule->job(FooJob::class)->everyMinute();
+        $this->schedule->command('inspire')->cron('0 9,17 * * *');
+        $this->schedule->command('inspire')->cron("0 10\t* * *");
 
         $this->schedule->call(fn () => '')->everyMinute();
         $closureLineNumber = __LINE__ - 1;
@@ -45,6 +47,8 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
+            ->expectsOutput('  0 9,17  * *      *  php artisan inspire ........ Next Due: 9 hours from now')
+            ->expectsOutput('  0 10    * *      *  php artisan inspire ........ Next Due: 10 hours from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }
 


### PR DESCRIPTION
Be more tolerant on task scheduling cron expression spacing, allowing any whitespace as separator. Previously, only a single space was allowed as separator, resulting in the following exception if e.g. a tab was used instead:

```php
$schedule->command('foobar:sample-task')->cron('5,35 *	* * *'); // "5,35 *\t* * *"
```

```bash
$ pa schedule:list

   ErrorException 

  Undefined array key 4

  at vendor/laravel/framework/src/Illuminate/Console/Scheduling/ScheduleListCommand.php:165
    161▕     {
    162▕         $expressions = explode(' ', $expression);
    163▕ 
    164▕         return collect($spacing)
  ➜ 165▕             ->map(fn ($length, $index) => str_pad($expressions[$index], $length))
    166▕             ->implode(' ');
    167▕     }
    168▕ 
    169▕     /**
```