### PR TITLE
Arr::get by sending keys as array

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -301,12 +301,16 @@ class Arr
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int|null  $key
+     * @param  array|string|int|null  $key
      * @param  mixed  $default
      * @return mixed
      */
     public static function get($array, $key, $default = null)
     {
+        if (is_array($key)) {
+            $key = implode('.', $key);
+        }
+
         if (! static::accessible($array)) {
             return value($default);
         }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -382,7 +382,7 @@ class SupportArrTest extends TestCase
         $array = ['products' => ['desk' => ['price' => 100]]];
         $value = Arr::get($array, ['products', 'desk']);
         $this->assertEquals(['price' => 100], $value);
-        
+
         $array = [
             'products' => [
                 ['name' => 'desk'],

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -377,6 +377,20 @@ class SupportArrTest extends TestCase
         $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', function () {
             return 'dayle';
         }));
+
+        // Test keys passed as array as per the depth
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        $value = Arr::get($array, ['products', 'desk']);
+        $this->assertEquals(['price' => 100], $value);
+        
+        $array = [
+            'products' => [
+                ['name' => 'desk'],
+                ['name' => 'chair'],
+            ],
+        ];
+        $this->assertSame('desk', Arr::get($array, ['products', 0, 'name']));
+        $this->assertSame('chair', Arr::get($array, ['products', 1, 'name']));
     }
 
     public function testHas()


### PR DESCRIPTION
Current functionality of `Arr::get` supports only dot notation. when trying to fetch the value from the multidimensional array.

But it creates a little problem to create a dot notation string when we have to deal with dynamic keys

`$key = 'parent.'. $dynamicKey.'.final_key;`

It hardens the readability of the code with too many dots when using dynamic keys (one for concatenation of strings, another defining the depth of my key)

But it will be easier if we can pass the depth directly in as the key

`$key = ['parent', $dynamicKey, 'final_key'];`

and then running `Arr::get($myArray, $key, 'default');`