### PR TITLE
[9.x] Add support for running queued jobs asynchronously in tests

### DIFF
--- a/phpstan.src.neon.dist
+++ b/phpstan.src.neon.dist
@@ -18,3 +18,4 @@ parameters:
   excludePaths:
     - "src/Illuminate/Testing/ParallelRunner.php"
     - "src/Illuminate/Testing/Constraints/ArraySubset.php"
+    - "src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php"

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -62,15 +62,11 @@ class Queue extends Facade
      */
     public static function fakeAsync(Closure $callback, $jobsToRunAsynchronously = [])
     {
-        $instance = static::getFacadeRoot();
-
         static::swap($fake = new AsyncQueueFake(static::getFacadeApplication(), $jobsToRunAsynchronously, static::getFacadeRoot()));
 
         $callback();
 
         $fake->dispatch();
-
-        static::swap($instance);
 
         return $fake;
     }

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Support\Facades;
 
+use Closure;
 use Illuminate\Queue\Worker;
+use Illuminate\Support\Testing\Fakes\AsyncQueueFake;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 
 /**
@@ -50,6 +52,21 @@ class Queue extends Facade
         static::swap($fake = new QueueFake(static::getFacadeApplication(), $jobsToFake, static::getFacadeRoot()));
 
         return $fake;
+    }
+
+    /**
+     * Replace the bound instance with a fake.
+     *
+     * @param  array|string  $jobsToFake
+     * @return \Illuminate\Support\Testing\Fakes\AsyncQueueFake
+     */
+    public static function async(Closure $callback, $jobsToRunAsynchronously = [])
+    {
+        static::swap($fake = new AsyncQueueFake(static::getFacadeApplication(), $jobsToRunAsynchronously, static::getFacadeRoot()));
+
+        $callback();
+
+        return $fake->dispatch();
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -55,18 +55,24 @@ class Queue extends Facade
     }
 
     /**
-     * Replace the bound instance with a fake.
+     * Execute all the jobs run during the callback in a clean application.
      *
-     * @param  array|string  $jobsToFake
+     * @param  array|string  $jobsToRunAsynchronously
      * @return \Illuminate\Support\Testing\Fakes\AsyncQueueFake
      */
