### PR TITLE
[9.x] Fix incrementing string keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUlids.php
@@ -55,4 +55,18 @@ trait HasUlids
 
         return $this->keyType;
     }
+
+    /**
+     * Get the value indicating whether the IDs are incrementing.
+     *
+     * @return bool
+     */
+    public function getIncrementing()
+    {
+        if (in_array($this->getKeyName(), $this->uniqueIds())) {
+            return false;
+        }
+
+        return $this->incrementing;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -55,4 +55,18 @@ trait HasUuids
 
         return $this->keyType;
     }
+
+    /**
+     * Get the value indicating whether the IDs are incrementing.
+     *
+     * @return bool
+     */
+    public function getIncrementing()
+    {
+        if (in_array($this->getKeyName(), $this->uniqueIds())) {
+            return false;
+        }
+
+        return $this->incrementing;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1851,10 +1851,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function getIncrementing()
     {
-        if ($this->getKeyType() === 'string') {
-            return false;
-        }
-
         return $this->incrementing;
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2216,10 +2216,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testStringKeyTypePreserved()
     {
         $model = $this->getMockBuilder(EloquentKeyTypeModelStub::class)->onlyMethods(['newModelQuery', 'updateTimestamps', 'refresh'])->getMock();
-        $model->id = 'string id';
 
         $query = m::mock(Builder::class);
-        $query->shouldReceive('insert')->once()->with(['id' => 'string id']);
+        $query->shouldReceive('insertGetId')->once()->with([], 'id')->andReturn('string id');
         $query->shouldReceive('getConnection')->once();
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
 


### PR DESCRIPTION
Something I feared about https://github.com/laravel/framework/pull/44146 became true. Apparently there is a use case for string keys that are incremental. In MongoDB the string key is generated in the database itself and later retrieved and set. Because of this change it didn't get automatically set on the model anymore.

I've changed the implementation by adding the `getIncrementing()` methods to the traits and doing the same check as in `getKeyType`.