### PR TITLE
[9.x] Support spread operator in component tag attributes

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -258,7 +258,6 @@ class ComponentTagCompiler
                 : "'$class'";
 
             $parameters = [
-                'view' => "'$class'",
                 'view' => $view,
                 'data' => $this->mergeAttributeSpreads($this->attributesToString($data->all(), $escapeBound = false)),
             ];
@@ -730,7 +729,9 @@ class ComponentTagCompiler
     protected function mergeAttributeSpreads(string $attributeString)
     {
         if ($this->attributeSpreads) {
-            return "array_merge(".implode(",", $this->attributeSpreads).",[$attributeString])";
+            $spreads = implode(',', $this->attributeSpreads);
+
+            return "array_merge({$spreads},[{$attributeString}])";
         }
 
         return "[$attributeString]";

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -674,7 +674,7 @@ class ComponentTagCompiler
             (\\$\w+)   # variable expression
         /xm";
 
-        return preg_replace_callback($pattern, function ($matches) {
+        return preg_replace_callback($pattern, function (array $matches) {
             $this->attributeSpreads[] = $matches[1];
 
             return '';
@@ -728,13 +728,13 @@ class ComponentTagCompiler
      */
     protected function mergeAttributeSpreads(string $attributeString)
     {
-        if ($this->attributeSpreads) {
-            $spreads = implode(',', $this->attributeSpreads);
-
-            return "array_merge({$spreads},[{$attributeString}])";
+        if (! $this->attributeSpreads) {
+            return "[{$attributeString}]";
         }
 
-        return "[$attributeString]";
+        $spreads = implode(',', $this->attributeSpreads);
+
+        return "array_merge({$spreads},[{$attributeString}])";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -563,7 +563,7 @@ class ComponentTagCompiler
             $value = $match['value'] ?? null;
 
             if (str_starts_with($attribute, 'unpack:')) {
-                $this->unpackedAttributes[$attribute] = '...$' . Str::after($attribute, 'unpack:');
+                $this->unpackedAttributes[$attribute] = '...$'.Str::after($attribute, 'unpack:');
 
                 return [$attribute => 'true'];
             }

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -563,9 +563,10 @@ class ComponentTagCompiler
             $value = $match['value'] ?? null;
 
             if (str_starts_with($attribute, 'unpack:')) {
-                $this->unpackedAttributes[$attribute] = '...$'.Str::after($attribute, 'unpack:');
+                $key = Str::camel($attribute);
+                $this->unpackedAttributes[$key] = '...$'.Str::after($attribute, 'unpack:');
 
-                return [$attribute => 'true'];
+                return [$key => 'true'];
             }
 
             if (is_null($value)) {

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -702,6 +702,18 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
+    public function testCanUnpackAttributesFromSnakeCaseVariables()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile ...$my_test class="bar" wire:model="foo"></x-profile>');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
+<?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([...\$my_test,'class' => 'bar','wire:model' => 'foo']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+    }
+
     protected function mockViewFactory($existsSucceeds = true)
     {
         $container = new Container;

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -654,7 +654,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileSlots('<x-slot:foo ...$test>
 </x-slot>');
 
-        $this->assertSame("@slot('foo', null, [...\$test]) \n".' @endslot', trim($result));
+        $this->assertSame("@slot('foo', null, array_merge(\$test,[])) \n".' @endslot', trim($result));
     }
 
     public function testComponentSupportsAttributeUnpacking()
@@ -666,7 +666,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php \$component->withAttributes([...\$test,'class' => 'bar','wire:model' => 'foo']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes(array_merge(\$test,['class' => 'bar','wire:model' => 'foo'])); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     public function testSelfClosingComponentSupportsAttributeUnpacking()
@@ -679,7 +679,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestAlertComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php \$component->withAttributes([...\$test,'class' => 'bar','wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(array_merge(\$test,['class' => 'bar','wire:model' => 'foo'])); ?>\n".
             '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
     }
 
@@ -694,11 +694,11 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler()->compileTags('<x-anonymous-component ...$test :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component','data' => [...\$test,'name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component','data' => array_merge(\$test,['name' => 'Taylor','age' => 31,'wire:model' => 'foo'])])
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\View\AnonymousComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php \$component->withAttributes([...\$test,'name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(array_merge(\$test,['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo'])); ?>\n".
 '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
     }
 
@@ -711,7 +711,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 <?php if (isset(\$attributes) && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestProfileComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>
-<?php \$component->withAttributes([...\$my_test,'class' => 'bar','wire:model' => 'foo']); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
+<?php \$component->withAttributes(array_merge(\$my_test,['class' => 'bar','wire:model' => 'foo'])); ?> @endComponentClass##END-COMPONENT-CLASS##", trim($result));
     }
 
     protected function mockViewFactory($existsSucceeds = true)


### PR DESCRIPTION
This PR is inspired by https://github.com/laravel/framework/pull/44217. It is a first attempt to add support for the spread operator (`...`) in component attributes:

```blade
@php
    $header = [
        'title' => 'Lorem ipsum',
        'secondaryTitle' => 'Dolor sit amet',
    ];
@endphp

<x-header ...$header class="foo" />
```

I believe this would be equivalent to:
```blade
<x-header
    :title="$header['title']"
    :secondary-title="$header['secondaryTitle']"
    class="foo"
/>
```

Under the hood, it compiles to something closer to:
```blade
@component('components.header', array_merge($header, ['class' => 'foo'])) @endcomponent
```

I'm sending it as a draft PR because I'm not 100% confident about this implementation. It's my first time digging into the Blade internals and I'm looking to validate (or invalidate... 🙈) the idea.

I've added a few tests for the following use cases:
- slot
- component
- self-closing component
- anonymous component

Looking forward to any thoughts and suggestions!

Best,

P.