### PR TITLE
[9.x] Check if isPrecognitive() method exists before calling it

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -24,7 +24,7 @@ trait ValidatesWhenResolvedTrait
 
         $instance = $this->getValidatorInstance();
 
-        if ($this->isPrecognitive()) {
+        if (method_exists($this, 'isPrecognitive') && $this->isPrecognitive()) {
             $instance->after(Precognition::afterValidationHook($this));
         }
 


### PR DESCRIPTION
The `ValidatesWhenResolvedTrait` calls `isPrecognitive()` which is only present in the `CanBePrecognitive` trait. The `CanBePrecognitive` trait is used in `Request`. This works fine with `FormRequest` because it extends `Request` but if you want to use the `ValidatesWhenResolvedTrait` to create your own validating objects it has an error. This change will check if the `isPrecognitive()` method exists before calling it.

I am using the `ValidatesWhenResolvedTrait` in my DTOs so that when it is resolved it can also validate the data.

