### PR TITLE
[9.x] Adds `Benchmark::measure` ⏱

### DIFF
--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
  * @method void error(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void info(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void line(string $style, string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
+ * @method void newLine(int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void task(string $description, ?callable $task = null, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void twoColumnDetail(string $first, ?string $second = null, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void warn(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)

--- a/src/Illuminate/Console/View/Components/NewLine.php
+++ b/src/Illuminate/Console/View/Components/NewLine.php
@@ -14,6 +14,6 @@ class NewLine extends Component
      */
     public function render($verbosity = OutputInterface::VERBOSITY_NORMAL)
     {
-        $this->output->write("\n", false, $verbosity);
+        $this->output->write(PHP_EOL, false, $verbosity);
     }
 }

--- a/src/Illuminate/Console/View/Components/NewLine.php
+++ b/src/Illuminate/Console/View/Components/NewLine.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Console\View\Components;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class NewLine extends Component
+{
+    /**
+     * Renders the component using the given arguments.
+     *
+     * @param  int  $verbosity
+     * @return void
+     */
+    public function render($verbosity = OutputInterface::VERBOSITY_NORMAL)
+    {
+        $this->output->write("\n", false, $verbosity);
+    }
+}

--- a/src/Illuminate/Contracts/Foundation/BenchmarkRenderer.php
+++ b/src/Illuminate/Contracts/Foundation/BenchmarkRenderer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation;
+
+interface BenchmarkRenderer
+{
+    /**
+     * Renders the benchmark results.
+     *
+     * @param  \Illuminate\Support\Collection<int, \Illuminate\Foundation\Benchmark\Result>  $results
+     * @param  int  $repeats
+     * @return never
+     */
+    public function render($results, $repeats);
+}

--- a/src/Illuminate/Contracts/Foundation/BenchmarkRenderer.php
+++ b/src/Illuminate/Contracts/Foundation/BenchmarkRenderer.php
@@ -8,8 +8,8 @@ interface BenchmarkRenderer
      * Renders the benchmark results.
      *
      * @param  \Illuminate\Support\Collection<int, \Illuminate\Foundation\Benchmark\Result>  $results
-     * @param  int  $repeats
+     * @param  int  $repetitions
      * @return never
      */
-    public function render($results, $repeats);
+    public function render($results, $repetitions);
 }

--- a/src/Illuminate/Foundation/Benchmark/Benchmark.php
+++ b/src/Illuminate/Foundation/Benchmark/Benchmark.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Foundation\Benchmark;
+
+use Illuminate\Support\Arr;
+
+class Benchmark
+{
+    /**
+     * The benchmark renderer.
+     *
+     * @var \Illuminate\Contracts\Foundation\BenchmarkRenderer
+     */
+    protected $renderer;
+
+    /**
+     * The number of repeats.
+     *
+     * @var int
+     */
+    protected $repeat = 10;
+
+    /**
+     * Creates a new "pending" Benchmark instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\BenchmarkRenderer  $renderer
+     * @return void
+     */
+    public function __construct($renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * The number of times a benchmark should be repeated.
+     *
+     * @param  int  $times
+     * @return $this
+     */
+    public function repeat($times)
+    {
+        $this->repeat = $times;
+
+        return $this;
+    }
+
+    /**
+     * Measure the execution time of a callback.
+     *
+     * @param  iterable<string|int, \Closure(): mixed>|\Closure(): mixed  $callbacks
+     * @return never
+     */
+    public function measure($callbacks)
+    {
+        $results = $this->getClosures($callbacks)->map(function ($callback, $key) {
+            $average = (float) collect(range(1, $this->repeat))->map(function () use ($callback) {
+                gc_collect_cycles();
+
+                $start = microtime(true);
+
+                $callback();
+
+                return microtime(true) - $start;
+            })->average();
+
+            return new Result($callback, $key, $average);
+        })->values();
+
+        $this->renderer->render($results, $this->repeat);
+    }
+
+    /**
+     * Get a collection of closures from the given callback(s).
+     *
+     * @param  iterable<string|int, \Closure(): mixed>|\Closure(): mixed  $callbacks
+     * @return \Illuminate\Support\Collection<string|int, \Closure(): mixed>
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function getClosures($callbacks)
+    {
+        return collect(Arr::wrap($callbacks))
+            ->whenEmpty(fn () => throw new \InvalidArgumentException('You must provide at least one callback.'));
+    }
+}

--- a/src/Illuminate/Foundation/Benchmark/Factory.php
+++ b/src/Illuminate/Foundation/Benchmark/Factory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Foundation\Benchmark;
+
+/**
+ * @method \Illuminate\Support\Benchmark repeat(int $times)
+ * @method \Illuminate\Support\Benchmark measure(iterable|callable $callables)
+ *
+ * @see \Illuminate\Foundation\Benchmark\Benchmark
+ */
+class Factory
+{
+    /**
+     * The renderer implementation..
+     *
+     * @var \Illuminate\Contracts\Foundation\BenchmarkRenderer
+     */
+    protected $renderer;
+
+    /**
+     * Create a new benchmark factory instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\BenchmarkRenderer  $renderer
+     * @return void
+     */
+    public function __construct($renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * Execute a method against a new pending benchmark instance.
+     *
+     * @param  string  $method
+     * @param  array<int, mixed>  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        $benchmark = new Benchmark($this->renderer);
+
+        return $benchmark->{$method}(...$parameters);
+    }
+}

--- a/src/Illuminate/Foundation/Benchmark/Factory.php
+++ b/src/Illuminate/Foundation/Benchmark/Factory.php
@@ -6,7 +6,7 @@ namespace Illuminate\Foundation\Benchmark;
  * @method \Illuminate\Support\Benchmark repeat(int $times)
  * @method \Illuminate\Support\Benchmark measure(iterable|callable $callables)
  *
- * @see \Illuminate\Foundation\Benchmark\Benchmark
+ * @see \Illuminate\Foundation\Benchmark\PendingBenchmark
  */
 class Factory
 {
@@ -29,16 +29,24 @@ class Factory
     }
 
     /**
-     * Execute a method against a new pending benchmark instance.
+     * Creates a new "pending" benchmark instance.
+     *
+     * @return \Illuminate\Foundation\Benchmark\PendingBenchmark
+     */
+    public function newPendingBenchmark()
+    {
+        return new PendingBenchmark($this->renderer);
+    }
+
+    /**
+     * Execute a method against a new "pending" benchmark instance.
      *
      * @param  string  $method
      * @param  array<int, mixed>  $parameters
-     * @return mixed
+     * @return \Illuminate\Foundation\Benchmark\PendingBenchmark|\Illuminate\Foundation\Benchmark\Result
      */
     public function __call($method, $parameters)
     {
-        $benchmark = new Benchmark($this->renderer);
-
-        return $benchmark->{$method}(...$parameters);
+        return $this->newPendingBenchmark()->{$method}(...$parameters);
     }
 }

--- a/src/Illuminate/Foundation/Benchmark/Factory.php
+++ b/src/Illuminate/Foundation/Benchmark/Factory.php
@@ -11,14 +11,14 @@ namespace Illuminate\Foundation\Benchmark;
 class Factory
 {
     /**
-     * The renderer implementation..
+     * The renderer implementation.
      *
      * @var \Illuminate\Contracts\Foundation\BenchmarkRenderer
      */
     protected $renderer;
 
     /**
-     * Create a new benchmark factory instance.
+     * Create a new Benchmark Factory instance.
      *
      * @param  \Illuminate\Contracts\Foundation\BenchmarkRenderer  $renderer
      * @return void

--- a/src/Illuminate/Foundation/Benchmark/Factory.php
+++ b/src/Illuminate/Foundation/Benchmark/Factory.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Foundation\Benchmark;
 
 /**
- * @method \Illuminate\Support\Benchmark repeat(int $times)
- * @method \Illuminate\Support\Benchmark measure(iterable|callable $callables)
+ * @method \Illuminate\Foundation\Benchmark\PendingBenchmark repeat(int $times)
+ * @method never measure(iterable|\Closure $callables)
  *
  * @see \Illuminate\Foundation\Benchmark\PendingBenchmark
  */

--- a/src/Illuminate/Foundation/Benchmark/PendingBenchmark.php
+++ b/src/Illuminate/Foundation/Benchmark/PendingBenchmark.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Benchmark;
 
 use Illuminate\Support\Arr;
 
-class Benchmark
+class PendingBenchmark
 {
     /**
      * The benchmark renderer.
@@ -45,7 +45,7 @@ class Benchmark
     }
 
     /**
-     * Measure the execution time of a callback.
+     * Measure the execution time of the given callbacks.
      *
      * @param  iterable<string|int, \Closure(): mixed>|\Closure(): mixed  $callbacks
      * @return never

--- a/src/Illuminate/Foundation/Benchmark/PendingBenchmark.php
+++ b/src/Illuminate/Foundation/Benchmark/PendingBenchmark.php
@@ -58,11 +58,11 @@ class PendingBenchmark
             $average = (float) collect(range(1, $this->repeat))->map(function () use ($callback) {
                 gc_collect_cycles();
 
-                $start = microtime(true);
+                $start = hrtime(true);
 
                 $callback();
 
-                return microtime(true) - $start;
+                return (int) (hrtime(true) - $start);
             })->average();
 
             return new Result($callback, $key, $average);

--- a/src/Illuminate/Foundation/Benchmark/PendingBenchmark.php
+++ b/src/Illuminate/Foundation/Benchmark/PendingBenchmark.php
@@ -23,7 +23,7 @@ class PendingBenchmark
     protected $repetitions = 10;
 
     /**
-     * Creates a new "pending" Benchmark instance.
+     * Creates a new Pending Benchmark instance.
      *
      * @param  \Illuminate\Contracts\Foundation\BenchmarkRenderer  $renderer
      * @return void
@@ -51,6 +51,8 @@ class PendingBenchmark
      *
      * @param  iterable<string|int, \Closure(): mixed>|\Closure(): mixed  $callbacks
      * @return never
+     *
+     * @throws \InvalidArgumentException
      */
     public function measure($callbacks)
     {
@@ -77,7 +79,7 @@ class PendingBenchmark
      * @param  iterable<string|int, \Closure(): mixed>|\Closure(): mixed  $callbacks
      * @return \Illuminate\Support\Collection<string|int, \Closure(): mixed>
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     protected function getClosures($callbacks)
     {

--- a/src/Illuminate/Foundation/Benchmark/PendingBenchmark.php
+++ b/src/Illuminate/Foundation/Benchmark/PendingBenchmark.php
@@ -16,11 +16,11 @@ class PendingBenchmark
     protected $renderer;
 
     /**
-     * The number of repeats.
+     * The number of repetitions.
      *
      * @var int
      */
-    protected $repeat = 10;
+    protected $repetitions = 10;
 
     /**
      * Creates a new "pending" Benchmark instance.
@@ -34,14 +34,14 @@ class PendingBenchmark
     }
 
     /**
-     * The number of times a benchmark should be repeated.
+     * Sets the number of repetitions.
      *
      * @param  int  $times
      * @return $this
      */
     public function repeat($times)
     {
-        $this->repeat = $times;
+        $this->repetitions = $times;
 
         return $this;
     }
@@ -55,7 +55,7 @@ class PendingBenchmark
     public function measure($callbacks)
     {
         $results = $this->getClosures($callbacks)->map(function ($callback, $key) {
-            $average = (float) collect(range(1, $this->repeat))->map(function () use ($callback) {
+            $average = (float) collect(range(1, $this->repetitions))->map(function () use ($callback) {
                 gc_collect_cycles();
 
                 $start = hrtime(true);
@@ -68,7 +68,7 @@ class PendingBenchmark
             return new Result($callback, $key, $average);
         })->values();
 
-        $this->renderer->render($results, $this->repeat);
+        $this->renderer->render($results, $this->repetitions);
     }
 
     /**

--- a/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Foundation\Benchmark\Renderers\Concerns;
+
+use Illuminate\Support\Str;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+
+trait InspectsClosures
+{
+    /**
+     * Get the code of the given callback.
+     *
+     * @param  \Closure  $callback
+     * @return string
+     */
+    protected function getCode($callback)
+    {
+        $code = (new ReflectionClosure($callback))->getCode();
+
+        if (Str::startsWith($code, 'fn () => ')) {
+            $code = Str::after($code, 'fn () => ');
+        }
+
+        if (Str::startsWith($code, 'function () {')) {
+            $code = Str::after($code, 'function () {');
+        }
+
+        if (Str::endsWith($code, '}')) {
+            $code = Str::beforeLast($code, '}');
+        }
+
+        return trim($code);
+    }
+}

--- a/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
@@ -10,7 +10,7 @@ use function Termwind\terminal;
 trait InspectsClosures
 {
     /**
-     * Get the code of the given callback.
+     * Get a code "description" from the given callback.
      *
      * @param  \Closure  $callback
      * @return string

--- a/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
@@ -19,16 +19,16 @@ trait InspectsClosures
     {
         $code = (new ReflectionClosure($callback))->getCode();
 
-        if (Str::startsWith($code, 'fn () => ')) {
-            $code = Str::after($code, 'fn () => ');
+        if (Str::startsWith($code, 'fn')) {
+            $code = Str::after($code, '=>');
         }
 
-        if (Str::startsWith($code, 'function () {')) {
-            $code = Str::after($code, 'function () {');
-        }
+        if (Str::startsWith($code, 'function')) {
+            $code = Str::after($code, '{');
 
-        if (Str::endsWith($code, '}')) {
-            $code = Str::beforeLast($code, '}');
+            if (Str::endsWith($code, '}')) {
+                $code = Str::beforeLast($code, '}');
+            }
         }
 
         $code = str($code)->trim();

--- a/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
@@ -41,6 +41,6 @@ trait InspectsClosures
             $code = Str::limit($code, $limit, '…');
         }
 
-        return $code;
+        return (string) $code;
     }
 }

--- a/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/InspectsClosures.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Foundation\Benchmark\Renderers\Concerns;
 
+use Illuminate\Foundation\Benchmark\Renderers\ConsoleRenderer;
 use Illuminate\Support\Str;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
+use function Termwind\terminal;
 
 trait InspectsClosures
 {
@@ -13,7 +15,7 @@ trait InspectsClosures
      * @param  \Closure  $callback
      * @return string
      */
-    protected function getCode($callback)
+    protected function getCodeDescription($callback)
     {
         $code = (new ReflectionClosure($callback))->getCode();
 
@@ -29,6 +31,16 @@ trait InspectsClosures
             $code = Str::beforeLast($code, '}');
         }
 
-        return trim($code);
+        $code = str($code)->trim();
+
+        $limit = $this instanceof ConsoleRenderer ? (terminal()->width() - 25) : 40;
+
+        if ($code->contains("\n")) {
+            $code = Str::limit($code->explode("\n")->first(), $limit, '').' …';
+        } else {
+            $code = Str::limit($code, $limit, '…');
+        }
+
+        return $code;
     }
 }

--- a/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/Terminatable.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/Terminatable.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Foundation\Benchmark\Renderers\Concerns;
+
+trait Terminatable
+{
+    /**
+     * The callback that should be used to terminate the benchmark.
+     *
+     * @var (callable(): never)|null
+     */
+    protected static $terminateUsing;
+
+    /**
+     * Set the callback that should be used to terminate the benchmark.
+     *
+     * @param  (callable(): never)|null  $callback
+     * @return void
+     */
+    public static function terminateUsing($callback)
+    {
+        static::$terminateUsing = $callback;
+    }
+
+    /**
+     * Terminate the benchmark.
+     *
+     * @return never
+     */
+    public function terminate()
+    {
+        if (static::$terminateUsing) {
+            return (static::$terminateUsing)();
+        }
+
+        exit(1);
+    }
+}

--- a/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/Terminatable.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/Concerns/Terminatable.php
@@ -27,7 +27,7 @@ trait Terminatable
      *
      * @return never
      */
-    public function terminate()
+    protected function terminate()
     {
         if (static::$terminateUsing) {
             return (static::$terminateUsing)();

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -36,7 +36,7 @@ class ConsoleRenderer implements BenchmarkRenderer
         $fasterIndex = min(array_keys($averages, min($averages)));
 
         $results->each(function ($result, $index) use ($results, $components, $fasterIndex) {
-            $average = number_format($result->average * 1000, 3).'ms';
+            $average = number_format($result->average / 1000000, 3).'ms';
 
             if (! is_string($key = $result->key)) {
                 $key = $this->getCodeDescription($result->callback);

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -11,11 +11,22 @@ class ConsoleRenderer implements BenchmarkRenderer
     use Concerns\InspectsClosures, Concerns\Terminatable;
 
     /**
-     * The output implementation, if any.
+     * The console output implementation.
      *
-     * @var \Symfony\Component\Console\Output\OutputInterface|null
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
+
+    /**
+     * Creates a new Renderer instance.
+     *
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    public function __construct($output)
+    {
+        $this->output = $output;
+    }
 
     /**
      * {@inheritdoc}
@@ -57,16 +68,5 @@ class ConsoleRenderer implements BenchmarkRenderer
         $components->newLine();
 
         $this->terminate();
-    }
-
-    /**
-     * Sets the output implementation.
-     *
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return void
-     */
-    public function setOutput($output)
-    {
-        $this->output = $output;
     }
 }

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Foundation\Benchmark\Renderers;
+
+use Illuminate\Console\View\Components\Factory;
+use Illuminate\Contracts\Foundation\BenchmarkRenderer;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use function Termwind\terminal;
+
+class ConsoleRenderer implements BenchmarkRenderer
+{
+    use Concerns\InspectsClosures, Concerns\Terminatable;
+
+    /**
+     * The output implementation, if any.
+     *
+     * @var \Symfony\Component\Console\Output\OutputInterface|null
+     */
+    protected $output;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($results, $repeats)
+    {
+        $components = new Factory($this->output ?: new ConsoleOutput());
+
+        $components->info(sprintf('Benchmarking [%s] script(s) using [%s] repetitions.', $results->count(), $repeats));
+
+        $averages = $results->map(fn ($result) => $result->average)->toArray();
+
+        $fasterIndex = min(array_keys($averages, min($averages)));
+
+        $results->each(function ($result, $index) use ($results, $components, $fasterIndex) {
+            $average = number_format($result->average * 1000, 3).'ms';
+
+            if (! is_string($key = $result->key)) {
+                $code = $this->getCode($result->callback);
+
+                $limit = terminal()->width() - strlen($average) - 16;
+                $key = Str::limit($code, $limit, '…');
+            }
+
+            $key = sprintf('[%s] <fg=gray>%s</>', $index + 1, $key);
+            $color = $index == $fasterIndex && $results->count() > 1 ? 'green' : 'default';
+
+            $components->twoColumnDetail($key, sprintf('<fg=%s;options=bold>%s</>', $color, $average));
+        });
+
+        $components->newLine();
+
+        $this->terminate();
+    }
+
+    /**
+     * Sets the output implementation.
+     *
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    public function setOutput($output)
+    {
+        $this->output = $output;
+    }
+}

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -4,9 +4,7 @@ namespace Illuminate\Foundation\Benchmark\Renderers;
 
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Foundation\BenchmarkRenderer;
-use Illuminate\Support\Str;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use function Termwind\terminal;
 
 class ConsoleRenderer implements BenchmarkRenderer
 {

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -37,7 +37,12 @@ class ConsoleRenderer implements BenchmarkRenderer
                 $key = $this->getCodeDescription($result->callback);
             }
 
-            $key = sprintf('[%s] <fg=gray>%s</>', $index + 1, $key);
+            $key = sprintf('<fg=gray>%s</>', $key);
+
+            if ($results->count() > 1) {
+                $key = sprintf('[%s] %s', $index + 1, $key);
+            }
+
             $color = $index == $fasterIndex && $results->count() > 1 ? 'green' : 'default';
 
             $components->twoColumnDetail($key, sprintf('<fg=%s;options=bold>%s</>', $color, $average));

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Benchmark\Renderers;
 
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Contracts\Foundation\BenchmarkRenderer;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 class ConsoleRenderer implements BenchmarkRenderer
 {

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -25,7 +25,7 @@ class ConsoleRenderer implements BenchmarkRenderer
      */
     public function __construct($output)
     {
-        $this->output = $output;
+        $this->output = $output ?: new ConsoleOutput();
     }
 
     /**
@@ -33,7 +33,7 @@ class ConsoleRenderer implements BenchmarkRenderer
      */
     public function render($results, $repetitions)
     {
-        $components = new Factory($this->output ?: new ConsoleOutput());
+        $components = new Factory($this->output);
 
         $components->info(sprintf(
             'Benchmarking [%s] %s using [%s] %s.',

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -24,7 +24,12 @@ class ConsoleRenderer implements BenchmarkRenderer
     {
         $components = new Factory($this->output ?: new ConsoleOutput());
 
-        $components->info(sprintf('Benchmarking [%s] script(s) using [%s] repetitions.', $results->count(), $repeats));
+        $components->info(sprintf(
+            'Benchmarking [%s] %s using [%s] repetitions.',
+            $results->count(),
+            str('callback')->plural($results->count()),
+            $repeats
+        ));
 
         $averages = $results->map(fn ($result) => $result->average)->toArray();
 

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -20,7 +20,7 @@ class ConsoleRenderer implements BenchmarkRenderer
     /**
      * {@inheritdoc}
      */
-    public function render($results, $repeats)
+    public function render($results, $repetitions)
     {
         $components = new Factory($this->output ?: new ConsoleOutput());
 
@@ -28,8 +28,8 @@ class ConsoleRenderer implements BenchmarkRenderer
             'Benchmarking [%s] %s using [%s] %s.',
             $results->count(),
             str('callback')->plural($results->count()),
-            $repeats,
-            str('repetition')->plural($repeats),
+            $repetitions,
+            str('repetition')->plural($repetitions),
         ));
 
         $averages = $results->map(fn ($result) => $result->average)->toArray();

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -36,10 +36,7 @@ class ConsoleRenderer implements BenchmarkRenderer
             $average = number_format($result->average * 1000, 3).'ms';
 
             if (! is_string($key = $result->key)) {
-                $code = $this->getCode($result->callback);
-
-                $limit = terminal()->width() - strlen($average) - 16;
-                $key = Str::limit($code, $limit, '…');
+                $key = $this->getCodeDescription($result->callback);
             }
 
             $key = sprintf('[%s] <fg=gray>%s</>', $index + 1, $key);

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -25,7 +25,7 @@ class ConsoleRenderer implements BenchmarkRenderer
      */
     public function __construct($output)
     {
-        $this->output = $output ?: new ConsoleOutput();
+        $this->output = $output;
     }
 
     /**

--- a/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/ConsoleRenderer.php
@@ -25,10 +25,11 @@ class ConsoleRenderer implements BenchmarkRenderer
         $components = new Factory($this->output ?: new ConsoleOutput());
 
         $components->info(sprintf(
-            'Benchmarking [%s] %s using [%s] repetitions.',
+            'Benchmarking [%s] %s using [%s] %s.',
             $results->count(),
             str('callback')->plural($results->count()),
-            $repeats
+            $repeats,
+            str('repetition')->plural($repeats),
         ));
 
         $averages = $results->map(fn ($result) => $result->average)->toArray();

--- a/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
@@ -30,13 +30,17 @@ class HtmlRenderer implements BenchmarkRenderer
                 $key = sprintf('[%s] %s', $index + 1, $key);
             }
 
-            return [$key => number_format($result->average * 1000, 3).'ms'];
+            return [$key => number_format($result->average / 1000000, 3).'ms'];
         });
 
-        HtmlDumper::resolveDumpSourceUsing(fn () => null);
+        $source = sprintf('%s %s', $repeats, str('repetition')->plural($repeats));
+
+        HtmlDumper::resolveDumpSourceUsing(fn () => [
+            $source, $source, '',
+        ]);
 
         try {
-            (static::$dumpUsing ?: 'dump')($results->prepend($repeats, 'repeats')->toArray());
+            (static::$dumpUsing ?: 'dump')($results->toArray());
         } finally {
             HtmlDumper::resolveDumpSourceUsing(null);
         }

--- a/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Benchmark\Renderers;
 
 use Illuminate\Contracts\Foundation\BenchmarkRenderer;
 use Illuminate\Foundation\Http\HtmlDumper;
-use Illuminate\Support\Str;
 
 class HtmlRenderer implements BenchmarkRenderer
 {
@@ -24,9 +23,7 @@ class HtmlRenderer implements BenchmarkRenderer
     {
         $results = $results->mapWithKeys(function ($result, $index) {
             if (! is_string($key = $result->key)) {
-                $code = $this->getCode($result->callback);
-
-                $key = Str::limit($code, 100, '…');
+                $key = $this->getCodeDescription($result->callback);
             }
 
             $key = sprintf('[%s] %s', $index + 1, $key);

--- a/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
@@ -19,7 +19,7 @@ class HtmlRenderer implements BenchmarkRenderer
     /**
      * {@inheritdoc}
      */
-    public function render($results, $repeats)
+    public function render($results, $repetitions)
     {
         $results = $results->mapWithKeys(function ($result, $index) use ($results) {
             if (! is_string($key = $result->key)) {
@@ -33,7 +33,7 @@ class HtmlRenderer implements BenchmarkRenderer
             return [$key => number_format($result->average / 1000000, 3).'ms'];
         });
 
-        $source = sprintf('%s %s', $repeats, str('repetition')->plural($repeats));
+        $source = sprintf('%s %s', $repetitions, str('repetition')->plural($repetitions));
 
         HtmlDumper::resolveDumpSourceUsing(fn () => [
             $source, $source, '',

--- a/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
@@ -34,7 +34,7 @@ class HtmlRenderer implements BenchmarkRenderer
         HtmlDumper::resolveDumpSourceUsing(fn () => null);
 
         try {
-            (static::$dumpUsing ?: 'dump')(['repeats' => $repeats, ...$results->toArray()]);
+            (static::$dumpUsing ?: 'dump')($results->prepend($repeats, 'repeats')->toArray());
         } finally {
             HtmlDumper::resolveDumpSourceUsing(null);
         }

--- a/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Foundation\Benchmark\Renderers;
+
+use Illuminate\Contracts\Foundation\BenchmarkRenderer;
+use Illuminate\Foundation\Http\HtmlDumper;
+use Illuminate\Support\Str;
+
+class HtmlRenderer implements BenchmarkRenderer
+{
+    use Concerns\InspectsClosures, Concerns\Terminatable;
+
+    /**
+     * The callable used to dump the results in the browser.
+     *
+     * @var (callable(): void)|null
+     */
+    protected static $dumpUsing;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($results, $repeats)
+    {
+        $results = $results->mapWithKeys(function ($result, $index) {
+            if (! is_string($key = $result->key)) {
+                $code = $this->getCode($result->callback);
+
+                $key = Str::limit($code, 100, '…');
+            }
+
+            $key = sprintf('[%s] %s', $index + 1, $key);
+
+            return [$key => number_format($result->average * 1000, 3).'ms'];
+        });
+
+        HtmlDumper::resolveDumpSourceUsing(fn () => null);
+
+        try {
+            (static::$dumpUsing ?: 'dump')(['repeats' => $repeats, ...$results->toArray()]);
+        } finally {
+            HtmlDumper::resolveDumpSourceUsing(null);
+        }
+
+        $this->terminate();
+    }
+
+    /**
+     * Sets the callable used to dump the results in the browser.
+     *
+     * @param  (callable(): void)|null  $callback
+     * @return void
+     */
+    public static function dumpUsing($callback)
+    {
+        static::$dumpUsing = $callback;
+    }
+}

--- a/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
+++ b/src/Illuminate/Foundation/Benchmark/Renderers/HtmlRenderer.php
@@ -21,12 +21,14 @@ class HtmlRenderer implements BenchmarkRenderer
      */
     public function render($results, $repeats)
     {
-        $results = $results->mapWithKeys(function ($result, $index) {
+        $results = $results->mapWithKeys(function ($result, $index) use ($results) {
             if (! is_string($key = $result->key)) {
                 $key = $this->getCodeDescription($result->callback);
             }
 
-            $key = sprintf('[%s] %s', $index + 1, $key);
+            if ($results->count() > 1) {
+                $key = sprintf('[%s] %s', $index + 1, $key);
+            }
 
             return [$key => number_format($result->average * 1000, 3).'ms'];
         });

--- a/src/Illuminate/Foundation/Benchmark/Result.php
+++ b/src/Illuminate/Foundation/Benchmark/Result.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Foundation\Benchmark;
+
+class Result
+{
+    /**
+     * The callback that was measured.
+     *
+     * @var \Closure(): mixed
+     */
+    public $callback;
+
+    /**
+     * The key of the callback.
+     *
+     * @var string|int
+     */
+    public $key;
+
+    /**
+     * The average execution time.
+     *
+     * @var float
+     */
+    public $average;
+
+    /**
+     * Create a new benchmark result instance.
+     *
+     * @param  \Closure(): mixed  $callback
+     * @param  string|int  $key
+     * @param  float  $average
+     * @return void
+     */
+    public function __construct($callback, $key, $average)
+    {
+        $this->callback = $callback;
+        $this->key = $key;
+        $this->average = $average;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/BenchmarkServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/BenchmarkServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Foundation\Providers;
+
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Foundation\Benchmark\Factory;
+use Illuminate\Foundation\Benchmark\Renderers\ConsoleRenderer;
+use Illuminate\Foundation\Benchmark\Renderers\HtmlRenderer;
+use Illuminate\Support\ServiceProvider;
+
+class BenchmarkServiceProvider extends ServiceProvider
+{
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton(Factory::class, function ($app) {
+            if ($this->app->runningInConsole()) {
+                $renderer = new ConsoleRenderer();
+
+                $this->app['events']->listen(
+                    CommandStarting::class,
+                    fn ($event) => $renderer->setOutput($event->output)
+                );
+
+                return new Factory(new ConsoleRenderer());
+            }
+
+            return new Factory(new HtmlRenderer());
+        });
+    }
+}

--- a/src/Illuminate/Foundation/Providers/BenchmarkServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/BenchmarkServiceProvider.php
@@ -11,25 +11,32 @@ use Illuminate\Support\ServiceProvider;
 class BenchmarkServiceProvider extends ServiceProvider
 {
     /**
+     * The console output instance, if any.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected $output;
+
+    /**
      * Register the service provider.
      *
      * @return void
      */
     public function register()
     {
+        if ($this->app->runningInConsole()) {
+            $this->app['events']->listen(
+                CommandStarting::class,
+                fn ($event) => $this->output = $event->output,
+            );
+        }
+
         $this->app->singleton(Factory::class, function ($app) {
-            if ($this->app->runningInConsole()) {
-                $renderer = new ConsoleRenderer();
+            $renderer = $this->app->runningInConsole()
+                ? new ConsoleRenderer($this->output)
+                : new HtmlRenderer();
 
-                $this->app['events']->listen(
-                    CommandStarting::class,
-                    fn ($event) => $renderer->setOutput($event->output)
-                );
-
-                return new Factory(new ConsoleRenderer());
-            }
-
-            return new Factory(new HtmlRenderer());
+            return new Factory($renderer);
         });
     }
 }

--- a/src/Illuminate/Foundation/Providers/BenchmarkServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/BenchmarkServiceProvider.php
@@ -2,21 +2,14 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Foundation\Benchmark\Factory;
 use Illuminate\Foundation\Benchmark\Renderers\ConsoleRenderer;
 use Illuminate\Foundation\Benchmark\Renderers\HtmlRenderer;
 use Illuminate\Support\ServiceProvider;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class BenchmarkServiceProvider extends ServiceProvider
 {
-    /**
-     * The console output instance, if any.
-     *
-     * @param \Symfony\Component\Console\Output\OutputInterface
-     */
-    protected $output;
-
     /**
      * Register the service provider.
      *
@@ -24,16 +17,9 @@ class BenchmarkServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->runningInConsole()) {
-            $this->app['events']->listen(
-                CommandStarting::class,
-                fn ($event) => $this->output = $event->output,
-            );
-        }
-
-        $this->app->singleton(Factory::class, function ($app) {
+        $this->app->bind(Factory::class, function ($app) {
             $renderer = $this->app->runningInConsole()
-                ? new ConsoleRenderer($this->output)
+                ? new ConsoleRenderer(new ConsoleOutput())
                 : new HtmlRenderer();
 
             return new Factory($renderer);

--- a/src/Illuminate/Foundation/Providers/BenchmarkServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/BenchmarkServiceProvider.php
@@ -17,7 +17,7 @@ class BenchmarkServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(Factory::class, function ($app) {
+        $this->app->singleton(Factory::class, function ($app) {
             $renderer = $this->app->runningInConsole()
                 ? new ConsoleRenderer(new ConsoleOutput())
                 : new HtmlRenderer();

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -23,6 +23,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
      * @var string[]
      */
     protected $providers = [
+        BenchmarkServiceProvider::class,
         FormRequestServiceProvider::class,
         ParallelTestingServiceProvider::class,
     ];

--- a/src/Illuminate/Support/Facades/Benchmark.php
+++ b/src/Illuminate/Support/Facades/Benchmark.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * @method static \Illuminate\Support\Benchmark repeat(int $times)
+ * @method static \Illuminate\Support\Benchmark measure(iterable|callable $callables)
+ *
+ * @see \Illuminate\Foundation\Benchmark\Factory
+ */
+class Benchmark extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return \Illuminate\Foundation\Benchmark\Factory::class;
+    }
+}

--- a/src/Illuminate/Support/Facades/Benchmark.php
+++ b/src/Illuminate/Support/Facades/Benchmark.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Support\Benchmark repeat(int $times)
- * @method static \Illuminate\Support\Benchmark measure(iterable|callable $callables)
+ * @method static \Illuminate\Foundation\Benchmark\PendingBenchmark repeat(int $times)
+ * @method static never measure(iterable|\Closure $callables)
  *
  * @see \Illuminate\Foundation\Benchmark\Factory
  */

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -95,6 +95,15 @@ class ComponentsTest extends TestCase
         $this->assertSame('a', $result);
     }
 
+    public function testNewLine()
+    {
+        $output = new BufferedOutput();
+
+        with(new Components\NewLine($output))->render();
+
+        $this->assertStringContainsString("\n", $output->fetch());
+    }
+
     public function testTask()
     {
         $output = new BufferedOutput();

--- a/tests/Console/View/ComponentsTest.php
+++ b/tests/Console/View/ComponentsTest.php
@@ -101,7 +101,7 @@ class ComponentsTest extends TestCase
 
         with(new Components\NewLine($output))->render();
 
-        $this->assertStringContainsString("\n", $output->fetch());
+        $this->assertStringContainsString(PHP_EOL, $output->fetch());
     }
 
     public function testTask()

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -169,9 +169,7 @@ class FoundationConsoleBenchmarkTest extends TestCase
         ConsoleRenderer::terminateUsing(fn () => null);
 
         $output = new BufferedOutput();
-        $renderer = new ConsoleRenderer();
-
-        $renderer->setOutput($output);
+        $renderer = new ConsoleRenderer($output);
         $factory = new Factory($renderer);
 
         return [$factory, $output];

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -131,6 +131,36 @@ class FoundationConsoleBenchmarkTest extends TestCase
         $this->assertStringEndsWith(sprintf('ms  %s%s', PHP_EOL, PHP_EOL), $buffer);
     }
 
+    public function testMeasureCodeDescription()
+    {
+        [$factory, $output] = $this->factory();
+
+        $factory->measure([
+            function () {
+                $myExpensiveCallA = 1 + 1;
+            },
+            function () {
+                $myExpensiveCallB = 2 + 2;
+            },
+            fn () => fn () => function () {
+                fn () => 1;
+            },
+            function () {
+                return function () {
+                    $myExpensiveCallA = 1 + 1;
+                };
+            },
+
+        ]);
+
+        $buffer = $output->fetch();
+
+        $this->assertStringContainsString('[1] $myExpensiveCallA = 1 + 1; ...', $buffer);
+        $this->assertStringContainsString('[2] $myExpensiveCallB = 2 + 2; ...', $buffer);
+        $this->assertStringContainsString('[3] fn () => function () { … ...', $buffer);
+        $this->assertStringContainsString('[4] return function () { … ...', $buffer);
+    }
+
     /**
      * @return array{0: \Illuminate\Foundation\Benchmark\Factory, 1: \Symfony\Component\Console\Output\BufferedOutput}
      */

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -49,7 +49,7 @@ class FoundationConsoleBenchmarkTest extends TestCase
         $this->assertStringContainsString('INFO  Benchmarking [2] script(s) using [10] repetitions.', $buffer);
     }
 
-    public function testMeasurePrefixesNumberOfCallback()
+    public function testMeasureDoesNotPrefixesNumberOfCallbackWhenUsingOneCallback()
     {
         [$factory, $output] = $this->factory();
 
@@ -59,7 +59,23 @@ class FoundationConsoleBenchmarkTest extends TestCase
 
         $buffer = $output->fetch();
 
-        $this->assertStringContainsString('  [1] $myExpensiveCallA = 1 + 1; ...', $buffer);
+        $this->assertStringContainsString("  \$myExpensiveCallA = 1 + 1; ...", $buffer);
+    }
+
+    public function testMeasurePrefixesNumberOfCallbackWhenUsingMultipleCallbacks()
+    {
+        [$factory, $output] = $this->factory();
+
+        $factory->measure([function () {
+            $myExpensiveCallA = 1 + 1;
+        }, function () {
+            $myExpensiveCallB = 2 + 2;
+        }]);
+
+        $buffer = $output->fetch();
+
+        $this->assertStringContainsString("  [1] \$myExpensiveCallA = 1 + 1; ...", $buffer);
+        $this->assertStringContainsString("  [2] \$myExpensiveCallB = 2 + 2; ...", $buffer);
     }
 
     public function testMeasureAddsCodeDescriptionToCallbackByDefault()

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -32,7 +32,7 @@ class FoundationConsoleBenchmarkTest extends TestCase
 
         $buffer = $output->fetch();
 
-        $this->assertStringContainsString('INFO  Benchmarking [2] script(s) using [5] repetitions.', $buffer);
+        $this->assertStringContainsString('INFO  Benchmarking [2] callbacks using [5] repetitions.', $buffer);
     }
 
     public function testMeasureUsesTenRepeatsByDefault()
@@ -46,7 +46,7 @@ class FoundationConsoleBenchmarkTest extends TestCase
 
         $buffer = $output->fetch();
 
-        $this->assertStringContainsString('INFO  Benchmarking [2] script(s) using [10] repetitions.', $buffer);
+        $this->assertStringContainsString('INFO  Benchmarking [2] callbacks using [10] repetitions.', $buffer);
     }
 
     public function testMeasureDoesNotPrefixesNumberOfCallbackWhenUsingOneCallback()

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -21,6 +21,16 @@ class FoundationConsoleBenchmarkTest extends TestCase
         $factory->measure([]);
     }
 
+    public function testMeasureFailsWhenClosuresAreOnTheSameLine()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given callbacks must be on separate lines.');
+
+        [$factory] = $this->factory();
+
+        $factory->measure([fn () => 1, fn () => 2]);
+    }
+
     public function testRepeats()
     {
         [$factory, $output] = $this->factory();

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Benchmark\Factory;
+use Illuminate\Foundation\Benchmark\Renderers\ConsoleRenderer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class FoundationConsoleBenchmarkTest extends TestCase
+{
+    public function testMeasureFailsOnEmptyCallbacks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You must provide at least one callback.');
+
+        [$factory] = $this->factory();
+
+        $factory->measure([]);
+    }
+
+    public function testRepeats()
+    {
+        [$factory, $output] = $this->factory();
+
+        $factory->repeat(5)->measure([
+            fn () => $myExpensiveCallA = 1 + 1,
+            fn () => $myExpensiveCallB = 'foo',
+        ]);
+
+        $buffer = $output->fetch();
+
+        $this->assertStringContainsString('INFO  Benchmarking [2] script(s) using [5] repetitions.', $buffer);
+    }
+
+    public function testMeasureUsesTenRepeatsByDefault()
+    {
+        [$factory, $output] = $this->factory();
+
+        $factory->measure([
+            fn () => $myExpensiveCallA = 1 + 1,
+            fn () => $myExpensiveCallB = 'foo',
+        ]);
+
+        $buffer = $output->fetch();
+
+        $this->assertStringContainsString('INFO  Benchmarking [2] script(s) using [10] repetitions.', $buffer);
+    }
+
+    public function testMeasurePrefixesNumberOfCallback()
+    {
+        [$factory, $output] = $this->factory();
+
+        $factory->measure(function () {
+            $myExpensiveCallA = 1 + 1;
+        });
+
+        $buffer = $output->fetch();
+
+        $this->assertStringContainsString("\n  [1] \$myExpensiveCallA = 1 + 1; ...", $buffer);
+    }
+
+    public function testMeasureAddsCodeDescriptionToCallbackByDefault()
+    {
+        [$factory, $output] = $this->factory();
+
+        $factory->measure([
+            fn () => class_exists(User::class),
+            fn () => class_exists(Team::class),
+        ]);
+
+        $buffer = $output->fetch();
+
+        $this->assertStringContainsString('[1] class_exists(\App\Models\User::class) ...', $buffer);
+        $this->assertStringContainsString('[2] class_exists(\App\Models\Team::class) ...', $buffer);
+    }
+
+    public function testMeasureAllowsToSetDescription()
+    {
+        [$factory, $output] = $this->factory();
+
+        $factory->measure([
+            'user' => fn () => class_exists(User::class),
+            fn () => class_exists(Team::class),
+        ]);
+
+        $buffer = $output->fetch();
+
+        $this->assertStringContainsString('[1] user ...', $buffer);
+        $this->assertStringContainsString('[2] class_exists(\App\Models\Team::class) ...', $buffer);
+    }
+
+    public function testMeasureDisplaysAverageInMilliseconds()
+    {
+        [$factory, $output] = $this->factory();
+
+        $factory->measure(function () {
+            $myExpensiveCall = 1 + 1;
+        });
+
+        $buffer = $output->fetch();
+
+        $this->assertStringEndsWith("ms  \n\n", $buffer);
+    }
+
+    /**
+     * @return array{0: \Illuminate\Foundation\Benchmark\Factory, 1: \Symfony\Component\Console\Output\BufferedOutput}
+     */
+    protected function factory()
+    {
+        ConsoleRenderer::terminateUsing(fn () => null);
+
+        $output = new BufferedOutput();
+        $renderer = new ConsoleRenderer();
+
+        $renderer->setOutput($output);
+        $factory = new Factory($renderer);
+
+        return [$factory, $output];
+    }
+
+    public function tearDown(): void
+    {
+        ConsoleRenderer::terminateUsing(null);
+
+        parent::tearDown();
+    }
+}

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -59,7 +59,7 @@ class FoundationConsoleBenchmarkTest extends TestCase
 
         $buffer = $output->fetch();
 
-        $this->assertStringContainsString("  \$myExpensiveCallA = 1 + 1; ...", $buffer);
+        $this->assertStringContainsString('  $myExpensiveCallA = 1 + 1; ...', $buffer);
     }
 
     public function testMeasurePrefixesNumberOfCallbackWhenUsingMultipleCallbacks()
@@ -74,8 +74,8 @@ class FoundationConsoleBenchmarkTest extends TestCase
 
         $buffer = $output->fetch();
 
-        $this->assertStringContainsString("  [1] \$myExpensiveCallA = 1 + 1; ...", $buffer);
-        $this->assertStringContainsString("  [2] \$myExpensiveCallB = 2 + 2; ...", $buffer);
+        $this->assertStringContainsString('  [1] $myExpensiveCallA = 1 + 1; ...', $buffer);
+        $this->assertStringContainsString('  [2] $myExpensiveCallB = 2 + 2; ...', $buffer);
     }
 
     public function testMeasureAddsCodeDescriptionToCallbackByDefault()

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -59,7 +59,7 @@ class FoundationConsoleBenchmarkTest extends TestCase
 
         $buffer = $output->fetch();
 
-        $this->assertStringContainsString("\n  [1] \$myExpensiveCallA = 1 + 1; ...", $buffer);
+        $this->assertStringContainsString("  [1] \$myExpensiveCallA = 1 + 1; ...", $buffer);
     }
 
     public function testMeasureAddsCodeDescriptionToCallbackByDefault()
@@ -102,7 +102,7 @@ class FoundationConsoleBenchmarkTest extends TestCase
 
         $buffer = $output->fetch();
 
-        $this->assertStringEndsWith("ms  \n\n", $buffer);
+        $this->assertStringEndsWith(sprintf('ms  %s%s', PHP_EOL, PHP_EOL), $buffer);
     }
 
     /**

--- a/tests/Foundation/FoundationConsoleBenchmarkTest.php
+++ b/tests/Foundation/FoundationConsoleBenchmarkTest.php
@@ -59,7 +59,7 @@ class FoundationConsoleBenchmarkTest extends TestCase
 
         $buffer = $output->fetch();
 
-        $this->assertStringContainsString("  [1] \$myExpensiveCallA = 1 + 1; ...", $buffer);
+        $this->assertStringContainsString('  [1] $myExpensiveCallA = 1 + 1; ...', $buffer);
     }
 
     public function testMeasureAddsCodeDescriptionToCallbackByDefault()

--- a/tests/Foundation/FoundationHtmlBenchmarkTest.php
+++ b/tests/Foundation/FoundationHtmlBenchmarkTest.php
@@ -116,6 +116,33 @@ class FoundationHtmlBenchmarkTest extends TestCase
         $this->assertStringContainsString('ms', $this->output['[2] class_exists(\App\Models\Team::class)']);
     }
 
+    public function testMeasureCodeDescription()
+    {
+        $factory = $this->factory();
+
+        $factory->measure([
+            function () {
+                $myExpensiveCallA = 1 + 1;
+            },
+            function () {
+                $myExpensiveCallB = 2 + 2;
+            },
+            fn () => fn () => function () {
+                fn () => 1;
+            },
+            function () {
+                return function () {
+                    $myExpensiveCallA = 1 + 1;
+                };
+            },
+
+        ]);
+        $this->assertStringContainsString('ms', $this->output['[1] $myExpensiveCallA = 1 + 1;']);
+        $this->assertStringContainsString('ms', $this->output['[2] $myExpensiveCallB = 2 + 2;']);
+        $this->assertStringContainsString('ms', $this->output['[3] fn () => function () { …']);
+        $this->assertStringContainsString('ms', $this->output['[4] return function () { …']);
+    }
+
     /**
      * @return \Illuminate\Foundation\Benchmark\Factory
      */

--- a/tests/Foundation/FoundationHtmlBenchmarkTest.php
+++ b/tests/Foundation/FoundationHtmlBenchmarkTest.php
@@ -73,7 +73,7 @@ class FoundationHtmlBenchmarkTest extends TestCase
             },
             function () {
                 $myExpensiveCallB = 2 + 2;
-            }
+            },
         ]);
 
         $this->assertStringContainsString('ms', $this->output['[1] $myExpensiveCallA = 1 + 1;']);

--- a/tests/Foundation/FoundationHtmlBenchmarkTest.php
+++ b/tests/Foundation/FoundationHtmlBenchmarkTest.php
@@ -41,7 +41,7 @@ class FoundationHtmlBenchmarkTest extends TestCase
 
         $pendingBenchmark = $factory->repeat(5);
 
-        $this->assertSame(5, (fn () => $this->repeat)->call($pendingBenchmark));
+        $this->assertSame(5, (fn () => $this->repetitions)->call($pendingBenchmark));
     }
 
     public function testMeasureUsesTenRepeatsByDefault()
@@ -50,7 +50,7 @@ class FoundationHtmlBenchmarkTest extends TestCase
 
         $pendingBenchmark = $factory->newPendingBenchmark();
 
-        $this->assertSame(10, (fn () => $this->repeat)->call($pendingBenchmark));
+        $this->assertSame(10, (fn () => $this->repetitions)->call($pendingBenchmark));
     }
 
     public function testMeasureDoesNotPrefixesNumberOfCallbackWhenUsingOneCallback()

--- a/tests/Foundation/FoundationHtmlBenchmarkTest.php
+++ b/tests/Foundation/FoundationHtmlBenchmarkTest.php
@@ -39,27 +39,18 @@ class FoundationHtmlBenchmarkTest extends TestCase
     {
         $factory = $this->factory();
 
-        $factory->repeat(5)->measure([
-            fn () => $myExpensiveCallA = 1 + 1,
-            fn () => $myExpensiveCallB = 'foo',
-        ]);
+        $pendingBenchmark = $factory->repeat(5);
 
-        $this->assertSame(5, $this->output['repeats']);
-        $this->assertStringContainsString('ms', $this->output['[1] $myExpensiveCallA = 1 + 1']);
-        $this->assertStringContainsString('ms', $this->output["[2] \$myExpensiveCallB = 'foo'"]);
-        $this->assertCount(3, $this->output);
+        $this->assertSame(5, (fn () => $this->repeat)->call($pendingBenchmark));
     }
 
     public function testMeasureUsesTenRepeatsByDefault()
     {
         $factory = $this->factory();
 
-        $factory->measure([
-            fn () => $myExpensiveCallA = 1 + 1,
-            fn () => $myExpensiveCallB = 'foo',
-        ]);
+        $pendingBenchmark = $factory->newPendingBenchmark();
 
-        $this->assertSame(10, $this->output['repeats']);
+        $this->assertSame(10, (fn () => $this->repeat)->call($pendingBenchmark));
     }
 
     public function testMeasureDoesNotPrefixesNumberOfCallbackWhenUsingOneCallback()

--- a/tests/Foundation/FoundationHtmlBenchmarkTest.php
+++ b/tests/Foundation/FoundationHtmlBenchmarkTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Illuminate\Tests\Foundation;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Benchmark\Factory;
+use Illuminate\Foundation\Benchmark\Renderers\HtmlRenderer;
+use PHPUnit\Framework\TestCase;
+
+class FoundationHtmlBenchmarkTest extends TestCase
+{
+    /**
+     * @var array<string, string|int>
+     */
+    protected $output;
+
+    public function testMeasureFailsOnEmptyCallbacks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('You must provide at least one callback.');
+
+        $factory = $this->factory();
+
+        $factory->measure([]);
+    }
+
+    public function testRepeats()
+    {
+        $factory = $this->factory();
+
+        $factory->repeat(5)->measure([
+            fn () => $myExpensiveCallA = 1 + 1,
+            fn () => $myExpensiveCallB = 'foo',
+        ]);
+
+        $this->assertSame(5, $this->output['repeats']);
+        $this->assertStringContainsString('ms', $this->output['[1] $myExpensiveCallA = 1 + 1']);
+        $this->assertStringContainsString('ms', $this->output["[2] \$myExpensiveCallB = 'foo'"]);
+        $this->assertCount(3, $this->output);
+    }
+
+    public function testMeasureUsesTenRepeatsByDefault()
+    {
+        $factory = $this->factory();
+
+        $factory->measure([
+            fn () => $myExpensiveCallA = 1 + 1,
+            fn () => $myExpensiveCallB = 'foo',
+        ]);
+
+        $this->assertSame(10, $this->output['repeats']);
+    }
+
+    public function testMeasurePrefixesNumberOfCallback()
+    {
+        $factory = $this->factory();
+
+        $factory->measure(function () {
+            $myExpensiveCallA = 1 + 1;
+        });
+
+        $this->assertStringContainsString('ms', $this->output['[1] $myExpensiveCallA = 1 + 1;']);
+    }
+
+    public function testMeasureAddsCodeDescriptionToCallbackByDefault()
+    {
+        $factory = $this->factory();
+
+        $factory->measure([
+            fn () => class_exists(User::class),
+            fn () => class_exists(Team::class),
+        ]);
+
+        $this->assertStringContainsString('ms', $this->output['[1] class_exists(\App\Models\User::class)']);
+        $this->assertStringContainsString('ms', $this->output['[2] class_exists(\App\Models\Team::class)']);
+    }
+
+    public function testMeasureAllowsToSetDescription()
+    {
+        $factory = $this->factory();
+
+        $factory->measure([
+            'user' => fn () => class_exists(User::class),
+            fn () => class_exists(Team::class),
+        ]);
+
+        $this->assertStringContainsString('ms', $this->output['[1] user']);
+        $this->assertStringContainsString('ms', $this->output['[2] class_exists(\App\Models\Team::class)']);
+    }
+
+    /**
+     * @return \Illuminate\Foundation\Benchmark\Factory
+     */
+    protected function factory()
+    {
+        $this->output = [];
+
+        HtmlRenderer::terminateUsing(fn () => null);
+        HtmlRenderer::dumpUsing(fn ($results) => $this->output = $results);
+
+        $renderer = new HtmlRenderer();
+
+        return new Factory($renderer);
+    }
+
+    public function tearDown(): void
+    {
+        HtmlRenderer::terminateUsing(null);
+        HtmlRenderer::dumpUsing(null);
+
+        parent::tearDown();
+    }
+}

--- a/tests/Foundation/FoundationHtmlBenchmarkTest.php
+++ b/tests/Foundation/FoundationHtmlBenchmarkTest.php
@@ -52,7 +52,7 @@ class FoundationHtmlBenchmarkTest extends TestCase
         $this->assertSame(10, $this->output['repeats']);
     }
 
-    public function testMeasurePrefixesNumberOfCallback()
+    public function testMeasureDoesNotPrefixesNumberOfCallbackWhenUsingOneCallback()
     {
         $factory = $this->factory();
 
@@ -60,7 +60,24 @@ class FoundationHtmlBenchmarkTest extends TestCase
             $myExpensiveCallA = 1 + 1;
         });
 
+        $this->assertStringContainsString('ms', $this->output['$myExpensiveCallA = 1 + 1;']);
+    }
+
+    public function testMeasurePrefixesNumberOfCallbackWhenUsingMultipleCallbacks()
+    {
+        $factory = $this->factory();
+
+        $factory->measure([
+            function () {
+                $myExpensiveCallA = 1 + 1;
+            },
+            function () {
+                $myExpensiveCallB = 2 + 2;
+            }
+        ]);
+
         $this->assertStringContainsString('ms', $this->output['[1] $myExpensiveCallA = 1 + 1;']);
+        $this->assertStringContainsString('ms', $this->output['[2] $myExpensiveCallB = 2 + 2;']);
     }
 
     public function testMeasureAddsCodeDescriptionToCallbackByDefault()

--- a/tests/Foundation/FoundationHtmlBenchmarkTest.php
+++ b/tests/Foundation/FoundationHtmlBenchmarkTest.php
@@ -25,6 +25,16 @@ class FoundationHtmlBenchmarkTest extends TestCase
         $factory->measure([]);
     }
 
+    public function testMeasureFailsWhenClosuresAreOnTheSameLine()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given callbacks must be on separate lines.');
+
+        $factory = $this->factory();
+
+        $factory->measure([fn () => 1, fn () => 2]);
+    }
+
     public function testRepeats()
     {
         $factory = $this->factory();


### PR DESCRIPTION
This pull request introduces a new `Benchmark::measure` facade that allows you quickly measure and compare Laravel code performance. Here is an example:

```php
use Illuminate\Support\Facades\Benchmark;

Benchmark::measure([
    fn () => User::count(),
    fn () => User::all()->count(),
]);
```

Using the following code, and if the application is running on the console, Artisan will output the following content:
<img width="100%" alt="console" src="https://user-images.githubusercontent.com/5457236/191987741-2cda8f0a-0e96-4797-8194-e6202e9923c1.png">

As you can see, this report shows the elapsed real time, and thehe unit of time is miliseconds. In addition, Ten "repeats" were used by default. Meaning that both the given callbacks were executed ten times, and the value on the right is the average time elapsed of those ten executions.

Also, the fastest callback gets highlighted by using the green color. And, the left content contains an "description" based on the given closure's code.

Next, besides passing a list of callbacks, you can also pass a single callback. And of course, you can equally specify the number of desired repetitons:

```php
Route::get('/', function () {
    Benchmark::repeat(100)->measure(function () {
        $user = User::first();

        $team = $user->team;

        // More code...
    });
});
```

When visiting this route, the output will be rendered on the browser like so:
<img width="1348" alt="http" src="https://user-images.githubusercontent.com/5457236/191987873-53704da8-6dc1-4d1e-b69c-f745847e5972.png">

---

**As future scope**, would be interesting to provide certain methods, in special places of the framework, so we can easily benchmark routes, commands, and other framework resources without having to put the entire code of those resources within a closure for the `Benchmark::measure` method. In concrete terms, this would mean something like this:

```php
// Not this...
Route::get('/', function () {
    Benchmark::measure(function () {
        // My code ...
    });
});

// But this...
Route::get('/', function () {
    // ...
})->benchmark();
```
