### PR TITLE
[9.x] Testing MailFake add missing cc

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -318,6 +318,17 @@ class MailFake implements Factory, Mailer, MailQueue
      * @param  mixed  $users
      * @return \Illuminate\Mail\PendingMail
      */
+    public function cc($users)
+    {
+        return (new PendingMailFake($this))->cc($users);
+    }
+
+    /**
+     * Begin the process of mailing a mailable class instance.
+     *
+     * @param  mixed  $users
+     * @return \Illuminate\Mail\PendingMail
+     */
     public function bcc($users)
     {
         return (new PendingMailFake($this))->bcc($users);

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -63,6 +63,15 @@ class SupportTestingMailFakeTest extends TestCase
         });
     }
 
+    public function testAssertCc()
+    {
+        $this->fake->cc('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function ($mail) {
+            return $mail->hasCc('taylor@laravel.com');
+        });
+    }
+
     public function testAssertBcc()
     {
         $this->fake->bcc('taylor@laravel.com')->send($this->mailable);

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -54,6 +54,24 @@ class SupportTestingMailFakeTest extends TestCase
         });
     }
 
+    public function testAssertTo()
+    {
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function ($mail) {
+            return $mail->hasTo('taylor@laravel.com');
+        });
+    }
+
+    public function testAssertBcc()
+    {
+        $this->fake->bcc('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function ($mail) {
+            return $mail->hasBcc('taylor@laravel.com');
+        });
+    }
+
     public function testAssertNotSent()
     {
         $this->fake->assertNotSent(MailableStub::class);


### PR DESCRIPTION
`Mail::fake()` does not handle `Mail::cc()`

The `Mail` facade supports `cc` but somehow is not part of the `Mailer` contract.

---
Fixes #37238