### PR TITLE
[9.x] Require symfony/uid to generate Ulid's

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -23,6 +23,7 @@
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
         "nesbot/carbon": "^2.53.1",
+        "symfony/uid": "^6.0",
         "voku/portable-ascii": "^2.0"
     },
     "conflict": {


### PR DESCRIPTION
The ```symfony/uid``` is required in order to use ```Str::ulid()```. Without it, an ```Class "Symfony\Component\Uid\Ulid" not found``` error gets triggered.