### PR TITLE
[9.x] Fix issue with aggregates (withSum, etc.) for pivot columns on self-referencing many-to-many relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -678,6 +678,13 @@ trait QueriesRelationships
         return $this;
     }
 
+    /**
+     * Get the relation hashed column name for the given column and relation.
+     *
+     * @param  string  $column
+     * @param  \Illuminate\Database\Eloquent\Relations\Relationship  $relation
+     * @return string
+     */
     protected function getRelationHashedColumn($column, $relation)
     {
         if (str_contains($column, '.')) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -622,7 +622,7 @@ trait QueriesRelationships
             $relation = $this->getRelationWithoutConstraints($name);
 
             if ($function) {
-                $hashedColumn = $this->getAttributeHashedColumn($column, $relation);
+                $hashedColumn = $this->getRelationHashedColumn($column, $relation);
 
                 $wrappedColumn = $this->getQuery()->getGrammar()->wrap(
                     $column === '*' ? $column : $relation->getRelated()->qualifyColumn($hashedColumn)
@@ -678,7 +678,7 @@ trait QueriesRelationships
         return $this;
     }
 
-    protected function getAttributeHashedColumn($column, $relation)
+    protected function getRelationHashedColumn($column, $relation)
     {
         if (str_contains($column, '.')) {
             return $column;

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -622,9 +622,7 @@ trait QueriesRelationships
             $relation = $this->getRelationWithoutConstraints($name);
 
             if ($function) {
-                $hashedColumn = $this->getQuery()->from === $relation->getQuery()->getQuery()->from
-                                            ? "{$relation->getRelationCountHash(false)}.$column"
-                                            : $column;
+                $hashedColumn = $this->getAttributeHashedColumn($column, $relation);
 
                 $wrappedColumn = $this->getQuery()->getGrammar()->wrap(
                     $column === '*' ? $column : $relation->getRelated()->qualifyColumn($hashedColumn)
@@ -678,6 +676,17 @@ trait QueriesRelationships
         }
 
         return $this;
+    }
+
+    protected function getAttributeHashedColumn($column, $relation)
+    {
+        if (str_contains($column, '.')) {
+            return $column;
+        }
+
+        return $this->getQuery()->from === $relation->getQuery()->getQuery()->from
+            ? "{$relation->getRelationCountHash(false)}.$column"
+            : $column;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
@@ -31,7 +31,7 @@ class DatabaseEloquentBelongsToManyAggregateTest extends TestCase
             ->withSum('products as total_products', 'order_product.quantity')
             ->first();
 
-        $this->assertSame(12, $order->total_products);
+        $this->assertEquals(12, $order->total_products);
     }
 
     public function testWithSumSameTable()
@@ -42,7 +42,7 @@ class DatabaseEloquentBelongsToManyAggregateTest extends TestCase
             ->withSum('allocatedTo as total_allocated', 'allocations.amount')
             ->first();
 
-        $this->assertSame(1200, $order->total_allocated);
+        $this->assertEquals(1200, $order->total_allocated);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyAggregateTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentBelongsToManyAggregateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    public function testWithSumDifferentTables()
+    {
+        $this->seedData();
+
+        $order = BelongsToManyAggregateTestTestOrder::query()
+            ->withSum('products as total_products', 'order_product.quantity')
+            ->first();
+
+        $this->assertSame(12, $order->total_products);
+    }
+
+    public function testWithSumSameTable()
+    {
+        $this->seedData();
+
+        $order = BelongsToManyAggregateTestTestTransaction::query()
+            ->withSum('allocatedTo as total_allocated', 'allocations.amount')
+            ->first();
+
+        $this->assertSame(1200, $order->total_allocated);
+    }
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('orders', function ($table) {
+            $table->increments('id');
+        });
+
+        $this->schema()->create('products', function ($table) {
+            $table->increments('id');
+        });
+
+        $this->schema()->create('order_product', function ($table) {
+            $table->integer('order_id')->unsigned();
+            $table->foreign('order_id')->references('id')->on('orders');
+            $table->integer('product_id')->unsigned();
+            $table->foreign('product_id')->references('id')->on('products');
+            $table->integer('quantity')->unsigned();
+        });
+
+        $this->schema()->create('transactions', function ($table) {
+            $table->increments('id');
+            $table->integer('value')->unsigned();
+        });
+
+        $this->schema()->create('allocations', function ($table) {
+            $table->integer('from_id')->unsigned();
+            $table->foreign('from_id')->references('id')->on('transactions');
+            $table->integer('to_id')->unsigned();
+            $table->foreign('to_id')->references('id')->on('transactions');
+            $table->integer('amount')->unsigned();
+        });
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('orders');
+        $this->schema()->drop('products');
+    }
+
+    /**
+     * Helpers...
+     */
+    protected function seedData()
+    {
+        $order = BelongsToManyAggregateTestTestOrder::create(['id' => 1]);
+
+        BelongsToManyAggregateTestTestProduct::query()->insert([
+            ['id' => 1],
+            ['id' => 2],
+            ['id' => 3],
+        ]);
+
+        $order->products()->sync([
+            1 => ['quantity' => 3],
+            2 => ['quantity' => 4],
+            3 => ['quantity' => 5],
+        ]);
+
+        $transaction = BelongsToManyAggregateTestTestTransaction::create(['id' => 1, 'value' => 1200]);
+
+        BelongsToManyAggregateTestTestTransaction::query()->insert([
+            ['id' => 2, 'value' => -300],
+            ['id' => 3, 'value' => -400],
+            ['id' => 4, 'value' => -500],
+        ]);
+
+        $transaction->allocatedTo()->sync([
+            2 => ['amount' => 300],
+            3 => ['amount' => 400],
+            4 => ['amount' => 500],
+        ]);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class BelongsToManyAggregateTestTestOrder extends Eloquent
+{
+    protected $table = 'orders';
+    protected $fillable = ['id'];
+    public $timestamps = false;
+
+    public function products()
+    {
+        return $this
+            ->belongsToMany(BelongsToManyAggregateTestTestProduct::class, 'order_product', 'order_id', 'product_id')
+            ->withPivot('quantity');
+    }
+}
+
+class BelongsToManyAggregateTestTestProduct extends Eloquent
+{
+    protected $table = 'products';
+    protected $fillable = ['id'];
+    public $timestamps = false;
+}
+
+class BelongsToManyAggregateTestTestTransaction extends Eloquent
+{
+    protected $table = 'transactions';
+    protected $fillable = ['id', 'value'];
+    public $timestamps = false;
+
+    public function allocatedTo()
+    {
+        return $this
+            ->belongsToMany(BelongsToManyAggregateTestTestTransaction::class, 'allocations', 'from_id', 'to_id')
+            ->withPivot('quantity');
+    }
+}


### PR DESCRIPTION
An SQL error currently occurs when trying to run any `withX` aggregate functions on a column from a pivot table for a many-to-many relation that references the same table. The error that occurs is similar to the below:

```
Illuminate\Database\QueryException : SQLSTATE[HY000]: General error: 1 no such column: laravel_reserved_0.transaction_transaction.amount (SQL: select "transactions".*, (select sum("laravel_reserved_0"."transaction_transaction"."amount") from "transactions" as "laravel_reserved_0" inner join "transaction_transaction" on "laravel_reserved_0"."id" = "transaction_transaction"."allocated_to_id" where "transactions"."id" = "transaction_transaction"."allocated_from_id") as "total_allocated" from "transactions" limit 1)
```

The issue at hand is from [lines 625–627 in QueriesRelationships](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L625):

```php
$hashedColumn = $this->getQuery()->from === $relation->getQuery()->getQuery()->from
     ? "{$relation->getRelationCountHash(false)}.$column"
     : $column;
```

The condition in this ternary checks whether the current query references the same table as the relation's query, and if so, it prepends a "relationCountHash" which in the above error is `"laravel_reserved_0"`. In a many-to-many relationship which references the same table, for example a "friends" relationship which links from a `users` table to the `users` table, this would return true and it would make referencing columns from a pivot table impossible in this situation.

My proposed fix for this is to move the above logic into a new method which checks for a period (`.`) in the `$column`, to see if the referenced column is on a different table to the original query. If this is the case, it just returns the `$column`, without the reserved table alias.

This shouldn't, to my knowledge, introduced any breaking changes with  current versions as any columns passed in with a period are automatically escaped into `"table_name"."column"` syntax, rather than treated as a single column (e.g.  `"table_name.column"`.