### PR TITLE
[9.x] Only prints source on `dd` calls from `dump.php`

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -22,10 +22,27 @@ trait ResolvesDumpSource
             return call_user_func(static::$dumpSourceResolver);
         }
 
-        $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 20);
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 20);
 
-        $file = $trace[7]['file'] ?? null;
-        $line = $trace[7]['line'] ?? null;
+        $sourceKey = null;
+
+        foreach ($trace as $traceKey => $traceFile) {
+            if (isset($traceFile['file']) && str_ends_with(
+                $traceFile['file'],
+                'symfony/var-dumper/Resources/functions/dump.php'
+            )) {
+                $sourceKey = $traceKey + 1;
+
+                break;
+            }
+        }
+
+        if (is_null($sourceKey)) {
+            return;
+        }
+
+        $file = $trace[$sourceKey]['file'] ?? null;
+        $line = $trace[$sourceKey]['line'] ?? null;
 
         if (is_null($file) || is_null($line)) {
             return;


### PR DESCRIPTION
This pull request solves 2 things:

1. Removes the `DEBUG_BACKTRACE_PROVIDE_OBJECT` flag from `debug_backtrace` making the call to that function more performant.
2. Removes hardcoded `7` key from trace, and guesses the trace key dynamically - as the trace may change as described on the [44366](https://github.com/laravel/framework/issues/44366) issue. By guessing the key dynamically, **we only try to guess the source** on the there is direct call to the `dd` or `dump` global functions.