### PR TITLE
check event listeners for shouldQueue{trait} methods

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -564,7 +564,7 @@ class Dispatcher implements DispatcherContract
         $traits = class_uses_recursive($instance);
 
         foreach ($traits as $trait) {
-            $method = 'shouldQueue' . $trait;
+            $method = 'shouldQueue'.$trait;
 
             if (method_exists($instance, $method)) {
                 $condition = $condition && call_user_func([$instance, $method], $arguments[0]);

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -559,11 +559,23 @@ class Dispatcher implements DispatcherContract
     {
         $instance = $this->container->make($class);
 
-        if (method_exists($instance, 'shouldQueue')) {
-            return $instance->shouldQueue($arguments[0]);
+        $condition = true;
+
+        $traits = class_uses_recursive($instance);
+
+        foreach ($traits as $trait) {
+            $method = 'shouldQueue' . $trait;
+
+            if (method_exists($instance, $method)) {
+                $condition = $condition && call_user_func([$instance, $method], $arguments[0]);
+            }
         }
 
-        return true;
+        if (method_exists($instance, 'shouldQueue')) {
+            $condition = $condition && $instance->shouldQueue($arguments[0]);
+        }
+
+        return $condition;
     }
 
     /**


### PR DESCRIPTION
I found in my project I was duplicating code to determine whether the listener `shouldQueue`. I started looking into adding this duplicated code to traits and thought this might be a useful dx feature. Essentially I am copying this livewire functionality https://laravel-livewire.com/docs/2.x/traits but for event listeners
```php
class DoThingListener implements ShouldQueue {
    use MyCondition;

    public function shouldQueue($event) {
        // my specific condition
    }
}

trait MyCondition {
    public function shouldQueueMyCondition($event) {
        // my trait condition
    }
}
```