### PR TITLE
[9.x] Correct channel matching

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -372,6 +372,8 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function channelNameMatchesPattern($channel, $pattern)
     {
-        return Str::is(preg_replace('/\{(.*?)\}/', '*', $pattern), $channel);
+        return preg_match('/'.preg_replace('/\{(.*?)\}/', '([^\.]+)', $pattern).'$/', $channel);
+
+        // return Str::is(preg_replace('/\{(.*?)\}/', '*', $pattern), $channel);
     }
 }

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -330,7 +330,7 @@ class BroadcasterTest extends TestCase
             ['something.23.test', 'something.{id}.test', true],
             ['something.23.test.42', 'something.{id}.test.{id2}', true],
             ['something-23:test-42', 'something-{id}:test-{id2}', true],
-            ['something..test.42', 'something.{id}.test.{id2}', true],
+            ['something..test.42', 'something.{id}.test.{id2}', false],
             ['23:string:test', '{id}:string:{text}', true],
             ['something.23', 'something', false],
             ['something.23.test.42', 'something.test.{id}', false],


### PR DESCRIPTION
Laravel previously had some unexpected behavior (imo) when matching channels. This was raised to me via email by a community member.

If you have:

```php
Broadcast::channel(
    'App.Interaction.{uuid}',
    static function ($user, $uuid) {
        return true;
    },
);
```

And you attempt to subscribe to channel `App.Interaction.some-uuid.Internal`, the channel will match; however, the injected parameter will just be "some-uuid"... ".Internal" will be removed. This is because the channel matching in Laravel was using a fairly naive Str::is check which did not match the regular expression logic of the parameter injection. IMO the logic should be the same between the two. So, I have updated the channel matching regular expression to match the parameter injection regular expression.

In theory this could break applications that expected this route to match; however, those routes were already receiving a sliced parameter that may not be what they expect. So, I am viewing this as a bug. Will revisit if community feedback pushes back on release.

There was a test that showed this broken behavior but it appears to be added just out of thoroughness by a community member 4 years ago when the test was first added. Not for a specific use case.