### PR TITLE
[9.x] Get the validated data Except keys from the request

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationException;
 
@@ -214,6 +215,18 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         return data_get($this->validator->validated(), $key, $default);
     }
+
+    /**
+     * Get the validated data Except keys from the request.
+     *
+     * @param  string|array  $keys
+     * @return array
+     */
+    public function validatedExcept($keys = [])
+    {
+        return Arr::except($this->validated(), $keys);
+    }
+    
 
     /**
      * Get custom messages for validator errors.

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -37,6 +37,24 @@ class FoundationFormRequestTest extends TestCase
 
         $this->assertEquals(['name' => 'specified'], $request->validated());
     }
+    
+    public function testValidatedMethodReturnsTheValidatedDataWithoutExceptKey()
+    {
+        $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['name' => 'specified'], $request->validatedExcept('with'));
+    }
+    
+    public function testValidatedMethodReturnsTheValidatedDataWithoutExceptKeys()
+    {
+        $request = $this->createRequest(['name' => 'specified', 'with' => 'extras']);
+
+        $request->validateResolved();
+        
+        $this->assertEquals([], $request->validatedExcept(['with', 'name']));
+    }
 
     public function testValidatedMethodReturnsTheValidatedDataNestedRules()
     {


### PR DESCRIPTION
Sometimes we want to validate the inputs and make sure that are correct, but when retrieve data in the controller `$request->validated() ` all keys will return! 
so I added function will filter keys with values and with be applicable with one key or array of keys `$request->validatedExcept(['keys'])` 
-> now, the validated keys will return except keys I passed to the function