### PR TITLE
[9.x] Fix PHPDoc of Vite facade

### DIFF
--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -6,7 +6,7 @@ namespace Illuminate\Support\Facades;
  * @method static string useCspNonce(?string $nonce = null)
  * @method static string|null cspNonce()
  * @method static string|null manifestHash(?string $buildDirectory = null)
- * @method static string asset(string $asset, string|null $buildDirectory)
+ * @method static string asset(string $asset, ?string $buildDirectory = null)
  * @method static string hotFile()
  * @method static \Illuminate\Foundation\Vite useBuildDirectory(string $path)
  * @method static \Illuminate\Foundation\Vite useHotFile(string $path)


### PR DESCRIPTION
This pull request fixes the PHPDoc of the `asset` function, where `$buildDirectory` is now a optional string parameter, just like `manifestHash`, where it already was an optional parameter.