### PR TITLE
[9.x] Fix relationships `->clone()` calls

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -492,6 +492,16 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Clone the Relationship.
+     *
+     * @return static
+     */
+    public function clone()
+    {
+        return clone $this;
+    }
+
+    /**
      * Force a clone of the underlying query builder when cloning.
      *
      * @return void

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -489,9 +489,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->seedData();
         $country = HasManyThroughTestCountry::first();
 
-        $posts = $country->posts()->get()->map(fn($post) => [$post->id, $post->title]);
-        $postsFromCloneKeyword = (clone $country->posts())->get()->map(fn($post) => [$post->id, $post->title]);
-        $postsFromCloneMethod = $country->posts()->clone()->get()->map(fn($post) => [$post->id, $post->title]);
+        $posts = $country->posts()->get()->map(fn ($post) => [$post->id, $post->title]);
+        $postsFromCloneKeyword = (clone $country->posts())->get()->map(fn ($post) => [$post->id, $post->title]);
+        $postsFromCloneMethod = $country->posts()->clone()->get()->map(fn ($post) => [$post->id, $post->title]);
 
         $this->assertEquals($posts, $postsFromCloneKeyword);
         $this->assertEquals($posts, $postsFromCloneMethod);

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
@@ -472,6 +473,28 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->assertSame('us', $country->shortname);
         $this->assertSame('A title', $country->posts[0]->title);
         $this->assertCount(2, $country->posts);
+    }
+
+    public function testCloneReturnsCorrectClass()
+    {
+        $country = HasManyThroughDefaultTestCountry::make();
+        $relation = $country->posts();
+        $clone = $relation->clone();
+
+        $this->assertInstanceOf(HasManyThrough::class, $clone);
+    }
+
+    public function testAfterCloneIdsArePreserved()
+    {
+        $this->seedData();
+        $country = HasManyThroughTestCountry::first();
+
+        $posts = $country->posts()->get()->map(fn($post) => [$post->id, $post->title]);
+        $postsFromCloneKeyword = (clone $country->posts())->get()->map(fn($post) => [$post->id, $post->title]);
+        $postsFromCloneMethod = $country->posts()->clone()->get()->map(fn($post) => [$post->id, $post->title]);
+
+        $this->assertEquals($posts, $postsFromCloneKeyword);
+        $this->assertEquals($posts, $postsFromCloneMethod);
     }
 
     /**


### PR DESCRIPTION
This PR aims to fix some unwanted behaviors when calling `->clone()` on a Model Relations:

**Issue 1: a Builder is returned**

given a model with a relationship:

```php
class Country extends Model
{
    public function users()
    {
        return $this->hasMany(User::class);
    }
}
```

when calling `$country->clone()` on a `Country` instance, an `Illuminate\Database\Eloquent\Builder` is returned instead of an `Illuminate\Database\Eloquent\Relations\HasMany` relation

for a failing test, check `tests/Database/DatabaseEloquentHasManyThroughIntegrationTest::testCloneReturnsCorrectClass`


**Issue 2: IDs are messed up in HasManyThrough relationship**

calling `->get()` on a `HasManyThrough` obtained from `->clone()`, causes Models IDs to be replaced by the ones in the intermediate table.

given:

```php
class Country extends Model
{
    public function users()
    {
        return $this->hasMany(User::class);
    }

   public function posts()
    {
        return $this->hasManyThrough(Post::class, User::class);
    }
}
```

and this seeded data:

```php

::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
     ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
           ->posts()->createMany([
               ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
               ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
           ]);
```

the returned IDs of the posts are replaced by their user's:

```php
$usCountry->posts()->clone()->get()->toArray();

/*
array:2 [
  0 => array:10 [
    "id" => 1
    "user_id" => 1
    "title" => "A title"
    "body" => "A body"
    "email" => "taylorotwell@gmail.com"
    "created_at" => "2022-10-11T20:29:09.000000Z"
    "updated_at" => "2022-10-11T20:29:09.000000Z"
    "country_id" => 1
    "country_short" => "us"
    "deleted_at" => null
  ]
  1 => array:10 [
    "id" => 1                 <<< SHOULD BE "2"
    "user_id" => 1
    "title" => "Another title"
    "body" => "Another body"
    "email" => "taylorotwell@gmail.com"
    "created_at" => "2022-10-11T20:29:09.000000Z"
    "updated_at" => "2022-10-11T20:29:09.000000Z"
    "country_id" => 1
    "country_short" => "us"
    "deleted_at" => null
  ]
]
*/

```

for a failing test, check `tests/Database/DatabaseEloquentHasManyThroughIntegrationTest::testAfterCloneIdsArePreserved`