### PR TITLE
[9.x] Allow each model to have different parent in Model Factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -29,6 +29,13 @@ class BelongsToRelationship
     protected $resolved;
 
     /**
+     * Bypass the cache mechanism.
+     *
+     * @var mixed
+     */
+    protected $withoutCache = false;
+
+    /**
      * Create a new "belongs to" relationship definition.
      *
      * @param  \Illuminate\Database\Eloquent\Factories\Factory|\Illuminate\Database\Eloquent\Model  $factory
@@ -68,7 +75,7 @@ class BelongsToRelationship
     protected function resolver($key)
     {
         return function () use ($key) {
-            if (! $this->resolved) {
+            if (! $this->resolved || $this->withoutCache) {
                 $instance = $this->factory instanceof Factory
                     ? ($this->factory->recycle->get($this->factory->modelName()) ?? $this->factory->create())
                     : $this->factory;
@@ -91,6 +98,18 @@ class BelongsToRelationship
         if ($this->factory instanceof Factory) {
             $this->factory = $this->factory->recycle($recycle);
         }
+
+        return $this;
+    }
+
+    /**
+     * Don't reuse created parent instance for subsequent calls.
+     *
+     * @return $this
+     */
+    public function withoutCache()
+    {
+        $this->withoutCache = true;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -619,6 +619,21 @@ abstract class Factory
     }
 
     /**
+     * Define a unique parent relationship for the model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory
+     * @param  string|null  $relationship
+     * @return static
+     */
+    public function eachFor(self $factory, $relationship = null)
+    {
+        return $this->newInstance(['for' => $this->for->concat([(new BelongsToRelationship(
+            $factory,
+            $relationship ?? Str::camel(class_basename($factory->modelName()))
+        ))->withoutCache()])]);
+    }
+
+    /**
      * Provide a model instance to use instead of any nested factory calls when creating relationships.
      *
      * @param  \Illuminate\Eloquent\Model|\Illuminate\Support\Collection|array  $model

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -303,6 +303,20 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(3, FactoryTestPost::all());
     }
 
+    public function test_each_belongs_to_relationship()
+    {
+        $posts = FactoryTestPostFactory::times(3)
+            ->eachFor(FactoryTestUserFactory::new(['name' => 'Taylor Otwell']), 'user')
+            ->create();
+
+        $this->assertCount(3, $posts->filter(function ($post) {
+            return $post->user->name === 'Taylor Otwell';
+        }));
+
+        $this->assertCount(3, FactoryTestUser::all());
+        $this->assertCount(3, FactoryTestPost::all());
+    }
+
     public function test_morph_to_relationship()
     {
         $posts = FactoryTestCommentFactory::times(3)


### PR DESCRIPTION
Sometimes we need to create models having unicity constraint on parent id.

When using `for()`, all addresses belongs to the same user.

Now, we need to explicit the usage of foreign key

```php
Address::factory(3)->state(['user_id' => User::factory->registered()])->create();
```

This PR adds the ability te declare that each address will have its own user without messing with foreign keys : 
```php
Address::factory(3)->eachFor(User::factory()->registered())->create();
```

