### PR TITLE
[9.x] Added rawValue to Database Query Builder (and Eloquent as wrapper)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -110,6 +110,7 @@ class Builder implements BuilderContract
         'max',
         'min',
         'raw',
+        'rawValue',
         'sum',
         'toSql',
     ];

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2597,6 +2597,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a single expression value from the first result of a query.
+     *
+     * @param  string  $expression
+     * @param  array  $bindings
+     * @return mixed
+     */
+    public function rawValue(string $expression, array $bindings = [])
+    {
+        if ($result = $this->selectRaw($expression, $bindings)->take(1)->first()) {
+            return reset($result);
+        }
+    }
+
+    /**
      * Get a single column's value from the first result of a query if it's the sole matching record.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2464,6 +2464,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('bar', $results);
     }
 
+    public function testRawValueMethodReturnsSingleColumn()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select UPPER("foo") from "users" where "id" = ? limit 1', [1], true)->andReturn([['UPPER("foo")' => 'BAR']]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['UPPER("foo")' => 'BAR']])->andReturn([['UPPER("foo")' => 'BAR']]);
+        $results = $builder->from('users')->where('id', '=', 1)->rawValue('UPPER("foo")');
+        $this->assertSame('BAR', $results);
+    }
+
     public function testAggregateFunctions()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Currently there are a method to get a existing column value from database called `value`, this PR adds the method `rawValue` to get a value from a SQL expression.

For example, get first and last year from `trip` table using the Trip Model.

```php
$first = TripModel::orderBy('date_at', 'ASC')->rawValue('YEAR(`date_at`)');
$last = TripModel::orderBy('date_at', 'DESC')->rawValue('YEAR(`date_at`)');
```

Or full name from the `user` table:

```php
$fullname = UserModel::where('id', $id)->rawValue('CONCAT(`first_name`, " ", `last_name`)');
```

I think that there are a lot of usage cases for this method :)

Regards!
Lito.