### PR TITLE
[9.x] Fallback to resolving controller middleware like before

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1093,13 +1093,9 @@ class Route
             );
         }
 
-        if (is_a($controllerClass, Controller::class, true)) {
-            return $this->controllerDispatcher()->getMiddleware(
-                $this->getController(), $controllerMethod
-            );
-        }
-
-        return [];
+        return $this->controllerDispatcher()->getMiddleware(
+            $this->getController(), $controllerMethod
+        );
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1093,9 +1093,27 @@ class Route
             );
         }
 
-        return $this->controllerDispatcher()->getMiddleware(
-            $this->getController(), $controllerMethod
-        );
+        if ($this->hasInstanceMiddleware($controllerClass)) {
+            return $this->controllerDispatcher()->getMiddleware(
+                $this->getController(), $controllerMethod
+            );
+        }
+
+        return [];
+    }
+
+    /**
+     * Whether the controller class contains middleware to load.
+     *
+     * @param  string  $controllerClass
+     * @return boolean
+     */
+    public function hasInstanceMiddleware(string $controllerClass)
+    {
+        $usedTraits = class_uses_recursive($controllerClass);
+
+        return is_a($controllerClass, Controller::class, true)
+            || in_array("Lorisleiva\Actions\Concerns\AsController", $usedTraits);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1093,27 +1093,13 @@ class Route
             );
         }
 
-        if ($this->hasInstanceMiddleware($controllerClass)) {
+        if (method_exists($controllerClass, 'getMiddleware')) {
             return $this->controllerDispatcher()->getMiddleware(
                 $this->getController(), $controllerMethod
             );
         }
 
         return [];
-    }
-
-    /**
-     * Whether the controller class contains middleware to load.
-     *
-     * @param  string  $controllerClass
-     * @return boolean
-     */
-    public function hasInstanceMiddleware(string $controllerClass)
-    {
-        $usedTraits = class_uses_recursive($controllerClass);
-
-        return is_a($controllerClass, Controller::class, true)
-            || in_array("Lorisleiva\Actions\Concerns\AsController", $usedTraits);
     }
 
     /**


### PR DESCRIPTION
## Context

PR https://github.com/laravel/framework/pull/44516 introduces a new way of resolving controller middleware statically so that they can be resolved before the controller is instantiated.

## Problem

The PR itself is fine and fills a need for the community but there's just a small implementation detail that makes it no longer possible for Laravel Actions to use controller middleware in its `ControllerDecorator`.

Inside the updated `Route@controllerMiddleware` method, we now check that the controller class is a `Controller` instance and, if not, return an empty array.

```php
// ...

if (is_a($controllerClass, Controller::class, true)) {
    return $this->controllerDispatcher()->getMiddleware(
        $this->getController(), $controllerMethod
    );
}

return [];
```

This is problematic for Laravel Actions since Actions can be used within any class architecture and will likely not want to be tight to a `Controller` abstract class.

## Solution

The simple solution proposed in this PR is to fall back to resolving controller middleware as we were before.

```diff
  // ...
  
- if (is_a($controllerClass, Controller::class, true)) {
-    return $this->controllerDispatcher()->getMiddleware(
-        $this->getController(), $controllerMethod
-     );
- }
  
- return [];
+ return $this->controllerDispatcher()->getMiddleware(
+     $this->getController(), $controllerMethod
+ );
```

This change does not cause any side effect because a safety check already exists within the `getMiddleware` method of the `ControllerDispatcher`.

```php
if (! method_exists($controller, 'getMiddleware')) {
    return [];
}
```

Note that this change does not affect the new feature brought by https://github.com/laravel/framework/pull/44516. It simply relaxes the second if statement so that both solutions can live together.