### PR TITLE
[9.x] Improves `dd` clickable link on multiple editors and docker environments

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -7,25 +7,25 @@ use Throwable;
 trait ResolvesDumpSource
 {
     /**
-     * The most common editor's href format.
+     * All of the href formats for common editors.
      *
      * @var array<string, string>
      */
-    protected $editorsHref = [
+    protected $editorHrefs = [
+        'atom' => 'atom://core/open/file?filename={file}&line={line}',
+        'emacs' => 'emacs://open?url=file://{file}&line={line}',
+        'idea' => 'idea://open?file={file}&line={line}',
+        'macvim' => 'mvim://open/?url=file://{file}&line={line}',
+        'netbeans' => 'netbeans://open/?f={file}:{line}',
+        'nova' => 'nova://core/open/file?filename={file}&line={line}',
+        'phpstorm' => 'phpstorm://open?file={file}&line={line}',
         'sublime' => 'subl://open?url=file://{file}&line={line}',
         'textmate' => 'txmt://open?url=file://{file}&line={line}',
-        'emacs' => 'emacs://open?url=file://{file}&line={line}',
-        'macvim' => 'mvim://open/?url=file://{file}&line={line}',
-        'phpstorm' => 'phpstorm://open?file={file}&line={line}',
-        'idea' => 'idea://open?file={file}&line={line}',
         'vscode' => 'vscode://file/{file}:{line}',
         'vscode-insiders' => 'vscode-insiders://file/{file}:{line}',
-        'vscode-remote' => 'vscode://vscode-remote/{file}:{line}',
         'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/{file}:{line}',
+        'vscode-remote' => 'vscode://vscode-remote/{file}:{line}',
         'vscodium' => 'vscodium://file/{file}:{line}',
-        'atom' => 'atom://core/open/file?filename={file}&line={line}',
-        'nova' => 'nova://core/open/file?filename={file}&line={line}',
-        'netbeans' => 'netbeans://open/?f={file}:{line}',
         'xdebug' => 'xdebug://{file}@{line}',
     ];
 
@@ -88,42 +88,6 @@ trait ResolvesDumpSource
     }
 
     /**
-     * Resolves the source href, if possible.
-     *
-     * @param  string  $file
-     * @param  int|null  $line
-     * @return string|null
-     */
-    protected function resolveSourceHref($file, $line)
-    {
-        try {
-            $editor = config('app.editor');
-        } catch (Throwable $e) {
-            // ..
-        }
-
-        if (! isset($editor)) {
-            return;
-        }
-
-        $href = is_array($editor) && isset($editor['href'])
-            ? $editor['href']
-            : ($this->editorsHref[$editor['name'] ?? $editor] ?? sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor));
-
-        if ($basePath = $editor['base_path'] ?? false) {
-            $file = str_replace($this->basePath, $basePath, $file);
-        }
-
-        $href = str_replace(
-            ['{file}', '{line}'],
-            [$file, is_null($line) ? 1 : $line],
-            $href,
-        );
-
-        return $href;
-    }
-
-    /**
      * Determine if the given file is a view compiled.
      *
      * @param  string  $file
@@ -149,6 +113,42 @@ trait ResolvesDumpSource
         }
 
         return $file;
+    }
+
+    /**
+     * Resolve the source href, if possible.
+     *
+     * @param  string  $file
+     * @param  int|null  $line
+     * @return string|null
+     */
+    protected function resolveSourceHref($file, $line)
+    {
+        try {
+            $editor = config('app.editor');
+        } catch (Throwable $e) {
+            // ..
+        }
+
+        if (! isset($editor)) {
+            return;
+        }
+
+        $href = is_array($editor) && isset($editor['href'])
+            ? $editor['href']
+            : ($this->editorHrefs[$editor['name'] ?? $editor] ?? sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor));
+
+        if ($basePath = $editor['base_path'] ?? false) {
+            $file = str_replace($this->basePath, $basePath, $file);
+        }
+
+        $href = str_replace(
+            ['{file}', '{line}'],
+            [$file, is_null($line) ? 1 : $line],
+            $href,
+        );
+
+        return $href;
     }
 
     /**

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -7,6 +7,29 @@ use Throwable;
 trait ResolvesDumpSource
 {
     /**
+     * The most common editor's href format.
+     *
+     * @var array<string, string>
+     */
+    protected $editorsHref = [
+        'sublime' => 'subl://open?url=file://{file}&line={line}',
+        'textmate' => 'txmt://open?url=file://{file}&line={line}',
+        'emacs' => 'emacs://open?url=file://{file}&line={line}',
+        'macvim' => 'mvim://open/?url=file://{file}&line={line}',
+        'phpstorm' => 'phpstorm://open?file={file}&line={line}',
+        'idea' => 'idea://open?file={file}&line={line}',
+        'vscode' => 'vscode://file/{file}:{line}',
+        'vscode-insiders' => 'vscode-insiders://file/{file}:{line}',
+        'vscode-remote' => 'vscode://vscode-remote/{file}:{line}',
+        'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/{file}:{line}',
+        'vscodium' => 'vscodium://file/{file}:{line}',
+        'atom' => 'atom://core/open/file?filename={file}&line={line}',
+        'nova' => 'nova://core/open/file?filename={file}&line={line}',
+        'netbeans' => 'netbeans://open/?f={file}:{line}',
+        'xdebug' => 'xdebug://{file}@{line}',
+    ];
+
+    /**
      * The source resolver.
      *
      * @var (callable(): (array{0: string, 1: string, 2: int|null}|null))|null
@@ -85,7 +108,7 @@ trait ResolvesDumpSource
 
         $href = is_array($editor) && isset($editor['href'])
             ? $editor['href']
-            : sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor);
+            : ($this->editorsHref[$editor['name'] ?? $editor] ?? sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor));
 
         if ($basePath = $editor['base_path'] ?? false) {
             $file = str_replace($this->basePath, $basePath, $file);

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Foundation\Concerns;
 
+use Throwable;
+
 trait ResolvesDumpSource
 {
     /**

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -83,18 +83,12 @@ trait ResolvesDumpSource
             return;
         }
 
-        $href = is_array($editor) ? ($editor['href'] ?? null) : $editor;
-
-        if (empty($href)) {
-            return;
-        }
+        $href = is_array($editor) && isset($editor['href'])
+            ? $editor['href']
+            : sprintf('%s://open?file={file}&line={line}', $editor['name'] ?? $editor);
 
         if ($basePath = $editor['base_path'] ?? false) {
             $file = str_replace($this->basePath, $basePath, $file);
-        }
-
-        if (! str_contains($href, '://')) {
-            $href = sprintf('%s://open?file={file}&line={line}', $href);
         }
 
         $href = str_replace(

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -63,6 +63,48 @@ trait ResolvesDumpSource
     }
 
     /**
+     * Resolves the source href, if possible.
+     *
+     * @param  string  $file
+     * @param  int|null  $line
+     * @return string|null
+     */
+    protected function resolveSourceHref($file, $line)
+    {
+        try {
+            $editor = config('app.editor');
+        } catch (Throwable $e) {
+            // ..
+        }
+
+        if (! isset($editor)) {
+            return;
+        }
+
+        $href = is_array($editor) ? ($editor['href'] ?? null) : $editor;
+
+        if (empty($href)) {
+            return;
+        }
+
+        if ($basePath = $editor['base_path'] ?? false) {
+            $file = str_replace($this->basePath, $basePath, $file);
+        }
+
+        if (! str_contains($href, '://')) {
+            $href = sprintf('%s://open?file={file}&line={line}', $href);
+        }
+
+        $href = str_replace(
+            ['{file}', '{line}'],
+            [$file, is_null($line) ? 1 : $line],
+            $href,
+        );
+
+        return $href;
+    }
+
+    /**
      * Determine if the given file is a view compiled.
      *
      * @param  string  $file

--- a/src/Illuminate/Foundation/Console/CliDumper.php
+++ b/src/Illuminate/Foundation/Console/CliDumper.php
@@ -114,10 +114,11 @@ class CliDumper extends BaseCliDumper
 
         [$file, $relativeFile, $line] = $dumpSource;
 
+        $href = $this->resolveSourceHref($file, $line);
+
         return sprintf(
-            ' <fg=gray>// <fg=gray;href=file://%s%s>%s%s</></>',
-            $file,
-            is_null($line) ? '' : "#L$line",
+            ' <fg=gray>// <fg=gray%s>%s%s</></>',
+            is_null($href) ? '' : ";href=$href",
             $relativeFile,
             is_null($line) ? '' : ":$line"
         );

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -8,7 +8,6 @@ use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper as BaseHtmlDumper;
 use Symfony\Component\VarDumper\VarDumper;
-use Throwable;
 
 class HtmlDumper extends BaseHtmlDumper
 {

--- a/src/Illuminate/Foundation/Http/HtmlDumper.php
+++ b/src/Illuminate/Foundation/Http/HtmlDumper.php
@@ -132,30 +132,10 @@ class HtmlDumper extends BaseHtmlDumper
 
         $source = sprintf('%s%s', $relativeFile, is_null($line) ? '' : ":$line");
 
-        if ($editor = $this->editor()) {
-            $source = sprintf(
-                '<a href="%s://open?file=%s%s">%s</a>',
-                $editor,
-                $file,
-                is_null($line) ? '' : "&line=$line",
-                $source,
-            );
+        if ($href = $this->resolveSourceHref($file, $line)) {
+            $source = sprintf('<a href="%s">%s</a>', $href, $source);
         }
 
         return sprintf('<span style="color: #A0A0A0;"> // %s</span>', $source);
-    }
-
-    /**
-     * Get the application editor, if applicable.
-     *
-     * @return string|null
-     */
-    protected function editor()
-    {
-        try {
-            return config('app.editor');
-        } catch (Throwable $e) {
-            // ...
-        }
     }
 }

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -243,14 +243,19 @@ class HtmlDumperTest extends TestCase
             'vscode://open?file=/my-docker-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
