### PR TITLE
[9.x] Adds source file to `dd` function output 💅🏻

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -12,7 +12,7 @@ trait ResolvesDumpSource
     protected static $dumpSourceResolver;
 
     /**
-     * Resolves the source of the dump call.
+     * Resolve the source of the dump call.
      *
      * @return array{0: string, 1: string, 2: int}|null
      */
@@ -41,7 +41,7 @@ trait ResolvesDumpSource
     }
 
     /**
-     * Sets the resolver that resolves the source of the dump call.
+     * Set the resolver that resolves the source of the dump call.
      *
      * @param  (callable(): (array{0: string, 1: string, 2: int}|null))|null  $callable
      * @return void

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -7,14 +7,14 @@ trait ResolvesDumpSource
     /**
      * The source resolver.
      *
-     * @var callable(): (array{0: string, 1: string: 2: int}|null)
+     * @var callable(): (array{0: string, 1: string, 2: int}|null)
      */
     protected static $dumpSourceResolver;
 
     /**
      * Resolves the source of the dump call.
      *
-     * @return array{0: string, 1: string: 2: int}|null
+     * @return array{0: string, 1: string, 2: int}|null
      */
     public function resolveDumpSource()
     {
@@ -43,7 +43,7 @@ trait ResolvesDumpSource
     /**
      * Sets the resolver that resolves the source of the dump call.
      *
-     * @param  (callable(): (array{0: string, 1: string: 2: int}|null))|null  $callable
+     * @param  (callable(): (array{0: string, 1: string, 2: int}|null))|null  $callable
      * @return void
      */
     public static function resolveDumpSourceUsing($callable)

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -7,7 +7,7 @@ trait ResolvesDumpSource
     /**
      * The source resolver.
      *
-     * @var callable(): (array{0: string, 1: string, 2: int}|null)
+     * @var (callable(): (array{0: string, 1: string, 2: int}|null))|null
      */
     protected static $dumpSourceResolver;
 

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Foundation\Concerns;
+
+trait ResolvesDumpSource
+{
+    /**
+     * The source resolver.
+     *
+     * @var callable(): (array{0: string, 1: string: 2: int}|null)
+     */
+    protected static $dumpSourceResolver;
+
+    /**
+     * Resolves the source of the dump call.
+     *
+     * @return array{0: string, 1: string: 2: int}|null
+     */
+    public function resolveDumpSource()
+    {
+        if (static::$dumpSourceResolver) {
+            return call_user_func(static::$dumpSourceResolver);
+        }
+
+        $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 20);
+
+        $file = $trace[7]['file'] ?? null;
+        $line = $trace[7]['line'] ?? null;
+
+        if (is_null($file) || is_null($line)) {
+            return;
+        }
+
+        $relativeFile = $file;
+
+        if (str_starts_with($file, $this->basePath)) {
+            $relativeFile = substr($file, strlen($this->basePath) + 1);
+        }
+
+        return [$file, $relativeFile, $line];
+    }
+
+    /**
+     * Sets the resolver that resolves the source of the dump call.
+     *
+     * @param  (callable(): (array{0: string, 1: string: 2: int}|null))|null  $callable
+     * @return void
+     */
+    public static function resolveDumpSourceUsing($callable)
+    {
+        static::$dumpSourceResolver = $callable;
+    }
+}

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -36,7 +36,7 @@ class CliDumper extends BaseCliDumper
     protected $dumping = false;
 
     /**
-     * Creates a new Cli Dumper instance.
+     * Create a new CLI dumper instance.
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  string  $basePath
@@ -51,7 +51,7 @@ class CliDumper extends BaseCliDumper
     }
 
     /**
-     * Creates a new Cli Dumper instance, and registers it as the default dumper.
+     * Create a new CLI dumper instance and register it as the default dumper.
      *
      * @param  string  $basePath
      * @return void
@@ -66,7 +66,7 @@ class CliDumper extends BaseCliDumper
     }
 
     /**
-     * Dumps a variable with its source file/line.
+     * Dump a variable with its source file / line.
      *
      * @param  \Symfony\Component\VarDumper\Cloner\Data  $data
      * @return void
@@ -82,7 +82,6 @@ class CliDumper extends BaseCliDumper
         $this->dumping = true;
 
         $output = (string) $this->dump($data, true);
-
         $lines = explode("\n", $output);
 
         $lines[0] .= $this->getDumpSourceContent();
@@ -93,15 +92,7 @@ class CliDumper extends BaseCliDumper
     }
 
     /**
-     * {@inheritDoc}
-     */
-    protected function supportsColors(): bool
-    {
-        return $this->output->isDecorated();
-    }
-
-    /**
-     * Gets the dump's source console content.
+     * Get the dump's source console content.
      *
      * @return string
      */
