### PR TITLE
[9.x] Add methods to cast Stringables

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Closure;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
@@ -1115,6 +1116,56 @@ class Stringable implements JsonSerializable
     public function toString()
     {
         return $this->value;
+    }
+
+    /**
+     * Get the underlying string value as an integer.
+     *
+     * @return int
+     */
+    public function toInteger()
+    {
+        return intval($this->value);
+    }
+
+    /**
+     * Get the underlying string value as a float.
+     *
+     * @return float
+     */
+    public function toFloat()
+    {
+        return floatval($this->value);
+    }
+
+    /**
+     * Get the underlying string value as a boolean.
+     *
+     * Returns true when value is "1", "true", "on", and "yes". Otherwise, returns false.
+     *
+     * @return bool
+     */
+    public function toBoolean()
+    {
+        return filter_var($this->value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Get the underlying string value as a Carbon instance.
+     *
+     * @param  string|null  $format
+     * @param  string|null  $tz
+     * @return \Illuminate\Support\Carbon
+     *
+     * @throws \Carbon\Exceptions\InvalidFormatException
+     */
+    public function toDate($format = null, $tz = null)
+    {
+        if (is_null($format)) {
+            return Date::parse($this->value, $tz);
+        }
+
+        return Date::createFromFormat($format, $this->value, $tz);
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Stringable;
@@ -1072,5 +1073,60 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('Foo')->exactly('foo'));
         $this->assertFalse($this->stringable('[]')->exactly([]));
         $this->assertFalse($this->stringable('0')->exactly(0));
+    }
+
+    public function testToInteger()
+    {
+        $this->assertSame(123, $this->stringable('123')->toInteger());
+        $this->assertSame(456, $this->stringable(456)->toInteger());
+        $this->assertSame(78, $this->stringable('078')->toInteger());
+        $this->assertSame(901, $this->stringable(' 901')->toInteger());
+        $this->assertSame(0, $this->stringable('nan')->toInteger());
+        $this->assertSame(1, $this->stringable('1ab')->toInteger());
+        $this->assertSame(2, $this->stringable('2_000')->toInteger());
+    }
+
+    public function testToFloat()
+    {
+        $this->assertSame(1.23, $this->stringable('1.23')->toFloat());
+        $this->assertSame(45.6, $this->stringable(45.6)->toFloat());
+        $this->assertSame(.6, $this->stringable('.6')->toFloat());
+        $this->assertSame(0.78, $this->stringable('0.78')->toFloat());
+        $this->assertSame(90.1, $this->stringable(' 90.1')->toFloat());
+        $this->assertSame(0.0, $this->stringable('nan')->toFloat());
+        $this->assertSame(1.0, $this->stringable('1.ab')->toFloat());
+        $this->assertSame(1e3, $this->stringable('1e3')->toFloat());
+    }
+
+    public function testBooleanMethod()
+    {
+        $this->assertTrue($this->stringable(true)->toBoolean());
+        $this->assertTrue($this->stringable('true')->toBoolean());
+        $this->assertFalse($this->stringable('false')->toBoolean());
+        $this->assertTrue($this->stringable('1')->toBoolean());
+        $this->assertFalse($this->stringable('0')->toBoolean());
+        $this->assertTrue($this->stringable('on')->toBoolean());
+        $this->assertFalse($this->stringable('off')->toBoolean());
+        $this->assertTrue($this->stringable('yes')->toBoolean());
+        $this->assertFalse($this->stringable('no')->toBoolean());
+    }
+
+    public function testToDate()
+    {
+        $current = Carbon::create(2020, 1, 1, 16, 30, 25);
+
+        $this->assertEquals($current, $this->stringable('20-01-01 16:30:25')->toDate());
+        $this->assertEquals($current, $this->stringable('1577896225')->toDate('U'));
+        $this->assertEquals($current, $this->stringable('20-01-01 13:30:25')->toDate(null, 'America/Santiago'));
+
+        $this->assertTrue($this->stringable('2020-01-01')->toDate()->isSameDay($current));
+        $this->assertTrue($this->stringable('16:30:25')->toDate()->isSameSecond('16:30:25'));
+    }
+
+    public function testToDateThrowsException()
+    {
+        $this->expectException(\Carbon\Exceptions\InvalidFormatException::class);
+
+        $this->stringable('not a date')->toDate();
     }
 }


### PR DESCRIPTION
This adds methods to conveniently cast stringables to common data types similar to those found in Laravel's HTTP Request.

**Before**
```php
intval(str('shift-worker-01')->afterLast('-')->toString());
floatval(str('Result: 1.23')->after(':')->trim()->toString());
str('YeS')->lower()->toString() === 'yes';
Carbon::parse(str('DOB: 12-31-2001')->after(':')->trim()->toString());
```

**After**
```php
str('shift-worker-01')->afterLast('-')->toInteger();
str('Result: 1.23')->after(':')->trim()->toFloat();
str('YeS')->lower()->toBoolean();
str('DOB: 12-31-2001')->after(':')->trim()->toDate();
```