### PR TITLE
[9.x] Implement `except` method for fake classes to define what should not be faked

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -29,6 +29,13 @@ class EventFake implements Dispatcher
     protected $eventsToFake;
 
     /**
+     * The event types that should be dispatched instead of intercepted.
+     *
+     * @var array
+     */
+    protected $eventsToDispatch = [];
+
+    /**
      * All of the events that have been intercepted keyed by type.
      *
      * @var array
@@ -283,6 +290,10 @@ class EventFake implements Dispatcher
      */
     protected function shouldFakeEvent($eventName, $payload)
     {
+        if ($this->shouldDispatchEvent($eventName, $payload)) {
+            return false;
+        }
+
         if (empty($this->eventsToFake)) {
             return true;
         }
@@ -295,6 +306,29 @@ class EventFake implements Dispatcher
             })
             ->isNotEmpty();
     }
+
+    /**
+     * Determine whether an event should be dispatched or not.
+     *
+     * @param  string  $eventName
+     * @param  mixed  $payload
+     * @return bool
+     */
+    protected function shouldDispatchEvent($eventName, $payload)
+    {
+        if (empty($this->eventsToDispatch)) {
+            return false;
+        }
+
+        return collect($this->eventsToDispatch)
+            ->filter(function ($event) use ($eventName, $payload) {
+                return $event instanceof Closure
+                    ? $event($eventName, $payload)
+                    : $event === $eventName;
+            })
+            ->isNotEmpty();
+    }
+
 
     /**
      * Remove a set of listeners from the dispatcher.
@@ -327,5 +361,18 @@ class EventFake implements Dispatcher
     public function until($event, $payload = [])
     {
         return $this->dispatch($event, $payload, true);
+    }
+
+    /**
+     * Specify the events that should be dispatched instead of faked.
+     *
+     * @param  array|string  $eventsToDispatch
+     * @return $this
+     */
+    public function except($eventsToDispatch)
+    {
+        $this->eventsToDispatch = array_merge($this->eventsToDispatch, Arr::wrap($eventsToDispatch));
+
+        return $this;
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -329,7 +329,6 @@ class EventFake implements Dispatcher
             ->isNotEmpty();
     }
 
-
     /**
      * Remove a set of listeners from the dispatcher.
      *

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -26,7 +26,7 @@ class EventFake implements Dispatcher
      *
      * @var array
      */
-    protected $eventsToFake;
+    protected $eventsToFake = [];
 
     /**
      * The event types that should be dispatched instead of intercepted.
@@ -54,6 +54,22 @@ class EventFake implements Dispatcher
         $this->dispatcher = $dispatcher;
 
         $this->eventsToFake = Arr::wrap($eventsToFake);
+    }
+
+    /**
+     * Specify the events that should be dispatched instead of faked.
+     *
+     * @param  array|string  $eventsToDispatch
+     * @return $this
+     */
+    public function except($eventsToDispatch)
+    {
+        $this->eventsToDispatch = array_merge(
+            $this->eventsToDispatch,
+            Arr::wrap($eventsToDispatch)
+        );
+
+        return $this;
     }
 
     /**
@@ -360,18 +376,5 @@ class EventFake implements Dispatcher
     public function until($event, $payload = [])
     {
         return $this->dispatch($event, $payload, true);
-    }
-
-    /**
-     * Specify the events that should be dispatched instead of faked.
-     *
-     * @param  array|string  $eventsToDispatch
-     * @return $this
-     */
-    public function except($eventsToDispatch)
-    {
-        $this->eventsToDispatch = array_merge($this->eventsToDispatch, Arr::wrap($eventsToDispatch));
-
-        return $this;
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -24,14 +24,14 @@ class QueueFake extends QueueManager implements Queue
     /**
      * The job types that should be intercepted instead of pushed to the queue.
      *
-     * @var array
+     * @var \Illuminate\Support\Collection
      */
     protected $jobsToFake;
 
     /**
      * The job types that should be pushed to the queue and not intercepted.
      *
-     * @var Collection
+     * @var \Illuminate\Support\Collection
      */
     protected $jobsToBeQueued;
 
@@ -57,6 +57,19 @@ class QueueFake extends QueueManager implements Queue
         $this->jobsToFake = Collection::wrap($jobsToFake);
         $this->jobsToBeQueued = Collection::make();
         $this->queue = $queue;
+    }
+
+    /**
+     * Specify the jobs that should be queued instead of faked.
+     *
+     * @param  array|string  $jobsToBeQueued
+     * @return $this
+     */
+    public function except($jobsToBeQueued)
+    {
+        $this->jobsToBeQueued = Collection::wrap($jobsToBeQueued)->merge($this->jobsToBeQueued);
+
+        return $this;
     }
 
     /**
@@ -350,7 +363,7 @@ class QueueFake extends QueueManager implements Queue
      * @param  object  $job
      * @return bool
      */
-    public function shouldDispatchJob($job)
+    protected function shouldDispatchJob($job)
     {
         if ($this->jobsToBeQueued->isEmpty()) {
             return false;
@@ -359,19 +372,6 @@ class QueueFake extends QueueManager implements Queue
         return $this->jobsToBeQueued->contains(
             fn ($jobToQueue) => $job instanceof ((string) $jobToQueue)
         );
-    }
-
-    /**
-     * Specify the jobs that should be queued instead of faked.
-     *
-     * @param  array|string  $jobsToBeQueued
-     * @return $this
-     */
-    public function except($jobsToBeQueued)
-    {
-        $this->jobsToBeQueued = Collection::wrap($jobsToBeQueued)->merge($this->jobsToBeQueued);
-
-        return $this;
     }
 
     /**

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -121,6 +121,22 @@ class EventFakeTest extends TestCase
         Event::assertNotDispatched('non-fake-event');
     }
 
+    public function testEventsListedInExceptAreProperlyDispatched()
+    {
+        Event::fake()->except('important-event');
+
+        Event::listen('test', function () {
+            return 'test';
+        });
+
+        Event::listen('important-event', function () {
+            return 'important';
+        });
+
+        $this->assertEquals(null, Event::dispatch('test'));
+        $this->assertEquals(['important'], Event::dispatch('important-event'));
+    }
+
     public function testAssertListening()
     {
         Event::fake();

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -328,6 +328,24 @@ class SupportTestingQueueFakeTest extends TestCase
             )));
         }
     }
+
+    public function testItDoesntFakeJobsViaPassedOnExcept()
+    {
+        $job = new JobStub;
+
+        $manager = m::mock(QueueManager::class);
+        $manager->shouldReceive('push')->once()->withArgs(function ($passedJob) use ($job) {
+            return $passedJob === $job;
+        });
+
+        $fake = (new QueueFake(new Application, [], $manager))->except(JobStub::class);
+
+        $fake->push($job);
+        $fake->push(new JobToFakeStub());
+
+        $fake->assertNotPushed(JobStub::class);
+        $fake->assertPushed(JobToFakeStub::class);
+    }
 }
 
 class JobStub

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -329,7 +329,7 @@ class SupportTestingQueueFakeTest extends TestCase
         }
     }
 
-    public function testItDoesntFakeJobsViaPassedOnExcept()
+    public function testItDoesntFakeJobsPassedViaExcept()
     {
         $job = new JobStub;
 


### PR DESCRIPTION
This PR is a follow up on #44106 and implements the same `except` method for the `Event` and `Queue` fake classes.

@jasonmccreary I'd appreciate your thoughts here :smiley: 
