### PR TITLE
[9.x] Make \Illuminate\Routing\Router redirect method accept several URIs

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -238,18 +238,28 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * Create a redirect from one URI to another.
+     * Create a redirect from one or many URIs to another.
      *
-     * @param  string  $uri
+     * @param  string|string[]  $uri
      * @param  string  $destination
      * @param  int  $status
-     * @return \Illuminate\Routing\Route
+     * @return \Illuminate\Routing\Route|\Illuminate\Routing\Route[]
      */
     public function redirect($uri, $destination, $status = 302)
     {
-        return $this->any($uri, '\Illuminate\Routing\RedirectController')
+        if(is_string($uri)) {
+            $uri = [$uri];
+        }
+
+        $routes = [];
+
+        foreach ($uri as $value) {
+            $routes[] = $this->any($value, '\Illuminate\Routing\RedirectController')
                 ->defaults('destination', $destination)
                 ->defaults('status', $status);
+        }
+
+        return count($routes) > 1 ? $routes : $routes[0];
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -247,13 +247,9 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function redirect($uri, $destination, $status = 302)
     {
-        if(is_string($uri)) {
-            $uri = [$uri];
-        }
-
         $routes = [];
 
-        foreach ($uri as $value) {
+        foreach ((array) $uri as $value) {
             $routes[] = $this->any($value, '\Illuminate\Routing\RedirectController')
                 ->defaults('destination', $destination)
                 ->defaults('status', $status);

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -18,7 +18,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route permanentRedirect(string $uri, string $destination)
  * @method static \Illuminate\Routing\Route post(string $uri, array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route put(string $uri, array|string|callable|null $action = null)
- * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 302)
+ * @method static \Illuminate\Routing\Route|\Illuminate\Routing\Route[] redirect(string|string[] $uri, string $destination, int $status = 302)
  * @method static \Illuminate\Routing\Route substituteBindings(\Illuminate\Support\Facades\Route $route)
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [], int|array $status = 200, array $headers = [])
  * @method static \Illuminate\Routing\RouteRegistrar as(string $value)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1882,6 +1882,31 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals(302, $response->getStatusCode());
     }
 
+    public function testRouteRedirectForManyUris()
+    {
+        $container = new Container;
+        $router = new Router(new Dispatcher, $container);
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+        $request = Request::create('contact-us-2', 'GET');
+        $container->singleton(Request::class, function () use ($request) {
+            return $request;
+        });
+        $urlGenerator = new UrlGenerator(new RouteCollection, $request);
+        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
+            return $urlGenerator;
+        });
+        $router->get('contact_us', function () {
+            throw new Exception('Route should not be reachable.');
+        });
+        $router->redirect(['contact_us', 'contact-us-2'], 'contact');
+
+        $response = $router->dispatch($request);
+        $this->assertTrue($response->isRedirect('contact'));
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+
     public function testRouteRedirectRetainsExistingStartingForwardSlash()
     {
         $container = new Container;


### PR DESCRIPTION

This PR makes the _\Illuminate\Routing\Router@redirect_ method accept an array of URIs instead of a single URI. 

I found myself having to redirect several routes to a single one and thought this would be useful. 

This should not be a breaking change.

```PHP
// Current
Route::redirect('contact-us', 'contact');
Route::redirect('contact-us-2', 'contact');
Route::redirect('another-contact-us', 'contact');

// Proposal
Route::redirect(['contact-us', 'contact-us-2', 'another-contact-us'], 'contact');
```