### PR TITLE
[10.x] Drop Predis v1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "pda/pheanstalk": "^4.0",
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^9.5.8",
-        "predis/predis": "^1.1.9|^2.0",
+        "predis/predis": "^2.0",
         "symfony/cache": "^6.2"
     },
     "provide": {
@@ -158,7 +158,7 @@
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
         "phpunit/phpunit": "Required to use assertions and run tests (^9.5.8).",
-        "predis/predis": "Required to use the predis connector (^1.1.9|^2.0).",
+        "predis/predis": "Required to use the predis connector (^2.0).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^6.2).",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -27,7 +27,7 @@
     },
     "suggest": {
         "ext-redis": "Required to use the phpredis connector (^4.0|^5.0).",
-        "predis/predis": "Required to use the predis connector (^1.1.9|^2.0)."
+        "predis/predis": "Required to use the predis connector (^2.0)."
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Judging from Predis v1 it seems it won't be getting any support anymore soon. It's best that we drop support for it ourselves in v10: https://github.com/predis/predis/pull/799