### PR TITLE
[9.x] Add helpers for accessor and mutator

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Foundation\Bus\PendingClosureDispatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
@@ -85,6 +86,19 @@ if (! function_exists('abort_unless')) {
         if (! $boolean) {
             abort($code, $message, $headers);
         }
+    }
+}
+
+if (! function_exists('accessor')) {
+    /**
+     * Returns an Attribute instance used as an accessor.
+     *
+     * @param  callable  $get
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    function accessor(callable $get)
+    {
+        return Attribute::get($get);
     }
 }
 
@@ -557,6 +571,20 @@ if (! function_exists('mix')) {
     function mix($path, $manifestDirectory = '')
     {
         return app(Mix::class)(...func_get_args());
+    }
+}
+
+if (! function_exists('mutator')) {
+    /**
+     * Returns an Attribute instance used as a mutator.
+     *
+     * @param  callable|null  $get
+     * @param  callable|null  $set
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
+     */
+    function mutator(callable $get = null, callable $set = null)
+    {
+        return Attribute::make($get, $set);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Add two new helper methods to facilitate creating accessors and mutators in Eloquent models.

Example:

```php
<?php
 
namespace App\Models;
 
use App\Support\Address;
use Illuminate\Database\Eloquent\Casts\Attribute;
use Illuminate\Database\Eloquent\Model;
 
class User extends Model
{
    /**
     * Interact with the user's full name.
     *
     * @return \Illuminate\Database\Eloquent\Casts\Attribute
     */
    protected function fullName(): Attribute
    {
        return accessor(fn ($value, $attributes) => $attributes['first_name'].' '.$attributes['last_name']);
    }

    /**
     * Interact with the user's address.
     *
     * @return \Illuminate\Database\Eloquent\Casts\Attribute
     */
    protected function address(): Attribute
    {
        return mutator(
            get: fn ($value, $attributes) => new Address(
                $attributes['address_line_one'],
                $attributes['address_line_two'],
            ),
            set: fn (Address $value) => [
                'address_line_one' => $value->lineOne,
                'address_line_two' => $value->lineTwo,
            ],
        );
    }
}
```

