### PR TITLE
[9.x] only load trashed models on relevant routes

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -106,7 +106,7 @@ class ResourceRegistrar
             }
 
             if (isset($options['trashed']) &&
-                in_array($m, ! empty($options['trashed']) ? $options['trashed'] : $resourceMethods)) {
+                in_array($m, ! empty($options['trashed']) ? $options['trashed'] : array_intersect($resourceMethods, ['show', 'edit', 'update']))) {
                 $route->withTrashed();
             }
 


### PR DESCRIPTION
As I was writing the docs for #44405, I came to the realization it didn't make a lot of sense to load trashed models for some of the default resource routes.  This PR will make it so calling `->withTrashed()` with no arguments only loads trashed models on the `show`, `edit`, and `update` routes.

- `index`, `create`, and `store` don't use route model binding, so from a performance and simplicity standpoint, we don't need to load those routes with trashed models
- it doesn't make a lot of sense to load soft deleted models on the `destroy` route.

Curious to hear if there'd be any argument for continuing to load soft deleted models on the `destroy` route.

If this gets merged before next Tuesday's release we'll be okay keeping this on 9.x, since it's technically a breaking change.

If this gets merged I'll need to make a minor adjustment to https://github.com/laravel/docs/pull/8277