### PR TITLE
[9.x] Partition support for migrations. (PostgreSQL supported)

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -79,6 +79,27 @@ class Blueprint
     public $after;
 
     /**
+     * Column key one for creating a composite key.
+     *
+     * @var bool
+     */
+    public $pkCompositeOne;
+
+    /**
+     * Column key two for creating a composite key.
+     *
+     * @var bool
+     */
+    public $pkCompositeTwo;
+
+    /**
+     * Partition range key for creating a partitioned table.
+     *
+     * @var bool
+     */
+    public $rangeKey;
+
+    /**
      * Create a new schema blueprint.
      *
      * @param  string  $table
@@ -265,7 +286,7 @@ class Blueprint
     public function creating()
     {
         return collect($this->commands)->contains(function ($command) {
-            return $command->name === 'create';
+            return $command->name === 'create' || 'createPartitioned';
         });
     }
 
@@ -277,6 +298,16 @@ class Blueprint
     public function create()
     {
         return $this->addCommand('create');
+    }
+
+    /**
+     * Indicate that the table needs to be created with a partition.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function createPartitioned()
+    {
+        return $this->addCommand('createPartitioned');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -270,17 +270,15 @@ class Builder
     /**
      * Create a new table on the schema with partitions.
      *
-     * @param string $table
-     * @param \Closure $callback
-     * @param string $pkCompositeOne
-     * @param string $pkCompositeTwo
-     * @param string $rangeKey
-     * @return void
+     * @param  string  $table
+     * @param  \Closure  $callback
+     * @param  string  $pkCompositeOne
+     * @param  string  $pkCompositeTwo
+     * @param  string  $rangeKey
      */
     public function createPartitioned($table, Closure $callback, string $pkCompositeOne, string $pkCompositeTwo, string $rangeKey)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint)
-        use ($callback, $pkCompositeOne, $pkCompositeTwo, $rangeKey) {
+        $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback, $pkCompositeOne, $pkCompositeTwo, $rangeKey) {
             $blueprint->createPartitioned();
             $blueprint->pkCompositeOne = $pkCompositeOne;
             $blueprint->pkCompositeTwo = $pkCompositeTwo;

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -268,6 +268,29 @@ class Builder
     }
 
     /**
+     * Create a new table on the schema with partitions.
+     *
+     * @param string $table
+     * @param \Closure $callback
+     * @param string $pkCompositeOne
+     * @param string $pkCompositeTwo
+     * @param string $rangeKey
+     * @return void
+     */
+    public function createPartitioned($table, Closure $callback, string $pkCompositeOne, string $pkCompositeTwo, string $rangeKey)
+    {
+        $this->build(tap($this->createBlueprint($table), function ($blueprint)
+        use ($callback, $pkCompositeOne, $pkCompositeTwo, $rangeKey) {
+            $blueprint->createPartitioned();
+            $blueprint->pkCompositeOne = $pkCompositeOne;
+            $blueprint->pkCompositeTwo = $pkCompositeTwo;
+            $blueprint->rangeKey = $rangeKey;
+
+            $callback($blueprint);
+        }));
+    }
+
+    /**
      * Drop a table from the schema.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -104,8 +104,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a create table command with its partitions.
      *
-     * @param  Blueprint $blueprint
-     * @param  Fluent $command
+     * @param  Blueprint  $blueprint
+     * @param  Fluent  $command
      * @return array
      */
     public function compileCreatePartitioned(Blueprint $blueprint, Fluent $command)
