### PR TITLE
[9.x] Formats benchmarkables on `dd` call

### DIFF
--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -11,7 +11,7 @@ class Benchmark
      *
      * @param  \Closure|array  $benchmarkables
      * @param  int  $iterations
-     * @return array
+     * @return array|float
      */
     public static function measure(Closure|array $benchmarkables, int $iterations = 1): array|float
     {
@@ -28,7 +28,7 @@ class Benchmark
         })->when(
             $benchmarkables instanceof Closure,
             fn ($c) => $c->first(),
-            fn ($c) => $c->all()
+            fn ($c) => $c->all(),
         );
     }
 


### PR DESCRIPTION
This pull request formats benchmarkables on `dd` calls.

```php
// Before...
Benchmark::dd(fn () => sleep(1)); // 1002.61591713213123

// After...
Benchmark::dd(fn () => sleep(1)); // "1,002.615ms"
```