### PR TITLE
[9.x] Enable PHP 8.2 tests for Ably

### DIFF
--- a/tests/Broadcasting/AblyBroadcasterTest.php
+++ b/tests/Broadcasting/AblyBroadcasterTest.php
@@ -122,8 +122,7 @@ class AblyBroadcasterTest extends TestCase
     protected function getMockRequestWithUserForChannel($channel)
     {
         $request = m::mock(Request::class);
-        $request->channel_name = $channel;
-        $request->socket_id = 'abcd.1234';
+        $request->shouldReceive('all')->andReturn(['channel_name' => $channel, 'socket_id' => 'abcd.1234']);
 
         $request->shouldReceive('input')
                 ->with('callback', false)
@@ -148,7 +147,7 @@ class AblyBroadcasterTest extends TestCase
     protected function getMockRequestWithoutUserForChannel($channel)
     {
         $request = m::mock(Request::class);
-        $request->channel_name = $channel;
+        $request->shouldReceive('all')->andReturn(['channel_name' => $channel]);
 
         $request->shouldReceive('user')
                 ->andReturn(null);

--- a/tests/Broadcasting/AblyBroadcasterTest.php
+++ b/tests/Broadcasting/AblyBroadcasterTest.php
@@ -20,10 +20,6 @@ class AblyBroadcasterTest extends TestCase
 
     protected function setUp(): void
     {
-        if (phpversion() >= '8.2') {
-            $this->markTestSkipped('Tests are broken on PHP 8.2');
-        }
-
         parent::setUp();
 
         $this->ably = m::mock(AblyRest::class, ['abcd:efgh']);


### PR DESCRIPTION
https://github.com/ably/ably-php/pull/167 got merged so we can enable these now.