### PR TITLE
[9.x] feat: use model values in upsert

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1003,19 +1003,27 @@ class Builder implements BuilderContract
     /**
      * Insert new records or update the existing ones.
      *
-     * @param  array  $values
-     * @param  array|string  $uniqueBy
+     * @param  array|null  $values
+     * @param  array|string|null  $uniqueBy
      * @param  array|null  $update
      * @return int
      */
-    public function upsert(array $values, $uniqueBy, $update = null)
+    public function upsert(array $values = null, $uniqueBy = null, $update = null)
     {
         if (empty($values)) {
-            return 0;
+            if (is_null($this->model)) {
+                return 0;
+            }
+
+            $values = $this->model->getDirty();
         }
 
         if (! is_array(reset($values))) {
             $values = [$values];
+        }
+
+        if (is_null($uniqueBy) && $this->model) {
+            $uniqueBy = [$this->model->getKeyName()];
         }
 
         if (is_null($update)) {


### PR DESCRIPTION
Sometimes you already know the ID of the model but don't know whether it exists in the database or not. This is what `upsert` was designed for but right now it only allows explicit values. This PR uses the dirty values and the key name of the model in case the `upsert` method was called on the instance of a model.

If you think this is a good idea, I am happy to create the relevant tests as well.