### PR TITLE
[10.x] Run route middleware before controller instantiation

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -129,6 +129,13 @@ class Route
     public $computedMiddleware;
 
     /**
+     * The computed gathered controller middleware.
+     *
+     * @var array|null
+     */
+    public $computedControllerMiddleware;
+
+    /**
      * The compiled version of the route.
      *
      * @var \Symfony\Component\Routing\CompiledRoute
@@ -264,8 +271,12 @@ class Route
      */
     protected function runController()
     {
+        $controller = tap($this->getController(), function () {
+            $this->controller = null;
+        });
+
         return $this->controllerDispatcher()->dispatch(
-            $this, $this->getController(), $this->getControllerMethod()
+            $this, $controller, $this->getControllerMethod()
         );
     }
 
@@ -1094,7 +1105,11 @@ class Route
             return [];
         }
 
-        return $this->controllerDispatcher()->getMiddleware(
+        if (! is_null($this->computedControllerMiddleware)) {
+            return $this->computedControllerMiddleware;
+        }
+
+        return $this->computedControllerMiddleware = $this->controllerDispatcher()->getMiddleware(
             $this->getController(), $this->getControllerMethod()
         );
     }

--- a/tests/Routing/RouteAndControllerMiddlewareTest.php
+++ b/tests/Routing/RouteAndControllerMiddlewareTest.php
@@ -66,7 +66,8 @@ class RouteAndControllerMiddlewareTest extends TestCase
         $this->assertSame(1, $counter);
     }
 
