### PR TITLE
[9.x] Add Model::withoutTimestamps(...)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -14,7 +14,7 @@ trait HasTimestamps
     public $timestamps = true;
 
     /**
-     * The list of models classes that should have timestamps disabled.
+     * The list of models classes that have timestamps temporarily disabled.
      *
      * @var array
      */
@@ -164,7 +164,7 @@ trait HasTimestamps
     }
 
     /**
-     * Disables timestamps for the current class during given callback scope.
+     * Disable timestamps for the current class during the given callback scope.
      *
      * @param  callable  $callback
      * @return void
@@ -175,7 +175,7 @@ trait HasTimestamps
     }
 
     /**
-     * Disables timestamps for the given model classes during given callback scope.
+     * Disable timestamps for the given model classes during the given callback scope.
      *
      * @param  array  $models
      * @param  callable  $callback
@@ -193,7 +193,7 @@ trait HasTimestamps
     }
 
     /**
-     * Determine if the given model is ignoring touches.
+     * Determine if the given model is ignoring timestamps / touches.
      *
      * @param  string|null  $class
      * @return bool

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -170,6 +170,10 @@ trait HasTimestamps
 
         $this->timestamps = false;
 
-        return tap($callback($this), fn () => $this->timestamps = true);
+        try {
+            return $callback($this);
+        } finally {
+            $this->timestamps = true;
+        }
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -155,4 +155,21 @@ trait HasTimestamps
     {
         return $this->qualifyColumn($this->getUpdatedAtColumn());
     }
+
+    /**
+     * Run the given callable without timestamping the model.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public function withoutTimestamps(callable $callback)
+    {
+        if (! $this->usesTimestamps()) {
+            return $callback();
+        }
+
+        $this->timestamps = false;
+
+        return tap($callback(), fn () => $this->timestamps = true);
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -165,11 +165,11 @@ trait HasTimestamps
     public function withoutTimestamps(callable $callback)
     {
         if (! $this->usesTimestamps()) {
-            return $callback();
+            return $callback($this);
         }
 
         $this->timestamps = false;
 
-        return tap($callback(), fn () => $this->timestamps = true);
+        return tap($callback($this), fn () => $this->timestamps = true);
     }
 }

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -87,7 +87,7 @@ trait SoftDeletes
 
         $this->{$this->getDeletedAtColumn()} = $time;
 
-        if ($this->timestamps && ! is_null($this->getUpdatedAtColumn())) {
+        if ($this->usesTimestamps() && ! is_null($this->getUpdatedAtColumn())) {
             $this->{$this->getUpdatedAtColumn()} = $time;
 
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class DatabaseEloquentTimestampsTest extends TestCase
 {
@@ -100,6 +101,178 @@ class DatabaseEloquentTimestampsTest extends TestCase
         ]);
 
         $this->assertEquals($now->toDateTimeString(), $user->updated_at->toDateTimeString());
+    }
+
+    public function testWithoutTimestamp()
+    {
+        Carbon::setTestNow($now = Carbon::now()->setYear(1995)->startOfYear());
+        $user = UserWithCreatedAndUpdated::create(['email' => 'foo@example.com']);
+        Carbon::setTestNow(Carbon::now()->addHour());
+
+        $this->assertTrue($user->usesTimestamps());
+
+        $user->withoutTimestamps(function () use ($user) {
+            $this->assertFalse($user->usesTimestamps());
+            $user->update([
+                'email' => 'bar@example.com',
+            ]);
+        });
+
+        $this->assertTrue($user->usesTimestamps());
+        $this->assertTrue($now->equalTo($user->updated_at));
+        $this->assertSame('bar@example.com', $user->email);
+    }
+
+    public function testWithoutTimestampWhenAlreadyIgnoringTimestamps()
+    {
+        Carbon::setTestNow($now = Carbon::now()->setYear(1995)->startOfYear());
+        $user = UserWithCreatedAndUpdated::create(['email' => 'foo@example.com']);
+        Carbon::setTestNow(Carbon::now()->addHour());
+
+        $user->timestamps = false;
+
+        $this->assertFalse($user->usesTimestamps());
+
+        $user->withoutTimestamps(function () use ($user) {
+            $this->assertFalse($user->usesTimestamps());
+            $user->update([
+                'email' => 'bar@example.com',
+            ]);
+        });
+
+        $this->assertFalse($user->usesTimestamps());
+        $this->assertTrue($now->equalTo($user->updated_at));
+        $this->assertSame('bar@example.com', $user->email);
+    }
+
+    public function testWithoutTimestampRestoresWhenClosureThrowsException()
+    {
+        $user = UserWithCreatedAndUpdated::create(['email' => 'foo@example.com']);
+
+        $user->timestamps = true;
+
+        try {
+            $user->withoutTimestamps(function () use ($user) {
+                $this->assertFalse($user->usesTimestamps());
+                throw new RuntimeException();
+            });
+            $this->fail();
+        } catch (RuntimeException) {
+            //
+        }
+
+        $this->assertTrue($user->timestamps);
+    }
+
+    public function testWithoutTimestampsRespectsClasses()
+    {
+        $a = new UserWithCreatedAndUpdated();
+        $b = new UserWithCreatedAndUpdated();
+        $z = new UserWithUpdated();
+
+        $this->assertTrue($a->usesTimestamps());
+        $this->assertTrue($b->usesTimestamps());
+        $this->assertTrue($z->usesTimestamps());
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+
+        Eloquent::withoutTimestamps(function () use ($a, $b, $z) {
+            $this->assertFalse($a->usesTimestamps());
+            $this->assertFalse($b->usesTimestamps());
+            $this->assertFalse($z->usesTimestamps());
+            $this->assertTrue(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+            $this->assertTrue(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+        });
+
+        $this->assertTrue($a->usesTimestamps());
+        $this->assertTrue($b->usesTimestamps());
+        $this->assertTrue($z->usesTimestamps());
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+
+        UserWithCreatedAndUpdated::withoutTimestamps(function () use ($a, $b, $z) {
+            $this->assertFalse($a->usesTimestamps());
+            $this->assertFalse($b->usesTimestamps());
+            $this->assertTrue($z->usesTimestamps());
+            $this->assertTrue(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+            $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+        });
+
+        $this->assertTrue($a->usesTimestamps());
+        $this->assertTrue($b->usesTimestamps());
+        $this->assertTrue($z->usesTimestamps());
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+
+        UserWithUpdated::withoutTimestamps(function () use ($a, $b, $z) {
+            $this->assertTrue($a->usesTimestamps());
+            $this->assertTrue($b->usesTimestamps());
+            $this->assertFalse($z->usesTimestamps());
+            $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+            $this->assertTrue(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+        });
+
+        $this->assertTrue($a->usesTimestamps());
+        $this->assertTrue($b->usesTimestamps());
+        $this->assertTrue($z->usesTimestamps());
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+
+        Eloquent::withoutTimestampsOn([], function () use ($a, $b, $z) {
+            $this->assertTrue($a->usesTimestamps());
+            $this->assertTrue($b->usesTimestamps());
+            $this->assertTrue($z->usesTimestamps());
+            $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+            $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+        });
+
+        $this->assertTrue($a->usesTimestamps());
+        $this->assertTrue($b->usesTimestamps());
+        $this->assertTrue($z->usesTimestamps());
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+
+        Eloquent::withoutTimestampsOn([UserWithCreatedAndUpdated::class], function () use ($a, $b, $z) {
+            $this->assertFalse($a->usesTimestamps());
+            $this->assertFalse($b->usesTimestamps());
+            $this->assertTrue($z->usesTimestamps());
+            $this->assertTrue(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+            $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+        });
+
+        $this->assertTrue($a->usesTimestamps());
+        $this->assertTrue($b->usesTimestamps());
+        $this->assertTrue($z->usesTimestamps());
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+
+        Eloquent::withoutTimestampsOn([UserWithUpdated::class], function () use ($a, $b, $z) {
+            $this->assertTrue($a->usesTimestamps());
+            $this->assertTrue($b->usesTimestamps());
+            $this->assertFalse($z->usesTimestamps());
+            $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+            $this->assertTrue(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+        });
+
+        $this->assertTrue($a->usesTimestamps());
+        $this->assertTrue($b->usesTimestamps());
+        $this->assertTrue($z->usesTimestamps());
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+
+        Eloquent::withoutTimestampsOn([UserWithCreatedAndUpdated::class, UserWithUpdated::class], function () use ($a, $b, $z) {
+            $this->assertFalse($a->usesTimestamps());
+            $this->assertFalse($b->usesTimestamps());
+            $this->assertFalse($z->usesTimestamps());
+            $this->assertTrue(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+            $this->assertTrue(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
+        });
+
+        $this->assertTrue($a->usesTimestamps());
+        $this->assertTrue($b->usesTimestamps());
+        $this->assertTrue($z->usesTimestamps());
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithCreatedAndUpdated::class));
+        $this->assertFalse(Eloquent::isIgnoringTimestamps(UserWithUpdated::class));
     }
 
     /**

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -29,6 +29,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
             'deleted_at',
             'updated_at',
         ]);
+        $model->shouldReceive('usesTimestamps')->once()->andReturn(true);
         $model->delete();
 
         $this->assertInstanceOf(Carbon::class, $model->deleted_at);

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use RuntimeException;
 
 class EloquentModelTest extends DatabaseTestCase
 {
@@ -22,12 +21,6 @@ class EloquentModelTest extends DatabaseTestCase
             $table->increments('id');
             $table->string('name');
             $table->string('title');
-        });
-
-        Schema::create('test_model3', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('name');
-            $table->timestamps();
         });
     }
 
@@ -71,53 +64,6 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertTrue($user->wasChanged());
         $this->assertTrue($user->wasChanged('name'));
     }
-
-    public function testWithoutTimestamp()
-    {
-        Carbon::setTestNow($now = Carbon::now()->setYear(1995)->startOfYear());
-        $user = TestModel3::create(['name' => 'foo']);
-        Carbon::setTestNow(Carbon::now()->addHour());
-
-        $this->assertTrue($user->timestamps);
-
-        $user->withoutTimestamps(fn () => $user->update([
-            'name' => 'bar',
-        ]));
-
-        $this->assertTrue($user->timestamps);
-        $this->assertTrue($now->equalTo($user->updated_at));
-    }
-
-    public function testWithoutTimestampWhenAlreadyIgnoringTimestamps()
-    {
-        Carbon::setTestNow($now = Carbon::now()->setYear(1995)->startOfYear());
-        $user = TestModel3::create(['name' => 'foo']);
-        Carbon::setTestNow(Carbon::now()->addHour());
-
-        $user->timestamps = false;
-
-        $user->withoutTimestamps(fn () => $user->update([
-            'name' => 'bar',
-        ]));
-
-        $this->assertFalse($user->timestamps);
-        $this->assertTrue($now->equalTo($user->updated_at));
-    }
-
-    public function testWithoutTimestampRestoresWhenClosureThrowsException()
-    {
-        $user = TestModel3::create(['name' => 'foo']);
-        $user->timestamps = true;
-
-        try {
-            $user->withoutTimestamps(fn () => throw new RuntimeException());
-            $this->fail();
-        } catch (RuntimeException) {
-            //
-        }
-
-        $this->assertTrue($user->timestamps);
-    }
 }
 
 class TestModel1 extends Model
@@ -132,12 +78,5 @@ class TestModel2 extends Model
 {
     public $table = 'test_model2';
     public $timestamps = false;
-    protected $guarded = [];
-}
-
-class TestModel3 extends Model
-{
-    public $table = 'test_model3';
-    public $timestamps = true;
     protected $guarded = [];
 }

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class EloquentModelTest extends DatabaseTestCase
 {
@@ -101,6 +102,21 @@ class EloquentModelTest extends DatabaseTestCase
 
         $this->assertFalse($user->timestamps);
         $this->assertTrue($now->equalTo($user->updated_at));
+    }
+
+    public function testWithoutTimestampRestoresWhenClosureThrowsException()
+    {
+        $user = TestModel3::create(['name' => 'foo']);
+        $user->timestamps = true;
+
+        try {
+            $user->withoutTimestamps(fn () => throw new RuntimeException());
+            $this->fail();
+        } catch (RuntimeException) {
+            //
+        }
+
+        $this->assertTrue($user->timestamps);
     }
 }
 


### PR DESCRIPTION
Re-submission of #44005 as static methods.

API now matching the static nature of `withoutTouching`, but hopefully with a simpler implementation than previous attempts at this functionality.

```php
$user = User::first();


// `updated_at` is not changed...

User::withoutTimestamps(
    fn () => $user->update(['reserved_at' => now()])
);
```