### PR TITLE
[9.x] Adding Arr::rotate and Arr::rotateReverse

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -822,4 +822,76 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Move the first element to the end.
+     *
+     * @param  array  $array
+     * @param  int  $times
+     * @param  bool  $preserveKeys
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function rotate($array, $times = 1, $preserveKeys = false)
+    {
+        if (!is_numeric($times) || $times < 0) {
+            throw new InvalidArgumentException(
+                "You requested to rotate but \$times can only be a number greater or equals to 0."
+            );
+        }
+
+        for ($i = 0; $i < $times; $i++) {
+            $index = array_key_first($array);
+            $value = $array[$index];
+            unset($array[$index]);
+            $array[$index] = $value;
+        }
+
+        return $preserveKeys ? $array : array_values($array);
+    }
+
+    /**
+     * Move the last element to the beginning.
+     *
+     * @param  array  $array
+     * @param  int  $times
+     * @param  bool  $preserveKeys
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function rotateReverse($array, $times = 1, $preserveKeys = false)
+    {
+        if (!is_numeric($times) || $times < 0) {
+            throw new InvalidArgumentException(
+                "You requested to rotate reverse but \$times can only be a number greater or equals to 0."
+            );
+        }
+
+        if ($preserveKeys) {
+            for ($i = 0; $i < $times; $i++) {
+                $index = array_key_last($array);
+                $value = $array[$index];
+                unset($array[$index]);
+
+                $result = [];
+                $result[$index] = $value;
+                foreach ($array as $key => $value) {
+                    $result[$key] = $value;
+                }
+
+                $array = $result;
+            }
+        } else {
+            for ($i = 0; $i < $times; $i++) {
+                $value = array_pop($array);
+                array_unshift($array, $value);
+            }
+
+            $array = array_values($array);
+        }
+
+        return $array;
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -835,7 +835,7 @@ class Arr
      */
     public static function rotate($array, $times = 1, $preserveKeys = false)
     {
-        if (!is_numeric($times) || $times < 0) {
+        if (! is_numeric($times) || $times < 0) {
             throw new InvalidArgumentException(
                 "You requested to rotate but \$times can only be a number greater or equals to 0."
             );
@@ -863,7 +863,7 @@ class Arr
      */
     public static function rotateReverse($array, $times = 1, $preserveKeys = false)
     {
-        if (!is_numeric($times) || $times < 0) {
+        if (! is_numeric($times) || $times < 0) {
             throw new InvalidArgumentException(
                 "You requested to rotate reverse but \$times can only be a number greater or equals to 0."
             );

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -837,7 +837,7 @@ class Arr
     {
         if (! is_numeric($times) || $times < 0) {
             throw new InvalidArgumentException(
-                "You requested to rotate but \$times can only be a number greater or equals to 0."
+                'You requested to rotate but $times can only be a number greater or equals to 0.'
             );
         }
 
@@ -865,7 +865,7 @@ class Arr
     {
         if (! is_numeric($times) || $times < 0) {
             throw new InvalidArgumentException(
-                "You requested to rotate reverse but \$times can only be a number greater or equals to 0."
+                'You requested to rotate reverse but $times can only be a number greater or equals to 0.'
             );
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1112,4 +1112,156 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testRotate()
+    {
+        // numeric keys
+        $array = [
+            10 => 'a',
+            20 => 'b',
+            30 => 'c',
+        ];
+        $this->assertSame([
+            0 => 'b',
+            1 => 'c',
+            2 => 'a',
+        ], Arr::rotate($array));
+
+        // alphanumeric keys
+        $array = [
+            10 => 'a',
+            'i' => 'b',
+            30 => 'c',
+        ];
+        $this->assertSame([
+            0 => 'b',
+            1 => 'c',
+            2 => 'a',
+        ], Arr::rotate($array));
+
+        // numeric keys, preserve keys
+        $array = [
+            10 => 'a',
+            20 => 'b',
+            30 => 'c',
+        ];
+        $this->assertSame([
+            20 => 'b',
+            30 => 'c',
+            10 => 'a',
+        ], Arr::rotate($array, 1, true));
+
+        // rotates 2 times, preserve keys
+        $this->assertSame([
+            30 => 'c',
+            10 => 'a',
+            20 => 'b',
+        ], Arr::rotate($array, 2, true));
+
+        // rotates 0 times
+        $this->assertSame([
+            0 => 'a',
+            1 => 'b',
+            2 => 'c',
+        ], Arr::rotate($array, 0));
+
+        // rotates 0 times, preserve keys
+        $this->assertSame([
+            10 => 'a',
+            20 => 'b',
+            30 => 'c',
+        ], Arr::rotate($array, 0, true));
+
+        // exceptions
+        $array = ['a', 'b', 'c'];
+        $exceptions = 0;
+
+        $timesArgs = [-1, 'a', new stdClass, null];
+
+        foreach ($timesArgs as $times) {
+            try {
+                Arr::rotate($array, $times);
+            } catch (InvalidArgumentException $e) {
+                $exceptions++;
+            }
+        }
+
+        $this->assertSame(count($timesArgs), $exceptions);
+    }
+
+    public function testRotateReverse()
+    {
+        // numeric keys
+        $array = [
+            10 => 'a',
+            20 => 'b',
+            30 => 'c',
+        ];
+        $this->assertSame([
+            0 => 'c',
+            1 => 'a',
+            2 => 'b',
+        ], Arr::rotateReverse($array));
+
+        // alphanumeric keys
+        $array = [
+            10 => 'a',
+            'i' => 'b',
+            30 => 'c',
+        ];
+        $this->assertSame([
+            0 => 'c',
+            1 => 'a',
+            2 => 'b',
+        ], Arr::rotateReverse($array));
+
+        // numeric keys, preserve keys
+        $array = [
+            10 => 'a',
+            20 => 'b',
+            30 => 'c',
+        ];
+        $this->assertSame([
+            30 => 'c',
+            10 => 'a',
+            20 => 'b',
+        ], Arr::rotateReverse($array, 1, true));
+
+        // rotates 2 times, preserve keys
+        $this->assertSame([
+            20 => 'b',
+            30 => 'c',
+            10 => 'a',
+        ], Arr::rotateReverse($array, 2, true));
+
+        // rotates 0 times
+        $this->assertSame([
+            0 => 'a',
+            1 => 'b',
+            2 => 'c',
+        ], Arr::rotateReverse($array, 0));
+
+        // rotates 0 times, preserve keys
+        $this->assertSame([
+            10 => 'a',
+            20 => 'b',
+            30 => 'c',
+        ], Arr::rotateReverse($array, 0, true));
+
+        // exceptions
+        $array = ['a', 'b', 'c'];
+        $exceptions = 0;
+
+        $timesArgs = [-1, 'a', new stdClass, null];
+
+        foreach ($timesArgs as $times) {
+            try {
+                Arr::rotateReverse($array, $times);
+            } catch (InvalidArgumentException $e) {
+                $exceptions++;
+            }
+        }
+
+        $this->assertSame(count($timesArgs), $exceptions);
+    }
 }


### PR DESCRIPTION
# Adding Arr::rotate and Arr:rotateReverse

```php
// move first to last
Arr::rotate(['A', 'B', 'C']); 
// ['B', 'C', 'A']

// rotates twice
Arr::rotate(['A', 'B', 'C'], 2); 
// ['C', 'A', 'B']


// move last to first
Arr::rotateReverse(['A', 'B', 'C']);
// ['C', 'A', 'B']

// rotates twice
Arr::rotateReverse(['A', 'B', 'C'], 2); 
// ['B', 'C', 'A']
```



## Example:
```php
$queues = ['default', 'invoices', 'emails'];
$command = "php artisan queue:listen --queue=";

for ($i = 0; $i < $workers; $i++) {
    // php artisan queue:listen --queue=default,invoices,emails
    $currentCommand = $command . implode(',', $queues);
    $this->processes[] = $process = new Process(explode(' ', $currentCommand));

    / ...

    $queues = Arr::rotate($queues);
    // $queues = ['invoices', 'emails', 'default'];
}

```