+        // When editor name is provided...
+        $config->set('app.editor', 'sublime');
+        $this->assertSame('subl://open?url=file:///my-work-directory/app/my-file&line=10', $resolveSourceHref());
+
         // Missing line
+        $config->set('app.editor', ['name' => 'vscode', 'base_path' => '/my-docker-work-directory']);
+
         $href = (fn () => $this->resolveSourceHref(
             '/my-work-directory/app/my-file',
             null,
         ))->call($dumper);
-        $config->set('app.editor', ['name' => 'vscode', 'base_path' => '/my-docker-work-directory']);
         $this->assertSame(
-            'vscode://open?file=/my-docker-work-directory/app/my-file&line=1',
+            'vscode://file//my-docker-work-directory/app/my-file:1',
             $href,
         );
     }

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Foundation\Http;
 
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
 use Illuminate\Foundation\Http\HtmlDumper;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -11,6 +13,8 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 class HtmlDumperTest extends TestCase
 {
+    protected $app;
+
     protected function setUp(): void
     {
         HtmlDumper::resolveDumpSourceUsing(function () {
@@ -20,6 +24,8 @@ class HtmlDumperTest extends TestCase
                 18,
             ];
         });
+
+        $this->app = Container::getInstance();
     }
 
     public function testString()
@@ -184,6 +190,81 @@ class HtmlDumperTest extends TestCase
         $this->assertStringContainsString($expected, $output);
     }
 
