### PR TITLE
[9.x] Dont require a host for sqlite connections in `php artisan db`

### DIFF
--- a/src/Illuminate/Database/Console/DbCommand.php
+++ b/src/Illuminate/Database/Console/DbCommand.php
@@ -34,7 +34,7 @@ class DbCommand extends Command
     {
         $connection = $this->getConnection();
 
-        if (! isset($connection['host'])) {
+        if (! isset($connection['host']) && $connection['driver'] !== 'sqlite') {
             $this->components->error('No host specified for this database connection.');
             $this->line('  Use the <options=bold>[--read]</> and <options=bold>[--write]</> options to specify a read or write connection.');
             $this->newLine();


### PR DESCRIPTION
Since #44394 it is no longer possible to use `php artisan db` for sqlite connections, because it doesn't require a `host` and only has a provided database path.

This PR fixes the command for sqlite connections.