### PR TITLE
[9.x] route:list Add check to detect method that not exists

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -153,6 +153,7 @@ class RouteListCommand extends Command
             'name' => $route->getName(),
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
+            'vendor' => $this->isVendorRoute($route),
         ];
 
         $action = $data['action'];

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -151,10 +151,10 @@ class RouteListCommand extends Command
         if ($this->option('check')) {
             if (strpos($action, '@') !== false) {
                 $parts = explode('@', $action);
-                if (!method_exists($parts[0], $parts[1])) {
+                if (! method_exists($parts[0], $parts[1])) {
                     $this->newLine();
                     $this->error(sprintf('Error method "%1$s" not found in class (%2$s)', $parts[1], $parts[0]));
-                    throw new \Exception("ERR_METHOD_NOT_FOUND", 1);
+                    throw new \Exception('ERR_METHOD_NOT_FOUND', 1);
                 }
             }
         }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -156,7 +156,7 @@ class RouteListCommand extends Command
         ];
 
         $action = $data['action'];
-        if (true || $this->option('check')) {
+        if ($this->option('check')) {
             if (strpos($action, '@') !== false) {
                 $parts = explode('@', $action);
                 if (! method_exists($parts[0], $parts[1])) {

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -146,12 +146,25 @@ class RouteListCommand extends Command
      */
     protected function getRouteInformation(Route $route)
     {
+        $action = ltrim($route->getActionName(), '\\');
+
+        if ($this->option('check')) {
+            if (strpos($action, '@') !== false) {
+                $parts = explode('@', $action);
+                if (!method_exists($parts[0], $parts[1])) {
+                    $this->newLine();
+                    $this->error(sprintf('Error method "%1$s" not found in class (%2$s)', $parts[1], $parts[0]));
+                    throw new \Exception("ERR_METHOD_NOT_FOUND", 1);
+                }
+            }
+        }
+
         return $this->filterRoute([
             'domain' => $route->domain(),
             'method' => implode('|', $route->methods()),
             'uri' => $route->uri(),
             'name' => $route->getName(),
-            'action' => ltrim($route->getActionName(), '\\'),
+            'action' => $action,
             'middleware' => $this->getMiddleware($route),
             'vendor' => $this->isVendorRoute($route),
         ]);
@@ -503,6 +516,7 @@ class RouteListCommand extends Command
             ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware) to sort by', 'uri'],
             ['except-vendor', null, InputOption::VALUE_NONE, 'Do not display routes defined by vendor packages'],
             ['only-vendor', null, InputOption::VALUE_NONE, 'Only display routes defined by vendor packages'],
+            ['check', null, InputOption::VALUE_NONE, 'Check action exists within class'],
         ];
     }
 }


### PR DESCRIPTION
Check class's method that not exists
```php
php artisan route:list --check
```

Description:
Throw error if action/method declared in route, but not yet declared inside class

Example screenshot:
![image](https://user-images.githubusercontent.com/20636828/192698724-5403ff2d-0928-4b1a-b4ff-90cc1fb6250c.png)
