### PR TITLE
[9.x]  Add `existsInDirectory` method to Filesystem

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -31,6 +31,18 @@ class Filesystem
     }
 
     /**
+     * Determine if a file exists in a directory.
+     *
+     * @param  string  $file
+     * @param  string  $directory
+     * @return bool
+     */
+    public function existsInDirectory($file, $directory)
+    {
+        return in_array($file, $this->files($directory));
+    }
+
+    /**
      * Determine if a file or directory is missing.
      *
      * @param  string  $path

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -181,6 +181,18 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Determine if a file exists in a directory.
+     *
+     * @param  string  $file
+     * @param  string  $directory
+     * @return bool
+     */
+    public function existsInDirectory($file, $directory)
+    {
+        return $this->driver->fileExists($directory.'/'.$file);
+    }
+
+    /**
      * Determine if a file or directory is missing.
      *
      * @param  string  $path

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -142,6 +142,13 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->fileExists('file.txt'));
     }
 
+    public function testExistsInDirectory()
+    {
+        $this->filesystem->write('/foo/bar/file.txt', 'Hello World');
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $this->assertTrue($filesystemAdapter->existsInDirectory('file.txt', '/foo/bar'));
+    }
+
     public function testMissing()
     {
         $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -189,6 +189,14 @@ class FilesystemTest extends TestCase
         $files->prepend(self::$tempDir.'/file.txt', 'Hello World');
         $this->assertStringEqualsFile(self::$tempDir.'/file.txt', 'Hello World');
     }
+    
+    public function testExistsInDirectory()
+    {
+        mkdir(self::$tempDir.'/foo');
+        file_put_contents(self::$tempDir.'/foo/file.txt', 'Hello World');
+        $files = new Filesystem;
+        $this->assertTrue($files->existsInDirectory(self::$tempDir.'/foo/file.txt', self::$tempDir.'/foo'));
+    }
 
     public function testMissingFile()
     {


### PR DESCRIPTION
The `existsInDirectory` method helps us check if a file exists in a (specific) directory or not.

* Add existsInDirectory method to FilesystemAdapter

* Add existsInDirectory method to Filesystem

* Add testExistsInDirectory method to FilesystemAdapterTest

* Add testExistsInDirectory method to FilesystemTest