### PR TITLE
[9.x] Fix `make:cast --inbound` so it's a boolean option, not value

### DIFF
--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -86,7 +86,7 @@ class CastMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the cast already exists'],
-            ['inbound', null, InputOption::VALUE_OPTIONAL, 'Generate an inbound cast class'],
+            ['inbound', null, InputOption::VALUE_NONE, 'Generate an inbound cast class'],
         ];
     }
 }


### PR DESCRIPTION
The `php artisan make:cast --inbound` option is currently ineffective unless you pass a value (`--inbound=INBOUND`) because it uses `InputOption::VALUE_OPTIONAL`.

I've changed this to `VALUE_NONE`, as `--force` and similar work, to reflect what is expected.