### PR TITLE
[9.x] Support using primary attribute keys for custom displayable values

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -438,8 +438,18 @@ trait FormatsMessages
      */
     public function getDisplayableValue($attribute, $value)
     {
-        if (isset($this->customValues[$attribute][$value])) {
-            return $this->customValues[$attribute][$value];
+        $primaryAttribute = $this->getPrimaryAttribute($attribute);
+
+        $expectedAttributes = $attribute != $primaryAttribute
+            ? [$attribute, $primaryAttribute] : [$attribute];
+
+        foreach ($expectedAttributes as $name) {
+            // The developer may dynamically specify the array of custom displayable values on this
+            // validator instance. If the displayable value exists in this array it is used over
+            // the other ways of pulling the displayable value for the given attributes.
+            if (isset($this->customValues[$name][$value])) {
+                return $this->customValues[$name][$value];
+            }
         }
 
         $key = "validation.values.{$attribute}.{$value}";

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -532,12 +532,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator(
             $trans,
             [
-                'packages' => [['country' => 'US'],['country' => 'AQ'],['country' => 'GB']],
+                'packages' => [['country' => 'US'], ['country' => 'AQ'], ['country' => 'GB']],
                 'country_mapping' => [
                     'foo' => 'EE',
                     'bar' => 'AQ',
                     'baz' => 'AQ',
-                ]
+                ],
             ],
             [
                 'packages.*.country' => 'shipping_country',


### PR DESCRIPTION
This PR allows using primary attribute keys (`foo.*`, `foo.*.bar`) when providing custom values for validation. The implementation is pretty much copied from the `Illuminate\Validation\Concerns\FormatsMessages::getDisplayableAttribute()` method.

This makes it possible to use custom values for attributes where the exact key is not known, or when using exact keys is not optimal. Consider the following example:

```php
use Illuminate\Support\Facades\Validator;

$validator = Validator::make([
  'packages' => [
    ['country' => 'AQ'],
    ['country' => 'US'],    
  ]
], [
  'packages.*.country' => 'in:US'
], [
  'packages.*.country.in' => ':input is not a valid shipping country'
]);
```

How can we provide custom values for the country attribute of each package? Right now, we would have to know each package key and provide the custom value for each of them

```php
$validator->addCustomValues([
  'packages.0.country' => ['AQ' => 'Antarctica', 'US' => 'United States'],
  'packages.1.country' => ['AQ' => 'Antarctica', 'US' => 'United States'],  
]);

// error message: "Antarctica is not a valid shipping country"
```

Clearly, this is not great - **we can do better**: this PR allows simply using the asterisk (just like for validation rules and custom attributes) to provide a single source of custom values for all the elements in the array:

```php
$validator->addCustomValues([
  'packages.*.country' => ['AQ' => 'Antarctica', 'US' => 'United States']
]);

// error message: "Antarctica is not a valid shipping country"
```

It works for associative arrays as well:
```php
// input: ['country_map' => ['foo' => 'US', 'bar' => 'AQ']]

$validator->addCustomValues([
  'country_map.*' => ['AQ' => 'Antarctica', 'US' => 'United States']
]);
```

It's still possible to provide values for each individual array element (specific values take precedence over primary attribute values):
```php
// input: ['country_map' => ['foo' => 'US', 'bar' => 'AQ']]

$validator->addCustomValues([
  'country_map.*' => ['AQ' => 'Antarctica', 'US' => 'United States']
  'country_map.bar' => ['AQ' => 'Antarktis', 'US' => 'Vereinigte Staaten']
]);
```