### PR TITLE
[9.x] Require symfony/uid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "symfony/mime": "^6.0",
         "symfony/process": "^6.0",
         "symfony/routing": "^6.0",
+        "symfony/uid": "^6.0",
         "symfony/var-dumper": "^6.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
         "vlucas/phpdotenv": "^5.4.1",
@@ -97,8 +98,7 @@
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^9.5.8",
         "predis/predis": "^1.1.9|^2.0",
-        "symfony/cache": "^6.0",
-        "symfony/uid": "^6.0"
+        "symfony/cache": "^6.0"
     },
     "provide": {
         "psr/container-implementation": "1.1|2.0",
@@ -169,8 +169,7 @@
         "symfony/http-client": "Required to enable support for the Symfony API mail transports (^6.0).",
         "symfony/mailgun-mailer": "Required to enable support for the Mailgun mail transport (^6.0).",
         "symfony/postmark-mailer": "Required to enable support for the Postmark mail transport (^6.0).",
-        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
-        "symfony/uid": "Required to generate ULIDs for Eloquent (^6.0)."
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0)."
     },
     "config": {
         "sort-packages": true,

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -46,7 +46,7 @@
         "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^2.0.2).",
         "ramsey/uuid": "Required to use Str::uuid() (^4.2.2).",
         "symfony/process": "Required to use the composer class (^6.0).",
-        "symfony/uid": "Required to generate ULIDs for Eloquent (^6.0).",
+        "symfony/uid": "Required to use Str::ulid() (^6.0).",
         "symfony/var-dumper": "Required to use the dd function (^6.0).",
         "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.4.1)."
     },


### PR DESCRIPTION
I see people struggling with this so let's just require the package as it's not that large anyway. Still optional for `illuminate/support` like `ramsey/uuid` is.

https://github.com/laravel/framework/issues/44167