### PR TITLE
[9.x] Improves `$request->enum()` type API

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -372,10 +372,11 @@ trait InteractsWithInput
     /**
      * Retrieve input from the request as an enum.
      *
-     * @template T
+     * @template TEnum
+     *
      * @param  string  $key
-     * @param  class-string<T>  $enumClass
-     * @return T|null
+     * @param  class-string<TEnum>  $enumClass
+     * @return TEnum|null
      */
     public function enum($key, $enumClass)
     {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -372,9 +372,10 @@ trait InteractsWithInput
     /**
      * Retrieve input from the request as an enum.
      *
+     * @template T
      * @param  string  $key
-     * @param  string  $enumClass
-     * @return mixed|null
+     * @param  class-string<T>  $enumClass
+     * @return T|null
      */
     public function enum($key, $enumClass)
     {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -373,6 +373,7 @@ trait InteractsWithInput
      * Retrieve input from the request as an enum.
      *
      * @template T
+     *
      * @param  string  $key
      * @param  class-string<T>  $enumClass
      * @return T|null

--- a/types/Http/Request.php
+++ b/types/Http/Request.php
@@ -3,12 +3,12 @@
 use Illuminate\Http\Request;
 use function PHPStan\Testing\assertType;
 
-enum TestEnum : string
+class TestEnum
 {
-    case test = 'test';
 }
 
 $request = Request::create('/', 'GET', [
-    'key' => 'test'
+    'key' => 'test',
 ]);
+
 assertType('TestEnum|null', $request->enum('key', TestEnum::class));

--- a/types/Http/Request.php
+++ b/types/Http/Request.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Http\Request;
+use function PHPStan\Testing\assertType;
+
+enum TestEnum : string
+{
+    case test = 'test';
+}
+
+$request = Request::create('/', 'GET', [
+    'key' => 'test'
+]);
+assertType('TestEnum|null', $request->enum('key', TestEnum::class));

--- a/types/Http/Request.php
+++ b/types/Http/Request.php
@@ -9,6 +9,6 @@ enum TestEnum : string
 }
 
 $request = Request::create('/', 'GET', [
-    'key' => 'test'
+    'key' => 'test',
 ]);
 assertType('TestEnum|null', $request->enum('key', TestEnum::class));


### PR DESCRIPTION
This pull request is inspired on https://github.com/laravel/framework/pull/44295, and improves `$request->enum()` type API so you can have autocompletion when doing: `$request->enum('key', TestEnum::class)->value`.