### PR TITLE
[9.x] Adds `retryQuietly` method to the HTTP Client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -542,6 +542,19 @@ class PendingRequest
     }
 
     /**
+     * Retry the request the specified number of times without throwing an exception on server or client errors.
+     *
+     * @param  int  $times
+     * @param  int  $sleepMilliseconds
+     * @param  callable|null  $when
+     * @return $this
+     */
+    public function retryQuietly(int $times, int $sleepMilliseconds = 0, ?callable $when = null)
+    {
+        return $this->retry($times, $sleepMilliseconds, $when, false);
+    }
+
+    /**
      * Replace the specified options on the request.
      *
      * @param  array  $options

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -22,6 +22,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest maxRedirects(int $max)
  * @method static \Illuminate\Http\Client\PendingRequest retry(int $times, int $sleepMilliseconds = 0, ?callable $when = null, bool $throw = true)
+ * @method static \Illuminate\Http\Client\PendingRequest retryQuietly(int $times, int $sleepMilliseconds = 0, ?callable $when = null)
  * @method static \Illuminate\Http\Client\ResponseSequence sequence(array $responses = [])
  * @method static \Illuminate\Http\Client\PendingRequest sink(string|resource $to)
  * @method static \Illuminate\Http\Client\PendingRequest stub(callable $callback)

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1318,6 +1318,21 @@ class HttpClientTest extends TestCase
         $this->factory->assertSentCount(1);
     }
 
+    public function testRequestExceptionIsNotThrownWhenRetriesExhaustedAndRunningQuietly()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $response = $this->factory
+            ->retryQuietly(2, 1000)
+            ->get('http://foo.com/get');
+
+        $this->assertTrue($response->failed());
+
+        $this->factory->assertSentCount(2);
+    }
+
     public function testRequestExceptionIsNotThrownWhenDisabledAndRetriesExhausted()
     {
         $this->factory->fake([


### PR DESCRIPTION
### TL;DR

This PR proposes a new method for the HTTP Client - `retryQuietly`. 

It's simply a wrapper around the existing `retry` method, setting `retryThrow` to false.

_____

### Background

Recently when working on a project, I needed to add the `retry` method to an existing implementation of the HTTP Client which looked a bit like this.

```php
$response = Http::get('https://example.com');

if ($response->failed()) {
    return;
}
```

Adding the retry method was as simple as you would expect:

```php
$response = Http::retry(3, 100)
    ->get('https://example.com');

if ($response->failed()) {
    return;
}
```
However, this came with the unexpected side effect of throwing an exception when encountering a server or client error.

When using the HTTP client without `retry`, the default is not to throw, but when using `retry` the default is to throw.

I was able to get around this with the below, but that didn't feel very Laravel.

```php
$response = Http::retry(3, 100, null, false) // :-(
    ->get('https://example.com');

if ($response->failed()) {
    return;
}
```

Using `retryQuietly`, the same can be achieved like so:

```php
$response = Http::retryQuietly(3, 100)
    ->get('https://example.com');

if ($response->failed()) {
    return;
}
```