### PR TITLE
[9.x] Add shuffle to str and stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -996,6 +996,17 @@ class Str
     }
 
     /**
+     * Shuffle the string.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function shuffle($value)
+    {
+        return str_shuffle($value);
+    }
+
+    /**
      * Get the singular form of an English word.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -653,6 +653,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Shuffle the string.
+     *
+     * @return static
+     */
+    public function shuffle()
+    {
+        return new static(Str::shuffle($this->value));
+    }
+
+    /**
      * Remove all "extra" blank space from the given string.
      *
      * @return static


### PR DESCRIPTION
Add the possibility to use `->shuffle()` on a stringable.

``` php
str('Hello World!')->shuffle();

// Output: "rlod ol!eHWl"
```

You can also call other functions on it.
For instance to generate a random number with 42 digits.
``` php
str('0123456789')
  ->repeat(42)
  ->shuffle()
  ->substr(0, 42);
```