@@ -114,5 +105,13 @@ class CliDumper extends BaseCliDumper
         [$file, $relativeFile, $line] = $dumpSource;
 
         return sprintf(' <fg=gray>// <fg=gray;href=file://%s#L%s>%s:%s</></>', $file, $line, $relativeFile, $line);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function supportsColors(): bool
+    {
+        return $this->output->isDecorated();
     }
 }

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Console;
 
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\VarDumper\Caster\ReflectionCaster;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\VarCloner;

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -29,11 +29,11 @@ class CliDumper extends BaseCliDumper
     /**
      * Creates a new Cli Dumper instance.
      *
-     * @param  string  $basePath
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @param  string  $basePath
      * @return void
      */
-    public function __construct($basePath, $output)
+    public function __construct($output, $basePath)
     {
         parent::__construct();
 
@@ -50,9 +50,8 @@ class CliDumper extends BaseCliDumper
     public static function register($basePath)
     {
         $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
-        $output = new ConsoleOutput(OutputInterface::VERBOSITY_NORMAL);
 
-        $dumper = new static($basePath, $output);
+        $dumper = new static(new ConsoleOutput(), $basePath);
 
         VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
     }

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper as BaseCliDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+class CliDumper extends BaseCliDumper
+{
+    /**
+     * The base path of the application.
+     *
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * The output instance.
+     *
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected $output;
+
+    /**
+     * Creates a new Cli Dumper instance.
+     *
+     * @param  string  $basePath
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    public function __construct($basePath, $output)
+    {
+        parent::__construct();
+
+        $this->basePath = $basePath;
+        $this->output = $output;
+    }
+
+    /**
+     * Creates a new Cli Dumper instance, and registers it as the default dumper.
+     *
+     * @param  string  $basePath
+     * @return void
+     */
+    public static function register($basePath)
+    {
+        $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+        $output = new ConsoleOutput(OutputInterface::VERBOSITY_NORMAL);
+
+        $dumper = new static($basePath, $output);
+
+        VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
+    }
+
+    /**
+     * Dumps a variable with its source file/line.
+     *
+     * @param  \Symfony\Component\VarDumper\Cloner\Data  $data
+     * @return void
+     */
+    public function dumpWithSource(Data $data)
+    {
+        $output = (string) $this->dump($data, true);
+
+        $lines = explode("\n", $output);
+
+        $lines[0] .= $this->displayableDumpSource();
+
+        $this->output->write(implode("\n", $lines));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function supportsColors(): bool
+    {
+        return $this->output->isDecorated();
+    }
+
+    /**
+     * Gets a console "displayble" source for the dump.
+     *
+     * @return string
+     */
+    protected function displayableDumpSource()
+    {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 20);
+
+        $file = $trace[6]['file'] ?? null;
+        $line = $trace[6]['line'] ?? null;
+
+        if (is_null($file) || is_null($line)) {
+            return '';
+        }
+
+        $relativeFile = $file;
+
+        if (str_starts_with($file, $this->basePath)) {
+            $relativeFile = substr($file, strlen($this->basePath) + 1);
+        }
+
+        return sprintf(' <fg=gray>// <fg=gray;href=file://%s#L%s>%s:%s</></>', $file, $line, $relativeFile, $line);
+    }
+}

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -29,6 +29,13 @@ class CliDumper extends BaseCliDumper
     protected $output;
 
     /**
+     * If the dumper is currently dumping.
+     *
+     * @var bool
+     */
+    protected $dumping = false;
+
+    /**
      * Creates a new Cli Dumper instance.
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
@@ -66,6 +73,14 @@ class CliDumper extends BaseCliDumper
      */
     public function dumpWithSource(Data $data)
     {
+        if ($this->dumping) {
+            $this->dump($data);
+
+            return;
+        }
+
+        $this->dumping = true;
+
         $output = (string) $this->dump($data, true);
 
         $lines = explode("\n", $output);
@@ -73,6 +88,8 @@ class CliDumper extends BaseCliDumper
         $lines[0] .= $this->getDumpSourceContent();
 
         $this->output->write(implode("\n", $lines));
+
+        $this->dumping = false;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -16,11 +16,15 @@ class HtmlDumper extends BaseHtmlDumper
 
     /**
      * Where the source should be placed on "expanded" kind of dumps.
+     *
+     * @var string
      */
     const EXPANDED_SEPARATOR = 'class=sf-dump-expanded>';
 
     /**
      * Where the source should be placed on "non expanded" kind of dumps.
+     *
+     * @var string
      */
     const NON_EXPANDED_SEPARATOR = "\n</pre><script>";
 
@@ -39,7 +43,7 @@ class HtmlDumper extends BaseHtmlDumper
     protected $dumping = false;
 
     /**
-     * Creates a new Html Dumper instance.
+     * Create a new HTML dumper instance.
      *
      * @param  string  $basePath
      * @return void
@@ -52,7 +56,7 @@ class HtmlDumper extends BaseHtmlDumper
     }
 
     /**
-     * Creates a new Html Dumper instance, and registers it as the default dumper.
+     * Create a new HTML dumper instance and register it as the default dumper.
      *
      * @param  string  $basePath
      * @return void
@@ -67,7 +71,7 @@ class HtmlDumper extends BaseHtmlDumper
     }
 
     /**
-     * Dumps a variable with its source file/line.
+     * Dump a variable with its source file / line.
      *
      * @param  \Symfony\Component\VarDumper\Cloner\Data  $data
      * @return void
@@ -104,7 +108,7 @@ class HtmlDumper extends BaseHtmlDumper
     }
 
     /**
-     * Gets the dump's source html content.
+     * Get the dump's source HTML content.
      *
      * @return string
      */
@@ -132,7 +136,7 @@ class HtmlDumper extends BaseHtmlDumper
     }
 
     /**
-     * Gets the application editor, if any.
+     * Get the application editor, if applicable.
      *
      * @return string|null
      */

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -79,7 +79,7 @@ class HtmlDumper extends BaseHtmlDumper
             ),
             default => $output,
         };
