### PR TITLE
[9.x] Prompt to create MySQL db when migrating

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Events\SchemaLoaded;
 use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
 use Illuminate\Database\SqlServerConnection;
+use PDOException;
+use Throwable;
 
 class MigrateCommand extends BaseCommand
 {
@@ -134,26 +136,88 @@ class MigrateCommand extends BaseCommand
     protected function repositoryExists()
     {
         return retry(2, fn () => $this->migrator->repositoryExists(), 0, function ($e) {
-            if (! $e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
+            try {
+                if ($e->getPrevious() instanceof SQLiteDatabaseDoesNotExistException) {
+                    return $this->createMissingSqliteDatbase($e->getPrevious()->path);
+                }
+
+                $connection = $this->migrator->resolveConnection($this->option('database'));
+
+                if (
+                    $e->getPrevious() instanceof PDOException &&
+                    $e->getPrevious()->getCode() === 1049 &&
+                    $connection->getDriverName() === 'mysql') {
+                    return $this->createMissingMysqlDatabase($connection);
+                }
+
+                return false;
+            } catch (Throwable) {
                 return false;
             }
+        });
+    }
 
-            if ($this->option('force')) {
-                return touch($e->getPrevious()->path);
-            }
+    /**
+     * Create a missing SQLite database.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    protected function createMissingSqliteDatbase($path)
+    {
+        if ($this->option('force')) {
+            return touch($path);
+        }
 
-            if ($this->option('no-interaction')) {
-                return false;
-            }
+        if ($this->option('no-interaction')) {
+            return false;
+        }
 
-            $this->components->warn('The SQLite database does not exist: '.$e->getPrevious()->path);
+        $this->components->warn('The SQLite database does not exist: '.$path);
+
+        if (! $this->components->confirm('Would you like to create it?')) {
+            return false;
+        }
+
+        return touch($path);
+    }
+
+    /**
+     * Create missing MySQL database.
+     *
+     * @return bool
+     */
+    protected function createMissingMysqlDatabase($connection)
+    {
+        if ($this->laravel['config']->get("database.connections.{$connection->getName()}.database") !== $connection->getDatabaseName()) {
+            return false;
+        }
+
+        if (! $this->option('force') && $this->option('no-interaction')) {
+            return false;
+        }
+
+        if (! $this->option('force') && ! $this->option('no-interaction')) {
+            $this->components->warn("The database '{$connection->getDatabaseName()}' does not exist on the '{$connection->getName()}' connection.");
 
             if (! $this->components->confirm('Would you like to create it?')) {
                 return false;
             }
+        }
 
-            return touch($e->getPrevious()->path);
-        });
+        try {
+            $this->laravel['config']->set("database.connections.{$connection->getName()}.database", null);
+
+            $this->laravel['db']->purge();
+
+            $freshConnection = $this->migrator->resolveConnection($this->option('database'));
+
+            return tap($freshConnection->unprepared("CREATE DATABASE IF NOT EXISTS {$connection->getDatabaseName()}"), function () {
+                $this->laravel['db']->purge();
+            });
+        } finally {
+            $this->laravel['config']->set("database.connections.{$connection->getName()}.database", $connection->getDatabaseName());
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -183,7 +183,7 @@ class MigrateCommand extends BaseCommand
     }
 
     /**
-     * Create missing MySQL database.
+     * Create a missing MySQL database.
      *
      * @return bool
      */


### PR DESCRIPTION
This PR is the MySQL counterpart to https://github.com/laravel/framework/pull/43867

<img width="1381" alt="Screen Shot 2022-09-16 at 4 34 49 pm" src="https://user-images.githubusercontent.com/24803032/190572352-18b2adfc-8ce9-4878-95f7-072d8982402e.png">

```
# No prompt, just attempts to create the file.
# If it fails the exception is shown.

php artisan migrate --force

# No prompt and the exception is shown.
# This is the same as the current behaviour.

php artisan migrate --force
```