### PR TITLE
[9.x] Improve Blade compilation exception messages

### DIFF
--- a/src/Illuminate/Contracts/View/ViewCompilationException.php
+++ b/src/Illuminate/Contracts/View/ViewCompilationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Contracts\View;
+
+use Exception;
+
+class ViewCompilationException extends Exception
+{
+    //
+}

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -23,7 +23,11 @@ trait CompilesLoops
     {
         $empty = '$__empty_'.++$this->forElseCounter;
 
-        preg_match('/\( *(.*) +as *(.*)\)$/is', $expression, $matches);
+        preg_match('/\( *(.+) +as +(.+)\)$/is', $expression, $matches);
+
+        if (count($matches) === 0) {
+            throw new ViewCompilationException('Malformed @forelse statement');
+        }
 
         $iteratee = trim($matches[1]);
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -23,7 +23,7 @@ trait CompilesLoops
     {
         $empty = '$__empty_'.++$this->forElseCounter;
 
-        preg_match('/\( *(.+) +as +(.+)\)$/is', $expression, $matches);
+        preg_match('/\( *(.+) +as +(.+)\)$/is', $expression ?? '', $matches);
 
         if (count($matches) === 0) {
             throw new ViewCompilationException('Malformed @forelse statement');
@@ -97,7 +97,7 @@ trait CompilesLoops
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.*) +as +(.*)\)$/is', $expression, $matches);
+        preg_match('/\( *(.+) +as +(.*)\)$/is', $expression ?? '', $matches);
 
         if (count($matches) === 0) {
             throw new ViewCompilationException('Malformed @foreach statement');

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -19,7 +19,7 @@ trait CompilesLoops
      * @param  string  $expression
      * @return string
      *
-     * @throws ViewCompilationException
+     * @throws \Illuminate\Contracts\View\ViewCompilationException
      */
     protected function compileForelse($expression)
     {
@@ -28,7 +28,7 @@ trait CompilesLoops
         preg_match('/\( *(.+) +as +(.+)\)$/is', $expression ?? '', $matches);
 
         if (count($matches) === 0) {
-            throw new ViewCompilationException('Malformed @forelse statement');
+            throw new ViewCompilationException('Malformed @forelse statement.');
         }
 
         $iteratee = trim($matches[1]);
@@ -96,14 +96,14 @@ trait CompilesLoops
      * @param  string  $expression
      * @return string
      *
-     * @throws ViewCompilationException
+     * @throws \Illuminate\Contracts\View\ViewCompilationException
      */
     protected function compileForeach($expression)
     {
         preg_match('/\( *(.+) +as +(.*)\)$/is', $expression ?? '', $matches);
 
         if (count($matches) === 0) {
-            throw new ViewCompilationException('Malformed @foreach statement');
+            throw new ViewCompilationException('Malformed @foreach statement.');
         }
 
         $iteratee = trim($matches[1]);

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -18,6 +18,8 @@ trait CompilesLoops
      *
      * @param  string  $expression
      * @return string
+     *
+     * @throws ViewCompilationException
      */
     protected function compileForelse($expression)
     {
@@ -93,6 +95,7 @@ trait CompilesLoops
      *
      * @param  string  $expression
      * @return string
+     *
      * @throws ViewCompilationException
      */
     protected function compileForeach($expression)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
+use Illuminate\Contracts\View\ViewCompilationException;
+
 trait CompilesLoops
 {
     /**
@@ -87,10 +89,15 @@ trait CompilesLoops
      *
      * @param  string  $expression
      * @return string
+     * @throws ViewCompilationException
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.*) +as *(.*)\)$/is', $expression, $matches);
+        preg_match('/\( *(.*) +as +(.*)\)$/is', $expression, $matches);
+
+        if (count($matches) === 0) {
+            throw new ViewCompilationException('Malformed @foreach statement');
+        }
 
         $iteratee = trim($matches[1]);
 

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -100,7 +100,7 @@ tag info
     public function testForeachStatementsThrowHumanizedMessageWhenInvalidStatement($initialStatement)
     {
         $this->expectException(ViewCompilationException::class);
-        $this->expectExceptionMessage('Malformed @foreach statement');
+        $this->expectExceptionMessage('Malformed @foreach statement.');
         $string = "$initialStatement
 test
 @endforeach";

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -107,7 +107,7 @@ test
         $this->compiler->compileString($string);
     }
 
-    private function invalidForeachStatementsDataProvider()
+    public function invalidForeachStatementsDataProvider()
     {
         return [
             ['@foreach'],

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -97,13 +97,13 @@ tag info
     /**
      * @dataProvider invalidForeachStatementsDataProvider
      */
-    public function testForeachStatementsThrowHumanizedMessageWhenInvalidStatement($statement)
+    public function testForeachStatementsThrowHumanizedMessageWhenInvalidStatement($initialStatement)
     {
         $this->expectException(ViewCompilationException::class);
         $this->expectExceptionMessage('Malformed @foreach statement');
-        $string = $statement . '
+        $string = "$initialStatement
 test
-@endforeach';
+@endforeach";
         $this->compiler->compileString($string);
     }
 

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\View\Blade;
 
+use Illuminate\Contracts\View\ViewCompilationException;
+
 class BladeForeachStatementsTest extends AbstractBladeTestCase
 {
     public function testForeachStatementsAreCompiled()
@@ -90,5 +92,29 @@ tag info
 <?php endforeach; \$__env->popLoop(); \$loop = \$__env->getLastLoop(); ?>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    /**
+     * @dataProvider invalidForeachStatementsDataProvider
+     */
+    public function testForeachStatementsThrowHumanizedMessageWhenInvalidStatement($statement)
+    {
+        $this->expectException(ViewCompilationException::class);
+        $this->expectExceptionMessage('Malformed @foreach statement');
+        $string = $statement . '
+test
+@endforeach';
+        $this->compiler->compileString($string);
+    }
+
+    private function invalidForeachStatementsDataProvider()
+    {
+        return [
+            ['@foreach'],
+            ['@foreach()'],
+            ['@foreach($test)'],
+            ['@foreach($test as)'],
+            ['@foreach(as)'],
+        ];
     }
 }

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -112,9 +112,11 @@ test
         return [
             ['@foreach'],
             ['@foreach()'],
+            ['@foreach ()'],
             ['@foreach($test)'],
             ['@foreach($test as)'],
             ['@foreach(as)'],
+            ['@foreach ( as )'],
         ];
     }
 }

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\View\Blade;
 
+use Illuminate\Contracts\View\ViewCompilationException;
+
 class BladeForelseStatementsTest extends AbstractBladeTestCase
 {
     public function testForelseStatementsAreCompiled()
@@ -76,5 +78,33 @@ tag empty
 empty
 <?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    /**
+     * @dataProvider invalidForelseStatementsDataProvider
+     */
+    public function testForelseStatementsThrowHumanizedMessageWhenInvalidStatement($initialStatement)
+    {
+        $this->expectException(ViewCompilationException::class);
+        $this->expectExceptionMessage('Malformed @forelse statement');
+        $string = $initialStatement.'
+breeze
+@empty
+tag empty
+@endforelse';
+        $this->compiler->compileString($string);
+    }
+
+    private function invalidForelseStatementsDataProvider()
+    {
+        return [
+            ['@forelse'],
+            ['@forelse()'],
+            ['@forelse ()'],
+            ['@forelse($test)'],
+            ['@forelse($test as)'],
+            ['@forelse(as)'],
+            ['@forelse ( as )'],
+        ];
     }
 }

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -87,11 +87,11 @@ empty
     {
         $this->expectException(ViewCompilationException::class);
         $this->expectExceptionMessage('Malformed @forelse statement');
-        $string = $initialStatement.'
+        $string = "$initialStatement
 breeze
 @empty
 tag empty
-@endforelse';
+@endforelse";
         $this->compiler->compileString($string);
     }
 

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -95,7 +95,7 @@ tag empty
         $this->compiler->compileString($string);
     }
 
-    private function invalidForelseStatementsDataProvider()
+    public function invalidForelseStatementsDataProvider()
     {
         return [
             ['@forelse'],

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -86,7 +86,7 @@ empty
     public function testForelseStatementsThrowHumanizedMessageWhenInvalidStatement($initialStatement)
     {
         $this->expectException(ViewCompilationException::class);
-        $this->expectExceptionMessage('Malformed @forelse statement');
+        $this->expectExceptionMessage('Malformed @forelse statement.');
         $string = "$initialStatement
 breeze
 @empty


### PR DESCRIPTION
# Problem

Currently, when we write a `@foreach` or `@forelse` the wrong way, the exception message is not descriptive. e.g:

Code:
```
@foreach
TEST
@endforeach
```

Exception:
![image](https://user-images.githubusercontent.com/11338999/190229319-9d63daee-6724-4ade-9aeb-673c866212a6.png)

The main objective of this PR is to improve this message:
![image](https://user-images.githubusercontent.com/11338999/190229833-ea21d231-3c20-4b79-b8bc-0525296da095.png)

In an actual situation, it occurred for a beginner developer to take hours to discover the problem since the stacktrace also doesn't make it easy to debug issues in rendering views.