### PR TITLE
[9.x] Allow enum route bindings to have default values

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -78,8 +78,10 @@ trait RouteDependencyResolverTrait
         // the list of parameters. If it is we will just skip it as it is probably a model
         // binding and we do not want to mess with those; otherwise, we resolve it here.
         if ($className && ! $this->alreadyInParameters($className, $parameters)) {
+            $isEnum = method_exists(ReflectionClass::class, 'isEnum') ? (new ReflectionClass($className))->isEnum() : false;
+            
             return $parameter->isDefaultValueAvailable()
-                ? ((new ReflectionClass($className))->isEnum() ? $parameter->getDefaultValue() : null)
+                ? ($isEnum ? $parameter->getDefaultValue() : null)
                 : $this->container->make($className);
         }
 

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -78,7 +78,7 @@ trait RouteDependencyResolverTrait
         // the list of parameters. If it is we will just skip it as it is probably a model
         // binding and we do not want to mess with those; otherwise, we resolve it here.
         if ($className && ! $this->alreadyInParameters($className, $parameters)) {
-            $isEnum = method_exists(ReflectionClass::class, 'isEnum') ? (new ReflectionClass($className))->isEnum() : false;
+            $isEnum = method_exists(ReflectionClass::class, 'isEnum') && (new ReflectionClass($className))->isEnum();
 
             return $parameter->isDefaultValueAvailable()
                 ? ($isEnum ? $parameter->getDefaultValue() : null)

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
+use ReflectionClass;
 use ReflectionFunctionAbstract;
 use ReflectionMethod;
 use ReflectionParameter;
@@ -77,7 +78,9 @@ trait RouteDependencyResolverTrait
         // the list of parameters. If it is we will just skip it as it is probably a model
         // binding and we do not want to mess with those; otherwise, we resolve it here.
         if ($className && ! $this->alreadyInParameters($className, $parameters)) {
-            return $parameter->isDefaultValueAvailable() ? null : $this->container->make($className);
+            return $parameter->isDefaultValueAvailable()
+                ? ((new ReflectionClass($className))->isEnum() ? $parameter->getDefaultValue() : null)
+                : $this->container->make($className);
         }
 
         return $skippableValue;

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -79,7 +79,7 @@ trait RouteDependencyResolverTrait
         // binding and we do not want to mess with those; otherwise, we resolve it here.
         if ($className && ! $this->alreadyInParameters($className, $parameters)) {
             $isEnum = method_exists(ReflectionClass::class, 'isEnum') ? (new ReflectionClass($className))->isEnum() : false;
-            
+
             return $parameter->isDefaultValueAvailable()
                 ? ($isEnum ? $parameter->getDefaultValue() : null)
                 : $this->container->make($className);

--- a/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitBackedEnumRouteBindingTest.php
@@ -24,6 +24,10 @@ use Illuminate\Tests\Integration\Routing\CategoryBackedEnum;
 Route::get('/categories/{category}', function (CategoryBackedEnum \$category) {
     return \$category->value;
 })->middleware('web');
+
+Route::get('/categories-default/{category?}', function (CategoryBackedEnum \$category = CategoryBackedEnum::Fruits) {
+    return \$category->value;
+})->middleware('web');
 PHP);
 
         $response = $this->get('/categories/fruits');
@@ -34,6 +38,15 @@ PHP);
 
         $response = $this->get('/categories/cars');
         $response->assertNotFound(404);
+
+        $response = $this->get('/categories-default/');
+        $response->assertSee('fruits');
+
+        $response = $this->get('/categories-default/people');
+        $response->assertSee('people');
+
+        $response = $this->get('/categories-default/fruits');
+        $response->assertSee('fruits');
     }
 
     public function testWithoutRouteCachingEnabled()
@@ -44,6 +57,10 @@ PHP);
             return $category->value;
         })->middleware(['web']);
 
+        Route::post('/categories-default/{category?}', function (CategoryBackedEnum $category = CategoryBackedEnum::Fruits) {
+            return $category->value;
+        })->middleware('web');
+
         $response = $this->post('/categories/fruits');
         $response->assertSee('fruits');
 
@@ -52,5 +69,14 @@ PHP);
 
         $response = $this->post('/categories/cars');
         $response->assertNotFound(404);
+
+        $response = $this->post('/categories-default/');
+        $response->assertSee('fruits');
+
+        $response = $this->post('/categories-default/people');
+        $response->assertSee('people');
+
+        $response = $this->post('/categories-default/fruits');
+        $response->assertSee('fruits');
     }
 }

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -39,6 +39,21 @@ class ImplicitRouteBindingTest extends TestCase
     /**
      * @requires PHP >= 8.1
      */
+    public function test_it_can_resolve_the_backed_enum_default_value_for_the_given_route()
+    {
+        $action = ['uses' => function (CategoryBackedEnum $category = CategoryBackedEnum::Fruits) {
+            return $category->value;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = [];
+
+        $this->assertSame('fruits', $route->run());
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
     public function test_it_does_not_resolve_implicit_non_backed_enum_route_bindings_for_the_given_route()
     {
         $action = ['uses' => function (CategoryEnum $category) {


### PR DESCRIPTION
It's possible already to bind route parameters to enums:

```php
enum Status: string {
  case Published = 'published';
  case Draft = 'draft';
}

Route::get('/posts/{status}', function(Status $status) {});
```

However, it's not yet possible to have default values for optional parameters, as I discovered in #44249:

```php
Route::get('/posts/{status?}', function(Status $status = Status::Published) {});
```

As discussed in #44249, I made the PR in a way, that it only applies, if the parameter is an enum, so it doesn't interfere with model binding in any way.

I'm not fully happy with the nested ternary operator, making it a bit more complex - I'm happy to change it so some other structure if you think something else is more readable.

I tried to keep the code change minimal to support this while having extensive tests, for them I looked at the existing backed enum binding tests and extended those.