### PR TITLE
[9.x] Add methods to get request data as integer or float

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -353,6 +353,8 @@ trait InteractsWithInput
      * @param  string|null  $format
      * @param  string|null  $tz
      * @return \Illuminate\Support\Carbon|null
+     *
+     * @throws \Carbon\Exceptions\InvalidFormatException
      */
     public function date($key, $format = null, $tz = null)
     {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -323,6 +323,30 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve input as an integer value.
+     *
+     * @param  string  $key
+     * @param  int  $default
+     * @return int
+     */
+    public function integer($key, $default = 0)
+    {
+        return intval($this->input($key, $default));
+    }
+
+    /**
+     * Retrieve input as an float value.
+     *
+     * @param  string  $key
+     * @param  float  $default
+     * @return float
+     */
+    public function float($key, $default = 0.0)
+    {
+        return floatval($this->input($key, $default));
+    }
+
+    /**
      * Retrieve input from the request as a Carbon instance.
      *
      * @param  string  $key

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -335,7 +335,7 @@ trait InteractsWithInput
     }
 
     /**
-     * Retrieve input as an float value.
+     * Retrieve input as a float value.
      *
      * @param  string  $key
      * @param  float  $default

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -562,6 +562,50 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->boolean('with_yes'));
     }
 
+    public function testIntegerMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'int' => '123',
+            'raw_int' => 456,
+            'zero_padded' => '078',
+            'space_padded' => ' 901',
+            'nan' => 'nan',
+            'mixed'=> '1ab',
+            'underscore_notation'=> '2_000',
+        ]);
+        $this->assertSame(123, $request->integer('int'));
+        $this->assertSame(456, $request->integer('raw_int'));
+        $this->assertSame(78, $request->integer('zero_padded'));
+        $this->assertSame(901, $request->integer('space_padded'));
+        $this->assertSame(0, $request->integer('nan'));
+        $this->assertSame(1, $request->integer('mixed'));
+        $this->assertSame(2, $request->integer('underscore_notation'));
+        $this->assertSame(123456, $request->integer('unknown_key', 123456));
+    }
+
+    public function testFloatMethod()
+    {
+        $request = Request::create('/', 'GET', [
+            'float' => '1.23',
+            'raw_float' => 45.6,
+            'decimal_only' => '.6',
+            'zero_padded' => '0.78',
+            'space_padded' => ' 90.1',
+            'nan' => 'nan',
+            'mixed'=> '1.ab',
+            'scientific_notation'=> '1e3',
+        ]);
+        $this->assertSame(1.23, $request->float('float'));
+        $this->assertSame(45.6, $request->float('raw_float'));
+        $this->assertSame(.6, $request->float('decimal_only'));
+        $this->assertSame(0.78, $request->float('zero_padded'));
+        $this->assertSame(90.1, $request->float('space_padded'));
+        $this->assertSame(0.0, $request->float('nan'));
+        $this->assertSame(1.0, $request->float('mixed'));
+        $this->assertSame(1e3, $request->float('scientific_notation'));
+        $this->assertSame(123.456, $request->float('unknown_key', 123.456));
+    }
+
     public function testCollectMethod()
     {
         $request = Request::create('/', 'GET', ['users' => [1, 2, 3]]);


### PR DESCRIPTION
This adds methods to conveniently retrieve and cast request data as an `int` and `float`. A `bool` cast already existed. So why not have other common scalar types.

**Before**
```php
intval($request->input('some_int_value'));
floatval($request->input('some_float_value'));
```

**After**
```php
$request->integer('some_int_value');
$request->float('some_float_value');
```