### PR TITLE
[9.x] Fixes memory leak on PHPUnit's Annotations registry

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -18,6 +18,7 @@ use Mockery;
 use Mockery\Exception\InvalidCountException;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use PHPUnit\Util\Annotation\Registry;
 use ReflectionProperty;
 use Throwable;
 
@@ -237,6 +238,11 @@ abstract class TestCase extends BaseTestCase
     public static function tearDownAfterClass(): void
     {
         static::$latestResponse = null;
+
+        (function () {
+            $this->classDocBlocks = [];
+            $this->methodDocBlocks = [];
+        })->call(Registry::getInstance());
     }
 
     /**


### PR DESCRIPTION
This pull request addresses one of the memory leaks being mentioned at https://github.com/laravel/framework/issues/44214, by performing a proper cleaning of the PHPUnit's Annotations registry.

On Vapor's test suite, here is the results on 600 tests: 26% less memory used.

```
// Before
Time: 00:57.879, Memory: 156.50 MB

// After
Time: 00:57.803, Memory: 116.50 MB
```

> The "Before" results, already contains the fixes https://github.com/laravel/framework/pull/44307, https://github.com/laravel/framework/pull/44306, https://github.com/bugsnag/bugsnag-laravel, https://github.com/bugsnag/bugsnag-php/pull/651.
