### PR TITLE
[9.x] Add test for dirname method

### DIFF
--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -173,6 +173,20 @@ class SupportStringableTest extends TestCase
             return $stringable->studly();
         }));
     }
+    
+    public function testDirname()
+    {
+        $this->assertSame('/framework/tests', (string) $this->stringable('/framework/tests/Support')->dirname());
+        $this->assertSame('/framework', (string) $this->stringable('/framework/tests/Support')->dirname(2));
+        
+        $this->assertSame('/', (string) $this->stringable('/framework/')->dirname());
+        
+        $this->assertSame('/', (string) $this->stringable('/')->dirname());
+        $this->assertSame('.', (string) $this->stringable('.')->dirname());
+        
+        //  without slash
+        $this->assertSame('.', (string) $this->stringable('framework')->dirname());
+    }
 
     public function testUcsplitOnStringable()
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
in this PR, add test for `dirname` method in `SupportStringableTest.php`