### PR TITLE
[9.x] Fix: swap zrevrangebyscore min and max

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -269,7 +269,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             ];
         }
 
-        return $this->command('zRevRangeByScore', [$key, $min, $max, $options]);
+        return $this->command('zRevRangeByScore', [$key, $max, $min, $options]);
     }
 
     /**


### PR DESCRIPTION
Since Redis 2.2.0: ZREVRANGEBYSCORE key max min [WITHSCORES] [LIMIT offset count]

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
