### PR TITLE
[9.x] Add viteNonce directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -75,4 +75,16 @@ trait CompilesHelpers
 
         return "<?php echo app('$class')->reactRefresh(); ?>";
     }
+
+    /**
+     * Compile the "viteNonce" statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileViteNonce()
+    {
+        $class = Vite::class;
+
+        return "<?php echo 'nonce=\"'.app('$class')->cspNonce().'\"'; ?>";
+    }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -16,6 +16,6 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(\'resources/js/app.js\'); ?>', $this->compiler->compileString('@vite(\'resources/js/app.js\')'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')([\'resources/js/app.js\']); ?>', $this->compiler->compileString('@vite([\'resources/js/app.js\'])'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')->reactRefresh(); ?>', $this->compiler->compileString('@viteReactRefresh'));
-        $this->assertSame('<?php echo \'nonce="\'.app(\'Illuminate\Foundation\Vite\')->cspNonce().\'"\'; ?>"', $this->compiler->compileString('@viteNonce'));
+        $this->assertSame('<?php echo \'nonce="\'.app(\'Illuminate\Foundation\Vite\')->cspNonce().\'"\'; ?>', $this->compiler->compileString('@viteNonce'));
     }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -16,5 +16,6 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(\'resources/js/app.js\'); ?>', $this->compiler->compileString('@vite(\'resources/js/app.js\')'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')([\'resources/js/app.js\']); ?>', $this->compiler->compileString('@vite([\'resources/js/app.js\'])'));
         $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')->reactRefresh(); ?>', $this->compiler->compileString('@viteReactRefresh'));
+        $this->assertSame('<?php echo \'nonce="\'.app(\'Illuminate\Foundation\Vite\')->cspNonce().\'"\'; ?>"', $this->compiler->compileString('@viteNonce'));
     }
 }


### PR DESCRIPTION
This PR adds a `@viteNonce` directive to easily add the Vite nonce to script, style and link tags that are not managed by Vite.