### PR TITLE
[9.x] Fix for `model:show` failing with models that have null timestamp columns

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -356,6 +356,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
     protected function getCastsWithDates($model)
     {
         return collect($model->getDates())
+            ->filter()
             ->flip()
             ->map(fn () => 'datetime')
             ->merge($model->getCasts());


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Motivation
I noticed that `model:show` currently fails with the following error for models with a null `created_at` or `updated_at` timestamp column:

```php
   ErrorException

  array_flip(): Can only flip string and integer values, entry skipped

  at vendor/laravel/framework/src/Illuminate/Collections/Collection.php:406
    402▕      * @return static<TValue, TKey>
    403▕      */
    404▕     public function flip()
    405▕     {
  ➜ 406▕         return new static(array_flip($this->items));
    407▕     }
    408▕
    409▕     /**
    410▕      * Remove an item from the collection by key.

      +4 vendor frames
  5   [internal]:0
      Illuminate\Foundation\Console\ShowModelCommand::Illuminate\Foundation\Console\{closure}(Object(Doctrine\DBAL\Schema\Column))

      +17 vendor frames
  23  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

The fix is to simply filter out any null results returned from `$model->getDates()` prior to flipping the collection.
