### PR TITLE
[9.x] Constraint withWhereHas on nested relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -165,8 +165,41 @@ trait QueriesRelationships
      */
     public function withWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
+        $relations = explode('.', $relation);
+        if (! $callback && sizeof($relations) > 1) {
+            return $this->withWhereHasNested($this, $relations);
+        }
+
         return $this->whereHas($relation, $callback, $operator, $count)
             ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
+    }
+
+    /**
+     * Add a relationship count / exists condition to the query with where clauses.
+     *
+     * Also load the relationship with same condition for nested relationships.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder|static  $query
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    protected function withWhereHasNested($query, $relations, $operator = '>=', $count = 1)
+    {
+        $topRelation = array_shift($relations);
+        if (empty($relations)) {
+            // At the bottom of the nested relationships
+            // we use the normal withWhereHas method
+            return $query->withWhereHas($topRelation, null, $operator, $count);
+        }
+
+        $callback = function ($query) use ($relations) {
+            $this->withWhereHasNested($query, $relations);
+        };
+
+        return $query->whereHas($topRelation, $callback, $operator, $count)
+                    ->with($topRelation, $callback);
     }
 
     /**


### PR DESCRIPTION
Related to this issue: https://github.com/laravel/framework/issues/44159

Calling `withWherehas` with a nested relationship and without a callback, the method returns all related models from the parent relationship even if it has no children.

```php
SomeModel::withWhereHas('parent.child');
```
In that case, it will return only `SomeModel` where the `parent` has `child` but it would eagerly load every `parent` related to `SomeModel` not only those that have a `child`. 


Another less abstract example:
```php
    $user = User::factory()->create();

    Comment::factory()
        ->for($user)
        ->for(Thread::factory()->trashed()) // soft deleted thread
        ->create();

    Comment::factory()
        ->for($user)
        ->for(Thread::factory())
        ->create();

    User::query()
        ->withWhereHas('comments.thread')
        ->get();
```

Here it would be expected for the query to return the `User` model with exactly one comment (the one that has the non-deleted thread). But, instead, we get the `User` with the two comments, one with the thread as `null`.

You can circumvent this by passing a callback that calls `withWhereHas` with the nested relationship:
```php
    User::query()
        ->withWhereHas('comments', function ($query) => {
            $query->withWhereHas('thread');
        })
        ->get();
```

With this pull request that is the generated query when calling `withWhereHas` with a nested relationship and no callback.

If you think the current behavior makes more sense feel free to close this pull request.


