### PR TITLE
Fixes NULL inspect response message issue

### DIFF
--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -121,11 +121,12 @@ class Response implements Arrayable
     /**
      * Get the response message.
      *
+     * @param  string|null  $message
      * @return string|null
      */
-    public function message()
+    public function message($message = null)
     {
-        return $this->message;
+        return $this->message ?? $message;
     }
 
     /**


### PR DESCRIPTION
As Laravel says in [gate-responses](https://laravel.com/docs/9.x/authorization#gate-responses) especially, when using `inspect` method to get a full authorization response then printing out the message

```PHP
$response = Gate::inspect('store-user');
 
if (! $response->allowed()) {
    return $response->message();
}
```

The previous scenario will return a **NULL** message,  and in case we want to return a message we have to get a `Response` instance to pass the message and then call the `message` method. It's not a **PRACTICAL** way, also it's not like the way that Laravel says in the example through the `inspect` method.

```PHP
$response = Gate::inspect('store-user');
 
if (! $response->allowed()) {
    return (new Response(false, 'Not Allowed!'))->message()
}
```

## AFTER this PR gets merged

We can pass the message directly to the `message` method.

```php
$response = Gate::inspect('store-user');
 
if (! $response->allowed()) {
    return $response->message('Not Allowed!');
}
```
