### PR TITLE
[9.x] Add `before` option to make:migration command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -18,7 +18,7 @@ class MigrateMakeCommand extends BaseCommand
         {--create= : The table to be created}
         {--table= : The table to migrate}
         {--path= : The location where the migration file should be created}
-        {--before= : The name of table the migration file should be created before that}
+        {--before= : The name of the table that this migration should precede}
         {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
         {--fullpath : Output the full path of the migration}';
 

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -50,11 +50,12 @@ class MigrationCreator
      * @param  string  $path
      * @param  string|null  $table
      * @param  bool  $create
+     * @param  string|null  $prefix
      * @return string
      *
      * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $table = null, $create = false, $prefix = null)
     {
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
 
@@ -63,7 +64,7 @@ class MigrationCreator
         // various place-holders, save the file, and run the post create event.
         $stub = $this->getStub($table, $create);
 
-        $path = $this->getPath($name, $path);
+        $path = $this->getPath($name, $path, $prefix);
 
         $this->files->ensureDirectoryExists(dirname($path));
 
@@ -167,11 +168,14 @@ class MigrationCreator
      *
      * @param  string  $name
      * @param  string  $path
+     * @param  string|null  $prefix
      * @return string
      */
-    protected function getPath($name, $path)
+    protected function getPath($name, $path, $prefix)
     {
-        return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
+        return is_null($prefix)
+            ? $path.'/'.$this->getDatePrefix().'_'.$name.'.php'
+            : $path.'/'.$prefix.'_'.$name.'.php';
     }
 
     /**

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -28,7 +28,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
         $composer->shouldReceive('dumpAutoloads')->once();
 
@@ -45,7 +45,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -61,7 +61,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true)
+                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'foo', true, null)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'CreateFoo']);
@@ -77,7 +77,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+                ->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, null)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_foo.php');
 
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
@@ -93,7 +93,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $creator->shouldReceive('create')->once()
-                ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true)
+                ->with('create_users_table', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true, null)
                 ->andReturn(__DIR__.'/migrations/2021_04_23_110457_create_users_table.php');
 
         $this->runCommand($command, ['name' => 'create_users_table']);
@@ -109,7 +109,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $command->setLaravel($app);
         $app->setBasePath('/home/laravel');
         $creator->shouldReceive('create')->once()
-                ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true)
+                ->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true, null)
                 ->andReturn('/home/laravel/vendor/laravel-package/migrations/2021_04_23_110457_create_foo.php');
         $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
     }


### PR DESCRIPTION
There are times when we need to create a migration before another migration, so what we're doing at this point is just changing the timestamps of the file, but It is very confusing looking at these timestamps and changing them to move.

I suggest having commands like the following to make this simple:
```php
php artisan make:migration  create_roles_table --before=users
```