### PR TITLE
[9.x] Add a hook to the serialisation of collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -665,16 +665,32 @@ class Collection extends BaseCollection implements QueueableCollection
             return;
         }
 
-        $class = get_class($this->first());
+        $class = $this->getModelClass($this->first());
 
         $this->each(function ($model) use ($class) {
-            if (get_class($model) !== $class) {
+            if ($this->getModelClass($model) !== $class) {
                 throw new LogicException('Queueing collections with multiple model types is not supported.');
             }
         });
 
         return $class;
     }
+
+    /**
+     * Get the identifiers for all of the entities.
+     *
+     * @return array<int, mixed>
+     */
+    protected function getModelClass($model)
+    {
+        if(method_exists($model,'getClassNameForSerialization')) {
+                return $model->getClassNameForSerialization();
+        }
+        
+        return get_class($model);
+    }
+    
+    
 
     /**
      * Get the identifiers for all of the entities.

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -683,14 +683,12 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     protected function getModelClass($model)
     {
-        if(method_exists($model,'getClassNameForSerialization')) {
-                return $model->getClassNameForSerialization();
+        if (method_exists($model, 'getClassNameForSerialization')) {
+            return $model->getClassNameForSerialization();
         }
-        
+
         return get_class($model);
     }
-    
-    
 
     /**
      * Get the identifiers for all of the entities.

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -677,9 +677,9 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get the identifiers for all of the entities.
+     * Get the identifiers for a single entity.
      *
-     * @return array<int, mixed>
+     * @return string
      */
     protected function getModelClass($model)
     {


### PR DESCRIPTION
This allows the use of parent/child Models in the same collection, to be properly serialized using the parent model (given a proper trait that facilitates the new function provided).

Parent/child models as implemented in for example (https://github.com/calebporzio/parental) currently cause serialization errors when attempting to queue or otherwise serialize a collection containing them. 

This hook would allow us to alleviate the issue.

If rather than checking for the existence of the function you'd rather just call the function, it can also easily be implemented on the model by default and then overwritten by the trait.