### PR TITLE
Check and get nested relations for Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -792,6 +792,37 @@ trait HasRelationships
     }
 
     /**
+     * Get a specified nested relationship.
+     *
+     * @param  string  $relation
+     * @return mixed
+     */
+    public function getNestedRelation($relation)
+    {
+        // If the specified relation is not nested, let's just fetch the
+        // relation.
+        if (! Str::contains($relation, '.')) {
+            return $this->getRelation($relation);
+        }
+
+        [$relation, $sub] = explode('.', $relation, 2);
+
+        // First, let's attempt to get the "root" relation.
+        $relation = $this->getRelation($relation);
+
+        // If the relation is a "many" relation, we map every model instance
+        // within the relation using this method recursively. The result
+        // will be a flattened collection.
+        if ($relation instanceof Collection) {
+            return $this->newCollection($relation->flatMap(function ($relation) use ($sub) {
+                return $relation->getNestedRelation($sub);
+            })->all());
+        }
+
+        return $relation->getNestedRelation($sub);
+    }
+
+    /**
      * Determine if the given relation is loaded.
      *
      * @param  string  $key

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -216,15 +216,15 @@ trait ConditionallyLoadsAttributes
             $default = new MissingValue;
         }
 
-        if (! $this->resource->relationLoaded($relationship)) {
+        if (! $this->resource->nestedRelationLoaded($relationship)) {
             return value($default);
         }
 
         if (func_num_args() === 1) {
-            return $this->resource->{$relationship};
+            return $this->resource->getNestedRelation($relationship);
         }
 
-        if ($this->resource->{$relationship} === null) {
+        if ($this->resource->getNestedRelation($relationship) === null) {
             return;
         }
 


### PR DESCRIPTION
This addition to Model class allows us to check and access nested relations with two new methods.

See following example:

```php
$u = User::first();

if ($u->nestedRelationLoaded('posts.comments')) { 
    return $u->getNestedRelation('posts.comments'); // Illuminate\Database\Eloquent\Collection<App\Models\Comment>
}
```

This pull request also introduces a change to JsonResources as well. When before, `whenLoaded` method didn't support nested relations, with this change it would.

Although this approach now supports doing API resources not in the most conventional way, this comes in handy especially in when creating index resources where you might want to keep the amount of items per row minimal.

```php
class UserResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            // ...
            'comments' => new CommentResourceCollection($this->whenLoaded('posts.comments')),
            // ...
        ];
    }
}
```

vs

```php
class UserResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            // ...
            'posts' => new PostResourceCollection($this->whenLoaded('posts')),
            // ...
        ];
    }
}

class PostResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            // ...
            'comments' => new CommentResourceCollection($this->whenLoaded('comments')),
            // ...
        ];
    }
}
```