### PR TITLE
[9.x] Add odd hour schedule method

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -181,8 +181,7 @@ trait ManagesFrequencies
      */
     public function everyOddHour()
     {
-        return $this->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, '1-23/2');
+        return $this->spliceIntoPosition(1, 0)->spliceIntoPosition(2, '1-23/2');
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -175,6 +175,17 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every odd hour.
+     *
+     * @return $this
+     */
+    public function everyOddHour()
+    {
+        return $this->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, '1-23/2');
+    }
+
+    /**
      * Schedule the event to run every two hours.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -79,6 +79,7 @@ class FrequencyTest extends TestCase
 
     public function testHourly()
     {
+        $this->assertSame('0 1-23/2 * * *', $this->event->everyOddHour()->getExpression());
         $this->assertSame('0 */2 * * *', $this->event->everyTwoHours()->getExpression());
         $this->assertSame('0 */3 * * *', $this->event->everyThreeHours()->getExpression());
         $this->assertSame('0 */4 * * *', $this->event->everyFourHours()->getExpression());


### PR DESCRIPTION
I usually schedule tasks to run on even or odd hours to avoid executing all the process at the same time. 

This small change will make it easier 😊.