### PR TITLE
Improve `Request` instance datetime parsing by introducing default value

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -352,14 +352,15 @@ trait InteractsWithInput
      * @param  string  $key
      * @param  string|null  $format
      * @param  string|null  $tz
+     * @param  \Illuminate\Support\Carbon|null  $default
      * @return \Illuminate\Support\Carbon|null
      *
      * @throws \Carbon\Exceptions\InvalidFormatException
      */
-    public function date($key, $format = null, $tz = null)
+    public function date($key, $format = null, $tz = null, \Illuminate\Support\Carbon $default = null)
     {
         if ($this->isNotFilled($key)) {
-            return null;
+            return $default ?? null;
         }
 
         if (is_null($format)) {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -660,6 +660,9 @@ class HttpRequestTest extends TestCase
 
         $this->assertTrue($request->date('as_date')->isSameDay($current));
         $this->assertTrue($request->date('as_time')->isSameSecond('16:30:25'));
+
+        $this->assertEquals($current, $request->date('as_null', null, null, $current));
+        $this->assertEquals($current, $request->date('doesnt_exists', null, null, $current));
     }
 
     public function testDateMethodExceptionWhenValueInvalid()


### PR DESCRIPTION
### Why 
Recently I bumped into the needs to add fallback value to the $request->date() helper.

As mentioned here https://github.com/laravel/framework/pull/39945#issuecomment-1059835329, there's a need for a default/fallback value which will then make it consistent with the rest of the parser (`boolean()`,` float()`, `integer()`, `string()` & `input()` )

### Usage

Previously 

````php
$startDate = Request::date('from', 'Ymd') ?? now()
````

Now

````php
$startDate =  $request->date('from', null, null, now())
````

Note: this is my first open source contributions, in the spirit of hacktoberfest.