### PR TITLE
[9.x] Container - Set tag on object based on instanceof

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -158,7 +158,7 @@ class Container implements ArrayAccess, ContainerContract
     protected $afterResolvingCallbacks = [];
 
     /**
-     * The classes loaded from the composer classmapper
+     * The classes loaded from the composer classmapper.
      *
      * @var array<int, string>
      */
@@ -535,17 +535,17 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Assign a set of tags to classes that extends or implements one of the provided classes
+     * Assign a set of tags to classes that extends or implements one of the provided classes.
      *
-     * @param  array|string $intanceofFQCN
-     * @param  array|string $tags
+     * @param  array|string  $intanceofFQCN
+     * @param  array|string  $tags
      * @return void
      */
     public function tagInstanceof(array|string $intanceofFQCN, array|string $tags): void
     {
-        if (!isset($this->classmap)) {
+        if (! isset($this->classmap)) {
             $classmapFile = app()->basePath('vendor/composer/autoload_classmap.php');
-            if ( ! file_exists($classmapFile)) {
+            if (! file_exists($classmapFile)) {
                 throw new RuntimeException('tagInstanceof relies on the autoload_classmap file from composer.');
             }
             $classmap = require $classmapFile;
@@ -560,7 +560,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         foreach ($this->classmap as $class) {
-            if (!class_exists($class, false)) {
+            if (! class_exists($class, false)) {
                 continue;
             }
 

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -36,11 +36,10 @@ interface Container extends ContainerInterface
     public function tag($abstracts, $tags);
 
     /**
-     * Assign a set of tags to classes that extends or implements one of the provided classes
+     * Assign a set of tags to classes that extends or implements one of the provided classes.
      *
-     * @param array|string $intanceofFQCN
-     * @param array|string $tags
-     *
+     * @param  array|string  $intanceofFQCN
+     * @param  array|string  $tags
      * @return void
      */
     public function tagInstanceof(array|string $intanceofFQCN, array|string $tags): void;

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -36,6 +36,16 @@ interface Container extends ContainerInterface
     public function tag($abstracts, $tags);
 
     /**
+     * Assign a set of tags to classes that extends or implements one of the provided classes
+     *
+     * @param array|string $intanceofFQCN
+     * @param array|string $tags
+     *
+     * @return void
+     */
+    public function tagInstanceof(array|string $intanceofFQCN, array|string $tags): void;
+
+    /**
      * Resolve all of the bindings for a given tag.
      *
      * @param  string  $tag

--- a/tests/Container/ContainerTaggingTest.php
+++ b/tests/Container/ContainerTaggingTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Container;
 
 use Illuminate\Container\Container;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 class ContainerTaggingTest extends TestCase
 {
@@ -87,9 +88,84 @@ class ContainerTaggingTest extends TestCase
         $this->assertInstanceOf(ContainerImplementationTaggedStub::class, $fooResults[0]);
         $this->assertInstanceOf(ContainerImplementationTaggedStubTwo::class, $fooResults[1]);
     }
+
+    public function testItHasAClassmapProperty()
+    {
+        $container = new Container();
+
+        // The stubs in this file are not loaded by the composer classmap file.
+        // Insert them manually to assert they are available for testing
+        $classmapProperty = new ReflectionProperty(get_class($container), 'classmap');
+        $classmapProperty->setAccessible(true);
+        $classmapProperty->setValue($container, get_declared_classes());
+
+        $this->assertGreaterThanOrEqual(1, $classmapProperty->getValue($container));
+
+        return $container;
+    }
+
+    /**
+     * @depends testItHasAClassmapProperty
+     */
+    public function testClassesCanBeTaggedByTheirInterface(Container $container)
+    {
+        $container->tagInstanceof(IContainerTaggedContractStub::class, 'foo-instanceof-interface');
+        $this->assertCount(3, $container->tagged('foo-instanceof-interface'));
+
+        $container->tagInstanceof(IContainerTaggedContractStub::class, ['foo-instanceof-interface-2', 'bar-instanceof-interface-2']);
+        $this->assertCount(3, $container->tagged('foo-instanceof-interface-2'));
+        $this->assertCount(3, $container->tagged('bar-instanceof-interface-2'));
+
+        $container->tagInstanceof(
+            [
+                IContainerTaggedContractStub::class,
+                IContainerTaggedContractStubTwo::class,
+            ],
+            'foo-instanceof-multiple-interface'
+        );
+        $this->assertCount(4, $container->tagged('foo-instanceof-multiple-interface'));
+    }
+
+    /**
+     * @depends testItHasAClassmapProperty
+     */
+    public function testClassesCanBeTaggedByTheirParentClass(Container $container)
+    {
+        $container->tagInstanceof(ContainerWithoutImplementationTaggedStub::class, 'foo-instanceof-class');
+        $this->assertCount(2, $container->tagged('foo-instanceof-class'));
+
+        $container->tagInstanceof(
+            [
+                ContainerImplementationTaggedStub::class,
+                ContainerWithoutImplementationTaggedStub::class,
+            ],
+            'foo-instanceof-multiple-classes'
+        );
+        $this->assertCount(4, $container->tagged('foo-instanceof-multiple-classes'));
+    }
+
+    /**
+     * @depends testItHasAClassmapProperty
+     */
+    public function testClassesCanBeTaggedByEitherTheirParentClassOrInterfaces(Container $container)
+    {
+        $container->tagInstanceof(
+            [
+                IContainerTaggedContractStub::class,
+                ContainerWithoutImplementationTaggedStub::class,
+            ],
+            'foo-instanceof-combined-classes-and-interfaces'
+        );
+        $this->assertCount(5, $container->tagged('foo-instanceof-combined-classes-and-interfaces'));
+    }
 }
 
 interface IContainerTaggedContractStub
+{
+    //
+}
+
+interface IContainerTaggedContractStubTwo
 {
     //
 }
@@ -100,6 +176,26 @@ class ContainerImplementationTaggedStub implements IContainerTaggedContractStub
 }
 
 class ContainerImplementationTaggedStubTwo implements IContainerTaggedContractStub
+{
+    //
+}
+
+class ContainerExtendingContainerWithImplementationTaggedStub extends ContainerImplementationTaggedStub
+{
+    //
+}
+
+class ContainerWithoutImplementationTaggedStub
+{
+    //
+}
+
+class ContainerWithoutImplementationTaggedStubTwo extends ContainerWithoutImplementationTaggedStub
+{
+    //
+}
+
+class ContainerImplementationTaggedStubThree implements IContainerTaggedContractStubTwo
 {
     //
 }


### PR DESCRIPTION
Allow tagging an object based on its parent(s), interface(s) or its own FQCN.

This enables a developer to tag multiple objects dynamically at once without having to manually add new objects when they are added and extend a certain interface or parent.

Dynamically tagging can be an useful addition when you use a strategy pattern in your code and want, for example, register a new handler.

An developer can influence the behaviour of the objects being considered for tagging by filling the classmap property in the container before calling the tagInstanceof method.

Its usage would result in line with the following sample code.

```php
$this->app->tagInstanceof(BaseServiceTypeInterface::class, 'my-tag');

$this->app
    ->when(MyDynamicHandlerService::class)
    ->needs(BaseServiceTypeInterface::class)
    ->giveTagged('my-tag');

// ...

class MyDynamicHandlerService
{
    public function __construct(BaseServiceTypeInterface ...$handlers)
    {
        $this->handlers = $handlers;
    }

    public function handle(string $type, array $config)
    {
        foreach ($this->handlers as $handler) {
            if (! $handler->supports($type)) {
                continue;
            }

            return $handler->handle($config);
        }

        throw new \LogicException('Missing handler for type '.$type);
    }
}
```

This update has been inspired by the Symfony methology to tag services through an instanceof provided value. @see https://symfony.com/doc/current/service_container/tags.html#autoconfiguring-tags

Resolves #42499
