### PR TITLE
Improve return type for `Eloquent\Collection::find()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -24,7 +24,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @param  mixed  $key
      * @param  TFindDefault  $default
-     * @return static<TKey|TModel>|TModel|TFindDefault
+     * @return ($key is array|Arrayable ? static<TKey|TModel> : TModel|TFindDefault)
      */
     public function find($key, $default = null)
     {

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -5,8 +5,10 @@ use function PHPStan\Testing\assertType;
 $collection = User::all();
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection);
 
-assertType('Illuminate\Database\Eloquent\Collection<int, User>|User|null', $collection->find(1));
-assertType('Illuminate\Database\Eloquent\Collection<int, User>|string|User', $collection->find(1, 'string'));
+assertType('User|null', $collection->find(1));
+assertType('string|User', $collection->find(1, 'string'));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->find([1]));
+assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->find([1], 'string'));
 
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load('string'));
 assertType('Illuminate\Database\Eloquent\Collection<int, User>', $collection->load(['string']));


### PR DESCRIPTION
Thanks to PHPStan's conditional return types, we can now infer what does the `find` method of the Eloquent Collection returns.
When the `$key` argument is an `array` or an `Arrayable` object, it returns a new collection with the found items.
In all other cases, it returns a single item, or the `$default` value.