### PR TITLE
[10.x] Possible fix for unexpected column in SQL Server offset

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -289,7 +289,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileOver($orderings)
     {
-        return ", row_number() over ({$orderings}) as row_num";
+        return ", row_number() over ({$orderings}) as temp_row_num";
     }
 
     /**
@@ -333,7 +333,7 @@ class SqlServerGrammar extends Grammar
     {
         $constraint = $this->compileRowConstraint($query);
 
-        return "select * from ({$sql}) as temp_table where row_num {$constraint} order by row_num";
+        return "select * from ({$sql}) as temp_table where temp_row_num {$constraint} order by temp_row_num /* remove_temp_row_num */";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -9,6 +9,24 @@ use Illuminate\Database\Query\Builder;
 class SqlServerProcessor extends Processor
 {
     /**
+     * Process the results of a "select" query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $results
+     * @return array
+     */
+    public function processSelect(Builder $query, $results)
+    {
+        if(str_ends_with($query->toSql(), '/* remove_temp_row_num */')){
+            array_map(function($row){
+                unset($row->temp_row_num);
+            }, $results);
+        }
+
+        return $results;
+    }
+
+    /**
      * Process an "insert get ID" query.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -17,8 +17,8 @@ class SqlServerProcessor extends Processor
      */
     public function processSelect(Builder $query, $results)
     {
-        if(str_ends_with($query->toSql(), '/* remove_temp_row_num */')){
-            array_map(function($row){
+        if (str_ends_with($query->toSql(), '/* remove_temp_row_num */')) {
+            array_map(function ($row) {
                 unset($row->temp_row_num);
             }, $results);
         }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3683,11 +3683,11 @@ SQL;
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10);
-        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11 order by row_num', $builder->toSql());
+        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as temp_row_num from [users]) as temp_table where temp_row_num >= 11 order by temp_row_num /* remove_temp_row_num */', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->take(10);
-        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
+        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as temp_row_num from [users]) as temp_table where temp_row_num between 11 and 20 order by temp_row_num /* remove_temp_row_num */', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(11)->take(10)->orderBy('email', 'desc');


### PR DESCRIPTION
Looking for feedback on this PR for resolving this issue:

Currently, if offset is used for SQL Server:

 1. You cannot use `row_num` as a column name or alias
 2. An unexpected column `row_num` is included in the results

This PR helps reduce query select conflicts and removes unexpected data generated by laravel. 

Changes:

- Renamed temporary column `row_num` to `temp_row_num` to help reduce conflicts 
- Removes the `temp_row_num` column from the results if offset used 

Fixes https://github.com/laravel/framework/issues/44354

### Examples

#### Scenario 1

If you have a `row_num` column or alias, SQL Server will throw:

```
SQLSTATE[42000]: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The column 'row_num' was specified multiple times for 'temp_table'
```

#### Scenario 2

If you try to insert the offset results into the same table by using `chunk`:

```php
db()->connection('db_1')->table('example')->chunk(500, function($chunk){
    db()->connection('db_2')->table('example')->insert($chunk);
});
```

`row_num` is added to the results and is an unexpected column, causing SQL server to throw:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'row_num' in 'field list'
```

Original PR: https://github.com/laravel/framework/pull/44355