### PR TITLE
[9.x] Controller middleware without resolving controller

### DIFF
--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -86,7 +86,7 @@ class ControllerDispatcher implements ControllerDispatcherContract
      * @param  array  $options
      * @return bool
      */
-    protected static function methodExcludedByOptions($method, array $options)
+    public static function methodExcludedByOptions($method, array $options)
     {
         return (isset($options['only']) && ! in_array($method, (array) $options['only'])) ||
             (! empty($options['except']) && in_array($method, (array) $options['except']));

--- a/src/Illuminate/Routing/Controllers/HasMiddleware.php
+++ b/src/Illuminate/Routing/Controllers/HasMiddleware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Routing\Controllers;
+
+interface HasMiddleware
+{
+    /**
+     * Get the middleware that should be assigned to the controller.
+     *
+     * @return \Illuminate\Routing\Controllers\Middleware|array
+     */
+    public static function resolveMiddleware();
+}

--- a/src/Illuminate/Routing/Controllers/HasMiddleware.php
+++ b/src/Illuminate/Routing/Controllers/HasMiddleware.php
@@ -9,5 +9,5 @@ interface HasMiddleware
      *
      * @return \Illuminate\Routing\Controllers\Middleware|array
      */
-    public static function resolveMiddleware();
+    public static function middleware();
 }

--- a/src/Illuminate/Routing/Controllers/Middleware.php
+++ b/src/Illuminate/Routing/Controllers/Middleware.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Routing\Controllers;
+
+use Closure;
+use Illuminate\Support\Arr;
+
+class Middleware
+{
+    /**
+     * The middleware that should be assigned.
+     *
+     * @var \Closure|string|array
+     */
+    public $middleware;
+
+    /**
+     * The controller methods the middleware should only apply to.
+     *
+     * @var array|null
+     */
+    public $only;
+
+    /**
+     * The controller methods the middleware should not apply to.
+     *
+     * @var array|null
+     */
+    public $except;
+
+    /**
+     * Create a new controller middleware definition.
+     *
+     * @param  \Closure|string|array  $middleware
+     * @return void
+     */
+    public function __construct(Closure|string|array $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
+    /**
+     * Specify the only controller methods the middleware should apply to.
+     *
+     * @param  array|string  $only
+     * @return $this
+     */
+    public function only(array|string $only)
+    {
+        $this->only = Arr::wrap($only);
+
+        return $this;
+    }
+
+    /**
+     * Specify the controller methods the middleware should not apply to.
+     *
+     * @param  array|string  $only
+     * @return $this
+     */
+    public function except(array|string $except)
+    {
+        $this->except = Arr::wrap($except);
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1093,9 +1093,13 @@ class Route
             );
         }
 
-        return $this->controllerDispatcher()->getMiddleware(
-            $this->getController(), $controllerMethod
-        );
+        if (is_a($controllerClass, Controller::class, true)) {
+            return $this->controllerDispatcher()->getMiddleware(
+                $this->getController(), $controllerMethod
+            );
+        }
+
+        return [];
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Contracts\CallableDispatcher;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
+use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
@@ -1081,9 +1082,36 @@ class Route
             return [];
         }
 
+        [$controllerClass, $controllerMethod] = [
+            $this->getControllerClass(),
+            $this->getControllerMethod(),
+        ];
+
+        if (is_a($controllerClass, HasMiddleware::class, true)) {
+            return $this->staticallyProvidedControllerMiddleware(
+                $controllerClass, $controllerMethod
+            );
+        }
+
         return $this->controllerDispatcher()->getMiddleware(
-            $this->getController(), $this->getControllerMethod()
+            $this->getController(), $controllerMethod
         );
+    }
+
+    /**
+     * Get the statically provided controller middleware for the given class and method.
+     *
+     * @param  string  $class
+     * @param  string  $method
+     * @return array
+     */
+    protected function staticallyProvidedControllerMiddleware(string $class, string $method)
+    {
+        return collect($class::resolveMiddleware())->reject(function ($middleware) use ($method) {
+            return $this->controllerDispatcher()::methodExcludedByOptions(
+                $method, ['only' => $middleware->only, 'except' => $middleware->except]
+            );
+        })->map->middleware->all();
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1111,11 +1111,11 @@ class Route
      */
     protected function staticallyProvidedControllerMiddleware(string $class, string $method)
     {
-        return collect($class::resolveMiddleware())->reject(function ($middleware) use ($method) {
+        return collect($class::middleware())->reject(function ($middleware) use ($method) {
             return $this->controllerDispatcher()::methodExcludedByOptions(
                 $method, ['only' => $middleware->only, 'except' => $middleware->except]
             );
-        })->map->middleware->all();
+        })->map->middleware->values()->all();
     }
 
     /**

--- a/tests/Integration/Routing/HasMiddlewareTest.php
+++ b/tests/Integration/Routing/HasMiddlewareTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Routing\Controllers\HasMiddleware;
+use Illuminate\Routing\Controllers\Middleware;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class HasMiddlewareTest extends TestCase
+{
+    public function test_has_middleware_is_respected()
+    {
+        $route = Route::get('/', [HasMiddlewareTestController::class, 'index']);
+        $this->assertEquals($route->controllerMiddleware(), ['all', 'only-index']);
+
+        $route = Route::get('/', [HasMiddlewareTestController::class, 'show']);
+        $this->assertEquals($route->controllerMiddleware(), ['all', 'except-index']);
+    }
+}
+
+class HasMiddlewareTestController implements HasMiddleware
+{
+    public static function middleware()
+    {
+        return [
+            new Middleware('all'),
+            (new Middleware('only-index'))->only('index'),
+            (new Middleware('except-index'))->except('index'),
+        ];
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    public function show()
+    {
+
+    }
+}

--- a/tests/Integration/Routing/HasMiddlewareTest.php
+++ b/tests/Integration/Routing/HasMiddlewareTest.php
@@ -37,6 +37,5 @@ class HasMiddlewareTestController implements HasMiddleware
 
     public function show()
     {
-
     }
 }


### PR DESCRIPTION
This allows controller middleware to be resolved statically without instantiating the controller. Closes https://github.com/laravel/framework/issues/44177

Alternative to https://github.com/laravel/framework/pull/44192

AFAIK, this does not affect the order middleware are run and middleware priority is preserved. Therefore, there are NO breaking changes and I have submitted this to 9.x. This new behavior would be documented as the only way to define middleware on controllers; however, the prior way to define middleware would not be removed.

A new interface `HasMiddleware` and value object `Middleware` have been introduced:

```php
<?php

namespace App\Http\Controllers;

use Illuminate\Http\Request;
use Illuminate\Routing\Controllers\HasMiddleware;
use Illuminate\Routing\Controllers\Middleware;

class TestController extends Controller implements HasMiddleware
{
    public static function resolveMiddleware()
    {
        return [
            (new Middleware('auth'))->only('index'),
        ];
    }

    public function index()
    {
        return 'Hello World';
    }
}
```

**However, I REALLY do not like method name `resolveMiddleware`.** I can't make it `middleware` because the base controller class already has that method defined non-statically. Does anyone have any ideas for better naming here?

@rodrigopedra @X-Coder264 @christhomas any thoughts on this?