### PR TITLE
[9.x] Improve generator command output

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -182,7 +182,7 @@ abstract class GeneratorCommand extends Command
             }
         }
 
-        $this->components->info($info.' created successfully.');
+        $this->components->info(sprintf('%s [%s] created successfully.', $info, $path));
     }
 
     /**


### PR DESCRIPTION
This PR augments the output of Laravel's generator command in order to include the generated file path in the output, consistent with the `make:migration` command.

Particularly useful [for users new](https://twitter.com/cjav_dev/status/1570855550640066561) to the framework who may not know where the generated files end up by convention.

I haven't modified the output of the `make:migration` command, however, as this has an explicit option to show the full path else the abbreviated migration filename. The added complication with this command being that it is possible to pass `--realpath`, such that the path is outside of the conventional location. Happy to amend this PR to include, but felt like changing that would be a BC break at this point.

<img width="1280" alt="CleanShot 2022-09-23 at 12 11 54" src="https://user-images.githubusercontent.com/558441/191883210-814b83cf-ff24-49ea-aa22-639b65e379ea.png">
