### PR TITLE
Adds `insertWithTimestamps` method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3272,6 +3272,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Insert new records with timestamps into the database.
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    public function insertWithTimestamps(array $values)
+    {
+        $timestamps = ['created_at' => now(), 'updated_at' => now()];
+
+        return $this->insert(array_merge($values, $timestamps));
+    }
+
+    /**
      * Update records in the database.
      *
      * @param  array  $values


### PR DESCRIPTION
As we know that when we insert a new record into the database using `Query Builder`, The `created_at`, and `updated_at` columns are still **NULL**, and the previous scenario forces us to add `created_at`, and `updated_at` into the values array so, this PR helps us to update the timestamps of the inserting process without adding these columns

## Before This PR

```PHP
DB::table('users')->insert([
    'name' => $request->name,
    'email' => $request->email,
    'password' => Hash::make($request->password),
    'created_at' => now(),
    'updated_at' => now(),
]);
```

## After this PR gets merged

```PHP
DB::table('users')->insertWithTimestamps([
    'name' => $request->name,
    'email' => $request->email,
    'password' => Hash::make($request->password),
]);
```