### PR TITLE
[9.x] - fix bug when using named arguments on Builder where method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -282,7 +282,7 @@ class Builder implements BuilderContract
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {
-            $this->query->where(...func_get_args());
+            $this->query->where($column, $operator, $value, $boolean);
         }
 
         return $this;


### PR DESCRIPTION
When using named arguments, for example: `User::where(column: 'id', operator: 123)` the where method breaks and replaces the value with the operator, in this case null, so the ran query is `where id = null`

This occurs because func_get_args used get the all arguments before the named one, for example:

`public function where($column, $operator = null, $value = null, $boolean = 'and')`

When using `User::where(column: 'id', value: 123)` func_get_args returns 3 arguments
When using  `User::where(column: 'id', operator: '>')` func_get_args returns 2 arguments