### PR TITLE
[9.x] Fixes `dd` source on windows

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -54,7 +54,7 @@ trait ResolvesDumpSource
         foreach ($trace as $traceKey => $traceFile) {
             if (isset($traceFile['file']) && str_ends_with(
                 $traceFile['file'],
-                'symfony/var-dumper/Resources/functions/dump.php'
+                'dump.php'
             )) {
                 $sourceKey = $traceKey + 1;
 


### PR DESCRIPTION
This pull request fixes displaying the `dd` source on Windows. This pull request was tested on Windows Powershell, WSL2, and Command Prompt with the help of @PHPGuus. 🫡

![image (4)](https://user-images.githubusercontent.com/5457236/193803354-b319bca9-c1eb-4c26-9ce3-1828c10c9d1d.png)
![image (3)](https://user-images.githubusercontent.com/5457236/193803358-70bdc72a-d5e3-41a8-a8fc-826ebdfcf659.png)
![image (2)](https://user-images.githubusercontent.com/5457236/193803362-fac3193e-aa74-44f9-afed-340eb84ac0f4.png)
