### PR TITLE
[9.x] Fixes artisan `serve` command with `PHP_CLI_SERVER_WORKERS` environment variable

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -284,7 +284,10 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        preg_match('/^\[([^\]]+)\]/', $line, $matches);
+        $regex = \env(PHP_CLI_SERVER_WORKERS, 1) > 1
+            ? '/^\[\d+]\s\[(.*)]/'
+            : '/^\[([^\]]+)\]/';
+        preg_match($regex, $line, $matches);
 
         return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);
     }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -54,6 +54,13 @@ class ServeCommand extends Command
     protected $requestsPool;
 
     /**
+     * If the "Server running on..." output message has been displayed.
+     *
+     * @var bool
+     */
+    protected $serverRunningHasBeenDisplayed = false;
+
+    /**
      * The environment variables that should be passed from host machine to the PHP server process.
      *
      * @var string[]
@@ -105,6 +112,8 @@ class ServeCommand extends Command
                 $this->components->info('Environment modified. Restarting server...');
 
                 $process->stop(5);
+
+                $this->serverRunningHasBeenDisplayed = false;
 
                 $process = $this->startProcess($hasEnvironment);
             }
@@ -228,10 +237,16 @@ class ServeCommand extends Command
     {
         return fn ($type, $buffer) => str($buffer)->explode("\n")->each(function ($line) {
             if (str($line)->contains('Development Server (http')) {
+                if ($this->serverRunningHasBeenDisplayed) {
+                    return;
+                }
+
                 $this->components->info("Server running on [http://{$this->host()}:{$this->port()}].");
                 $this->comment('  <fg=yellow;options=bold>Press Ctrl+C to stop the server</>');
 
                 $this->newLine();
+
+                $this->serverRunningHasBeenDisplayed = true;
             } elseif (str($line)->contains(' Accepted')) {
                 $requestPort = $this->getRequestPortFromLine($line);
 
@@ -284,9 +299,10 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        $regex = \env('PHP_CLI_SERVER_WORKERS', 1) > 1
+        $regex = env('PHP_CLI_SERVER_WORKERS', 1) > 1
             ? '/^\[\d+]\s\[(.*)]/'
             : '/^\[([^\]]+)\]/';
+
         preg_match($regex, $line, $matches);
 
         return Carbon::createFromFormat('D M d H:i:s Y', $matches[1]);

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -54,7 +54,7 @@ class ServeCommand extends Command
     protected $requestsPool;
 
     /**
-     * If the "Server running on..." output message has been displayed.
+     * Indicates if the "Server running on..." output message has been displayed.
      *
      * @var bool
      */

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -66,7 +66,7 @@ class ServeCommand extends Command
         'SYSTEMROOT',
         'XDEBUG_CONFIG',
         'XDEBUG_MODE',
-        'XDEBUG_SESSION',
+        'XDEBUG_SESSION'
     ];
 
     /**
@@ -284,7 +284,7 @@ class ServeCommand extends Command
      */
     protected function getDateFromLine($line)
     {
-        $regex = \env(PHP_CLI_SERVER_WORKERS, 1) > 1
+        $regex = \env('PHP_CLI_SERVER_WORKERS', 1) > 1
             ? '/^\[\d+]\s\[(.*)]/'
             : '/^\[([^\]]+)\]/';
         preg_match($regex, $line, $matches);

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -66,7 +66,7 @@ class ServeCommand extends Command
         'SYSTEMROOT',
         'XDEBUG_CONFIG',
         'XDEBUG_MODE',
-        'XDEBUG_SESSION'
+        'XDEBUG_SESSION',
     ];
 
     /**


### PR DESCRIPTION
This pull request makes the new `serve` output compatible with the `PHP_CLI_SERVER_WORKERS` environment variable.

When set, the `PHP_CLI_SERVER_WORKERS` will change the format of the output being printed by the PHP's server causing a runtime exception described here: https://github.com/laravel/framework/issues/44082.