### PR TITLE
[10.x] Stick with ordered uuid

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -29,7 +29,7 @@ trait HasUuids
      */
     public function newUniqueId()
     {
-        return (string) Str::uuid();
+        return (string) Str::orderedUuid();
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1235,7 +1235,7 @@ class Str
      */
     public static function orderedUuid()
     {
-        return Str::uuid();
+        return Uuid::uuid7();
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1217,7 +1217,7 @@ class Str
     }
 
     /**
-     * Generate a UUID (version 7).
+     * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface
      */
@@ -1225,7 +1225,7 @@ class Str
     {
         return static::$uuidFactory
                     ? call_user_func(static::$uuidFactory)
-                    : Uuid::uuid7();
+                    : Uuid::uuid4();
     }
 
     /**


### PR DESCRIPTION
This is a follow-up to #44210.

- Stick with `orderedUuid()` in `HasUuids::newUniqueId()`
- Revert changed from v4 to v7 in `Str::uuid()`

IMO it makes no sense to change the default `Str::uuid()` to v7, which will always reveal the timestamp (minor data leak), especially since the `Str::orderedUuid()` still exists.

I'd expect `Str::uuid()` to be fully random and not an alias of `Str::orderedUuid()`.