### PR TITLE
Fixes `make:model` issues

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -145,12 +145,12 @@ class ModelMakeCommand extends GeneratorCommand
 
         $modelName = $this->qualifyClass($this->getNameInput());
 
-        $this->call('make:controller', array_filter([
+        $this->call('make:controller', [
             'name' => "{$controller}Controller",
-            '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
+            '--model' => $modelName,
             '--api' => $this->option('api'),
-            '--requests' => $this->option('requests') || $this->option('all'),
-        ]));
+            '--requests' => $this->option('requests'),
+        ]);
     }
 
     /**


### PR DESCRIPTION
When I tried to run the next command as exists in [docs](https://laravel.com/docs/9.x/eloquent#generating-model-classes), I noticed that the model and `controller` **ONLY** are created, and when I analyzed the code I discovered that the request class did not create because it will be created **ONLY** in case we pass a valid model name to `make:controller` command as exists in [ControllerMakeCommand](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Routing/Console/ControllerMakeCommand.php#L123), and because I did not pass `resource`, or `api` options the **NULL** value is passed to the `--model` option so, I have passed the given model name directly which passed to `make:model` option.

```SHELL
php artisan make:model Flight -c -R
```

- I removed `array_filter` method because it does nothing where we did not pass a closure.
- I removed `$this->option('all')` with `--requests` option also because it is meaningless as all model classes are created when we pass `--all` option.