### PR TITLE
[9.x] Defineable editor href in dd

### DIFF
--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -133,16 +133,30 @@ class HtmlDumper extends BaseHtmlDumper
         $source = sprintf('%s%s', $relativeFile, is_null($line) ? '' : ":$line");
 
         if ($editor = $this->editor()) {
-            $source = sprintf(
-                '<a href="%s://open?file=%s%s">%s</a>',
-                $editor,
-                $file,
-                is_null($line) ? '' : "&line=$line",
-                $source,
+            $href = str_replace(
+                ['{file}', '{line}'],
+                [$file, is_null($line) ? 1 : $line],
+                $this->editorHref()
             );
+
+            $source = sprintf('<a href="%s://%s">%s</a>', $editor, $href, $source);
         }
 
         return sprintf('<span style="color: #A0A0A0;"> // %s</span>', $source);
+    }
+
+    /**
+     * Get the application editor href, if applicable.
+     *
+     * @return string
+     */
+    protected function editorHref()
+    {
+        try {
+            return config('app.editor_href', 'open?file={file}&line={line}');
+        } catch (Throwable $e) {
+            // ...
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR enhances the awesome new feature, clickable dd output (#44211).

The structure of the href can be different in various editors. This allows you to define it to fit your needs. For example the issue for me was that since I develop sometimes on Windows' WSL2, I had to be able to customize the href quite significantly.

If config key `app.editor_href` is not defined, the default value is `open?file={file}&line={line}`.

How it works:

```php
// config/app.php

return [
    // ....
    'editor' => 'vscode',
    'editor_href' => 'vscode-remote/wsl+Ubuntu-20.04{file}:{line}'
    // ...
];
```

Now the href will be for example `vscode://vscode-remote/wsl+Ubuntu-20.04/home/matti/code/project/routes/web.php:17`.
