### PR TITLE
Add ```spread``` method to Collection

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -915,6 +915,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function split($numberOfGroups);
 
     /**
+     * Spread a collection into more members using given callback
+     * 
+     * @param callable $callback
+     * @return static
+     */
+    public function spread(callable $callback);
+
+    /**
      * Get the first item in the collection, but only if exactly one item exists. Otherwise, throw an exception.
      *
      * @param  (callable(TValue, TKey): bool)|string  $key

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -806,6 +806,17 @@ trait EnumeratesValues
     }
 
     /**
+     * Spread a collection into more members using given callback
+     * 
+     * @param  callable $callback
+     * @return static
+     */
+    public function spread(callable $callback)
+    {
+        return $this->reduce(fn ($carry, $row) => array_merge($carry, Arr::wrap($callback($row))), []);
+    }
+
+    /**
      * Pass the collection to the given callback and then return it.
      *
      * @param  callable($this): mixed  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3843,6 +3843,30 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSpreadReturnsExpandedItems($collection)
+    {
+        $data = new $collection([1, 2, 3]);
+        $this->assertSame(
+            [1, 1.5, 2, 2.5, 3, 3.5],
+            $data->spread(fn ($i) => [$i, $i + 0.5])
+        );
+
+        $data = new $collection([1, 2, 3]);
+        $this->assertSame(
+            [1, 1.5, 2, 3, 3.5],
+            $data->spread(fn ($i) => $i === 2 ? 2 : [$i, $i + 0.5])
+        );
+
+        $data = new $collection([1, 2, 3]);
+        $this->assertSame(
+            [1, 2, 3],
+            $data->spread(fn ($i) => $i)
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSearchReturnsIndexOfFirstFoundItem($collection)
     {
         $c = new $collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);


### PR DESCRIPTION
This pull request adds ```spread()``` method to Collections.

### Why?
There are many cases where we need to produce more collection items from each item in the given collection.

For example, given we have the following notes:
```php
collect(['C', 'D', 'E', 'F', 'G', 'A', 'B']);
```

Now we want to get all possible notes including sharps.

### Solution

```php
collect(['C', 'D', 'E', 'F', 'G', 'A', 'B'])
    ->spread(fn ($note) => in_array($note, ['E', 'B']) ? $note : [$note, $note . '#']);

// output: ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
```

Edit:
Alternatively, the method can also be named as ```expand()```