### PR TITLE
[9.x] Adds Eloquent User Provider query handler

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -25,11 +25,11 @@ class EloquentUserProvider implements UserProvider
     protected $model;
 
     /**
-     * The callback to modify the query to find the user.
+     * The callback that may modify the user retrieval queries.
      *
      * @var (\Closure(\Illuminate\Database\Eloquent\Builder):mixed)|null
      */
-    protected $queryHandler;
+    protected $queryCallback;
 
     /**
      * Create a new database user provider.
@@ -166,7 +166,7 @@ class EloquentUserProvider implements UserProvider
                 ? $this->createModel()->newQuery()
                 : $model->newQuery();
 
-        with($query, $this->queryHandler);
+        with($query, $this->queryCallback);
 
         return $query;
     }
@@ -230,24 +230,24 @@ class EloquentUserProvider implements UserProvider
     }
 
     /**
-     * Gets the callback to modify the query before retrieving the user.
+     * Get the callback that modifies the query before retrieving users.
      *
-     * @return \Closure
+     * @return \Closure|null
      */
-    public function getQueryHandler()
+    public function getQueryCallback()
     {
-        return $this->queryHandler;
+        return $this->queryCallback;
     }
 
     /**
-     * Sets or removes a callback to modify the query before retrieving the user.
+     * Sets the callback to modify the query before retrieving users.
      *
-     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder):mixed)|null  $queryHandler
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder):mixed)|null  $queryCallback
      * @return $this
      */
-    public function setQueryHandler($queryHandler = null)
+    public function withQuery($queryCallback = null)
     {
-        $this->queryHandler = $queryHandler;
+        $this->queryCallback = $queryCallback;
 
         return $this;
     }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -25,6 +25,13 @@ class EloquentUserProvider implements UserProvider
     protected $model;
 
     /**
+     * The callback to modify the query to find the user.
+     *
+     * @var (\Closure(\Illuminate\Database\Eloquent\Builder):mixed)|null
+     */
+    protected $queryHandler;
+
+    /**
      * Create a new database user provider.
      *
      * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
@@ -155,9 +162,13 @@ class EloquentUserProvider implements UserProvider
      */
     protected function newModelQuery($model = null)
     {
-        return is_null($model)
+        $query = is_null($model)
                 ? $this->createModel()->newQuery()
                 : $model->newQuery();
+
+        with($query, $this->queryHandler);
+
+        return $query;
     }
 
     /**
@@ -214,6 +225,29 @@ class EloquentUserProvider implements UserProvider
     public function setModel($model)
     {
         $this->model = $model;
+
+        return $this;
+    }
+
+    /**
+     * Gets the callback to modify the query before retrieving the user.
+     *
+     * @return \Closure
+     */
+    public function getQueryHandler()
+    {
+        return $this->queryHandler;
+    }
+
+    /**
+     * Sets or removes a callback to modify the query before retrieving the user.
+     *
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder):mixed)|null  $queryHandler
+     * @return $this
+     */
+    public function setQueryHandler($queryHandler = null)
+    {
+        $this->queryHandler = $queryHandler;
 
         return $this;
     }

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -11,8 +11,6 @@ use RuntimeException;
  * @method static \Illuminate\Contracts\Auth\Authenticatable loginUsingId(mixed $id, bool $remember = false)
  * @method static \Illuminate\Contracts\Auth\Authenticatable|null user()
  * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard guard(string|null $name = null)
- * @method static \Closure|null getQueryHandler()
- * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard setQueryHandler(\Closure $queryHandler = null)
  * @method static \Illuminate\Contracts\Auth\UserProvider|null createUserProvider(string $provider = null)
  * @method static \Symfony\Component\HttpFoundation\Response|null onceBasic(string $field = 'email',array $extraConditions = [])
  * @method static bool attempt(array $credentials = [], bool $remember = false)

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -11,6 +11,8 @@ use RuntimeException;
  * @method static \Illuminate\Contracts\Auth\Authenticatable loginUsingId(mixed $id, bool $remember = false)
  * @method static \Illuminate\Contracts\Auth\Authenticatable|null user()
  * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard guard(string|null $name = null)
+ * @method static \Closure|null getQueryHandler()
+ * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard setQueryHandler(\Closure $queryHandler = null)
  * @method static \Illuminate\Contracts\Auth\UserProvider|null createUserProvider(string $provider = null)
  * @method static \Symfony\Component\HttpFoundation\Response|null onceBasic(string $field = 'email',array $extraConditions = [])
  * @method static bool attempt(array $credentials = [], bool $remember = false)

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -149,6 +149,28 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertInstanceOf(EloquentProviderUserStub::class, $model);
     }
 
+    public function testRegistersQueryHandler()
+    {
+        $callback = function ($builder) {
+            $builder->whereIn('group', ['one', 'two']);
+        };
+
+        $provider = $this->getProviderMock();
+        $mock = m::mock(stdClass::class);
+        $mock->shouldReceive('newQuery')->once()->andReturn($mock);
+        $mock->shouldReceive('where')->once()->with('username', 'dayle');
+        $mock->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
+        $mock->shouldReceive('first')->once()->andReturn('bar');
+        $provider->expects($this->once())->method('createModel')->willReturn($mock);
+        $provider->setQueryHandler($callback);
+        $user = $provider->retrieveByCredentials([function ($builder) {
+            $builder->where('username', 'dayle');
+        }]);
+
+        $this->assertSame('bar', $user);
+        $this->assertSame($callback, $provider->getQueryHandler());
+    }
+
     protected function getProviderMock()
     {
         $hasher = m::mock(Hasher::class);

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -162,13 +162,13 @@ class AuthEloquentUserProviderTest extends TestCase
         $mock->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
         $mock->shouldReceive('first')->once()->andReturn('bar');
         $provider->expects($this->once())->method('createModel')->willReturn($mock);
-        $provider->setQueryHandler($callback);
+        $provider->withQuery($callback);
         $user = $provider->retrieveByCredentials([function ($builder) {
             $builder->where('username', 'dayle');
         }]);
 
         $this->assertSame('bar', $user);
-        $this->assertSame($callback, $provider->getQueryHandler());
+        $this->assertSame($callback, $provider->getQueryCallback());
     }
 
     protected function getProviderMock()


### PR DESCRIPTION
## What

Allows the user to register a query handler for retrieving the user from the `EloquentUserProvider`. This allows to tap into the query and modify columns to retrieve, like bypassing columns that may have too much data or are unused.

```php
Auth::guard('web')->getProvider()->setQueryHandler(function ($query) {
    // ...
});
```

Since it works a `newModelQuery()` level, any change be overridden through callbacks when retrieving the user.

```php
Auth::guard('web')->attempt([
    'email' => $email,
    'password' => $password,
    fn($query) => ...
});
```

Also the `setQueryHandler()` can be used to erase it with `null` and it can be retrieved for further inspection (or even wrapping).