### PR TITLE
[9.x] Add `forceRootUrl` to `URL` facade doc block

### DIFF
--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -21,6 +21,7 @@ namespace Illuminate\Support\Facades;
  * @method static string to(string $path, $extra = [], bool $secure = null)
  * @method static void defaults(array $defaults)
  * @method static void forceScheme(string $scheme)
+ * @method static void forceRootUrl(string $root)
  * @method static bool isValidUrl(string $path)
  *
  * @see \Illuminate\Routing\UrlGenerator


### PR DESCRIPTION
I find this a useful method especially when dealing with multiple sub-domains. Adding it to the doc block just so IDEs don't see it as an error.