@@ -114,7 +114,7 @@ class PostgresGrammar extends Grammar
             $blueprint->temporary ? 'create temporary' : 'create',
             $this->wrapTable($blueprint),
             sprintf('%s, %s', implode(', ', $this->getColumns($blueprint)),
-                sprintf("primary key (%s, %s)", $blueprint->pkCompositeOne, $blueprint->pkCompositeTwo)),
+                sprintf('primary key (%s, %s)', $blueprint->pkCompositeOne, $blueprint->pkCompositeTwo)),
             $blueprint->rangeKey
 
         )], $this->compileAutoIncrementStartingValues($blueprint))));

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -88,8 +88,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a create table command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return array
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
@@ -102,10 +102,29 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a create table command with its partitions.
+     *
+     * @param Blueprint $blueprint
+     * @param Fluent $command
+     * @return array
+     */
+    public function compileCreatePartitioned(Blueprint $blueprint, Fluent $command)
+    {
+        return array_values(array_filter(array_merge([sprintf('%s table %s (%s) partition by range (%s)',
+            $blueprint->temporary ? 'create temporary' : 'create',
+            $this->wrapTable($blueprint),
+            sprintf('%s, %s', implode(', ', $this->getColumns($blueprint)),
+                sprintf("primary key (%s, %s)", $blueprint->pkCompositeOne, $blueprint->pkCompositeTwo)),
+            $blueprint->rangeKey
+
+        )], $this->compileAutoIncrementStartingValues($blueprint))));
+    }
+
+    /**
      * Compile a column addition command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileAdd(Blueprint $blueprint, Fluent $command)
@@ -119,7 +138,7 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the auto-incrementing column starting values.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param Blueprint $blueprint
      * @return array
      */
     public function compileAutoIncrementStartingValues(Blueprint $blueprint)
@@ -132,8 +151,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a primary key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
@@ -146,8 +165,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a unique key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
@@ -172,8 +191,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a plain index key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
@@ -189,8 +208,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a fulltext index key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      *
      * @throws \RuntimeException
@@ -213,8 +232,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a spatial index key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
@@ -227,8 +246,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a foreign key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileForeign(Blueprint $blueprint, Fluent $command)
@@ -253,8 +272,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop table command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDrop(Blueprint $blueprint, Fluent $command)
@@ -265,8 +284,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop table (if exists) command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDropIfExists(Blueprint $blueprint, Fluent $command)
@@ -342,8 +361,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop column command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
@@ -356,8 +375,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop primary key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
@@ -370,8 +389,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop unique key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
@@ -384,8 +403,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop index command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDropIndex(Blueprint $blueprint, Fluent $command)
@@ -396,8 +415,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop fulltext index command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDropFullText(Blueprint $blueprint, Fluent $command)
@@ -408,8 +427,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop spatial index command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDropSpatialIndex(Blueprint $blueprint, Fluent $command)
@@ -420,8 +439,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop foreign key command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileDropForeign(Blueprint $blueprint, Fluent $command)
@@ -434,8 +453,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a rename table command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileRename(Blueprint $blueprint, Fluent $command)
@@ -448,8 +467,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a rename index command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileRenameIndex(Blueprint $blueprint, Fluent $command)
@@ -483,8 +502,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a comment command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileComment(Blueprint $blueprint, Fluent $command)
@@ -499,8 +518,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a table comment command.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $command
+     * @param Blueprint $blueprint
+     * @param Fluent $command
      * @return string
      */
     public function compileTableComment(Blueprint $blueprint, Fluent $command)
