### PR TITLE
[9.x] Update schedule:work usleep from 0.1 seconds to 0.5 seconds

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -47,7 +47,7 @@ class ScheduleWorkCommand extends Command
         [$lastExecutionStartedAt, $keyOfLastExecutionWithOutput, $executions] = [null, null, []];
 
         while (true) {
-            usleep(100 * 1000);
+            usleep(500 * 1000); // 0.5 seconds
 
             if (Carbon::now()->second === 0 &&
                 ! Carbon::now()->startOfMinute()->equalTo($lastExecutionStartedAt)) {


### PR DESCRIPTION
Howdy,

Its a minor thing, but do we need to poll every 0.1 second in `artisan schedule:work`? there could be a specific reason that I'm not aware of?

Its not a super scientific test, but I tested with a schedule to run `$schedule->command('inspire')->everyMinute();`, then tested the following sleep configurations for a total of 10 minutes.

```
100 = 0.1 seconds
500 = 0.5 seconds
1000 = 1 second
```

There is a minor decrease in CPU utilization shown in `htop` for both the `0.5 second` and `1 second` test
![image](https://user-images.githubusercontent.com/54159303/195042901-e88de9b3-57d6-44ad-8fa8-34bc3b387bbc.png)

Personally I would be inclined to shoot for a straight 1 second sleep in the loop, but I figured there is probably a reason why this was initially not set as such, in which case 0.5 might be a nice middle ground.

Having said that, I'd understand if this PR gets knocked back because of how minor 0.1% cpu usage is, at the very least I figure its worth a shot to see if the sleep timer is worth discussion.
