### PR TITLE
[9.x] Introduce Arr::firstNotEmpty helper

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -205,7 +205,7 @@ class Arr
 
         return value($default);
     }
-    
+
     /**
      * Return the first non-empty element in an array using a list of keys.
      *
@@ -219,17 +219,17 @@ class Arr
         if (! static::accessible($array) || $array === []) {
             return value($default);
         }
-        
+
         $keys = (array) $keys;
-        
+
         foreach ($keys as $key) {
             $value = static::get($array, $key);
-            
+
             if (! empty($value)) {
                 return $value;
             }
         }
-        
+
         return value($default);
     }
 

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -205,6 +205,33 @@ class Arr
 
         return value($default);
     }
+    
+    /**
+     * Return the first non-empty element in an array using a list of keys.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function firstNotEmpty($array, $keys, $default = null)
+    {
+        if (! static::accessible($array) || $array === []) {
+            return value($default);
+        }
+        
+        $keys = (array) $keys;
+        
+        foreach ($keys as $key) {
+            $value = static::get($array, $key);
+            
+            if (! empty($value)) {
+                return $value;
+            }
+        }
+        
+        return value($default);
+    }
 
     /**
      * Return the last element in an array passing a given truth test.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -212,6 +212,20 @@ class SupportArrTest extends TestCase
         $this->assertSame('baz', $value4);
     }
 
+    public function testFirstNotEmpty()
+    {
+        $array = [
+            'name' => 'Taylor',
+            'developer' => [
+                'name' => 'Abigail'
+            ]
+        ];
+        $this->assertNull(Arr::firstNotEmpty($array, []))
+        $this->assertNull(Arr::firstNotEmpty($array, ['real_name', 'developer.real_name']));
+        $this->assertSame('Taylor', Arr::firstNotEmpty($array, ['name', 'developer.name']));
+        $this->assertSame('Abigail', Arr::firstNotEmpty($array, ['real_name', 'developer.name']));
+    }
+
     public function testJoin()
     {
         $this->assertSame('a, b, c', Arr::join(['a', 'b', 'c'], ', '));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -220,7 +220,7 @@ class SupportArrTest extends TestCase
                 'name' => 'Abigail'
             ]
         ];
-        $this->assertNull(Arr::firstNotEmpty($array, []))
+        $this->assertNull(Arr::firstNotEmpty($array, []));
         $this->assertNull(Arr::firstNotEmpty($array, ['real_name', 'developer.real_name']));
         $this->assertSame('Taylor', Arr::firstNotEmpty($array, ['name', 'developer.name']));
         $this->assertSame('Abigail', Arr::firstNotEmpty($array, ['real_name', 'developer.name']));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -217,7 +217,7 @@ class SupportArrTest extends TestCase
         $array = [
             'name' => 'Taylor',
             'developer' => [
-                'name' => 'Abigail'
+                'name' => 'Abigail',
             ]
         ];
         $this->assertNull(Arr::firstNotEmpty($array, []));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -218,7 +218,7 @@ class SupportArrTest extends TestCase
             'name' => 'Taylor',
             'developer' => [
                 'name' => 'Abigail',
-            ]
+            ],
         ];
         $this->assertNull(Arr::firstNotEmpty($array, []));
         $this->assertNull(Arr::firstNotEmpty($array, ['real_name', 'developer.real_name']));


### PR DESCRIPTION
This PR introduces a new ``Arr`` helper function which allows you to get the first non-empty item from an array using a list of keys.

Example usage:

```php
$array = [
    'name' => null, 
    'owner' => [
        'name' => 'John Smith'
    ]
];

$value = Arr::firstNotEmpty($array, ['name', 'owner.name']);

// 'John Smith'

```

This is particularly helpful when you want to quickly extract non-empty value from a nested array structure based on a priority defined through keys.