### PR TITLE
[9.x] Fix the "Implicit conversion from float to int loses precision" error in Timebox Class

### DIFF
--- a/src/Illuminate/Support/Timebox.php
+++ b/src/Illuminate/Support/Timebox.php
@@ -24,7 +24,7 @@ class Timebox
 
         $result = $callback($this);
 
-        $remainder = $microseconds - ((microtime(true) - $start) * 1000000);
+        $remainder = intval($microseconds - ((microtime(true) - $start) * 1000000));
 
         if (! $this->earlyReturn && $remainder > 0) {
             $this->usleep($remainder);
@@ -60,10 +60,10 @@ class Timebox
     /**
      * Sleep for the specified number of microseconds.
      *
-     * @param  $microseconds
+     * @param  int  $microseconds
      * @return void
      */
-    protected function usleep($microseconds)
+    protected function usleep(int $microseconds)
     {
         usleep($microseconds);
     }


### PR DESCRIPTION
The _"Implicit conversion from float to int loses precision"_ error could be triggered since the `$remainder` variable on the line 27 is not always an integer.

https://github.com/laravel/framework/blob/c86e883a136276a32fedc7fd464ab49dbf35a4d8/src/Illuminate/Support/Timebox.php#L27-L31
