### PR TITLE
[9.x] Adds support for PHP's `BackedEnum` to be "rendered" on blade views.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -102,7 +102,7 @@ if (! function_exists('e')) {
     /**
      * Encode HTML special characters in a string.
      *
-     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|string|null  $value
+     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|\BackedEnum|string|null  $value
      * @param  bool  $doubleEncode
      * @return string
      */
@@ -116,7 +116,7 @@ if (! function_exists('e')) {
             return $value->toHtml();
         }
 
-        if (is_object($value) && enum_exists($value::class)) {
+        if ($value instanceof BackedEnum) {
             $value = $value->value;
         }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
-use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 
 if (! function_exists('append_config')) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Reflector;
 use Illuminate\Support\Str;
 
 if (! function_exists('append_config')) {
@@ -114,6 +115,10 @@ if (! function_exists('e')) {
 
         if ($value instanceof Htmlable) {
             return $value->toHtml();
+        }
+
+        if (is_object($value) && enum_exists($value::class)) {
+            $value = $value->value;
         }
 
         return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8', $doubleEncode);

--- a/tests/Support/Fixtures/IntBackedEnum.php
+++ b/tests/Support/Fixtures/IntBackedEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Support\Fixtures;
+
+enum IntBackedEnum: int
+{
+    case ROLE_ADMIN = 1;
+}

--- a/tests/Support/Fixtures/StringBackedEnum.php
+++ b/tests/Support/Fixtures/StringBackedEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Support\Fixtures;
+
+enum StringBackedEnum: string
+{
+    case ADMIN_LABEL = 'I am \'admin\'';
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -34,8 +34,11 @@ class SupportHelpersTest extends TestCase
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
 
-        $enumValue = SupportTestEnum::ADMIN;
-        $this->assertSame('Admin', e($enumValue));
+        $enumValue = SupportTestStringEnum::ADMIN_LABEL;
+        $this->assertSame('I am &#039;admin&#039;', e($enumValue));
+
+        $enumValue = SupportTestIntEnum::ROLE_ADMIN;
+        $this->assertSame('1', e($enumValue));
     }
 
     public function testBlank()
@@ -939,9 +942,14 @@ class SupportTestArrayIterable implements IteratorAggregate
     }
 }
 
-enum SupportTestEnum: string
+enum SupportTestStringEnum: string
 {
-    case ADMIN = 'Admin';
+    case ADMIN_LABEL = 'I am \'admin\'';
+}
+
+enum SupportTestIntEnum: int
+{
+    case ROLE_ADMIN = 1;
 }
 
 class SupportTestCountable implements Countable

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -9,6 +9,8 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Stringable;
+use Illuminate\Tests\Support\Fixtures\IntBackedEnum;
+use Illuminate\Tests\Support\Fixtures\StringBackedEnum;
 use IteratorAggregate;
 use LogicException;
 use Mockery as m;
@@ -33,11 +35,17 @@ class SupportHelpersTest extends TestCase
         $html = m::mock(Htmlable::class);
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
+    }
 
-        $enumValue = SupportTestStringEnum::ADMIN_LABEL;
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testEWithEnums()
+    {
+        $enumValue = StringBackedEnum::ADMIN_LABEL;
         $this->assertSame('I am &#039;admin&#039;', e($enumValue));
 
-        $enumValue = SupportTestIntEnum::ROLE_ADMIN;
+        $enumValue = IntBackedEnum::ROLE_ADMIN;
         $this->assertSame('1', e($enumValue));
     }
 
@@ -940,16 +948,6 @@ class SupportTestArrayIterable implements IteratorAggregate
     {
         return new ArrayIterator($this->items);
     }
-}
-
-enum SupportTestStringEnum: string
-{
-    case ADMIN_LABEL = 'I am \'admin\'';
-}
-
-enum SupportTestIntEnum: int
-{
-    case ROLE_ADMIN = 1;
 }
 
 class SupportTestCountable implements Countable

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -29,9 +29,13 @@ class SupportHelpersTest extends TestCase
     {
         $str = 'A \'quote\' is <b>bold</b>';
         $this->assertSame('A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;', e($str));
+
         $html = m::mock(Htmlable::class);
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
+
+        $enumValue = SupportTestEnum::ADMIN;
+        $this->assertSame('Admin', e($enumValue));
     }
 
     public function testBlank()
@@ -933,6 +937,11 @@ class SupportTestArrayIterable implements IteratorAggregate
     {
         return new ArrayIterator($this->items);
     }
+}
+
+enum SupportTestEnum: string
+{
+    case ADMIN = 'Admin';
 }
 
 class SupportTestCountable implements Countable


### PR DESCRIPTION
This pull request is a very simple change that allows PHP's `BackedEnum` to be "rendered" on blade views. 

```php
enum UserRoles: string
{
    case ADMIN = 'Admin';
}

// routes/web.php
Route::get('/', function () {
    return view('dashboard', ['role' => UserRoles:: ADMIN]);
});

// dashboard.blade.php
Hello, {{ $role }}.

// ❌ Before: TypeError: htmlspecialchars(): Argument #1 ($string) must be of type string
// ✅ After: Hello, Admin.
```

Fixes https://github.com/laravel/framework/issues/44431.