### PR TITLE
[9.x] Fix method name in shouldBeStrict method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -398,7 +398,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         static::preventLazyLoading();
         static::preventSilentlyDiscardingAttributes();
-        static::preventsAccessingMissingAttributes();
+        static::preventAccessingMissingAttributes();
     }
 
     /**


### PR DESCRIPTION
We should be strict. (pun intended) 😅
To enable this feature, we call `preventAccessingMissingAttributes` method and not `preventsAccessingMissingAttributes` method.

Introduced in #44283