### PR TITLE
[9.x] Check pivot keys existence on pivot models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use LogicException;
 
 trait AsPivot
 {
@@ -146,6 +147,8 @@ trait AsPivot
      */
     protected function getDeleteQuery()
     {
+        $this->checkPivotKeys();
+
         return $this->newQueryWithoutRelationships()->where([
             $this->foreignKey => $this->getOriginal($this->foreignKey, $this->getAttribute($this->foreignKey)),
             $this->relatedKey => $this->getOriginal($this->relatedKey, $this->getAttribute($this->relatedKey)),
@@ -260,6 +263,8 @@ trait AsPivot
             return $this->getKey();
         }
 
+        $this->checkPivotKeys();
+
         return sprintf(
             '%s:%s:%s:%s',
             $this->foreignKey, $this->getAttribute($this->foreignKey),
@@ -329,5 +334,12 @@ trait AsPivot
         $this->relations = [];
 
         return $this;
+    }
+
+    protected function checkPivotKeys()
+    {
+        if (! $this->foreignKey || ! $this->relatedKey) {
+            throw new LogicException('Pivot keys must be set on the model. ('.get_class($this).')');
+        }
     }
 }


### PR DESCRIPTION
When we have a model extending `MorphPivot` and we forget to specify default values for the `foreignKey` and the `relatedKey` properties on the class, like below:

----------------------


![image](https://user-images.githubusercontent.com/6961695/195979450-477366d9-7228-46d4-88b7-e4313e96a52e.png)

The exception thrown while deleting the model (`$myModel->delete()`) will be like this: (which is not clear)

![image](https://user-images.githubusercontent.com/6961695/195979651-dd8a7920-39cd-4bd0-9fff-7d4e187aae6c.png)

----------------------

- **After this change the message will be:**

![image](https://user-images.githubusercontent.com/6961695/195979865-a3a78a1a-d6e0-4428-947d-c2939c6632ee.png)

