### PR TITLE
[9.x] Allow loading trashed models for resource routes

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -228,7 +228,7 @@ class PendingResourceRegistration
     }
 
     /**
-     * Set which methods should load trashed models.
+     * Define which routes should allow "trashed" models to be retrieved when resolving implicit model bindings.
      *
      * @param  array  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -230,7 +230,7 @@ class PendingResourceRegistration
     /**
      * Set which methods should load trashed models.
      *
-     * @param  array $methods
+     * @param  array  $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function withTrashed(array $methods = [])

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -228,6 +228,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Set which methods should load trashed models.
+     *
+     * @param array $methods
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function withTrashed(array $methods = [])
+    {
+        $this->options['trashed'] = $methods;
+
+        return $this;
+    }
+
+    /**
      * Register the resource route.
      *
      * @return \Illuminate\Routing\RouteCollection

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -230,7 +230,7 @@ class PendingResourceRegistration
     /**
      * Set which methods should load trashed models.
      *
-     * @param array $methods
+     * @param  array $methods
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function withTrashed(array $methods = [])

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -105,7 +105,8 @@ class ResourceRegistrar
                 $this->setResourceBindingFields($route, $options['bindingFields']);
             }
 
-            if (isset($options['trashed']) && in_array($m, ! empty($options['trashed']) ? $options['trashed'] : $resourceMethods)) {
+            if (isset($options['trashed']) &&
+                in_array($m, ! empty($options['trashed']) ? $options['trashed'] : $resourceMethods)) {
                 $route->withTrashed();
             }
 

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -94,13 +94,19 @@ class ResourceRegistrar
 
         $collection = new RouteCollection;
 
-        foreach ($this->getResourceMethods($defaults, $options) as $m) {
+        $resourceMethods = $this->getResourceMethods($defaults, $options);
+
+        foreach ($resourceMethods as $m) {
             $route = $this->{'addResource'.ucfirst($m)}(
                 $name, $base, $controller, $options
             );
 
             if (isset($options['bindingFields'])) {
                 $this->setResourceBindingFields($route, $options['bindingFields']);
+            }
+
+            if (isset($options['trashed']) && in_array($m, ! empty($options['trashed']) ? $options['trashed'] : $resourceMethods)) {
+                $route->withTrashed();
             }
 
             $collection->add($route);


### PR DESCRIPTION
This change gives the ability to load trashed models when registering a route resource.

You can load trashed models on **all** the resource routes by calling `withTrashed()` with no parameters:

```php
Route::resource('users', UserController::class)->withTrashed();
```

You can **selectively** load trashed models on methods by passing an array:

```php
Route::resource('users', UserController::class)->withTrashed(['show']);
```
