### PR TITLE
[9.x] Use get methods to access application locale

### DIFF
--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -22,11 +22,11 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
             // When registering the translator component, we'll need to set the default
             // locale as well as the fallback locale. So, we'll grab the application
             // configuration so we can easily get both of these values from there.
-            $locale = $app['config']->get('app.locale');
+            $locale = $app->getLocale();
 
             $trans = new Translator($loader, $locale);
 
-            $trans->setFallback($app['config']->get('app.fallback_locale'));
+            $trans->setFallback($app->getFallbackLocale());
 
             return $trans;
         });

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -22,11 +22,11 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
             // When registering the translator component, we'll need to set the default
             // locale as well as the fallback locale. So, we'll grab the application
             // configuration so we can easily get both of these values from there.
-            $locale = $app['config']['app.locale'];
+            $locale = $app['config']->get('app.locale');
 
             $trans = new Translator($loader, $locale);
 
-            $trans->setFallback($app['config']['app.fallback_locale']);
+            $trans->setFallback($app['config']->get('app.fallback_locale'));
 
             return $trans;
         });


### PR DESCRIPTION
This PR allows to easily mock access to config (`app.locale` & `app.fallback_locale`) in TranslationServiceProvider.

I got this error
```
Error: Cannot use object of type Mockery_0_stdClass as array

/vendor/laravel/framework/src/Illuminate/Translation/TranslationServiceProvider.php:25
```

When I apply similar mock as https://github.com/laravel/framework/blob/9.x/tests/Foundation/FoundationApplicationTest.php#L22
```
class CommandTest extends TestCase
{
    protected Application $app;

    protected function setUp(): void
    {
        $this->app = new Application();
        $this->app['config'] = m::mock(\stdClass::class);
        $this->app['env'] = 'testing';

        $this->app->register(ValidationServiceProvider::class);
        $this->app->register(TranslationServiceProvider::class);
        $this->app->register(FilesystemServiceProvider::class);

        $this->app->instance('path.config', __DIR__ . '/../config');
        $this->app->instance('path.storage', __DIR__ . '/../storage');
        $this->app->instance('path.lang', __DIR__ . '/../lang');

        $this->app->boot();

        $this
            ->app['config']
            ->shouldReceive('get')
            ->once()
            ->with('app.locale')
            ->andReturns('en');
        $this
            ->app['config']
            ->shouldReceive('get')
            ->once()
            ->with('app.fallback_locale')
            ->andReturns('en');

        Facade::setFacadeApplication($this->app);
    }
```
