### PR TITLE
[9.x] Can add `after()` method in policy

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -489,6 +489,15 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
+    public function testPoliciesMayHaveAfterMethodsToOverrideChecks()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithAfter::class);
+
+        $this->assertTrue($gate->check('update', new AccessGateTestDummy));
+    }
+
     public function testPoliciesAlwaysOverrideClosuresWithSameName()
     {
         $gate = $this->getBasicGate();
@@ -1240,6 +1249,19 @@ class AccessGateTestPolicyWithBefore
     public function update($user, AccessGateTestDummy $dummy)
     {
         return false;
+    }
+}
+
+class AccessGateTestPolicyWithAfter
+{
+    public function after($user, $ability)
+    {
+        return true;
+    }
+
+    public function update($user, AccessGateTestDummy $dummy)
+    {
+        return null;
     }
 }
 


### PR DESCRIPTION
This PR aims to allow to define a `after()` method in policies which will be called when the ability method returns `null`. Much like the `before()` method, the `after()` method wont be called if the ability method is not defined.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
