### PR TITLE
[9.x] Add `Collection::rangeByKey` method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -55,7 +55,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Create a new collection with default starting key by invoking the callback a given range.
+     * Create a new collection with range of key.
      *
      * @param  int  $start
      * @param  int  $number

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -55,6 +55,24 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Create a new collection with default starting key by invoking the callback a given amount of times.
+     *
+     * @template TTimesValue
+     *
+     * @param  int  $start
+     * @param  int  $number
+     * @param  (callable(int): TTimesValue)|null  $callback
+     * @return static<int, TTimesValue>
+     */
+    public static function rangeByKey($start, $number, callable $callback = null)
+    { 
+        return static::range($start, $number)
+            ->keyBy(fn ($item, $key) => $key + $start)
+            ->unless($callback == null)
+            ->map($callback);
+    }
+
+    /**
      * Get all of the items in the collection.
      *
      * @return array<TKey, TValue>

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -55,7 +55,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
-     * Create a new collection with default starting key by invoking the callback a given amount of times.
+     * Create a new collection with default starting key by invoking the callback a given range.
      *
      * @param  int  $start
      * @param  int  $number

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -57,12 +57,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * Create a new collection with default starting key by invoking the callback a given amount of times.
      *
-     * @template TTimesValue
-     *
      * @param  int  $start
      * @param  int  $number
-     * @param  (callable(int): TTimesValue)|null  $callback
-     * @return static<int, TTimesValue>
+     * @param  (callable(int): mixed)|null  $callback
+     * @return static<int, mixed>
      */
     public static function rangeByKey($start, $number, callable $callback = null)
     { 

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -63,7 +63,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @return static<int, mixed>
      */
     public static function rangeByKey($start, $number, callable $callback = null)
-    { 
+    {
         return static::range($start, $number)
             ->keyBy(fn ($item) => $item)
             ->unless($callback == null)

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -65,7 +65,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public static function rangeByKey($start, $number, callable $callback = null)
     { 
         return static::range($start, $number)
-            ->keyBy(fn ($item, $key) => $key + $start)
+            ->keyBy(fn ($item) => $item)
             ->unless($callback == null)
             ->map($callback);
     }

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -49,7 +49,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public static function range($from, $to);
 
     /**
-     * Create a new collection with default starting key by invoking the callback a given amount of times.
+     * Create a new collection with default starting key by invoking the callback a given range.
      *
      * @param  int  $start
      * @param  int  $number

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -49,7 +49,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public static function range($from, $to);
 
     /**
-     * Create a new collection with default starting key by invoking the callback a given range.
+     * Create a new collection with range of key.
      *
      * @param  int  $start
      * @param  int  $number

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -49,6 +49,16 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public static function range($from, $to);
 
     /**
+     * Create a new collection with default starting key by invoking the callback a given amount of times.
+     *
+     * @param  int  $start
+     * @param  int  $number
+     * @param  (callable(int): mixed)|null  $callback
+     * @return static<int, mixed>
+     */
+    public static function rangeByKey($start, $number, callable $callback = null);
+
+    /**
      * Wrap the given value in a collection if applicable.
      *
      * @template TWrapKey of array-key

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -92,7 +92,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
-     * Create a new collection with default starting key by invoking the callback a given range.
+     * Create a new collection with range of key.
      *
      * @param  int  $start
      * @param  int  $number

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -92,6 +92,22 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Create a new collection with default starting key by invoking the callback a given range.
+     *
+     * @param  int  $start
+     * @param  int  $number
+     * @param  (callable(int): mixed)|null  $callback
+     * @return static<int, mixed>
+     */
+    public static function rangeByKey($start, $number, callable $callback = null)
+    {
+        return static::range($start, $number)
+            ->keyBy(fn ($item) => $item)
+            ->unless($callback == null)
+            ->map($callback);
+    }
+
+    /**
      * Get all items in the enumerable.
      *
      * @return array<TKey, TValue>

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2830,7 +2830,7 @@ class SupportCollectionTest extends TestCase
         );
 
         $this->assertSame(
-            [5 => 5, 4, 3, 2, 1],
+            [5 => 5, 4 => 4, 3 => 3, 2 => 2, 1 => 1],
             $collection::rangeByKey(5, 1)->all()
         );
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2812,6 +2812,52 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testRangeByKeyMethod($collection)
+    {
+        $this->assertSame(
+            [1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5],
+            $collection::rangeByKey(1, 5)->all()
+        );
+
+        $this->assertSame(
+            [-2 => -2, -1 => -1, 0 => 0, 1 => 1, 2 => 2],
+            $collection::rangeByKey(-2, 2)->all()
+        );
+
+        $this->assertSame(
+            [-4 => -4, -3 => -3, -2 => -2],
+            $collection::rangeByKey(-4, -2)->all()
+        );
+
+        $this->assertSame(
+            [5 => 5, 4, 3, 2, 1],
+            $collection::rangeByKey(5, 1)->all()
+        );
+
+        $this->assertSame(
+            [2 => 2, 1 => 1, 0 => 0, -1 => -1, -2 => -2],
+            $collection::rangeByKey(2, -2)->all()
+        );
+
+        $this->assertSame(
+            [-2 => -2, -3 => -3, -4 => -4],
+            $collection::rangeByKey(-2, -4)->all()
+        );
+
+        $this->assertSame(
+            [1 => 1],
+            $collection::rangeByKey(1, 1)->all()
+        );
+
+        $this->assertSame(
+            [-1 => -2, 0 => 0, 1 => 2],
+            $collection::rangeByKey(-1, 1, fn ($key) => $key * 2)->all()
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testConstructMakeFromObject($collection)
     {
         $object = new stdClass;


### PR DESCRIPTION
****Can generate collection by adding range of keys.****
Inspired by: PR #44595

In mentioned PR tried to add a new array generation function that is too similar to `Collection::times` and `Collection::range` functions, but there request only values. So need a function that can generate a new Collection by taking into range of keys.

The `rangeByKey()` is more like the `range()` function, but I added a value modifier opportunity (maybe unnecessary?) as in the `times()` method, because `rangeByKey()` does not request values, just a range of keys.

```php
public static function rangeByKey($start, $number, callable $callback = null)
{ 
    return static::range($start, $number)
        ->keyBy(fn ($item) => $item)
        ->unless($callback == null)
        ->map($callback);
}
```

[Tests / Examples](https://github.com/laravel/framework/pull/44606/files)

<details>
  <summary>Collection::range() - keys can only start with 0</summary>

  First key always is 0 with `range()`:
  (values always equal our range)
  ```php
  Collection::range(-1, 1)->all();
  
  /*
    return: [
      0 => -1,
      1 => 0,
      2 => 1
    ]
  */
  ```
</details>

<details>
  <summary>Collection::rangeByKey() - keys can start with any number</summary>

  Can generate Collection with unique first key with `rangeByKey`:
  (values always equal our range, but values always equal their keys after generation)
  ```php
  Collection::rangeByKey(1, 3)->all();
  
  /*
    return: [
      1 => 1,
      2 => 2,
      3 => 3
    ]
  */
  ```
</details>

<details>
  <summary>Collection::rangeByKey() - unique starting key with manipulated values</summary>

  Can manipulate values:
  (if you need different range of values)
  ```php
  Collection::rangeByKey(1, 3, fn ($key) => $key - 2)->all();
  
  /*
    return: [
      1 => -1,
      2 => 0,
      3 => 1
    ]
  */
  ```
</details>