### PR TITLE
[9.x] Allow factories to recycle models with `for` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -69,7 +69,9 @@ class BelongsToRelationship
     {
         return function () use ($key) {
             if (! $this->resolved) {
-                $instance = $this->factory instanceof Factory ? $this->factory->create() : $this->factory;
+                $instance = $this->factory instanceof Factory
+                    ? $this->factory->recycle->get($this->factory->modelName()) ?? $this->factory->create()
+                    : $this->factory;
 
                 return $this->resolved = $key ? $instance->{$key} : $instance->getKey();
             }

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -70,7 +70,7 @@ class BelongsToRelationship
         return function () use ($key) {
             if (! $this->resolved) {
                 $instance = $this->factory instanceof Factory
-                    ? $this->factory->recycle->get($this->factory->modelName()) ?? $this->factory->create()
+                    ? ($this->factory->recycle->get($this->factory->modelName()) ?? $this->factory->create())
                     : $this->factory;
 
                 return $this->resolved = $key ? $instance->{$key} : $instance->getKey();

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -68,7 +68,7 @@ abstract class Factory
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $recycle;
+    public $recycle;
 
     /**
      * The "after making" callbacks that will be applied to the model.

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -670,7 +670,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertEquals($user->id, $post->comments[1]->user_id);
     }
 
-    public function test_for_method_with_recycle()
+    public function test_for_method_recycles_models()
     {
         Factory::guessFactoryNamesUsing(function ($model) {
             return $model.'Factory';

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -670,6 +670,21 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertEquals($user->id, $post->comments[1]->user_id);
     }
 
+    public function test_for_method_with_recycle()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $user = FactoryTestUserFactory::new()->create();
+        $post = FactoryTestPostFactory::new()
+            ->recycle($user)
+            ->for(FactoryTestUserFactory::new())
+            ->create();
+
+        $this->assertSame(1, FactoryTestUser::count());
+    }
+
     /**
      * Get a database connection instance.
      *

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -685,6 +685,22 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(1, FactoryTestUser::count());
     }
 
+    public function test_has_method_does_not_reassign_the_parent()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $post = FactoryTestPostFactory::new()->create();
+        $user = FactoryTestUserFactory::new()
+            ->recycle($post)
+            // The recycled post already belongs to a user, so it shouldn't be recycled here.
+            ->has(FactoryTestPostFactory::new(), 'posts')
+            ->create();
+
+        $this->assertSame(2, FactoryTestPost::count());
+    }
+
     /**
      * Get a database connection instance.
      *


### PR DESCRIPTION
This PR addresses https://github.com/laravel/framework/pull/44107#issuecomment-1249158498 where using the Factory `for` method instead of specifying a `'model_id' => Model::factory()` definition does not use recycled models. I *think* this makes sense, although typically you'd call `for` from your test where you could just pass the model directly, so I think it's more of an edge case.

I considered adding support for the `has` method as well, however, I don't think that one makes as much sense. If the recycled model _belongs to_ another model, then I don't think it's parent relationship should be re-assigned, especially if it's part of a _has many_ relationship where more than one model might be needed. I could make it attach the model in a _many-to-many_ relationship, but it would probably need to be conditional on whether one or many models were requested. In any case, I can't think of a scenario where this would be a papercut so I'm not inclined to look into it further right now.