### PR TITLE
[9.x] Add a new function `withSoftDeletes` in routes

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -142,13 +142,13 @@ class PendingResourceRegistration
     }
 
     /**
-     * Tell the resource to include softDelete routes.
+     * Tell the resource to include softDeletes routes.
      *
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
-    public function withSoftDelete()
+    public function withSoftDeletes()
     {
-        $this->options['withSoftDelete'] = true;
+        $this->options['withSoftDeletes'] = true;
 
         return $this;
     }

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -142,6 +142,18 @@ class PendingResourceRegistration
     }
 
     /**
+     * Tell the resource to include softDelete routes.
+     *
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function withSoftDelete()
+    {
+        $this->options['withSoftDelete'] = true;
+
+        return $this;
+    }
+
+    /**
      * Add middleware to the resource routes.
      *
      * @param  mixed  $middleware

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -330,7 +330,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceTrashed($name, $base, $controller, $options)
@@ -348,7 +348,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceRestore($name, $base, $controller, $options)

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -357,7 +357,7 @@ class ResourceRegistrar
 
         $action = $this->getResourceAction($name, $controller, 'restore', $options);
 
-        return $$this->router->match(['PUT', 'PATCH'], $uri, $action);
+        return $this->router->match(['PUT', 'PATCH'], $uri, $action);
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -25,7 +25,7 @@ class ResourceRegistrar
      *
      * @var string[]
      */
