### PR TITLE
[9.x] Adds error output to `db` command when missing host

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -34,6 +34,14 @@ class DbCommand extends Command
     {
         $connection = $this->getConnection();
 
+        if (! isset($connection['host'])) {
+            $this->components->error('No host specified for this database connection.');
+            $this->line('  '.'Use the <options=bold>[--read]</> and <options=bold>[--write]</> options to specify a read or write connection.');
+            $this->newLine();
+
+            return Command::FAILURE;
+        }
+
         (new Process(
             array_merge([$this->getCommand($connection)], $this->commandArguments($connection)),
             null,

--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -36,7 +36,7 @@ class DbCommand extends Command
 
         if (! isset($connection['host'])) {
             $this->components->error('No host specified for this database connection.');
-            $this->line('  '.'Use the <options=bold>[--read]</> and <options=bold>[--write]</> options to specify a read or write connection.');
+            $this->line('  Use the <options=bold>[--read]</> and <options=bold>[--write]</> options to specify a read or write connection.');
             $this->newLine();
 
             return Command::FAILURE;


### PR DESCRIPTION
This PR resolves #44383 by checking for a host key on the connection configuration before attempting to connect.

<img width="652" alt="Screenshot 2022-09-30 at 11 47 56" src="https://user-images.githubusercontent.com/3438564/193254420-62300616-8d90-487b-ae82-8d8c35d85fbb.png">

