### PR TITLE
[9.x] Use prefix for url when generating url for scoped disk

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -620,6 +620,10 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function url($path)
     {
+        if (isset($this->config['prefix'])) {
+            $path = $this->concatPathToUrl($this->config['prefix'], $path);
+        }
+
         $adapter = $this->adapter;
 
         if (method_exists($adapter, 'getUrl')) {

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -564,4 +564,11 @@ class FilesystemAdapterTest extends TestCase
 
         $this->assertFalse($filesystemAdapter->providesTemporaryUrls());
     }
+
+    public function testPrefixesUrls()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter, ['url' => 'https://example.org/', 'prefix' => 'images']);
+
+        $this->assertEquals('https://example.org/images/picture.jpeg', $filesystemAdapter->url('picture.jpeg'));
+    }
 }


### PR DESCRIPTION
The S3 adapter already had its own prefixing, the local prefixing for the generated URL is added in this PR. This fixes #44327.
