### PR TITLE
[9.x] Fix `Arr` set test style

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -805,8 +805,9 @@ class SupportArrTest extends TestCase
         Arr::set($array, 'products.desk.price', 300);
         $this->assertSame(['products' => ['desk' => ['price' => 300]]], $array);
 
-        $array = [1 => 'test'];
-        $this->assertEquals([1 => 'hAz'], Arr::set($array, 1, 'hAz'));
+        $array = [1 => 'foo'];
+        Arr::set($array, 1, 'bar');
+        $this->assertSame([1 => 'bar'], $array);
     }
 
     public function testShuffleWithSeed()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
* Fix testSet method style in `SupportArrTest.php`