### PR TITLE
[9.x] Optimize code style for `originalIsEquivalent`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2000,7 +2000,7 @@ trait HasAttributes
 
         if ($attribute === $original) {
             return true;
-        } elseif (is_null($attribute)) {
+        } elseif (is_null($attribute) || is_null($original)) {
             return false;
         } elseif ($this->isDateAttribute($key) || $this->isDateCastableWithCustomFormat($key)) {
             return $this->fromDateTime($attribute) ===
@@ -2009,17 +2009,13 @@ trait HasAttributes
             return $this->fromJson($attribute) ===
                 $this->fromJson($original);
         } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
-            if ($original === null) {
-                return false;
-            }
-
             return abs($this->castAttribute($key, $attribute) - $this->castAttribute($key, $original)) < PHP_FLOAT_EPSILON * 4;
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {
             return $this->castAttribute($key, $attribute) ===
                 $this->castAttribute($key, $original);
         } elseif ($this->isClassCastable($key) && in_array($this->getCasts()[$key], [AsArrayObject::class, AsCollection::class])) {
             return $this->fromJson($attribute) === $this->fromJson($original);
-        } elseif ($this->isClassCastable($key) && $original !== null && in_array($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
+        } elseif ($this->isClassCastable($key) && in_array($this->getCasts()[$key], [AsEncryptedArrayObject::class, AsEncryptedCollection::class])) {
             return $this->fromEncryptedString($attribute) === $this->fromEncryptedString($original);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -98,6 +98,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty(['foo', 'bar']));
     }
 
+    public function testOriginalIsEquivalentWhenOriginalIsNull()
+    {
+        // test is not equivalent
+        $model = new EloquentModelStub(['nullAttribute' => null]);
+        $model->syncOriginal();
+        $model->nullAttribute = '';
+        $this->assertFalse($model->originalIsEquivalent('nullAttribute'));
+        // test is equivalent
+        $model->nullAttribute = null;
+        $this->assertTrue($model->originalIsEquivalent('nullAttribute'));
+    }
+
     public function testIntAndNullComparisonWhenDirty()
     {
         $model = new EloquentModelCastingStub;


### PR DESCRIPTION

At present, we can think, the original and attribute are not equivalent when the `$original` is null and the `$attribute` is not null.