-    protected $resourceSoftDelete = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy', 'trashed', 'restore'];
+    protected $resourceSoftDeletes = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy', 'trashed', 'restore'];
 
     /**
      * The parameters set for this resource instance.
@@ -101,8 +101,8 @@ class ResourceRegistrar
 
         $defaults = $this->resourceDefaults;
 
-        if (isset($options['withSoftDelete']) && $options['withSoftDelete'] == true) {
-            $defaults = $this->resourceSoftDelete;
+        if (isset($options['withSoftDeletes']) && $options['withSoftDeletes'] == true) {
+            $defaults = $this->resourceSoftDeletes;
         }
 
         $collection = new RouteCollection;

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -21,6 +21,13 @@ class ResourceRegistrar
     protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
 
     /**
+     * The actions for a resource full controller with a model with softDelete.
+     *
+     * @var string[]
+     */
+    protected $resourceSoftDelete = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy', 'trashed', 'restore'];
+
+    /**
      * The parameters set for this resource instance.
      *
      * @var array|string
@@ -49,6 +56,8 @@ class ResourceRegistrar
     protected static $verbs = [
         'create' => 'create',
         'edit' => 'edit',
+        'trashed' => 'trashed',
+        'restore' => 'restore',
     ];
 
     /**
@@ -91,6 +100,10 @@ class ResourceRegistrar
         $base = $this->getResourceWildcard(last(explode('.', $name)));
 
         $defaults = $this->resourceDefaults;
+
+        if (isset($options['withSoftDelete']) && $options['withSoftDelete'] == true) {
+            $defaults = $this->resourceSoftDelete;
+        }
 
         $collection = new RouteCollection;
 
@@ -309,6 +322,42 @@ class ResourceRegistrar
         $action = $this->getResourceAction($name, $controller, 'destroy', $options);
 
         return $this->router->delete($uri, $action);
+    }
+
+    /**
+     * Add the trashed method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addResourceTrashed($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/'.static::$verbs['trashed'];
+
+        $action = $this->getResourceAction($name, $controller, 'trashed', $options);
+
+        return $this->router->get($uri, $action);
+    }
+
+    /**
+     * Add the restore method for a resourceful route.
+     *
+     * @param  string  $name
+     * @param  string  $base
+     * @param  string  $controller
+     * @param  array   $options
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addResourceRestore($name, $base, $controller, $options)
+    {
+        $uri = $this->getResourceUri($name).'/{'.$base.'}/'.static::$verbs['restore'];
+
+        $action = $this->getResourceAction($name, $controller, 'restore', $options);
+
+        return $$this->router->match(['PUT', 'PATCH'], $uri, $action);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -359,7 +359,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $only = ['index', 'show', 'store', 'update', 'destroy'];
 
-        if (isset($options['withSoftDelete']) && $options['withSoftDelete'] == true) {
+        if (isset($options['withSoftDeletes']) && $options['withSoftDeletes'] == true) {
             array_merge($only, ['trashed', 'restore']);
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -359,6 +359,10 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $only = ['index', 'show', 'store', 'update', 'destroy'];
 
+        if (isset($options['withSoftDelete']) && $options['withSoftDelete'] == true) {
+            array_merge($only, ['trashed', 'restore']);
+        }
+
         if (isset($options['except'])) {
             $only = array_diff($only, (array) $options['except']);
         }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
@@ -1456,7 +1457,7 @@ class RoutingRouteTest extends TestCase
     public function testResourceRouteNaming()
     {
         $router = $this->getRouter();
-        $router->resource('foo', 'FooController');
+        $router->resource('foo', 'FooController')->withSoftDeletes();
 
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.index'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.show'));
@@ -1465,9 +1466,11 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.edit'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.update'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.destroy'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.trashed'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.restore'));
 
         $router = $this->getRouter();
-        $router->resource('foo.bar', 'FooController');
+        $router->resource('foo.bar', 'FooController')->withSoftDeletes();
 
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.index'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.show'));
@@ -1476,9 +1479,11 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.edit'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.update'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.destroy'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.trashed'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.restore'));
 
         $router = $this->getRouter();
-        $router->resource('prefix/foo.bar', 'FooController');
+        $router->resource('prefix/foo.bar', 'FooController')->withSoftDeletes();
 
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.index'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.show'));
@@ -1487,12 +1492,14 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.edit'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.update'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.destroy'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.trashed'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.restore'));
 
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['names' => [
             'index' => 'foo',
             'show' => 'bar',
-        ]]);
+        ]])->withSoftDeletes();
 
         $this->assertTrue($router->getRoutes()->hasNamedRoute('foo'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar'));
@@ -1507,6 +1514,8 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.edit'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.update'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.destroy'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.trashed'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.restore'));
     }
 
     public function testRouterFiresRoutedEvent()
@@ -2318,6 +2327,10 @@ class RoutingTestMiddlewareGroupTwo
     }
 }
 
+class RoutingTestUserSoftDeleteModel extends Model
+{
+    use SoftDeletes;
+}
 class RoutingTestUserModel extends Model
 {
     public function posts()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -12,7 +12,6 @@ use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1396,13 +1396,17 @@ class RoutingRouteTest extends TestCase
         ResourceRegistrar::verbs([
             'create' => 'ajouter',
             'edit' => 'modifier',
+            'trashed' => 'saccagé',
+            'restore' => 'restaurer',
         ]);
         $router = $this->getRouter();
-        $router->resource('foo', 'FooController');
+        $router->resource('foo', 'FooController')->withSoftDeletes();
         $routes = $router->getRoutes();
 
         $this->assertSame('foo/ajouter', $routes->getByName('foo.create')->uri());
         $this->assertSame('foo/{foo}/modifier', $routes->getByName('foo.edit')->uri());
+        $this->assertSame('foo/saccagé', $routes->getByName('foo.trashed')->uri());
+        $this->assertSame('foo/{foo}/restaurer', $routes->getByName('foo.restore')->uri());
     }
 
     public function testResourceRoutingParameters()
@@ -1505,7 +1509,7 @@ class RoutingRouteTest extends TestCase
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar'));
 
         $router = $this->getRouter();
-        $router->resource('foo', 'FooController', ['names' => 'bar']);
+        $router->resource('foo', 'FooController', ['names' => 'bar'])->withSoftDeletes();
 
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.index'));
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar.show'));


### PR DESCRIPTION
Laravel allows models to have soft delete to not remove from the row form database. to add the date the resource is deleted.
This contribution allows a developer to create a resource route that supports soft delete routes.

For ex:
```php
Route::resource('users', UserController::class)->withSoftDeletes();
```