### PR TITLE
[9.x] Allow to create databases with dots

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -212,7 +212,7 @@ class MigrateCommand extends BaseCommand
 
             $freshConnection = $this->migrator->resolveConnection($this->option('database'));
 
-            return tap($freshConnection->unprepared("CREATE DATABASE IF NOT EXISTS {$connection->getDatabaseName()}"), function () {
+            return tap($freshConnection->unprepared("CREATE DATABASE IF NOT EXISTS `{$connection->getDatabaseName()}`"), function () {
                 $this->laravel['db']->purge();
             });
         } finally {


### PR DESCRIPTION
When trying to create a database with dots like `laravel.com` it gives the following error:

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/823088/193616664-c1c1cf44-0796-403a-bcb4-b16b6da5f7d0.png">

This PR fixes that by adding "`" to wrap the name:

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/823088/193617029-fb851934-5d2d-4427-a9f0-082163978bd8.png">

Cheers