### PR TITLE
[9.x] Improves `dd` source on compiled views

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -31,6 +31,10 @@ trait ResolvesDumpSource
             return;
         }
 
+        if ($this->isFileViewCompiled($file)) {
+            $file = $this->getOriginalViewCompiledFile($file);
+        }
+
         $relativeFile = $file;
 
         if (str_starts_with($file, $this->basePath)) {
@@ -38,6 +42,34 @@ trait ResolvesDumpSource
         }
 
         return [$file, $relativeFile, $line];
+    }
+
+    /**
+     * Checks if the given file is a view compiled.
+     *
+     * @param  string  $file
+     * @return bool
+     */
+    protected function isFileViewCompiled($file)
+    {
+        return str_starts_with($file, $this->viewCompiledPath);
+    }
+
+    /**
+     * Gets the original view compiled file by the given compiled file.
+     *
+     * @param  string  $file
+     * @return string
+     */
+    protected function getOriginalViewCompiledFile($file)
+    {
+        preg_match('/\/\*\*PATH\s(.*)\sENDPATH/', file_get_contents($file), $matches);
+
+        if (isset($matches[1])) {
+            $file = $matches[1];
+        }
+
+        return $file;
     }
 
     /**

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -33,8 +33,8 @@ trait ResolvesDumpSource
 
         $relativeFile = $file;
 
-        if ($this->isFileViewCompiled($file)) {
-            $file = $this->getOriginalViewCompiledFile($file);
+        if ($this->isCompiledViewFile($file)) {
+            $file = $this->getOriginalFileForCompiledView($file);
             $line = null;
         }
 
@@ -46,23 +46,23 @@ trait ResolvesDumpSource
     }
 
     /**
-     * Checks if the given file is a view compiled.
+     * Determine if the given file is a view compiled.
      *
      * @param  string  $file
      * @return bool
      */
-    protected function isFileViewCompiled($file)
+    protected function isCompiledViewFile($file)
     {
-        return str_starts_with($file, $this->viewCompiledPath);
+        return str_starts_with($file, $this->compiledViewPath);
     }
 
     /**
-     * Gets the original view compiled file by the given compiled file.
+     * Get the original view compiled file by the given compiled file.
      *
      * @param  string  $file
      * @return string
      */
