### PR TITLE
[9.x] Fix `Route::withoutMiddleware()` docblock

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1090,7 +1090,7 @@ class Route
      * Specify middleware that should be removed from the given route.
      *
      * @param  array|string  $middleware
-     * @return $this|array
+     * @return $this
      */
     public function withoutMiddleware($middleware)
     {


### PR DESCRIPTION
Tiny doc block fix
