### PR TITLE
[9.x] Add test for explode method

### DIFF
--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -944,6 +944,18 @@ class SupportStringableTest extends TestCase
         $this->assertSame('❤MultiByte☆     ', (string) $this->stringable('❤MultiByte☆')->padRight(16));
     }
 
+    public function testExplode()
+    {
+        $this->assertInstanceOf(Collection::class, $this->stringable("Foo Bar Baz")->explode(" "));
+        
+        $this->assertSame('["Foo","Bar","Baz"]', (string) $this->stringable("Foo Bar Baz")->explode(" "));
+        
+        //  with limit
+        $this->assertSame('["Foo","Bar Baz"]', (string) $this->stringable("Foo Bar Baz")->explode(" ", 2));
+        $this->assertSame('["Foo","Bar"]', (string) $this->stringable("Foo Bar Baz")->explode(" ", -1));
+
+    }
+    
     public function testChunk()
     {
         $chunks = $this->stringable('foobarbaz')->split(3);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
in this PR, add test for `explode` method in `SupportStringableTest.php`