### PR TITLE
[9.x] Add Ignore Case of Str::contains and Str::containsAll to Stringable contains and containsAll

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -168,22 +168,24 @@ class Stringable implements JsonSerializable
      * Determine if a given string contains a given substring.
      *
      * @param  string|iterable<string>  $needles
+     * @param  bool  $ignoreCase
      * @return bool
      */
-    public function contains($needles)
+    public function contains($needles, $ignoreCase = false)
     {
-        return Str::contains($this->value, $needles);
+        return Str::contains($this->value, $needles, $ignoreCase);
     }
 
     /**
      * Determine if a given string contains all array values.
      *
      * @param  iterable<string>  $needles
+     * @param  bool  $ignoreCase
      * @return bool
      */
-    public function containsAll($needles)
+    public function containsAll($needles, $ignoreCase = false)
     {
-        return Str::containsAll($this->value, $needles);
+        return Str::containsAll($this->value, $needles, $ignoreCase);
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -623,6 +623,7 @@ class SupportStringableTest extends TestCase
         $this->assertTrue($this->stringable('taylor')->contains(['ylo']));
         $this->assertTrue($this->stringable('taylor')->contains(['xxx', 'ylo']));
         $this->assertTrue($this->stringable('taylor')->contains(collect(['xxx', 'ylo'])));
+        $this->assertTrue($this->stringable('taylor')->contains(['LOR'], true));
         $this->assertFalse($this->stringable('taylor')->contains('xxx'));
         $this->assertFalse($this->stringable('taylor')->contains(['xxx']));
         $this->assertFalse($this->stringable('taylor')->contains(''));
@@ -631,6 +632,7 @@ class SupportStringableTest extends TestCase
     public function testContainsAll()
     {
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor', 'otwell']));
+        $this->assertTrue($this->stringable('taylor otwell')->containsAll(['TAYLOR', 'OTWELL'], true));
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(collect(['taylor', 'otwell'])));
         $this->assertTrue($this->stringable('taylor otwell')->containsAll(['taylor']));
         $this->assertFalse($this->stringable('taylor otwell')->containsAll(['taylor', 'xxx']));


### PR DESCRIPTION
This PR is here to resolve a little gremlin I found when using Fluent Strings. I wanted to do `->contains()` and I needed it to ignore case. It turns out this isn't possible with the Stringable class. I've added in the ability to pass a boolean to Stringable `contains` and `containsAll` like how Str `contains` and `containsAll` works. I've also updated the pre-existing tests to test that ignore case works.

This doesn't break any existing implementations of these functions because it is an optional parameter placed last.

Now I did think about adding this to `whenContains` and `whenContainsAll` - if you feel this would be of benefit also within this PR then let me know and I'll get that bashed in.

I'm aware this is my first PR to the framework, so any feedback would be greatly appreciated.
