### PR TITLE
[9.x] Consider newlines in foreach/forelse Blade statements

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLoops.php
@@ -25,7 +25,7 @@ trait CompilesLoops
     {
         $empty = '$__empty_'.++$this->forElseCounter;
 
-        preg_match('/\( *(.+) +as +(.+)\)$/is', $expression ?? '', $matches);
+        preg_match('/\( *(.+)\s+as\s+(.+)\)$/is', $expression ?? '', $matches);
 
         if (count($matches) === 0) {
             throw new ViewCompilationException('Malformed @forelse statement.');
@@ -100,7 +100,7 @@ trait CompilesLoops
      */
     protected function compileForeach($expression)
     {
-        preg_match('/\( *(.+) +as +(.*)\)$/is', $expression ?? '', $matches);
+        preg_match('/\( *(.+)\s+as\s+(.*)\)$/is', $expression ?? '', $matches);
 
         if (count($matches) === 0) {
             throw new ViewCompilationException('Malformed @foreach statement.');

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -33,7 +33,9 @@ test
         $string = '@foreach ([
 foo,
 bar,
-] as $label)
+]
+as
+$label)
 test
 @endforeach';
         $expected = '<?php $__currentLoopData = [

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -41,7 +41,9 @@ empty
         $string = '@forelse ([
 foo,
 bar,
-] as $label)
+]
+as
+$label)
 breeze
 @empty
 empty


### PR DESCRIPTION
A few weeks ago I submitted a PR that implements some validations in foreach/forelse statements in Blade:
https://github.com/laravel/framework/pull/44134

All tests were passing, but, there was a case that didn't have any tests covering: newlines inside statement declaration.
See more: https://github.com/laravel/framework/pull/44134#issuecomment-1264042847

This PR fixes this behavior, replacing ` ` to `\s` in the REGEX, and adjusting tests to cover this case.