### PR TITLE
[9.x] Allow `Model::shouldBeStrict(false)` to disable "strict mode"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -392,13 +392,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public static function shouldBeStrict(bool $shouldBeStrict = true)
     {
-        if (! $shouldBeStrict) {
-            return;
-        }
-
-        static::preventLazyLoading();
-        static::preventSilentlyDiscardingAttributes();
-        static::preventAccessingMissingAttributes();
+        static::preventLazyLoading($shouldBeStrict);
+        static::preventSilentlyDiscardingAttributes($shouldBeStrict);
+        static::preventAccessingMissingAttributes($shouldBeStrict);
     }
 
     /**


### PR DESCRIPTION
This is useful when you want to disable "strict" for specific routes.

E.g: packages that need to have access to dynamic accessor and can't comply with "strict mode"

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

