### PR TITLE
[9.x] Add setIf and forgetIf methods to the Arr class

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -822,4 +822,39 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+
+    /**
+     * Set an array item to a given value using "dot" notation if the given condition is true.
+     *
+     * If no key is given to the method, the entire array will be replaced.
+     *
+     * @param boolean $condition
+     * @param array $array
+     * @param string|int|null $key
+     * @param mixed $value
+     * @return array
+     */
+    public static function setWhen($condition, &$array, $key, $value): array
+    {
+        if ($condition) {
+            return self::set($array, $key, $value);
+        }
+
+        return $array;
+    }
+
+    /**
+     * Remove one or many array items from a given array using "dot" notation if the given condition is true.
+     *
+     * @param boolean $condition
+     * @param array $array
+     * @param array|string|int|float $keys
+     * @return void
+     */
+    public static function forgetWhen($condition, &$array, $keys)
+    {
+        if ($condition) {
+            self::forget($array, $keys);
+        }
+    }
 }

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -834,7 +834,7 @@ class Arr
      * @param  mixed  $value
      * @return array
      */
-    public static function setWhen($condition, &$array, $key, $value): array
+    public static function setIf($condition, &$array, $key, $value): array
     {
         if ($condition) {
             return self::set($array, $key, $value);
@@ -851,7 +851,7 @@ class Arr
      * @param  array|string|int|float  $keys
      * @return void
      */
-    public static function forgetWhen($condition, &$array, $keys)
+    public static function forgetIf($condition, &$array, $keys)
     {
         if ($condition) {
             self::forget($array, $keys);

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -828,10 +828,10 @@ class Arr
      *
      * If no key is given to the method, the entire array will be replaced.
      *
-     * @param boolean $condition
-     * @param array $array
-     * @param string|int|null $key
-     * @param mixed $value
+     * @param  boolean  $condition
+     * @param  array  $array
+     * @param  string|int|null  $key
+     * @param  mixed  $value
      * @return array
      */
     public static function setWhen($condition, &$array, $key, $value): array
@@ -846,9 +846,9 @@ class Arr
     /**
      * Remove one or many array items from a given array using "dot" notation if the given condition is true.
      *
-     * @param boolean $condition
-     * @param array $array
-     * @param array|string|int|float $keys
+     * @param  boolean  $condition
+     * @param  array  $array
+     * @param  array|string|int|float  $keys
      * @return void
      */
     public static function forgetWhen($condition, &$array, $keys)

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -828,7 +828,7 @@ class Arr
      *
      * If no key is given to the method, the entire array will be replaced.
      *
-     * @param  boolean  $condition
+     * @param  bool  $condition
      * @param  array  $array
      * @param  string|int|null  $key
      * @param  mixed  $value
@@ -846,7 +846,7 @@ class Arr
     /**
      * Remove one or many array items from a given array using "dot" notation if the given condition is true.
      *
-     * @param  boolean  $condition
+     * @param  bool  $condition
      * @param  array  $array
      * @param  array|string|int|float  $keys
      * @return void

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1113,27 +1113,27 @@ class SupportArrTest extends TestCase
         ], Arr::prependKeysWith($array, 'test.'));
     }
 
-    public function testSetWhen()
+    public function testSetIf()
     {
         $user = [
             'name' => 'Taylor',
         ];
 
-        Arr::setWhen(true, $user, 'role', 'OWNER');
-        Arr::setWhen(false, $user, 'role', 'USER');
-        Arr::setWhen(null, $user, 'role', 'GUEST');
+        Arr::setIf(true, $user, 'role', 'OWNER');
+        Arr::setIf(false, $user, 'role', 'USER');
+        Arr::setIf(null, $user, 'role', 'GUEST');
 
         $this->assertEquals(['name' => 'Taylor', 'role' => 'OWNER'], $user);
     }
 
-    public function testForgetWhen()
+    public function testForgetIf()
     {
         $user = [
             'name' => 'Taylor',
             'role' => 'GUEST',
         ];
 
-        Arr::forgetWhen(true, $user, 'role');
+        Arr::forgetIf(true, $user, 'role');
         $this->assertEquals(['name' => 'Taylor'], $user);
 
         $user = [
@@ -1141,8 +1141,8 @@ class SupportArrTest extends TestCase
             'role' => 'OWNER',
         ];
 
-        Arr::forgetWhen(false, $user, 'role');
-        Arr::forgetWhen(null, $user, 'role');
+        Arr::forgetIf(false, $user, 'role');
+        Arr::forgetIf(null, $user, 'role');
 
         $this->assertEquals(['name' => 'Taylor', 'role' => 'OWNER'], $user);
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1112,4 +1112,38 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::prependKeysWith($array, 'test.'));
     }
+
+    public function testSetWhen()
+    {
+        $user = [
+            'name' => 'Taylor',
+        ];
+
+        Arr::setWhen(true, $user, 'role', 'OWNER');
+        Arr::setWhen(false, $user, 'role', 'USER');
+        Arr::setWhen(null, $user, 'role', 'GUEST');
+
+        $this->assertEquals(['name' => 'Taylor', 'role' => 'OWNER'], $user);
+    }
+
+    public function testForgetWhen()
+    {
+        $user = [
+            'name' => 'Taylor',
+            'role' => 'GUEST',
+        ];
+
+        Arr::forgetWhen(true, $user, 'role');
+        $this->assertEquals(['name' => 'Taylor'], $user);
+
+        $user = [
+            'name' => 'Taylor',
+            'role' => 'OWNER',
+        ];
+
+        Arr::forgetWhen(false, $user, 'role');
+        Arr::forgetWhen(null, $user, 'role');
+
+        $this->assertEquals(['name' => 'Taylor', 'role' => 'OWNER'], $user);
+    }
 }


### PR DESCRIPTION
Sometimes I need to modify an array using the Arr class.
There are cases where modifying an array depends on some condition. 

Example:
```php
$isOwner = $role === 'OWNER';

if ($isOwner) {
    Arr::set($user, 'role', $role);
}
```

It would be good if it was possible to use the if method to make the code more clean and readable. 

```php
Arr::setIf($isOwner, $user, 'role', $role);
```

Also for the basic forget method I added an option with "if"

```php
Arr::forgetIf(
    $request->boolean('remove_attributes'),
    $product,
    'attributes'
);
```


What do you think about it? Hope these methods will be useful.
