### PR TITLE
[9.x] Fixed date extraction when PHP_CLI_SERVER_WORKERS is set

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -284,7 +284,10 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        preg_match('/^\[([^\]]+)\]/', $line, $matches);
+        $regex = \env(PHP_CLI_SERVER_WORKERS, 1) > 1
+            ? '/^\[\d+]\s\[(.*)]/'
+            : '/^\[([^\]]+)\]/';
+        preg_match($regex, $line, $matches);
 
         return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);
     }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -66,7 +66,7 @@ class ServeCommand extends Command
         'SYSTEMROOT',
         'XDEBUG_CONFIG',
         'XDEBUG_MODE',
-        'XDEBUG_SESSION',
+        'XDEBUG_SESSION'
     ];
 
     /**
@@ -284,7 +284,7 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        $regex = \env(PHP_CLI_SERVER_WORKERS, 1) > 1
+        $regex = \env('PHP_CLI_SERVER_WORKERS', 1) > 1
             ? '/^\[\d+]\s\[(.*)]/'
             : '/^\[([^\]]+)\]/';
         preg_match($regex, $line, $matches);


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/44082

When running with PHP_CLI_SERVER_WORKERS set, the PHP CLI output is prepended with the worker PID, leading to erroneous date extraction. 

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
