### PR TITLE
[9.x] Remove hard coded Menlo font from `dd` source file function output

### DIFF
--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -132,7 +132,7 @@ class HtmlDumper extends BaseHtmlDumper
             );
         }
 
-        return sprintf('<span style="color: #A0A0A0; font-family: Menlo"> // %s</span>', $source);
+        return sprintf('<span style="color: #A0A0A0;"> // %s</span>', $source);
     }
 
     /**

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -25,7 +25,7 @@ class HtmlDumperTest extends TestCase
     {
         $output = $this->dump('string');
 
-        $expected = "string</span>\"<span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+        $expected = "string</span>\"<span style=\"color: #A0A0A0;\"> // app/routes/console.php:18</span>\n</pre>";
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -34,7 +34,7 @@ class HtmlDumperTest extends TestCase
     {
         $output = $this->dump(1);
 
-        $expected = "1</span><span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+        $expected = "1</span><span style=\"color: #A0A0A0;\"> // app/routes/console.php:18</span>\n</pre>";
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -43,7 +43,7 @@ class HtmlDumperTest extends TestCase
     {
         $output = $this->dump(1.1);
 
-        $expected = "1.1</span><span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+        $expected = "1.1</span><span style=\"color: #A0A0A0;\"> // app/routes/console.php:18</span>\n</pre>";
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -52,7 +52,7 @@ class HtmlDumperTest extends TestCase
     {
         $output = $this->dump(['string', 1, 1.1, ['string', 1, 1.1]]);
 
-        $expected = '<samp data-depth=1 class=sf-dump-expanded><span style="color: #A0A0A0; font-family: Menlo"> // app/routes/console.php:18</span>';
+        $expected = '<samp data-depth=1 class=sf-dump-expanded><span style="color: #A0A0A0;"> // app/routes/console.php:18</span>';
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -61,7 +61,7 @@ class HtmlDumperTest extends TestCase
     {
         $output = $this->dump(true);
 
-        $expected = "true</span><span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+        $expected = "true</span><span style=\"color: #A0A0A0;\"> // app/routes/console.php:18</span>\n</pre>";
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -73,7 +73,7 @@ class HtmlDumperTest extends TestCase
 
         $output = $this->dump($user);
 
-        $expected = '<samp data-depth=1 class=sf-dump-expanded><span style="color: #A0A0A0; font-family: Menlo"> // app/routes/console.php:18</span>';
+        $expected = '<samp data-depth=1 class=sf-dump-expanded><span style="color: #A0A0A0;"> // app/routes/console.php:18</span>';
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -82,7 +82,7 @@ class HtmlDumperTest extends TestCase
     {
         $output = $this->dump(null);
 
-        $expected = "null</span><span style=\"color: #A0A0A0; font-family: Menlo\"> // app/routes/console.php:18</span>\n</pre>";
+        $expected = "null</span><span style=\"color: #A0A0A0;\"> // app/routes/console.php:18</span>\n</pre>";
 
         $this->assertStringContainsString($expected, $output);
     }


### PR DESCRIPTION
Hi,

The PR was made by awesome @nunomaduro #44211. There was a hardcoded 'font-family: Menlo' which not everyone has except apple macOS users. I think browser should auto fallback to system font 😄 

I'm on windows so I don't have this font installed I see this:

![2022-09-27_23-24](https://user-images.githubusercontent.com/30714223/192629481-e6d53dfa-eff7-46d0-bea5-e25dc4be04b5.png)

It should be like this:

![2022-09-27_23-25](https://user-images.githubusercontent.com/30714223/192629540-b1ca0562-b342-49c3-b0ab-b3ad1eeb8481.png)