### PR TITLE
[9.x] Adds ShouldNotify contract

### DIFF
--- a/src/Illuminate/Contracts/Notifications/ShouldNotify.php
+++ b/src/Illuminate/Contracts/Notifications/ShouldNotify.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Notifications;
+
+interface ShouldNotify
+{
+    /**
+     * Get the notifiables the event should notify.
+     *
+     * @return object|object[]
+     */
+    public function notifyTo();
+}

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -354,15 +354,16 @@ class Dispatcher implements DispatcherContract
     /**
      * Notify the given event class.
      *
-     * @param  \Illuminate\Contracts\Notifications\ShouldNotify  $event  // TODO:
+     * @param  \Illuminate\Contracts\Notifications\ShouldNotify  $event
      * @return void
      */
     protected function notifyEvent($event)
     {
+        $dispatcher = $this->container->make(NotificationsDispatcher::class);
         $notifiables = Arr::wrap($event->notifyTo());
 
         foreach ($notifiables as $notifiable) {
-            $this->container->make(NotificationsDispatcher::class)->send($notifiable, $event);
+            $dispatcher->send($notifiable, $event);
         }
     }
 

--- a/tests/Integration/Notifications/SendingNotificationsWithShouldNotify.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithShouldNotify.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Notifications;
+
+use Illuminate\Contracts\Notifications\ShouldNotify;
+use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+use Illuminate\Support\Testing\Fakes\NotificationFake;
+use Orchestra\Testbench\TestCase;
+
+class SendingNotificationsWithShouldNotify extends TestCase
+{
+    public function testNotificationIsSentWhenImplementingShouldNotify()
+    {
+        $fake = NotificationFacade::fake();
+        $this->assertInstanceOf(NotificationFake::class, $fake);
+
+        $model = new FakeModel;
+        $model->user = new AnonymousNotifiable;
+
+        Event::dispatch(new FakeModelEventWithShouldNotify($model));
+
+        NotificationFacade::assertSentTo(new $model->user, FakeModelEventWithShouldNotify::class);
+    }
+}
+
+class FakeModel
+{
+    public $user;
+}
+
+class FakeModelEventWithShouldNotify extends Notification implements ShouldNotify
+{
+    public $user;
+
+    public function __construct($model)
+    {
+        $this->user = $model->user;
+    }
+
+    public function notifyTo()
+    {
+        return $this->user;
+    }
+
+    public function via($notifiable)
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Broadcasting events is fairly easy with Laravel. All you have to do is to add the `ShouldBroadcast` interface to the event and implement the `broadcastOn` method.

Another feature that commonly uses events as a triggers is the Notification. Although broadcast and notifications serve the same purpose (notifying some third party about some event), dispatching notifications requires extra steps. People must create a Notification object, listen to the event and manually dispatch the notification, like the following.

```php
Event::listen(IssueClosedEvent::class, function ($event) {
    $event->issue->author->notify(new IssueClosedNotification($event->issue));
});
```

This PR adds a `ShouldNotify` interface that can be added to any event, which automatically dispatches a notification when the event is dispatched, similar with how broadcasting works.

When the following event is dispatched, the author of the Issue will be automatically notified.

```php
class IssueClosedEvent extends Notification implements ShouldNotify
{
    public function __construct(
        public Issue $issue
    ){
    }

    public function notifyTo()
    {
        return [
            $this->issue->author,
        ];
    }

    public function via($notifiable)
    {
        return ['mail'];
    }

    public function toMail()
    {
    }
}

```