### PR TITLE
[9.x] Adding additional PHP extensions to shouldBlockPhpUpload Function

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1396,7 +1396,7 @@ trait ValidatesAttributes
         }
 
         $phpExtensions = [
-            'php', 'php3', 'php4', 'php5', 'phtml', 'phar',
+            'php', 'php3', 'php4', 'php5', 'phtml', 'phar','php7','php8'
         ];
 
         return ($value instanceof UploadedFile)

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1396,7 +1396,7 @@ trait ValidatesAttributes
         }
 
         $phpExtensions = [
-            'php', 'php3', 'php4', 'php5', 'phtml', 'phar','php7','php8'
+            'php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar',
         ];
 
         return ($value instanceof UploadedFile)


### PR DESCRIPTION
## _Adding additional PHP extensions to shouldBlockPhpUpload() Function_


Some webserver configurations will treat php7 and php8 as a valid php extensions will execute them as a normal php file.
Laravel by default will block list of php extensions from being uploaded using shouldBlockPhpUpload function.
```php
protected function shouldBlockPhpUpload($value, $parameters)
    {
        if (in_array('php', $parameters)) {
            return false;
        }

        $phpExtensions = [
            'php', 'php3', 'php4', 'php5', 'phtml', 'phar',
        ];

        return ($value instanceof UploadedFile)
           ? in_array(trim(strtolower($value->getClientOriginalExtension())), $phpExtensions)
           : in_array(trim(strtolower($value->getExtension())), $phpExtensions);
    }
```
Yet by using this function the application can not prevent uploading php files using php7 or php8 extentions which some webservers will treat them as a normal php code and will execute it.

To prevent uploading php7 or php8 files i just added php7,php8 to blocked php extensions.

```php
protected function shouldBlockPhpUpload($value, $parameters)
    {
        if (in_array('php', $parameters)) {
            return false;
        }

        $phpExtensions = [
            'php', 'php3', 'php4', 'php5', 'phtml', 'phar','php7','php8'
        ];

        return ($value instanceof UploadedFile)
           ? in_array(trim(strtolower($value->getClientOriginalExtension())), $phpExtensions)
           : in_array(trim(strtolower($value->getExtension())), $phpExtensions);
    }
```
### _Vulnerable webservers_
Duirng my research i found out, A lot of cloud and host providers will configure there webservers to execute php7 and php8 file extensions as a normal php file.

Here is an example of vulnrable configured apache2 webserver.
This is contents of /etc/apache2/conf/mime.types file
```code
application/x-httpd-ea-php80 		 php php8
application/x-httpd-ea-php71 		 php php7
application/x-httpd-ea-php56 		 php php5
text/x-registry 		 reg
application/x-httpd-ea-php54 		 php php5
application/x-httpd-ea-php55 		 php php5
text/x-sql 		 sql
application/x-httpd-ea-php74 		 php php7
application/x-httpd-ea-php72 		 php php7
application/perl 		 pl plx ppl perl pm
application/x-gzip 		 tgz
text/x-log 		 log
application/cgi 		 cgi
application/x-img 		 img
application/x-httpd-php-source 		 phps
application/x-httpd-ea-php73 		 php php7
application/ruby 		 rb
text/vbscript 		 vbs
text/x-config 		 cnf conf
application/x-httpd-ea-php70 		 php php7
```

### _Fixing Webservers_
Make sure your webserver configuration didn't treat other php extension types as a valid php file like example above.

Also you can add .htaccess file to uploads directory to prevent execution of php in uploads directory which is controlled by end users.
Add this to .htaccess file in uploads directory
```code
php_flag engine off
```