### PR TITLE
[9.x] Fix bug in Fluent Class with named arguments in migrations

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -149,7 +149,7 @@ class Fluent implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
      */
     public function __call($method, $parameters)
     {
-        $this->attributes[$method] = count($parameters) > 0 ? $parameters[0] : true;
+        $this->attributes[$method] = count($parameters) > 0 ? reset($parameters) : true;
 
         return $this;
     }


### PR DESCRIPTION
When used named arguments on migration methods, e.g: `$table->boolean('isActive')->default(value: true); `the Fluent Class throws a Exception with "Undefined array key"

![image](https://user-images.githubusercontent.com/585263/191755685-d1d1a9be-26db-4e8c-9544-ef11a65cd6d2.png)

This fixes the way to get the first value on $parameter from array index to reset() 