+    public function testHref()
+    {
+        $dumper = new HtmlDumper(
+            '/my-work-directory',
+            '/my-work-directory/storage/framework/views'
+        );
+
+        // Failure...
+        $href = (fn () => $this->href(
+            '/my-work-directory/app/my-file',
+            10,
+        ))->call($dumper);
+        $this->assertNull($href);
+
+        $config = new Repository();
+        $this->app->instance('config', $config);
+        $href = fn () => (fn () => $this->href(
+            '/my-work-directory/app/my-file',
+            10,
+        ))->call($dumper);
+
+        // Empty...
+        $this->assertNull($href());
+
+        // When editor is provided...
+        $config->set('app.editor', 'phpstorm');
+        $this->assertSame(
+            'phpstorm://open?file=/my-work-directory/app/my-file&line=10', $href()
+        );
+
+        // When href is provided...
+        $config->set('app.editor', 'vscode://open?file={file}&line={line}');
+        $this->assertSame(
+            'vscode://open?file=/my-work-directory/app/my-file&line=10', $href()
+        );
+
+        // When editoe is provided on array format...
+        $config->set('app.editor', ['href' => 'phpstorm']);
+        $this->assertSame(
+            'phpstorm://open?file=/my-work-directory/app/my-file&line=10', $href()
+        );
+
+        // When editor and base path is provided on array format...
+        $config->set('app.editor', ['href' => 'phpstorm', 'base_path' => '/my-docker-work-directory']);
+        $this->assertSame(
+            'phpstorm://open?file=/my-docker-work-directory/app/my-file&line=10', $href());
+
+        // When base path is provided on array format...
+        $config->set('app.editor', ['base_path' => '/my-docker-work-directory']);
+        $this->assertNull($href());
+
+        // When href is provided on array format...
+        $config->set('app.editor', ['href' => 'vscode://open?file={file}&line={line}']);
+        $this->assertSame(
+            'vscode://open?file=/my-work-directory/app/my-file&line=10', $href()
+        );
+
+        // Array with href and base path
+        $config->set('app.editor', ['href' => 'vscode://open?file={file}&line={line}', 'base_path' => '/my-docker-work-directory']);
+        $this->assertSame(
+            'vscode://open?file=/my-docker-work-directory/app/my-file&line=10', $href()
+        );
+
+        // Missing line
+        $href = (fn () => $this->href(
+            '/my-work-directory/app/my-file',
+            null,
+        ))->call($dumper);
+        $config->set('app.editor', ['href' => 'vscode', 'base_path' => '/my-docker-work-directory']);
+        $this->assertSame(
+            'vscode://open?file=/my-docker-work-directory/app/my-file&line=1',
+            $href,
+        );
+    }
+
     protected function dump($value)
     {
         $outputFile = stream_get_meta_data(tmpfile())['uri'];
@@ -205,5 +286,6 @@ class HtmlDumperTest extends TestCase
     protected function tearDown(): void
     {
         HtmlDumper::resolveDumpSourceUsing(null);
+        Container::setInstance(null);
     }
 }

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -198,7 +198,7 @@ class HtmlDumperTest extends TestCase
         );
 
         // Failure...
