### PR TITLE
build Mailables when mocking mails

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Testing\Fakes;
 
 use Closure;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Factory;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
@@ -360,6 +361,10 @@ class MailFake implements Factory, Mailer, MailQueue
             return;
         }
 
+        if (method_exists($view, 'build')) {
+            Container::getInstance()->call([$view, 'build']);
+        }
+
         $view->mailer($this->currentMailer);
 
         if ($view instanceof ShouldQueue) {
@@ -382,6 +387,10 @@ class MailFake implements Factory, Mailer, MailQueue
     {
         if (! $view instanceof Mailable) {
             return;
+        }
+
+        if (method_exists($view, 'build')) {
+            Container::getInstance()->call([$view, 'build']);
         }
 
         $view->mailer($this->currentMailer);

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -63,6 +63,14 @@ class SupportTestingMailFakeTest extends TestCase
         });
     }
 
+    public function testAssertFrom() {
+        $this->fake->to('taylor@laravel.com')->send($this->mailable);
+
+        $this->fake->assertSent(MailableStub::class, function($mail) {
+            return $mail->hasFrom('from@laravel.com');
+        });
+    }
+
     public function testAssertCc()
     {
         $this->fake->cc('taylor@laravel.com')->send($this->mailable);
@@ -138,6 +146,23 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
         $this->fake->assertQueued(MailableStub::class);
+    }
+
+    public function testAssertQueuedFrom() {
+        try {
+            $this->fake->assertQueued(MailableStub::class, function($mail) {
+                return $mail->hasFrom('from@laravel.com');
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\MailableStub] mailable was not queued.'));
+        }
+
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        $this->fake->assertQueued(MailableStub::class, function($mail) {
+            return $mail->hasFrom('from@laravel.com');
+        });
     }
 
     public function testAssertQueuedTimes()
@@ -230,7 +255,8 @@ class MailableStub extends Mailable
     public function build()
     {
         $this->with('first_name', 'Taylor')
-             ->withLastName('Otwell');
+             ->withLastName('Otwell')
+             ->from('from@laravel.com');
     }
 }
 
@@ -248,7 +274,8 @@ class QueueableMailableStub extends Mailable implements ShouldQueue
     public function build()
     {
         $this->with('first_name', 'Taylor')
-             ->withLastName('Otwell');
+             ->withLastName('Otwell')
+             ->from('from@laravel.com');
     }
 }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -63,10 +63,11 @@ class SupportTestingMailFakeTest extends TestCase
         });
     }
 
-    public function testAssertFrom() {
+    public function testAssertFrom()
+    {
         $this->fake->to('taylor@laravel.com')->send($this->mailable);
 
-        $this->fake->assertSent(MailableStub::class, function($mail) {
+        $this->fake->assertSent(MailableStub::class, function ($mail) {
             return $mail->hasFrom('from@laravel.com');
         });
     }
@@ -148,9 +149,10 @@ class SupportTestingMailFakeTest extends TestCase
         $this->fake->assertQueued(MailableStub::class);
     }
 
-    public function testAssertQueuedFrom() {
+    public function testAssertQueuedFrom()
+    {
         try {
-            $this->fake->assertQueued(MailableStub::class, function($mail) {
+            $this->fake->assertQueued(MailableStub::class, function ($mail) {
                 return $mail->hasFrom('from@laravel.com');
             });
             $this->fail();
@@ -160,7 +162,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->to('taylor@laravel.com')->queue($this->mailable);
 
-        $this->fake->assertQueued(MailableStub::class, function($mail) {
+        $this->fake->assertQueued(MailableStub::class, function ($mail) {
             return $mail->hasFrom('from@laravel.com');
         });
     }


### PR DESCRIPTION
According to the [documentation](https://laravel.com/docs/9.x/mocking#mail-fake) you should be able to fetch the variables (from, cc, etc) defined during the build of the Mailable, however this never gets run when mocking the mail.

This PR should fix https://github.com/laravel/framework/issues/44486 and might also be relevant for https://github.com/laravel/framework/pull/44462

First time submitting a PR to Laravel - so please let me know if there's something more I can do.
