### PR TITLE
[9.x] Fixes memory leak on `TestCase::$latestResponse`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -64,11 +64,11 @@ trait MakesHttpRequests
     protected $withCredentials = false;
 
     /**
-     * The latest test response.
+     * The latest test response (if any).
      *
      * @var \Illuminate\Testing\TestResponse|null
      */
-    public $latestResponse;
+    public static $latestResponse;
 
     /**
      * Define additional headers to be sent with the request.
@@ -551,7 +551,7 @@ trait MakesHttpRequests
             $response = $this->followRedirects($response);
         }
 
-        return $this->latestResponse = $this->createTestResponse($response);
+        return static::$latestResponse = $this->createTestResponse($response);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -86,7 +86,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function setUp(): void
     {
-        $this->latestResponse = null;
+        static::$latestResponse = null;
 
         Facade::clearResolvedInstances();
 
@@ -227,6 +227,16 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
+     * Clean up the testing environment before the next test case.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void
+    {
+        static::$latestResponse = null;
+    }
+
+    /**
      * Register a callback to be run after the application is created.
      *
      * @param  callable  $callback
@@ -278,18 +288,18 @@ abstract class TestCase extends BaseTestCase
      */
     protected function onNotSuccessfulTest(Throwable $exception): void
     {
-        if (! $exception instanceof ExpectationFailedException || is_null($this->latestResponse)) {
+        if (! $exception instanceof ExpectationFailedException || is_null(static::$latestResponse)) {
             parent::onNotSuccessfulTest($exception);
         }
 
-        if ($lastException = $this->latestResponse->exceptions->last()) {
+        if ($lastException = static::$latestResponse->exceptions->last()) {
             parent::onNotSuccessfulTest($this->appendExceptionToException($lastException, $exception));
 
             return;
         }
 
-        if ($this->latestResponse->baseResponse instanceof RedirectResponse) {
-            $session = $this->latestResponse->baseResponse->getSession();
+        if (static::$latestResponse->baseResponse instanceof RedirectResponse) {
+            $session = static::$latestResponse->baseResponse->getSession();
 
             if (! is_null($session) && $session->has('errors')) {
                 parent::onNotSuccessfulTest($this->appendErrorsToException($session->get('errors')->all(), $exception));
@@ -298,8 +308,8 @@ abstract class TestCase extends BaseTestCase
             }
         }
 
-        if ($this->latestResponse->baseResponse->headers->get('Content-Type') === 'application/json') {
-            $testJson = new AssertableJsonString($this->latestResponse->getContent());
+        if (static::$latestResponse->baseResponse->headers->get('Content-Type') === 'application/json') {
+            $testJson = new AssertableJsonString(static::$latestResponse->getContent());
 
             if (isset($testJson['errors'])) {
                 parent::onNotSuccessfulTest($this->appendErrorsToException($testJson->json(), $exception, true));

--- a/tests/Foundation/Testing/TestCaseTest.php
+++ b/tests/Foundation/Testing/TestCaseTest.php
@@ -17,7 +17,7 @@ class TestCaseTest extends BaseTestCase
     public function test_it_includes_response_exceptions_on_test_failures()
     {
         $testCase = new ExampleTestCase();
-        $testCase->latestResponse = TestResponse::fromBaseResponse(new Response())
+        $testCase::$latestResponse = TestResponse::fromBaseResponse(new Response())
             ->withExceptions(collect([new Exception('Unexpected exception.')]));
 
         $this->expectException(ExpectationFailedException::class);
@@ -29,7 +29,7 @@ class TestCaseTest extends BaseTestCase
     public function test_it_includes_validation_errors_on_test_failures()
     {
         $testCase = new ExampleTestCase();
-        $testCase->latestResponse = TestResponse::fromBaseResponse(
+        $testCase::$latestResponse = TestResponse::fromBaseResponse(
             tap(new RedirectResponse('/'))
                 ->setSession(new Store('test-session', new NullSessionHandler()))
                 ->withErrors([
@@ -45,7 +45,7 @@ class TestCaseTest extends BaseTestCase
     public function test_it_includes_json_validation_errors_on_test_failures()
     {
         $testCase = new ExampleTestCase();
-        $testCase->latestResponse = TestResponse::fromBaseResponse(
+        $testCase::$latestResponse = TestResponse::fromBaseResponse(
             new Response(['errors' => ['first_name' => 'The first name field is required.']])
         );
 
@@ -57,7 +57,7 @@ class TestCaseTest extends BaseTestCase
     public function test_it_doesnt_fail_with_false_json()
     {
         $testCase = new ExampleTestCase();
-        $testCase->latestResponse = TestResponse::fromBaseResponse(
+        $testCase::$latestResponse = TestResponse::fromBaseResponse(
             new Response(false, 200, ['Content-Type' => 'application/json'])
         );
 
@@ -69,7 +69,7 @@ class TestCaseTest extends BaseTestCase
     public function test_it_doesnt_fail_with_encoded_json()
     {
         $testCase = new ExampleTestCase();
-        $testCase->latestResponse = TestResponse::fromBaseResponse(
+        $testCase::$latestResponse = TestResponse::fromBaseResponse(
             tap(new Response, function ($response) {
                 $response->header('Content-Type', 'application/json');
                 $response->header('Content-Encoding', 'gzip');
@@ -80,6 +80,11 @@ class TestCaseTest extends BaseTestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessageMatches('/Assertion message/s');
         $testCase->onNotSuccessfulTest(new ExpectationFailedException('Assertion message.'));
+    }
+
+    public function tearDown(): void
+    {
+        ExampleTestCase::$latestResponse = null;
     }
 }
 


### PR DESCRIPTION
This pull request addresses one of the memory leaks being mentioned at https://github.com/laravel/framework/issues/44214, by performing a proper cleaning of the `$latestResponse` on the Laravel's base test case class.

On Vapor's test suite, we heavily perform HTTP testing, and here is the results on 600 tests: 33% less memory used.

```
Before…
Time: 01:05.160, Memory: 280.50 MB

After…
Time: 01:05.153, Memory: 190.50 MB
```