### PR TITLE
[9.x] Allow clearing of stub responses of HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -231,6 +231,18 @@ class Factory
     }
 
     /**
+     * Clear all the stub callbacks.
+     *
+     * @return $this
+     */
+    public function clearStubs()
+    {
+        $this->stubCallbacks = collect();
+
+        return $this;
+    }
+
+    /**
      * Indicate that an exception should be thrown if any request is not faked.
      *
      * @param  bool  $prevent

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1654,4 +1654,21 @@ class HttpClientTest extends TestCase
 
         $this->assertSame(['connect_timeout' => 10, 'http_errors' => false, 'timeout' => 30, 'allow_redirects' => ['max' => 10]], $request->getOptions());
     }
+
+    public function testItCanClearStubCallbacks()
+    {
+        $this->factory->preventStrayRequests();
+        $this->factory->fake(['https://laravel.com' => Factory::response('ok', 200)]);
+
+        $response = $this->factory->get('https://laravel.com');
+
+        $this->assertTrue($response->ok());
+
+        $this->factory->clearStubs();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Attempted request to [https://laravel.com] without a matching fake.');
+
+        $this->factory->get('https://laravel.com');
+    }
 }


### PR DESCRIPTION
I think it’s quite common that when dealing with an external API, that’s used throughout your app, that you set a standard fake response for it in your tests by adding something like below to your `tests/CreatesApplication.php` file:

```php
Http::fake(['https://api.example.com/*' => Http::response(['success' => true], 200)]);
```

This way your external API always responds with something expected in your tests.

The problem is if you want to test a non-successful response (maybe `401` or `500`) you can’t overwrite this fake response so you always get the default `200` response back. This PR adds a function to clear the stub callbacks of the HTTP client that you can call before testing any response that’s different from the default fake that has been set.

For example when you want to test that your application handles a `500` response from an external API correctly in one of your tests you can do:

```php
Http::clearStubs()->fake(['https://api.example.com/some-endpoint' => Http::response(['success' => false], 500)]);
```