### PR TITLE
[9.x] Added new method in Attribute Cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/Attribute.php
+++ b/src/Illuminate/Database/Eloquent/Casts/Attribute.php
@@ -19,6 +19,13 @@ class Attribute
     public $set;
 
     /**
+     * Indicates if need to add this attribute in append.
+     *
+     * @var bool
+     */
+    public $withAppend = false;
+
+    /**
      * Indicates if caching is enabled for this attribute.
      *
      * @var bool
@@ -77,6 +84,18 @@ class Attribute
     public static function set(callable $set)
     {
         return new static(null, $set);
+    }
+
+    /**
+     * Enable append for the attribute.
+     *
+     * @return static
+     */
+    public function withAppend()
+    {
+        $this->withAppend = true;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -243,9 +243,7 @@ trait HasAttributes
             })
             ->map(function ($match) {
                 return lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
-            })
-            ->values()
-            ->all();
+            })->all();
     }
 
     /**

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -341,8 +341,9 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithAppend;
 
-        $this->assertTrue(isset($model->firstName));
-        $this->assertSame('Michael', $model->firstName);
+        $this->assertTrue(isset($model->first_name));
+        $this->assertSame('Michael', $model->first_name);
+
         $this->assertSame(['first_name'], $model->getAppends());
     }
 }

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -18,6 +18,11 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
             $table->increments('id');
             $table->timestamps();
         });
+
+        Schema::create('test_eloquent_model_with_appends', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
     }
 
     public function testBasicCustomCasting()
@@ -331,6 +336,15 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
             $this->assertNotSame($previous, $previous = $model->virtualDateTimeWithoutCachingFluent);
         }
     }
+
+    public function testEloquentModelWithAppend()
+    {
+        $model = new TestEloquentModelWithAppend;
+
+        $this->assertTrue(isset($model->firstName));
+        $this->assertSame('Michael', $model->firstName);
+        $this->assertSame(['first_name'], $model->getAppends());
+    }
 }
 
 class TestEloquentModelWithAttributeCast extends Model
@@ -506,6 +520,16 @@ class TestEloquentModelWithAttributeCast extends Model
         return Attribute::get(function () {
             return Date::now()->addSeconds(mt_rand(0, 10000));
         })->withoutObjectCaching();
+    }
+}
+
+class TestEloquentModelWithAppend extends Model
+{
+    protected function firstName(): Attribute
+    {
+        return Attribute::get(function () {
+            return 'Michael';
+        })->withAppend();
     }
 }
 

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -341,10 +341,10 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithAppend;
 
-        $this->assertTrue(isset($model->first_name));
-        $this->assertSame('Michael', $model->first_name);
+        $this->assertTrue(isset($model->firstName));
+        $this->assertSame('Michael', $model->firstName);
 
-        $this->assertSame(['first_name'], $model->getAppends());
+        $this->assertSame(['firstName'], $model->getAppends());
     }
 }
 

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -344,7 +344,7 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
         $this->assertTrue(isset($model->firstName));
         $this->assertSame('Michael', $model->firstName);
 
-        $this->assertSame(['firstName'], $model->getAppends());
+        $this->assertSame(['first_name'], $model->getAppends());
     }
 }
 


### PR DESCRIPTION
This pull request adds a new method to attribute Cast `withAppend`.

It shortens a bit to put the new value extracted from `attribute` to append so that the developer can use it immediately

Before:
```php
class User extends Model
{
    /**
     * The accessors to append to the model's array form.
     *
     * @var array
     */
    protected $appends = [
        'full_name',
    ];

    /**
     * Get the user's full name.
     *
     * @return \Illuminate\Database\Eloquent\Casts\Attribute
     */
    protected function fullName(): Attribute
    {
        return Attribute::get(function () {
            return $this->first_name.' '.$this->last_name;
        });
    }
}
```

After:
```php
class User extends Model
{
    /**
     * Get the user's full name.
     *
     * @return \Illuminate\Database\Eloquent\Casts\Attribute
     */
    protected function fullName(): Attribute
    {
        return Attribute::get(function () {
            return $this->first_name.' '.$this->last_name;
        })->withAppend();
    }
}
```