### PR TITLE
add new test, that a value for a castable date can be an empty string or null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -891,10 +891,7 @@ trait HasAttributes
     protected function serializeClassCastableAttribute($key, $value)
     {
         return $this->resolveCasterClass($key)->serialize(
-            $this,
-            $key,
-            $value,
-            $this->attributes
+            $this, $key, $value, $this->attributes
         );
     }
 
@@ -1092,9 +1089,7 @@ trait HasAttributes
         [$key, $path] = explode('->', $key, 2);
 
         $value = $this->asJson($this->getArrayAttributeWithValue(
-            $path,
-            $key,
-            $value
+            $path, $key, $value
         ));
 
         $this->attributes[$key] = $this->isEncryptedCastable($key)
@@ -1229,9 +1224,7 @@ trait HasAttributes
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
-                $this,
-                $key,
-                json_last_error_msg()
+                $this, $key, json_last_error_msg()
             );
         }
 
@@ -1799,8 +1792,7 @@ trait HasAttributes
     public function getOriginal($key = null, $default = null)
     {
         return (new static)->setRawAttributes(
-            $this->original,
-            $sync = true
+            $this->original, $sync = true
         )->getOriginalWithoutRewindingModel($key, $default);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -298,8 +298,7 @@ trait HasAttributes
                 $attributes[$key] = $this->serializeDate($attributes[$key]);
             }
 
-            if (isset($attributes[$key]) && ($this->isCustomDateTimeCast($value) ||
-                $this->isImmutableCustomDateTimeCast($value))) {
+            if (isset($attributes[$key]) && ($this->isCustomDateTimeCast($value) || $this->isImmutableCustomDateTimeCast($value)) && method_exists($attributes[$key], 'format')) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
 
@@ -1400,7 +1399,7 @@ trait HasAttributes
             $date = false;
         }
 
-        return $date ?: Date::make($value);
+        return $date ?: Date::make($value) ?: $value;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -196,14 +196,16 @@ trait HasAttributes
         );
 
         $attributes = $this->addMutatedAttributesToArray(
-            $attributes, $mutatedAttributes = $this->getMutatedAttributes()
+            $attributes,
+            $mutatedAttributes = $this->getMutatedAttributes()
         );
 
         // Next we will handle any casts that have been setup for this model and cast
         // the values to their appropriate type. If the attribute has a mutator we
         // will not perform the cast on those attributes to avoid any confusion.
         $attributes = $this->addCastAttributesToArray(
-            $attributes, $mutatedAttributes
+            $attributes,
+            $mutatedAttributes
         );
 
         // Here we will grab all of the appended, calculated attributes to this model
@@ -258,7 +260,8 @@ trait HasAttributes
             // mutated attribute's actual values. After we finish mutating each of the
             // attributes we will return this final array of the mutated attributes.
             $attributes[$key] = $this->mutateAttributeForArray(
-                $key, $attributes[$key]
+                $key,
+                $attributes[$key]
             );
         }
 
@@ -284,7 +287,8 @@ trait HasAttributes
             // then we will serialize the date for the array. This will convert the dates
             // to strings based on the date format specified for these Eloquent models.
             $attributes[$key] = $this->castAttribute(
-                $key, $attributes[$key]
+                $key,
+                $attributes[$key]
             );
 
             // If the attribute cast was a date or a datetime, we will serialize the date as
@@ -574,12 +578,16 @@ trait HasAttributes
         if (! $relation instanceof Relation) {
             if (is_null($relation)) {
                 throw new LogicException(sprintf(
-                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
+                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?',
+                    static::class,
+                    $method
                 ));
             }
 
             throw new LogicException(sprintf(
-                '%s::%s must return a relationship instance.', static::class, $method
+                '%s::%s must return a relationship instance.',
+                static::class,
+                $method
             ));
         }
 
@@ -878,7 +886,10 @@ trait HasAttributes
     protected function deviateClassCastableAttribute($method, $key, $value)
     {
         return $this->resolveCasterClass($key)->{$method}(
-            $this, $key, $value, $this->attributes
+            $this,
+            $key,
+            $value,
+            $this->attributes
         );
     }
 
@@ -892,7 +903,10 @@ trait HasAttributes
     protected function serializeClassCastableAttribute($key, $value)
     {
         return $this->resolveCasterClass($key)->serialize(
-            $this, $key, $value, $this->attributes
+            $this,
+            $key,
+            $value,
+            $this->attributes
         );
     }
 
@@ -1055,7 +1069,8 @@ trait HasAttributes
         $this->attributes = array_merge(
             $this->attributes,
             $this->normalizeCastClassResponse(
-                $key, $callback($value, $this->attributes)
+                $key,
+                $callback($value, $this->attributes)
             )
         );
 
@@ -1090,7 +1105,9 @@ trait HasAttributes
         [$key, $path] = explode('->', $key, 2);
 
         $value = $this->asJson($this->getArrayAttributeWithValue(
-            $path, $key, $value
+            $path,
+            $key,
+            $value
         ));
 
         $this->attributes[$key] = $this->isEncryptedCastable($key)
