### PR TITLE
Fluent envelope methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Release Notes for 9.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.32.0...9.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.33.0...9.x)
+
+
+## [v9.33.0](https://github.com/laravel/framework/compare/v9.32.0...v9.33.0) - 2022-09-30
+
+### Added
+- Added `Illuminate/Support/Testing/Fakes/MailFake::cc()` ([#44319](https://github.com/laravel/framework/pull/44319))
+- Added Ignore Case of Str::contains and Str::containsAll to Stringable contains and containsAll ([#44369](https://github.com/laravel/framework/pull/44369))
+- Added missing morphs methods for the ULID support ([#44364](https://github.com/laravel/framework/pull/44364))
+- Introduce Laravel Precognition ([#44339](https://github.com/laravel/framework/pull/44339))
+- Added `Illuminate/Routing/Route::flushController()` ([#44386](https://github.com/laravel/framework/pull/44386))
+
+### Fixed
+- Fixes memory leak on PHPUnit's Annotations registry ([#44324](https://github.com/laravel/framework/pull/44324), [#44336](https://github.com/laravel/framework/pull/44336))
+- Fixed `Illuminate/Filesystem/FilesystemAdapter::url()` with config `prefix` ([#44330](https://github.com/laravel/framework/pull/44330))
+- Fixed the "Implicit conversion from float to int loses precision" error in Timebox Class ([#44357](https://github.com/laravel/framework/pull/44357))
+
+### Changed
+- Improves dd source on compiled views ([#44347](https://github.com/laravel/framework/pull/44347))
+- Only prints source on dd calls from dump.php ([#44367](https://github.com/laravel/framework/pull/44367))
+- Ensures a Carbon version that supports PHP 8.2 ([#44374](https://github.com/laravel/framework/pull/44374))
 
 
 ## [v9.32.0](https://github.com/laravel/framework/compare/v9.31.0...v9.32.0) - 2022-09-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Release Notes for 9.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.33.0...9.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.34.0...9.x)
+
+
+## [v9.34.0](https://github.com/laravel/framework/compare/v9.33.0...v9.34.0) - 2022-10-04
+
+### Added
+- Short attribute syntax for Self Closing Blade Components ([#44413](https://github.com/laravel/framework/pull/44413))
+- Adds support for PHP's BackedEnum to be "rendered" on blade views ([#44445](https://github.com/laravel/framework/pull/44445))
+
+### Fixed
+- Fixed Precognition headers for Symfony responses ([#44424](https://github.com/laravel/framework/pull/44424))
+- Allow to create databases with dots ([#44436](https://github.com/laravel/framework/pull/44436))
+- Fixes dd source on windows ([#44451](https://github.com/laravel/framework/pull/44451))
+
+### Changed
+- Adds error output to db command when missing host ([#44394](https://github.com/laravel/framework/pull/44394))
+- Changed `Illuminate/Database/Schema/ForeignIdColumnDefinition::constrained()` ([#44425](https://github.com/laravel/framework/pull/44425))
+- Allow maintenance mode events to be listened to in closure based listeners ([#44417](https://github.com/laravel/framework/pull/44417))
+- Allow factories to recycle multiple models of a given typ ([#44328](https://github.com/laravel/framework/pull/44328))
+- Improves dd clickable link on multiple editors and docker environments ([#44406](https://github.com/laravel/framework/pull/44406))
 
 
 ## [v9.33.0](https://github.com/laravel/framework/compare/v9.32.0...v9.33.0) - 2022-09-30

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -980,12 +980,12 @@ trait EnumeratesValues
             return $items->all();
         } elseif ($items instanceof Arrayable) {
             return $items->toArray();
+        } elseif ($items instanceof Traversable) {
+            return iterator_to_array($items);
         } elseif ($items instanceof Jsonable) {
             return json_decode($items->toJson(), true);
         } elseif ($items instanceof JsonSerializable) {
             return (array) $items->jsonSerialize();
-        } elseif ($items instanceof Traversable) {
-            return iterator_to_array($items);
         } elseif ($items instanceof UnitEnum) {
             return [$items];
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -167,11 +167,11 @@ trait HasTimestamps
      * Disable timestamps for the current class during the given callback scope.
      *
      * @param  callable  $callback
-     * @return void
+     * @return mixed
      */
     public static function withoutTimestamps(callable $callback)
     {
-        static::withoutTimestampsOn([static::class], $callback);
+        return static::withoutTimestampsOn([static::class], $callback);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -99,9 +99,9 @@ class Envelope
     }
 
     /**
-     * Add additional recipients to the message
+     * Add additional recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
      * @return $this
      */
     public function addTo($address)
@@ -114,7 +114,7 @@ class Envelope
     /**
      * Add "cc" recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
      * @return $this
      */
     public function addCc($address)
@@ -127,7 +127,7 @@ class Envelope
     /**
      * Add "bcc" recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
      * @return $this
      */
     public function addBcc($address)
@@ -140,7 +140,7 @@ class Envelope
     /**
      * Add "reply to" recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
      * @return $this
      */
     public function addReplyTo($address)
@@ -153,19 +153,21 @@ class Envelope
     /**
      * Add additional recipients to the message
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
      * @param $type
      * @return $this
+     *
      * @throws \InvalidArgumentException
      */
-    protected function addRecipient($address, $type) {
-        if (!in_array($type, ['to', 'cc', 'bcc', 'replyTo'])) {
+    protected function addRecipient($address, $type)
+    {
+        if (! in_array($type, ['to', 'cc', 'bcc', 'replyTo'])) {
             throw new \InvalidArgumentException("$type is not a valid recipient type.");
         }
 
         $this->{$type} = [
             ...$this->{$type},
-            ...$this->normalizeAddresses(is_array($address) ? $address : [$address])
+            ...$this->normalizeAddresses(is_array($address) ? $address : [$address]),
         ];
 
         return $this;

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -101,7 +101,7 @@ class Envelope
     /**
      * Add additional recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
+     * @param  string|\Illuminate\Mail\Mailables\Address|array  $address
      * @return $this
      */
     public function addTo($address)
@@ -114,7 +114,7 @@ class Envelope
     /**
      * Add "cc" recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
+     * @param  string|\Illuminate\Mail\Mailables\Address|array  $address
      * @return $this
      */
     public function addCc($address)
@@ -127,7 +127,7 @@ class Envelope
     /**
      * Add "bcc" recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
+     * @param  string|\Illuminate\Mail\Mailables\Address|array  $address
      * @return $this
      */
     public function addBcc($address)
@@ -151,9 +151,9 @@ class Envelope
     }
 
     /**
-     * Add additional recipients to the message
+     * Add additional recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
+     * @param  string|\Illuminate\Mail\Mailables\Address|array  $address
      * @param $type
      * @return $this
      *

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -99,6 +99,79 @@ class Envelope
     }
 
     /**
+     * Add additional recipients to the message
+     *
+     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @return $this
+     */
+    public function addTo($address)
+    {
+        $this->addRecipient($address, 'to');
+
+        return $this;
+    }
+
+    /**
+     * Add "cc" recipients to the message.
+     *
+     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @return $this
+     */
+    public function addCc($address)
+    {
+        $this->addRecipient($address, 'cc');
+
+        return $this;
+    }
+
+    /**
+     * Add "bcc" recipients to the message.
+     *
+     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @return $this
+     */
+    public function addBcc($address)
+    {
+        $this->addRecipient($address, 'bcc');
+
+        return $this;
+    }
+
+    /**
+     * Add "reply to" recipients to the message.
+     *
+     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @return $this
+     */
+    public function addReplyTo($address)
+    {
+        $this->addRecipient($address, 'replyTo');
+
+        return $this;
+    }
+
+    /**
+     * Add additional recipients to the message
+     *
+     * @param string|\Illuminate\Mail\Mailables\Address|array $address
+     * @param $type
+     * @return $this
+     * @throws \InvalidArgumentException
+     */
+    protected function addRecipient($address, $type) {
+        if (!in_array($type, ['to', 'cc', 'bcc', 'replyTo'])) {
+            throw new \InvalidArgumentException("$type is not a valid recipient type.");
+        }
+
+        $this->{$type} = [
+            ...$this->{$type},
+            ...$this->normalizeAddresses(is_array($address) ? $address : [$address])
+        ];
+
+        return $this;
+    }
+
+    /**
      * Determine if the message is from the given address.
      *
      * @param  string  $address

--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -140,7 +140,7 @@ class Envelope
     /**
      * Add "reply to" recipients to the message.
      *
-     * @param string|\Illuminate\Mail\Mailables\Address|array  $address
+     * @param  string|\Illuminate\Mail\Mailables\Address|array  $address
      * @return $this
      */
     public function addReplyTo($address)

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -106,7 +106,7 @@ class ResourceRegistrar
             }
 
             if (isset($options['trashed']) &&
-                in_array($m, ! empty($options['trashed']) ? $options['trashed'] : $resourceMethods)) {
+                in_array($m, ! empty($options['trashed']) ? $options['trashed'] : array_intersect($resourceMethods, ['show', 'edit', 'update']))) {
                 $route->withTrashed();
             }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1090,7 +1090,7 @@ class Route
      * Specify middleware that should be removed from the given route.
      *
      * @param  array|string  $middleware
-     * @return $this|array
+     * @return $this
      */
     public function withoutMiddleware($middleware)
     {

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -113,11 +113,12 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertSimilar(array $data)
     {
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decoded
-        ));
+        $actual = json_encode(
+            Arr::sortRecursive((array) $this->decoded),
+            JSON_UNESCAPED_UNICODE
+        );
 
-        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data)), $actual);
+        PHPUnit::assertEquals(json_encode(Arr::sortRecursive($data), JSON_UNESCAPED_UNICODE), $actual);
 
         return $this;
     }
@@ -130,9 +131,10 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertFragment(array $data)
     {
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decoded
-        ));
+        $actual = json_encode(
+            Arr::sortRecursive((array) $this->decoded),
+            JSON_UNESCAPED_UNICODE
+        );
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $expected = $this->jsonSearchStrings($key, $value);
@@ -140,7 +142,7 @@ class AssertableJsonString implements ArrayAccess, Countable
             PHPUnit::assertTrue(
                 Str::contains($actual, $expected),
                 'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
-                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
+                '['.json_encode([$key => $value], JSON_UNESCAPED_UNICODE).']'.PHP_EOL.PHP_EOL.
                 'within'.PHP_EOL.PHP_EOL.
                 "[{$actual}]."
             );
@@ -162,9 +164,10 @@ class AssertableJsonString implements ArrayAccess, Countable
             return $this->assertMissingExact($data);
         }
 
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decoded
-        ));
+        $actual = json_encode(
+            Arr::sortRecursive((array) $this->decoded),
+            JSON_UNESCAPED_UNICODE
+        );
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $unexpected = $this->jsonSearchStrings($key, $value);
@@ -172,7 +175,7 @@ class AssertableJsonString implements ArrayAccess, Countable
             PHPUnit::assertFalse(
                 Str::contains($actual, $unexpected),
                 'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
+                '['.json_encode([$key => $value], JSON_UNESCAPED_UNICODE).']'.PHP_EOL.PHP_EOL.
                 'within'.PHP_EOL.PHP_EOL.
                 "[{$actual}]."
             );
@@ -189,9 +192,10 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     public function assertMissingExact(array $data)
     {
-        $actual = json_encode(Arr::sortRecursive(
-            (array) $this->decoded
-        ));
+        $actual = json_encode(
+            Arr::sortRecursive((array) $this->decoded),
+            JSON_UNESCAPED_UNICODE
+        );
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
             $unexpected = $this->jsonSearchStrings($key, $value);
@@ -203,7 +207,7 @@ class AssertableJsonString implements ArrayAccess, Countable
 
         PHPUnit::fail(
             'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
-            '['.json_encode($data).']'.PHP_EOL.PHP_EOL.
+            '['.json_encode($data, JSON_UNESCAPED_UNICODE).']'.PHP_EOL.PHP_EOL.
             'within'.PHP_EOL.PHP_EOL.
             "[{$actual}]."
         );
@@ -322,9 +326,9 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     protected function assertJsonMessage(array $data)
     {
-        $expected = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $expected = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
-        $actual = json_encode($this->decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $actual = json_encode($this->decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
         return 'Unable to find JSON: '.PHP_EOL.PHP_EOL.
             "[{$expected}]".PHP_EOL.PHP_EOL.
@@ -341,7 +345,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      */
     protected function jsonSearchStrings($key, $value)
     {
-        $needle = substr(json_encode([$key => $value]), 1, -1);
+        $needle = Str::substr(json_encode([$key => $value], JSON_UNESCAPED_UNICODE), 1, -1);
 
         return [
             $needle.']',

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -567,10 +567,10 @@ class ComponentTagCompiler
      */
     protected function parseShortAttributeSyntax(string $value)
     {
-        $pattern = "/\:\\\$(\w+)/x";
+        $pattern = "/\s\:\\\$(\w+)/x";
 
         return preg_replace_callback($pattern, function (array $matches) {
-            return ":{$matches[1]}=\"\${$matches[1]}\"";
+            return " :{$matches[1]}=\"\${$matches[1]}\"";
         }, $value);
     }
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -47,7 +47,7 @@ class JobDispatchingTest extends TestCase
         $this->assertTrue(Job::$ran);
     }
 
-    public function testDoesNotDispatchesConditionallyWithBoolean()
+    public function testDoesNotDispatchConditionallyWithBoolean()
     {
         Job::dispatchUnless(true, 'test')->replaceValue('new-test');
 
@@ -60,7 +60,7 @@ class JobDispatchingTest extends TestCase
         $this->assertSame('new-test', Job::$value);
     }
 
-    public function testDoesNotDispatchesConditionallyWithClosure()
+    public function testDoesNotDispatchConditionallyWithClosure()
     {
         Job::dispatchUnless(fn ($job) => $job instanceof Job ? 1 : 0, 'test')->replaceValue('new-test');
 

--- a/tests/Mail/MailableAlternativeSyntaxTest.php
+++ b/tests/Mail/MailableAlternativeSyntaxTest.php
@@ -40,6 +40,55 @@ class MailableAlternativeSyntaxTest extends TestCase
         $this->assertEquals(1, count($mailable->cc));
         $this->assertEquals(1, count($mailable->bcc));
     }
+
+    public function testFluentEnvelopeMethods()
+    {
+        $mailable = new MailableWithFluentEnvelopeMethods;
+
+        $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
+        $this->assertTrue($mailable->hasCc('adam@laravel.com'));
+        $this->assertTrue($mailable->hasBcc('tyler@laravel.com'));
+        $this->assertTrue($mailable->hasReplyTo('reply-to@laravel.com'));
+
+        $this->assertTrue($mailable->hasTo('string@example.com'));
+        $this->assertTrue($mailable->hasTo('array@example.com'));
+        $this->assertTrue($mailable->hasTo('address@example.com'));
+        $this->assertTrue($mailable->hasTo('address-array@example.com'));
+        $this->assertTrue($mailable->hasCc('cc@example.com'));
+        $this->assertTrue($mailable->hasBcc('bcc@example.com'));
+        $this->assertTrue($mailable->hasReplyTo('reply-to@example.com'));
+    }
+}
+
+class MailableWithFluentEnvelopeMethods extends Mailable
+{
+    public function envelope()
+    {
+        return (new Envelope(
+            to: [new Address('taylor@laravel.com', 'Taylor Otwell')],
+            cc: [new Address('adam@laravel.com', 'Adam Wathan')],
+            bcc: [new Address('tyler@laravel.com', 'Tyler Blair')],
+            replyTo: [new Address('reply-to@laravel.com', 'Reply To')],
+            subject: 'Test Subject',
+            tags: ['tag-1', 'tag-2'],
+            metadata: ['test-meta' => 'test-meta-value'],
+        ))
+            ->addTo('string@example.com')
+            ->addTo(['array@example.com'])
+            ->addTo(new Address('address@example.com'))
+            ->addTo([new Address('address-array@example.com')])
+            ->addCc('cc@example.com')
+            ->addBcc('bcc@example.com')
+            ->addReplyTo('reply-to@example.com');
+    }
+
+    public function content()
+    {
+        return new Content(
+            view: 'test-view',
+            with: ['test-data-key' => 'test-data-value'],
+        );
+    }
 }
 
 class MailableWithAlternativeSyntax extends Mailable

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -575,6 +575,74 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('bar', $route->parameter('foo', 'bar'));
     }
 
+    public function testHasParameters()
+    {
+        $route = new Route('GET', 'images/{id}.{ext}', function () {
+            //
+        });
+        $request1 = Request::create('images/1.png', 'GET');
+        $this->assertFalse($route->hasParameters());
+        $this->assertTrue($route->matches($request1));
+        $route->bind($request1);
+        $this->assertTrue($route->hasParameters());
+    }
+
+    public function testForgetParameter()
+    {
+        $route = new Route('GET', 'images/{id}.{ext}', function () {
+            //
+        });
+        $request1 = Request::create('images/1.png', 'GET');
+        $route->bind($request1);
+        $this->assertTrue($route->hasParameter('id'));
+        $this->assertTrue($route->hasParameter('ext'));
+        $route->forgetParameter('id');
+        $this->assertFalse($route->hasParameter('id'));
+        $this->assertTrue($route->hasParameter('ext'));
+    }
+
+    public function testParameterNames()
+    {
+        $route = new Route('GET', 'images/{id}.{ext}', function () {
+            //
+        });
+        $this->assertSame(['id', 'ext'], $route->parameterNames());
+
+        $route = new Route('GET', 'foo/{bar?}', function () {
+            //
+        });
+        $this->assertSame(['bar'], $route->parameterNames());
+
+        $route = new Route('GET', '/', function () {
+            //
+        });
+        $this->assertSame([], $route->parameterNames());
+    }
+
+    public function testParametersWithoutNulls()
+    {
+        $route = new Route('GET', 'users/{id?}/{name?}/', function () {
+            //
+        });
+        $request1 = Request::create('users/12/amir', 'GET');
+        $route->bind($request1);
+        $this->assertSame(['id' => '12', 'name' => 'amir'], $route->parametersWithoutNulls());
+
+        $route = new Route('GET', 'users/{id?}/{name?}/', function () {
+            //
+        });
+        $request1 = Request::create('users/12', 'GET');
+        $route->bind($request1);
+        $this->assertSame(['id' => '12'], $route->parametersWithoutNulls());
+
+        $route = new Route('GET', 'users/{id?}/{name?}/', function () {
+            //
+        });
+        $request1 = Request::create('users/', 'GET');
+        $route->bind($request1);
+        $this->assertSame([], $route->parametersWithoutNulls());
+    }
+
     public function testRouteParametersDefaultValue()
     {
         $router = $this->getRouter();

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -173,6 +173,20 @@ class SupportStringableTest extends TestCase
             return $stringable->studly();
         }));
     }
+    
+    public function testDirname()
+    {
+        $this->assertSame('/framework/tests', (string) $this->stringable('/framework/tests/Support')->dirname());
+        $this->assertSame('/framework', (string) $this->stringable('/framework/tests/Support')->dirname(2));
+        
+        $this->assertSame('/', (string) $this->stringable('/framework/')->dirname());
+        
+        $this->assertSame('/', (string) $this->stringable('/')->dirname());
+        $this->assertSame('.', (string) $this->stringable('.')->dirname());
+        
+        //  without slash
+        $this->assertSame('.', (string) $this->stringable('framework')->dirname());
+    }
 
     public function testUcsplitOnStringable()
     {

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -946,6 +946,18 @@ class SupportStringableTest extends TestCase
         $this->assertSame('❤MultiByte☆     ', (string) $this->stringable('❤MultiByte☆')->padRight(16));
     }
 
+    public function testExplode()
+    {
+        $this->assertInstanceOf(Collection::class, $this->stringable("Foo Bar Baz")->explode(" "));
+        
+        $this->assertSame('["Foo","Bar","Baz"]', (string) $this->stringable("Foo Bar Baz")->explode(" "));
+        
+        //  with limit
+        $this->assertSame('["Foo","Bar Baz"]', (string) $this->stringable("Foo Bar Baz")->explode(" ", 2));
+        $this->assertSame('["Foo","Bar"]', (string) $this->stringable("Foo Bar Baz")->explode(" ", -1));
+
+    }
+    
     public function testChunk()
     {
         $chunks = $this->stringable('foobarbaz')->split(3);

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -173,17 +173,17 @@ class SupportStringableTest extends TestCase
             return $stringable->studly();
         }));
     }
-    
+
     public function testDirname()
     {
         $this->assertSame('/framework/tests', (string) $this->stringable('/framework/tests/Support')->dirname());
         $this->assertSame('/framework', (string) $this->stringable('/framework/tests/Support')->dirname(2));
-        
+
         $this->assertSame('/', (string) $this->stringable('/framework/')->dirname());
-        
+
         $this->assertSame('/', (string) $this->stringable('/')->dirname());
         $this->assertSame('.', (string) $this->stringable('.')->dirname());
-        
+
         //  without slash
         $this->assertSame('.', (string) $this->stringable('framework')->dirname());
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -948,16 +948,15 @@ class SupportStringableTest extends TestCase
 
     public function testExplode()
     {
-        $this->assertInstanceOf(Collection::class, $this->stringable("Foo Bar Baz")->explode(" "));
-        
-        $this->assertSame('["Foo","Bar","Baz"]', (string) $this->stringable("Foo Bar Baz")->explode(" "));
-        
-        //  with limit
-        $this->assertSame('["Foo","Bar Baz"]', (string) $this->stringable("Foo Bar Baz")->explode(" ", 2));
-        $this->assertSame('["Foo","Bar"]', (string) $this->stringable("Foo Bar Baz")->explode(" ", -1));
+        $this->assertInstanceOf(Collection::class, $this->stringable('Foo Bar Baz')->explode(' '));
 
+        $this->assertSame('["Foo","Bar","Baz"]', (string) $this->stringable('Foo Bar Baz')->explode(' '));
+
+        //  with limit
+        $this->assertSame('["Foo","Bar Baz"]', (string) $this->stringable('Foo Bar Baz')->explode(' ', 2));
+        $this->assertSame('["Foo","Bar"]', (string) $this->stringable('Foo Bar Baz')->explode(' ', -1));
     }
-    
+
     public function testChunk()
     {
         $chunks = $this->stringable('foobarbaz')->split(3);

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -865,6 +865,16 @@ class TestResponseTest extends TestCase
         $response->assertJsonFragment(['id' => 1]);
     }
 
+    public function testAssertJsonFragmentUnicodeCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessageMatches('/Привет|Мир/');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithUnicodeStub));
+
+        $response->assertJsonFragment(['id' => 1]);
+    }
+
     public function testAssertJsonStructure()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
@@ -1947,6 +1957,18 @@ class JsonSerializableSingleResourceWithIntegersStub implements JsonSerializable
             ['id' => 10, 'foo' => 'bar'],
             ['id' => 20, 'foo' => 'bar'],
             ['id' => 30, 'foo' => 'bar'],
+        ];
+    }
+}
+
+class JsonSerializableSingleResourceWithUnicodeStub implements JsonSerializable
+{
+    public function jsonSerialize(): array
+    {
+        return [
+            ['id' => 10, 'foo' => 'bar'],
+            ['id' => 20, 'foo' => 'Привет'],
+            ['id' => 30, 'foo' => 'Мир'],
         ];
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2659,7 +2659,7 @@ class ValidationValidatorTest extends TestCase
      *
      * @dataProvider multipleOfDataProvider
      */
-    public function testValidateMutlpleOf($input, $allowed, $passes)
+    public function testValidateMultipleOf($input, $allowed, $passes)
     {
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.multiple_of' => 'The :attribute must be a multiple of :value'], 'en');

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -148,12 +148,75 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
+    public function testColonDataWithStaticClassProperty()
+    {
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :userId="User::$id"></x-profile>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => User::\$id])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
+    public function testColonDataWithStaticClassPropertyAndMultipleAttributes()
+    {
+        $result = $this->compiler(['input' => TestInputComponent::class])->compileTags('<x-input :label="Input::$label" :$name value="Joe"></x-input>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestInputComponent', 'input', ['label' => Input::\$label,'name' => \$name,'value' => 'Joe'])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestInputComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+
+        $result = $this->compiler(['input' => TestInputComponent::class])->compileTags('<x-input value="Joe" :$name :label="Input::$label"></x-input>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestInputComponent', 'input', ['value' => 'Joe','name' => \$name,'label' => Input::\$label])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestInputComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
     public function testSelfClosingComponentWithColonDataShortSyntax()
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :$userId/>');
 
         $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => \$userId])
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+'@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
+    public function testSelfClosingComponentWithColonDataAndStaticClassPropertyShortSyntax()
+    {
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :userId="User::$id"/>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => User::\$id])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+'@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
+    public function testSelfClosingComponentWithColonDataMultipleAttributesAndStaticClassPropertyShortSyntax()
+    {
+        $result = $this->compiler(['input' => TestInputComponent::class])->compileTags('<x-input :label="Input::$label" value="Joe" :$name />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestInputComponent', 'input', ['label' => Input::\$label,'value' => 'Joe','name' => \$name])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestInputComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+'@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+
+        $result = $this->compiler(['input' => TestInputComponent::class])->compileTags('<x-input :$name :label="Input::$label" value="Joe" />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestInputComponent', 'input', ['name' => \$name,'label' => Input::\$label,'value' => 'Joe'])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestInputComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
 <?php \$component->withAttributes([]); ?>\n".
@@ -491,7 +554,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
             }
         };
 
-        $model = new class extends Model {};
+        $model = new class extends Model
+        {
+        };
 
         $this->assertEquals(e('<hi>'), BladeCompiler::sanitizeComponentAttribute('<hi>'));
         $this->assertEquals(e('1'), BladeCompiler::sanitizeComponentAttribute('1'));
@@ -605,5 +670,22 @@ class TestProfileComponent extends Component
     public function render()
     {
         return 'profile';
+    }
+}
+
+class TestInputComponent extends Component
+{
+    public $userId;
+
+    public function __construct($name, $label, $value)
+    {
+        $this->name = $name;
+        $this->label = $label;
+        $this->value = $value;
+    }
+
+    public function render()
+    {
+        return 'input';
     }
 }


### PR DESCRIPTION
Just testing if this PR even works... apologies if it's making a mess.

Relates to https://github.com/laravel/framework/pull/44462

Specifically https://github.com/laravel/framework/pull/44462#pullrequestreview-1133853073

This enables fluent methods for recipients;
```php
    public function envelope()
    {
        return (new Envelope(
            to: [new Address('taylor@laravel.com', 'Taylor Otwell')],
            cc: [new Address('adam@laravel.com', 'Adam Wathan')],
            bcc: [new Address('tyler@laravel.com', 'Tyler Blair')],
            replyTo: [new Address('reply-to@laravel.com', 'Reply To')],
            subject: 'Test Subject',
            tags: ['tag-1', 'tag-2'],
            metadata: ['test-meta' => 'test-meta-value'],
        ))
            ->addTo('string@example.com')
            ->addTo(['array@example.com'])
            ->addTo(new Address('address@example.com'))
            ->addTo([new Address('address-array@example.com')])
            ->addCc('cc@example.com')
            ->addBcc('bcc@example.com')
            ->addReplyTo('reply-to@example.com');
    }
```