### PR TITLE
[9.x] Allow signed URLs with custom key resolver

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -812,6 +812,17 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Create a new instance of the UrlGenerator with a different encryption key resolver.
+     *
+     * @param  callable  $keyResolver
+     * @return \Illuminate\Routing\UrlGenerator
+     */
+    public function withKeyResolver(callable $keyResolver)
+    {
+        return (clone $this)->setKeyResolver($keyResolver);
+    }
+
+    /**
      * Get the root controller namespace.
      *
      * @return string

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -812,7 +812,7 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
-     * Create a new instance of the UrlGenerator with a different encryption key resolver.
+     * Clone a new instance of the URL generator with a different encryption key resolver.
      *
      * @param  callable  $keyResolver
      * @return \Illuminate\Routing\UrlGenerator

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -867,6 +867,41 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertSame('http://www.foo.com/foo/fruits', $url->route('foo.bar', CategoryBackedEnum::Fruits));
     }
+
+    public function testSignedUrlWithKeyResolver()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        $route = new Route(['GET'], 'foo', ['as' => 'foo', function () {
+            //
+        }]);
+        $routes->add($route);
+
+        $request = Request::create($url->signedRoute('foo'));
+
+        $this->assertTrue($url->hasValidSignature($request));
+
+        $request = Request::create($url->signedRoute('foo').'?tempered=true');
+
+        $this->assertFalse($url->hasValidSignature($request));
+
+        $url2 = $url->withKeyResolver(function () {
+            return 'other-secret';
+        });
+
+        $this->assertFalse($url2->hasValidSignature($request));
+
+        $request = Request::create($url2->signedRoute('foo'));
+
+        $this->assertTrue($url2->hasValidSignature($request));
+        $this->assertFalse($url->hasValidSignature($request));
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable


### PR DESCRIPTION
In case there are multiple applications communicating together, you don't want to share the same encryption key throughout all applications, but you may have a different pre-shared secret to sign URLs with. With this new `withKeyResolver` method on the UrlGenerator, a clone of the current UrlGenerator will be created where a different key can be used to validate the signature or generate signed URLs 

If you were to call `url()->setKeyResolver()`, then this will change the key for the remainder of the request, potentially generating incorrect signed URLs where this custom key wasn't needed.

Two very basic examples of how it could be used:

It can be used in middleware to validate with custom key:
```php
public function handle(Request $request, Closure $next)
{
    $urlGenerator = url()->withKeyResolver(fn() => config('services.my-service.key'));
    
    if(!$urlGenerator->hasValidSignature($request)) {
       throw new InvalidSignatureException;
    }
   
    return $next($request);
}
```

It can be used in a controller to generate a URL with custom key:
```php
public function __invoke()
{
    $urlGenerator = url()->withKeyResolver(fn() => config('services.my-service.key'));

    return response()->json([
        'return_url' => $urlGenerator->signedRoute('test')
    ]);
}
```
