### PR TITLE
[9.x] Fix ->clone() on Relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,38 @@
 # Release Notes for 9.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v9.34.0...9.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v9.35.1...9.x)
+
+
+## [v9.35.1](https://github.com/laravel/framework/compare/v9.35.0...v9.35.1) - 2022-10-11
+
+### Fixed
+- Remove check for `$viewFactory->exists($component)` in `Illuminate/View/Compilers/ComponentTagCompiler::componentClass` ([7c6db00](https://github.com/laravel/framework/commit/7c6db000928be240dfc6996537a0fed5b8c68ebb))
+
+
+## [v9.35.0](https://github.com/laravel/framework/compare/v9.34.0...v9.35.0) - 2022-10-11
+
+### Added
+- Allow loading trashed models for resource routes ([#44405](https://github.com/laravel/framework/pull/44405))
+- Added `Illuminate/Database/Eloquent/Model::shouldBeStrict()` and other ([#44283](https://github.com/laravel/framework/pull/44283))
+- Controller middleware without resolving controller ([#44516](https://github.com/laravel/framework/pull/44516))
+- Alternative Mailable Syntax ([#44462](https://github.com/laravel/framework/pull/44462))
+
+### Fixed
+- Fix issue with aggregates (withSum, etc.) for pivot columns on self-referencing many-to-many relations ([#44286](https://github.com/laravel/framework/pull/44286))
+- Fixes issue using static class properties as blade attributes ([#44473](https://github.com/laravel/framework/pull/44473))
+- Traversable should have priority over JsonSerializable in EnumerateValues ([#44456](https://github.com/laravel/framework/pull/44456))
+- Fixed `make:cast --inbound` so it's a boolean option, not value ([#44505](https://github.com/laravel/framework/pull/44505))
+
+### Changed
+- Testing methods. Making error messages with json_encode more readable ([#44397](https://github.com/laravel/framework/pull/44397))
+- Have 'Model::withoutTimestamps()' return the callback's return value ([#44457](https://github.com/laravel/framework/pull/44457))
+- only load trashed models on relevant routes ([#44478](https://github.com/laravel/framework/pull/44478))
+- Adding additional PHP extensions to shouldBlockPhpUpload Function ([#44512](https://github.com/laravel/framework/pull/44512))
+- Register cutInternals casters for particularly noisy objects ([#44514](https://github.com/laravel/framework/pull/44514))
+- Use get methods to access application locale ([#44521](https://github.com/laravel/framework/pull/44521))
+- return only on non empty response from channels ([09d53ee](https://github.com/laravel/framework/commit/09d53eea674db7daa8bb65aa8fa7f2ca95e62b8d), [3944a3e](https://github.com/laravel/framework/commit/3944a3e34fe860633c77b574bbfbbcdabcf7d1e7))
+- Correct channel matching ([#44531](https://github.com/laravel/framework/pull/44531))
+- Migrate mail components ([#44527](https://github.com/laravel/framework/pull/44527))
 
 
 ## [v9.34.0](https://github.com/laravel/framework/compare/v9.33.0...v9.34.0) - 2022-10-04

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -492,7 +492,7 @@ abstract class Relation implements BuilderContract
     }
 
     /**
-     * Clone the Relationship
+     * Clone the Relationship.
      *
      * @return static
      */

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -492,6 +492,16 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Clone the Relationship
+     *
+     * @return static
+     */
+    public function clone()
+    {
+        return clone $this;
+    }
+
+    /**
      * Force a clone of the underlying query builder when cloning.
      *
      * @return void

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -38,7 +38,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '9.35.0';
+    const VERSION = '9.35.1';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -312,7 +312,7 @@ class ComponentTagCompiler
             return $guess;
         }
 
-        if (Str::startsWith($component, 'mail::') && $viewFactory->exists($component)) {
+        if (Str::startsWith($component, 'mail::')) {
             return $component;
         }
 

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -489,9 +489,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->seedData();
         $country = HasManyThroughTestCountry::first();
 
-        $posts = $country->posts()->get()->map(fn($post) => [$post->id, $post->title]);
-        $postsFromCloneKeyword = (clone $country->posts())->get()->map(fn($post) => [$post->id, $post->title]);
-        $postsFromCloneMethod = $country->posts()->clone()->get()->map(fn($post) => [$post->id, $post->title]);
+        $posts = $country->posts()->get()->map(fn ($post) => [$post->id, $post->title]);
+        $postsFromCloneKeyword = (clone $country->posts())->get()->map(fn ($post) => [$post->id, $post->title]);
+        $postsFromCloneMethod = $country->posts()->clone()->get()->map(fn ($post) => [$post->id, $post->title]);
 
         $this->assertEquals($posts, $postsFromCloneKeyword);
         $this->assertEquals($posts, $postsFromCloneMethod);

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
@@ -472,6 +473,28 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertSame('us', $country->shortname);
         $this->assertSame('A title', $country->posts[0]->title);
         $this->assertCount(2, $country->posts);
+    }
+
+    public function testCloneReturnsCorrectClass()
+    {
+        $country = HasManyThroughDefaultTestCountry::make();
+        $relation = $country->posts();
+        $clone = $relation->clone();
+
+        $this->assertInstanceOf(HasManyThrough::class, $clone);
+    }
+
+    public function testAfterCloneIdsArePreserved()
+    {
+        $this->seedData();
+        $country = HasManyThroughTestCountry::first();
+
+        $posts = $country->posts()->get()->map(fn($post) => [$post->id, $post->title]);
+        $postsFromCloneKeyword = (clone $country->posts())->get()->map(fn($post) => [$post->id, $post->title]);
+        $postsFromCloneMethod = $country->posts()->clone()->get()->map(fn($post) => [$post->id, $post->title]);
+
+        $this->assertEquals($posts, $postsFromCloneKeyword);
+        $this->assertEquals($posts, $postsFromCloneMethod);
     }
 
     /**


### PR DESCRIPTION
This PR aims to fix some unwanted behaviors when calling `->clone()` on a Model Relations:

**Issue 1: a Builder is returned**

given a model with a relationship:

```php
class Country extends Model
{
    public function users()
    {
        return $this->hasMany(User::class);
    }
}
```

when calling `$country->clone()` on a `Country` instance, an `Illuminate\Database\Eloquent\Builder` is returned instead of an `Illuminate\Database\Eloquent\Relations\HasMany` relation

for a failing test, check `tests/Database/DatabaseEloquentHasManyThroughIntegrationTest::testCloneReturnsCorrectClass`


**Issue 2: IDs are messed up in HasManyThrough relationship**

calling `->get()` on a `HasManyThrough` obtained from `->clone()`, causes Models IDs to be replaced by the ones in the intermediate table.

given:

```php
class Country extends Model
{
    public function users()
    {
        return $this->hasMany(User::class);
    }

   public function posts()
    {
        return $this->hasManyThrough(Post::class, User::class);
    }
}
```

and this seeded data:

```php

::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
     ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
           ->posts()->createMany([
               ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
               ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
           ]);
```

the returned IDs of the posts are replaced by their user's:

```php
$usCountry->posts()->clone()->get()->toArray();

/*
array:2 [
  0 => array:10 [
    "id" => 1
    "user_id" => 1
    "title" => "A title"
    "body" => "A body"
    "email" => "taylorotwell@gmail.com"
    "created_at" => "2022-10-11T20:29:09.000000Z"
    "updated_at" => "2022-10-11T20:29:09.000000Z"
    "country_id" => 1
    "country_short" => "us"
    "deleted_at" => null
  ]
  1 => array:10 [
    "id" => 1                 <<< SHOULD BE "2"
    "user_id" => 1
    "title" => "Another title"
    "body" => "Another body"
    "email" => "taylorotwell@gmail.com"
    "created_at" => "2022-10-11T20:29:09.000000Z"
    "updated_at" => "2022-10-11T20:29:09.000000Z"
    "country_id" => 1
    "country_short" => "us"
    "deleted_at" => null
  ]
]
*/

```

for a failing test, check tests/Database/DatabaseEloquentHasManyThroughIntegrationTest::testAfterCloneIdsArePreserved