### PR TITLE
[9.x] Allow maintenance mode events to be listened to in closure based listeners

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -64,7 +64,7 @@ class DownCommand extends Command
                 file_get_contents(__DIR__.'/stubs/maintenance-mode.stub')
             );
 
-            $this->laravel->get('events')->dispatch(MaintenanceModeEnabled::class);
+            $this->laravel->get('events')->dispatch(new MaintenanceModeEnabled());
 
             $this->components->info('Application is now in maintenance mode.');
         } catch (Exception $e) {

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -55,7 +55,7 @@ class UpCommand extends Command
                 unlink(storage_path('framework/maintenance.php'));
             }
 
-            $this->laravel->get('events')->dispatch(MaintenanceModeDisabled::class);
+            $this->laravel->get('events')->dispatch(new MaintenanceModeDisabled());
 
             $this->components->info('Application is now live.');
         } catch (Exception $e) {


### PR DESCRIPTION
I'm not sure if this is a *bug* as such but I ran into this today.

I was trying to listen to `MaintenanceModeDisabled::class` and broadcast this (which I don't think works in maintenance mode anyway) but nonetheless, was faced with this error when registering my listener as usual, with the event type-hinted in the handler so I could then dispatch my own event to broadcast it;
```php
class MaintenanceModeDisabledListener
{
    public function handle(\Illuminate\Foundation\Events\MaintenanceModeDisabled $event)
    {
        MyCustomMaintenanceModeDisabledEvent::dispatch();
    }
}
```
This was met with an error;
`Too few arguments to function ....\MaintenanceModeDisabledListener::handle(), 0 passed in .../vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php on line 441 and exactly 1 expected`

Upon further experimenting I realised that the following listener would also fail and mean you couldn't listen to these events using closures;
```php
Event::listen(function (MaintenanceModeDisabled $event) {
    // custom logic here
});
```

This behaviour is confirmed with the following failing tests;
```php
public function testDisabledEventCanBeListenedTo()
{
    file_put_contents(
        storage_path('framework/down'),
        json_encode([
            'retry' => 60,
            'refresh' => 60,
        ])
    );

    Event::listen(function (MaintenanceModeDisabled $event) {
        $this->assertTrue(true);
    });

    $this->artisan(UpCommand::class);
}

public function testEnabledEventCanBeListenedTo()
{
    Event::listen(function (MaintenanceModeEnabled $event) {
        $this->assertTrue(true);
    });

    $this->artisan(DownCommand::class);
}
```

By instantiating the events for dispatch, the events can be listened to using closures. I also couldn't really find anywhere else in the framework where `->dispatch($eventClassNameAsString)` was used so hoped that this would be the solution. I wasn't sure if any tests were relevant or required.