### PR TITLE
Provide option to choose different mail field name to notify using mail driver

### DIFF
--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -31,6 +31,18 @@ trait RoutesNotifications
     }
 
     /**
+     * Get the e-mail address field to notify through mail.
+     * This function will provide option to choose different field name 
+     * which contain email address.
+     * 
+     * @return string
+     */
+    public function getEmailForMailNotification()
+    {
+        return $this->email;
+    }
+
+    /**
      * Get the notification routing information for the given driver.
      *
      * @param  string  $driver
@@ -45,7 +57,7 @@ trait RoutesNotifications
 
         return match ($driver) {
             'database' => $this->notifications(),
-            'mail' => $this->getEmailForPasswordReset(),
+            'mail' => $this->getEmailForMailNotification(),
             default => null,
         };
     }

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -32,9 +32,9 @@ trait RoutesNotifications
 
     /**
      * Get the e-mail address field to notify through mail.
-     * This function will provide option to choose different field name 
+     * This function will provide option to choose different field name
      * which contain email address.
-     * 
+     *
      * @return string
      */
     public function getEmailForMailNotification()

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -45,7 +45,7 @@ trait RoutesNotifications
 
         return match ($driver) {
             'database' => $this->notifications(),
-            'mail' => $this->email,
+            'mail' => $this->getEmailForPasswordReset(),
             default => null,
         };
     }


### PR DESCRIPTION
Referring to issue #44463 and cancelled previous pull request #44464

New function ```$this->getEmailForMailNotification()``` should be called instead of ```$this->email```

Returning ```$this->email``` is restricting notify to use "email" as email field name.

If user want to notify through mail driver and email is stored in different field (other than email) like "personal_email"
OR
If "email" field is exist but user want to notify to some other email field like "personal_email" then he can override function ```getEmailForMailNotification``` in his model and that field will be used to notify through "mail" driver.



<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