-    protected function getOriginalViewCompiledFile($file)
+    protected function getOriginalFileForCompiledView($file)
     {
         preg_match('/\/\*\*PATH\s(.*)\sENDPATH/', file_get_contents($file), $matches);
 

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -7,14 +7,14 @@ trait ResolvesDumpSource
     /**
      * The source resolver.
      *
-     * @var (callable(): (array{0: string, 1: string, 2: int}|null))|null
+     * @var (callable(): (array{0: string, 1: string, 2: int|null}|null))|null
      */
     protected static $dumpSourceResolver;
 
     /**
      * Resolve the source of the dump call.
      *
-     * @return array{0: string, 1: string, 2: int}|null
+     * @return array{0: string, 1: string, 2: int|null}|null
      */
     public function resolveDumpSource()
     {
@@ -31,11 +31,12 @@ trait ResolvesDumpSource
             return;
         }
 
+        $relativeFile = $file;
+
         if ($this->isFileViewCompiled($file)) {
             $file = $this->getOriginalViewCompiledFile($file);
+            $line = null;
         }
-
-        $relativeFile = $file;
 
         if (str_starts_with($file, $this->basePath)) {
             $relativeFile = substr($file, strlen($this->basePath) + 1);
@@ -75,7 +76,7 @@ trait ResolvesDumpSource
     /**
      * Set the resolver that resolves the source of the dump call.
      *
-     * @param  (callable(): (array{0: string, 1: string, 2: int}|null))|null  $callable
+     * @param  (callable(): (array{0: string, 1: string, 2: int|null}|null))|null  $callable
      * @return void
      */
     public static function resolveDumpSourceUsing($callable)

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -29,11 +29,11 @@ class CliDumper extends BaseCliDumper
     protected $output;
 
     /**
-     * The view compiled path of the application.
+     * The compiled view path for the application.
      *
      * @var string
      */
-    protected $viewCompiledPath;
+    protected $compiledViewPath;
 
     /**
      * If the dumper is currently dumping.
@@ -47,30 +47,30 @@ class CliDumper extends BaseCliDumper
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  string  $basePath
-     * @param  string  $viewCompiledPath
+     * @param  string  $compiledViewPath
      * @return void
      */
-    public function __construct($output, $basePath, $viewCompiledPath)
+    public function __construct($output, $basePath, $compiledViewPath)
     {
         parent::__construct();
 
         $this->basePath = $basePath;
         $this->output = $output;
-        $this->viewCompiledPath = $viewCompiledPath;
+        $this->compiledViewPath = $compiledViewPath;
     }
 
     /**
      * Create a new CLI dumper instance and register it as the default dumper.
      *
      * @param  string  $basePath
-     * @param  string  $viewCompiledPath
+     * @param  string  $compiledViewPath
      * @return void
      */
-    public static function register($basePath, $viewCompiledPath)
+    public static function register($basePath, $compiledViewPath)
     {
         $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
 
-        $dumper = new static(new ConsoleOutput(), $basePath, $viewCompiledPath);
+        $dumper = new static(new ConsoleOutput(), $basePath, $compiledViewPath);
 
         VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
     }

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -114,7 +114,13 @@ class CliDumper extends BaseCliDumper
 
         [$file, $relativeFile, $line] = $dumpSource;
 
-        return sprintf(' <fg=gray>// <fg=gray;href=file://%s#L%s>%s:%s</></>', $file, $line, $relativeFile, $line);
+        return sprintf(
+            ' <fg=gray>// <fg=gray;href=file://%s%s>%s%s</></>',
+            $file,
+            is_null($line) ? '' : "#L$line",
+            $relativeFile,
+            is_null($line) ? '' : ":$line"
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -29,6 +29,13 @@ class CliDumper extends BaseCliDumper
     protected $output;
 
     /**
+     * The view compiled path of the application.
+     *
+     * @var string
+     */
+    protected $viewCompiledPath;
+
+    /**
      * If the dumper is currently dumping.
      *
      * @var bool
@@ -40,27 +47,30 @@ class CliDumper extends BaseCliDumper
      *
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @param  string  $basePath
+     * @param  string  $viewCompiledPath
      * @return void
      */
-    public function __construct($output, $basePath)
+    public function __construct($output, $basePath, $viewCompiledPath)
     {
         parent::__construct();
 
         $this->basePath = $basePath;
         $this->output = $output;
+        $this->viewCompiledPath = $viewCompiledPath;
     }
 
     /**
      * Create a new CLI dumper instance and register it as the default dumper.
      *
      * @param  string  $basePath
+     * @param  string  $viewCompiledPath
      * @return void
      */
-    public static function register($basePath)
+    public static function register($basePath, $viewCompiledPath)
     {
         $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
 
-        $dumper = new static(new ConsoleOutput(), $basePath);
+        $dumper = new static(new ConsoleOutput(), $basePath, $viewCompiledPath);
 
         VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
     }

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -36,6 +36,13 @@ class HtmlDumper extends BaseHtmlDumper
     protected $basePath;
 
     /**
+     * The view compiled path of the application.
+     *
+     * @var string
+     */
+    protected $viewCompiledPath;
+
+    /**
      * If the dumper is currently dumping.
      *
      * @var bool
@@ -46,26 +53,29 @@ class HtmlDumper extends BaseHtmlDumper
      * Create a new HTML dumper instance.
      *
      * @param  string  $basePath
+     * @param  string  $viewCompiledPath
      * @return void
      */
-    public function __construct($basePath)
+    public function __construct($basePath, $viewCompiledPath)
     {
         parent::__construct();
 
         $this->basePath = $basePath;
+        $this->viewCompiledPath = $viewCompiledPath;
     }
 
     /**
      * Create a new HTML dumper instance and register it as the default dumper.
      *
      * @param  string  $basePath
+     * @param  string  $viewCompiledPath
      * @return void
      */
-    public static function register($basePath)
+    public static function register($basePath, $viewCompiledPath)
     {
         $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
 
-        $dumper = new static($basePath);
+        $dumper = new static($basePath, $viewCompiledPath);
 
         VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
     }

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -130,14 +130,14 @@ class HtmlDumper extends BaseHtmlDumper
 
         [$file, $relativeFile, $line] = $dumpSource;
 
-        $source = sprintf('%s:%s', $relativeFile, $line);
+        $source = sprintf('%s%s', $relativeFile, is_null($line) ? '' : ":$line");
 
         if ($editor = $this->editor()) {
             $source = sprintf(
-                '<a href="%s://open?file=%s&line=%s">%s</a>',
+                '<a href="%s://open?file=%s%s">%s</a>',
                 $editor,
                 $file,
-                $line,
+                is_null($line) ? '' : "&line=$line",
                 $source,
             );
         }

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -36,11 +36,11 @@ class HtmlDumper extends BaseHtmlDumper
     protected $basePath;
 
     /**
-     * The view compiled path of the application.
+     * The compiled view path of the application.
      *
      * @var string
      */
-    protected $viewCompiledPath;
+    protected $compiledViewPath;
 
     /**
      * If the dumper is currently dumping.
@@ -53,29 +53,29 @@ class HtmlDumper extends BaseHtmlDumper
      * Create a new HTML dumper instance.
      *
      * @param  string  $basePath
-     * @param  string  $viewCompiledPath
+     * @param  string  $compiledViewPath
      * @return void
      */
-    public function __construct($basePath, $viewCompiledPath)
+    public function __construct($basePath, $compiledViewPath)
     {
         parent::__construct();
 
         $this->basePath = $basePath;
-        $this->viewCompiledPath = $viewCompiledPath;
+        $this->compiledViewPath = $compiledViewPath;
     }
 
     /**
      * Create a new HTML dumper instance and register it as the default dumper.
      *
      * @param  string  $basePath
-     * @param  string  $viewCompiledPath
+     * @param  string  $compiledViewPath
      * @return void
      */
-    public static function register($basePath, $viewCompiledPath)
+    public static function register($basePath, $compiledViewPath)
     {
         $cloner = tap(new VarCloner())->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
 
-        $dumper = new static($basePath, $viewCompiledPath);
+        $dumper = new static($basePath, $compiledViewPath);
 
         VarDumper::setHandler(fn ($value) => $dumper->dumpWithSource($cloner->cloneVar($value)));
     }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -74,15 +74,16 @@ class FoundationServiceProvider extends AggregateServiceProvider
     public function registerDumper()
     {
         $basePath = $this->app->basePath();
+        $viewCompiledPath = $this->app['config']->get('view.compiled');
 
         $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? null;
 
         match (true) {
-            'html' == $format => HtmlDumper::register($basePath),
-            'cli' == $format => CliDumper::register($basePath),
+            'html' == $format => HtmlDumper::register($basePath, $viewCompiledPath),
+            'cli' == $format => CliDumper::register($basePath, $viewCompiledPath),
             'server' == $format => null,
             $format && 'tcp' == parse_url($format, PHP_URL_SCHEME) => null,
-            default => in_array(PHP_SAPI, ['cli', 'phpdbg']) ? CliDumper::register($basePath) : HtmlDumper::register($basePath),
+            default => in_array(PHP_SAPI, ['cli', 'phpdbg']) ? CliDumper::register($basePath, $viewCompiledPath) : HtmlDumper::register($basePath, $viewCompiledPath),
         };
     }
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -74,16 +74,17 @@ class FoundationServiceProvider extends AggregateServiceProvider
     public function registerDumper()
     {
         $basePath = $this->app->basePath();
-        $viewCompiledPath = $this->app['config']->get('view.compiled');
+
+        $compiledViewPath = $this->app['config']->get('view.compiled');
 
         $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? null;
 
         match (true) {
-            'html' == $format => HtmlDumper::register($basePath, $viewCompiledPath),
-            'cli' == $format => CliDumper::register($basePath, $viewCompiledPath),
+            'html' == $format => HtmlDumper::register($basePath, $compiledViewPath),
+            'cli' == $format => CliDumper::register($basePath, $compiledViewPath),
             'server' == $format => null,
             $format && 'tcp' == parse_url($format, PHP_URL_SCHEME) => null,
-            default => in_array(PHP_SAPI, ['cli', 'phpdbg']) ? CliDumper::register($basePath, $viewCompiledPath) : HtmlDumper::register($basePath, $viewCompiledPath),
+            default => in_array(PHP_SAPI, ['cli', 'phpdbg']) ? CliDumper::register($basePath, $compiledViewPath) : HtmlDumper::register($basePath, $compiledViewPath),
         };
     }
 

--- a/tests/Foundation/Console/CliDumperTest.php
+++ b/tests/Foundation/Console/CliDumperTest.php
@@ -148,7 +148,7 @@ class CliDumperTest extends TestCase
 
     public function testGetOriginalViewCompiledFile()
     {
-        $compiled = __DIR__ . '/../fixtures/fake-compiled-view.php';
+        $compiled = __DIR__.'/../fixtures/fake-compiled-view.php';
         $original = '/my-work-directory/resources/views/welcome.blade.php';
 
         $output = new BufferedOutput();
@@ -167,7 +167,7 @@ class CliDumperTest extends TestCase
 
     public function testWhenGetOriginalViewCompiledFileFails()
     {
-        $compiled = __DIR__ . '/../fixtures/fake-compiled-view-without-source-map.php';
+        $compiled = __DIR__.'/../fixtures/fake-compiled-view-without-source-map.php';
         $original = $compiled;
 
         $output = new BufferedOutput();
@@ -191,6 +191,23 @@ class CliDumperTest extends TestCase
         $output = $this->dump('string');
 
         $expected = "\"string\"\n";
+
+        $this->assertSame($expected, $output);
+    }
+
+    public function testUnresolvableLine()
+    {
+        CliDumper::resolveDumpSourceUsing(function () {
+            return [
+                '/my-work-directory/resources/views/welcome.blade.php',
+                'resources/views/welcome.blade.php',
+                null,
+            ];
+        });
+
+        $output = $this->dump('hey from view');
+
+        $expected = "\"hey from view\" // resources/views/welcome.blade.php\n";
 
         $this->assertSame($expected, $output);
     }

--- a/tests/Foundation/Console/CliDumperTest.php
+++ b/tests/Foundation/Console/CliDumperTest.php
@@ -120,11 +120,11 @@ class CliDumperTest extends TestCase
         );
 
         $reflection = new ReflectionClass($dumper);
-        $method = $reflection->getMethod('isFileViewCompiled');
+        $method = $reflection->getMethod('isCompiledViewFile');
         $method->setAccessible(true);
-        $isFileViewCompiled = $method->invoke($dumper, $file);
+        $isCompiledViewFile = $method->invoke($dumper, $file);
 
-        $this->assertFalse($isFileViewCompiled);
+        $this->assertFalse($isCompiledViewFile);
     }
 
     public function testWhenIsFileViewIsViewCompiled()
@@ -139,11 +139,11 @@ class CliDumperTest extends TestCase
         );
 
         $reflection = new ReflectionClass($dumper);
-        $method = $reflection->getMethod('isFileViewCompiled');
+        $method = $reflection->getMethod('isCompiledViewFile');
         $method->setAccessible(true);
-        $isFileViewCompiled = $method->invoke($dumper, $file);
+        $isCompiledViewFile = $method->invoke($dumper, $file);
 
-        $this->assertTrue($isFileViewCompiled);
+        $this->assertTrue($isCompiledViewFile);
     }
 
     public function testGetOriginalViewCompiledFile()
