### PR TITLE
[9.x] TestResponse new assertion about rendered views

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -46,6 +46,13 @@ class TestResponse implements ArrayAccess
     public $exceptions;
 
     /**
+     * The array of rendered views for the request.
+     *
+     * @var array
+     */
+    public $renderedViews = [];
+
+    /**
      * The streamed content of the response.
      *
      * @var string
@@ -1039,6 +1046,49 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the given view has been rendered during the response.
+     *
+     * @param  string  $view
+     * @param  int|null  $expectedCount
+     * @return $this
+     */
+    public function assertViewRendered($view, $expectedCount = null)
+    {
+        PHPUnit::assertArrayHasKey(
+            $view,
+            $this->renderedViews,
+            "[{$view}] was not rendered"
+        );
+
+        if ($expectedCount !== null) {
+            PHPUnit::assertEquals(
+                $expectedCount,
+                $actualCount = ($this->renderedViews[$view] ?? 0),
+                "[{$view}] was rendered {$actualCount} times instead of {$expectedCount}"
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given view has not been rendered during the response.
+     *
+     * @param  string  $view
+     * @return $this
+     */
+    public function assertViewHasntRendered($view)
+    {
+        PHPUnit::assertArrayNotHasKey(
+            $view,
+            $this->renderedViews,
+            "[{$view}] was rendered"
+        );
+
+        return $this;
+    }
+
+    /**
      * Ensure that the response has a view as its original content.
      *
      * @return $this
@@ -1503,6 +1553,19 @@ class TestResponse implements ArrayAccess
     public function withExceptions(Collection $exceptions)
     {
         $this->exceptions = $exceptions;
+
+        return $this;
+    }
+
+    /**
+     * Set the previous rendered views on the response.
+     *
+     * @param  array  $renderedViews
+     * @return $this
+     */
+    public function withRenderedViews(array $renderedViews)
+    {
+        $this->renderedViews = $renderedViews;
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -211,6 +211,23 @@ class TestResponseTest extends TestCase
         $response->assertViewMissing('foo.baz');
     }
 
+    public function testAssertViewRendered()
+    {
+        $response = $this->makeMockResponse(['render' => ''])
+             ->withRenderedViews(['foo' => 1]);
+
+        $response->assertViewRendered('foo');
+        $response->assertViewRendered('foo', 1);
+    }
+
+    public function testAssertViewHasntRendered()
+    {
+        $response = $this->makeMockResponse(['render' => ''])
+             ->withRenderedViews(['baz' => 1]);
+
+        $response->assertViewHasntRendered('foo');
+    }
+
     public function testAssertSee()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
Currently, it's not possible to test if the response includes a specific view partial or not, as `assertSee*` is not the best fit for this case.

My Solution:
* Listen to all `composing` events (which are dispatched during the view rendering)
* Store the view names and count how often they were called

Possible problems:
* false positives due to `View` usage during the response from pdf/mail generation

Alternativ solution:
* use a rendering engine (during tests) to wrap blade directives and components with HTML comments and search for them in the actual rendered result