### PR TITLE
Feature: Preventing Missing Translation Keys Flag

### DIFF
--- a/src/Illuminate/Translation/MissingTranslationKeyViolationException.php
+++ b/src/Illuminate/Translation/MissingTranslationKeyViolationException.php
@@ -7,11 +7,18 @@ use RuntimeException;
 class MissingTranslationKeyViolationException extends RuntimeException
 {
     /**
-     * The name of the affected Eloquent model.
+     * The Key of the missing translation.
      *
      * @var string
      */
     public $key;
+
+    /**
+     * The default locale that was used.
+     *
+     * @var array
+     */
+    public $locales;
 
     /**
      * Create a new exception instance.
@@ -20,10 +27,12 @@ class MissingTranslationKeyViolationException extends RuntimeException
      * @param  string  $relation
      * @return static
      */
-    public function __construct($key)
+    public function __construct($key, $locales)
     {
-        parent::__construct("Attempted to translate [{$key}] but prevention for missing translation key is enabled.");
+        $l = implode(',', $locales);
+        parent::__construct("Attempted to translate [{$key}] under the locales [{$l}] but prevention for missing translation key is enabled.");
 
         $this->key = $key;
+        $this->locales = $locales;
     }
 }

--- a/src/Illuminate/Translation/MissingTranslationKeyViolationException.php
+++ b/src/Illuminate/Translation/MissingTranslationKeyViolationException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Translation;
+
+use RuntimeException;
+
+class MissingTranslationKeyViolationException extends RuntimeException
+{
+    /**
+     * The name of the affected Eloquent model.
+     *
+     * @var string
+     */
+    public $key;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  object  $model
+     * @param  string  $relation
+     * @return static
+     */
+    public function __construct($key)
+    {
+        parent::__construct("Attempted to translate [{$key}] but prevention for missing translation key is enabled.");
+
+        $this->key = $key;
+    }
+}

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -58,12 +58,19 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     protected $determineLocalesUsing;
 
     /**
-     * Indicates whether translation keys should throw an error when it's missing on a specific locale.
+     * Indicates whether translation keys should throw an error when it's missing on a all locale.
      *
      * @var bool
      */
     protected static $preventMissingTranslationKey = false;
 
+    /**
+     * Indicates whether preventing missing translation keys will allow fallback locales.
+     *
+     * @var bool
+     */
+    protected static $preventMissingTranslationKeyAllowFallback = true;
+  
     /**
      * Create a new translator instance.
      *
@@ -84,19 +91,30 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  bool  $value
      * @return void
      */
