### PR TITLE
[9.x] Add validation rules to check the between, maximum and minimum of the…

### DIFF
--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -8,6 +8,9 @@ use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
+use Illuminate\Validation\Rules\MaxFilesSize;
+use Illuminate\Validation\Rules\MinFilesSize;
+use Illuminate\Validation\Rules\BetweenFilesSize;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
@@ -137,5 +140,39 @@ class Rule
     public static function unique($table, $column = 'NULL')
     {
         return new Unique($table, $column);
+    }
+
+    /**
+     * Get a max multi files size constraint builder instance.
+     *
+     * @param  int  $size
+     * @return MaxFilesSize
+     */
+    public static function maxFilesSize(int $size): MaxFilesSize
+    {
+        return new MaxFilesSize($size);
+    }
+
+    /**
+     * Get a min multi files size constraint builder instance.
+     *
+     * @param  int  $size
+     * @return MinFilesSize
+     */
+    public static function minFilesSize(int $size): MinFilesSize
+    {
+        return new MinFilesSize($size);
+    }
+
+    /**
+     * Get a between multi files size constraint builder instance.
+     *
+     * @param  int $minSize
+     * @param  int $maxSize
+     * @return BetweenFilesSize
+     */
+    public static function betweenFilesSize(int $minSize, int $maxSize): BetweenFilesSize
+    {
+        return new BetweenFilesSize($minSize, $maxSize);
     }
 }

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,13 +4,13 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\BetweenFilesSize;
 use Illuminate\Validation\Rules\Dimensions;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\MaxFilesSize;
 use Illuminate\Validation\Rules\MinFilesSize;
-use Illuminate\Validation\Rules\BetweenFilesSize;
 use Illuminate\Validation\Rules\NotIn;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
@@ -167,8 +167,8 @@ class Rule
     /**
      * Get a between multi files size constraint builder instance.
      *
-     * @param  int $minSize
-     * @param  int $maxSize
+     * @param  int  $minSize
+     * @param  int  $maxSize
      * @return BetweenFilesSize
      */
     public static function betweenFilesSize(int $minSize, int $maxSize): BetweenFilesSize

--- a/src/Illuminate/Validation/Rules/BetweenFilesSize.php
+++ b/src/Illuminate/Validation/Rules/BetweenFilesSize.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class BetweenFilesSize implements Rule
+{
+    protected int $maxSize;
+    protected int $minSize;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct(int $minSize, int $maxSize)
+    {
+        $this->minSize = $minSize * 1024;
+        $this->maxSize = $maxSize * 1024;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $totalSize = 0;
+        foreach ($value as $file) {
+            $totalSize += filesize($file);
+        }
+
+        return $totalSize >= $this->minSize && $totalSize <= $this->maxSize;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The Files Size Should be between ' . $this->minSize / 1048576 . ' MegaByte and ' . $this->maxSize / 1048576 . ' MegaByte';
+    }
+}

--- a/src/Illuminate/Validation/Rules/BetweenFilesSize.php
+++ b/src/Illuminate/Validation/Rules/BetweenFilesSize.php
@@ -23,8 +23,8 @@ class BetweenFilesSize implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed $value
+     * @param  string  $attribute
+     * @param  mixed  $value
      * @return bool
      */
     public function passes($attribute, $value)
@@ -44,6 +44,6 @@ class BetweenFilesSize implements Rule
      */
     public function message()
     {
-        return 'The Files Size Should be between ' . $this->minSize / 1048576 . ' MegaByte and ' . $this->maxSize / 1048576 . ' MegaByte';
+        return 'The Files Size Should be between '.$this->minSize / 1048576 .' MegaByte and '.$this->maxSize / 1048576 .' MegaByte';
     }
 }

