### PR TITLE
[9.x] Add `manifestHash` function to `Illuminate\Foundation\Vite`

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -184,26 +184,6 @@ class Vite implements Htmlable
     }
 
     /**
-     * Get a unique hash or null if there is no manifest.
-     *
-     * @return string|null
-     */
-    public function manifestHash($buildDirectory = null)
-    {
-        $buildDirectory ??= $this->buildDirectory;
-
-        if ($this->isRunningHot()) {
-            return null;
-        }
-
-        if (! is_file($path = $this->manifestPath($buildDirectory))) {
-            return null;
-        }
-
-        return md5_file($path) ?: null;
-    }
-
-    /**
      * Generate Vite tags for an entrypoint.
      *
      * @param  string|string[]  $entrypoints
@@ -554,6 +534,26 @@ class Vite implements Htmlable
     protected function manifestPath($buildDirectory)
     {
         return public_path($buildDirectory.'/manifest.json');
+    }
+
+    /**
+     * Get a unique hash representing the current manifest, or null if there is no manifest.
+     *
+     * @return string|null
+     */
+    public function manifestHash($buildDirectory = null)
+    {
+        $buildDirectory ??= $this->buildDirectory;
+
+        if ($this->isRunningHot()) {
+            return null;
+        }
+
+        if (! is_file($path = $this->manifestPath($buildDirectory))) {
+            return null;
+        }
+
+        return md5_file($path) ?: null;
     }
 
     /**

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -184,6 +184,26 @@ class Vite implements Htmlable
     }
 
     /**
+     * Get a unique hash or null if there is no manifest.
+     *
+     * @return string|null
+     */
+    public function hash($buildDirectory = null)
+    {
+        $buildDirectory ??= $this->buildDirectory;
+
+        if ($this->isRunningHot()) {
+            return null;
+        }
+
+        if (! is_file($path = $this->manifestPath($buildDirectory))) {
+            return null;
+        }
+
+        return md5_file($path) ?: null;
+    }
+
+    /**
      * Generate Vite tags for an entrypoint.
      *
      * @param  string|string[]  $entrypoints

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -188,7 +188,7 @@ class Vite implements Htmlable
      *
      * @return string|null
      */
-    public function hash($buildDirectory = null)
+    public function manifestHash($buildDirectory = null)
     {
         $buildDirectory ??= $this->buildDirectory;
 

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
+ * @method static string|null hash(?string $buildDirectory = null)
  * @method static string asset(string $asset, string|null $buildDirectory)
  * @method static string hotFile()
  * @method static \Illuminate\Foundation\Vite useBuildDirectory(string $path)

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
- * @method static string|null hash(?string $buildDirectory = null)
+ * @method static string|null manifestHash(?string $buildDirectory = null)
  * @method static string asset(string $asset, string|null $buildDirectory)
  * @method static string hotFile()
  * @method static \Illuminate\Foundation\Vite useBuildDirectory(string $path)

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -539,7 +539,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteHotFile();
 
-        $this->assertNull(ViteFacade::hash());
+        $this->assertNull(ViteFacade::manifestHash());
 
         $this->cleanViteHotFile();
     }
@@ -548,7 +548,7 @@ class FoundationViteTest extends TestCase
     {
         $this->makeViteManifest(['a.js' => ['src' => 'a.js']]);
 
-        $this->assertSame('98ca5a789544599b562c9978f3147a0f', ViteFacade::hash());
+        $this->assertSame('98ca5a789544599b562c9978f3147a0f', ViteFacade::manifestHash());
 
         $this->cleanViteManifest();
     }
@@ -558,8 +558,8 @@ class FoundationViteTest extends TestCase
         $this->makeViteManifest(['a.js' => ['src' => 'a.js']]);
         $this->makeViteManifest(['b.js' => ['src' => 'b.js']], 'admin');
 
-        $this->assertSame('98ca5a789544599b562c9978f3147a0f', ViteFacade::hash());
-        $this->assertSame('928a60835978bae84e5381fbb08a38b2', ViteFacade::hash('admin'));
+        $this->assertSame('98ca5a789544599b562c9978f3147a0f', ViteFacade::manifestHash());
+        $this->assertSame('928a60835978bae84e5381fbb08a38b2', ViteFacade::manifestHash('admin'));
 
         $this->cleanViteManifest();
         $this->cleanViteManifest('admin');

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -535,6 +535,36 @@ class FoundationViteTest extends TestCase
         ViteFacade::asset('resources/js/missing.js');
     }
 
+    public function testItDoesNotReturnHashInDevMode()
+    {
+        $this->makeViteHotFile();
+
+        $this->assertNull(ViteFacade::hash());
+
+        $this->cleanViteHotFile();
+    }
+
+    public function testItGetsHashInBuildMode()
+    {
+        $this->makeViteManifest(['a.js' => ['src' => 'a.js']]);
+
+        $this->assertSame('98ca5a789544599b562c9978f3147a0f', ViteFacade::hash());
+
+        $this->cleanViteManifest();
+    }
+
+    public function testItGetsDifferentHashesForDifferentManifestsInBuildMode()
+    {
+        $this->makeViteManifest(['a.js' => ['src' => 'a.js']]);
+        $this->makeViteManifest(['b.js' => ['src' => 'b.js']], 'admin');
+
+        $this->assertSame('98ca5a789544599b562c9978f3147a0f', ViteFacade::hash());
+        $this->assertSame('928a60835978bae84e5381fbb08a38b2', ViteFacade::hash('admin'));
+
+        $this->cleanViteManifest();
+        $this->cleanViteManifest('admin');
+    }
+
     public function testViteCanSetEntryPointsWithFluentBuilder()
     {
         $this->makeViteManifest();


### PR DESCRIPTION
This PR adds a `hash` method to `Illuminate\Foundation\Vite` that returns a unique hash if the manifest exists. This is useful to invalidate assets, for instance using Inertia:

```php
<?php

// ...

class HandleInertiaRequests extends Middleware
{

    // ...

    public function version(Request $request): ?string
    {
        return Vite::hash();
    }
}
```