### PR TITLE
[9.x] Fixes order of migrations in StatusCommand

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -85,20 +85,17 @@ class StatusCommand extends BaseCommand
      */
     protected function getStatusFor(array $ran, array $batches)
     {
-        return Collection::make($this->getAllMigrationFiles())
-                    ->map(function ($migration) use ($ran, $batches) {
-                        $migrationName = $this->migrator->getMigrationName($migration);
-
-                        $status = in_array($migrationName, $ran)
-                            ? '<fg=green;options=bold>Ran</>'
-                            : '<fg=yellow;options=bold>Pending</>';
-
-                        if (in_array($migrationName, $ran)) {
-                            $status = '['.$batches[$migrationName].'] '.$status;
-                        }
-
-                        return [$migrationName, $status];
-                    });
+        return Collection::make($batches)
+            ->map(function ($batch, $migration) {
+                return [$migration, '['.$batch.'] '.'<fg=green;options=bold>Ran</>'];
+            })
+            ->merge(
+                Collection::make($this->getAllMigrationFiles())
+                    ->diffKeys($batches)
+                    ->map(function ($migration) {
+                        return [$this->migrator->getMigrationName($migration), '<fg=yellow;options=bold>Pending</>'];
+                    })
+            );
     }
 
     /**

--- a/tests/Database/DatabaseMigrationStatusCommandTest.php
+++ b/tests/Database/DatabaseMigrationStatusCommandTest.php
@@ -73,8 +73,6 @@ class DatabaseMigrationStatusCommandTest extends TestCase
 
         $method->setAccessible(true);
 
-        $command->flag = true;
-
         $value = $method->invoke($command, $ran, $batches);
 
         $this->assertEquals([

--- a/tests/Database/DatabaseMigrationStatusCommandTest.php
+++ b/tests/Database/DatabaseMigrationStatusCommandTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Console\Migrations\StatusCommand;
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Foundation\Application;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class DatabaseMigrationStatusCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testStatusCommandOutputIsInCorrectOrderWithoutPending()
+    {
+        $ran = [
+            '2019_12_11_000000_create_users_table',
+            '2019_12_13_000000_create_clients_table',
+            '2019_12_12_000000_create_sellers_table',
+        ];
+
+        $batches = [
+            '2019_12_11_000000_create_users_table' => 1,
+            '2019_12_13_000000_create_clients_table' => 2,
+            '2019_12_12_000000_create_sellers_table' => 3,
+        ];
+
+        $migrationFiles = [
+            '2019_12_11_000000_create_users_table' => __DIR__.'/migrations/2019_12_11_000000_create_users_table.php',
+            '2019_12_12_000000_create_sellers_table' => __DIR__.'/migrations/2019_12_12_000000_create_sellers_table.php',
+            '2019_12_13_000000_create_clients_table' => __DIR__.'/migrations/2019_12_13_000000_create_clients_table.php',
+        ];
+
+        $command = new StatusCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseMigrationStatusStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('getRepository')->andReturn($repository = m::mock(MigrationRepositoryInterface::class));
+        $repository->shouldReceive('getRan')->andReturn($ran);
+        $repository->shouldReceive('getMigrationBatches')->andReturn($batches);
+        $migrator->shouldReceive('paths')->andReturn([]);
+
+        $migrator->shouldReceive('getMigrationFiles')->andReturn($migrationFiles);
+
+        $migrator->shouldReceive('getMigrationName')->andReturnValues([
+            '2019_12_11_000000_create_users_table',
+            '2019_12_12_000000_create_sellers_table',
+            '2019_12_13_000000_create_clients_table',
+
+            '2019_12_11_000000_create_users_table',
+            '2019_12_12_000000_create_sellers_table',
+            '2019_12_13_000000_create_clients_table',
+        ]);
+
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+
+        $this->runCommand($command);
+
+        $class = new ReflectionClass($command);
+
+        $method = $class->getMethod('getStatusFor');
+
+        $method->setAccessible(true);
+
+        $command->flag = true;
+
+        $value = $method->invoke($command, $ran, $batches);
+
+        $this->assertEquals([
+            '2019_12_11_000000_create_users_table',
+            '2019_12_13_000000_create_clients_table',
+            '2019_12_12_000000_create_sellers_table',
+        ], $value->keys()->toArray());
+    }
+
+    public function testStatusCommandOutputIsInCorrectOrderWithPending()
+    {
+        $ran = [
+            '2019_12_11_000000_create_users_table',
+            '2019_12_13_000000_create_clients_table',
+            '2019_12_12_000000_create_sellers_table',
+        ];
+
+        $batches = [
+            '2019_12_11_000000_create_users_table' => 1,
+            '2019_12_13_000000_create_clients_table' => 2,
+            '2019_12_12_000000_create_sellers_table' => 3,
+        ];
+
+        $migrationFiles = [
+            '2019_12_10_000000_jobs_table' => __DIR__.'/migrations/2019_12_10_000000_jobs_table.php',
+            '2019_12_11_000000_create_users_table' => __DIR__.'/migrations/2019_12_11_000000_create_users_table.php',
+            '2019_12_12_000000_create_sellers_table' => __DIR__.'/migrations/2019_12_12_000000_create_sellers_table.php',
+            '2019_12_13_000000_create_clients_table' => __DIR__.'/migrations/2019_12_13_000000_create_clients_table.php',
+        ];
+
+        $command = new StatusCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseMigrationStatusStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('getRepository')->andReturn($repository = m::mock(MigrationRepositoryInterface::class));
+        $repository->shouldReceive('getRan')->andReturn($ran);
+        $repository->shouldReceive('getMigrationBatches')->andReturn($batches);
+        $migrator->shouldReceive('paths')->andReturn([]);
+
+        $migrator->shouldReceive('getMigrationFiles')->andReturn($migrationFiles);
+
+        $migrator->shouldReceive('getMigrationName')->andReturnValues([
+            '2019_12_10_000000_jobs_table',
+        ]);
+
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+            return $callback();
+        });
+
+        $this->runCommand($command);
+        $class = new ReflectionClass($command);
+        $method = $class->getMethod('getStatusFor');
+        $method->setAccessible(true);
+        $value = $method->invoke($command, $ran, $batches);
+
+        $this->assertEquals([
+            '2019_12_11_000000_create_users_table',
+            '2019_12_13_000000_create_clients_table',
+            '2019_12_12_000000_create_sellers_table',
+            '2019_12_10_000000_jobs_table',
+        ], $value->keys()->toArray());
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}
+
+class ApplicationDatabaseMigrationStatusStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment(...$environments)
+    {
+        return 'development';
+    }
+}


### PR DESCRIPTION
The `migrate:status` command doesn't sort the migrations by batch when outputting to console.

I've noticed this issue by running an old migration I forgot to migrate after having ran other migrations.

This can be easily reproduced running the following commands on a fresh Laravel installation.

```
// Commands
php artisan migrate --path=/database/migrations/2014_10_12_100000_create_password_resets_table.php
php artisan migrate --path=/database/migrations/2014_10_12_000000_create_users_table.php 
php artisan migrate --path=/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
php artisan migrate:status
```

```
// Expected
2014_10_12_100000_create_password_resets_table ... [1] Ran
2014_10_12_000000_create_users_table ............. [2] Ran
2019_08_19_000000_create_failed_jobs_table ....... [3] Ran
```

```
// Actual
2014_10_12_000000_create_users_table ............. [2] Ran
2014_10_12_100000_create_password_resets_table ... [1] Ran  
2019_08_19_000000_create_failed_jobs_table ....... [3] Ran
```

Note the batch numbers are not sorted. 

This actually can happen quite often when working with a team on different branches.

Hopefully this PR fixes it 🙂



