### PR TITLE
[9.x] Request lifecycle duration handler

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -2,18 +2,24 @@
 
 namespace Illuminate\Foundation\Http;
 
+use Carbon\CarbonInterval;
+use DateTimeInterface;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Routing\Pipeline;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\InteractsWithTime;
 use InvalidArgumentException;
 use Throwable;
 
 class Kernel implements KernelContract
 {
+    use InteractsWithTime;
+
     /**
      * The application implementation.
      *
@@ -64,6 +70,20 @@ class Kernel implements KernelContract
     protected $routeMiddleware = [];
 
     /**
+     * All of the registered request duration handlers.
+     *
+     * @var array
+     */
+    protected $requestLifecycleDurationHandlers = [];
+
+    /**
+     * When the currently handled request started.
+     *
+     * @var \Illuminate\Support\Carbon|null
+     */
+    protected $requestStartedAt;
+
+    /**
      * The priority-sorted list of middleware.
      *
      * Forces non-global middleware to always be in the given order.
@@ -105,6 +125,8 @@ class Kernel implements KernelContract
      */
     public function handle($request)
     {
+        $this->requestStartedAt = Carbon::now();
+
         try {
             $request->enableHttpMethodParameterOverride();
 
@@ -180,6 +202,16 @@ class Kernel implements KernelContract
         $this->terminateMiddleware($request, $response);
 
         $this->app->terminate();
+
+        foreach ($this->requestLifecycleDurationHandlers as ['threshold' => $threshold, 'handler' => $handler]) {
+            $end ??= Carbon::now();
+
+            if ($this->requestStartedAt->diffInMilliseconds($end) > $threshold) {
+                $handler($this->requestStartedAt, $request, $response);
+            }
+        }
+
+        $this->requestStartedAt = null;
     }
 
     /**
@@ -209,6 +241,39 @@ class Kernel implements KernelContract
                 $instance->terminate($request, $response);
             }
         }
+    }
+
+    /**
+     * Register a callback to be invoked when the requests lifecyle duration exceeds a given amount of time.
+     *
+     * @param  \DateTimeInterface|\Carbon\CarbonInterval|float|int  $threshold
+     * @param  callable  $handler
+     * @return void
+     */
+    public function whenRequestLifecycleIsLongerThan($threshold, $handler)
+    {
+        $threshold = $threshold instanceof DateTimeInterface
+            ? $this->secondsUntil($threshold) * 1000
+            : $threshold;
+
+        $threshold = $threshold instanceof CarbonInterval
+            ? $threshold->totalMilliseconds
+            : $threshold;
+
+        $this->requestLifecycleDurationHandlers[] = [
+            'threshold' => $threshold,
+            'handler' => $handler,
+        ];
+    }
+
+    /**
+     * When the request being handled started.
+     *
+     * @return \Illuminate\Support\Carbon|null
+     */
+    public function requestStartedAt()
+    {
+        return $this->requestStartedAt;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -77,7 +77,7 @@ class Kernel implements KernelContract
     protected $requestLifecycleDurationHandlers = [];
 
     /**
-     * When the currently handled request started.
+     * When the kernel starting handling the current request.
      *
      * @var \Illuminate\Support\Carbon|null
      */

--- a/tests/Integration/Http/RequestDurationThresholdTest.php
+++ b/tests/Integration/Http/RequestDurationThresholdTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Carbon\CarbonInterval;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class RequestDurationThresholdTest extends TestCase
+{
+    public function testItCanHandleExceedingRequestDuration()
+    {
+        Route::get('test-route', fn () => 'ok');
+        $request = Request::create('http://localhost/test-route');
+        $response = new Response();
+        $called = false;
+        $kernel = $this->app[Kernel::class];
+        $kernel->whenRequestLifecycleIsLongerThan(CarbonInterval::seconds(1), function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(now());
+        $kernel->handle($request);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
+        $kernel->terminate($request, $response);
+
+        $this->assertTrue($called);
+    }
+
+    public function testItDoesntCallWhenExactlyThresholdDuration()
+    {
+        Route::get('test-route', fn () => 'ok');
+        $request = Request::create('http://localhost/test-route');
+        $response = new Response();
+        $called = false;
+        $kernel = $this->app[Kernel::class];
+        $kernel->whenRequestLifecycleIsLongerThan(CarbonInterval::seconds(1), function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(now());
+        $kernel->handle($request);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1));
+        $kernel->terminate($request, $response);
+
+        $this->assertFalse($called);
+    }
+
+    public function testItProvidesRequestToHandler()
+    {
+        Route::get('test-route', fn () => 'ok');
+        $request = Request::create('http://localhost/test-route');
+        $response = new Response();
+        $url = null;
+        $kernel = $this->app[Kernel::class];
+        $kernel->whenRequestLifecycleIsLongerThan(CarbonInterval::seconds(1), function ($startedAt, $request) use (&$url) {
+            $url = $request->url();
+        });
+
+        Carbon::setTestNow(now());
+        $kernel->handle($request);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(2));
+        $kernel->terminate($request, $response);
+
+        $this->assertSame('http://localhost/test-route', $url);
+    }
+
+    public function testItCanExceedThresholdWhenSpecifyingDurationAsMilliseconds()
+    {
+        Route::get('test-route', fn () => 'ok');
+        $request = Request::create('http://localhost/test-route');
+        $response = new Response();
+        $called = false;
+        $kernel = $this->app[Kernel::class];
+        $kernel->whenRequestLifecycleIsLongerThan(1000, function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(now());
+        $kernel->handle($request);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
+        $kernel->terminate($request, $response);
+
+        $this->assertTrue($called);
+    }
+
+    public function testItCanStayUnderThresholdWhenSpecifyingDurationAsMilliseconds()
+    {
+        Route::get('test-route', fn () => 'ok');
+        $request = Request::create('http://localhost/test-route');
+        $response = new Response();
+        $called = false;
+        $kernel = $this->app[Kernel::class];
+        $kernel->whenRequestLifecycleIsLongerThan(1000, function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(now());
+        $kernel->handle($request);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1));
+        $kernel->terminate($request, $response);
+
+        $this->assertFalse($called);
+    }
+
+    public function testItCanExceedThresholdWhenSpecifyingDurationAsDateTime()
+    {
+        Route::get('test-route', fn () => 'ok');
+        $request = Request::create('http://localhost/test-route');
+        $response = new Response();
+        $called = false;
+        $kernel = $this->app[Kernel::class];
+        $kernel->whenRequestLifecycleIsLongerThan(now()->addSeconds(1), function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(now());
+        $kernel->handle($request);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
+        $kernel->terminate($request, $response);
+
+        $this->assertTrue($called);
+    }
+
+    public function testItCanStayUnderThresholdWhenSpecifyingDurationAsDateTime()
+    {
+        Route::get('test-route', fn () => 'ok');
+        $request = Request::create('http://localhost/test-route');
+        $response = new Response();
+        $called = false;
+        $kernel = $this->app[Kernel::class];
+        $kernel->whenRequestLifecycleIsLongerThan(now()->addSeconds(1), function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(now());
+        $kernel->handle($request);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1));
+        $kernel->terminate($request, $response);
+
+        $this->assertFalse($called);
+    }
+
+    public function testItClearsStartTimeAfterHandlingRequest()
+    {
+        $kernel = $this->app[Kernel::class];
+        Route::get('test-route', fn () => 'ok');
+        $request = Request::create('http://localhost/test-route');
+        $response = new Response();
+
+        Carbon::setTestNow(now());
+        $kernel->handle($request);
+        $this->assertTrue(Carbon::now()->eq($kernel->requestStartedAt()));
+
+        $kernel->terminate($request, $response);
+        $this->assertNull($kernel->requestStartedAt());
+    }
+}


### PR DESCRIPTION
This PR is in a similar spirit the the [cumulative query duration PR](https://github.com/laravel/framework/pull/42744). It allows developers to easily handle when an application request lifecycle exceeds a certain threshold.

```php
use Carbon\CarbonInterval as Interval;
use Illuminate\Contracts\Http\Kernel;
use Illuminate\Support\Facades\Log;


public function boot()
{
    if ($this->app->runningInConsole()) {
        return;
    }

    $this->app[Kernel::class]->whenRequestLifecycleIsLongerThan(
        Interval::seconds(1),
        fn ($startedAt, $request, $response) => /* ... */
    );

}
```


The feature includes the duration of the request handle method and the terminating of the middleware and application.

This gives developers a nice hook around the entire lifecycle of the request, as seen: https://github.com/laravel/laravel/blob/c1dc4199b83466a3a6a8c70953250b0e2ec70001/public/index.php#L51-L55

This is an easy starting point for tracking slow requests and not a full blown replacement for APM, but gives developers some quick insight into their system with little to no extra knowledge / setup.

```php
$this->app[Kernel::class]->whenRequestLifecycleIsLongerThan(
    Interval::seconds(1),
    fn ($startedAt, $request, $response) =>
        Log::notice('Request exceeded duration threshold.', [
            'user' => $request->user()?->id,
            'url' => $request->fullUrl(),
            'duration' => $startedAt->floatDiffInSeconds(),
        ])
);
```

The handler is invoked after the request has been returned to the user.

Command compliment: https://github.com/laravel/framework/pull/44125