### PR TITLE
[9.x] Ability to guess policy from container

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Auth\Access\Events\GateEvaluated;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
@@ -678,6 +679,14 @@ class Gate implements GateContract
         }
 
         $classDirname = str_replace('/', '\\', dirname(str_replace('\\', '/', $class)));
+
+        if ($classDirname === '.') {
+            try {
+                $classDirname = get_class(app($class));
+            } catch (BindingResolutionException) {
+                // Do nothing if resolution failed.
+            }
+        }
 
         $classDirnameSegments = explode('\\', $classDirname);
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -683,7 +683,7 @@ class Gate implements GateContract
         if ($classDirname === '.') {
             try {
                 $classDirname = get_class(app($class));
-            } catch (BindingResolutionException) {
+            } catch (\Throwable) {
                 // Do nothing if resolution failed.
             }
         }

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -6,7 +6,6 @@ use Closure;
 use Exception;
 use Illuminate\Auth\Access\Events\GateEvaluated;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -37,6 +37,20 @@ class GatePolicyResolutionTest extends TestCase
         );
     }
 
+    public function testPolicyCanBeGuessedUsingContainerResolution()
+    {
+        app()->bind('AuthenticationTestUser', AuthenticationTestUserPolicy::class);
+
+        $this->assertInstanceOf(
+            AuthenticationTestUserPolicy::class,
+            Gate::getPolicyFor('AuthenticationTestUser')
+        );
+
+        $this->assertNull(
+            Gate::getPolicyFor('NonExistingBinding')
+        );
+    }
+
     public function testPolicyCanBeGuessedUsingCallback()
     {
         Gate::guessPolicyNamesUsing(function () {


### PR DESCRIPTION
## About

When using authorization, you often end up writing `@can` like this:

```php
@can('useDashboard', App\Models\Company::class)
    ...
@endcan
```

But currently, it's impossible to guess policy based on the container binding. This PR adds the possibility to do this:
```php
@can('useDashboard', Company::class)
    ...
@endcan
```

If you have aliases for models, you'll be able to use them when resolving policies.
It shouldn't break anything, because in case of failed resolution we just do nothing.

---
