### PR TITLE
[9.x] Adds `Route::environment` 🐝

### DIFF
--- a/src/Illuminate/Http/Middleware/VerifyEnvironment.php
+++ b/src/Illuminate/Http/Middleware/VerifyEnvironment.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Foundation\Application;
+
+class VerifyEnvironment
+{
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  ...$environments
+     * @return mixed
+     */
+    public function handle($request, Closure $next, ...$environments)
+    {
+        if (! in_array($this->app->environment(), $environments, true)) {
+            return response(status: 404);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\Middleware\VerifyEnvironment;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Contracts\CallableDispatcher;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
@@ -1027,6 +1028,22 @@ class Route
         return $this->computedMiddleware = Router::uniqueMiddleware(array_merge(
             $this->middleware(), $this->controllerMiddleware()
         ));
+    }
+
+    /**
+     * Sets the list of allowed environments.
+     *
+     * @param  array<int, string>|string  $names
+     * @return $this
+     */
+    public function environment($names)
+    {
+        $this->action['middleware'] = array_merge(
+            [sprintf('%s:%s', VerifyEnvironment::class, implode(',', Arr::wrap($names)))],
+            (array) ($this->action['middleware'] ?? []),
+        );
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/Http/Middleware/VerifyEnvironmentTest.php
+++ b/tests/Integration/Http/Middleware/VerifyEnvironmentTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class VerifyEnvironmentTest extends TestCase
+{
+    public function testNotAllowedEnvironment()
+    {
+        Route::get('/test', function () {
+            return 'My test code...';
+        })->environment('staging');
+
+        $response = $this->get('/test');
+        $response->assertStatus(404);
+
+        Route::get('/test', function () {
+            return 'My test code...';
+        })->environment(['staging', 'local']);
+
+        $response = $this->get('/test');
+        $response->assertStatus(404);
+    }
+
+    public function testAllowedEnvironment()
+    {
+        Route::get('/test', function () {
+            return 'My test code...';
+        })->environment('testing');
+
+        $response = $this->get('/test');
+        $response->assertStatus(200);
+
+        Route::get('/test', function () {
+            return 'My test code...';
+        })->environment(['testing', 'local']);
+
+        $response = $this->get('/test');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
This pull request is a work in progress, and it proposes the addition of a minimal `environment` method to the route definition that allows the creation routes for certain environments only. In other words, sometimes, we may have those "test" routes that we want to use locally — or in staging — but not in production:

```php
Route::get('/playground', function () {
    // My test code...
})->environment('local');

Route::get('/playground', function () {
    // My test code...
})->environment(['local', 'staging']);
```

Of course, when trying to visit these routes from `production` the response back will be an `404`.