### PR TITLE
[9.x] Make `$path` optional in Filesystem methods

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -370,13 +370,17 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Store the uploaded file on the disk.
      *
-     * @param  string  $path
-     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string  $file
+     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string  $path
+     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string|array|null  $file
      * @param  mixed  $options
      * @return string|false
      */
-    public function putFile($path, $file, $options = [])
+    public function putFile($path, $file = null, $options = [])
     {
+        if (is_null($file) || is_array($file)) {
+            [$path, $file, $options] = ['', $path, $file ?? []];
+        }
+
         $file = is_string($file) ? new File($file) : $file;
 
         return $this->putFileAs($path, $file, $file->hashName(), $options);
@@ -385,14 +389,18 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Store the uploaded file on the disk with a given name.
      *
-     * @param  string  $path
-     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string  $file
-     * @param  string  $name
+     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string  $path
+     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string|array|null  $file
+     * @param  string|array|null  $name
      * @param  mixed  $options
      * @return string|false
      */
-    public function putFileAs($path, $file, $name, $options = [])
+    public function putFileAs($path, $file, $name = null, $options = [])
     {
+        if (is_null($name) || is_array($name)) {
+            [$path, $file, $name, $options] = ['', $path, $file, $name ?? []];
+        }
+
         $stream = fopen(is_string($file) ? $file : $file->getRealPath(), 'r');
 
         // Next, we will format the path of the file and store the file using a stream since

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -31,7 +31,7 @@ class UploadedFile extends SymfonyUploadedFile
      * @param  array|string  $options
      * @return string|false
      */
-    public function store($path, $options = [])
+    public function store($path = '', $options = [])
     {
         return $this->storeAs($path, $this->hashName(), $this->parseOptions($options));
     }
@@ -43,7 +43,7 @@ class UploadedFile extends SymfonyUploadedFile
      * @param  array|string  $options
      * @return string|false
      */
-    public function storePublicly($path, $options = [])
+    public function storePublicly($path = '', $options = [])
     {
         $options = $this->parseOptions($options);
 
@@ -60,8 +60,12 @@ class UploadedFile extends SymfonyUploadedFile
      * @param  array|string  $options
      * @return string|false
      */
-    public function storePubliclyAs($path, $name, $options = [])
+    public function storePubliclyAs($path, $name = null, $options = [])
     {
+        if (is_null($name) || is_array($name)) {
+            [$path, $name, $options] = ['', $path, $options ?? []];
+        }
+
         $options = $this->parseOptions($options);
 
         $options['visibility'] = 'public';
@@ -73,12 +77,16 @@ class UploadedFile extends SymfonyUploadedFile
      * Store the uploaded file on a filesystem disk.
      *
      * @param  string  $path
-     * @param  string  $name
+     * @param  string|array  $name
      * @param  array|string  $options
      * @return string|false
      */
-    public function storeAs($path, $name, $options = [])
+    public function storeAs($path, $name = null, $options = [])
     {
+        if (is_null($name) || is_array($name)) {
+            [$path, $name, $options] = ['', $path, $options ?? []];
+        }
+
         $options = $this->parseOptions($options);
 
         $disk = Arr::pull($options, 'disk');

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -350,6 +350,17 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }
 
+    public function testPutFileAsWithoutPath()
+    {
+        file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $storagePath = $filesystemAdapter->putFileAs($filePath, 'new.txt');
+
+        $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
+    }
+
     public function testPutFile()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
@@ -388,6 +399,17 @@ class FilesystemAdapterTest extends TestCase
             $storagePath,
             'uploaded file content'
         );
+    }
+
+    public function testPutFileWithoutPath()
+    {
+        file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+
+        $storagePath = $filesystemAdapter->putFile($filePath);
+
+        $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }
 
     /**


### PR DESCRIPTION
This PR makes the `$path` parameter optional in the following methods:
- `FilesystemAdapter#putFile`
- `FilesystemAdapter#putFileAs`
- `UploadedFile#store`
- `UploadedFile#storeAs`
- `UploadedFile#storePublicly`
- `UploadedFile#storePubliclyAs`

Since https://github.com/laravel/framework/pull/44105 (thanks Frank), I've been using the `scoped` driver in order to be able not to repeat paths throughout my codebases. It allows me to do the following:

```php
// Before
Storage::disk('s3')->putFile('chat/attachments', $uploadedFile);
//                           ~~~~~~~~~~~~~~~~~~  This could be repeated in some places

// After
Storage::disk(Disk::ChatAttachments)->putFile('', $uploadedFile)
```

With this PR, it's possible to omit the first argument, so one could do this instead:

```php
Storage::disk(Disk::ChatAttachments)->putFile($uploadedFile)
```