### PR TITLE
Add support to collections for using dot notation in get functions

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -432,11 +432,15 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      */
     public function get($key, $default = null)
     {
+        if (is_null($key)) {
+            return;
+        }
+
         if (array_key_exists($key, $this->items)) {
             return $this->items[$key];
         }
 
-        return value($default);
+        return data_get($this->items, $key, $default);
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -500,13 +500,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             return;
         }
 
-        foreach ($this as $outerKey => $outerValue) {
-            if ($outerKey == $key) {
-                return $outerValue;
+        return array_reduce(explode('.', $key), function ($carry, $key) use ($default) {
+            if (is_iterable($carry)) {
+                foreach ($carry as $outerKey => $outerValue) {
+                    if ($outerKey == $key) {
+                        return $outerValue;
+                    }
+                }
             }
-        }
 
-        return value($default);
+            return value($default);
+        }, $this);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5336,6 +5336,46 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testGetWithDotNotation($collection)
+    {
+        $data = new $collection([
+            'emails' => [
+                'test' => 'taylor@example.com',
+            ]
+        ]);
+        $result = $data->get('emails.test');
+        $this->assertEquals('taylor@example.com', $result);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGetWithDeeperDotNotation($collection)
+    {
+        $data = new $collection([
+            'emails' => [
+                'test' => ['taylor' => 'taylor@example.com'],
+            ]
+        ]);
+        $result = $data->get('emails.test');
+        $this->assertEquals(['taylor' => 'taylor@example.com'], $result);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGetWithDotNotationButTooFlat($collection)
+    {
+        $data = new $collection([
+            'emails' => 'taylor@example.com',
+        ]);
+        $result = $data->get('emails.test');
+        $this->assertNull($result);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhereNull($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
This adds support for using dot notation on `$collection->get()` functions.

```php
$collection = collect([
    'a' => [
        'b' => 'c',
    ],
]);
$collection->get('a.b'); // c
```

For normal collections, it's pretty straightforward. My hesitation is with lazy collections. I'm not sure if my implementation is good enough. Looking forward to feedback!