### PR TITLE
Add except method to HasAttributes trait.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1825,6 +1825,21 @@ trait HasAttributes
     }
 
     /**
+     * Get all of the model's visible attributes except specified attributes.
+     * Does not return any attributes marked as hidden.
+     *
+     * @param  array|mixed  $attributes
+     * @return array
+     */
+    public function except($attributes)
+    {
+        $modelAsArray = array_merge($this->attributesToArray(), $this->relationsToArray());
+        $excludedAttributes = is_array($attributes) ? $attributes : func_get_args();
+
+        return Arr::except($modelAsArray, $excludedAttributes);
+    }
+
+    /**
      * Sync the original attributes with the current.
      *
      * @return $this

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -372,6 +372,27 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
     }
 
+    public function testExcept()
+    {
+        // Arrange
+        $model = new EloquentModelDynamicHiddenStub();
+        $model->first_name = 'taylor';
+        $model->last_name = 'otwell';
+        $model->project = 'laravel';
+        // Hidden 'age' attribute
+        $model->age = 30;
+
+        // Act
+        $exceptUsingOneField = $model->except('project');
+        $exceptUsingFieldsInCommaDelimitedList = $model->except('first_name', 'project');
+        $exceptUsingFieldsInArray = $model->except(['first_name', 'project']);
+
+        // Assert
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $exceptUsingOneField);
+        $this->assertEquals(['last_name' => 'otwell'], $exceptUsingFieldsInCommaDelimitedList);
+        $this->assertEquals(['last_name' => 'otwell'], $exceptUsingFieldsInArray);
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Adds a method `except($attributes)` to HasAttributes.

This is roughly an inverse to the existing method, `only($attributes)` with a nearly identical signature.

It is useful in cases where you have a Model and would to get the fields as an array, however there are a limited number of fields that would otherwise be returned when calling `toArray()` that you wish to exclude.

This method can be used  in lieu of temporarily adding fields to the `$hidden` fields on the Model, and has a cleaner appearance than existing methods of performing the described filtering.

Example:

```php
// Usage
$user->except('id', 'email');

// Or
$user->except(['id', 'email']);

// Is equivalent to 
Arr::except($user->toArray(), ['id', 'email']);
```