### PR TITLE
[9.x] Share WithoutOverlapping key across jobs

### DIFF
--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -39,6 +39,13 @@ class WithoutOverlapping
     public $prefix = 'laravel-queue-overlap:';
 
     /**
+     * Share the key across different jobs.
+     *
+     * @var bool
+     */
+    public $shareKey = false;
+
+    /**
      * Create a new middleware instance.
      *
      * @param  string  $key
@@ -128,6 +135,13 @@ class WithoutOverlapping
         return $this;
     }
 
+    public function shareKey()
+    {
+        $this->shareKey = true;
+
+        return $this;
+    }
+
     /**
      * Get the lock key for the given job.
      *
@@ -136,6 +150,8 @@ class WithoutOverlapping
      */
     public function getLockKey($job)
     {
-        return $this->prefix.get_class($job).':'.$this->key;
+        return $this->shareKey
+            ? $this->prefix.$this->key
+            : $this->prefix.get_class($job).':'.$this->key;
     }
 }

--- a/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
+++ b/src/Illuminate/Queue/Middleware/WithoutOverlapping.php
@@ -135,7 +135,12 @@ class WithoutOverlapping
         return $this;
     }
 
-    public function shareKey()
+    /**
+     * Indicate that the lock key should be shared across job classes.
+     *
+     * @return void
+     */
+    public function shared()
     {
         $this->shareKey = true;
 

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -118,7 +118,7 @@ class WithoutOverlappingJobsTest extends TestCase
         OverlappingTestJobWithSharedKeyOne::$handled = false;
         $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
 
-        $lockKey = (new WithoutOverlapping)->shareKey()->getLockKey(new OverlappingTestJobWithSharedKeyTwo);
+        $lockKey = (new WithoutOverlapping)->shared()->getLockKey(new OverlappingTestJobWithSharedKeyTwo);
         $this->app->get(Cache::class)->lock($lockKey, 10)->acquire();
 
         $job = m::mock(Job::class);
@@ -146,7 +146,7 @@ class WithoutOverlappingJobsTest extends TestCase
 
         $this->assertSame(
             'laravel-queue-overlap:key',
-            (new WithoutOverlapping('key'))->shareKey()->getLockKey($job)
+            (new WithoutOverlapping('key'))->shared()->getLockKey($job)
         );
 
         $this->assertSame(
@@ -156,7 +156,7 @@ class WithoutOverlappingJobsTest extends TestCase
 
         $this->assertSame(
             'prefix:key',
-            (new WithoutOverlapping('key'))->withPrefix('prefix:')->shareKey()->getLockKey($job)
+            (new WithoutOverlapping('key'))->withPrefix('prefix:')->shared()->getLockKey($job)
         );
     }
 }
@@ -209,7 +209,7 @@ class OverlappingTestJobWithSharedKeyOne
 
     public function middleware()
     {
-        return [(new WithoutOverlapping)->shareKey()];
+        return [(new WithoutOverlapping)->shared()];
     }
 }
 
@@ -226,6 +226,6 @@ class OverlappingTestJobWithSharedKeyTwo
 
     public function middleware()
     {
-        return [(new WithoutOverlapping)->shareKey()];
+        return [(new WithoutOverlapping)->shared()];
     }
 }

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -112,6 +112,53 @@ class WithoutOverlappingJobsTest extends TestCase
 
         $this->assertFalse(SkipOverlappingTestJob::$handled);
     }
+
+    public function testCanShareKeyAcrossJobs()
+    {
+        OverlappingTestJobWithSharedKeyOne::$handled = false;
+        $instance = new CallQueuedHandler(new Dispatcher($this->app), $this->app);
+
+        $lockKey = (new WithoutOverlapping)->shareKey()->getLockKey(new OverlappingTestJobWithSharedKeyTwo);
+        $this->app->get(Cache::class)->lock($lockKey, 10)->acquire();
+
+        $job = m::mock(Job::class);
+
+        $job->shouldReceive('release')->once();
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(true);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(true);
+
+        $instance->call($job, [
+            'command' => serialize(new OverlappingTestJobWithSharedKeyOne),
+        ]);
+
+        $this->assertFalse(OverlappingTestJob::$handled);
+    }
+
+    public function testGetLock()
+    {
+        $job = new OverlappingTestJob;
+
+        $this->assertSame(
+            'laravel-queue-overlap:Illuminate\\Tests\\Integration\\Queue\\OverlappingTestJob:key',
+            (new WithoutOverlapping('key'))->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'laravel-queue-overlap:key',
+            (new WithoutOverlapping('key'))->shareKey()->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'prefix:Illuminate\\Tests\\Integration\\Queue\\OverlappingTestJob:key',
+            (new WithoutOverlapping('key'))->withPrefix('prefix:')->getLockKey($job)
+        );
+
+        $this->assertSame(
+            'prefix:key',
+            (new WithoutOverlapping('key'))->withPrefix('prefix:')->shareKey()->getLockKey($job)
+        );
+    }
 }
 
 class OverlappingTestJob
@@ -146,5 +193,39 @@ class FailedOverlappingTestJob extends OverlappingTestJob
         static::$handled = true;
 
         throw new Exception;
+    }
+}
+
+class OverlappingTestJobWithSharedKeyOne
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+
+    public function middleware()
+    {
+        return [(new WithoutOverlapping)->shareKey()];
+    }
+}
+
+class OverlappingTestJobWithSharedKeyTwo
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+
+    public function middleware()
+    {
+        return [(new WithoutOverlapping)->shareKey()];
     }
 }


### PR DESCRIPTION
This PR allows `WithoutOverlapping` to apply across different job classes. Currently this feature only allows without overlapping to be applied to instances of a single class.

```php
use Illuminate\Queue\Middleware\WithoutOverlapping;

class ProviderIsDown
{
    // ...


    public function middleware()
    {
        return [
            (new WithoutOverlapping("provider-status:{$this->provider}"))->shareKey(),
        ];
    }
}

class ProviderIsUp
{
    // ...


    public function middleware()
    {
        return [
            (new WithoutOverlapping("provider-status:{$this->provider}"))->shareKey(),
        ];
    }
}
```

These two jobs will now not overlap even though they are different classes. They both utilise the same lock key (assuming the provider is the same) `"provider-status:{providerName}".

Thanks @andrewbroberg for raising and chatting to me about this.

Documentation PR: https://github.com/laravel/docs/pull/8240