### PR TITLE
[9.x] Bootstrapping duration handler

### DIFF
--- a/tests/Foundation/Bootstrap/HandleExceedingDurationTest.php
+++ b/tests/Foundation/Bootstrap/HandleExceedingDurationTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Bootstrap;
+
+use Carbon\CarbonInterval;
+use Illuminate\Foundation\Application;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+use Mockery as m;
+
+class HandleExceedingDurationTest extends TestCase
+{
+    public function testItCanHandleExceedingHttpKernelBootstrappingDuration()
+    {
+        $app = new Application();
+        $app->instance('called', false);
+        $app->instance('bootstrapper', new class () {
+            public function bootstrap($app)
+            {
+                $app->whenBootstrappingLongerThan(CarbonInterval::seconds(1), function () use ($app) {
+                    $app->instance('called', true);
+                });
+
+                Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds());
+            }
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $app->bootstrapWith(['bootstrapper']);
+
+        $this->assertTrue($app['called']);
+    }
+
+    public function testItDoesntCallWhenExactlyThresholdDuration()
+    {
+        $app = new Application();
+        $app->instance('called', false);
+        $app->instance('bootstrapper', new class () {
+            public function bootstrap($app)
+            {
+                $app->whenBootstrappingLongerThan(CarbonInterval::seconds(1), function () use ($app) {
+                    $app->instance('called', true);
+                });
+
+                Carbon::setTestNow(Carbon::now()->addSeconds(1));
+            }
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $app->bootstrapWith(['bootstrapper']);
+
+        $this->assertFalse($app['called']);
+    }
+
+    public function testItCanExceedDurationWhenSpecifyingDurationAsDateTime()
+    {
+        $app = new Application();
+        $app->instance('called', false);
+        $app->instance('bootstrapper', new class () {
+            public function bootstrap($app)
+            {
+                $app->whenBootstrappingLongerThan(Carbon::now()->addSeconds(1), function () use ($app) {
+                    $app->instance('called', true);
+                });
+
+                Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
+            }
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $app->bootstrapWith(['bootstrapper']);
+
+        $this->assertTrue($app['called']);
+    }
+
+    public function testItCanStayUnderDurationWhenSpecifyingDurationAsDateTime()
+    {
+        $app = new Application();
+        $app->instance('called', false);
+        $app->instance('bootstrapper', new class () {
+            public function bootstrap($app)
+            {
+                $app->whenBootstrappingLongerThan(Carbon::now()->addSeconds(1), function () use ($app) {
+                    $app->instance('called', true);
+                });
+
+                Carbon::setTestNow(Carbon::now()->addSeconds(1));
+            }
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $app->bootstrapWith(['bootstrapper']);
+
+        $this->assertFalse($app['called']);
+    }
+
+    public function testItCanExceedThresholdWhenSpecifyingDurationAsMilliseconds()
+    {
+        $app = new Application();
+        $app->instance('called', false);
+        $app->instance('bootstrapper', new class () {
+            public function bootstrap($app)
+            {
+                $app->whenBootstrappingLongerThan(1000, function () use ($app) {
+                    $app->instance('called', true);
+                });
+
+                Carbon::setTestNow(Carbon::now()->addSeconds(1)->addMilliseconds(1));
+            }
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $app->bootstrapWith(['bootstrapper']);
+
+        $this->assertTrue($app['called']);
+    }
+
+    public function testItCanStayUnderThresholdWhenSpecifyingDurationAsMilliseconds()
+    {
+        $app = new Application();
+        $app->instance('called', false);
+        $app->instance('bootstrapper', new class () {
+            public function bootstrap($app)
+            {
+                $app->whenBootstrappingLongerThan(1000, function () use ($app) {
+                    $app->instance('called', true);
+                });
+
+                Carbon::setTestNow(Carbon::now()->addSeconds(1));
+            }
+        });
+
+        Carbon::setTestNow(Carbon::now());
+        $app->bootstrapWith(['bootstrapper']);
+
+        $this->assertFalse($app['called']);
+    }
+
+    public function testItClearsStartTimeAfterBootstrapping()
+    {
+        $app = new Application();
+        $app->instance('bootstrapper', new class () {
+            public function bootstrap($app)
+            {
+                $app->whenBootstrappingLongerThan(1000, function () use ($app) {
+                    $app->instance('called', true);
+                });
+
+                Carbon::setTestNow(Carbon::now()->addSeconds(1));
+            }
+        });
+
+        $this->assertNull($app->bootstrappingStartedAt());
+        $app->bootstrapWith([]);
+        $this->assertNull($app->bootstrappingStartedAt());
+    }
+}


### PR DESCRIPTION
This PR is similar to the request and command lifecycle handlers, but instead allow for handling the bootstrapping process.

I've worked in applications where to service providers started to become rather messy. Database calls were happening inline, etc, rather than having things registered via Closures to be lazily evaluated.

This PR allows developers to keep their bootstrapping process under a given threshold by potentially throwing an exception locally and in CI, and then logging in production.

This can also be useful to ensure packages do not introduce long running tasks to the bootstrapping process.

```php
use Carbon\CarbonInterval as Interval;

public function boot()
{
    $this->app->whenBootstrappingForLongerThan(
        Interval::seconds(1),
        fn () => /* ... */
    );
}
```

