### PR TITLE
[9.x] Adds `inverse` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1083,6 +1083,21 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Inverse the column's value by a given condition.
+     *
+     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  bool|null  $condition
+     * @param  array  $extra
+     * @return int
+     */
+    public function inverse($column, $condition = null, array $extra = [])
+    {
+        return $this->toBase()->inverse(
+            $column, $condition, $this->addUpdatedAtColumn($extra)
+        );
+    }
+
+    /**
      * Add the "updated at" column to an array of values.
      *
      * @param  array  $values

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3421,6 +3421,23 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Inverse the column's value by a given condition.
+     *
+     * @param  string  $column
+     * @param  bool|null  $condition
+     * @param  array  $extra
+     * @return int
+     */
+    public function inverse($column, $condition = null, array $extra = [])
+    {
+        $wrapped = $this->grammar->wrap($column);
+
+        $columns = array_merge([$column => $condition ? $condition : $this->raw("!$wrapped")], $extra);
+
+        return $this->update($columns);
+    }
+
+    /**
      * Delete records from the database.
      *
      * @param  mixed  $id


### PR DESCRIPTION
This PR introduces an `inverse` method that enables us to inverse the boolean column value with a given condition, for instance, If we have a system that switches the user status if was an `enabled` or `disabled`, the implementation of the previous scenario would be like so,

```PHP
/**
 * Update the specified resource in storage.
 *
 * @param  \Illuminate\Http\Request  $request
 * @param  \App\Models\User  $user
 * @return \Illuminate\Http\Response
 */
public function update(Request $request, User $user)
{
    $data = $request->validate([
        'name' => ['required'],
        'email' => ['required', 'unique:users,email,' . $user->id],
    ]);

    $toUpdate = array_merge($data, ['status' => !$user->status]);

    $user->update($toUpdate);

    return redirect()->back()->with('success', 'Data was updated.');
}
```

## AFTER this PR gets merged

We can easily use the `inverse` method to inverse the user's status with a given column's name that we want to inverse its value in addition, we can provide the `condition` to inverse the status with some `extra` columns to be updated with the status.

```PHP
/**
 * Update the specified resource in storage.
 *
 * @param  \Illuminate\Http\Request  $request
 * @param  \App\Models\User  $user
 * @return \Illuminate\Http\Response
 */
public function update(Request $request, User $user)
{
    $data = $request->validate([
        'name' => ['required'],
        'email' => ['required', 'unique:users,email,' . $user->id],
    ]);

    $user->inverse('status', $data);

    return redirect()->back()->with('success', 'Data was updated.');
}
```