### PR TITLE
[9.x] Correctly reference class

### DIFF
--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
  * @method static \Illuminate\Broadcasting\BroadcastManager socket($request = null)
  * @method static \Illuminate\Contracts\Broadcasting\Broadcaster connection($name = null);
  * @method static mixed auth(\Illuminate\Http\Request $request)
- * @method static void resolveAuthenticatedUserUsing(Closure $callback)
+ * @method static void resolveAuthenticatedUserUsing(\Closure $callback)
  * @method static void routes(array $attributes = null)
  *
  * @see \Illuminate\Contracts\Broadcasting\Factory


### PR DESCRIPTION
classes in the root namespace should be prefixed with a slash