### PR TITLE
[9.x] Allow database connection to be specified for test migrations

### DIFF
--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -12,7 +12,7 @@ trait CanConfigureMigrationCommands
     protected function migrateFreshUsing()
     {
         $seeder = $this->seeder();
-        $database = $this->database();
+        $database = $this->connectionToMigrate();
 
         return array_merge(
             [
@@ -69,8 +69,8 @@ trait CanConfigureMigrationCommands
      *
      * @return mixed
      */
-    protected function database()
+    protected function connectionToMigrate()
     {
-        return property_exists($this, 'database') ? $this->database : false;
+        return property_exists($this, 'connectionToMigrate') ? $this->connectionToMigrate : false;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -12,13 +12,15 @@ trait CanConfigureMigrationCommands
     protected function migrateFreshUsing()
     {
         $seeder = $this->seeder();
+        $database = $this->database();
 
         return array_merge(
             [
                 '--drop-views' => $this->shouldDropViews(),
                 '--drop-types' => $this->shouldDropTypes(),
             ],
-            $seeder ? ['--seeder' => $seeder] : ['--seed' => $this->shouldSeed()]
+            $seeder ? ['--seeder' => $seeder] : ['--seed' => $this->shouldSeed()],
+            $database ? ['--database' => $database] : [],
         );
     }
 
@@ -60,5 +62,15 @@ trait CanConfigureMigrationCommands
     protected function seeder()
     {
         return property_exists($this, 'seeder') ? $this->seeder : false;
+    }
+
+    /**
+     * Determine the database connection to use when refreshing the database.
+     *
+     * @return mixed
+     */
+    protected function database()
+    {
+        return property_exists($this, 'database') ? $this->database : false;
     }
 }

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -85,7 +85,7 @@ class CanConfigureMigrationCommandsTest extends TestCase
 
         $this->traitObject->dropViews = true;
         $this->traitObject->dropTypes = true;
-        $this->traitObject->database = 'db-connection';
+        $this->traitObject->connectionToMigrate = 'db-connection';
 
         $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
     }

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -85,7 +85,7 @@ class CanConfigureMigrationCommandsTest extends TestCase
 
         $this->traitObject->dropViews = true;
         $this->traitObject->dropTypes = true;
-        $this->traitObject->databse = 'db-connection';
+        $this->traitObject->database = 'db-connection';
 
         $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
     }

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -75,6 +75,19 @@ class CanConfigureMigrationCommandsTest extends TestCase
         $this->traitObject->dropTypes = true;
 
         $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
+
+        $expected = [
+            '--drop-views' => true,
+            '--drop-types' => true,
+            '--seed' => false,
+            '--database' => 'db-connection',
+        ];
+
+        $this->traitObject->dropViews = true;
+        $this->traitObject->dropTypes = true;
+        $this->traitObject->databse = 'db-connection';
+
+        $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
     }
 }
 


### PR DESCRIPTION
I'm working on a project with two database connections: one is elevated with specific grants (e.g. CREATE, ALTER, DROP), whereas the other is limited (e.g. SELECT, INSERT, UPDATE, DELETE). 

The limited database connect is the default, so adding `use RefreshesDatabase` to test cases blows up, because it doesn't have the grants to migrate. 

This PR adds a `connectionToMigrate` property that allows the database connection for test migrations to be specified.