### PR TITLE
[9.x] Register `MigrationServiceProvider` in `DatabaseServiceProvider`

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -43,6 +43,8 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->registerConnectionServices();
         $this->registerEloquentFactory();
         $this->registerQueueableEntityResolver();
+
+        $this->app->register(MigrationServiceProvider::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Contracts\Support\DeferrableProvider;
-use Illuminate\Database\MigrationServiceProvider;
 use Illuminate\Support\AggregateServiceProvider;
 
 class ConsoleSupportServiceProvider extends AggregateServiceProvider implements DeferrableProvider

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -15,7 +15,6 @@ class ConsoleSupportServiceProvider extends AggregateServiceProvider implements 
      */
     protected $providers = [
         ArtisanServiceProvider::class,
-        MigrationServiceProvider::class,
         ComposerServiceProvider::class,
     ];
 }


### PR DESCRIPTION
Currently, it is not possible to remove the `DatabaseServiceProvider` in `app/config.php` because the `MigrationServiceProvider` requires `db` to be registered in the container, and thus an error is thrown.  
Right now, `MigrationServiceProvider` is loaded and resolved through `ConsoleSupportServiceProvider`.

This PR moves the registration of `MigrationServiceProvider` to `DatabaseServiceProvider`, making it possible to remove the `DatabaseServiceProvider` in projects that do not require a database.