### PR TITLE
[9.x] Add App::isNotProduction()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -602,6 +602,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Determine if the application is not in the production environment.
+     *
+     * @return bool
+     */
+    public function isNotProduction()
+    {
+        return ! $this->isProduction();
+    }
+
+    /**
      * Detect the application's current environment.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -14,6 +14,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool isDownForMaintenance()
  * @method static bool isLocal()
  * @method static bool isProduction()
+ * @method static bool isNotProduction()
  * @method static bool routesAreCached()
  * @method static bool runningInConsole()
  * @method static bool runningUnitTests()

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -229,12 +229,14 @@ class FoundationApplicationTest extends TestCase
 
         $this->assertTrue($local->isLocal());
         $this->assertFalse($local->isProduction());
+        $this->assertTrue($local->isNotProduction());
         $this->assertFalse($local->runningUnitTests());
 
         $production = new Application;
         $production['env'] = 'production';
 
         $this->assertTrue($production->isProduction());
+        $this->assertFalse($production->isNotProduction());
         $this->assertFalse($production->isLocal());
         $this->assertFalse($production->runningUnitTests());
 
@@ -244,6 +246,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($testing->runningUnitTests());
         $this->assertFalse($testing->isLocal());
         $this->assertFalse($testing->isProduction());
+        $this->assertTrue($testing->isNotProduction());
     }
 
     public function testDebugHelper()


### PR DESCRIPTION
## What is this?

This PR adds a `App::isNotProduction()` helper that will return `true` if the app is **not in a production** environment.

## Why?

Due to recent releases such as "Strict Mode", "Prevent Lazy Loading", etc., it feels like most people use these within any environment **except** production.

In fact, even the official [Laravel docs](https://laravel.com/docs/9.x/eloquent#configuring-eloquent-strictness) hint the usage of these in non-production environments.

For example, take the code snippet given in this recent Tweet - https://twitter.com/kniklas/status/1580188955160477701

```php
Model::shouldBeStrict(! App::isProduction());

// Alternatively use these 3 statements
Model::preventLazyLoading(! App::isProduction());
Model::preventSilentlyDiscardingAttributes(! App::isProduction());
Model::preventAccessingMissingAttributes(! App::isProduction());
```

Notice the use of logic negatives to configure these to be enabled when **not** in production.

This PR offers an alternative:
```php
Model::shouldBeStrict(App::isNotProduction());

// Alternatively use these 3 statements
Model::preventLazyLoading(App::isNotProduction());
Model::preventSilentlyDiscardingAttributes(App::isNotProduction());
Model::preventAccessingMissingAttributes(App::isNotProduction());
```

Here's the diff for comparison:
```diff
-Model::shouldBeStrict(! App::isProduction());
+Model::shouldBeStrict(App::isNotProduction());

// Alternatively use these 3 statements
-Model::preventLazyLoading(! App::isProduction());
+Model::preventLazyLoading(App::isNotProduction());

-Model::preventSilentlyDiscardingAttributes(! App::isProduction());
+Model::preventSilentlyDiscardingAttributes(App::isNotProduction());

-Model::preventAccessingMissingAttributes(! App::isProduction());
+Model::preventAccessingMissingAttributes(App::isNotProduction());
```

## Why not just `$this['env'] !== 'production'` ?

Because it's meant to result in a negative of `isProduction()` method call, I feel like it should depend on that method, otherwise risking bugs if `isProduction()` is updated but `isNotProduction()` is not.