### PR TITLE
fixed: multiple route cache loading

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -105,7 +105,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function loadCachedRoutes()
     {
         $this->app->booted(function () {
-            require $this->app->getCachedRoutesPath();
+            require_once $this->app->getCachedRoutesPath();
         });
     }
 


### PR DESCRIPTION
Used this:
```php
protected function loadCachedRoutes()
    {
        $this->app->booted(function () {
            $key = 'Routes: ' . static::class;
            \BeyondCode\ServerTiming\Facades\ServerTiming::start($key);
            require $this->app->getCachedRoutesPath();
            \BeyondCode\ServerTiming\Facades\ServerTiming::stop($key);
        });
    }
```
And discovered that some packages use extended `RouteServiceProvider` therefore route cache included multiple times:
![image](https://user-images.githubusercontent.com/32728904/191353520-aa6aac74-56ff-40d0-8a3b-d4e9e0e0e753.png)

Since route cache uses heavy function calls better to include it only once.