### PR TITLE
[9.x] Method getTokenFromRequest may return null values

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -146,7 +146,7 @@ class VerifyCsrfToken
      * Get the CSRF token from the request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return string
+     * @return string|null
      */
     protected function getTokenFromRequest($request)
     {


### PR DESCRIPTION
When `_token`, `X-CSRF-TOKEN` and `X-XSRF-TOKEN` are `null`, this method returns a `null`. This PR updates the phpdoc to make it more explicit.