### PR TITLE
[9.x] Add ext-gmp to composer suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,7 @@
         "ext-bcmath": "Required to use the multiple_of validation rule.",
         "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
+        "ext-gmp": "Required to run tests in Illuminate\\Tests\\Integration\\Database\\EloquentModelCustomCastingTest.",
         "ext-memcached": "Required to use the memcache cache driver.",
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",


### PR DESCRIPTION
Running the tests in `Illuminate\Tests\Integration\Database\EloquentModelCustomCastingTest` without the `ext-gmp` extension installed leads to multiple `Call to undefined function Illuminate\Tests\Integration\Database\gmp_init()` errors.

This PR adds `ext-gmp` to composer's suggested packages.