### PR TITLE
[9.x] Testing methods. Making error messages with json_encode more readable.

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -113,11 +113,12 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertSimilar(array $data)
     {
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decoded
-        ));
+        $actual = json_encode(
+            Arr::sortRecursive((array)$this->decoded),
+            JSON_UNESCAPED_UNICODE
+        );
 
-        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
+        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data), JSON_UNESCAPED_UNICODE), $actual);
 
         return $this;
     }
@@ -130,18 +131,19 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertFragment(array $data)
     {
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decoded
-        ));
+        $actual = json_encode(
+            Arr::sortRecursive((array)$this->decoded),
+            JSON_UNESCAPED_UNICODE
+        );
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $expected = $this->jsonSearchStrings($key, $value);
 
             PHPUnit::assertTrue(
                 Str::contains($actual, $expected),
-                'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
-                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
-                'within'.PHP_EOL.PHP_EOL.
+                'Unable to find JSON fragment: ' . PHP_EOL . PHP_EOL .
+                '[' . json_encode([$key => $value]) . ']' . PHP_EOL . PHP_EOL .
+                'within' . PHP_EOL . PHP_EOL .
                 "[{$actual}]."
             );
         }
@@ -162,18 +164,19 @@ class AssertableJsonString implements ArrayAccess, Countable
             return $this->assertMissingExact($data);
         }
 
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decoded
-        ));
+        $actual = json_encode(
+            Arr::sortRecursive((array)$this->decoded),
+            JSON_UNESCAPED_UNICODE
+        );
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $unexpected = $this->jsonSearchStrings($key, $value);
 
             PHPUnit::assertFalse(
                 Str::contains($actual, $unexpected),
-                'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
-                'within'.PHP_EOL.PHP_EOL.
+                'Found unexpected JSON fragment: ' . PHP_EOL . PHP_EOL .
+                '[' . json_encode([$key => $value], JSON_UNESCAPED_UNICODE) . ']' . PHP_EOL . PHP_EOL .
+                'within' . PHP_EOL . PHP_EOL .
                 "[{$actual}]."
             );
         }
@@ -189,22 +192,23 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertMissingExact(array $data)
     {
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decoded
-        ));
+        $actual = json_encode(
+            Arr::sortRecursive((array)$this->decoded),
+            JSON_UNESCAPED_UNICODE
+        );
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $unexpected = $this->jsonSearchStrings($key, $value);
 
-            if (! Str::contains($actual, $unexpected)) {
+            if (!Str::contains($actual, $unexpected)) {
                 return $this;
             }
         }
 
         PHPUnit::fail(
-            'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-            '['.json_encode($data).']'.PHP_EOL.PHP_EOL.
-            'within'.PHP_EOL.PHP_EOL.
+            'Found unexpected JSON fragment: ' . PHP_EOL . PHP_EOL .
+            '[' . json_encode($data, JSON_UNESCAPED_UNICODE) . ']' . PHP_EOL . PHP_EOL .
+            'within' . PHP_EOL . PHP_EOL .
             "[{$actual}]."
         );
 
@@ -322,9 +326,9 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     protected function assertJsonMessage(array $data)
     {
-        $expected = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $expected = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
-        $actual = json_encode($this->decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $actual = json_encode($this->decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
         return 'Unable to find JSON: '.PHP_EOL.PHP_EOL.
             "[{$expected}]".PHP_EOL.PHP_EOL.
@@ -341,7 +345,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     protected function jsonSearchStrings($key, $value)
     {
-        $needle = substr(json_encode([$key => $value]), 1, -1);
+        $needle = substr(json_encode([$key => $value], JSON_UNESCAPED_UNICODE), 1, -1);
 
         return [
             $needle.']',

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -865,6 +865,16 @@ class TestResponseTest extends TestCase
         $response->assertJsonFragment(['id' => 1]);
     }
 
+    public function testAssertJsonFragmentUnicodeCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessageMatches('/Привет|Мир/');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithUnicodeStub));
+
+        $response->assertJsonFragment(['id' => 1]);
+    }
+
     public function testAssertJsonStructure()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
@@ -1947,6 +1957,18 @@ class JsonSerializableSingleResourceWithIntegersStub implements JsonSerializable
             ['id' => 10, 'foo' => 'bar'],
             ['id' => 20, 'foo' => 'bar'],
             ['id' => 30, 'foo' => 'bar'],
+        ];
+    }
+}
+
+class JsonSerializableSingleResourceWithUnicodeStub implements JsonSerializable
+{
+    public function jsonSerialize(): array
+    {
+        return [
+            ['id' => 10, 'foo' => 'bar'],
+            ['id' => 20, 'foo' => 'Привет'],
+            ['id' => 30, 'foo' => 'Мир'],
         ];
     }
 }


### PR DESCRIPTION
Added JSON_UNESCAPED_UNICODE in json_encode to make error messages more readable.

Before patching, error messages looks like this (look at Unicode \u0000):
```
Failed asserting that exception message 'Unable to find JSON fragment: 

[{"id":1}]

within

[[{"foo":"bar","id":10},{"foo":"\u041c\u0438\u0440","id":30},{"foo":"\u041f\u0440\u0438\u0432\u0435\u0442","id":20}]].
```

After patching, error messages become more readable:
```
Failed asserting that exception message 'Unable to find JSON fragment: 

[{"id":1}]

within

[[{"foo":"bar","id":10},{"foo":"Мир","id":30},{"foo":"Привет","id":20}]].
```

This feature allows reading Unicode text without converting it in external tools or sites.