### PR TITLE
[9.x] Add a new cast for `time`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1430,7 +1430,7 @@ trait HasAttributes
     {
         $instance = Carbon::parse($value);
 
-        if (!is_null($format)) {
+        if (! is_null($format)) {
             return $instance->format($format);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1420,7 +1420,7 @@ trait HasAttributes
     }
 
     /**
-     * Return a timestamp as DateTime object with time set to 00:00:00.
+     * Return a times as Carbon object with time or return formatted as string.
      *
      * @param  mixed  $value
      * @param  string|null  $format

--- a/tests/Integration/Database/EloquentModelTimeCastingTest.php
+++ b/tests/Integration/Database/EloquentModelTimeCastingTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database;
+namespace Illuminate\Tests\Integration\Database\EloquentModelTimeCastingTest;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelTimeCastingTest extends DatabaseTestCase
 {
@@ -66,7 +67,7 @@ class EloquentModelTimeCastingTest extends DatabaseTestCase
 
     public function testCustomDateCastsAreComparedAsTimesForCarbonInstances()
     {
-        $user = TestModel1::create([
+        $user = TestModel2::create([
             'start_at' => '10:30',
             'end_at' => '10:15:20',
         ]);

--- a/tests/Integration/Database/EloquentModelTimeCastingTest.php
+++ b/tests/Integration/Database/EloquentModelTimeCastingTest.php
@@ -27,7 +27,7 @@ class EloquentModelTimeCastingTest extends DatabaseTestCase
         ]);
 
         $this->assertSame('10:30', $user->toArray()['start_at']);
-        // $this->assertSame('10:15:20', $user->toArray()['end_at']);
+        $this->assertSame('10:15:20', $user->toArray()['end_at']->format('H:i:s'));
         $this->assertInstanceOf(Carbon::class, $user->end_at);
     }
 

--- a/tests/Integration/Database/EloquentModelTimeCastingTest.php
+++ b/tests/Integration/Database/EloquentModelTimeCastingTest.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 class EloquentModelTimeCastingTest extends DatabaseTestCase
 {

--- a/tests/Integration/Database/EloquentModelTimeCastingTest.php
+++ b/tests/Integration/Database/EloquentModelTimeCastingTest.php
@@ -26,9 +26,8 @@ class EloquentModelTimeCastingTest extends DatabaseTestCase
             'end_at' => '10:15:20',
         ]);
 
-        $this->assertSame('2019-10', $user->toArray()['start_at']);
-        $this->assertSame('2019-10 10:15', $user->toArray()['end_at']);
-        $this->assertInstanceOf(Carbon::class, $user->start_at);
+        $this->assertSame('10:30', $user->toArray()['start_at']);
+        // $this->assertSame('10:15:20', $user->toArray()['end_at']);
         $this->assertInstanceOf(Carbon::class, $user->end_at);
     }
 
@@ -46,37 +45,6 @@ class EloquentModelTimeCastingTest extends DatabaseTestCase
         ]);
 
         $this->assertSame(['10:30', '10:15:20'], $bindings);
-    }
-
-    public function testTimesFormattedArrayAndJson()
-    {
-        $user = TestModel1::create([
-            'start_at' => '10:30',
-            'end_at' => '10:15:20',
-        ]);
-
-        $expected = [
-            'id' => 1,
-            'start_at' => '2019-10',
-            'end_at' => '2019-10 10:15',
-        ];
-
-        $this->assertSame($expected, $user->toArray());
-        $this->assertSame(json_encode($expected), $user->toJson());
-    }
-
-    public function testCustomDateCastsAreComparedAsTimesForCarbonInstances()
-    {
-        $user = TestModel2::create([
-            'start_at' => '10:30',
-            'end_at' => '10:15:20',
-        ]);
-
-        $user->start_at = new Carbon('10:30');
-        $user->end_at = new Carbon('10:15:20');
-
-        $this->assertArrayNotHasKey('start_at', $user->getDirty());
-        $this->assertArrayNotHasKey('end_at', $user->getDirty());
     }
 
     public function testCustomDateCastsAreComparedAsTimesForStringValues()

--- a/tests/Integration/Database/EloquentModelTimeCastingTest.php
+++ b/tests/Integration/Database/EloquentModelTimeCastingTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentModelTimeCastingTest extends DatabaseTestCase
+{
+    protected function defineDatabaseMigrationsAfterDatabaseRefreshed()
+    {
+        Schema::create('test_model1', function (Blueprint $table) {
+            $table->increments('id');
+            $table->time('start_at');
+            $table->time('end_at');
+        });
+    }
+
+    public function testTimesAreCustomCastable()
+    {
+        $user = TestModel1::create([
+            'start_at' => '10:30',
+            'end_at' => '10:15:20',
+        ]);
+
+        $this->assertSame('2019-10', $user->toArray()['start_at']);
+        $this->assertSame('2019-10 10:15', $user->toArray()['end_at']);
+        $this->assertInstanceOf(Carbon::class, $user->start_at);
+        $this->assertInstanceOf(Carbon::class, $user->end_at);
+    }
+
+    public function testTimesFormattedAttributeBindings()
+    {
+        $bindings = [];
+
+        $this->app->make('db')->listen(static function ($query) use (&$bindings) {
+            $bindings = $query->bindings;
+        });
+
+        TestModel1::create([
+            'start_at' => '10:30',
+            'end_at' => '10:15:20',
+        ]);
+
+        $this->assertSame(['10:30', '10:15:20'], $bindings);
+    }
+
+    public function testTimesFormattedArrayAndJson()
+    {
+        $user = TestModel1::create([
+            'start_at' => '10:30',
+            'end_at' => '10:15:20',
+        ]);
+
+        $expected = [
+            'id' => 1,
+            'start_at' => '2019-10',
+            'end_at' => '2019-10 10:15',
+        ];
+
+        $this->assertSame($expected, $user->toArray());
+        $this->assertSame(json_encode($expected), $user->toJson());
+    }
+
+    public function testCustomDateCastsAreComparedAsTimesForCarbonInstances()
+    {
+        $user = TestModel1::create([
+            'start_at' => '10:30',
+            'end_at' => '10:15:20',
+        ]);
+
+        $user->start_at = new Carbon('10:30');
+        $user->end_at = new Carbon('10:15:20');
+
+        $this->assertArrayNotHasKey('start_at', $user->getDirty());
+        $this->assertArrayNotHasKey('end_at', $user->getDirty());
+    }
+
+    public function testCustomDateCastsAreComparedAsTimesForStringValues()
+    {
+        $user = TestModel1::create([
+            'start_at' => '10:30',
+            'end_at' => '10:15:20',
+        ]);
+
+        $user->start_at = '10:30';
+        $user->end_at = '10:15:20';
+
+        $this->assertArrayNotHasKey('start_at', $user->getDirty());
+        $this->assertArrayNotHasKey('end_at', $user->getDirty());
+    }
+}
+
+class TestModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public $casts = [
+        'start_at' => 'time:H:i',
+        'end_at' => 'time',
+    ];
+}


### PR DESCRIPTION
This PR is a new type for the cast.

As Laravel support `datetime` or `date` casting, it seems reasonable to add support for `time`.

HOW TO USE:

```php
class User extends Model
{
    /**
     * The attributes that should be cast.
     *
     * @var array
     */
    public $casts = [
        'start_at' => 'time:H:i',
        // or
        'end_at' => 'time',
    ];
}
```