### PR TITLE
[9.x] Allow factories to recycle multiple models of a given type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToRelationship.php
@@ -70,7 +70,7 @@ class BelongsToRelationship
         return function () use ($key) {
             if (! $this->resolved) {
                 $instance = $this->factory instanceof Factory
-                    ? ($this->factory->recycle->get($this->factory->modelName()) ?? $this->factory->create())
+                    ? ($this->factory->getRandomRecycledModel($this->factory->modelName()) ?? $this->factory->create())
                     : $this->factory;
 
                 return $this->resolved = $key ? $instance->{$key} : $instance->getKey();

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -632,7 +632,7 @@ abstract class Factory
                 ->merge(
                     Collection::wrap($model instanceof Model ? func_get_args() : $model)
                         ->flatten()
-                )->groupBy(fn ($model) => get_class($model))
+                )->groupBy(fn ($model) => get_class($model)),
         ]);
     }
 
@@ -640,7 +640,7 @@ abstract class Factory
      * Retrieves a random model of a given type from previously provided models to recycle.
      *
      * @param  string  $modelClassName
-     * @return  \Illuminate\Database\Eloquent\Model|null
+     * @return \Illuminate\Database\Eloquent\Model|null
      */
     public function getRandomRecycledModel($modelClassName)
     {

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -138,7 +138,7 @@ abstract class Factory
                                 ?Collection $for = null,
                                 ?Collection $afterMaking = null,
                                 ?Collection $afterCreating = null,
-        $connection = null,
+                                $connection = null,
                                 ?Collection $recycle = null)
     {
         $this->count = $count;
@@ -592,10 +592,10 @@ abstract class Factory
                 $factory,
                 $pivot,
                 $relationship ?? Str::camel(Str::plural(class_basename(
-                $factory instanceof Factory
-                    ? $factory->modelName()
-                    : Collection::wrap($factory)->first()
-            )))
+                    $factory instanceof Factory
+                        ? $factory->modelName()
+                        : Collection::wrap($factory)->first()
+                )))
             )]),
         ]);
     }
@@ -612,8 +612,8 @@ abstract class Factory
         return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
             $factory,
             $relationship ?? Str::camel(class_basename(
-            $factory instanceof Factory ? $factory->modelName() : $factory
-        ))
+                $factory instanceof Factory ? $factory->modelName() : $factory
+            ))
         )])]);
     }
 
@@ -772,8 +772,8 @@ abstract class Factory
             $appNamespace = static::appNamespace();
 
             return class_exists($appNamespace.'Models\\'.$namespacedFactoryBasename)
-                ? $appNamespace.'Models\\'.$namespacedFactoryBasename
-                : $appNamespace.$factoryBasename;
+                        ? $appNamespace.'Models\\'.$namespacedFactoryBasename
+                        : $appNamespace.$factoryBasename;
         };
 
         return $this->model ?? $resolver($this);
@@ -865,8 +865,8 @@ abstract class Factory
     {
         try {
             return Container::getInstance()
-                ->make(Application::class)
-                ->getNamespace();
+                            ->make(Application::class)
+                            ->getNamespace();
         } catch (Throwable $e) {
             return 'App\\';
         }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -741,7 +741,6 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(3, FactoryTestUser::count());
         $this->assertSame(3, FactoryTestPost::count());
 
-
         $comments = FactoryTestCommentFactory::new()
             ->recycle($users)
             ->recycle($posts)

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -701,6 +701,73 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertSame(2, FactoryTestPost::count());
     }
 
+    public function test_multiple_models_can_be_provided_to_recycle()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $users = FactoryTestUserFactory::new()->count(3)->create();
+
+        $posts = FactoryTestPostFactory::new()
+            ->recycle($users)
+            ->for(FactoryTestUserFactory::new())
+            ->has(FactoryTestCommentFactory::new()->count(5), 'comments')
+            ->count(2)
+            ->create();
+
+        $this->assertSame(3, FactoryTestUser::count());
+    }
+
+    public function test_recycled_models_can_be_combined_with_multiple_calls()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $users = FactoryTestUserFactory::new()
+            ->count(2)
+            ->create();
+        $posts = FactoryTestPostFactory::new()
+            ->recycle($users)
+            ->count(2)
+            ->create();
+        $additionalUser = FactoryTestUserFactory::new()
+            ->create();
+        $additionalPost = FactoryTestPostFactory::new()
+            ->recycle($additionalUser)
+            ->create();
+
+        $this->assertSame(3, FactoryTestUser::count());
+        $this->assertSame(3, FactoryTestPost::count());
+
+
+        $comments = FactoryTestCommentFactory::new()
+            ->recycle($users)
+            ->recycle($posts)
+            ->recycle([$additionalUser, $additionalPost])
+            ->count(5)
+            ->create();
+
+        $this->assertSame(3, FactoryTestUser::count());
+        $this->assertSame(3, FactoryTestPost::count());
+    }
+
+    public function test_no_models_can_be_provided_to_recycle()
+    {
+        Factory::guessFactoryNamesUsing(function ($model) {
+            return $model.'Factory';
+        });
+
+        $posts = FactoryTestPostFactory::new()
+            ->recycle([])
+            ->count(2)
+            ->create();
+
+        $this->assertSame(2, FactoryTestPost::count());
+        $this->assertSame(2, FactoryTestUser::count());
+    }
+
     /**
      * Get a database connection instance.
      *


### PR DESCRIPTION
This PR is an enhancement to recently added feature, Eloquent Factory recycling (#44107) and adds support for recycling multiple models of the same type.
Model recycling is a great feature, making factories much cleaner and easier to write. While recycling a single model has its valid use cases, it doesn't really help if we want to create multiple models (`->count(10)`) with our factory - all of them will be related to that same model.

This PR allows developers to provide their own, already created pool of models (collections), so they could be reused in all nested relations. For each relation, factory class **picks a random model** from a provided collection of models, instead of depending on a single one.
Sample usage:

        $users = User::all();
        $companies = Company::all();

        Posts::factory()
            ->recycle($users)
            ->recycle($companies)
            ->count(10)
            ->create();

For example, we often see that the User model relates to everything - as an author of some content, comments, reactions, performed operations etc. In more complex applications, that nesting can go deep. In that scenario, much easier would be to seed a number of users once and then reuse them in all nested relations (so we don't create a user only to be the author of a single comment). It's then closer to a real-life case, where we could have a set number of users in the system and all the actions performed and content created is within that group.



This approach leads to cleaner factories, less database pollution and overall higher seeding quality - created models will be much more related to each other. 


New recycle method still allows for providing a single model so the PR is backward-compatible, without any breaking changes.