### PR TITLE
[9.x] Add Custom Path to Env Encryption Command and Add Test

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -22,6 +22,7 @@ class EnvironmentDecryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be decrypted}
+                    {--path= : Where is the environment file path is located}
                     {--force : Overwrite the existing environment file}
                     {--filename= : Where to write the decrypted file contents}';
 
@@ -82,9 +83,14 @@ class EnvironmentDecryptCommand extends Command
 
         $key = $this->parseKey($key);
 
-        $environmentFile = $this->option('env')
-                    ? base_path('.env').'.'.$this->option('env')
-                    : $this->laravel->environmentFilePath();
+        $filePath = ltrim(rtrim($this->option('path'), '/'), '/');
+
+        $this->laravel->useEnvironmentPath(base_path($filePath));
+
+        $environmentFile = rtrim(
+            $this->laravel->environmentFilePath().'.'.$this->option('env'),
+            '.'
+        );
 
         $encryptedFile = $environmentFile.'.encrypted';
 

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -20,6 +20,7 @@ class EnvironmentEncryptCommand extends Command
                     {--key= : The encryption key}
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be encrypted}
+                    {--path= : Where is the environment file path is located}
                     {--force : Overwrite the existing encrypted environment file}';
 
     /**
@@ -73,9 +74,14 @@ class EnvironmentEncryptCommand extends Command
 
         $keyPassed = $key !== null;
 
-        $environmentFile = $this->option('env')
-                            ? base_path('.env').'.'.$this->option('env')
-                            : $this->laravel->environmentFilePath();
+        $filePath = ltrim(rtrim($this->option('path'), '/'), '/');
+
+        $this->laravel->useEnvironmentPath(base_path($filePath));
+
+        $environmentFile = rtrim(
+            $this->laravel->environmentFilePath().'.'.$this->option('env'),
+            '.'
+        );
 
         $encryptedFile = $environmentFile.'.encrypted';
 

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -236,4 +236,29 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->expectsOutputToContain('Invalid filename.')
             ->assertExitCode(1);
     }
+
+    public function testItWritesTheEnvironmentFileCustomPath()
+    {
+        $path = 'path/environment/';
+
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter($key = Encrypter::generateKey('AES-256-CBC'), 'AES-256-CBC'))
+                    ->encrypt('APP_NAME=Laravel Two')
+            );
+
+        $this->artisan('env:decrypt', ['--force' => true, '--path' => $path, '--key' => 'base64:'.base64_encode($key)])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path($path.'.env'), 'APP_NAME=Laravel Two');
+    }
 }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -120,4 +120,24 @@ class EnvironmentEncryptCommandTest extends TestCase
         $this->filesystem->shouldHaveReceived('put')
             ->with(base_path('.env.encrypted'), m::any());
     }
+
+    public function testItGeneratesTheEncryptionFileCustomPath()
+    {
+        $path = 'path/environment/';
+
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get');
+
+        $this->artisan('env:encrypt', ['--path' => $path])
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path($path.'.env.encrypted'), m::any());
+    }
 }


### PR DESCRIPTION
This PR proposes 1 new argument for commands; env:encrypt and env:decrypt which provide custom path of environment file. 

Why? because sometime developers located their .env for staging / production for CI on another folders instead of base project path.

We may utilise our own path by using the --path option.
```
php artisan env:encrypt --path=docker/dev/environment --key=abcdefghijklmnopabcdefghijklmnop
```

![Screenshot 2022-09-29 at 11 50 34 AM](https://user-images.githubusercontent.com/9051312/192934617-7cb547c2-143d-4c01-9491-447bf80d800d.png)

php artisan env:decrypt --path=docker/dev/environment

```
php artisan env:decrypt --path=docker/dev/environment --key=abcdefghijklmnopabcdefghijklmnop
```

![Screenshot 2022-09-29 at 11 51 38 AM](https://user-images.githubusercontent.com/9051312/192934749-31a13419-5eba-468e-8e6d-7cb69eb08ad9.png)


I added tests for this PR