### PR TITLE
[9.x] Adds Custom Components to Query Builder

### DIFF
--- a/src/Illuminate/Database/Concerns/CustomComponents.php
+++ b/src/Illuminate/Database/Concerns/CustomComponents.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+trait CustomComponents
+{
+    /**
+     * An array of custom components for the current instance.
+     *
+     * @var array<string, mixed>
+     */
+    protected $customComponents = [];
+
+    /**
+     * Sets a custom component for the current instance.
+     *
+     * @param  string  $component
+     * @param  mixed  $data
+     * @return $this
+     */
+    public function setComponent($component, $data)
+    {
+        $this->customComponents[$component] = $data;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves a component data, or null if it doesn't exist.
+     *
+     * @param  string  $component
+     * @param  mixed|null  $default
+     * @return mixed|null
+     */
+    public function getComponent($component, $default = null)
+    {
+        return $this->customComponents[$component] ?? value($default, $this);
+    }
+
+    /**
+     * Determine a custom component has been registered in the instance.
+     *
+     * @param  string  $component
+     * @return bool
+     */
+    public function hasComponent($component)
+    {
+        return isset($this->customComponents[$component]);
+    }
+}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -8,6 +8,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Concerns\CustomComponents;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
@@ -28,7 +29,7 @@ use RuntimeException;
 
 class Builder implements BuilderContract
 {
-    use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
+    use BuildsQueries, ExplainsQueries, CustomComponents, ForwardsCalls, Macroable {
         __call as macroCall;
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5331,6 +5331,27 @@ SQL;
         $this->assertEquals([], $clone->getBindings());
     }
 
+    public function testCustomComponents()
+    {
+        $expected = new stdClass();
+
+        $builder = $this->getBuilder();
+
+        $this->assertFalse($builder->hasComponent('foo'));
+        $this->assertSame($expected, $builder->getComponent('foo', $expected));
+        $this->assertSame($expected, $builder->getComponent('foo', fn($builder) => $builder instanceof Builder ? $expected : false));
+
+        $builder->setComponent('foo', $expected);
+
+        $this->assertTrue($builder->hasComponent('foo'));
+        $this->assertSame($expected, $builder->getComponent('foo', false));
+
+        $builder->setComponent('foo', null);
+
+        $this->assertFalse($builder->hasComponent('foo'));
+        $this->assertFalse($builder->getComponent('foo', false));
+    }
+
     protected function getConnection()
     {
         $connection = m::mock(ConnectionInterface::class);


### PR DESCRIPTION
## What?

Allows to register custom instance-living components to the Query Builder, which allows to save data state or functionality, and expand on them. This implementation is in light of Deprecated Dynamic Properties in PHP 8.2, will be enforced in PHP 9.0.

For example, a macro setting a dynamic property will now have the option to use the internal `customComponent` array and helpers.

```php
use Illuminate\Database\Query\Builder;

Builder::macro('isCool', function () {
    // Before
    // return $this->coolness ?? false;

    // After
    return $this->getComponent('coolness', false);
});
```

> Considering the impact of macros setting dynamic properties in the future, a `Composable` trait could be available framework-wide for PHP 8.2 >= compatibility, or include it on the `Macroable` trait.