### PR TITLE
[9.x] Makes Blade inline components 10x faster. ⛽️

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -99,12 +99,14 @@ abstract class Component
      */
     protected function extractBladeViewFromString($factory, $contents)
     {
-        if (isset(static::$bladeViewCache[$contents])) {
-            return static::$bladeViewCache[$contents];
+        $key = sprintf('%s::%s', static::class, $contents);
+
+        if (isset(static::$bladeViewCache[$key])) {
+            return static::$bladeViewCache[$key];
         }
 
         if (strlen($contents) <= PHP_MAXPATHLEN && $factory->exists($contents)) {
-            return static::$bladeViewCache[$contents] = $contents;
+            return static::$bladeViewCache[$key] = $contents;
         }
 
         $factory->addNamespace(
@@ -120,7 +122,7 @@ abstract class Component
             file_put_contents($viewFile, $contents);
         }
 
-        return static::$bladeViewCache[$contents] = '__components::'.basename($viewFile, '.blade.php');
+        return static::$bladeViewCache[$key] = '__components::'.basename($viewFile, '.blade.php');
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -27,7 +27,7 @@ abstract class Component
     protected static $methodCache = [];
 
     /**
-     * The cache of blade view names, keyed by class.
+     * The cache of blade view names, keyed by contents.
      *
      * @var array
      */
@@ -81,7 +81,7 @@ abstract class Component
         $resolver = function ($view) {
             $factory = Container::getInstance()->make('view');
 
-            return $this->extractBladeViewFromString($factory, $view);
+            return $this->extractBladeViewFromString($factory, (string) $view);
         };
 
         return $view instanceof Closure ? function (array $data = []) use ($view, $resolver) {
@@ -99,14 +99,12 @@ abstract class Component
      */
     protected function extractBladeViewFromString($factory, $contents)
     {
-        $class = get_class($this);
-
-        if (isset(static::$bladeViewCache[$class])) {
-            return static::$bladeViewCache[$class];
+        if (isset(static::$bladeViewCache[$contents])) {
+            return static::$bladeViewCache[$contents];
         }
 
         if (strlen($contents) <= PHP_MAXPATHLEN && $factory->exists($contents)) {
-            return static::$bladeViewCache[$class] = $contents;
+            return static::$bladeViewCache[$contents] = $contents;
         }
 
         $factory->addNamespace(
@@ -122,7 +120,7 @@ abstract class Component
             file_put_contents($viewFile, $contents);
         }
 
-        return static::$bladeViewCache[$class] = '__components::'.basename($viewFile, '.blade.php');
+        return static::$bladeViewCache[$contents] = '__components::'.basename($viewFile, '.blade.php');
     }
 
     /**
@@ -306,5 +304,17 @@ abstract class Component
     public function shouldRender()
     {
         return true;
+    }
+
+    /**
+     * Flush the cache of components.
+     *
+     * @return void
+     */
+    public static function flushCache()
+    {
+        static::$propertyCache = [];
+        static::$methodCache = [];
+        static::$bladeViewCache = [];
     }
 }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -9,6 +9,13 @@ use Orchestra\Testbench\TestCase;
 
 class BladeTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        Component::flushCache();
+
+        parent::tearDown();
+    }
+
     public function test_rendering_blade_string()
     {
         $this->assertSame('Hello Taylor', Blade::render('Hello {{ $name }}', ['name' => 'Taylor']));


### PR DESCRIPTION
This pull request is a work in progress, and it makes rendering Blade inline components nearly **10x faster**. So, assuming the following environment:

```php
class Button extends Component
{
    function __construct(public $number) {}

    function render() { return <<<'blade'
        <div class="alert alert-danger">
            {{ $number }}
        </div>
    blade; }
}

// and welcome.blade.php
@for ($i = 0; $i < $numberOfComponents; $i++)
    <x-button :number="$i" />
@endfor

// before:
- 1 component: 3.332ms
- 10 components: 5.010ms
- 100 components: 47.670ms
- 1000 components: 482.629ms // 0.5 seconds ...
- 10000 components: 5,046.893ms // 5 seconds ...

// after:
- 1 component: 3.296ms
- 10 components: 0.875ms
- 100 components: 7.285ms
- 1000 components: 65.646ms // 0,06 seconds
- 10000 components: 642.549ms // 0,6 seconds
```

~~Important note: this pull request assumes static content being returned from the Component::render. If we think this may not be the case for some users. We will need to adjust this pull request.~~