### PR TITLE
Keep url query string clean when user visits first page again

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -174,14 +174,16 @@ abstract class AbstractPaginator implements Htmlable
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
+        $parameters = $page === 1 ? [] : [$this->pageName => $page];
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
         }
 
         return $this->path()
-                        .(str_contains($this->path(), '?') ? '&' : '?')
+                        .($page > 1 || count($parameters) > 0
+                            ? (str_contains($this->path(), '?') ? '&' : '?')
+                            : '')
                         .Arr::query($parameters)
                         .$this->buildFragment();
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -592,12 +592,12 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->get('http://foo.com/get?foo=bar&page=1');
+        $this->factory->get('http://foo.com/get?foo=bar');
 
         $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'http://foo.com/get?foo=bar&page=1'
+            return $request->url() === 'http://foo.com/get?foo=bar'
                 && $request['foo'] === 'bar'
-                && $request['page'] === '1';
+                && ! isset($request['page']);
         });
     }
 
@@ -605,13 +605,13 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->get('http://foo.com/get?foo;bar;1;5;10&page=1');
+        $this->factory->get('http://foo.com/get?foo;bar;1;5;10');
 
         $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1'
+            return $request->url() === 'http://foo.com/get?foo;bar;1;5;10'
                 && ! isset($request['foo'])
                 && ! isset($request['bar'])
-                && $request['page'] === '1';
+                && ! isset($request['page']);
         });
     }
 
@@ -619,7 +619,7 @@ class HttpClientTest extends TestCase
     {
         $this->factory->fake();
 
-        $this->factory->get('http://foo.com/get?foo=bar&page=1', ['hello' => 'world']);
+        $this->factory->get('http://foo.com/get?foo=bar', ['hello' => 'world']);
 
         $this->factory->assertSent(function (Request $request) {
             return $request->url() === 'http://foo.com/get?hello=world'

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -632,7 +632,7 @@ class ResourceTest extends TestCase
         );
 
         $this->assertEquals(
-            '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/?page=1","last":"\/?page=1","prev":null,"next":null},"meta":{"current_page":1,"from":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","active":false},{"url":"\/?page=1","label":"1","active":true},{"url":null,"label":"Next &raquo;","active":false}],"path":"\/","per_page":15,"to":1,"total":10}}',
+            '{"data":[{"id":5,"title":"Test Title","reading_time":3.0}],"links":{"first":"\/","last":"\/","prev":null,"next":null},"meta":{"current_page":1,"from":1,"last_page":1,"links":[{"url":null,"label":"&laquo; Previous","active":false},{"url":"\/","label":"1","active":true},{"url":null,"label":"Next &raquo;","active":false}],"path":"\/","per_page":15,"to":1,"total":10}}',
             $response->baseResponse->content()
         );
     }
@@ -744,8 +744,8 @@ class ResourceTest extends TestCase
                 ],
             ],
             'links' => [
-                'first' => '/?page=1',
-                'last' => '/?page=1',
+                'first' => '/',
+                'last' => '/',
                 'prev' => null,
                 'next' => null,
             ],
@@ -786,9 +786,9 @@ class ResourceTest extends TestCase
                 ],
             ],
             'links' => [
-                'first' => '/?framework=laravel&author=Otwell&page=1',
+                'first' => '/?framework=laravel&author=Otwell',
                 'last' => '/?framework=laravel&author=Otwell&page=3',
-                'prev' => '/?framework=laravel&author=Otwell&page=1',
+                'prev' => '/?framework=laravel&author=Otwell',
                 'next' => '/?framework=laravel&author=Otwell&page=3',
             ],
             'meta' => [
@@ -828,9 +828,9 @@ class ResourceTest extends TestCase
                 ],
             ],
             'links' => [
-                'first' => '/?author=Taylor&page=1',
+                'first' => '/?author=Taylor',
                 'last' => '/?author=Taylor&page=3',
-                'prev' => '/?author=Taylor&page=1',
+                'prev' => '/?author=Taylor',
                 'next' => '/?author=Taylor&page=3',
             ],
             'meta' => [
@@ -982,8 +982,8 @@ class ResourceTest extends TestCase
                 ],
             ],
             'links' => [
-                'first' => '/?page=1',
-                'last' => '/?page=1',
+                'first' => '/',
+                'last' => '/',
                 'prev' => null,
                 'next' => null,
             ],

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -80,10 +80,10 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertSame('http://website.com?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertSame('http://website.com?foo=1',
+        $this->assertSame('http://website.com',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertSame('http://website.com?foo=1',
+        $this->assertSame('http://website.com',
                             $this->p->url($this->p->currentPage() - 2));
     }
 
@@ -104,10 +104,10 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertSame('http://website.com/test?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertSame('http://website.com/test?foo=1',
+        $this->assertSame('http://website.com/test',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertSame('http://website.com/test?foo=1',
+        $this->assertSame('http://website.com/test',
                             $this->p->url($this->p->currentPage() - 2));
     }
 

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -19,9 +19,9 @@ class PaginatorTest extends TestCase
         $pageInfo = [
             'per_page' => 2,
             'current_page' => 2,
-            'first_page_url' => '/?page=1',
+            'first_page_url' => '/',
             'next_page_url' => '/?page=3',
-            'prev_page_url' => '/?page=1',
+            'prev_page_url' => '/',
             'from' => 3,
             'to' => 4,
             'data' => ['item3', 'item4'],
@@ -36,7 +36,7 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test/']);
 
-        $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertSame('http://website.com/test', $p->previousPageUrl());
     }
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
@@ -44,7 +44,7 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);
 
-        $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertSame('http://website.com/test', $p->previousPageUrl());
     }
 
     public function testItRetrievesThePaginatorOptions()

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -19,7 +19,7 @@ class UrlWindowTest extends TestCase
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
     }
 
     public function testPresenterCanGetAUrlRangeForAWindowOfLinks()
@@ -35,7 +35,7 @@ class UrlWindowTest extends TestCase
             $slider[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [19 => '/?page=19', 20 => '/?page=20']], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => $slider, 'last' => [19 => '/?page=19', 20 => '/?page=20']], $window->get());
 
         /*
          * Test Being Near The End Of The List
@@ -50,7 +50,7 @@ class UrlWindowTest extends TestCase
         for ($i = 11; $i <= 20; $i++) {
             $last[$i] = '/?page='.$i;
         }
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
     }
 
     public function testCustomUrlRangeForAWindowOfLinks()
@@ -69,6 +69,6 @@ class UrlWindowTest extends TestCase
             $slider[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [19 => '/?page=19', 20 => '/?page=20']], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => $slider, 'last' => [19 => '/?page=19', 20 => '/?page=20']], $window->get());
     }
 }


### PR DESCRIPTION
Keep the query string clean when a user navigates to first page using the pagination.

**Problem:** when navigating using pagination, when a user goes back to the first page the url keeps the query string `?page=1`.



**Goal:**  Keep it clean like: `https://blog.laravel.com/posts`, instead of `https://blog.laravel.com/posts/?page=1`.