@@ -159,7 +159,7 @@ class CliDumperTest extends TestCase
         );
 
         $reflection = new ReflectionClass($dumper);
-        $method = $reflection->getMethod('getOriginalViewCompiledFile');
+        $method = $reflection->getMethod('getOriginalFileForCompiledView');
         $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));
@@ -178,7 +178,7 @@ class CliDumperTest extends TestCase
         );
 
         $reflection = new ReflectionClass($dumper);
-        $method = $reflection->getMethod('getOriginalViewCompiledFile');
+        $method = $reflection->getMethod('getOriginalFileForCompiledView');
         $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -135,7 +135,7 @@ class HtmlDumperTest extends TestCase
 
     public function testGetOriginalViewCompiledFile()
     {
-        $compiled = __DIR__ . '/../fixtures/fake-compiled-view.php';
+        $compiled = __DIR__.'/../fixtures/fake-compiled-view.php';
         $original = '/my-work-directory/resources/views/welcome.blade.php';
 
         $dumper = new HtmlDumper(
@@ -152,7 +152,7 @@ class HtmlDumperTest extends TestCase
 
     public function testWhenGetOriginalViewCompiledFileFails()
     {
-        $compiled = __DIR__ . '/../fixtures/fake-compiled-view-without-source-map.php';
+        $compiled = __DIR__.'/../fixtures/fake-compiled-view-without-source-map.php';
         $original = $compiled;
 
         $dumper = new HtmlDumper(
@@ -165,6 +165,23 @@ class HtmlDumperTest extends TestCase
         $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));
+    }
+
+    public function testUnresolvableLine()
+    {
+        HtmlDumper::resolveDumpSourceUsing(function () {
+            return [
+                '/my-work-directory/resources/views/welcome.blade.php',
+                'resources/views/welcome.blade.php',
+                null,
+            ];
+        });
+
+        $output = $this->dump('hey from view');
+
+        $expected = "hey from view</span>\"<span style=\"color: #A0A0A0; font-family: Menlo\"> // resources/views/welcome.blade.php</span>\n</pre>";
+
+        $this->assertStringContainsString($expected, $output);
     }
 
     protected function dump($value)

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -109,11 +109,11 @@ class HtmlDumperTest extends TestCase
         );
 
         $reflection = new ReflectionClass($dumper);
