### PR TITLE
[9.x] Add ability to use [$column, $operator, $value] syntax in database assertions

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -81,7 +81,7 @@ class HasInDatabase extends Constraint
 
         $columns = array_values(Arr::map(
             $this->data,
-            fn($value, $key) => is_numeric($key) && is_array($value) ? $value[0] : $key,
+            fn ($value, $key) => is_numeric($key) && is_array($value) ? $value[0] : $key,
         ));
 
         $similarResults = $query->where(


### PR DESCRIPTION
This ability was not actually included in this PR but tests with this syntax did not exist.

This syntax allows the developer to use another operator than `=` in database assertions.

For example :
```php
$this->assertDatabaseHas(User::class, [
    ['remember_token', '!=', null]
]);

$this->assertDatabaseHas(Post::class, [
    ['title', 'like', 'Laracon%']
]);
```
You can also mix the syntax : 
```php
$this->assertDatabaseHas(User::class, [
    'id' => $user->id,
    ['remember_token', '!=', null]
]);
```

The changes made in `HasInDatabase` are related to the fact that this syntax was not taken in account when generating the additional info of the assertion failure.

