### PR TITLE
throw exception if push job to queue failed

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use Exception;
 use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Redis\Factory as Redis;
@@ -156,9 +157,10 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
             LuaScripts::push(), 2, $this->getQueue($queue),
             $this->getQueue($queue).':notify', $payload
         );
-        if (!$success) {
+        if (! $success) {
             throw new Exception('Failed push job to the queue');
         }
+        
         return json_decode($payload, true)['id'] ?? null;
     }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -152,11 +152,13 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        $this->getConnection()->eval(
+        $success = $this->getConnection()->eval(
             LuaScripts::push(), 2, $this->getQueue($queue),
             $this->getQueue($queue).':notify', $payload
         );
-
+        if (!$success) {
+            throw new Exception('Failed push job to the queue');
+        }
         return json_decode($payload, true)['id'] ?? null;
     }
 


### PR DESCRIPTION
this PR will throw an exception when `Queue::push` failed to pushed the job to redis which happened when redis `maxmemory` exceeded. user can catch the error and save the payload to other alternative db then repush the job when the redis available.