### PR TITLE
Fixes uploading a multi-files issue

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1308,6 +1308,10 @@ trait ValidatesAttributes
      */
     public function validateMax($attribute, $value, $parameters)
     {
+        if(is_array($value)) {
+            return $this->checkMultiValues(__FUNCTION__, $attribute, $value, $parameters);
+        }
+        
         $this->requireParameterCount(1, $parameters, 'max');
 
         if ($value instanceof UploadedFile && ! $value->isValid()) {
@@ -1376,7 +1380,7 @@ trait ValidatesAttributes
         if(is_array($value)) {
             return $this->checkMultiValues(__FUNCTION__, $attribute, $value, $parameters);
         }
-        
+
         if (! $this->isValidFileInstance($value)) {
             return false;
         }
@@ -1422,6 +1426,10 @@ trait ValidatesAttributes
      */
     public function validateMin($attribute, $value, $parameters)
     {
+        if(is_array($value)) {
+            return $this->checkMultiValues(__FUNCTION__, $attribute, $value, $parameters);
+        }
+
         $this->requireParameterCount(1, $parameters, 'min');
 
         return $this->getSize($attribute, $value) >= $parameters[0];
@@ -2267,12 +2275,12 @@ trait ValidatesAttributes
      */
     protected function checkMultiValues($functionName, $attribute, $value, $parameters)
     {
-        $isOk = true;
-
         foreach ($value as $file) {
-            $isOk = $isOk && $this->$functionName($attribute, $file, $parameters);
+            if (!$this->{$functionName}($attribute, $file, $parameters)) {
+                return false;
+            }
         }
 
-        return $isOk;
+        return true;
     }
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1344,6 +1344,10 @@ trait ValidatesAttributes
      */
     public function validateMimes($attribute, $value, $parameters)
     {
+        if(is_array($value)) {
+            return $this->checkMultiValues(__FUNCTION__, $attribute, $value, $parameters);
+        }
+
         if (! $this->isValidFileInstance($value)) {
             return false;
         }
@@ -1369,6 +1373,10 @@ trait ValidatesAttributes
      */
     public function validateMimetypes($attribute, $value, $parameters)
     {
+        if(is_array($value)) {
+            return $this->checkMultiValues(__FUNCTION__, $attribute, $value, $parameters);
+        }
+        
         if (! $this->isValidFileInstance($value)) {
             return false;
         }
@@ -2246,5 +2254,25 @@ trait ValidatesAttributes
         if (is_numeric($this->getValue($attribute))) {
             $this->numericRules[] = $rule;
         }
+    }
+
+    /**
+     * Check the given value and loop over each file then return the result.
+     *
+     * @param  string  $functionName
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    protected function checkMultiValues($functionName, $attribute, $value, $parameters)
+    {
+        $isOk = true;
+
+        foreach ($value as $file) {
+            $isOk = $isOk && $this->$functionName($attribute, $file, $parameters);
+        }
+
+        return $isOk;
     }
 }


### PR DESCRIPTION
When we validate uploading **ONLY** one file, will be no validation error, like so

```HTML
<input type="file" name="image" class="form-control">
```

```PHP
$request->validate([
    'image' => ['mimes:png'],
]);
```

## Before this PR gets merged

When we try to upload multi-files that fit validation, the validation will fail, for instance

```HTML
<input type="file" name="images[]" class="form-control" multiple>
```

```PHP
$request->validate([
    'images' => ['mimes:png'],
]);
```

![uplaoding-mutli-file-issue](https://user-images.githubusercontent.com/48416569/192061964-756e0611-0ba5-4755-a7f3-417008160568.gif)

## After this PR gets merged

The issue has been solved 🎉

![fixes-uplaoding-mutli-file-issue](https://user-images.githubusercontent.com/48416569/192062276-77e67d28-71d4-4b31-8cd5-4c15ee0d893b.gif)