### PR TITLE
[9.x] Have `Model::withoutTimestamps()` return the callback's return value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -167,11 +167,11 @@ trait HasTimestamps
      * Disable timestamps for the current class during the given callback scope.
      *
      * @param  callable  $callback
-     * @return void
+     * @return mixed
      */
     public static function withoutTimestamps(callable $callback)
     {
-        static::withoutTimestampsOn([static::class], $callback);
+        return static::withoutTimestampsOn([static::class], $callback);
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/framework/pull/44138 introduced the ability to perform actions on models without timestamps.

This PR makes `Model::withoutTimestamps()` act the same as `Model::withoutEvents()`, `Model::withoutTimestampsOn()` and various other "without" methods, by having it return the callbacks return value.

This would then allow e.g.:

```php
$user = User::withoutTimestamps(fn () => User::create($request->validated());
```