-        $href = (fn () => $this->href(
+        $href = (fn () => $this->resolveSourceHref(
             '/my-work-directory/app/my-file',
             10,
         ))->call($dumper);
@@ -206,55 +206,55 @@ class HtmlDumperTest extends TestCase
 
         $config = new Repository();
         $this->app->instance('config', $config);
-        $href = fn () => (fn () => $this->href(
+        $resolveSourceHref = fn () => (fn () => $this->resolveSourceHref(
             '/my-work-directory/app/my-file',
             10,
         ))->call($dumper);
 
         // Empty...
-        $this->assertNull($href());
+        $this->assertNull($resolveSourceHref());
 
         // When editor is provided...
         $config->set('app.editor', 'phpstorm');
         $this->assertSame(
-            'phpstorm://open?file=/my-work-directory/app/my-file&line=10', $href()
+            'phpstorm://open?file=/my-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
         // When href is provided...
         $config->set('app.editor', 'vscode://open?file={file}&line={line}');
         $this->assertSame(
-            'vscode://open?file=/my-work-directory/app/my-file&line=10', $href()
+            'vscode://open?file=/my-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
         // When editoe is provided on array format...
         $config->set('app.editor', ['href' => 'phpstorm']);
         $this->assertSame(
-            'phpstorm://open?file=/my-work-directory/app/my-file&line=10', $href()
+            'phpstorm://open?file=/my-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
         // When editor and base path is provided on array format...
         $config->set('app.editor', ['href' => 'phpstorm', 'base_path' => '/my-docker-work-directory']);
         $this->assertSame(
-            'phpstorm://open?file=/my-docker-work-directory/app/my-file&line=10', $href());
+            'phpstorm://open?file=/my-docker-work-directory/app/my-file&line=10', $resolveSourceHref());
 
         // When base path is provided on array format...
         $config->set('app.editor', ['base_path' => '/my-docker-work-directory']);
-        $this->assertNull($href());
+        $this->assertNull($resolveSourceHref());
 
         // When href is provided on array format...
         $config->set('app.editor', ['href' => 'vscode://open?file={file}&line={line}']);
         $this->assertSame(
-            'vscode://open?file=/my-work-directory/app/my-file&line=10', $href()
+            'vscode://open?file=/my-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
         // Array with href and base path
         $config->set('app.editor', ['href' => 'vscode://open?file={file}&line={line}', 'base_path' => '/my-docker-work-directory']);
         $this->assertSame(
-            'vscode://open?file=/my-docker-work-directory/app/my-file&line=10', $href()
+            'vscode://open?file=/my-docker-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
         // Missing line
-        $href = (fn () => $this->href(
+        $href = (fn () => $this->resolveSourceHref(
             '/my-work-directory/app/my-file',
             null,
         ))->call($dumper);

--- a/tests/Foundation/Http/HtmlDumperTest.php
+++ b/tests/Foundation/Http/HtmlDumperTest.php
@@ -214,32 +214,22 @@ class HtmlDumperTest extends TestCase
         // Empty...
         $this->assertNull($resolveSourceHref());
 
-        // When editor is provided...
+        // When editor name is provided...
         $config->set('app.editor', 'phpstorm');
         $this->assertSame(
             'phpstorm://open?file=/my-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
-        // When href is provided...
-        $config->set('app.editor', 'vscode://open?file={file}&line={line}');
-        $this->assertSame(
-            'vscode://open?file=/my-work-directory/app/my-file&line=10', $resolveSourceHref()
-        );
-
-        // When editoe is provided on array format...
-        $config->set('app.editor', ['href' => 'phpstorm']);
+        // When editor name is provided on array format...
+        $config->set('app.editor', ['name' => 'phpstorm']);
         $this->assertSame(
             'phpstorm://open?file=/my-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
-        // When editor and base path is provided on array format...
-        $config->set('app.editor', ['href' => 'phpstorm', 'base_path' => '/my-docker-work-directory']);
+        // When editor name and base path is provided on array format...
+        $config->set('app.editor', ['name' => 'phpstorm', 'base_path' => '/my-docker-work-directory']);
         $this->assertSame(
             'phpstorm://open?file=/my-docker-work-directory/app/my-file&line=10', $resolveSourceHref());
-
-        // When base path is provided on array format...
-        $config->set('app.editor', ['base_path' => '/my-docker-work-directory']);
-        $this->assertNull($resolveSourceHref());
 
         // When href is provided on array format...
         $config->set('app.editor', ['href' => 'vscode://open?file={file}&line={line}']);
@@ -247,7 +237,7 @@ class HtmlDumperTest extends TestCase
             'vscode://open?file=/my-work-directory/app/my-file&line=10', $resolveSourceHref()
         );
 
-        // Array with href and base path
+        // When href and base path is provided on array format...
         $config->set('app.editor', ['href' => 'vscode://open?file={file}&line={line}', 'base_path' => '/my-docker-work-directory']);
         $this->assertSame(
             'vscode://open?file=/my-docker-work-directory/app/my-file&line=10', $resolveSourceHref()
@@ -258,7 +248,7 @@ class HtmlDumperTest extends TestCase
             '/my-work-directory/app/my-file',
             null,
         ))->call($dumper);
-        $config->set('app.editor', ['href' => 'vscode', 'base_path' => '/my-docker-work-directory']);
+        $config->set('app.editor', ['name' => 'vscode', 'base_path' => '/my-docker-work-directory']);
         $this->assertSame(
             'vscode://open?file=/my-docker-work-directory/app/my-file&line=1',
             $href,


### PR DESCRIPTION
This pull request addresses both https://github.com/laravel/framework/pull/44378, and https://github.com/laravel/framework/pull/44360, and it provides 4 new things:

1. Offers better native support for the URLs protocols: `sublime`, `textmate`, `emacs`, `macvim`, `phpstorm`, `idea`, `vscode`, `vscode-insiders`, `vscode-remote`, `vscode-insiders-remote`, `vscodium`, `atom`, `nova`, `netbeans`, `xdebug`. Note, operating system still need to support these protocols in order this to work.

```php
// As usual, people may define their editor on the `config/app.php`:
'editor' => 'phpstorm', // phpstorm://open?file=/my-work-directory/laravel/routes/web.php&line=17

// Yet, if editor is `vcode`, the generated URL will be different:
'editor' => 'vscode', // vscode://file//Users/nunomaduro/Work/Code/laravel/routes/web.php:17
```

2. Next, if people are using `docker`, they may now define the project's `base_path`. Not that now, people need to use the `array` format, and not a simple `string`:
```php
'editor' => [
    'name' => 'phpstorm',
    'base_path' => '/my-pc-directory/laravel', // phpstorm://open?file=//my-pc-directory/laravel/laravel/routes/web.php&line=17
],
```

3. Finally, for people who are using something very different, they may now define their own custom `href` format — instead of specifying the editor's `name`:

```php
'editor' => [
    'href' => 'vscode://vscode-remote/wsl+Ubuntu-20.04{file}:{line}',
    'base_path' => '/my-pc-directory/laravel',  '/my-pc-directory/laravel', // vscode://vscode-remote/wsl+Ubuntu-20.04/my-pc-directory/laravel/laravel/routes/web.php&line=17
],
```

4. Makes the `dd` output on console equally use the `href` approach we are using on the HTTP layer.