### PR TITLE
[9.x] Add ability to inject route parameters in FormRequest::rules

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -109,7 +109,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function createDefaultValidator(ValidationFactory $factory)
     {
-        $rules = $this->container->call([$this, 'rules']);
+        $rules = $this->container->call([$this, 'rules'], $this->route()?->parameters() ?? []);
 
         if ($this->isPrecognitive()) {
             $rules = $this->filterPrecognitiveRules($rules);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -6,11 +6,9 @@ use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
 use Illuminate\Contracts\Validation\Validator;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
@@ -163,11 +161,11 @@ class FoundationFormRequestTest extends TestCase
             );
         });
 
-        $route = new Route('GET','{min}', fn(int $min) => 'ok');
+        $route = new Route('GET', '{min}', fn (int $min) => 'ok');
         $request = FoundationTestFormRequestReceivesRouteParameters::create('10', 'GET', $payload);
         $request->setRedirector($this->createMockRedirector($request))
             ->setContainer($container)
-            ->setRouteResolver(fn() => $route);
+            ->setRouteResolver(fn () => $route);
         $route->bind($request);
 
         $request->validateResolved();


### PR DESCRIPTION
It's pretty common to require route parameters when defining FormRequest rules

```php
class UpdateTagRequest extends FormRequest {
    public function rules()
    {
        return [
            'label' => ['required', string', 'email', Rule::unique(Tag::class)->ignore($this->tag)],
            'color' => [
                Rule::when($this->tag->is_built_in, 'exclude', ['required', 'string', 'in:blue,red,yellow']),
            ]
        ];
    }
}
```
While this works perfectly, static analysis tools are completely lost because `tag` property does not exist in the FormRequest.

There are few alternatives in order to make the analysable and to provide completions : 
1) Use `route` method
```php
class UpdateTagRequest extends FormRequest {
    public function rules()
    {
        return [
            'label' => ['required', string', 'email', Rule::unique(Tag::class)->ignore($this->route('tag'))],
            'color' => [
                Rule::when($this->route('tag')->is_built_in, 'exclude', ['required', 'string', 'in:blue,red,yellow']),
            ]
        ];
    }
}
```
Analyzer won't complain about undefined property `tag` but type of `$this->route('tag')` won't be the one we expect and there will be issues with `$this->route('tag')->is_built_in`

2) Use class docblock
```php
/**
 * @property-read \App\Models\Tag $tag
 */
class UpdateTagRequest extends FormRequest {
    public function rules()
    {
        return [
            'label' => ['required', string', 'email', Rule::unique(Tag::class)->ignore($this->tag)],
            'color' => [
                Rule::when($this->tag->is_built_in, 'exclude', ['required', 'string', 'in:blue,red,yellow']),
            ]
        ];
    }
}
```
It solves analysis issues and provide completions but it feels like cheating with the tools and the information lost in the docblock.

This PR adds the ability to inject route parameters in `FormRequest::rules` in the same way they are injected in the controller.
We will then be able to write
```php
class UpdateTagRequest extends FormRequest {
    public function rules(Tag $tag)
    {
        return [
            'label' => ['required', string', 'email', Rule::unique(Tag::class)->ignore($tag)],
            'color' => [
                Rule::when($tag->is_built_in, 'exclude', ['required', 'string', 'in:blue,red,yellow']),
            ]
        ];
    }
}
```
which solves analysis issues in a more elegant way IMHO.

If this PR is accepted, I will send a follow-up PR for `FormRequest::authorize` method.
