### PR TITLE
allow high order method calling on arrays

### DIFF
--- a/src/Illuminate/Collections/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Collections/HigherOrderCollectionProxy.php
@@ -57,7 +57,7 @@ class HigherOrderCollectionProxy
     public function __call($method, $parameters)
     {
         return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
-            return $value->{$method}(...$parameters);
+            return is_array($value) ? Arr::$method($value, ...$parameters) : $value->{$method}(...$parameters);
         });
     }
 }


### PR DESCRIPTION
Currently something like: 

```php
$collection = collect([
  ['product_id' => 1, 'product_name' => 'Product 1', 'product_type' => 'book'],
  ['product_id' => 2, 'product_name' => 'Product 2', 'product_type' => 'video'],
  ['product_id' => 3, 'product_name' => 'Product 3', 'product_type' => 'book'],
  ['product_id' => 4, 'product_name' => 'Product 4', 'product_type' => 'video'],
]);

$only = $collection->map->only(['product_id', 'product_name']);
```
Is not working because of `Call to a member function only() on array`. 

This PR allows usage of high order methods and arrays.
