### PR TITLE
Fixed #44332: dd shows compiled view not the original view file

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -37,12 +37,12 @@ trait ResolvesDumpSource
             $relativeFile = substr($file, strlen($this->basePath) + 1);
         }
 
-        if(str_starts_with($relativeFile,"storage/framework/views/")){
+        if (str_starts_with($relativeFile, 'storage/framework/views/')) {
             $fileArr = file($file);
             $lastLine = end($fileArr);
 
-            $result = str_replace("<"."?php /**PATH ", "", $lastLine);
-            $result = str_replace(" ENDPATH**/ ?>", "", $result);
+            $result = str_replace('<' . '?php /**PATH ', '', $lastLine);
+            $result = str_replace(' ENDPATH**/ ?>', '', $result);
             $relativeFile = substr($result, strlen($this->basePath) + 1);
         }
 
@@ -52,7 +52,7 @@ trait ResolvesDumpSource
     /**
      * Set the resolver that resolves the source of the dump call.
      *
-     * @param  (callable(): (array{0: string, 1: string, 2: int}|null))|null  $callable
+     * @param (callable(): (array{0: string, 1: string, 2: int}|null))|null $callable
      * @return void
      */
     public static function resolveDumpSourceUsing($callable)

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -54,7 +54,7 @@ trait ResolvesDumpSource
     /**
      * Resolve the source of the dump call.
      *
-     * @param string $path
+     * @param  string  $path
      * @return string
      */
     public function getAbsolutePath(string $path): string

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -41,7 +41,7 @@ trait ResolvesDumpSource
             $fileArr = file($file);
             $lastLine = end($fileArr);
 
-            $result = str_replace('<' . '?php /**PATH ', '', $lastLine);
+            $result = str_replace('<'.'?php /**PATH ', '', $lastLine);
             $result = str_replace(' ENDPATH**/ ?>', '', $result);
             $relativeFile = substr($result, strlen($this->basePath) + 1);
         }

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -34,19 +34,32 @@ trait ResolvesDumpSource
         $relativeFile = $file;
 
         if (str_starts_with($file, $this->basePath)) {
-            $relativeFile = substr($file, strlen($this->basePath) + 1);
+            $relativeFile = $this->getAbsolutePath($file);
         }
 
-        if (str_starts_with($relativeFile, 'storage/framework/views/')) {
+        $viewPath = $this->getAbsolutePath(config('view.compiled'));
+
+        if (str_starts_with($relativeFile, $viewPath)) {
             $fileArr = file($file);
             $lastLine = end($fileArr);
 
             $result = str_replace('<'.'?php /**PATH ', '', $lastLine);
             $result = str_replace(' ENDPATH**/ ?>', '', $result);
-            $relativeFile = substr($result, strlen($this->basePath) + 1);
+            $relativeFile = $this->getAbsolutePath($result);
         }
 
         return [$file, $relativeFile, $line];
+    }
+
+    /**
+     * Resolve the source of the dump call.
+     *
+     * @param string $path
+     * @return string
+     */
+    public function getAbsolutePath(string $path): string
+    {
+        return substr($path, strlen($this->basePath) + 1);
     }
 
     /**

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -37,6 +37,15 @@ trait ResolvesDumpSource
             $relativeFile = substr($file, strlen($this->basePath) + 1);
         }
 
+        if(str_starts_with($relativeFile,"storage/framework/views/")){
+            $fileArr = file($file);
+            $lastLine = end($fileArr);
+
+            $result = str_replace("<"."?php /**PATH ", "", $lastLine);
+            $result = str_replace(" ENDPATH**/ ?>", "", $result);
+            $relativeFile = substr($result, strlen($this->basePath) + 1);
+        }
+
         return [$file, $relativeFile, $line];
     }
 


### PR DESCRIPTION
Allow dd to print out the correct path for the view file that being dump not the compiled one, This fixes https://github.com/laravel/framework/issues/44332.
![Screenshot from 2022-09-28 00-55-59](https://user-images.githubusercontent.com/27627958/192653180-ea814abc-e942-4b51-bd06-d8837828f913.png)
