### PR TITLE
[10.x] Remove option from `make:rule` re-added by mistake

### DIFF
--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -84,7 +84,6 @@ class RuleMakeCommand extends GeneratorCommand
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the rule already exists'],
             ['implicit', 'i', InputOption::VALUE_NONE, 'Generate an implicit rule'],
-            ['invokable', null, InputOption::VALUE_NONE, 'Generate a single method, invokable rule class'],
         ];
     }
 }


### PR DESCRIPTION
PR #44016 re-added the `--invokable` option to the `MakeRuleCommand` after it was removed by PR #43868

As Invokable rules will be the default in 10.x, this PR removes this option again.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
