### PR TITLE
[9.x] Fix BC issues introduced in #44080

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -578,20 +578,12 @@ class Dispatcher implements DispatcherContract
     {
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
-        $viaConnection = isset($arguments[0])
-            ? $listener->viaConnection($arguments[0])
-            : $listener->viaConnection();
-
-        $viaQueue = isset($arguments[0])
-            ? $listener->viaQueue($arguments[0])
-            : $listener->viaQueue();
-
         $connection = $this->resolveQueue()->connection(method_exists($listener, 'viaConnection')
-                    ? $viaConnection
+                    ? (isset($arguments[0]) ? $listener->viaConnection($arguments[0]) : $listener->viaConnection())
                     : $listener->connection ?? null);
 
         $queue = method_exists($listener, 'viaQueue')
-                    ? $viaQueue
+                    ? (isset($arguments[0]) ? $listener->viaQueue($arguments[0]) : $listener->viaQueue())
                     : $listener->queue ?? null;
 
         isset($listener->delay)

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -578,8 +578,12 @@ class Dispatcher implements DispatcherContract
     {
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
+        $viaConnection = isset($arguments[0])
+            ? $listener->viaConnection($arguments[0])
+            : $listener->viaConnection();
+
         $connection = $this->resolveQueue()->connection(method_exists($listener, 'viaConnection')
-                    ? $listener->viaConnection($arguments[0])
+                    ? $viaConnection
                     : $listener->connection ?? null);
 
         $queue = method_exists($listener, 'viaQueue')

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -582,12 +582,16 @@ class Dispatcher implements DispatcherContract
             ? $listener->viaConnection($arguments[0])
             : $listener->viaConnection();
 
+        $viaQueue = isset($arguments[0])
+            ? $listener->viaQueue($arguments[0])
+            : $listener->viaQueue();
+
         $connection = $this->resolveQueue()->connection(method_exists($listener, 'viaConnection')
                     ? $viaConnection
                     : $listener->connection ?? null);
 
         $queue = method_exists($listener, 'viaQueue')
-                    ? $listener->viaQueue($arguments[0])
+                    ? $viaQueue
                     : $listener->queue ?? null;
 
         isset($listener->delay)


### PR DESCRIPTION
Hi team, following this PR: https://github.com/laravel/framework/pull/44080


We introduced a BC issue where the app will fail if that argument is not there. Thus, we need to keep it as it was when arguments are not present.

> Issue
```
0 passed in /Users/FOO/bar-api/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php 
on line 582 and exactly 1 expected
```