### PR TITLE
 [9.x] Ability to disable route scope bindings

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -46,7 +46,7 @@ class ImplicitRouteBinding
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 
-            if ($parent instanceof UrlRoutable && $route->getAction('scope_bindings') !== false && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
+            if ($parent instanceof UrlRoutable && ! $route->preventsScopedBindings() && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
                 $childRouteBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -46,7 +46,7 @@ class ImplicitRouteBinding
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 
-            if ($parent instanceof UrlRoutable && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
+            if ($parent instanceof UrlRoutable && $route->getAction('scope_bindings') !== false && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
                 $childRouteBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -46,7 +46,9 @@ class ImplicitRouteBinding
                         ? 'resolveSoftDeletableRouteBinding'
                         : 'resolveRouteBinding';
 
-            if ($parent instanceof UrlRoutable && ! $route->preventsScopedBindings() && ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
+            if ($parent instanceof UrlRoutable &&
+                ! $route->preventsScopedBindings() &&
+                ($route->enforcesScopedBindings() || array_key_exists($parameterName, $route->bindingFields()))) {
                 $childRouteBindingMethod = $route->allowsTrashedBindings() && in_array(SoftDeletes::class, class_uses_recursive($instance))
                             ? 'resolveSoftDeletableChildRouteBinding'
                             : 'resolveChildRouteBinding';

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1124,6 +1124,18 @@ class Route
     }
 
     /**
+     * Indicate that the route should not enforce scoping of multiple implicit Eloquent bindings.
+     *
+     * @return $this
+     */
+    public function withoutScopeBindings()
+    {
+        $this->action['scope_bindings'] = false;
+
+        return $this;
+    }
+
+    /**
      * Determine if the route should enforce scoping of multiple implicit Eloquent bindings.
      *
      * @return bool

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1128,7 +1128,7 @@ class Route
      *
      * @return $this
      */
-    public function withoutScopeBindings()
+    public function withoutScopedBindings()
     {
         $this->action['scope_bindings'] = false;
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1146,6 +1146,16 @@ class Route
     }
 
     /**
+     * Determine if the route should prevent scoping of multiple implicit Eloquent bindings.
+     *
+     * @return bool
+     */
+    public function preventsScopedBindings()
+    {
+        return isset($this->action['scope_bindings']) && $this->action['scope_bindings'] === false;
+    }
+
+    /**
      * Specify that the route should not allow concurrent requests from the same session.
      *
      * @param  int|null  $lockSeconds

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -26,7 +26,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method \Illuminate\Routing\RouteRegistrar where(array $where)
  * @method \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string $middleware)
- * @method \Illuminate\Routing\RouteRegistrar withoutScopeBindings()
+ * @method \Illuminate\Routing\RouteRegistrar withoutScopedBindings()
  */
 class RouteRegistrar
 {

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -26,6 +26,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method \Illuminate\Routing\RouteRegistrar where(array $where)
  * @method \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string $middleware)
+ * @method \Illuminate\Routing\RouteRegistrar withoutScopeBindings()
  */
 class RouteRegistrar
 {
@@ -70,6 +71,7 @@ class RouteRegistrar
         'scopeBindings',
         'where',
         'withoutMiddleware',
+        'withoutScopeBindings',
     ];
 
     /**

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -71,7 +71,6 @@ class RouteRegistrar
         'scopeBindings',
         'where',
         'withoutMiddleware',
-        'withoutScopeBindings',
     ];
 
     /**

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -31,7 +31,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method static \Illuminate\Routing\RouteRegistrar where(array $where)
  * @method static \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string $middleware)
- * @method static \Illuminate\Routing\RouteRegistrar withoutScopeBindings()
+ * @method static \Illuminate\Routing\RouteRegistrar withoutScopedBindings()
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)
  * @method static \Illuminate\Routing\ResourceRegistrar resourceVerbs(array $verbs = [])
  * @method static string|null currentRouteAction()

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -31,6 +31,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar scopeBindings()
  * @method static \Illuminate\Routing\RouteRegistrar where(array $where)
  * @method static \Illuminate\Routing\RouteRegistrar withoutMiddleware(array|string $middleware)
+ * @method static \Illuminate\Routing\RouteRegistrar withoutScopeBindings()
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)
  * @method static \Illuminate\Routing\ResourceRegistrar resourceVerbs(array $verbs = [])
  * @method static string|null currentRouteAction()

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -183,7 +183,7 @@ PHP);
 use Illuminate\Tests\Integration\Routing\ImplicitBindingUser;
 use Illuminate\Tests\Integration\Routing\ImplicitBindingPost;
 
-Route::group(['scoping' => true], function () {
+Route::group(['scope_bindings' => true], function () {
     Route::get('/user/{user}/post/{post}', function (ImplicitBindingUser \$user, ImplicitBindingPost \$post) {
         return [\$user, \$post];
     })->middleware(['web']);
@@ -203,7 +203,7 @@ PHP);
 
         config(['app.key' => str_repeat('a', 32)]);
 
-        Route::group(['scoping' => false], function () {
+        Route::group(['scope_bindings' => false], function () {
             Route::get('/user/{user}/post/{post}', function (ImplicitBindingUser $user, ImplicitBindingPost $post) {
                 return [$user, $post];
             })->middleware(['web']);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1753,7 +1753,7 @@ class RoutingRouteTest extends TestCase
 
                 return $testTeam->value.'|'.$user->value;
             },
-        ])->withoutScopeBindings();
+        ])->withoutScopedBindings();
 
         $this->assertSame('1|4', $router->dispatch(Request::create('foo/1/4', 'GET'))->getContent());
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1741,6 +1741,23 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testImplicitBindingsWhereScopedBindingsArePrevented()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/{test_team}/{user:id}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (RoutingTestTeamWithoutUserModel $testTeam, RoutingTestUserModel $user) {
+                $this->assertInstanceOf(RoutingTestTeamWithoutUserModel::class, $testTeam);
+                $this->assertInstanceOf(RoutingTestUserModel::class, $user);
+
+                return $testTeam->value.'|'.$user->value;
+            },
+        ])->withoutScopeBindings();
+
+        $this->assertSame('1|4', $router->dispatch(Request::create('foo/1/4', 'GET'))->getContent());
+    }
+
     public function testParentChildImplicitBindings()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Per the [docs](https://laravel.com/docs/9.x/routing#implicit-model-binding-scoping):

> When using a custom keyed implicit binding as a nested route parameter, Laravel will automatically scope the query to retrieve the nested model by its parent using conventions to guess the relationship name on the parent

The problem is that there are situations where the models are unrelated, but we would still prefer to use a custom key. 

Consider an eCommerce app with the route `stores/{seller}/{category:slug}`; a seller store can be browsed by category, but the`$seller->categories` relationship does not exist, because categories are shared amongst all sellers. 

I came across another completely different [use case here](https://github.com/laravel/framework/discussions/39643).

The two workarounds i've found are:
- define a custom route parameter like `categoryForStore` and have that query remove the parent/child scope
- ~~pass the `scope_bindings` attribute manually like `Route::get('foo', ['uses' => ..., 'scope_bindings' => false]`~~ (UPDATE - actually providing a false value to `scope_bindings` only started working with this PR due to the change to this if statement: https://github.com/laravel/framework/pull/44528/files#diff-614b34c8eaac77de1d4faf100a7133e526cfe1350ce4f02e9f60c24a88179c77L49)

This PR provides a more fluent `withoutScopeBindings()` method which disables child parameter scoping logic. It does this by setting `scope_bindings` to false in the route `$action` array, and then checking whether scope bindings has been disabled in the `ImplicitRouteBinding` class. 

This shouldn't break anything, because `scope_bindings` can only be set using `->scopeBindings()` on the route, so by internally checking whether it is set first, we can ascertain whether the user is explicitly wanting to modify the behaviour of scope bindings. 

With this change, the store route above can now be defined as:

```php
Route::get('stores/{seller}/{category:slug}', ShowStoreComponent::class)
    ->name('stores.show')
    ->withoutScopeBindings();
```

I also believe I fixed a bug, which was a reference to `scoping` instead of `scope_bindings` in an integration test; I couldn't find any reference to a `scoping` attribute anywhere in routing.