### PR TITLE
[9.x] Generalizes the output result

### DIFF
--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -11,9 +11,9 @@ class Benchmark
      *
      * @param  \Closure|array  $benchmarkables
      * @param  int  $iterations
-     * @return array|float
+     * @return array|string
      */
-    public static function measure(Closure|array $benchmarkables, int $iterations = 1): array|float
+    public static function measure(Closure|array $benchmarkables, int $iterations = 1): array|string
     {
         return collect(Arr::wrap($benchmarkables))->map(function ($callback) use ($iterations) {
             return collect(range(1, $iterations))->map(function () use ($callback) {
@@ -25,7 +25,7 @@ class Benchmark
 
                 return (hrtime(true) - $start) / 1000000;
             })->average();
-        })->when(
+        })->map(fn ($average) => number_format($average, 3))->when(
             $benchmarkables instanceof Closure,
             fn ($c) => $c->first(),
             fn ($c) => $c->all(),


### PR DESCRIPTION
This PR generalizes the number format of all methods in the `Benchmark` class.

## BEFORE this PR gets merged

```PHP
$data = [];

return Benchmark::measure(function () use ($data) {
    User::create($data);
});
```

The output will be **4.9183**

## AFTER this PR gets merged

The output for the previous code will be **3.343**