### PR TITLE
Add @__ blade directive to "__" helper function.

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -75,4 +75,15 @@ trait CompilesHelpers
 
         return "<?php echo app('$class')->reactRefresh(); ?>";
     }
+
+    /**
+     * Compile the "__" statements into valid PHP.
+     *
+     * @param  string  $arguments
+     * @return string
+     */
+    protected function compile__($arguments)
+    {
+        return "<?php echo __{$arguments}; ?>";
+    }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -11,6 +11,7 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
         $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
         $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
+        $this->assertSame('<?php echo __($var1, $var2); ?>', $this->compiler->compileString('@__($var1, $var2)'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite()'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(\'resources/js/app.js\'); ?>', $this->compiler->compileString('@vite(\'resources/js/app.js\')'));


### PR DESCRIPTION
Adding @__ blade directive makes it much easier to use the "__" helper function without the need for the boilerplate `{{ }}`

Taking the following lines from Laravel Breeze as an example
```blade
<span class="ml-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
<a class="..." href="{{ route('password.request') }}">{{ __('Forgot your password?') }}</a>
<x-primary-button class="ml-3">{{ __('Log in') }}</x-primary-button>
```
Will be transformed to
```blade
<span class="ml-2 text-sm text-gray-600">@__('Remember me')</span>
<a class="..." href="{{ route('password.request') }}">@__('Forgot your password?')</a>
<x-primary-button class="ml-3">@__('Log in')</x-primary-button>
```
It also supports placeholders
```blade
<h1>@__('messages.welcome', ['name' => 'Mohamed'])</h1> <!-- Welcome Mohamed -->
```

It will have more benefits with sites that have a lot of strings that need to be translated.
It makes the code look closer to the Laravel way :)

Credits to [Mark Snape Tweet](https://twitter.com/snapey/status/1575224543781584896)
