### PR TITLE
[9.x] Fix phpdoc for `componentNamespace` method

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -18,7 +18,7 @@ namespace Illuminate\Support\Facades;
  * @method static void component(string $class, string|null $alias = null, string $prefix = '')
  * @method static void components(array $components, string $prefix = '')
  * @method static void anonymousComponentNamespace(string $directory, string $prefix = null)
- * @method static void componentNamespace(string $prefix, string $directory = null)
+ * @method static void componentNamespace(string $namespace, string $prefix)
  * @method static void directive(string $name, callable $handler)
  * @method static void extend(callable $compiler)
  * @method static void if(string $name, callable $callback)


### PR DESCRIPTION
## About

As mentioned in #44574, there's a name mismatch in method phpdoc.
This PR fixes the confusion.