### PR TITLE
[9.x] Connection can accept object as well as classname for new doctrine type

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1134,7 +1134,7 @@ class Connection implements ConnectionInterface
     /**
      * Register a custom Doctrine mapping type.
      *
-     * @param  string  $class
+     * @param  Type|class-string<Type>  $class
      * @param  string  $name
      * @param  string  $type
      * @return void
@@ -1142,7 +1142,7 @@ class Connection implements ConnectionInterface
      * @throws \Doctrine\DBAL\DBALException
      * @throws \RuntimeException
      */
-    public function registerDoctrineType(string $class, string $name, string $type): void
+    public function registerDoctrineType(Type|string $class, string $name, string $type): void
     {
         if (! $this->isDoctrineAvailable()) {
             throw new RuntimeException(
@@ -1151,7 +1151,8 @@ class Connection implements ConnectionInterface
         }
 
         if (! Type::hasType($name)) {
-            Type::addType($name, $class);
+            Type::getTypeRegistry()
+                ->register($name, is_string($class) ? new $class() : $class);
         }
 
         $this->doctrineTypeMappings[$name] = $type;


### PR DESCRIPTION
We use custom types on postgresql to create our enums there. That means that we have to create classes for each one of them:

```php
class CustomType1 extends Type
{
  public function getSQLDeclaration(array $column, AbstractPlatform $platform)
  {
      return 'custom_type1';
  }
  
  public function getName()
  {
      return 'custom_type1';
  }
}
```

And then register them:

```php
Connection::resolverFor('pgsql', function($connection, $database, $prefix, $config) {
  $connection = new PostgresConnection($connection, $database, $prefix, $config);
  
  $connection->registerDoctrineType(CustomType1::class, 'custom_type1', 'string')
  $connection->registerDoctrineType(CustomType2::class, 'custom_type2', 'string')
  $connection->registerDoctrineType(CustomType3::class, 'custom_type3', 'string')
  // ...
  
  return $connection;
}
```

We have a growing number of enums (30+ so far) and this has become cumbersome.

So, instead of creating a huge number of classes if we could pass a `Type` object to `registerDoctrineType` we could just implement something like:
```php

Connection::resolverFor('pgsql', function($connection, $database, $prefix, $config) {
  $connection = new PostgresConnection($connection, $database, $prefix, $config);
  
  foreach (self::$enums as $type) {
    $connection->registerDoctrineType((new class extends Type {
      protected $name;

      public function getSQLDeclaration(array $column, AbstractPlatform $platform)
      {
        return $this->name;
      }

      public function getName()
      {
        return $this->name;
      }

      public function setName($name): self
      {
        $this->name = $name;
        return $this;
      }
    })->setName($type), $type, 'string');
  }
    
  return $connection;
}
```

I know it's a niche thing but I can't see a downside to this implementation