### PR TITLE
[9.x] Command lifecycle handler

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Carbon\CarbonInterval;
 use Closure;
+use DateTimeInterface;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
@@ -11,7 +13,9 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Env;
+use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
@@ -19,6 +23,8 @@ use Throwable;
 
 class Kernel implements KernelContract
 {
+    use InteractsWithTime;
+
     /**
      * The application implementation.
      *
@@ -53,6 +59,20 @@ class Kernel implements KernelContract
      * @var bool
      */
     protected $commandsLoaded = false;
+
+    /**
+     * All of the registered command duration handlers.
+     *
+     * @var array
+     */
+    protected $commandLifecycleDurationHandlers = [];
+
+    /**
+     * When the currently handled command started.
+     *
+     * @var \Illuminate\Support\Carbon|null
+     */
+    protected $commandStartedAt;
 
     /**
      * The bootstrap classes for the application.
@@ -123,6 +143,8 @@ class Kernel implements KernelContract
      */
     public function handle($input, $output = null)
     {
+        $this->commandStartedAt = Carbon::now();
+
         try {
             $this->bootstrap();
 
@@ -146,6 +168,49 @@ class Kernel implements KernelContract
     public function terminate($input, $status)
     {
         $this->app->terminate();
+
+        foreach ($this->commandLifecycleDurationHandlers as ['threshold' => $threshold, 'handler' => $handler]) {
+            $end ??= Carbon::now();
+
+            if ($this->commandStartedAt->diffInMilliseconds($end) > $threshold) {
+                $handler($this->commandStartedAt, $input, $status);
+            }
+        }
+
+        $this->commandStartedAt = null;
+    }
+
+    /**
+     * Register a callback to be invoked when the command lifecyle duration exceeds a given amount of time.
+     *
+     * @param  \DateTimeInterface|\Carbon\CarbonInterval|float|int  $threshold
+     * @param  callable  $handler
+     * @return void
+     */
+    public function whenCommandLifecycleIsLongerThan($threshold, $handler)
+    {
+        $threshold = $threshold instanceof DateTimeInterface
+            ? $this->secondsUntil($threshold) * 1000
+            : $threshold;
+
+        $threshold = $threshold instanceof CarbonInterval
+            ? $threshold->totalMilliseconds
+            : $threshold;
+
+        $this->commandLifecycleDurationHandlers[] = [
+            'threshold' => $threshold,
+            'handler' => $handler,
+        ];
+    }
+
+    /**
+     * When the command being handled started.
+     *
+     * @return \Illuminate\Support\Carbon|null
+     */
+    public function commandStartedAt()
+    {
+        return $this->commandStartedAt;
     }
 
     /**

--- a/tests/Integration/Console/CommandDurationThresholdTest.php
+++ b/tests/Integration/Console/CommandDurationThresholdTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Carbon\CarbonInterval;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Carbon;
+use Orchestra\Testbench\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class CommandDurationThresholdTest extends TestCase
+{
+    public function testItCanHandleExceedingCommandDuration()
+    {
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $input = new StringInput('foo');
+        $called = false;
+        $kernel->whenCommandLifecycleIsLongerThan(CarbonInterval::seconds(1), function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $kernel->handle($input, new ConsoleOutput);
+
+        $this->assertFalse($called);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
+        $kernel->terminate($input, 21);
+
+        $this->assertTrue($called);
+    }
+
+    public function testItDoesntCallWhenExactlyThresholdDuration()
+    {
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $input = new StringInput('foo');
+        $called = false;
+        $kernel->whenCommandLifecycleIsLongerThan(CarbonInterval::seconds(1), function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $kernel->handle($input, new ConsoleOutput);
+
+        $this->assertFalse($called);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1));
+        $kernel->terminate($input, 21);
+
+        $this->assertFalse($called);
+    }
+
+    public function testItProvidesArgsToHandler()
+    {
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $input = new StringInput('foo');
+        $args = null;
+        $kernel->whenCommandLifecycleIsLongerThan(CarbonInterval::seconds(0), function () use (&$args) {
+            $args = func_get_args();
+        });
+
+        Carbon::setTestNow($startedAt = Carbon::now());
+        $kernel->handle($input, new ConsoleOutput);
+        Carbon::setTestNow(Carbon::now()->addSeconds(1));
+        $kernel->terminate($input, 21);
+
+        $this->assertCount(3, $args);
+        $this->assertTrue($startedAt->eq($args[0]));
+        $this->assertSame($input, $args[1]);
+        $this->assertSame(21, $args[2]);
+    }
+
+    public function testItCanExceedThresholdWhenSpecifyingDurationAsMilliseconds()
+    {
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $input = new StringInput('foo');
+        $called = false;
+        $kernel->whenCommandLifecycleIsLongerThan(1000, function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $kernel->handle($input, new ConsoleOutput);
+
+        $this->assertFalse($called);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
+        $kernel->terminate($input, 21);
+
+        $this->assertTrue($called);
+    }
+
+    public function testItCanStayUnderThresholdWhenSpecifyingDurationAsMilliseconds()
+    {
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $input = new StringInput('foo');
+        $called = false;
+        $kernel->whenCommandLifecycleIsLongerThan(1000, function () use (&$called) {
+            $called = true;
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $kernel->handle($input, new ConsoleOutput);
+
+        $this->assertFalse($called);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1));
+        $kernel->terminate($input, 21);
+
+        $this->assertFalse($called);
+    }
+
+    public function testItCanExceedThresholdWhenSpecifyingDurationAsDateTime()
+    {
+        Carbon::setTestNow(Carbon::now());
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $input = new StringInput('foo');
+        $called = false;
+        $kernel->whenCommandLifecycleIsLongerThan(Carbon::now()->addSecond()->addMillisecond(), function () use (&$called) {
+            $called = true;
+        });
+
+        $kernel->handle($input, new ConsoleOutput);
+
+        $this->assertFalse($called);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
+        $kernel->terminate($input, 21);
+
+        $this->assertTrue($called);
+    }
+
+    public function testItCanStayUnderThresholdWhenSpecifyingDurationAsDateTime()
+    {
+        Carbon::setTestNow(Carbon::now());
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $input = new StringInput('foo');
+        $called = false;
+        $kernel->whenCommandLifecycleIsLongerThan(Carbon::now()->addSecond()->addMillisecond(), function () use (&$called) {
+            $called = true;
+        });
+
+        $kernel->handle($input, new ConsoleOutput);
+
+        $this->assertFalse($called);
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(1));
+        $kernel->terminate($input, 21);
+
+        $this->assertFalse($called);
+    }
+
+    public function testItClearsStartTimeAfterHandlingCommand()
+    {
+        $kernel = $this->app[Kernel::class];
+        $kernel->command('foo', fn () => null);
+        $input = new StringInput('foo');
+
+        $this->assertNull($kernel->commandStartedAt());
+
+        $kernel->handle($input, new ConsoleOutput);
+        $this->assertNotNull($kernel->commandStartedAt());
+
+        $kernel->terminate($input, 21);
+        $this->assertNull($kernel->commandStartedAt());
+    }
+}


### PR DESCRIPTION
This is the command compliment to: https://github.com/laravel/framework/pull/44122

```php
use Carbon\CarbonInterval as Interval;
use Illuminate\Contracts\Console\Kernel;

public function boot()
{
    if (! $this->app->runningInConsole()) {
        return;
    }

    $this->app[Kernel::class]->whenCommandLifecycleIsLongerThan(
        Interval::seconds(1),
        fn ($startedAt, $input, $status) => /* ... */
    );
}
```

This hook wraps around the Artisan lifecycle, as seen here: https://github.com/laravel/laravel/blob/9.x/artisan#L35-L51

If you were to call the following from a **request**, it would **not** trigger this handler.

```php
class MyController
{
    public function __invoke()
    {
        Artisan::call('my-slow-command');
    }
}
```

I felt that "command lifecycle" made sense, however perhaps it is in fact the "artisan lifecycle".

Request lifecycle and artisan lifecycle? Not sure.