### PR TITLE
[10.x] Validate request data keys with dots and asterisks

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1097,11 +1097,7 @@ class Validator implements ValidatorContract
             return Arr::get($this->data, $attribute);
         }
 
-        if (Arr::has($this->data, $key = $this->replaceDotsAndAsterisksInString($attribute))) {
-            return Arr::get($this->data, $key);
-        }
-
-        return null;
+        return Arr::get($this->data, $this->replaceDotsAndAsterisksInString($attribute));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -329,11 +329,7 @@ class Validator implements ValidatorContract
                 $value = $this->parseData($value);
             }
 
-            $key = str_replace(
-                ['.', '*'],
-                [$this->dotPlaceholder, '__asterisk__'],
-                $key
-            );
+            $key = $this->replaceDotsAndAsterisksInString($key);
 
             $newData[$key] = $value;
         }
@@ -371,6 +367,21 @@ class Validator implements ValidatorContract
         return str_replace(
             [$this->dotPlaceholder, '__asterisk__'],
             ['.', '*'],
+            $value
+        );
+    }
+
+    /**
+     * Replace the dots and asterisks in the given string.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function replaceDotsAndAsterisksInString(string $value)
+    {
+        return str_replace(
+            ['.', '*'],
+            [$this->dotPlaceholder, '__asterisk__'],
             $value
         );
     }
@@ -1082,7 +1093,15 @@ class Validator implements ValidatorContract
      */
     protected function getValue($attribute)
     {
-        return Arr::get($this->data, $attribute);
+        if (Arr::has($this->data, $attribute)) {
+            return Arr::get($this->data, $attribute);
+        }
+
+        if (Arr::has($this->data, $key = $this->replaceDotsAndAsterisksInString($attribute))) {
+            return Arr::get($this->data, $key);
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5176,6 +5176,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
+    public function testParsingReplacedArrayKeysWithDot()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['foo.bar' => 'valid'], ['foo.bar' => 'required']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo.bar' => ''], ['foo.bar' => 'required']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testParsingArrayKeysWithDotWhenTestingExistence()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR attempts to fix validation for values that have dots or asterisks in their key at the top level.

Recently I faced with a situation, where I had to validate data with dots (`.`) in their keys at the top level. The validator failed every time. First, I tought it's a bug, but then after taking a look at the tests (https://github.com/laravel/framework/blob/master/tests/Validation/ValidationValidatorTest.php#L5159-L5177) I realized, this is intentional.

However, in my opinion having dots or asterisks in an array key is valid and a very possible use-case, even if it's not very common. For example:

```php
$data = ['price.eur' => 20];

 $v = new Validator($translator, $data, ['price.eur => ['required']]);
 $v->passes(); // fails, while it is present and filled
```

This is because the Valiadtor transforms the top level data keys that contain `.` or `*`.

-------
So what this PR does, is just an extra check in the `getValue` method if there is a transformed key matching with the given attribute.

This should not be a BC, since nested arrays are still have the priority for dot notation rules (as the original tests are still passing), and handling top level keys with special characters are just a "fallback" for a not very common but a very possible scenario. However, I still submit this into master to make sure nothing breaks.