@@ -529,7 +548,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeChar(Fluent $column)
@@ -544,7 +563,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeString(Fluent $column)
@@ -559,7 +578,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a tiny text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeTinyText(Fluent $column)
@@ -570,7 +589,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeText(Fluent $column)
@@ -581,7 +600,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeMediumText(Fluent $column)
@@ -592,7 +611,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeLongText(Fluent $column)
@@ -603,7 +622,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeInteger(Fluent $column)
@@ -614,7 +633,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeBigInteger(Fluent $column)
@@ -625,7 +644,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeMediumInteger(Fluent $column)
@@ -636,7 +655,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeTinyInteger(Fluent $column)
@@ -647,7 +666,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeSmallInteger(Fluent $column)
@@ -659,7 +678,7 @@ class PostgresGrammar extends Grammar
      * Create the column definition for a generatable column.
      *
      * @param  string  $type
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function generatableColumn($type, Fluent $column)
@@ -693,7 +712,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeFloat(Fluent $column)
@@ -704,7 +723,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeDouble(Fluent $column)
@@ -715,7 +734,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a real type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeReal(Fluent $column)
@@ -726,7 +745,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeDecimal(Fluent $column)
@@ -737,7 +756,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeBoolean(Fluent $column)
@@ -748,7 +767,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeEnum(Fluent $column)
@@ -763,7 +782,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeJson(Fluent $column)
@@ -774,7 +793,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeJsonb(Fluent $column)
@@ -785,7 +804,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeDate(Fluent $column)
@@ -796,7 +815,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeDateTime(Fluent $column)
@@ -807,7 +826,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date-time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeDateTimeTz(Fluent $column)
@@ -818,7 +837,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeTime(Fluent $column)
@@ -829,7 +848,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeTimeTz(Fluent $column)
@@ -840,7 +859,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeTimestamp(Fluent $column)
@@ -853,7 +872,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a timestamp (with time zone) type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeTimestampTz(Fluent $column)
@@ -866,7 +885,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeYear(Fluent $column)
@@ -877,7 +896,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a binary type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeBinary(Fluent $column)
@@ -888,7 +907,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeUuid(Fluent $column)
@@ -899,7 +918,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeIpAddress(Fluent $column)
@@ -910,7 +929,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeMacAddress(Fluent $column)
@@ -921,7 +940,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeGeometry(Fluent $column)
@@ -932,7 +951,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typePoint(Fluent $column)
@@ -943,7 +962,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeLineString(Fluent $column)
@@ -954,7 +973,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typePolygon(Fluent $column)
@@ -965,7 +984,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeGeometryCollection(Fluent $column)
@@ -976,7 +995,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeMultiPoint(Fluent $column)
@@ -987,7 +1006,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     public function typeMultiLineString(Fluent $column)
@@ -998,7 +1017,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeMultiPolygon(Fluent $column)
@@ -1009,7 +1028,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygonZ type.
      *
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     protected function typeMultiPolygonZ(Fluent $column)
@@ -1021,7 +1040,7 @@ class PostgresGrammar extends Grammar
      * Format the column definition for a PostGIS spatial type.
      *
      * @param  string  $type
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Fluent $column
      * @return string
      */
     private function formatPostGisType($type, Fluent $column)
@@ -1040,8 +1059,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a collation column modifier.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Blueprint $blueprint
+     * @param Fluent $column
      * @return string|null
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
@@ -1054,8 +1073,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a nullable column modifier.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Blueprint $blueprint
+     * @param Fluent $column
      * @return string|null
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
@@ -1066,8 +1085,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a default column modifier.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Blueprint $blueprint
+     * @param Fluent $column
      * @return string|null
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
@@ -1080,8 +1099,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for an auto-increment column modifier.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Blueprint $blueprint
+     * @param Fluent $column
      * @return string|null
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
@@ -1094,8 +1113,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a generated virtual column modifier.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Blueprint $blueprint
+     * @param Fluent $column
      * @return string|null
      */
     protected function modifyVirtualAs(Blueprint $blueprint, Fluent $column)
@@ -1108,8 +1127,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a generated stored column modifier.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
-     * @param  \Illuminate\Support\Fluent  $column
+     * @param Blueprint $blueprint
+     * @param Fluent $column
      * @return string|null
      */
     protected function modifyStoredAs(Blueprint $blueprint, Fluent $column)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -88,8 +88,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a create table command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return array
      */
     public function compileCreate(Blueprint $blueprint, Fluent $command)
