### PR TITLE
[9.x] update database migration creator constructor customStubPath

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -37,7 +37,7 @@ class MigrationCreator
      * @param  string  $customStubPath
      * @return void
      */
-    public function __construct(Filesystem $files, $customStubPath)
+    public function __construct(Filesystem $files, string $customStubPath = '')
     {
         $this->files = $files;
         $this->customStubPath = $customStubPath;


### PR DESCRIPTION
The customStubPath is set with a phpDoc as String but without the type defined on the function and is setted as an obrigatory param, this make we obligated to, when extending the class, to give a value for this param.

On this fix we don't need anymore to give the customStubPath, it just sets as a empty string, which on future usage on the same class, search for the path or takes the default stub path and just don't break anything.

When don't given the customStubPath, it just goes to the default `/src/Illuminate/Database/Migrations/stubs/` folder


Come accross the error today and tought about this to be my first contribution 😄  _(First of many, i hope)_