### PR TITLE
[9.x] Adds support for ltree when inspecting Postrges databases

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -28,6 +28,7 @@ abstract class DatabaseInspectionCommand extends Command
         'geometry' => 'string',
         'geomcollection' => 'string',
         'linestring' => 'string',
+        'ltree' => 'string',
         'multilinestring' => 'string',
         'multipoint' => 'string',
         'multipolygon' => 'string',


### PR DESCRIPTION
This PR resolves #44213 

DBAL does not have support for the ltree column type, so this PR maps it to a string as has been done with other unsupported types.