### PR TITLE
[9.x] Add `dontIncludeSource` to `CliDumper` and `HtmlDumper`

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -167,11 +167,11 @@ trait ResolvesDumpSource
     }
 
     /**
-     * Prevent dumping the source of the dump call.
+     * Don't include the location / file of the dump in dumps.
      *
      * @return void
      */
-    public static function preventDumpingSource()
+    public static function dontIncludeSource()
     {
         static::$dumpSourceResolver = false;
     }

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -32,7 +32,7 @@ trait ResolvesDumpSource
     /**
      * The source resolver.
      *
-     * @var (callable(): (array{0: string, 1: string, 2: int|null}|null))|null
+     * @var (callable(): (array{0: string, 1: string, 2: int|null}|null))|null|false
      */
     protected static $dumpSourceResolver;
 
@@ -43,6 +43,10 @@ trait ResolvesDumpSource
      */
     public function resolveDumpSource()
     {
+        if (static::$dumpSourceResolver === false) {
+            return null;
+        }
+
         if (static::$dumpSourceResolver) {
             return call_user_func(static::$dumpSourceResolver);
         }
@@ -160,5 +164,15 @@ trait ResolvesDumpSource
     public static function resolveDumpSourceUsing($callable)
     {
         static::$dumpSourceResolver = $callable;
+    }
+
+    /**
+     * Prevent dumping the source of the dump call.
+     *
+     * @return void
+     */
+    public static function preventDumpingSource()
+    {
+        static::$dumpSourceResolver = false;
     }
 }


### PR DESCRIPTION
This pull request adds a `preventDumpingSource` static method to `Illuminate\Foundation\Concerns\ResolvesDumpSource`, effectively affecting `Illuminate\Foundation\Console\CliDumper` and `Illuminate\Foundation\Http\HtmlDumper`.

When called, this method prevents the `dump` and `dd` functions from displaying a comment with the source of the dump.

While the idea is very nice, in practice it has made dumps cumbersome to read and understand for me. Here is an example:

![image](https://user-images.githubusercontent.com/16060559/196262198-e546c628-ab0c-489c-8f26-fa9a0022545e.png)

The functionality can already be disabled by calling `HtmlDumper::resolveDumpSourceUsing(fn () => null)`, but I didn't found out until I dove into the code. The point of this pull request is to allow preventing the dump resolution in a cleaner and more accessible way:

```php
// Before
HtmlDumper::resolveDumpSourceUsing(fn () => null);
CliDumper::resolveDumpSourceUsing(fn () => null);

// After
HtmlDumper::preventDumpingSource();
CliDumper::preventDumpingSource();
```