### PR TITLE
[9.x] Fix Precognition headers for Symfony responses

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
@@ -72,9 +72,9 @@ class HandlePrecognitiveRequests
      */
     protected function appendVaryHeader($request, $response)
     {
-        return $response->header('Vary', implode(', ', array_filter([
+        return tap($response, fn () => $response->headers->set('Vary', implode(', ', array_filter([
             $response->headers->get('Vary'),
             'Precognition',
-        ])));
+        ]))));
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
@@ -45,7 +45,9 @@ class HandlePrecognitiveRequests
         $this->prepareForPrecognition($request);
 
         return tap($next($request), function ($response) use ($request) {
-            $this->appendVaryHeader($request, $response->header('Precognition', 'true'));
+            $response->headers->set('Precognition', 'true');
+
+            $this->appendVaryHeader($request, $response);
         });
     }
 

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -743,6 +743,20 @@ class PrecognitionTest extends TestCase
         $response->assertOk();
         $this->assertSame('http://localhost/expected-route-2', session()->previousUrl());
     }
+
+    public function testItHandlesSymfonyResponses()
+    {
+        Route::get('test-route', function () {
+            return response()->streamDownload(function () {
+                echo 'foo';
+            }, 'bar', ['Expected' => 'Header']);
+        })->middleware(HandlePrecognitiveRequests::class);
+
+        $response = $this->get('test-route');
+
+        $response->assertOk();
+        $response->assertHeader('Expected', 'Header');
+    }
 }
 
 class PrecognitionTestController

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -744,18 +744,32 @@ class PrecognitionTest extends TestCase
         $this->assertSame('http://localhost/expected-route-2', session()->previousUrl());
     }
 
-    public function testItHandlesSymfonyResponses()
+    public function testItAppendsVaryHeaderToSymfonyResponse()
     {
         Route::get('test-route', function () {
             return response()->streamDownload(function () {
                 echo 'foo';
-            }, 'bar', ['Expected' => 'Header']);
+            }, null, ['Expected' => 'Header']);
         })->middleware(HandlePrecognitiveRequests::class);
 
         $response = $this->get('test-route');
-
         $response->assertOk();
         $response->assertHeader('Expected', 'Header');
+    }
+
+    public function testItAppendsPrecognitionHeaderToSymfonyResponse()
+    {
+        Route::get('test-route', function () {
+            //
+        })->middleware([
+            HandlePrecognitiveRequests::class,
+            MiddlewareReturningSymfonyResponse::class,
+        ]);
+
+        $response = $this->get('test-route', ['Precognition' => 'true']);
+        $response->assertOk();
+        $response->assertHeader('Expected', 'Header');
+        $response->assertHeader('Precognition', 'true');
     }
 }
 
@@ -920,5 +934,15 @@ class PrecognitionInvokingController extends HandlePrecognitiveRequests
 
         app()->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
         app()->bind(ControllerDispatcherContract::class, fn ($app) => new ControllerDispatcher($app));
+    }
+}
+
+class MiddlewareReturningSymfonyResponse
+{
+    public function handle($request, $next)
+    {
+        return response()->streamDownload(function () {
+            //
+        }, null, ['Expected' => 'Header']);
     }
 }


### PR DESCRIPTION
The `$response->header()` function is only available on Laravel responses. This PR fixes usage with Symfony responses, such as `BinaryFileResponse`.