@@ -1118,7 +1135,10 @@ trait HasAttributes
         $this->attributes = array_merge(
             $this->attributes,
             $this->normalizeCastClassResponse($key, $caster->set(
-                $this, $key, $value, $this->attributes
+                $this,
+                $key,
+                $value,
+                $this->attributes
             ))
         );
 
@@ -1225,7 +1245,9 @@ trait HasAttributes
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
-                $this, $key, json_last_error_msg()
+                $this,
+                $key,
+                json_last_error_msg()
             );
         }
 
@@ -1348,7 +1370,8 @@ trait HasAttributes
         // when checking the field. We will just return the DateTime right away.
         if ($value instanceof DateTimeInterface) {
             return Date::parse(
-                $value->format('Y-m-d H:i:s.u'), $value->getTimezone()
+                $value->format('Y-m-d H:i:s.u'),
+                $value->getTimezone()
             );
         }
 
@@ -1377,7 +1400,7 @@ trait HasAttributes
             $date = false;
         }
 
-        return $date ?: Date::parse($value);
+        return $date ?: Date::make($value);
     }
 
     /**
@@ -1722,7 +1745,8 @@ trait HasAttributes
             $this->attributes = array_merge(
                 $this->attributes,
                 $this->normalizeCastClassResponse(
-                    $key, $callback($value, $this->attributes)
+                    $key,
+                    $callback($value, $this->attributes)
                 )
             );
         }
@@ -1793,7 +1817,8 @@ trait HasAttributes
     public function getOriginal($key = null, $default = null)
     {
         return (new static)->setRawAttributes(
-            $this->original, $sync = true
+            $this->original,
+            $sync = true
         )->getOriginalWithoutRewindingModel($key, $default);
     }
 
@@ -1808,7 +1833,8 @@ trait HasAttributes
     {
         if ($key) {
             return $this->transformModelValue(
-                $key, Arr::get($this->original, $key, $default)
+                $key,
+                Arr::get($this->original, $key, $default)
             );
         }
 
@@ -1909,7 +1935,8 @@ trait HasAttributes
     public function isDirty($attributes = null)
     {
         return $this->hasChanges(
-            $this->getDirty(), is_array($attributes) ? $attributes : func_get_args()
+            $this->getDirty(),
+            is_array($attributes) ? $attributes : func_get_args()
         );
     }
 
@@ -1945,7 +1972,8 @@ trait HasAttributes
     public function wasChanged($attributes = null)
     {
         return $this->hasChanges(
-            $this->getChanges(), is_array($attributes) ? $attributes : func_get_args()
+            $this->getChanges(),
+            is_array($attributes) ? $attributes : func_get_args()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -196,16 +196,14 @@ trait HasAttributes
         );
 
         $attributes = $this->addMutatedAttributesToArray(
-            $attributes,
-            $mutatedAttributes = $this->getMutatedAttributes()
+            $attributes, $mutatedAttributes = $this->getMutatedAttributes()
         );
 
         // Next we will handle any casts that have been setup for this model and cast
         // the values to their appropriate type. If the attribute has a mutator we
         // will not perform the cast on those attributes to avoid any confusion.
         $attributes = $this->addCastAttributesToArray(
-            $attributes,
-            $mutatedAttributes
+            $attributes, $mutatedAttributes
         );
 
         // Here we will grab all of the appended, calculated attributes to this model
@@ -260,8 +258,7 @@ trait HasAttributes
             // mutated attribute's actual values. After we finish mutating each of the
             // attributes we will return this final array of the mutated attributes.
             $attributes[$key] = $this->mutateAttributeForArray(
-                $key,
-                $attributes[$key]
+                $key, $attributes[$key]
             );
         }
 
@@ -287,8 +284,7 @@ trait HasAttributes
             // then we will serialize the date for the array. This will convert the dates
             // to strings based on the date format specified for these Eloquent models.
             $attributes[$key] = $this->castAttribute(
-                $key,
-                $attributes[$key]
+                $key, $attributes[$key]
             );
 
             // If the attribute cast was a date or a datetime, we will serialize the date as
@@ -577,16 +573,12 @@ trait HasAttributes
         if (! $relation instanceof Relation) {
             if (is_null($relation)) {
                 throw new LogicException(sprintf(
-                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?',
-                    static::class,
-                    $method
+                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
                 ));
             }
 
             throw new LogicException(sprintf(
-                '%s::%s must return a relationship instance.',
-                static::class,
-                $method
+                '%s::%s must return a relationship instance.', static::class, $method
             ));
         }
 
@@ -885,10 +877,7 @@ trait HasAttributes
     protected function deviateClassCastableAttribute($method, $key, $value)
     {
         return $this->resolveCasterClass($key)->{$method}(
-            $this,
-            $key,
-            $value,
-            $this->attributes
+            $this, $key, $value, $this->attributes
         );
     }
 
@@ -1068,8 +1057,7 @@ trait HasAttributes
         $this->attributes = array_merge(
             $this->attributes,
             $this->normalizeCastClassResponse(
-                $key,
-                $callback($value, $this->attributes)
+                $key, $callback($value, $this->attributes)
             )
         );
 
@@ -1134,10 +1122,7 @@ trait HasAttributes
         $this->attributes = array_merge(
             $this->attributes,
             $this->normalizeCastClassResponse($key, $caster->set(
-                $this,
-                $key,
-                $value,
-                $this->attributes
+                $this, $key, $value, $this->attributes
             ))
         );
 
@@ -1369,8 +1354,7 @@ trait HasAttributes
         // when checking the field. We will just return the DateTime right away.
         if ($value instanceof DateTimeInterface) {
             return Date::parse(
-                $value->format('Y-m-d H:i:s.u'),
-                $value->getTimezone()
+                $value->format('Y-m-d H:i:s.u'), $value->getTimezone()
             );
         }
 
@@ -1744,8 +1728,7 @@ trait HasAttributes
             $this->attributes = array_merge(
                 $this->attributes,
                 $this->normalizeCastClassResponse(
-                    $key,
-                    $callback($value, $this->attributes)
+                    $key, $callback($value, $this->attributes)
                 )
             );
         }
@@ -1832,8 +1815,7 @@ trait HasAttributes
     {
         if ($key) {
             return $this->transformModelValue(
-                $key,
-                Arr::get($this->original, $key, $default)
+                $key, Arr::get($this->original, $key, $default)
             );
         }
 
@@ -1934,8 +1916,7 @@ trait HasAttributes
     public function isDirty($attributes = null)
     {
         return $this->hasChanges(
-            $this->getDirty(),
-            is_array($attributes) ? $attributes : func_get_args()
+            $this->getDirty(), is_array($attributes) ? $attributes : func_get_args()
         );
     }
 
@@ -1971,8 +1952,7 @@ trait HasAttributes
     public function wasChanged($attributes = null)
     {
         return $this->hasChanges(
-            $this->getChanges(),
-            is_array($attributes) ? $attributes : func_get_args()
+            $this->getChanges(), is_array($attributes) ? $attributes : func_get_args()
         );
     }
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -121,7 +121,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             'datetime_field' => null,
         ]);
 
-        $this->assertSame(null, $user->toArray()['date_field']);
+        $this->assertSame('', $user->toArray()['date_field']);
         $this->assertSame(null, $user->toArray()['datetime_field']);
     }
 }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -113,6 +113,17 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertArrayNotHasKey('immutable_date_field', $user->getDirty());
         $this->assertArrayNotHasKey('immutable_datetime_field', $user->getDirty());
     }
+
+    public function testDatesCanBeEmptyOrNull()
+    {
+        $user = TestModel1::create([
+            'date_field' => '',
+            'datetime_field' => null,
+        ]);
+
+        $this->assertSame(null, $user->toArray()['date_field']);
+        $this->assertSame(null, $user->toArray()['datetime_field']);
+    }
 }
 
 class TestModel1 extends Model

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -116,7 +116,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
 
     public function testDatesCanBeEmptyOrNull()
     {
-        $user = TestModel1::create([
+        $user = TestModel1::make([
             'date_field' => '',
             'datetime_field' => null,
         ]);


### PR DESCRIPTION
This PR fixes a bug, I found in custom castables for dates.

## Given

Imagine you have a model with a custom cast property to date. The code below will demonstrate it:

```php
class Foo extends \Illuminate\Database\Eloquent\Model {
  protected $guarded = [];
  protected $casts = ['something' => 'datetime:Y-m-d\TH:i',];
}

$foo = new Foo(['something' => '']);
```

## Expectation

I expect that I convert my model to an array or to json and the property `something` that has an empty string as a value, will be empty after conversion.

```php
dump([$foo, $foo->something, $foo->toJson()]);
```

The output I expect is:
```
[
  Foo {#2298
    something: "",
  },
  null,
  "{"something":""}",
]
```

## Bug

Instead of getting an empty value, I got the current datetime in my castable property, which is clearly wrong and manipulates the integrity of my data. The least expectation will be, that an empty field will get a random datetime, instead of an empty value

Let us add a dump to the given code above:

```php
dump([$foo, $foo->something, $foo->toJson()]);
```

The output is:
```
[
  Foo {#2298
    something: "",
  },
  Illuminate\Support\Carbon @1666016419 {#2294
    value: "2022-10-17 14:20:19",
  },
  "{"something":"2022-10-17T14:20"}",
]
```

## Solution

instead of using `Carbon::parse()` which always returns an instance of it self and in case it fails, it returns now (https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Traits/Creator.php#L211).
We switch to the more safe method `Carbon::make()`, which returns the value we gave in, when it is not possible to transform into datatime. https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Traits/Creator.php#L899-L919