### PR TITLE
[9.x] Add helper to dispatch fake job batches

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
 /**
  * @method static \Illuminate\Bus\Batch|null findBatch(string $batchId)
  * @method static \Illuminate\Bus\PendingBatch batch(array|mixed $jobs)
+ * @method static \Illuminate\Bus\Batch dispatchFakeBatch($name = '')
  * @method static \Illuminate\Contracts\Bus\Dispatcher map(array $map)
  * @method static \Illuminate\Contracts\Bus\Dispatcher pipeThrough(array $pipes)
  * @method static \Illuminate\Foundation\Bus\PendingChain chain(array $jobs)

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -676,6 +676,17 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
+     * Dispatch an empty job batch for testing.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Bus\Batch
+     */
+    public function dispatchFakeBatch($name = '')
+    {
+        return $this->batch([])->name($name)->dispatch();
+    }
+
+    /**
      * Record the fake pending batch dispatch.
      *
      * @param  \Illuminate\Bus\PendingBatch  $pendingBatch
@@ -686,17 +697,6 @@ class BusFake implements QueueingDispatcher
         $this->batches[] = $pendingBatch;
 
         return $this->batchRepository->store($pendingBatch);
-    }
-
-    /**
-     * Dispatch an empty job batch for testing.
-     *
-     * @param  string  $name
-     * @return \Illuminate\Bus\Batch
-     */
-    public function dispatchFakeBatch($name = '')
-    {
-        return $this->batch([])->name($name)->dispatch();
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -689,6 +689,17 @@ class BusFake implements QueueingDispatcher
     }
 
     /**
+     * Dispatch an empty job batch for testing.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Bus\Batch
+     */
+    public function dispatchFakeBatch($name = '')
+    {
+        return $this->batch([])->name($name)->dispatch();
+    }
+
+    /**
      * Determine if a command should be faked or actually dispatched.
      *
      * @param  mixed  $command

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Support\Testing\Fakes\BusFake;
@@ -519,6 +520,25 @@ class SupportTestingBusFakeTest extends TestCase
         $batch->cancel();
 
         $this->assertTrue($batch->cancelled());
+    }
+
+    public function testDispatchFakeBatch()
+    {
+        $this->fake->assertNothingBatched();
+
+        $batch = $this->fake->dispatchFakeBatch('my fake job batch');
+
+        $this->fake->assertBatchCount(1);
+        $this->assertInstanceOf(Batch::class, $batch);
+        $this->assertSame('my fake job batch', $batch->name);
+        $this->assertSame(0, $batch->totalJobs);
+
+        $batch = $this->fake->dispatchFakeBatch();
+
+        $this->fake->assertBatchCount(2);
+        $this->assertInstanceOf(Batch::class, $batch);
+        $this->assertSame('', $batch->name);
+        $this->assertSame(0, $batch->totalJobs);
     }
 }
 


### PR DESCRIPTION
This adds a helper method to the `BusFake` for quickly dispatching a fake job batch with no jobs for testing purpose. It's similar to the new `Job` helper added in #44104, but when you want to test a batch independently.

**Before:**
```php
Bus::fake();

$batch = Bus::batch([])->dispatch();
Cache::put('batched-automation', $batch->id);

Shift::runAutomation('v9.31.0'); // cancels previous batched job

Bus::assertDispatched(UpdateRepositories::class);
$this->assertTrue($batch->cancelled());
```

**After**
```php
Bus::fake();

$batch = Bus::dispatchFakeBatch();
// ...
```

For convenience of testing, you may optionally pass the name of the batch. If your test requires more detail, you may continue to create and dispatch a batch with the longhand methods.