-        $method = $reflection->getMethod('isFileViewCompiled');
+        $method = $reflection->getMethod('isCompiledViewFile');
         $method->setAccessible(true);
-        $isFileViewCompiled = $method->invoke($dumper, $file);
+        $isCompiledViewFile = $method->invoke($dumper, $file);
 
-        $this->assertFalse($isFileViewCompiled);
+        $this->assertFalse($isCompiledViewFile);
     }
 
     public function testWhenIsFileViewIsViewCompiled()
@@ -126,11 +126,11 @@ class HtmlDumperTest extends TestCase
         );
 
         $reflection = new ReflectionClass($dumper);
-        $method = $reflection->getMethod('isFileViewCompiled');
+        $method = $reflection->getMethod('isCompiledViewFile');
         $method->setAccessible(true);
-        $isFileViewCompiled = $method->invoke($dumper, $file);
+        $isCompiledViewFile = $method->invoke($dumper, $file);
 
-        $this->assertTrue($isFileViewCompiled);
+        $this->assertTrue($isCompiledViewFile);
     }
 
     public function testGetOriginalViewCompiledFile()
@@ -144,7 +144,7 @@ class HtmlDumperTest extends TestCase
         );
 
         $reflection = new ReflectionClass($dumper);
-        $method = $reflection->getMethod('getOriginalViewCompiledFile');
+        $method = $reflection->getMethod('getOriginalFileForCompiledView');
         $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));
