### PR TITLE
[9.x] Make Vite macroable

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -7,9 +7,12 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 
 class Vite implements Htmlable
 {
+    use Macroable;
+
     /**
      * The Content Security Policy nonce to apply to all generated tags.
      *

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -584,6 +584,25 @@ class FoundationViteTest extends TestCase
         $this->cleanViteHotFile('cold');
     }
 
+    public function testViteIsMacroable()
+    {
+        $this->makeViteManifest([
+            'resources/images/profile.png' => [
+                'src' => 'resources/images/profile.png',
+                'file' => 'assets/profile.versioned.png',
+            ],
+        ], $buildDir = Str::random());
+        Vite::macro('image', function ($asset, $buildDir = null) {
+            return $this->asset("resources/images/{$asset}", $buildDir);
+        });
+
+        $path = ViteFacade::image('profile.png', $buildDir);
+
+        $this->assertSame("https://example.com/{$buildDir}/assets/profile.versioned.png", $path);
+
+        $this->cleanViteManifest($buildDir);
+    }
+
     protected function makeViteManifest($contents = null, $path = 'build')
     {
         app()->singleton('path.public', fn () => __DIR__);


### PR DESCRIPTION
This PR makes the Vite class Macroable. This is rather nice for creating aliases for the Vite class to match those in your JS config.

Documentation  PR: https://github.com/laravel/docs/pull/8232

In JS land, configuration:

```js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';
 
export default defineConfig({
    plugins: [
        laravel(/* ... */),
    ],
    resolve: {
        alias: {
            'image': '/resources/images',
            'page': '/resources/js/Pages',
        },
    },
});
```

Usage:

```js
import Profile from '@image/profile.png'
```

In Laravel land, configuration:

```php
<?php
 
namespace App\Providers;
 
use Illuminate\Support\Vite;
use Illuminate\Support\ServiceProvider;
 
class AppServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        Vite::macro('image', fn ($asset) => $this->asset("resources/images/{$asset}"));
    }
}
```

Usage:

```blade
<img src="{{ Vite::image('profile.png') }}" ... >
```

You can also make more complicated alises based on things like the apps environment:

```php
Vite::macro('localeAsset', function ($asset) {
    $locale = config('app.locale');

    // resources/jp/images/*
    // resources/en/images/*
    // resources/fr/images/*
    return $this->asset("resources/{$locale}/images/{$asset}");
});
```

```blade
<img src="{{ Vite::localeAsset('logo.png') }}" alt="...">
```