-        
+
         fwrite($this->outputStream, $output);
     }
 

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Illuminate\Foundation\Http;
+
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper as BaseHtmlDumper;
+use Symfony\Component\VarDumper\VarDumper;
+use Throwable;
+
+class HtmlDumper extends BaseHtmlDumper
+{
+    /**
+     * Where the source should be placed on "expanded" kind of dumps.
+     */
+    const EXPANDED_SEPARATOR = 'data-depth=1 class=sf-dump-expanded>';
+
+    /**
+     * Where the source should be placed on "non expanded" kind of dumps.
+     */
+    const NON_EXPANDED_SEPARATOR = "\n</pre><script>";
+
+    /**
+     * The base path of the application.
+     *
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * Creates a new Html Dumper instance.
+     *
+     * @param  string  $basePath
+     * @return void
+     */
+    public function __construct($basePath)
+    {
+        parent::__construct();
+
+        $this->basePath = $basePath;
+    }
+
+    /**
+     * Creates a new Html Dumper instance, and registers it as the default dumper.
+     *
+     * @param  string  $basePath
+     * @return void
+     */
+    public static function register($basePath)
+    {
+        $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+
+        $dumper = new static($basePath);
+
+        VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
+    }
+
+    /**
+     * Dumps a variable with its source file/line.
+     *
+     * @param  \Symfony\Component\VarDumper\Cloner\Data  $data
+     * @return void
+     */
+    public function dumpWithSource(Data $data)
+    {
+        $output = $this->dump($data, true);
+
+        $output = match (true) {
+            str_contains($output, static::EXPANDED_SEPARATOR) => str_replace(
+                static::EXPANDED_SEPARATOR,
+                static::EXPANDED_SEPARATOR.$this->displayableDumpSource(),
+                $output,
+            ),
+            str_contains($output, static::NON_EXPANDED_SEPARATOR) => str_replace(
+                static::NON_EXPANDED_SEPARATOR,
+                $this->displayableDumpSource().static::NON_EXPANDED_SEPARATOR,
+                $output,
+            ),
+            default => $output,
+        };
+        
+        fwrite($this->outputStream, $output);
+    }
+
+    /**
+     * Gets a console "displayble" source for the dump.
+     *
+     * @return string
+     */
+    protected function displayableDumpSource()
+    {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 20);
+
+        $file = $trace[6]['file'] ?? null;
+        $line = $trace[6]['line'] ?? null;
+
+        if (is_null($file) || is_null($line)) {
+            return '';
+        }
+
+        $relativeFile = $file;
+
+        if (str_starts_with($file, $this->basePath)) {
+            $relativeFile = substr($file, strlen($this->basePath) + 1);
+        }
+
+        $source = sprintf('%s:%s', $relativeFile, $line);
+
+        if ($editor = $this->editor()) {
+            $source = sprintf(
+                '<a href="%s://open?file=%s&line=%s">%s</a>',
+                $editor,
+                $file,
+                $line,
+                $source,
+            );
+        }
+
+        return sprintf('<span style="color: #A0A0A0; font-family: Menlo"> // %s</span>', $source);
+    }
+
+    /**
+     * Gets the application editor, if any.
+     *
+     * @return string|null
+     */
+    protected function editor()
+    {
+        try {
+            return config('app.editor');
+        } catch (Throwable $e) {
+            // ...
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -32,6 +32,13 @@ class HtmlDumper extends BaseHtmlDumper
     protected $basePath;
 
     /**
+     * If the dumper is currently dumping.
+     *
+     * @var bool
+     */
+    protected $dumping = false;
+
+    /**
      * Creates a new Html Dumper instance.
      *
      * @param  string  $basePath
@@ -67,6 +74,14 @@ class HtmlDumper extends BaseHtmlDumper
      */
     public function dumpWithSource(Data $data)
     {
+        if ($this->dumping) {
+            $this->dump($data);
+
+            return;
+        }
+
+        $this->dumping = true;
+
         $output = (string) $this->dump($data, true);
 
         $output = match (true) {
@@ -84,6 +99,8 @@ class HtmlDumper extends BaseHtmlDumper
         };
 
         fwrite($this->outputStream, $output);
+
+        $this->dumping = false;
     }
 
     /**
@@ -121,8 +138,6 @@ class HtmlDumper extends BaseHtmlDumper
      */
     protected function editor()
     {
-        // TODO: Spatie\Ignition\Config\IgnitionConfig::loadFromConfigFile()->editor
-
         try {
             return config('app.editor');
         } catch (Throwable $e) {

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -17,7 +17,7 @@ class HtmlDumper extends BaseHtmlDumper
     /**
      * Where the source should be placed on "expanded" kind of dumps.
      */
-    const EXPANDED_SEPARATOR = 'data-depth=1 class=sf-dump-expanded>';
+    const EXPANDED_SEPARATOR = 'class=sf-dump-expanded>';
 
     /**
      * Where the source should be placed on "non expanded" kind of dumps.

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -64,7 +64,7 @@ class HtmlDumper extends BaseHtmlDumper
      */
     public function dumpWithSource(Data $data)
     {
-        $output = $this->dump($data, true);
+        $output = (string) $this->dump($data, true);
 
         $output = match (true) {
             str_contains($output, static::EXPANDED_SEPARATOR) => str_replace(

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
+use Illuminate\Foundation\Console\CliDumper;
 use Illuminate\Foundation\MaintenanceModeManager;
 use Illuminate\Foundation\Vite;
 use Illuminate\Http\Request;
@@ -57,10 +58,30 @@ class FoundationServiceProvider extends AggregateServiceProvider
     {
         parent::register();
 
+        $this->registerDumper();
         $this->registerRequestValidation();
         $this->registerRequestSignatureValidation();
         $this->registerExceptionTracking();
         $this->registerMaintenanceModeManager();
+    }
+
+    /**
+     * Register an var dumper (with source) to debug variables.
+     *
+     * @return void
+     */
+    public function registerDumper()
+    {
+        $basePath = $this->app->basePath();
+        $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? null;
+
+        match (true) {
+            'html' == $format => null,
+            'cli' == $format => CliDumper::register($basePath),
+            'server' == $format => null,
+            $format && 'tcp' == parse_url($format, PHP_URL_SCHEME) => null,
+            default => in_array(PHP_SAPI, ['cli', 'phpdbg']) ? CliDumper::register($basePath) : null,
+        };
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
 use Illuminate\Foundation\Console\CliDumper;
+use Illuminate\Foundation\Http\HtmlDumper;
 use Illuminate\Foundation\MaintenanceModeManager;
 use Illuminate\Foundation\Vite;
 use Illuminate\Http\Request;
@@ -76,11 +77,11 @@ class FoundationServiceProvider extends AggregateServiceProvider
         $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? null;
 
         match (true) {
-            'html' == $format => null,
+            'html' == $format => HtmlDumper::register($basePath),
             'cli' == $format => CliDumper::register($basePath),
             'server' == $format => null,
             $format && 'tcp' == parse_url($format, PHP_URL_SCHEME) => null,
-            default => in_array(PHP_SAPI, ['cli', 'phpdbg']) ? CliDumper::register($basePath) : null,
+            default => in_array(PHP_SAPI, ['cli', 'phpdbg']) ? CliDumper::register($basePath) : HtmlDumper::register($basePath),
         };
     }
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -74,6 +74,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     public function registerDumper()
     {
         $basePath = $this->app->basePath();
+
         $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? null;
 
         match (true) {

--- a/tests/Foundation/Console/CliDumperTest.php
+++ b/tests/Foundation/Console/CliDumperTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Console;
+
+use Illuminate\Foundation\Console\CliDumper;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+
+class CliDumperTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        CliDumper::resolveDumpSourceUsing(function () {
+            return [
+                '/my-work-director/app/routes/console.php',
+                'app/routes/console.php',
+                18,
+            ];
+        });
+    }
+
+    public function testString()
+    {
+        $output = $this->dump('string');
+
+        $expected = "\"string\" // app/routes/console.php:18\n";
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testInteger()
+    {
+        $output = $this->dump(1);
+
+        $expected = "1 // app/routes/console.php:18\n";
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testFloat()
+    {
+        $output = $this->dump(1.1);
+
+        $expected = "1.1 // app/routes/console.php:18\n";
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testArray()
+    {
+        $output = $this->dump(['string', 1, 1.1, ['string', 1, 1.1]]);
+
+        $expected = <<<'EOF'
+        array:4 [ // app/routes/console.php:18
+          0 => "string"
+          1 => 1
+          2 => 1.1
+          3 => array:3 [
+            0 => "string"
+            1 => 1
+            2 => 1.1
+          ]
+        ]
+
+        EOF;
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testBoolean()
+    {
+        $output = $this->dump(true);
+
+        $expected = "true // app/routes/console.php:18\n";
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testObject()
+    {
+        $user = new stdClass();
+        $user->name = 'Guus';
+
+        $output = $this->dump($user);
+
+        $objectId = spl_object_id($user);
+
+        $expected = <<<EOF
+        {#$objectId // app/routes/console.php:18
+          +"name": "Guus"
+        }
+
+        EOF;
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testNull()
+    {
+        $output = $this->dump(null);
+
+        $expected = "null // app/routes/console.php:18\n";
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testUnresolvableSource()
+    {
+        CliDumper::resolveDumpSourceUsing(fn () => null);
+
+        $output = $this->dump('string');
+
+        $expected = "\"string\"\n";
+
+        $this->assertSame($expected, $output);
+    }
+
+    protected function dump($value)
+    {
+        $output = new BufferedOutput();
+        $dumper = new CliDumper($output, '/my-work-directory');
+
+        $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+
+        $dumper->dumpWithSource($cloner->cloneVar($value));
+
+        return $output->fetch();
+    }
+
+    protected function tearDown(): void
+    {
+        CliDumper::resolveDumpSourceUsing(null);
+    }
+}

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http;
+
+use Illuminate\Foundation\Http\HtmlDumper;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+
+class HtmlDumperTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        HtmlDumper::resolveDumpSourceUsing(function () {
+            return [
+                '/my-work-director/app/routes/console.php',
+                'app/routes/console.php',
+                18,
+            ];
+        });
+    }
+
+    public function testString()
+    {
+        $output = $this->dump('string');
+
+        $expected = "string</span>\"<span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    public function testInteger()
+    {
+        $output = $this->dump(1);
+
+        $expected = "1</span><span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    public function testFloat()
+    {
+        $output = $this->dump(1.1);
+
+        $expected = "1.1</span><span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    public function testArray()
+    {
+        $output = $this->dump(['string', 1, 1.1, ['string', 1, 1.1]]);
+
+        $expected = '<samp data-depth=1 class=sf-dump-expanded><span style="color: #A0A0A0; font-family: Menlo"> // app/routes/console.php:18</span>';
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    public function testBoolean()
+    {
+        $output = $this->dump(true);
+
+        $expected = "true</span><span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    public function testObject()
+    {
+        $user = new stdClass();
+        $user->name = 'Guus';
+
+        $output = $this->dump($user);
+
+        $expected = '<samp data-depth=1 class=sf-dump-expanded><span style="color: #A0A0A0; font-family: Menlo"> // app/routes/console.php:18</span>';
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    public function testNull()
+    {
+        $output = $this->dump(null);
+
+        $expected = "null</span><span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    public function testUnresolvableSource()
+    {
+        HtmlDumper::resolveDumpSourceUsing(fn () => null);
+
+        $output = $this->dump('string');
+
+        $expected = "string</span>\"\n</pre>";
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    protected function dump($value)
+    {
+        $outputFile = stream_get_meta_data(tmpfile())['uri'];
+
+        $dumper = new HtmlDumper('/my-work-directory');
+        $dumper->setOutput($outputFile);
+
+        $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+
+        $dumper->dumpWithSource($cloner->cloneVar($value));
+
+        return tap(file_get_contents($outputFile), fn () => @unlink($outputFile));
+    }
+
+    protected function tearDown(): void
+    {
+        HtmlDumper::resolveDumpSourceUsing(null);
+    }
+}


### PR DESCRIPTION
This pull request improves the `dd` output by adding the source file/line to the `dd` output.

It's very common to use `dd` while developing Laravel applications and forget about the original place where the `dd` was left. So, this pull request solves that, by adding a **very minimal** gray text with the source file/line:

<img width="981" alt="Screenshot 2022-09-19 at 18 03 47" src="https://user-images.githubusercontent.com/5457236/191073279-a61b7408-a147-4d29-a924-2cc582345b28.png">

This improvement also works on the HTTP layer, and any `dd` call on the browser will look like so:

<img width="893" alt="Screenshot 2022-09-20 at 12 34 56" src="https://user-images.githubusercontent.com/5457236/191247499-8df2ff20-d266-4b12-85e2-782bdbb98ed3.png">

In addition, if the `app.editor` configuration is defined, the source link will be clickable:

<img width="865" alt="Screenshot 2022-09-20 at 12 35 56" src="https://user-images.githubusercontent.com/5457236/191247627-b6af84f8-8f17-43bf-ac50-5ce0fde44035.png">