### PR TITLE
[9.x] Improve type definitions of the enum() method

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -372,9 +372,10 @@ trait InteractsWithInput
     /**
      * Retrieve input from the request as an enum.
      *
+     * @template T
      * @param  string  $key
-     * @param  string  $enumClass
-     * @return mixed|null
+     * @param  class-string<T>  $enumClass
+     * @return T|null
      */
     public function enum($key, $enumClass)
     {

--- a/types/Http/Request.php
+++ b/types/Http/Request.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Http\Request;
+use function PHPStan\Testing\assertType;
+
+enum TestEnum : string
+{
+    case test = 'test';
+}
+
+$request = Request::create('/', 'GET', [
+    'key' => 'test'
+]);
+assertType('TestEnum|null', $request->enum('key', TestEnum::class));


### PR DESCRIPTION
This pull request improves the types of the `$request->enum()` method. 

Currently, in the following code, `$type` is `mixed`.

```php
$type = $request->enum('key', MyEnum::class);
// $type is mixed
```

With this pull request, `$type` will have `MyEnum|null` type.

```php
$type = $request->enum('key', MyEnum::class);
// $type is now MyEnum|null
```

[Here's](https://phpstan.org/r/86115cd3-052d-4a50-b0fe-71fa8799d6b1) a PHPStan playground to play with the generics of this. 

I am not sure if the place where I added type-level tests is the best place (`/types/Http/Request.php`)

This pull request does not change any actual functionalities - just the PHPDoc types.