### PR TITLE
[9.x] Return `true` from policy stub methods by default

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -18,7 +18,7 @@ class {{ class }}
      */
     public function viewAny({{ user }} $user)
     {
-        //
+        return true;
     }
 
     /**
@@ -30,7 +30,7 @@ class {{ class }}
      */
     public function view({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
-        //
+        return true;
     }
 
     /**
@@ -41,7 +41,7 @@ class {{ class }}
      */
     public function create({{ user }} $user)
     {
-        //
+        return true;
     }
 
     /**
@@ -53,7 +53,7 @@ class {{ class }}
      */
     public function update({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
-        //
+        return true;
     }
 
     /**
@@ -65,7 +65,7 @@ class {{ class }}
      */
     public function delete({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
-        //
+        return true;
     }
 
     /**
@@ -77,7 +77,7 @@ class {{ class }}
      */
     public function restore({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
-        //
+        return true;
     }
 
     /**
@@ -89,6 +89,6 @@ class {{ class }}
      */
     public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
-        //
+        return true;
     }
 }


### PR DESCRIPTION
This is just a proposal. I welcome discussion from others to decide if this would be a better default. I am aware that people can customise the stubs themselves if they wish.

Laravel's `make:policy` method currently generates empty stub files. For example:

```php
public function update(User $user, Post $post)
{
    //
}
```

However, this doesn't feel very "batteries included" to me.

Often, these policies are generated when the rest of the authorisation system has not yet been set up, and we then have to deliberately go through 7 separate methods in the file, to `return true`. If not, then any policy checks will fail, which is unexpected behaviour.

This is especially a "gotcha" when you use `make:model --all` which generates a policy amongst other files. People often forget about the policy though, and then are confused why their app isn't working. In particular, some packages like Nova and Filament which read policies will simply not show a resource at all, as the policy method exists but doesn't `return true`.

This PR simply changes the stub that is used to generate policies, so that all methods `return true`:

```php
public function update(User $user, Post $post)
{
    return true;
}
```

## The better (breaking change) alternative

Ideally, we'd keep the stubs as they are, and just tweak Laravel's authorisation system to allow access when a policy method returns `null` instead of `false`. Then people still clearly know which methods they haven't implemented in their policy, but aren't surprised by policy checks returning `false`. Of course though, this is a breaking change, so it's not gonna be merged.