### PR TITLE
[9.x] Fixes memory leak on `TestCase` handlers

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -217,6 +217,9 @@ abstract class TestCase extends BaseTestCase
         $this->afterApplicationCreatedCallbacks = [];
         $this->beforeApplicationDestroyedCallbacks = [];
 
+        $this->originalExceptionHandler = null;
+        $this->originalDeprecationHandler = null;
+
         Artisan::forgetBootstrappers();
         Queue::createPayloadUsing(null);
         HandleExceptions::forgetApp();


### PR DESCRIPTION
This pull request addresses one of the memory leaks being mentioned at https://github.com/laravel/framework/issues/44214, by performing a proper cleaning of the `$originalExceptionHandler` and `$originalDeprecationHandler` on the Laravel's base test case class.

On Vapor's test suite, after having https://github.com/laravel/framework/pull/44306 (33% less memory), and after disabling bugsnag (14% less memory) - here is the results on 600 tests: 1% less memory used.

```
Before…
Time: 01:02.732, Memory: 168.50 MB

After…
Time: 01:02.595, Memory: 166.50 MB
```