### PR TITLE
[9.x] Detect broken connection after MSSQL upgrade

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -60,6 +60,7 @@ trait DetectsLostConnections
             'TCP Provider: Error code 0x274C',
             'SQLSTATE[HY000] [2002] No such file or directory',
             'SSL: Operation timed out',
+            'Reason: Server is in script upgrade mode. Only administrator can connect at this time.',
         ]);
     }
 }


### PR DESCRIPTION
After upgrading our SQL Server cluster last week, which normally fails over gracefully and happens with zero-downtime, we experienced the following error in a few of our pods until manually restarting them:
> SQLSTATE[42000]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Login failed for user 'SomeUser'. Reason: Server is in script upgrade mode. Only administrator can connect at this time.

Apparently, when applying a patch to SQL Server, it will go in _script upgrade mode_ during the recovery phase while restarting to patch system objects (like system tables and views). The time this takes depends on the patch and what objects it needs to update. Most times it will take like a minute or two. More details can be found [in this blog post](https://blog.sqlauthority.com/2015/04/10/sql-server-login-failed-for-user-reason-server-is-in-script-upgrade-mode/#:~:text=Script%20upgrade%20mode%20is%20the,take%20varying%20amount%20of%20time.).

Since this is a very rare issue and hard & time consuming to reproduce, and because restarting our containers to force a reconnect to SQL Server helped, I assume this can be seen as an error indicating a broken connection. The SQL Server Management Studio (a Windows GUI) actually detects this error as a failed attempt to connect (as can be seen in [this screenshot](https://3.bp.blogspot.com/-qeFBDWk-LYA/UnOSbnt1ogI/AAAAAAAAAA8/VEvPWbR7qFI/s400/scriptupgrade.png)).