### PR TITLE
[9.x] First Data from DB get in array format

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -297,6 +297,17 @@ trait BuildsQueries
     }
 
     /**
+     * Execute the query and get the first result in Array.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|array|static|null
+     */
+    public function firstToArray($columns = ['*'])
+    {
+        return (array)$this->take(1)->get($columns)->first();
+    }
+
+    /**
      * Execute the query and get the first result if it's the sole matching record.
      *
      * @param  array|string  $columns

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -304,7 +304,7 @@ trait BuildsQueries
      */
     public function firstToArray($columns = ['*'])
     {
-        return (array)$this->take(1)->get($columns)->first();
+        return (array) $this->first($columns);
     }
 
     /**


### PR DESCRIPTION
Hi there,

When we get data from $query->get(), its returning data in collection formate with toArray() we convert it into Array formate, but why we can't do the same with $query->first()?
I faced this several times and thought about the solution $query->firstToArray() and I added it here.

Thanks