### PR TITLE
flushable routes cache

### DIFF
--- a/src/Illuminate/Contracts/Foundation/CachesRoutes.php
+++ b/src/Illuminate/Contracts/Foundation/CachesRoutes.php
@@ -17,4 +17,18 @@ interface CachesRoutes
      * @return string
      */
     public function getCachedRoutesPath();
+
+    /**
+     * Check if the routes cache file loaded.
+     *
+     * @return bool
+     */
+    public function isCachedRoutesLoaded();
+
+    /**
+     * Load the routes cache file.
+     *
+     * @return void
+     */
+    public function loadCachedRoutes();
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -62,6 +62,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $booted = false;
 
     /**
+     * Indicates if the routes cache has loaded.
+     *
+     * @var bool
+     */
+    protected $isRoutesCacheLoaded = false;
+
+    /**
      * The array of booting callbacks.
      *
      * @var callable[]
@@ -1061,6 +1068,28 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Check if the routes cache file loaded.
+     *
+     * @return bool
+     */
+    public function isCachedRoutesLoaded()
+    {
+        return $this->isRoutesCacheLoaded;
+    }
+
+    /**
+     * Load the routes cache file.
+     *
+     * @return void
+     */
+    public function loadCachedRoutes()
+    {
+        require $this->getCachedRoutesPath();
+
+        $this->isCachedRoutesLoaded = true;
+    }
+
+    /**
      * Determine if the application events are cached.
      *
      * @return bool
@@ -1401,6 +1430,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->globalBeforeResolvingCallbacks = [];
         $this->globalResolvingCallbacks = [];
         $this->globalAfterResolvingCallbacks = [];
+
+        $this->isCachedRoutesLoaded = false;
     }
 
     /**

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -105,7 +105,9 @@ class RouteServiceProvider extends ServiceProvider
     protected function loadCachedRoutes()
     {
         $this->app->booted(function () {
-            require $this->app->getCachedRoutesPath();
+            if (!$this->app->isCachedRoutesLoaded()) {
+                $this->app->loadCachedRoutes();
+            }
         });
     }
 

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -15,6 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool isLocal()
  * @method static bool isProduction()
  * @method static bool routesAreCached()
+ * @method static bool isCachedRoutesLoaded()
  * @method static bool runningInConsole()
  * @method static bool runningUnitTests()
  * @method static bool shouldSkipMiddleware()
@@ -48,6 +49,7 @@ namespace Illuminate\Support\Facades;
  * @method static void registerDeferredProvider(string $provider, string $service = null)
  * @method static void setLocale(string $locale)
  * @method static void terminate()
+ * @method static void loadCachedRoutes()
  *
  * @see \Illuminate\Contracts\Foundation\Application
  */


### PR DESCRIPTION
Prevents multiple loading when application has multiple `RouteServiceProvider` classes.

Related with #44221

@taylorotwell what about this approach? This way should be possible to reload routes cache.