@@ -161,7 +161,7 @@ class HtmlDumperTest extends TestCase
         );
 
         $reflection = new ReflectionClass($dumper);
-        $method = $reflection->getMethod('getOriginalViewCompiledFile');
+        $method = $reflection->getMethod('getOriginalFileForCompiledView');
         $method->setAccessible(true);
 
         $this->assertSame($original, $method->invoke($dumper, $compiled));

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -179,7 +179,7 @@ class HtmlDumperTest extends TestCase
 
         $output = $this->dump('hey from view');
 
-        $expected = "hey from view</span>\"<span style=\"color: #A0A0A0; font-family: Menlo\"> // resources/views/welcome.blade.php</span>\n</pre>";
+        $expected = "hey from view</span>\"<span style=\"color: #A0A0A0;\"> // resources/views/welcome.blade.php</span>\n</pre>";
 
         $this->assertStringContainsString($expected, $output);
     }

--- a/tests/Foundation/fixtures/fake-compiled-view-without-source-map.php
+++ b/tests/Foundation/fixtures/fake-compiled-view-without-source-map.php
@@ -1,0 +1,8 @@
+<<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title></title>
+</head>
+<body>

--- a/tests/Foundation/fixtures/fake-compiled-view.php
+++ b/tests/Foundation/fixtures/fake-compiled-view.php
@@ -1,0 +1,9 @@
+<<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title></title>
+</head>
+<body>
+<?php /**PATH /my-work-directory/resources/views/welcome.blade.php ENDPATH**/ ?>


### PR DESCRIPTION
This pull request is inspired by https://github.com/laravel/framework/pull/44334, and co-authored by [baselrabia](https://github.com/baselrabia), and it improves displaying the `dd` source on compiled views.

```php
// resources/views/welcome.blade.php on line 23...
@php dd('hey'); @endphp

// Before
"hey" // storage/framework/views/6687c33c38b71a8560bb0c404ec753054fa3a941.php:23

// After
"hey" // resources/views/welcome.blade.php
```

Fixes #44334 