### PR TITLE
[9.x] Add `assertServerError` to `TestResponse`.

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -166,6 +166,21 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response is a server error.
+     *
+     * @return $this
+     */
+    public function assertServerError()
+    {
+        PHPUnit::assertTrue(
+            $this->isServerError(),
+            $this->statusMessageWithDetails('>=500, < 600', $this->getStatusCode())
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the given status code.
      *
      * @param  int  $status

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -580,6 +580,18 @@ class TestResponseTest extends TestCase
         $response->assertUnprocessable();
     }
 
+    public function testAssertServerError()
+    {
+        $statusCode = 500;
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertServerError();
+    }
+
     public function testAssertNoContentAsserts204StatusCodeByDefault()
     {
         $statusCode = 500;


### PR DESCRIPTION
This PR adds the `assertServerError` to the `TestResponse` class.

This will allow to use:

```php
$response->assertServerError();
```

instead of:

```php
$response->assertStatus(500);
```

It also allows for other server errors between `500` to `599`, based on here https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses.