### PR TITLE
[9.x] Fix DB::getPdo() docblock

### DIFF
--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Doctrine\DBAL\Driver\PDOConnection getPdo()
+ * @method static \PDO getPdo()
  * @method static \Illuminate\Database\ConnectionInterface connection(string $name = null)
  * @method static \Illuminate\Database\Query\Builder table(string $table, string $as = null)
  * @method static \Illuminate\Database\Query\Builder query()


### PR DESCRIPTION
On the file /vendor/laravel/framework/src/Illuminate/Support/Facades/DB.php
The docblock for getPdo is incorrect, it says \Doctrine\DBAL\Driver\PDOConnection but it returns a PDO

without proper type, autocompletion will be incorrect, and this type doesn't exist anymore
