### PR TITLE
[9.x] Traversable should have priority over JsonSerializable in EnumerateValues

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -980,12 +980,12 @@ trait EnumeratesValues
             return $items->all();
         } elseif ($items instanceof Arrayable) {
             return $items->toArray();
+        } elseif ($items instanceof Traversable) {
+            return iterator_to_array($items);
         } elseif ($items instanceof Jsonable) {
             return json_decode($items->toJson(), true);
         } elseif ($items instanceof JsonSerializable) {
             return (array) $items->jsonSerialize();
-        } elseif ($items instanceof Traversable) {
-            return iterator_to_array($items);
         } elseif ($items instanceof UnitEnum) {
             return [$items];
         }


### PR DESCRIPTION
Using an unrelated third party package I came across this problem, this exact same issue happened to someone else, as per (https://github.com/laravel/ideas/issues/2556) and was introduced in #14628.

**Problem**

EnumerateValues::getArrayableItems checks for JsonSerializable before checking for Traversable. 

This is a problem because a class implementing both JsonSerializable and Traversable will have its JSON representation used in the Collection instead of its actual iterable representantion, which should have priority. There is no need to transform a Traversable object to a JSON.

This is not an expected behaviour since a Traversable object can be traversed (no pun intended).

**Consider the following:**

```PHP
// Person.php

class Person
{
    public string $firstName;
    public string $lastName;

    public function __construct(string $firstName, string $lastName)
    {
        $this->firstName = $firstName;
        $this->lastName = $lastName;
    }

    public function getFullName(): string
    {
        return $this->firstName . ' ' .  $this->lastName;
    }
}
```

```PHP
// MyIterator.php

use ArrayIterator;
use IteratorAggregate;
use JsonSerializable;
use Traversable;

class MyIterator implements IteratorAggregate, JsonSerializable
{
    public function __construct(
        public $items,
    ) {
    }

    public function getIterator(): Traversable
    {
        return new ArrayIterator($this->items);
    }

    public function jsonSerialize(): mixed
    {
        return array_map(fn ($item) => (array) $item, $this->items);
    }
}
```

```PHP
// Example.php

$iterator = new MyIterator([
    new Person('John', 'Doe'),
    new Person('Jane', 'Smith'),
]);

$collection = collect($iterator);

$collection->first()->getFullName();
```


EnumerateValues::getArrayableItems will use MyIterator JSON representantion, and now the items in the Collection will **no longer be of type Person**, meaning that $collection->first()->getFullName() will throw `Call to a member function getFullName() on array`.

That's assumming that the implementation of jsonSerialize returns an array of the items, but it can be worse if it returns other data such as:

```PHP
public function jsonSerialize(): mixed
{
    return [
        'otherData' => ['my', 'other', 'data'],
        'data' => array_map(fn ($item) => (array) $item, $this->items),
    ];
}
```

Although this can be solved in user-land, EnumerateValues should accurately parse the items given the fact that Traversable is a native PHP feature.