### PR TITLE
Prompt to output friendly error message when migrating PostgreSQL db

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -244,7 +244,6 @@ class MigrateCommand extends BaseCommand
             $this->components->warn("Create your database'{$connection->getDatabaseName()}' first, then run this command again.");
             exit();
         }
-        exit();
     }
 
     /**


### PR DESCRIPTION
This PR is the PostgreSQL counterpart (well, sort of) to https://github.com/laravel/framework/pull/43867

<img width="564" alt="image" src="https://user-images.githubusercontent.com/7894265/195230446-e9b8dcd9-a897-4718-8f18-bfe6462be82a.png">


Unlike sqlite and MySQL, it's hard for PostgreSQL to create db during running migrations 😕

What does that mean? Well, like `touch database/database.sqlite` command for sqlite, PostgreSQL has `createdb` command to create database but even using this command has two problems:

1. User might not have permission to run `createdb` command.
2. Even if user can run the command, you need to stop migration process in order to use that freshly created database.

So this PR, unlike sqlite and MySQL PRs, will not creating db on behalf of user but rather just output a friendly error message to avoid  that "wall of hell" mentioned this original [PR](https://github.com/laravel/framework/pull/43867).

If someone can create better solution for PostgreSQL, please help.
Until then, hopefully this output change helps some PostgreSQL users.