### PR TITLE
[9.x] Ensures a Carbon version that supports `PHP 8.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "league/commonmark": "^2.2",
         "league/flysystem": "^3.0.16",
         "monolog/monolog": "^2.0",
-        "nesbot/carbon": "^2.53.1",
+        "nesbot/carbon": "^2.62.1",
         "nunomaduro/termwind": "^1.13",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -22,7 +22,7 @@
         "illuminate/conditionable": "^9.0",
         "illuminate/contracts": "^9.0",
         "illuminate/macroable": "^9.0",
-        "nesbot/carbon": "^2.53.1",
+        "nesbot/carbon": "^2.62.1",
         "voku/portable-ascii": "^2.0"
     },
     "conflict": {


### PR DESCRIPTION
This pull request ensures the Laravel package `laravel/framework` is installable when running `PHP 8.2 prefer-lowest` jobs.

Fixes https://github.com/nunomaduro/collision/actions/runs/3151326161/jobs/5125136732.