### PR TITLE
[9.x] Add value directive to Blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -24,6 +24,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesHelpers,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,
+        Concerns\CompilesInputs,
         Concerns\CompilesJson,
         Concerns\CompilesJs,
         Concerns\CompilesLayouts,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesInputs.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInputs.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesInputs
+{
+    /**
+     * Compile the value of 'input' or 'select' HTML elements.
+     *
+     * @param $value
+     * @return string
+     */
+    protected function compileValue($value)
+    {
+        $expression = $this->stripParentheses($value);
+
+        return "<?php echo 'value=\"' . $expression . '\"'; ?>";
+    }
+}

--- a/tests/View/Blade/BladeInputValueTest.php
+++ b/tests/View/Blade/BladeInputValueTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeInputValueTest extends AbstractBladeTestCase
+{
+    public function testValuesAreCompiledWithString()
+    {
+        $string = "<input @value('test')/>";
+        $expected = "<input <?php echo 'value=\"' . 'test' . '\"'; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testValuesAreCompiledWithNumber()
+    {
+        $string = '<input @value(1)/>';
+        $expected = "<input <?php echo 'value=\"' . 1 . '\"'; ?>/>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladeInputValueTest.php
+++ b/tests/View/Blade/BladeInputValueTest.php
@@ -16,6 +16,18 @@ class BladeInputValueTest extends AbstractBladeTestCase
     {
         $string = '<input @value(1)/>';
         $expected = "<input <?php echo 'value=\"' . 1 . '\"'; ?>/>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testValuesAreCompiledWithObjectAttribute()
+    {
+        $object = new \stdClass();
+        $object->id = 1;
+
+        $string = "<input @value($object->id)/>";
+        $expected = "<input <?php echo 'value=\"' . 1 . '\"'; ?>/>";
+
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
This PR adds a short diretive `value` to assign values to the 'input' and 'option' elements in Blade.

Current sintaxy:
`<input type="text" value="{{ $someValue }}"/>`

New possible sintaxy:
`<input type="text" @value($someValue)/>`

or

Current sintaxy:
```
<option value="{{ $someValue }}"/>
  Foo Bar
</option>
```

New possible sintaxy:
```
<option @value($someValue)/>
  Foo Bar
</option>
```

If it's merged, I'll create the PR for the docs.