### PR TITLE
Adds `strong` password validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Password.php
+++ b/src/Illuminate/Validation/Rules/Password.php
@@ -147,6 +147,25 @@ class Password implements Rule, DataAwareRule, ValidatorAwareRule
     }
 
     /**
+     * Provide a reasonably strong password rule.
+     *
+     * @param  int  $minLength
+     * @return static
+     */
+    public static function strong($minLength = 12)
+    {
+        if ($minLength < 12) {
+            throw new InvalidArgumentException('A strong password should be at least 12 characters long.');
+        }
+
+        return static::min($minLength)
+            ->mixedCase()
+            ->numbers()
+            ->symbols()
+            ->uncompromised();
+    }
+
+    /**
      * Get the default configuration of the password rule and mark the field as required.
      *
      * @return array

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -137,7 +137,7 @@ class ValidationPasswordRuleTest extends TestCase
     public function testStrong()
     {
         $this->fails(Password::strong(), ['a1B#'], [
-            'validation.min.string'
+            'validation.min.string',
         ]);
 
         $this->fails(Password::strong(), ['1234567898765$'], [
@@ -145,15 +145,15 @@ class ValidationPasswordRuleTest extends TestCase
         ]);
 
         $this->fails(Password::strong(), ['aaaaaabbbbbb1$'], [
-            'The my password must contain at least one uppercase and one lowercase letter.'
+            'The my password must contain at least one uppercase and one lowercase letter.',
         ]);
 
         $this->fails(Password::strong(), ['aaaaaaBBBBBBB$'], [
-            'The my password must contain at least one number.'
+            'The my password must contain at least one number.',
         ]);
 
         $this->fails(Password::strong(), ['aaaaaaBBBBBBB1'], [
-            'The my password must contain at least one symbol.'
+            'The my password must contain at least one symbol.',
         ]);
 
         $this->passes(Password::strong(), [
@@ -167,7 +167,7 @@ class ValidationPasswordRuleTest extends TestCase
             '&xe6VeKWF#n4Re',
             '%HurHUnw7zM!Re',
         ], [
-            'validation.min.string'
+            'validation.min.string',
         ]);
 
         $this->passes(Password::strong(16), [

--- a/tests/Validation/ValidationPasswordRuleTest.php
+++ b/tests/Validation/ValidationPasswordRuleTest.php
@@ -134,6 +134,55 @@ class ValidationPasswordRuleTest extends TestCase
         ]);
     }
 
+    public function testStrong()
+    {
+        $this->fails(Password::strong(), ['a1B#'], [
+            'validation.min.string'
+        ]);
+
+        $this->fails(Password::strong(), ['1234567898765$'], [
+            'The my password must contain at least one uppercase and one lowercase letter.',
+        ]);
+
+        $this->fails(Password::strong(), ['aaaaaabbbbbb1$'], [
+            'The my password must contain at least one uppercase and one lowercase letter.'
+        ]);
+
+        $this->fails(Password::strong(), ['aaaaaaBBBBBBB$'], [
+            'The my password must contain at least one number.'
+        ]);
+
+        $this->fails(Password::strong(), ['aaaaaaBBBBBBB1'], [
+            'The my password must contain at least one symbol.'
+        ]);
+
+        $this->passes(Password::strong(), [
+            '&xe6VeKWF#n4Re',
+            '%HurHUnw7zM!Re',
+            '7Z^k5EvqQ9g%c!Jt9$ufnNpQy#Kf',
+            'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwSX',
+        ]);
+
+        $this->fails(Password::strong(16), [
+            '&xe6VeKWF#n4Re',
+            '%HurHUnw7zM!Re',
+        ], [
+            'validation.min.string'
+        ]);
+
+        $this->passes(Password::strong(16), [
+            '7Z^k5EvqQ9g%c!Jt9$ufnNpQy#Kf',
+            'NRs*Gz2@hSmB$vVBSPDfqbRtEzk4nF7ZAbM29VMW$BPD%b2U%3VmJAcrY5eZGVxP%z%apnwSX',
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        new Validator(
+            resolve('translator'),
+            ['my_password' => 'pwd', 'my_password_confirmation' => 'pwd'],
+            ['my_password' => Password::strong(8)]
+        );
+    }
+
     public function testMessagesOrder()
     {
         $makeRules = function () {


### PR DESCRIPTION
I think it would be beneficial - as well as convenient - to provide a "recommendable" strong password rule (that hopefully most people already implement anyway), that would probably evolve in time as technology change. Nowadays an 8-characters password for example is just [not OK anymore](https://www.techrepublic.com/article/how-an-8-character-password-could-be-cracked-in-less-than-an-hour) for any reasonably secure system.