### PR TITLE
[9.x] Use `match` expression for Email Validation drivers

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -749,16 +749,14 @@ trait ValidatesAttributes
 
         $validations = collect($parameters)
             ->unique()
-            ->map(function ($validation) {
-                return match ($validation) {
-                    'strict' => new NoRFCWarningsValidation(),
-                    'dns' => new DNSCheckValidation(),
-                    'spoof' => new SpoofCheckValidation(),
-                    'filter' => new FilterEmailValidation(),
-                    'filter_unicode' => FilterEmailValidation::unicode(),
-                    is_string($validation) && class_exists($validation) => $this->container->make($validation),
-                    default => new RFCValidation()
-                };
+            ->map(fn ($validation) => match (true) {
+                $validation === 'strict' => new NoRFCWarningsValidation(),
+                $validation === 'dns' => new DNSCheckValidation(),
+                $validation === 'spoof' => new SpoofCheckValidation(),
+                $validation === 'filter' => new FilterEmailValidation(),
+                $validation === 'filter_unicode' => FilterEmailValidation::unicode(),
+                is_string($validation) && class_exists($validation) => $this->container->make($validation),
+                default => new RFCValidation(),
             })
             ->values()
             ->all() ?: [new RFCValidation];

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -750,21 +750,15 @@ trait ValidatesAttributes
         $validations = collect($parameters)
             ->unique()
             ->map(function ($validation) {
-                if ($validation === 'rfc') {
-                    return new RFCValidation;
-                } elseif ($validation === 'strict') {
-                    return new NoRFCWarningsValidation;
-                } elseif ($validation === 'dns') {
-                    return new DNSCheckValidation;
-                } elseif ($validation === 'spoof') {
-                    return new SpoofCheckValidation;
-                } elseif ($validation === 'filter') {
-                    return new FilterEmailValidation;
-                } elseif ($validation === 'filter_unicode') {
-                    return FilterEmailValidation::unicode();
-                } elseif (is_string($validation) && class_exists($validation)) {
-                    return $this->container->make($validation);
-                }
+                return match ($validation) {
+                    'strict' => new NoRFCWarningsValidation(),
+                    'dns' => new DNSCheckValidation(),
+                    'spoof' => new SpoofCheckValidation(),
+                    'filter' => new FilterEmailValidation(),
+                    'filter_unicode' => FilterEmailValidation::unicode(),
+                    is_string($validation) && class_exists($validation) => $this->container->make($validation),
+                    default => new RFCValidation()
+                };
             })
             ->values()
             ->all() ?: [new RFCValidation];


### PR DESCRIPTION
Hi team,

Since Laravel requires PHP 8.0.2 and above, thus adding `match` expression here will provide higher readability, less lines & ` { } ` for Email Validation.

Thanks 😄 