### PR TITLE
[10.x] Prevent silently discarding model attributes by default

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -179,7 +179,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @var bool
      */
-    protected static $modelsShouldPreventSilentlyDiscardingAttributes = false;
+    protected static $modelsShouldPreventSilentlyDiscardingAttributes = true;
 
     /**
      * Indicates if broadcasting is currently enabled.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1259,13 +1259,19 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUnderscorePropertiesAreNotFilled()
     {
+        Model::preventSilentlyDiscardingAttributes(false);
+
         $model = new EloquentModelStub;
         $model->fill(['_method' => 'PUT']);
         $this->assertEquals([], $model->getAttributes());
+
+        Model::preventSilentlyDiscardingAttributes(true);
     }
 
     public function testGuarded()
     {
+        Model::preventSilentlyDiscardingAttributes(false);
+
         $model = new EloquentModelStub;
 
         EloquentModelStub::setConnectionResolver($resolver = m::mock(Resolver::class));
@@ -1285,14 +1291,15 @@ class DatabaseEloquentModelTest extends TestCase
 
         $handledMassAssignmentExceptions = 0;
 
-        Model::preventSilentlyDiscardingAttributes();
+        Model::preventSilentlyDiscardingAttributes(true);
+    }
 
+    public function testGuardedException()
+    {
         $this->expectException(MassAssignmentException::class);
         $model = new EloquentModelStub;
         $model->guard(['name', 'age']);
         $model->fill(['Foo' => 'bar']);
-
-        Model::preventSilentlyDiscardingAttributes(false);
     }
 
     public function testFillableOverridesGuarded()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -491,6 +491,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testFirstOrNewMethod()
     {
+        Model::preventSilentlyDiscardingAttributes(false);
+
         $post = Post::create(['title' => Str::random()]);
 
         $tag = Tag::create(['name' => Str::random()]);
@@ -501,6 +503,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $this->assertNull($post->tags()->firstOrNew(['id' => 666])->id);
         $this->assertInstanceOf(Tag::class, $post->tags()->firstOrNew(['id' => 666]));
+
+        Model::preventSilentlyDiscardingAttributes(true);
     }
 
     // public function testFirstOrNewUnrelatedExisting()
@@ -608,6 +612,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testUpdateOrCreateMethod()
     {
+        Model::preventSilentlyDiscardingAttributes(false);
+
         $post = Post::create(['title' => Str::random()]);
 
         $tag = Tag::create(['name' => Str::random()]);
@@ -619,6 +625,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post->tags()->updateOrCreate(['id' => 666], ['name' => 'dives']);
         $this->assertNotNull($post->tags()->whereName('dives')->first());
+
+        Model::preventSilentlyDiscardingAttributes(true);
     }
 
     public function testUpdateOrCreateUnrelatedExisting()


### PR DESCRIPTION
It makes sense to be verbose as the default, especially for beginners.

Replaces https://github.com/laravel/laravel/pull/5993.
Follow-up to #43893.