### PR TITLE
Update: Fix Error spatie/laravel-missing-page-redirector

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
+use ReflectionFunction;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class Route
@@ -234,7 +235,16 @@ class Route
             $callable = unserialize($this->action['uses'])->getClosure();
         }
 
-        return $this->container[CallableDispatcher::class]->dispatch($this, $callable);
+        return $this->container[CallableDispatcher::class]
+            ->dispatch($this, 
+                $callable(...array_values(
+                    $this->resolveMethodDependencies(
+                        $this->parametersWithoutNulls(), 
+                        new ReflectionFunction($callable
+                        )
+                    )
+                ))
+            );
     }
 
     /**


### PR DESCRIPTION
Since update from Laravel 9.32 to 9.33 the package spatie/laravel-missing-page-redirector did not work anymore.

This should fix it.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
