### PR TITLE
[9.x] Fix mail tags silently failing

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -236,8 +236,12 @@ class ComponentTagCompiler
         // component and pass the component as a view parameter to the data so it
         // can be accessed within the component and we can render out the view.
         if (! class_exists($class)) {
+            $view = Str::startsWith($component, 'mail::')
+                ? "\$__env->getContainer()->make(Illuminate\\View\\Factory::class)->make('{$component}')"
+                : "'$class'";
+
             $parameters = [
-                'view' => "'$class'",
+                'view' => $view,
                 'data' => '['.$this->attributesToString($data->all(), $escapeBound = false).']',
             ];
 


### PR DESCRIPTION
Extending on the recent fix: https://github.com/laravel/framework/commit/7c6db000928be240dfc6996537a0fed5b8c68ebb

This PR ensures that unknown mail components throw an error at render time.

If a mail view uses the following unknown view component...

```blade
Hi!

<x-mail::foo>
    <!-- ... -->
</x-mail::foo>

Bye.
```

It results in the following render:

```html
Hi!

mail::foo

Bye.
```

Under the hood, the resulting blade compiled template is the following...

```php
Hi!

<?php if (isset($component)) { $__componentOriginalc254754b9d5db91d5165876f9d051922ca0066f4 = $component; } ?>
<?php $component = $__env->getContainer()->make(Illuminate\View\AnonymousComponent::class, ['view' => 'mail::foo','data' => []] + (isset($attributes) ? (array) $attributes->getIterator() : [])); ?>
<?php $component->withName('mail::foo'); ?>
<?php if ($component->shouldRender()): ?>
<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
<?php if (isset($attributes) && $constructor = (new ReflectionClass(Illuminate\View\AnonymousComponent::class))->getConstructor()): ?>
<?php $attributes = $attributes->except(collect($constructor->getParameters())->map->getName()->all()); ?>
<?php endif; ?>
<?php $component->withAttributes([]); ?>
    <!-- ... -->
 <?php echo $__env->renderComponent(); ?>
<?php endif; ?>
<?php if (isset($__componentOriginalc254754b9d5db91d5165876f9d051922ca0066f4)): ?>
<?php $component = $__componentOriginalc254754b9d5db91d5165876f9d051922ca0066f4; ?>
<?php unset($__componentOriginalc254754b9d5db91d5165876f9d051922ca0066f4); ?>
<?php endif; ?>

Bye.
<?php /**PATH /Users/tim/Code/play/resources/views/mail/shipped.blade.php ENDPATH**/ ?>
```

The important line bit being...

```php
$component = $__env->getContainer()->make(
    Illuminate\View\AnonymousComponent::class,
    ['view' => 'mail::foo','data' => /* ... */]
); ?>
```

When Blade renders a component, if the returned `render()` value is a string and a view does not exist for the given string, it assumes it is an _inline_ component...

```php
class Foo extends Component
{
    public function render()
    {
        return '<div>Hello world!</div>';
    }
}
```

But in our `mail::foo` example, we end up with the following....

```php
class AnonymousComponent extends Component
{
    public function render()
    {
        return $this->view; // 'mail::foo'
    }
}
```

This PR makes it that all `mail::` views are passed down as `View` instances from within the template, essentially doing the following...

```diff
$component = $__env->getContainer()->make(
    Illuminate\View\AnonymousComponent::class,
-   ['view' => view('mail::foo'),'data' => /* ... */]
+   ['view' => view('mail::foo'),'data' => /* ... */]
); ?>
```

so then the component is doing the following...


```php
class AnonymousComponent extends Component
{
    public function render()
    {
        return $this->view; // view('mail::foo')
    }
}
```

So if `mail::foo` does not exist at render time, the following error will be shown:


<img width="1612" alt="Screen Shot 2022-10-12 at 12 00 18 pm" src="https://user-images.githubusercontent.com/24803032/195225162-fa16a34a-2503-4da0-bb35-2501cece00a8.png">

This is the exact same error message received when using the older style syntax with a mail component that does not exist...

```blade
Hi!

@component('mail::foo')
    <!-- ... -->
@endcomponent

Bye.
```

- ✅ Views are still able to be cached
- ✅ Only applies to `<x-mail::...>` components