-    public static function preventMissingTranslationKey($value = true)
+    public static function preventMissingTranslationKey($value = true, $allow_fallback = true)
     {
       static::$preventMissingTranslationKey = $value;
+      static::$preventMissingTranslationKeyAllowFallback = $allow_fallback;
     }
 
     /**
-     * Determine if missing translation key prevention is disabled.
+     * Determine if missing translation key prevention is enabled.
      *
      * @return bool
      */
     public static function preventsMissingTranslationKey()
     {
         return static::$preventMissingTranslationKey;
+    }
+
+    /**
+     * Determine if missing translation key prevention should allow fallback.
+     *
+     * @return bool
+     */
+    public static function preventsMissingTranslationKeyAllowFallback()
+    {
+        return static::$preventMissingTranslationKeyAllowFallback;
     }
 
     /**
@@ -154,7 +172,11 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             // Here we will get the locale that should be used for the language line. If one
             // was not passed, we will use the default locales which was given to us when
             // the translator was instantiated. Then, we can load the lines and return.
-            $locales = $fallback ? $this->localeArray($locale) : [$locale];
+            if ($this->preventsMissingTranslationKeyAllowFallback()) {
+              $locales = $fallback ? $this->localeArray($locale) : [$locale];
+            } else {
+              $locales = [$locale];
+            }
 
             foreach ($locales as $locale) {
               

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -120,6 +120,25 @@ class TranslationTranslatorTest extends TestCase
         $t->get('foo::unknown.bar');
     }
 
+    public function testGetMethodFindsLineUnderFallbackLocaleThrowsErrorWhenPreventingMissingTranslationKeysFallbackOveride()
+    {
+        $this->expectException(MissingTranslationKeyViolationException::class);
+
+        Translator::preventMissingTranslationKey(value: true, allow_fallback: true);
+
+        $t = new Translator($this->getLoader(), 'en');
+        $t->setFallback('lv');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'unknown', 'foo')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->with('lv', 'unknown', 'foo')->andReturn(['bar' => 'baz']);
+
+        // Act 
+        $this->assertSame('baz', $t->get('foo::unknown.bar'));
+
+        Translator::preventMissingTranslationKey(value: true, allow_fallback: false);
+        $t->get('foo::unknown.bar');
+    }
+
     public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
     {
         $t = new Translator($this->getLoader(), 'en');

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -276,27 +276,23 @@ class TranslationTranslatorTest extends TestCase
         $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
     }
 
-    public function testGetJsonForNonExistingThrowsAnErrorWhenPreventingMissingTranslationKeys()
+    public function testGetJsonForNonExistingThrowsAnErrorWhenPreventingMissingTranslationKeysDisallowsReplace()
     {
         $this->expectException(MissingTranslationKeyViolationException::class);
-        Translator::preventMissingTranslationKey();
+        Translator::preventMissingTranslationKey(true, true, false);
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
         $t->get('foo :message', ['message' => 'baz']);
     }
 
-    public function testGetJsonForNonExistingThrowsAnErrorWhenPreventingMissingTranslationKeysDisallowsReplace()
+    public function testGetJsonForNonExistingThrowsAnErrorWhenPreventingMissingTranslationKeysAllowsReplace()
     {
-        $this->expectException(MissingTranslationKeyViolationException::class);
-        Translator::preventMissingTranslationKey();
+        Translator::preventMissingTranslationKey(true, true, true);
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
-        $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz'])); 
-
-        Translator::preventMissingTranslationKey(true, true, false);
-        $t->get('foo :message', ['message' => 'baz']);
+        $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
     }
 
     public function testEmptyFallbacks()

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -286,6 +286,19 @@ class TranslationTranslatorTest extends TestCase
         $t->get('foo :message', ['message' => 'baz']);
     }
 
+    public function testGetJsonForNonExistingThrowsAnErrorWhenPreventingMissingTranslationKeysDisallowsReplace()
+    {
+        $this->expectException(MissingTranslationKeyViolationException::class);
+        Translator::preventMissingTranslationKey();
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+        $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz'])); 
+
+        Translator::preventMissingTranslationKey(true, true, false);
+        $t->get('foo :message', ['message' => 'baz']);
+    }
+
     public function testEmptyFallbacks()
     {
         $t = new Translator($this->getLoader(), 'en');


### PR DESCRIPTION
## Description

Feature is inspired by `Model::preventLazyLoading()`

This will benefit the end user when trying to develop locally and makes it easier when trying to figure out which translations are missing.

## How to use

on your `AppServiceProvider.php`

```php
use Illuminate\Translation\Translator;

public function boot()
{
   Translator::preventMissingTranslationKey(! app()->isProduction());
}
```

you can also disallow fallbacks...

> Normal Flow: if key does not exists in main locale it will try to look for the same key in your fallback locale

disallowing fallback will disrupt this flow:

> Disruptive Flow: if key does not exists in main locale, it will throw an error, skipping fallback checks

### How to disallow fallback

```php
use Illuminate\Translation\Translator;

public function boot()
{
   Translator::preventMissingTranslationKey(
       value: ! app()->isProduction(), 
       allow_fallback: false
   );
}
```

You can also disallow replace...

> Normal Flow: if `__("foo :message", ['message' => 'bar'])` does not exists in main json locale it will try to make replacements directly from the `key` string

disallowing replace will disrupt this flow:

> Disruptive Flow: if `__("foo :message", ['message' => 'bar'])` does not exists in main json locale it will throw an error, skipping replacements..

### How to disallow replacements

```php
use Illuminate\Translation\Translator;

public function boot()
{
   Translator::preventMissingTranslationKey(
       value: ! app()->isProduction(), 
       allow_fallback: false,
       allow_replace: false
   );
}
```