### PR TITLE
[9.x] Add TestResponse::assertContent($string)

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -515,6 +515,19 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the given string matches the response content.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function assertContent($value)
+    {
+        PHPUnit::assertSame($value, $this->content());
+
+        return $this;
+    }
+
+    /**
      * Assert that the given string or array of strings are contained within the response.
      *
      * @param  string|array  $value

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -211,6 +211,29 @@ class TestResponseTest extends TestCase
         $response->assertViewMissing('foo.baz');
     }
 
+    public function testAssertContent()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'expected response data',
+        ]);
+
+        $response->assertContent('expected response data');
+
+        try {
+            $response->assertContent('expected');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
+        }
+
+        try {
+            $response->assertContent('expected response data with extra');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
+        }
+    }
+
     public function testAssertSee()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
Papercut: asserting the exact string content of a test response feels out of place with the existing response assertions.

```php
// Response content string should match this exactly. Nothing more. Nothing less.

// before...

$this->assertSame('foo bar', $response->content());

// after...

$response->assertContent('foo bar');
```