@@ -104,9 +104,9 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a create table command with its partitions.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
-     * @return array
+     * @param  Blueprint $blueprint
+     * @param  Fluent $command
+     * @return  array
      */
     public function compileCreatePartitioned(Blueprint $blueprint, Fluent $command)
     {
@@ -123,8 +123,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a column addition command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileAdd(Blueprint $blueprint, Fluent $command)
@@ -138,7 +138,7 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the auto-incrementing column starting values.
      *
-     * @param Blueprint $blueprint
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @return array
      */
     public function compileAutoIncrementStartingValues(Blueprint $blueprint)
@@ -151,8 +151,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a primary key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compilePrimary(Blueprint $blueprint, Fluent $command)
@@ -165,8 +165,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a unique key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileUnique(Blueprint $blueprint, Fluent $command)
@@ -191,8 +191,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a plain index key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileIndex(Blueprint $blueprint, Fluent $command)
@@ -208,8 +208,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a fulltext index key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      *
      * @throws \RuntimeException
@@ -232,8 +232,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a spatial index key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileSpatialIndex(Blueprint $blueprint, Fluent $command)
@@ -246,8 +246,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a foreign key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileForeign(Blueprint $blueprint, Fluent $command)
@@ -272,8 +272,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop table command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDrop(Blueprint $blueprint, Fluent $command)
@@ -284,8 +284,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop table (if exists) command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropIfExists(Blueprint $blueprint, Fluent $command)
@@ -361,8 +361,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop column command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
@@ -375,8 +375,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop primary key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropPrimary(Blueprint $blueprint, Fluent $command)
@@ -389,8 +389,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop unique key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
@@ -403,8 +403,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop index command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropIndex(Blueprint $blueprint, Fluent $command)
@@ -415,8 +415,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop fulltext index command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropFullText(Blueprint $blueprint, Fluent $command)
@@ -427,8 +427,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop spatial index command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropSpatialIndex(Blueprint $blueprint, Fluent $command)
@@ -439,8 +439,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a drop foreign key command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileDropForeign(Blueprint $blueprint, Fluent $command)
@@ -453,8 +453,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a rename table command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileRename(Blueprint $blueprint, Fluent $command)
@@ -467,8 +467,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a rename index command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileRenameIndex(Blueprint $blueprint, Fluent $command)
@@ -502,8 +502,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a comment command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileComment(Blueprint $blueprint, Fluent $command)
@@ -518,8 +518,8 @@ class PostgresGrammar extends Grammar
     /**
      * Compile a table comment command.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
     public function compileTableComment(Blueprint $blueprint, Fluent $command)
@@ -548,7 +548,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a char type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeChar(Fluent $column)
@@ -563,7 +563,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a string type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeString(Fluent $column)
@@ -578,7 +578,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a tiny text type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTinyText(Fluent $column)
@@ -589,7 +589,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a text type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeText(Fluent $column)
@@ -600,7 +600,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a medium text type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeMediumText(Fluent $column)
@@ -611,7 +611,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a long text type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeLongText(Fluent $column)
@@ -622,7 +622,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an integer type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeInteger(Fluent $column)
@@ -633,7 +633,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a big integer type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeBigInteger(Fluent $column)
@@ -644,7 +644,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a medium integer type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeMediumInteger(Fluent $column)
@@ -655,7 +655,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a tiny integer type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTinyInteger(Fluent $column)
@@ -666,7 +666,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a small integer type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeSmallInteger(Fluent $column)
@@ -678,7 +678,7 @@ class PostgresGrammar extends Grammar
      * Create the column definition for a generatable column.
      *
      * @param  string  $type
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function generatableColumn($type, Fluent $column)
@@ -712,7 +712,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a float type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeFloat(Fluent $column)
@@ -723,7 +723,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a double type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeDouble(Fluent $column)
@@ -734,7 +734,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a real type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeReal(Fluent $column)
@@ -745,7 +745,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a decimal type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeDecimal(Fluent $column)
@@ -756,7 +756,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a boolean type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeBoolean(Fluent $column)
@@ -767,7 +767,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an enumeration type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeEnum(Fluent $column)
@@ -782,7 +782,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a json type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeJson(Fluent $column)
@@ -793,7 +793,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a jsonb type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeJsonb(Fluent $column)
@@ -804,7 +804,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeDate(Fluent $column)
@@ -815,7 +815,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date-time type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeDateTime(Fluent $column)
@@ -826,7 +826,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a date-time (with time zone) type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeDateTimeTz(Fluent $column)
@@ -837,7 +837,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a time type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTime(Fluent $column)
@@ -848,7 +848,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a time (with time zone) type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimeTz(Fluent $column)
@@ -859,7 +859,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a timestamp type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimestamp(Fluent $column)
@@ -872,7 +872,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a timestamp (with time zone) type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeTimestampTz(Fluent $column)
@@ -885,7 +885,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a year type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeYear(Fluent $column)
@@ -896,7 +896,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a binary type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeBinary(Fluent $column)
@@ -907,7 +907,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a uuid type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeUuid(Fluent $column)
@@ -918,7 +918,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for an IP address type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeIpAddress(Fluent $column)
@@ -929,7 +929,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a MAC address type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeMacAddress(Fluent $column)
@@ -940,7 +940,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Geometry type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeGeometry(Fluent $column)
@@ -951,7 +951,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Point type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typePoint(Fluent $column)
@@ -962,7 +962,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial LineString type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeLineString(Fluent $column)
@@ -973,7 +973,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial Polygon type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typePolygon(Fluent $column)
@@ -984,7 +984,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial GeometryCollection type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeGeometryCollection(Fluent $column)
@@ -995,7 +995,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPoint type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeMultiPoint(Fluent $column)
@@ -1006,7 +1006,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiLineString type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     public function typeMultiLineString(Fluent $column)
@@ -1017,7 +1017,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygon type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeMultiPolygon(Fluent $column)
@@ -1028,7 +1028,7 @@ class PostgresGrammar extends Grammar
     /**
      * Create the column definition for a spatial MultiPolygonZ type.
      *
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     protected function typeMultiPolygonZ(Fluent $column)
@@ -1040,7 +1040,7 @@ class PostgresGrammar extends Grammar
      * Format the column definition for a PostGIS spatial type.
      *
      * @param  string  $type
-     * @param Fluent $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     private function formatPostGisType($type, Fluent $column)
@@ -1059,8 +1059,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a collation column modifier.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $column
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
@@ -1073,8 +1073,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a nullable column modifier.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $column
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
@@ -1085,8 +1085,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a default column modifier.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $column
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
@@ -1099,8 +1099,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for an auto-increment column modifier.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $column
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
@@ -1113,8 +1113,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a generated virtual column modifier.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $column
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
      */
     protected function modifyVirtualAs(Blueprint $blueprint, Fluent $column)
@@ -1127,8 +1127,8 @@ class PostgresGrammar extends Grammar
     /**
      * Get the SQL for a generated stored column modifier.
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $column
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string|null
      */
     protected function modifyStoredAs(Blueprint $blueprint, Fluent $column)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -106,7 +106,7 @@ class PostgresGrammar extends Grammar
      *
      * @param  Blueprint $blueprint
      * @param  Fluent $command
-     * @return  array
+     * @return array
      */
     public function compileCreatePartitioned(Blueprint $blueprint, Fluent $command)
     {

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Database\Schema\Builder create(string $table, \Closure $callback)
+ * @method static \Illuminate\Database\Schema\Builder createPartitioned(string $table, \Closure $callback, string $pkCompositeOne, string $pkCompositeTwo, string $rangeKey)
  * @method static \Illuminate\Database\Schema\Builder createDatabase(string $name)
  * @method static \Illuminate\Database\Schema\Builder disableForeignKeyConstraints()
  * @method static \Illuminate\Database\Schema\Builder drop(string $table)


### PR DESCRIPTION
Additions:
- Added logic to PostgresGrammar.php for partition creation while generating tables. 
- Added logic for compile command creation. 
- Added builder link to support facade.
- Added extra parameters for dynamic partition creation while defining the migration.

In order to work with partitions, PostgreSQL requires tables to be created as "partitioned table", and it's impossible to convert a regular table into a partitioned one. Solutions on the internet show that people use raw queries to make their tables when they are using  Laravel and PostgreSQL. They lose the beauty of Laravel and its features. If this feature is implemented, users can use the new Schema static method to create their partitioned table. 