### PR TITLE
$this->getEmailForPasswordReset() should be called instead of $this->email

### DIFF
--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -45,7 +45,7 @@ trait RoutesNotifications
 
         return match ($driver) {
             'database' => $this->notifications(),
-            'mail' => $this->email,
+            'mail' => $this->getEmailForPasswordReset(),
             default => null,
         };
     }


### PR DESCRIPTION
$this->getEmailForPasswordReset() function should be called instead of $this->email

Referring to this issue #44463

I think at this line $this->getEmailForPasswordReset() function should be called instead of $this->email if the driver is 'mail' then it should return email field value but in my users table the name of email field is different. returning ```$this->email``` is restricting notify to use "email" as email field name.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
