### PR TITLE
[9.x] Add `Arr:fill()` method.

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -224,7 +224,7 @@ class Arr
     }
 
     /**
-     * Fill an array with values
+     * Fill an array with values.
      *
      * @param  int  $start
      * @param  int  $count

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -224,6 +224,29 @@ class Arr
     }
 
     /**
+     * Fill an array with values
+     *
+     * @param  int  $start
+     * @param  int  $count
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function fill($start, $count, $value)
+    {
+        if (! is_callable($value)) {
+            return array_fill($start, $count, $value);
+        }
+
+        $array = array_fill($start, $count, '');
+
+        foreach ($array as $key => $v) {
+            $array[$key] = $value($key);
+        }
+
+        return $array;
+    }
+
+    /**
      * Flatten a multi-dimensional array into a single level.
      *
      * @param  iterable  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -242,6 +242,24 @@ class SupportArrTest extends TestCase
         $this->assertEquals(300, Arr::last($array));
     }
 
+    public function testFill()
+    {
+        $this->assertEquals(
+            [1 => 'string', 2 => 'string'],
+            Arr::fill(1, 2, 'string')
+        );
+
+        $this->assertEquals(
+            [-1 => -1, 0 => 0],
+            Arr::fill(-1, 2, fn ($key) => $key)
+        );
+
+        $this->assertEquals(
+            [0 => 'Item: 0', 1 => 'Item: 1'],
+            Arr::fill(0, 2, fn ($key) => "Item: {$key}")
+        );
+    }
+
     public function testFlatten()
     {
         // Flat arrays are unaffected


### PR DESCRIPTION
Hey,

This PR adds the capability to use `array_fill` with a callback to fill the values.

## Before

If you need to fill an array with **10** items, and change every key on it, you need to use a `foreach` to loop over each item and change the value on it.

```php
$array = collect(array_fill(1, 10, ''));
foreach ($array as $key => $value) {
    $array[$key] = $key;
}
```

## After

```php
Arr::fill(0, 10, fn ($key) => $key);
```

With this approach you would archive the same result as before, with an array that as the same `key` and `value`.

## Also it would work, the same as `array_fill` if you pass any other value than a `callable`.

### Example

```php
Arr::fill(0, 10, 'string');
```

This will have an `array` with **10** items with the value of `string`.

Thanks,
Francisco