### PR TITLE
[9.x] Implement markdown as built-in model casting type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Markdown.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Markdown.php
@@ -64,8 +64,19 @@ class Markdown implements Castable
                         return [];
                     }
 
-                    // Properly type cast option integer value
-                    $value = is_numeric($parts[1]) ? (int) $parts[1] : $parts[1];
+                    $value = $parts[1];
+
+                    // Type cast integers properly
+                    if (is_numeric($value)) {
+                        $value = (int)$value;
+                    }
+                    // Type cast boolean properly
+                    elseif ($value == 'true'){
+                        $value = true;
+                    }
+                    elseif ($value == 'false'){
+                        $value = false;
+                    }
 
                     return [$parts[0] => $value];
                 });

--- a/src/Illuminate/Database/Eloquent/Casts/Markdown.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Markdown.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Casts;
 
-use Illuminate\Support\Str;
-use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Str;
 
 class Markdown implements Castable
 {
@@ -16,16 +16,17 @@ class Markdown implements Castable
      */
     public static function castUsing(array $arguments)
     {
-        return new class($arguments) implements CastsAttributes {
+        return new class($arguments) implements CastsAttributes
+        {
             /**
-             * Instruct it to convert string using inline HTML converter
+             * Instruct it to convert string using inline HTML converter.
              *
              * @var bool
              */
             protected $useInlineConverter = false;
 
             /**
-             * Hold user defined options
+             * Hold user defined options.
              *
              * @var array
              */
@@ -34,7 +35,6 @@ class Markdown implements Castable
             /**
              * Create a new instance of the class.
              *
-             * @param bool $useInlineConverter
              * @param array $options
              * @return void
              */
@@ -44,7 +44,7 @@ class Markdown implements Castable
             }
 
             /**
-             * Parse user defined options
+             * Parse user defined options.
              *
              * @param array $options
              * @return void
@@ -52,15 +52,15 @@ class Markdown implements Castable
             protected function setOptions($options)
             {
                 $this->options = collect($options)->flatMap(function ($values) {
-                    $parts = explode("=", $values);
+                    $parts = explode('=', $values);
 
                     // Use Inline HTML converter
-                    if ($parts[0] == "inline"){
+                    if ($parts[0] == 'inline') {
                         $this->useInlineConverter = true;
                     }
 
                     // Execlude any option defined without value
-                    if (!isset($parts[1])){
+                    if (! isset($parts[1])){
                         return [];
                     }
 
@@ -68,13 +68,13 @@ class Markdown implements Castable
 
                     // Type cast integers properly
                     if (is_numeric($value)) {
-                        $value = (int)$value;
+                        $value = (int) $value;
                     }
                     // Type cast boolean properly
-                    elseif ($value == 'true'){
+                    elseif ($value == 'true') {
                         $value = true;
                     }
-                    elseif ($value == 'false'){
+                    elseif ($value == 'false') {
                         $value = false;
                     }
 
@@ -83,7 +83,7 @@ class Markdown implements Castable
             }
 
             /**
-             * Get options as array
+             * Get options as array.
              *
              * @return mixed
              */
@@ -95,11 +95,11 @@ class Markdown implements Castable
             /**
              * Cast the given value into markdown.
              *
-             * @param \Illuminate\Database\Eloquent\Model $model
-             * @param string $key
-             * @param mixed $value
-             * @param array $attributes
-             * @return string
+             * @param  \Illuminate\Database\Eloquent\Model  $model
+             * @param  string  $key
+             * @param  mixed  $value
+             * @param  array  $attributes
+             * @return  string
              */
             public function get($model, $key, $value, $attributes)
             {
@@ -113,11 +113,11 @@ class Markdown implements Castable
             /**
              * Prepare the given value for storage.
              *
-             * @param \Illuminate\Database\Eloquent\Model $model
-             * @param string $key
-             * @param mixed $value
-             * @param array $attributes
-             * @return string
+             * @param  \Illuminate\Database\Eloquent\Model  $model
+             * @param  string  $key
+             * @param  mixed  $value
+             * @param  array  $attributes
+             * @return  string
              */
             public function set($model, $key, $value, $attributes)
             {

--- a/src/Illuminate/Database/Eloquent/Casts/Markdown.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Markdown.php
@@ -35,7 +35,7 @@ class Markdown implements Castable
             /**
              * Create a new instance of the class.
              *
-             * @param array $options
+             * @param  array  $options
              * @return void
              */
             public function __construct($options = [])
@@ -46,7 +46,7 @@ class Markdown implements Castable
             /**
              * Parse user defined options.
              *
-             * @param array $options
+             * @param  array  $options
              * @return void
              */
             protected function setOptions($options)
@@ -60,21 +60,18 @@ class Markdown implements Castable
                     }
 
                     // Execlude any option defined without value
-                    if (! isset($parts[1])){
+                    if (! isset($parts[1])) {
                         return [];
                     }
 
                     $value = $parts[1];
 
-                    // Type cast integers properly
+                    // Type cast option values properly
                     if (is_numeric($value)) {
                         $value = (int) $value;
-                    }
-                    // Type cast boolean properly
-                    elseif ($value == 'true') {
+                    } elseif ($value == 'true') {
                         $value = true;
-                    }
-                    elseif ($value == 'false') {
+                    } elseif ($value == 'false') {
                         $value = false;
                     }
 
@@ -95,11 +92,11 @@ class Markdown implements Castable
             /**
              * Cast the given value into markdown.
              *
-             * @param  \Illuminate\Database\Eloquent\Model  $model
-             * @param  string  $key
-             * @param  mixed  $value
-             * @param  array  $attributes
-             * @return  string
+             * @param   \Illuminate\Database\Eloquent\Model  $model
+             * @param   string  $key
+             * @param   mixed  $value
+             * @param   array  $attributes
+             * @return string
              */
             public function get($model, $key, $value, $attributes)
             {
@@ -117,7 +114,7 @@ class Markdown implements Castable
              * @param  string  $key
              * @param  mixed  $value
              * @param  array  $attributes
-             * @return  string
+             * @return string
              */
             public function set($model, $key, $value, $attributes)
             {

--- a/src/Illuminate/Database/Eloquent/Casts/Markdown.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Markdown.php
@@ -92,10 +92,10 @@ class Markdown implements Castable
             /**
              * Cast the given value into markdown.
              *
-             * @param   \Illuminate\Database\Eloquent\Model  $model
-             * @param   string  $key
-             * @param   mixed  $value
-             * @param   array  $attributes
+             * @param  \Illuminate\Database\Eloquent\Model  $model
+             * @param  string  $key
+             * @param  mixed  $value
+             * @param  array  $attributes
              * @return string
              */
             public function get($model, $key, $value, $attributes)

--- a/src/Illuminate/Database/Eloquent/Casts/Markdown.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Markdown.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use Illuminate\Support\Str;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+
+class Markdown implements Castable
+{
+    /**
+     * Get the name of the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return string
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes {
+            /**
+             * Instruct it to convert string using inline HTML converter
+             *
+             * @var bool
+             */
+            protected $useInlineConverter = false;
+
+            /**
+             * Hold user defined options
+             *
+             * @var array
+             */
+            protected $options = [];
+
+            /**
+             * Create a new instance of the class.
+             *
+             * @param bool $useInlineConverter
+             * @param array $options
+             * @return void
+             */
+            public function __construct($options = [])
+            {
+                $this->setOptions($options);
+            }
+
+            /**
+             * Parse user defined options
+             *
+             * @param array $options
+             * @return void
+             */
+            protected function setOptions($options)
+            {
+                $this->options = collect($options)->flatMap(function ($values) {
+                    $parts = explode("=", $values);
+
+                    // Use Inline HTML converter
+                    if ($parts[0] == "inline"){
+                        $this->useInlineConverter = true;
+                    }
+
+                    // Execlude any option defined without value
+                    if (!isset($parts[1])){
+                        return [];
+                    }
+
+                    // Properly type cast option integer value
+                    $value = is_numeric($parts[1]) ? (int) $parts[1] : $parts[1];
+
+                    return [$parts[0] => $value];
+                });
+            }
+
+            /**
+             * Get options as array
+             *
+             * @return mixed
+             */
+            protected function getOptions()
+            {
+                return $this->options->undot()->toArray();
+            }
+
+            /**
+             * Cast the given value into markdown.
+             *
+             * @param \Illuminate\Database\Eloquent\Model $model
+             * @param string $key
+             * @param mixed $value
+             * @param array $attributes
+             * @return string
+             */
+            public function get($model, $key, $value, $attributes)
+            {
+                if ($this->useInlineConverter) {
+                    return Str::inlineMarkdown($value, $this->getOptions());
+                }
+
+                return Str::markdown($value, $this->getOptions());
+            }
+
+            /**
+             * Prepare the given value for storage.
+             *
+             * @param \Illuminate\Database\Eloquent\Model $model
+             * @param string $key
+             * @param mixed $value
+             * @param array $attributes
+             * @return string
+             */
+            public function set($model, $key, $value, $attributes)
+            {
+                return $value;
+            }
+        };
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -724,11 +724,11 @@ trait HasAttributes
         }
         
         // If the key is markdown castable, we will pull cast parameters and update
-        // cast type so it will be handled later
-        if ($this->isMarkdownCastable($castType)){
+        // cast type so it will be handled later.
+        if ($this->isMarkdownCastable($castType)) {
             $markdownOptions = Str::after($castType, 'markdown:');
 
-            $castType = "markdown";
+            $castType = 'markdown';
         }
 
         switch ($castType) {
@@ -2204,7 +2204,7 @@ trait HasAttributes
      * Determine if the cast type is Markdown castable.
      *
      * @param  string  $cast
-     * @return bool
+     * @return  bool
      */
     protected function isMarkdownCastable($cast)
     {
@@ -2212,7 +2212,7 @@ trait HasAttributes
     }
 
     /**
-     * Return string as Markdown
+     * Return string as Markdown.
      *
      * @param $key
      * @param $value

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -722,7 +722,7 @@ trait HasAttributes
 
             $castType = Str::after($castType, 'encrypted:');
         }
-        
+
         // If the key is markdown castable, we will pull cast parameters and update
         // cast type so it will be handled later.
         if ($this->isMarkdownCastable($castType)) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2204,7 +2204,7 @@ trait HasAttributes
      * Determine if the cast type is Markdown castable.
      *
      * @param  string  $cast
-     * @return  bool
+     * @return bool
      */
     protected function isMarkdownCastable($cast)
     {
@@ -2214,9 +2214,9 @@ trait HasAttributes
     /**
      * Return string as Markdown.
      *
-     * @param $key
-     * @param $value
-     * @param $options
+     * @param  $key
+     * @param  $value
+     * @param  $options
      * @return mixed
      */
     protected function asMarkdown($key, $value, $options)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2199,7 +2199,7 @@ trait HasAttributes
             return false;
         })->map->name->values()->all();
     }
-    
+
     /**
      * Determine if the cast type is Markdown castable.
      *

--- a/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
+++ b/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
@@ -73,7 +73,7 @@ class EloquentModelMarkdownCastingTest extends TestCase
      */
     public function testInit()
     {
-        $model = \Tests\Feature\MarkdownCustomCasts::firstOrCreate([
+        $model = MarkdownCustomCasts::firstOrCreate([
             'content' => '# Taylor <b>Otwell</b>',
         ]);
 

--- a/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
+++ b/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
@@ -104,6 +104,18 @@ class EloquentModelMarkdownCastingTest extends TestCase
         $this->assertSame("<h1>Taylor Otwell</h1>\n", $model->content);
     }
 
+    public function testCommonMarkNestedOption(){
+        $model = MarkdownCustomCasts::firstOrCreate([
+            'content' => '# Taylor *Otwell*'
+        ]);
+
+        $model->mergeCasts([
+            'content' => Markdown::class . ':commonmark.enable_em=false'
+        ]);
+
+        $this->assertSame("<h1>Taylor *Otwell*</h1>\n", $model->content);
+    }
+
     public function testCastableClass(){
         $model = MarkdownCustomCasts::firstOrCreate([
             'content' => '# Taylor <b>Otwell</b>'

--- a/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
+++ b/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
@@ -2,13 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-
-use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Database\Eloquent\Casts\Markdown;
-use PHPUnit\Framework\TestCase;
-
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Casts\Markdown;
 use Illuminate\Database\Eloquent\Model as Eloquent;

--- a/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
+++ b/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
@@ -9,6 +9,12 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Eloquent\Casts\Markdown;
 use PHPUnit\Framework\TestCase;
 
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Casts\Markdown;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Schema\Blueprint;
+use PHPUnit\Framework\TestCase;
+
 class EloquentModelMarkdownCastingTest extends TestCase
 {
     protected function setUp(): void
@@ -72,57 +78,62 @@ class EloquentModelMarkdownCastingTest extends TestCase
     /**
      * Tests..
      */
-    public function testInit(){
-        $model = MarkdownCustomCasts::firstOrCreate([
-            'content' => '# Taylor <b>Otwell</b>'
+    public function testInit()
+    {
+        $model = \Tests\Feature\MarkdownCustomCasts::firstOrCreate([
+            'content' => '# Taylor <b>Otwell</b>',
         ]);
 
         $this->assertSame("<h1>Taylor <b>Otwell</b></h1>\n", $model->content);
     }
 
-    public function testInline(){
+    public function testInline()
+    {
         $model = MarkdownCustomCasts::firstOrCreate([
-            'content' => '**Taylor Otwell**'
+            'content' => '**Taylor Otwell**',
         ]);
 
         $model->mergeCasts([
-            'content' => 'markdown:inline'
+            'content' => 'markdown:inline',
         ]);
 
         $this->assertSame("<strong>Taylor Otwell</strong>\n", $model->content);
     }
 
-    public function testHtmlInputStrip(){
+    public function testHtmlInputStrip()
+    {
         $model = MarkdownCustomCasts::firstOrCreate([
-            'content' => '# Taylor <b>Otwell</b>'
+            'content' => '# Taylor <b>Otwell</b>',
         ]);
 
         $model->mergeCasts([
-            'content' => 'markdown:html_input=strip'
+            'content' => 'markdown:html_input=strip',
         ]);
 
         $this->assertSame("<h1>Taylor Otwell</h1>\n", $model->content);
     }
 
-    public function testCommonMarkNestedOption(){
+    public function testCommonMarkNestedOption()
+    {
         $model = MarkdownCustomCasts::firstOrCreate([
-            'content' => '# Taylor *Otwell*'
+            'content' => '# Taylor *Otwell*',
         ]);
 
         $model->mergeCasts([
-            'content' => Markdown::class . ':commonmark.enable_em=false'
+            'content' => Markdown::class.':commonmark.enable_em=false',
         ]);
 
         $this->assertSame("<h1>Taylor *Otwell*</h1>\n", $model->content);
     }
 
-    public function testCastableClass(){
+    public function testCastableClass()
+    {
         $model = MarkdownCustomCasts::firstOrCreate([
-            'content' => '# Taylor <b>Otwell</b>'
+            'content' => '# Taylor <b>Otwell</b>',
         ]);
 
         $model->mergeCasts([
-            'content' => Markdown::class . ':html_input=strip'
+            'content' => Markdown::class.':html_input=strip',
         ]);
 
         $this->assertSame("<h1>Taylor Otwell</h1>\n", $model->content);

--- a/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
+++ b/tests/Integration/Database/EloquentModelMarkdownCastingTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\Casts\Markdown;
+use PHPUnit\Framework\TestCase;
+
+class EloquentModelMarkdownCastingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('markdown_casting_table', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('content');
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('markdown_casting_table');
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Tests..
+     */
+    public function testInit(){
+        $model = MarkdownCustomCasts::firstOrCreate([
+            'content' => '# Taylor <b>Otwell</b>'
+        ]);
+
+        $this->assertSame("<h1>Taylor <b>Otwell</b></h1>\n", $model->content);
+    }
+
+    public function testInline(){
+        $model = MarkdownCustomCasts::firstOrCreate([
+            'content' => '**Taylor Otwell**'
+        ]);
+
+        $model->mergeCasts([
+            'content' => 'markdown:inline'
+        ]);
+
+        $this->assertSame("<strong>Taylor Otwell</strong>\n", $model->content);
+    }
+
+    public function testHtmlInputStrip(){
+        $model = MarkdownCustomCasts::firstOrCreate([
+            'content' => '# Taylor <b>Otwell</b>'
+        ]);
+
+        $model->mergeCasts([
+            'content' => 'markdown:html_input=strip'
+        ]);
+
+        $this->assertSame("<h1>Taylor Otwell</h1>\n", $model->content);
+    }
+
+    public function testCastableClass(){
+        $model = MarkdownCustomCasts::firstOrCreate([
+            'content' => '# Taylor <b>Otwell</b>'
+        ]);
+
+        $model->mergeCasts([
+            'content' => Markdown::class . ':html_input=strip'
+        ]);
+
+        $this->assertSame("<h1>Taylor Otwell</h1>\n", $model->content);
+    }
+}
+
+/**
+ * Eloquent Models...
+ */
+class MarkdownCustomCasts extends Eloquent
+{
+    /**
+     * @var string
+     */
+    protected $table = 'markdown_casting_table';
+
+    /**
+     * @var string[]
+     */
+    protected $guarded = [];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'content' => 'markdown',
+    ];
+
+    /**
+     * @var bool
+     */
+    public $timestamps = false;
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello,

as I used to write an attribute accessor whenever I needed to cast value as markdown, even years before `Str::markdown` was implemented, today I wrote this custom casting type, and with some effort I was able to include it as a native one.

it would be very helpful to simply write `$casts = ['column_name' => 'markdown']` and let laravel do the heavy task as usual.

+ tests included
+ I can write the documentation once approved
+ open to any modification request