### PR TITLE
[9.x] Register `cutInternals` casters for particularly noisy objects

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -81,11 +81,11 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public function registerDumper()
     {
+        AbstractCloner::$defaultCasters[ConnectionInterface::class] = [StubCaster::class, 'cutInternals'];
         AbstractCloner::$defaultCasters[Container::class] = [StubCaster::class, 'cutInternals'];
         AbstractCloner::$defaultCasters[Dispatcher::class] = [StubCaster::class, 'cutInternals'];
-        AbstractCloner::$defaultCasters[ConnectionInterface::class] = [StubCaster::class, 'cutInternals'];
-        AbstractCloner::$defaultCasters[Grammar::class] = [StubCaster::class, 'cutInternals'];
         AbstractCloner::$defaultCasters[Factory::class] = [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[Grammar::class] = [StubCaster::class, 'cutInternals'];
 
         $basePath = $this->app->basePath();
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -2,7 +2,12 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Grammar;
 use Illuminate\Foundation\Console\CliDumper;
 use Illuminate\Foundation\Http\HtmlDumper;
 use Illuminate\Foundation\MaintenanceModeManager;
@@ -15,6 +20,8 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Testing\LoggedExceptionCollection;
 use Illuminate\Testing\ParallelTestingServiceProvider;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\VarDumper\Caster\StubCaster;
+use Symfony\Component\VarDumper\Cloner\AbstractCloner;
 
 class FoundationServiceProvider extends AggregateServiceProvider
 {
@@ -74,6 +81,12 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     public function registerDumper()
     {
+        AbstractCloner::$defaultCasters[Container::class] = [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[Dispatcher::class] = [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[ConnectionInterface::class] = [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[Grammar::class] = [StubCaster::class, 'cutInternals'];
+        AbstractCloner::$defaultCasters[Factory::class] = [StubCaster::class, 'cutInternals'];
+
         $basePath = $this->app->basePath();
 
         $compiledViewPath = $this->app['config']->get('view.compiled');


### PR DESCRIPTION
This is a much smaller version of #44408 that addresses the major pain point of using `dd()` in Laravel—dumping an object that holds a reference to the container (or another potentially large object that you don't actually care about from a debugging context).

By default, Symfony registers the `StubCaster::cutInternals` caster for many internal classes, including the Symfony container and event dispatcher. This caster cuts down the object when dumping, but only if it's nested. This PR registers that same caster for a couple of Laravel interfaces that tend to be very large.

For example, currently if you were to call `dd()` on an instance of the `Router`, your output will include include about 500 lines showing the `Dispatcher` and another 500 lines showing the `Container` before you get anywhere near the `$routes` or other values that you're likely trying to view.

After this PR, those 1000 lines are collapsed to:

```
Illuminate\Routing\Router {
  #events: Illuminate\Events\Dispatcher { …20 }
  #container: Illuminate\Container\Container { …19 }
}
```

The `cutInternals` caster only applies if the object is nested, though. So if you call `dd()` directly on the container or event dispatcher, the entire object will be dumped.

This feels like 70% of the benefits of [Laravel Dumper](https://github.com/glhd/laravel-dumper) for about 1% of the maintenance cost.