### PR TITLE
[9.x] Fix `whereIn` doc block changes for column parameter

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -998,7 +998,7 @@ class Builder implements BuilderContract
     /**
      * Add a "where in" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|Expression  $column
      * @param  mixed  $values
      * @param  string  $boolean
      * @param  bool  $not


### PR DESCRIPTION
Doc Block changes for the $column parameter on the whereIn method.
[Larastan](https://github.com/nunomaduro/larastan) throws an error when we put an expression on the whereIn method. Because, as per the framework doc block expecting string only.

**For Example:**
by default whereIn method filter record case insensitive but we need to filter out the records as per in case sensitive for that we need to do like: 
`whereIn(DB::raw('BINARY `name`'), ['abc', 'abcd'])` and, DB raw returns the `Illuminate\Database\Query\Expression` that's why we need to updates the doc blocks. 
These changes don't affect the functionality and do not need to be written tests.

This is my first PR to the framework. if there is anything, feel free to update me.

Thanks, 
