### PR TITLE
[9.x] Fixes livewire components that were using `createBladeViewFromString`

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -170,7 +170,19 @@ abstract class Component
             return static::$bladeViewCache[$key] = $contents;
         }
 
-        $this->factory()->addNamespace(
+        return $this->createBladeViewFromString($this->factory(), $contents);
+    }
+
+    /**
+     * Create a Blade view with the raw component string content.
+     *
+     * @param  \Illuminate\Contracts\View\Factory  $factory
+     * @param  string  $contents
+     * @return string
+     */
+    protected function createBladeViewFromString($factory, $contents)
+    {
+        $factory->addNamespace(
             '__components',
             $directory = Container::getInstance()['config']->get('view.compiled')
         );

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -170,7 +170,7 @@ abstract class Component
             return static::$bladeViewCache[$key] = $contents;
         }
 
-        return $this->createBladeViewFromString($this->factory(), $contents);
+        return static::$bladeViewCache[$key] = $this->createBladeViewFromString($this->factory(), $contents);
     }
 
     /**
@@ -186,16 +186,14 @@ abstract class Component
             '__components',
             $directory = Container::getInstance()['config']->get('view.compiled')
         );
-
         if (! is_file($viewFile = $directory.'/'.sha1($contents).'.blade.php')) {
             if (! is_dir($directory)) {
                 mkdir($directory, 0755, true);
             }
-
             file_put_contents($viewFile, $contents);
         }
 
-        return static::$bladeViewCache[$key] = '__components::'.basename($viewFile, '.blade.php');
+        return '__components::'.basename($viewFile, '.blade.php');
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -186,10 +186,12 @@ abstract class Component
             '__components',
             $directory = Container::getInstance()['config']->get('view.compiled')
         );
+
         if (! is_file($viewFile = $directory.'/'.sha1($contents).'.blade.php')) {
             if (! is_dir($directory)) {
                 mkdir($directory, 0755, true);
             }
+
             file_put_contents($viewFile, $contents);
         }
 


### PR DESCRIPTION
This pull request is an attempt to fix livewire components that were using the removed method  `createBladeViewFromString`.