### PR TITLE
[9.x] Adds randomFirst method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -557,6 +557,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Put the query's results in random order and take the first.
+     *
+     * @param  string  $seed
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     */
+    public function randomFirst($seed = '', $columns = ['*'])
+    {
+        return $this->model->inRandomOrder($seed)->first($columns);
+    }
+
+    /**
      * Create or update a record matching the attributes, and fill it with values.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2282,6 +2282,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Put the query's results in random order and take the first.
+     *
+     * @param  string  $seed
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     */
+    public function randomFirst($seed = '', $columns = ['*'])
+    {
+        return $this->inRandomOrder($seed)->first($columns);
+    }
+
+    /**
      * Add a raw "order by" clause to the query.
      *
      * @param  string  $sql

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2281,7 +2281,6 @@ class Builder implements BuilderContract
         return $this->orderByRaw($this->grammar->compileRandom($seed));
     }
 
-
     /**
      * Add a raw "order by" clause to the query.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2281,17 +2281,6 @@ class Builder implements BuilderContract
         return $this->orderByRaw($this->grammar->compileRandom($seed));
     }
 
-    /**
-     * Put the query's results in random order and take the first.
-     *
-     * @param  string  $seed
-     * @param  array|string  $columns
-     * @return \Illuminate\Database\Eloquent\Model|object|static|null
-     */
-    public function randomFirst($seed = '', $columns = ['*'])
-    {
-        return $this->inRandomOrder($seed)->first($columns);
-    }
 
     /**
      * Add a raw "order by" clause to the query.


### PR DESCRIPTION
this method allows you to get first result of the query execution in random order

before:

`User::inRandomOrder()->first()`

After:

`User::randomFirst()`

Tests are not included on PR because it's a chain of already test functions.
I'm open to suggestions.
