### PR TITLE
[9.x] Fix dirname failed test on Windows

### DIFF
--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -178,14 +178,12 @@ class SupportStringableTest extends TestCase
     {
         $this->assertSame('/framework/tests', (string) $this->stringable('/framework/tests/Support')->dirname());
         $this->assertSame('/framework', (string) $this->stringable('/framework/tests/Support')->dirname(2));
+        $this->assertSame('.', (string) $this->stringable('framework')->dirname());
 
-        $this->assertSame('/', (string) $this->stringable('/framework/')->dirname());
-
-        $this->assertSame('/', (string) $this->stringable('/')->dirname());
         $this->assertSame('.', (string) $this->stringable('.')->dirname());
 
-        //  without slash
-        $this->assertSame('.', (string) $this->stringable('framework')->dirname());
+        $this->assertSame(DIRECTORY_SEPARATOR, (string) $this->stringable('/framework/')->dirname());
+        $this->assertSame(DIRECTORY_SEPARATOR, (string) $this->stringable('/')->dirname());
     }
 
     public function testUcsplitOnStringable()


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In PR #44491, some tests failed in the `Windows` environment because the `dirname` method works differently in `Windows` and `Unix|Unix-like` operating systems in some circumstances.
in this PR, the issue was fixed.
* Fix `dirname` method tests in `SupportStringableTest.php`
* Resolve branch conflict #44504 