-    public function testRouteMiddlewareAffectsControllerDependencies() {
+    public function testRouteMiddlewareAffectsControllerDependencies()
+    {
         $container = new Container;
         $router = $this->getRouter($container);
 
@@ -97,7 +98,8 @@ class RouteAndControllerMiddlewareTest extends TestCase
         $this->assertSame('bar', $response->getContent());
     }
 
-    public function testControllerIsRecreatedOnEveryDispatch() {
+    public function testControllerIsRecreatedOnEveryDispatch()
+    {
         $container = new Container;
         $router = $this->getRouter($container);
 
@@ -112,7 +114,8 @@ class RouteAndControllerMiddlewareTest extends TestCase
         $container->when(ControllerMiddleware::class)
             ->needs('$callback')
             ->give(function () {
-                return function () {};
+                return function () {
+                };
             });
 
         $router->get('/', TestController::class);
@@ -124,7 +127,8 @@ class RouteAndControllerMiddlewareTest extends TestCase
         $this->assertSame('2', $response->getContent());
     }
 
-    public function testControllerIsTheSameInstanceWhileRouteIsNotDispatched() {
+    public function testControllerIsTheSameInstanceWhileRouteIsNotDispatched()
+    {
         $container = new Container;
         $router = $this->getRouter($container);
         $route = $router->get('/', TestController::class);
@@ -144,7 +148,8 @@ class RouteAndControllerMiddlewareTest extends TestCase
     }
 }
 
-class TestController extends Controller {
+class TestController extends Controller
+{
     public function __construct(
         public readonly Dependency $dependency
     ) {
@@ -157,16 +162,20 @@ class TestController extends Controller {
     }
 }
 
-class Dependency {
+class Dependency
+{
     public function __construct(
         public readonly string $value = 'foo'
-    ) {}
+    ) {
+    }
 }
 
-class RouteMiddleware {
+class RouteMiddleware
+{
     public function __construct(
         public $callback
-    ) {}
+    ) {
+    }
 
     public function handle($request, $next) {
         call_user_func($this->callback);
@@ -175,10 +184,12 @@ class RouteMiddleware {
     }
 }
 
-class ControllerMiddleware {
+class ControllerMiddleware
+{
     public function __construct(
         public $callback
-    ) {}
+    ) {
+    }
 
     public function handle($request, $next) {
         call_user_func($this->callback);

--- a/tests/Routing/RouteAndControllerMiddlewareTest.php
+++ b/tests/Routing/RouteAndControllerMiddlewareTest.php
@@ -177,7 +177,8 @@ class RouteMiddleware
     ) {
     }
 
-    public function handle($request, $next) {
+    public function handle($request, $next)
+    {
         call_user_func($this->callback);
 
         return $next($request);
@@ -191,7 +192,8 @@ class ControllerMiddleware
     ) {
     }
 
-    public function handle($request, $next) {
+    public function handle($request, $next)
+    {
         call_user_func($this->callback);
 
         return $next($request);

--- a/tests/Routing/RouteAndControllerMiddlewareTest.php
+++ b/tests/Routing/RouteAndControllerMiddlewareTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\TestCase;
+
+class RouteAndControllerMiddlewareTest extends TestCase
+{
+    public function testControllerMiddlewareIsRanAfterRouteMiddleware()
+    {
+        $counter = 0;
+
+        $container = new Container;
+        $router = $this->getRouter($container);
+        $router->middlewarePriority = [ControllerMiddleware::class, RouteMiddleware::class];
+
+        $container->when(RouteMiddleware::class)
+            ->needs('$callback')
+            ->give(function () use (&$counter) {
+                return function () use (&$counter) {
+                    $counter++;
+                    $this->assertSame(1, $counter);
+                };
+            });
+
+        $container->when(ControllerMiddleware::class)
+            ->needs('$callback')
+            ->give(function () use (&$counter) {
+                return function () use (&$counter) {
+                    $counter++;
+                    $this->assertSame(2, $counter);
+                };
+            });
+
+        $route = $router->get('/', TestController::class);
+        $route->middleware(RouteMiddleware::class);
+
+        $router->dispatch(Request::create('/', 'GET'));
+    }
+
+    public function testMiddlewareRunsOnce()
+    {
+        $counter = 0;
+
+        $container = new Container;
+        $router = $this->getRouter($container);
+
+        $container->when(ControllerMiddleware::class)
+            ->needs('$callback')
+            ->give(function () use (&$counter) {
+                return function () use (&$counter) {
+                    $counter++;
+                };
+            });
+
+        $route = $router->get('/', TestController::class);
+        $route->middleware(ControllerMiddleware::class);
+
+        $router->dispatch(Request::create('/', 'GET'));
+        $this->assertSame(1, $counter);
+    }
+
+    public function testRouteMiddlewareAffectsControllerDependencies() {
+        $container = new Container;
+        $router = $this->getRouter($container);
+
+        $container->when(RouteMiddleware::class)
+            ->needs('$callback')
+            ->give(function ($container) {
+                return function () use ($container) {
+                    $container->when(Dependency::class)
+                        ->needs('$value')
+                        ->give('bar');
+                };
+            });
+
+        $container->when(ControllerMiddleware::class)
+            ->needs('$callback')
+            ->give(function ($container) {
+                return function () use ($container) {
+                    $container->when(Dependency::class)
+                        ->needs('$value')
+                        ->give('qux');
+                };
+            });
+
+        $route = $router->get('/', TestController::class);
+        $route->middleware(RouteMiddleware::class);
+
+        $response = $router->dispatch(Request::create('/', 'GET'));
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testControllerIsRecreatedOnEveryDispatch() {
+        $container = new Container;
+        $router = $this->getRouter($container);
+
+        $container->when(Dependency::class)
+            ->needs('$value')
+            ->give(function () use (&$counter) {
+                $counter++;
+
+                return $counter;
+            });
+
+        $container->when(ControllerMiddleware::class)
+            ->needs('$callback')
+            ->give(function () {
+                return function () {};
+            });
+
+        $router->get('/', TestController::class);
+
+        $response = $router->dispatch(Request::create('/', 'GET'));
+        $this->assertSame('1', $response->getContent());
+
+        $response = $router->dispatch(Request::create('/', 'GET'));
+        $this->assertSame('2', $response->getContent());
+    }
+
+    public function testControllerIsTheSameInstanceWhileRouteIsNotDispatched() {
+        $container = new Container;
+        $router = $this->getRouter($container);
+        $route = $router->get('/', TestController::class);
+
+        $this->assertSame($route->getController(), $route->getController());
+    }
+
+    protected function getRouter(Container $container)
+    {
+        $router = new Router(new Dispatcher, $container);
+
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        return $router;
+    }
+}
+
+class TestController extends Controller {
+    public function __construct(
+        public readonly Dependency $dependency
+    ) {
+        $this->middleware(ControllerMiddleware::class);
+    }
+
+    public function __invoke()
+    {
+        return $this->dependency->value;
+    }
+}
+
+class Dependency {
+    public function __construct(
+        public readonly string $value = 'foo'
+    ) {}
+}
+
+class RouteMiddleware {
+    public function __construct(
+        public $callback
+    ) {}
+
+    public function handle($request, $next) {
+        call_user_func($this->callback);
+
+        return $next($request);
+    }
+}
+
+class ControllerMiddleware {
+    public function __construct(
+        public $callback
+    ) {}
+
+    public function handle($request, $next) {
+        call_user_func($this->callback);
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #44177

Currently a controller based route resolves its associated controller instance before running its middleware, regardless if the middleware were defined in the route definition (let's refer to those as **route middleware**), or in the controller's constructor (let's refer to those as **controller middleware**).

For some users this behavior is not intuitive, as they expect the controller to be resolved after middleware are run, at least after **route middleware** are run. 

This is particularly an issue when a controller's dependencies are injected through its constructor, which is a common OOP pattern.

If a user writes a middleware where they expect to tweak the container to affect a  controller's dependency resolution, these changes are not applied as expected due to the controller instance was already resolved from the container and bound to the route.

For example assume this controller:

~~~php
class AController {
    public function __constructor(
        private readonly ApiClient $client,
    ) {}

    public function __invoke() {
        return $this->client->run();
    }
}
~~~

with this dependency:

~~~php
class ApiClient {
    public function __constructor(
        private readonly string $apiKey,
    ) {}

    // ...
}
~~~

And this middleware:

~~~php
class AMiddleware {
    public function ($request, $next) {
        app()->when(ApiClient::class)
            ->needs('$apiKey')
            ->give(function () use ($request) {
                if ($request->is('admin/*') return '1234';
                else return '4567';
            });

        return $next($request);
    }
}
~~~

and finally these route definition:

~~~php
Route::get('/dashboard', AController::class)->middleware(AMiddleware::class);
Route::get('/admin/dashboard', AController::class)->middleware(AMiddleware::class);
~~~

When running these routes, as the controller is resolved before the middleware are run, the container would not be able to resolve the `ApiClient` instance, or at least it could give a wrong `$apiKey` value, in case a default value was bound in a service provider.

### Prior attempts

There were some prior attempts to handle this, some recent are: 

- #40165 (which during review narrowed scope)
- #40306
- #40397 (reverted in #40675)

The difference in this PR implementation is that it tries to keep changes needed by an application to a minimum. Prior PRs attempted to add a dedicated static method to a controller to gather middleware, which would require code changes for many apps that declare middleware on their constructor. 

Also a static method won't allow closure-based middleware to interact with the controller instance. Although I don't follow this practice, this was one of the reasons closure-based middleware were introduced back in 2016 to accommodate the fact the session would not be available to the controller's constructor anymore.

Actually, I believe most apps won't need to change nothing, as I believe (total personal opinion, from personal experience) it is uncommon to mix **route middleware** with **controller middleware**.

### Desired side affects

If any authentication, authorization or other "safeguard"/"firewall" middleware are defined as **route middleware**, the request will fail before any controller's dependency is resolved.

### This PR:

- Changes how the route pipeline is handled, by first handling **route middleware**, and then resolving the controller and handling its **controller middleware**
- Resets the route's controller instance after the route is ran, to address a concern on controller reuse between requests in tests or octane, as explained here: https://github.com/laravel/framework/pull/40675#issuecomment-1023415277
- Adds relevant tests, most would not run without this PR proposed changes, and one (`testMiddlewareRunsOnce`) was added to ensure behavior won't change by mistake in the future

### Breaking Changes

This PR was sent to master due to middleware priority order not being fully respected anymore.

Currently as all middleware are gathered and pre-processed together, the middleware are sorted, and deduplicated, to respect the middleware priority as a single stack.

This PR breaks middleware processing in two steps: **route middleware** (including global and group middleware) are gathered together, sorted, deduplicated before the request is dispatched.

Then the **controller middleware** are gathered, sorted, deduplicated (including any middleware already processed) and the request is ran trough these remaining middleware.

By breaking this process into two steps, a middleware defined in a controller's constructor that should have a higher priority will be executed after any middleware defined globally, as a group or as **route middleware** that should have a lower priority.

This is shown in the `testControllerMiddlewareIsRanAfterRouteMiddleware` test.

I believe this can be documented in the upgrade guide. This would be, as far as I know, the only downside of the approach proposed by this PR.

One last note: the pipeline is broke into two pipelines, but the controller instantiation happens on the end of the first pipeline inside its `->then()` method. So even by breaking into two pipelines all middleware that depends on the response will be handled as usual.

### Epilogue

I want to thanks @christhomas for the suggestion on handling middleware by sets on this comment https://github.com/laravel/framework/issues/44177#issuecomment-1249809010, @X-Coder264 for the discussion on issue #44177 that inspired me writing this PR besides both of us having different opinion regarding this, and to @lorisleiva for the comments on previous attempts.

I would really appreciate if any of them could review or add any suggestions or critics to improve this PR.

Although I don't think there is an issue to be fixed -- as all the issues described above could be solved by using method injection on a controller's method -- I understand different people might have different views on how software should be built and I thought on this proposal as a middle ground solution to accommodate both views.
