### PR TITLE
Add continueIf, breakIf, continueUnless & breakUnless blade conditionals

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -197,7 +197,6 @@ trait CompilesLoops
      *
      * @param  string  $expression
      * @return string
-     *
      */
     protected function compileContinueIf($expression)
     {
@@ -209,7 +208,6 @@ trait CompilesLoops
      *
      * @param  string  $expression
      * @return string
-     *
      */
     protected function compileBreakIf($expression)
     {
@@ -221,7 +219,6 @@ trait CompilesLoops
      *
      * @param  string  $expression
      * @return string
-     *
      */
     protected function compileContinueUnless($expression)
     {
@@ -233,7 +230,6 @@ trait CompilesLoops
      *
      * @param  string  $expression
      * @return string
-     *
      */
     protected function compileBreakUnless($expression)
     {

--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -191,4 +191,52 @@ trait CompilesLoops
     {
         return '<?php endwhile; ?>';
     }
+
+    /**
+     * Compile the continueIf statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     *
+     */
+    protected function compileContinueIf($expression)
+    {
+        return "<?php if{$expression} continue; ?>";
+    }
+
+    /**
+     * Compile the breakIf statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     *
+     */
+    protected function compileBreakIf($expression)
+    {
+        return "<?php if{$expression} break; ?>";
+    }
+
+    /**
+     * Compile the continueUnless statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     *
+     */
+    protected function compileContinueUnless($expression)
+    {
+        return "<?php if(!$expression) continue; ?>";
+    }
+
+    /**
+     * Compile the breakUnless statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     *
+     */
+    protected function compileBreakUnless($expression)
+    {
+        return "<?php if(!$expression) break; ?>";
+    }
 }

--- a/tests/View/Blade/BladeBreakStatementsTest.php
+++ b/tests/View/Blade/BladeBreakStatementsTest.php
@@ -68,4 +68,30 @@ test
 <?php endfor; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testBreakIfStatementsAreCompiled()
+    {
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@breakIf($i == 2)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php if($i == 2) break; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testBreakUnlessStatementsAreCompiled()
+    {
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@breakUnless($i == 2)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php if(!($i == 2)) break; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladeContinueStatementsTest.php
+++ b/tests/View/Blade/BladeContinueStatementsTest.php
@@ -68,4 +68,30 @@ test
 <?php endfor; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testContinueIfStatementsAreCompiled()
+    {
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@continueIf($i == 2)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php if($i == 2) continue; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testContinueUnlessStatementsAreCompiled()
+    {
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@continueUnless($i == 2)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php if(!($i == 2)) continue; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
This PR adds new conditionals to the blade compiler so we can write statements like 

```php
@for($i = 0; $i < 10; $i++ )

  @continueIf($i  == 2)
  
  @breakIf($i == 2)
   
  @continueUnless(($i % 2 ) == 0)
   
  @breakUnless(($i % 2 ) == 0)

@endfor
```