### PR TITLE
[9.x] Fix relative links for regular files

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -359,7 +359,7 @@ class Filesystem
 
         $relativeTarget = (new SymfonyFilesystem)->makePathRelative($target, dirname($link));
 
-        $this->link($relativeTarget, $link);
+        $this->link($this->isFile($target) ? rtrim($relativeTarget, '/') : $relativeTarget, $link);
     }
 
     /**


### PR DESCRIPTION
Laravel's `storage:link --relative` command breaks when configuring paths to regular files.

### How to reproduce

Add `symfony/filesystem` to [support relative links](https://github.com/luchaos/laravel-framework/blob/9.x/composer.json#L168):

```shell
composer require symfony/filesystem
```

Add link to regular file in `config/filesystems.php`:

```php
'links' => [
    public_path('README.md') => base_path('README.md'),
],
```

Run storage link command with relative option:

```shell
php artisan storage:link --relative
```

Results in...

```
  ErrorException 

  symlink(): No such file or directory
```

... because the relative path now has a trailing slash: `../README.md/`.

This PR mitigates a [bug in Symfony's filesystem component](https://github.com/symfony/symfony/pull/47424/files#diff-8ed4bb257b072f37dd45c63894e898136213634b10e033fef75abc46577649a8R493-R497) which [dates back all the way to 2012](https://github.com/symfony/symfony/pull/4842), introduced in [Laravel 8.x](https://github.com/laravel/framework/pull/33882).

I wouldn't expect this bug to be fixed in Symfony itself anytime soon given its history. The fix on Laravel's framework level is simple enough without breaking any existing behaviour (I don't think this particular case ever worked in the first place).

This could be backported to 8.x easily if desired; [adhering to the support policy](https://laravel.com/docs/9.x/releases#support-policy).