### PR TITLE
[10.x] Fix: select maximum supported timestamp precision

### DIFF
--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -4,14 +4,12 @@ namespace Illuminate\Database\DBAL;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MariaDb1027Platform;
-use Doctrine\DBAL\Platforms\MySQL57Platform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
-use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\DBAL\Types\Type;
 
@@ -26,12 +24,10 @@ class TimestampType extends Type implements PhpDateTimeMappingType
     {
         return match (get_class($platform)) {
             MySQLPlatform::class,
-            MySQL57Platform::class,
             MySQL80Platform::class,
-            MariaDb1027Platform::class => $this->getMySqlPlatformSQLDeclaration($column),
-            PostgreSQL94Platform::class,
-            PostgreSQL100Platform::class => $this->getPostgresPlatformSQLDeclaration($column),
-            SQLServer2012Platform::class => $this->getSqlServerPlatformSQLDeclaration($column),
+            MariaDBPlatform::class => $this->getMySqlPlatformSQLDeclaration($column),
+            PostgreSQLPlatform::class => $this->getPostgresPlatformSQLDeclaration($column),
+            SQLServerPlatform::class => $this->getSqlServerPlatformSQLDeclaration($column),
             SqlitePlatform::class => 'DATETIME',
             default => throw new DBALException('Invalid platform: '. substr(strrchr(get_class($platform), '\\'), 1)),
         };

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -39,7 +39,7 @@ class TimestampType extends Type implements PhpDateTimeMappingType
             SQLServerPlatform::class,
             SQLServer2012Platform::class => $this->getSqlServerPlatformSQLDeclaration($column),
             SqlitePlatform::class => 'DATETIME',
-            default => throw new DBALException('Invalid platform: '. substr(strrchr(get_class($platform), '\\'), 1)),
+            default => throw new DBALException('Invalid platform: '.substr(strrchr(get_class($platform), '\\'), 1)),
         };
     }
 

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -4,11 +4,16 @@ namespace Illuminate\Database\DBAL;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\DBAL\Types\Type;
@@ -24,10 +29,15 @@ class TimestampType extends Type implements PhpDateTimeMappingType
     {
         return match (get_class($platform)) {
             MySQLPlatform::class,
+            MySQL57Platform::class,
             MySQL80Platform::class,
-            MariaDBPlatform::class => $this->getMySqlPlatformSQLDeclaration($column),
-            PostgreSQLPlatform::class => $this->getPostgresPlatformSQLDeclaration($column),
-            SQLServerPlatform::class => $this->getSqlServerPlatformSQLDeclaration($column),
+            MariaDBPlatform::class,
+            MariaDb1027Platform::class => $this->getMySqlPlatformSQLDeclaration($column),
+            PostgreSQLPlatform::class,
+            PostgreSQL94Platform::class,
+            PostgreSQL100Platform::class => $this->getPostgresPlatformSQLDeclaration($column),
+            SQLServerPlatform::class,
+            SQLServer2012Platform::class => $this->getSqlServerPlatformSQLDeclaration($column),
             SqlitePlatform::class => 'DATETIME',
             default => throw new DBALException('Invalid platform: '. substr(strrchr(get_class($platform), '\\'), 1)),
         };

--- a/src/Illuminate/Database/DBAL/TimestampType.php
+++ b/src/Illuminate/Database/DBAL/TimestampType.php
@@ -4,6 +4,14 @@ namespace Illuminate\Database\DBAL;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Platforms\MySQL57Platform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Types\PhpDateTimeMappingType;
 use Doctrine\DBAL\Types\Type;
 
@@ -11,37 +19,39 @@ class TimestampType extends Type implements PhpDateTimeMappingType
 {
     /**
      * {@inheritdoc}
+     *
+     * @throws DBALException
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return match ($name = $platform->getName()) {
-            'mysql',
-            'mysql2' => $this->getMySqlPlatformSQLDeclaration($fieldDeclaration),
-            'postgresql',
-            'pgsql',
-            'postgres' => $this->getPostgresPlatformSQLDeclaration($fieldDeclaration),
-            'mssql' => $this->getSqlServerPlatformSQLDeclaration($fieldDeclaration),
-            'sqlite',
-            'sqlite3' => $this->getSQLitePlatformSQLDeclaration($fieldDeclaration),
-            default => throw new DBALException('Invalid platform: '.$name),
+        return match (get_class($platform)) {
+            MySQLPlatform::class,
+            MySQL57Platform::class,
+            MySQL80Platform::class,
+            MariaDb1027Platform::class => $this->getMySqlPlatformSQLDeclaration($column),
+            PostgreSQL94Platform::class,
+            PostgreSQL100Platform::class => $this->getPostgresPlatformSQLDeclaration($column),
+            SQLServer2012Platform::class => $this->getSqlServerPlatformSQLDeclaration($column),
+            SqlitePlatform::class => 'DATETIME',
+            default => throw new DBALException('Invalid platform: '. substr(strrchr(get_class($platform), '\\'), 1)),
         };
     }
 
     /**
      * Get the SQL declaration for MySQL.
      *
-     * @param  array  $fieldDeclaration
+     * @param  array  $column
      * @return string
      */
-    protected function getMySqlPlatformSQLDeclaration(array $fieldDeclaration)
+    protected function getMySqlPlatformSQLDeclaration(array $column): string
     {
         $columnType = 'TIMESTAMP';
 
-        if ($fieldDeclaration['precision']) {
-            $columnType = 'TIMESTAMP('.$fieldDeclaration['precision'].')';
+        if ($column['precision']) {
+            $columnType = 'TIMESTAMP('.min((int) $column['precision'], 6).')';
         }
 
-        $notNull = $fieldDeclaration['notnull'] ?? false;
+        $notNull = $column['notnull'] ?? false;
 
         if (! $notNull) {
             return $columnType.' NULL';
@@ -53,36 +63,25 @@ class TimestampType extends Type implements PhpDateTimeMappingType
     /**
      * Get the SQL declaration for PostgreSQL.
      *
-     * @param  array  $fieldDeclaration
+     * @param  array  $column
      * @return string
      */
-    protected function getPostgresPlatformSQLDeclaration(array $fieldDeclaration)
+    protected function getPostgresPlatformSQLDeclaration(array $column): string
     {
-        return 'TIMESTAMP('.(int) $fieldDeclaration['precision'].')';
+        return 'TIMESTAMP('.min((int) $column['precision'], 6).')';
     }
 
     /**
      * Get the SQL declaration for SQL Server.
      *
-     * @param  array  $fieldDeclaration
+     * @param  array  $column
      * @return string
      */
-    protected function getSqlServerPlatformSQLDeclaration(array $fieldDeclaration)
+    protected function getSqlServerPlatformSQLDeclaration(array $column): string
     {
-        return $fieldDeclaration['precision'] ?? false
-                    ? 'DATETIME2('.$fieldDeclaration['precision'].')'
-                    : 'DATETIME';
-    }
-
-    /**
-     * Get the SQL declaration for SQLite.
-     *
-     * @param  array  $fieldDeclaration
-     * @return string
-     */
-    protected function getSQLitePlatformSQLDeclaration(array $fieldDeclaration)
-    {
-        return 'DATETIME';
+        return $column['precision'] ?? false
+            ? 'DATETIME2('.min((int) $column['precision'], 7).')'
+            : 'DATETIME';
     }
 
     /**

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -397,7 +397,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             // Expecting something similar to:
             // Illuminate\Database\QueryException
             //   SQLSTATE[42000]: Syntax error or access violation: 1426 Too big precision 10 specified for 'my_timestamp'. Maximum is 6....
-            $this->fail('test_it_does_not_set_precision_higher_than_supported_when_renaming_timestamps has failed. Error: ' . $e->getMessage());
+            $this->fail('test_it_does_not_set_precision_higher_than_supported_when_renaming_timestamps has failed. Error: '.$e->getMessage());
         }
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -381,6 +381,26 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         });
     }
 
+    public function testItDoesNotSetPrecisionHigherThanSupportedWhenRenamingTimestamps()
+    {
+        $this->db->connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
+            $table->timestamp('created_at');
+        });
+
+        try {
+            // this would only fail in mysql, postgres and sql server
+            $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+                $table->renameColumn('created_at', 'new_created_at');
+            });
+            $this->addToAssertionCount(1); // it did not throw
+        } catch (\Exception $e) {
+            // Expecting something similar to:
+            // Illuminate\Database\QueryException
+            //   SQLSTATE[42000]: Syntax error or access violation: 1426 Too big precision 10 specified for 'my_timestamp'. Maximum is 6....
+            $this->fail('test_it_does_not_set_precision_higher_than_supported_when_renaming_timestamps has failed. Error: ' . $e->getMessage());
+        }
+    }
+
     public function testItEnsuresDroppingForeignKeyIsAvailable()
     {
         $this->expectException(BadMethodCallException::class);


### PR DESCRIPTION
Targeting master as did not get a response to https://github.com/laravel/framework/pull/43535#issuecomment-1223161842

On the latest version (9.23.0) when renaming a timestamp column, it does not correctly gets the precision when using the `TIMESTAMP()` function in the generated alter statement. `$table->renameColumn('created_at', 'old_created_at');` would result something similar to:
```
Illuminate\Database\QueryException
SQLSTATE[42000]: Syntax error or access violation: 1426 Too big precision 10 specified for 'old_created_at'. Maximum is 6....
```

To replicate, rename a timestamp while using sql server, postgres or mysql.

**NOTE:** In testing, I cannot replicate the issue as the test suit seems to be ran with sqlite which ignores the precision and uses `DATETIME`. If the testing workflow also run the tests using the above platforms, then they won't fail due to my changes and this was not covered before. In any case my migration now succesfully runs after this change.

This PR ensures when the inferred precision value is higher than what the platform supports, it defaults back to the highest supported value.

Rest of the changes are updates advised by deprecations (using classnames as oppoed to deprecated `->getName()` and match the abstract function's argument name).

Issue where this was previously reported: https://github.com/laravel/framework/issues/43535