### PR TITLE
[9.x] Fix error message for incorrect rendering of components due to missing closing tag

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -86,6 +86,15 @@ class ComponentTagCompiler
      */
     public function compileTags(string $value)
     {
+        $hasOpeningTag = preg_match($this->getOpeningTagsPattern(), $value, $matches);
+        $hasClosingTag = preg_match($this->getClosingTagsPattern(), $value);
+
+        if ($hasOpeningTag === 1 && $hasClosingTag === 0) {
+            throw new InvalidArgumentException(
+                "Missing Closing Tag for component [{$matches[1]}]."
+            );
+        }
+
         $value = $this->compileSelfClosingTags($value);
         $value = $this->compileOpeningTags($value);
         $value = $this->compileClosingTags($value);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -103,7 +103,26 @@ class ComponentTagCompiler
      */
     protected function compileOpeningTags(string $value)
     {
-        $pattern = "/
+        $pattern = $this->getOpeningTagsPattern();
+
+        return preg_replace_callback($pattern, function (array $matches) {
+            $this->boundAttributes = [];
+
+            $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
+
+            return $this->componentString($matches[1], $attributes);
+        }, $value);
+    }
+
+    /**
+     * Get the opening tags pattern.
+     *
+     * @return string
+     *
+     */
+    protected function getOpeningTagsPattern()
+    {
+        return "/
             <
                 \s*
                 x[-\:]([\w\-\:\.]*)
@@ -143,14 +162,6 @@ class ComponentTagCompiler
                 (?<![\/=\-])
             >
         /x";
-
-        return preg_replace_callback($pattern, function (array $matches) {
-            $this->boundAttributes = [];
-
-            $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
-
-            return $this->componentString($matches[1], $attributes);
-        }, $value);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -127,7 +127,6 @@ class ComponentTagCompiler
      * Get the opening tags pattern.
      *
      * @return string
-     *
      */
     protected function getOpeningTagsPattern()
     {

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -442,7 +442,17 @@ class ComponentTagCompiler
      */
     protected function compileClosingTags(string $value)
     {
-        return preg_replace("/<\/\s*x[-\:][\w\-\:\.]*\s*>/", ' @endComponentClass##END-COMPONENT-CLASS##', $value);
+        return preg_replace($this->getClosingTagsPattern(), ' @endComponentClass##END-COMPONENT-CLASS##', $value);
+    }
+
+    /**
+     * Get the closing tags pattern.
+     *
+     * @return string
+     */
+    protected function getClosingTagsPattern()
+    {
+        return "/<\/\s*x[-\:][\w\-\:\.]*\s*>/";
     }
 
     /**


### PR DESCRIPTION
This PR will close #44553 

While compiling blade components tags to valid PHP it checks for opening and closing tags, If a component has an opening tag But missing a closing tag then it'll through an expectation saying `Missing Closing Tag for component [foo]`.

