### PR TITLE
[9.x] Update BusFake to use new BatchFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchRepositoryFake.php
@@ -4,11 +4,9 @@ namespace Illuminate\Support\Testing\Fakes;
 
 use Carbon\CarbonImmutable;
 use Closure;
-use Illuminate\Bus\Batch;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\UpdatedBatchJobCounts;
-use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Str;
 
 class BatchRepositoryFake implements BatchRepository
@@ -53,9 +51,7 @@ class BatchRepositoryFake implements BatchRepository
     {
         $id = (string) Str::orderedUuid();
 
-        $this->batches[$id] = new Batch(
-            new QueueFake(Facade::getFacadeApplication()),
-            $this,
+        $this->batches[$id] = new BatchFake(
             $id,
             $batch->name,
             count($batch->jobs),
@@ -129,7 +125,7 @@ class BatchRepositoryFake implements BatchRepository
     public function cancel(string $batchId)
     {
         if (isset($this->batches[$batchId])) {
-            $this->batches[$batchId]->cancelledAt = now();
+            $this->batches[$batchId]->cancel();
         }
     }
 


### PR DESCRIPTION
This updates the changes in [my previous PR](https://github.com/laravel/framework/pull/44075) to use the since created `BatchFake`.

I did not change the docblocks to keep this an implementation detail. If you feel there is value in changing them so the developer knows they are interacting with a `BatchFake`, I'm glad to update them.