### PR TITLE
[9.x] Update dd function when running on virtualized dev environments

### DIFF
--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -133,10 +133,11 @@ class HtmlDumper extends BaseHtmlDumper
         $source = sprintf('%s%s', $relativeFile, is_null($line) ? '' : ":$line");
 
         if ($editor = $this->editor()) {
+            $editorProjectPath = $this->editorProjectPath();
             $source = sprintf(
                 '<a href="%s://open?file=%s%s">%s</a>',
                 $editor,
-                $file,
+                $editorProjectPath ? "$editorProjectPath/$relativeFile" : $file,
                 is_null($line) ? '' : "&line=$line",
                 $source,
             );
@@ -154,6 +155,20 @@ class HtmlDumper extends BaseHtmlDumper
     {
         try {
             return config('app.editor');
+        } catch (Throwable $e) {
+            // ...
+        }
+    }
+
+    /**
+     * Get the base path for the editor, if applicable.
+     *
+     * @return string|null
+     */
+    protected function editorProjectPath()
+    {
+        try {
+            return config('app.editor_project_path');
         } catch (Throwable $e) {
             // ...
         }

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -134,6 +134,7 @@ class HtmlDumper extends BaseHtmlDumper
 
         if ($editor = $this->editor()) {
             $editorProjectPath = $this->editorProjectPath();
+
             $source = sprintf(
                 '<a href="%s://open?file=%s%s">%s</a>',
                 $editor,
@@ -168,7 +169,7 @@ class HtmlDumper extends BaseHtmlDumper
     protected function editorProjectPath()
     {
         try {
-            return config('app.editor_project_path');
+            return config('app.editor_base_path');
         } catch (Throwable $e) {
             // ...
         }


### PR DESCRIPTION
This PR enhances the recently added feature, dd function output (#44211).
The great feature "clickable file path" doesn't work when running on virtualized dev environments, including Laravel Sail.

You just add the `app.editor_project_path` configuration, and the source link will work properly even on your virtualized dev environments. 

_config/app.php_
```
<?php

use Illuminate\Support\Facades\Facade;

return [
    'editor' => env('EDITOR'),  // UPDATE
    'editor_project_path' => env('EDITOR_PROJECT_PATH'),  // ADD!

    // the other settings
];
```
Of course, this is optional.


And I also think the params should be in the .env file.
_.env(example)_
```
EDITOR=phpstorm
EDITOR_PROJECT_PATH=/Users/username/Desktop/example-app
```

This is my first PR for any OSS projects,  maybe something weird...