### PR TITLE
[9.x] Add $added array to Translator to store added lines

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -41,6 +41,13 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @var array
      */
     protected $loaded = [];
+    
+    /**
+     * The array of added translation lines.
+     *
+     * @var array
+     */
+    protected $added = [];
 
     /**
      * The message selector.
@@ -195,7 +202,8 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $this->load($namespace, $group, $locale);
 
-        $line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
+        $lines = array_replace_recursive($this->loaded, $this->added);
+        $line = Arr::get($lines[$namespace][$group][$locale], $item);
 
         if (is_string($line)) {
             return $this->makeReplacements($line, $replace);
@@ -245,7 +253,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         foreach ($lines as $key => $value) {
             [$group, $item] = explode('.', $key, 2);
 
-            Arr::set($this->loaded, "$namespace.$group.$locale.$item", $value);
+            Arr::set($this->added, "$namespace.$group.$locale.$item", $value);
         }
     }
 


### PR DESCRIPTION
Adding lines to the Translator prevents the Translator from loading the translation files, as it thinks it has already loaded. By storing the added lines in a separate array, and merging the 'loaded array' and the 'added array' when getting a line, you can prevent that behavior.

Steps to reproduce:
Set a different language (eg. nl) as main locale, and English as fallback. Duplicate the lang/en/passwords.php file to the new language dir and update the values to something different. In your view, echo
```
{{ __('passwords.reset') }}
{{ __('passwords.sent') }}
```

It should show your new language output.

If you add a line to the translator before the files are loaded (eg. in a service provider):

```
    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        app('translator')->addLines(['passwords.reset' => 'UPDATED LINE'], 'nl');
    }
```

Now, if you open your view again, it shows the UPDATED LINE for the 'passwords.reset' entry, but the 'passwords.sent' entry shows the English fallback line. This is because after adding the line to the nl locale, the Translator->isLoaded returns true for the current locale, as it is set by adding the line.

This update will fix that, as it stores added lines in a separate array.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
