### PR TITLE
[9.x] Add verbosity level checking to console alerts

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -364,17 +364,18 @@ trait InteractsWithIO
      * Write a string in an alert box.
      *
      * @param  string  $string
+     * @param  int|string|null  $verbosity
      * @return void
      */
-    public function alert($string)
+    public function alert($string, $verbosity = null)
     {
         $length = Str::length(strip_tags($string)) + 12;
 
-        $this->comment(str_repeat('*', $length));
-        $this->comment('*     '.$string.'     *');
-        $this->comment(str_repeat('*', $length));
+        $this->comment(str_repeat('*', $length), $verbosity);
+        $this->comment('*     '.$string.'     *', $verbosity);
+        $this->comment(str_repeat('*', $length), $verbosity);
 
-        $this->newLine();
+        $this->comment('', $verbosity);
     }
 
     /**


### PR DESCRIPTION
First of all, let me point out some inconsistencies.

Many logging systems and PSR-3 introduces _severity level_ ([Syslog](https://en.wikipedia.org/wiki/Syslog#Severity_level), [Monolog](https://github.com/Seldaek/monolog/blob/main/doc/01-usage.md#log-levels) [PSR-3](https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel)). In most cases they are: emergency, alert, critical, error, warning, notice, info, debug. And all of them are the same in terms, that **alert** is more important than **error**.

In Laravel console commands we can control the amount of generated output information by specifying -vvv, -v and -q options. It is provided by the underlying [Symfony's Verbosity Levels](https://symfony.com/doc/current/console/verbosity.html).
Also Laravel provides several helper functions _to colorize_ the console output: error, warn, info, comment, question. They are utilizing [Symfony's Color Styles](https://symfony.com/doc/current/console/coloring.html#using-color-styles).
Next we have few useful blocks: alert, table. They can be used _to decorate_ the output.

As you can see several names partially matches severity names: alert, error, warn, info. And the main problem is in **alert** which is intended to "write a string in an alert box". It gives us a highly visible box, but it lacks the ability to be used as extra important text.

Lets assume this snippet:

```
class TestSeverity extends Command
{
    protected $signature = 'test:severity';

    public function handle()
    {
        $this->line('Debug message', null, 'vvv');
        $this->line('Detailed report', 'vv');
        $this->info('More info', null, 'v');
        $this->info('Info');
        $this->warn('Warning');
        $this->error('Error');
        $this->error('Error with quiet', 'quiet');
        $this->alert('Alert! Something really dangerous happened!');
        return Command::SUCCESS;
    }
}
```

Would we run this command with `-q` (we want to see only important messages) we will see only error:
> Error with quiet

And won't see alert at all. _Our alert is not an alert, and we can't change this behavior._

The most correct solution would be to rename method **alert** to _box_, _panel_, _header_ or something else. But it would be a breaking change and should be discussed at first place.

Now, about this PR.

Now users can specify _verbosity level_ (importance) for _alert boxes_ (decorated output blocks).
```
        $this->alert('Alert box only for debug mode', 'vvv');
        $this->alert('Normal alert box');
        $this->alert('Very important alert box', 'quiet');
```
Boxes are printed based on the current level of output detail. It won't generate dangling blank lines unless the box is printed.

It's not a BC. Currently alert doesn't accept second argument. The parameter has a default value that retains the old behavior. Extra parameter passed to older frameworks will be ignored.

There is no tests. It's still a questionable should we rename this method or not. And, as far as none of this methods were covered with tests, and current fix is trivial, I decide to not write a test that would be removed in the future. But if it is really required, I can provide one. Just let me know.