-    public static function async(Closure $callback, $jobsToRunAsynchronously = [])
+    public static function fakeAsync(Closure $callback, $jobsToRunAsynchronously = [])
     {
+        $instance = static::getFacadeRoot();
+
         static::swap($fake = new AsyncQueueFake(static::getFacadeApplication(), $jobsToRunAsynchronously, static::getFacadeRoot()));
 
         $callback();
 
-        return $fake->dispatch();
+        $fake->dispatch();
+
+        static::swap($instance);
+
+        return $fake;
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php
@@ -45,7 +45,7 @@ class AsyncQueueFake extends QueueFake
             $db = app('db');
             $queue = app('queue');
 
-            $app = require getcwd().'/bootstrap/app.php'
+            $app = require getcwd().'/bootstrap/app.php';
             $app->make(Kernel::class)->bootstrap();
 
             Queue::swap($queue);

--- a/src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php
@@ -2,14 +2,16 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Testing\Concerns\CreatesApplication;
 use RuntimeException;
 
 class AsyncQueueFake extends QueueFake
 {
+    use CreatesApplication;
+
     /**
      * Process all of the jobs on the queue using a fresh application instance.
      *
@@ -41,20 +43,15 @@ class AsyncQueueFake extends QueueFake
      */
     protected function refreshApplication()
     {
-        if (file_exists(getcwd().'/bootstrap/app.php')) {
-            $db = app('db');
-            $queue = app('queue');
+        $db = app('db');
+        $queue = app('queue');
 
-            $app = require getcwd().'/bootstrap/app.php';
-            $app->make(Kernel::class)->bootstrap();
+        $app = $this->createApplication();
 
-            Queue::swap($queue);
-            DB::swap($db);
-            Model::setConnectionResolver($db);
+        Queue::swap($queue);
+        DB::swap($db);
+        Model::setConnectionResolver($db);
 
-            return $app;
-        }
-
-        throw new RuntimeException('Unable to resolve application.');
+        return $app;
     }
 }

--- a/src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/AsyncQueueFake.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use RuntimeException;
+
+class AsyncQueueFake extends QueueFake
+{
+    /**
+     * Process all of the jobs on the queue using a fresh application instance.
+     *
+     * @return self
+     */
+    public function dispatch()
+    {
+        foreach ($this->jobs as $job => $instances) {
+            foreach ($instances as $instance) {
+                $this->refreshApplication();
+
+                [$job, $data, $queue] = array_values($instance);
+
+                is_object($job) && isset($job->connection)
+                    ? $this->queue->connection($job->connection)->push($job, $data, $queue)
+                    : $this->queue->push($job, $data, $queue);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Refresh the application.
+     *
+     * @return \Illuminate\Foundation\Application
+     *
+     * @throws RuntimeException
+     */
+    protected function refreshApplication()
+    {
+        if (file_exists(getcwd().'/bootstrap/app.php')) {
+            $db = app('db');
+            $queue = app('queue');
+
+            $app = require getcwd().'/bootstrap/app.php'
+            $app->make(Kernel::class)->bootstrap();
+
+            Queue::swap($queue);
+            DB::swap($db);
+            Model::setConnectionResolver($db);
+
+            return $app;
+        }
+
+        throw new RuntimeException('Unable to resolve application.');
+    }
+}

--- a/src/Illuminate/Testing/Concerns/CreatesApplication.php
+++ b/src/Illuminate/Testing/Concerns/CreatesApplication.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Testing\Concerns;
+
+use RuntimeException;
+
+trait CreatesApplication
+{
+    /**
+     * The application resolver callback.
+     *
+     * @var \Closure|null
+     */
+    protected static $applicationResolver;
+
+    /**
+     * Set the application resolver callback.
+     *
+     * @param  \Closure|null  $resolver
+     * @return void
+     */
+    public static function resolveApplicationUsing($resolver)
+    {
+        static::$applicationResolver = $resolver;
+    }
+
+    /**
+     * Creates the application.
+     *
+     * @return \Illuminate\Contracts\Foundation\Application
+     *
+     * @throws \RuntimeException
+     */
+    protected function createApplication()
+    {
+        $applicationResolver = static::$applicationResolver ?: function () {
+            if (trait_exists(\Tests\CreatesApplication::class)) {
+                $applicationCreator = new class
+                {
+                    use \Tests\CreatesApplication;
+                };
+
+                return $applicationCreator->createApplication();
+            } elseif (file_exists(getcwd().'/bootstrap/app.php')) {
+                $app = require getcwd().'/bootstrap/app.php';
+
+                $app->make(Kernel::class)->bootstrap();
+
+                return $app;
+            }
+
+            throw new RuntimeException('Unable to resolve application.');
+        };
+
+        return $applicationResolver();
+    }
+}

--- a/tests/Integration/Queue/AsyncQueueFakeTest.php
+++ b/tests/Integration/Queue/AsyncQueueFakeTest.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Testing\Fakes\AsyncQueueFake;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
-class SupportTestingAsyncQueueFakeTest extends TestCase
+class AsyncQueueFakeTest extends TestCase
 {
     /**
      * @var \Illuminate\Support\Testing\Fakes\AsyncQueueFake

--- a/tests/Support/SupportTestingAsyncQueueFakeTest.php
+++ b/tests/Support/SupportTestingAsyncQueueFakeTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Testing\Fakes\AsyncQueueFake;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+
+class SupportTestingAsyncQueueFakeTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Support\Testing\Fakes\AsyncQueueFake
+     */
+    private $fake;
+
+    /**
+     * @var \Illuminate\Tests\Support\JobStub
+     */
+    private $job;
+
+    /**
+     * @var int
+     */
+    private $applicationRefreshes = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+
+        $this->post = Post::create(['title' => 'xyz', 'slug' => 'xyz']);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        m::close();
+    }
+
+    public function testModelRehydrated()
+    {
+        $job = new JobStub($this->post);
+        $queue = $this->mockQueueManager();
+
+        $queue->push($job);
+        $queue->dispatch();
+
+        $queue->assertPushed(JobStub::class);
+    }
+
+    public function testDeletedModelIsNotRehydrated()
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $job = new JobStub($this->post);
+        $queue = $this->mockQueueManager();
+
+        $queue->push($job);
+        $this->post->delete();
+        $queue->dispatch();
+    }
+
+    public function testJobsAreAllDispatchedInANewProcess()
+    {
+        $job = new JobStub($this->post);
+        $queue = $this->mockQueueManager();
+
+        $queue->push($job);
+        $queue->push($job);
+        $queue->dispatch();
+
+        $queue->assertPushed(JobStub::class, 2);
+        $this->assertSame(2, $this->applicationRefreshes);
+    }
+
+    public function testOnlySpecifiedJobsAreRunAsynchronously()
+    {
+        $job = new JobStub($this->post);
+        $queue = $this->mockQueueManager([JobStub::class]);
+
+        $queue->push($job);
+        $queue->push($job);
+        $queue->push(new SecondJobStub);
+        $queue->dispatch();
+
+        $queue->assertPushed(JobStub::class, 2);
+        $this->assertSame(2, $this->applicationRefreshes);
+    }
+
+    protected function refreshQueueApplication()
+    {
+        $db = $this->app->make('db');
+        $queue = $this->app->make('queue');
+
+        $app = parent::refreshApplication();
+
+        Queue::swap($queue);
+        DB::swap($db);
+        Model::setConnectionResolver($db);
+
+        $this->applicationRefreshes++;
+
+        return $app;
+    }
+
+    protected function mockQueueManager($jobsToRunAsynchronously = [], $app = null, $queue = null)
+    {
+        $queueManager = m::mock(
+            AsyncQueueFake::class, [
+                $app ?: $this->app,
+                $jobsToRunAsynchronously,
+                $queue ?: $this->app->make('queue'),
+            ])
+        ->makePartial();
+        $queueManager->shouldAllowMockingProtectedMethods();
+        $queueManager->shouldReceive('refreshApplication')
+            ->andReturnUsing(fn () => $this->refreshQueueApplication());
+
+        return $queueManager;
+    }
+}
+
+class JobStub implements ShouldQueue
+{
+    use SerializesModels;
+
+    public $post;
+
+    public function __construct(Post $post)
+    {
+        $this->post = $post;
+    }
+
+    public function handle()
+    {
+        //
+    }
+}
+
+class SecondJobStub implements ShouldQueue
+{
+    public function handle()
+    {
+        //
+    }
+}
+
+class Post extends Model
+{
+    protected $guarded = [];
+
+    public $table = 'posts';
+}


### PR DESCRIPTION
This PR adds support for asynchronously queued jobs in tests.

Imagine a scenario where you have a feature test for an endpoint that deletes a users. Inside the associated controller, a job is fired off called `DeleteUserPosts`.

That job should receive a `User` model which you pass in from your controller, but without thinking, you delete the model later in the request.

```php
// Controller
class UserController extends Controller
{
    //

    public function destroy(User $user)
    {
        //

        dispatch(new DeleteUserPosts($user));

        $user->delete();  // This is going to be a problem when the above job is queued...
    }
}

// Job
class DeleteUserPosts implements ShouldQueue
{
    use SerializesModels;

    public function __construct(public User $user)
    {
    }
    
    public function handle()
    {
        $this->user->posts->delete();
    }   
}
```

Now, when you run the test, the job runs synchronously and you get the warm fuzzies seeing a nice green tick appear in your terminal. However out in the wild, the job is queued, a `ModelNotFoundException` is thrown as it no longer exists when the job handler attempts to refetch it.

```php
public function testUserAndPostsCanBeDeleted()
{
    $user = User::factory()
        ->has(Post::factory()->count(3))
        ->create();

    $this->delete('/users/'.$user->id);

    $this->assertNull($user->posts);
}
```

This is just one example, but a few times, I have run into scenarios that have bitten me as I've not been able to execute that job in isolation as part of my test.

Of course, some of these issues are taken away if the job is unit tested (though this doesn't guard against the deleted model example), but sometimes I just want to test my feature end to end and know it's behaving as it will do in production.

**Introducing the new test helper - `fakeAsync`.**

`fakeAsync` accepts and executes a callback while catching all the queued jobs dispatched during its execution. When the execution completes, each job is processed within a fresh application state.

```php
public function testUserAndPostsCanBeDeleted()
{
    $user = User::factory()
        ->has(Post::factory()->count(3))
        ->create();

    Queue::fakeAsync(function () use ($user) {
        $this->delete('/users/'.$user->id);
    });

    $this->assertNull($user->fresh()->posts);
}
```

Running this test would result in a `ModelNotFoundException` being thrown as the job attempts to unserialize the `$user` model.

You may pass an array of jobs as the second argument of `fakeAsync` to have control over which to process asynchronously.

```php
Queue::fakeAsync(function () use ($user) {
    $this->delete('/users/'.$user->id);
}, [DeleteUserPosts::class]);
```

Any other jobs will be processed synchronously.

_____

**Update**

I tested this PR on the Laravel.io codebase and managed to catch a bug using `Queue::fakeAsync` 🎉 

```php
public function delete(Request $request, Thread $thread)
{
    $this->authorize(ThreadPolicy::DELETE, $thread);

    $this->dispatchSync(new DeleteThread($thread));

    $request->whenFilled('reason', function () use ($thread) {
        $thread->author()?->notify(
            new ThreadDeletedNotification($thread, request('reason')),
        );
    });

    $this->success('forum.threads.deleted');

    return redirect()->route('forum');
}
```

Here, you can see the thread is deleted before firing off a queued notification which requires that thread. What makes this more interesting is we didn't know this was an issue a `ModelNotFoundException` is not reported by default.

It's worth pointing out `fakeAsync` does not work in conjunction when mocking other facades such as `Notification::fake()` or `Bus::fake()` - it will only work if jobs are actually pushed on to the queue.