### PR TITLE
[9.x] Add unique deferrable initially deferred constants for PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -152,11 +152,21 @@ class PostgresGrammar extends Grammar
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
     {
-        return sprintf('alter table %s add constraint %s unique (%s)',
+        $sql = sprintf('alter table %s add constraint %s unique (%s)',
             $this->wrapTable($blueprint),
             $this->wrap($command->index),
             $this->columnize($command->columns)
         );
+
+        if (! is_null($command->deferrable)) {
+            $sql .= $command->deferrable ? ' deferrable' : ' not deferrable';
+        }
+
+        if ($command->deferrable && ! is_null($command->initiallyImmediate)) {
+            $sql .= $command->initiallyImmediate ? ' initially immediate' : ' initially deferred';
+        }
+
+        return $sql;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Fluent;
 /**
  * @method $this algorithm(string $algorithm) Specify an algorithm for the index (MySQL/PostgreSQL)
  * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
- * @method $this deferrable(bool $value = true) Set the unique index as deferrable (PostgreSQL)
- * @method $this initiallyImmediate(bool $value = true) Set the default time to check the constraint (PostgreSQL)
+ * @method $this deferrable(bool $value = true) Specify that the unique index is deferrable (PostgreSQL)
+ * @method $this initiallyImmediate(bool $value = true) Specify the default time to check the unique index constraint (PostgreSQL)
  */
 class IndexDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/IndexDefinition.php
+++ b/src/Illuminate/Database/Schema/IndexDefinition.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Fluent;
 /**
  * @method $this algorithm(string $algorithm) Specify an algorithm for the index (MySQL/PostgreSQL)
  * @method $this language(string $language) Specify a language for the full text index (PostgreSQL)
+ * @method $this deferrable(bool $value = true) Set the unique index as deferrable (PostgreSQL)
+ * @method $this initiallyImmediate(bool $value = true) Set the default time to check the constraint (PostgreSQL)
  */
 class IndexDefinition extends Fluent
 {


### PR DESCRIPTION
Currently it is not possible to check a unique constraint only after updating.

For this, `DEFERRABLE INITIALLY DEFERRED` is needed.
```
create table pictures
(
    id bigserial primary key,
    ...
    constraint pictures_post_id_post_type_sequence_unique
        unique (post_id, post_type, sequence)
            deferrable initially deferred
);
```

You can easily apply this to a foreign id with the following function:
```
$table->foreignId('foo')->deferrable();
```

This works because it is already observed in the foreign id. 
https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Schema/ForeignKeyDefinition.php#L8-L9 

However, not with the UNIQUE Keys.
https://github.com/laravel/framework/blob/9.x/src//Illuminate/Database/Schema/Grammars/PostgresGrammar.php#L146-L160

This problem has already been listed in discussion #40953.

Now you can also put a `DEFERRABLE INITIALLY DEFERRED` or a `DEFERRABLE INITIALLY IMMEDIATE` on unique keys.

DEFERRABLE INITIALLY DEFERRED:
```
$table->unique(['post_id', 'post_type', 'sequence'])
    ->deferrable()
    ->initiallyImmediate(false);
```

DEFERRABLE INITIALLY IMMEDIATE
```
$table->unique(['post_id', 'post_type', 'sequence'])
    ->deferrable()
    ->initiallyImmediate();
```