--- a/src/Illuminate/Validation/Rules/MaxFilesSize.php
+++ b/src/Illuminate/Validation/Rules/MaxFilesSize.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class MaxFilesSize implements Rule
+{
+    protected int $maxSize;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct($maxSize)
+    {
+        $this->maxSize = $maxSize * 1024;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        $totalSize = 0;
+        foreach ($value as $file) {
+            $totalSize += filesize($file);
+        }
+
+        return $totalSize <= $this->maxSize;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message(): string
+    {
+        return 'The Files Size Should be less than or equal ' . $this->maxSize / 1048576 . ' MegaByte';
+    }
+}

--- a/src/Illuminate/Validation/Rules/MaxFilesSize.php
+++ b/src/Illuminate/Validation/Rules/MaxFilesSize.php
@@ -21,8 +21,8 @@ class MaxFilesSize implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed $value
+     * @param  string  $attribute
+     * @param  mixed  $value
      * @return bool
      */
     public function passes($attribute, $value): bool
@@ -42,6 +42,6 @@ class MaxFilesSize implements Rule
      */
     public function message(): string
     {
-        return 'The Files Size Should be less than or equal ' . $this->maxSize / 1048576 . ' MegaByte';
+        return 'The Files Size Should be less than or equal '.$this->maxSize / 1048576 .' MegaByte';
     }
 }

--- a/src/Illuminate/Validation/Rules/MinFilesSize.php
+++ b/src/Illuminate/Validation/Rules/MinFilesSize.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class MinFilesSize implements Rule
+{
+    protected int $minSize;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct($minSize)
+    {
+        $this->minSize = $minSize * 1024;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function passes($attribute, $value): bool
+    {
+        $totalSize = 0;
+        foreach ($value as $file) {
+            $totalSize += filesize($file);
+        }
+
+        return $totalSize >= $this->minSize;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message(): string
+    {
+        return 'The Files Size Should be more than or equal ' . $this->minSize / 1048576 . ' MegaByte';
+    }
+}

--- a/src/Illuminate/Validation/Rules/MinFilesSize.php
+++ b/src/Illuminate/Validation/Rules/MinFilesSize.php
@@ -21,8 +21,8 @@ class MinFilesSize implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed $value
+     * @param  string  $attribute
+     * @param  mixed  $value
      * @return bool
      */
     public function passes($attribute, $value): bool
@@ -42,6 +42,6 @@ class MinFilesSize implements Rule
      */
     public function message(): string
     {
-        return 'The Files Size Should be more than or equal ' . $this->minSize / 1048576 . ' MegaByte';
+        return 'The Files Size Should be more than or equal '.$this->minSize / 1048576 .' MegaByte';
     }
 }


### PR DESCRIPTION
### Our Chalange

We wanted to validate that the total size of an array of files should be less than or equal to 10 MegaBytes but there was only the max validation which is apply only to the size of one file, not an array so we came up with these brand new validation features to support this kind of validation (dealing with an array of files):

### Features

- **Min Multiple Files Size**

Parameter: min size (in bytes)
ex: if you have an array of files and you want to check that the total size of these files should be greater than or equal to size ( 2 MB) and there is no validation rule to handle this case but now you could use the "minFilesSize" function rule.

` Rule::minFilesSize(2048)`

- **Max Multiple Files Size**

Parameter: max size (in bytes)
ex: if you have an array of files and you want to check that the total size of these files should be less than or equal to size ( 10 MB) and there is no validation rule to handle this case but now you could use the "`maxFilesSize`" function rule.

` Rule::maxFilesSize(10240)`

- **Between Multiple Files Size**

Parameter: min size (in bytes), max size (in bytes)
ex: if you have an array of files and you want to check that the total size of these files should be between two sizes the min (2 MB) and max( 10 MB) and there is no validation rule to handle this case but now you could use the "`betweenFilesSize`" function rule.

`Rule::betweenFilesSize(2048, 10240)`
### Benefits

- You will find it as built-in validation rules features and you don't have to create them as custom rules.
- Now you could deal easily with an array of multi files and validate the size of these files by using one of the three rule functions

### Author
Youssof Okiel

### Co-author
Fady Ibrahim @FadySobhy

