### PR TITLE
[9.x] Ensures view creators and composers are called when `*` is present

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesEvents.php
+++ b/src/Illuminate/View/Concerns/ManagesEvents.php
@@ -33,12 +33,14 @@ trait ManagesEvents
     public function creator($views, $callback)
     {
         if (is_array($this->shouldCallCreators)) {
-            if (is_string($views) && str_contains($views, '*')) {
-                $this->shouldCallCreators = true;
-            } else {
-                foreach (Arr::wrap($views) as $view) {
-                    $this->shouldCallCreators[$this->normalizeName($view)] = true;
+            foreach (Arr::wrap($views) as $view) {
+                if (str_contains($view, '*')) {
+                    $this->shouldCallCreators = true;
+
+                    break;
                 }
+
+                $this->shouldCallCreators[$this->normalizeName($view)] = true;
             }
         }
 
@@ -78,12 +80,14 @@ trait ManagesEvents
     public function composer($views, $callback)
     {
         if (is_array($this->shouldCallComposers)) {
-            if (is_string($views) && str_contains($views, '*')) {
-                $this->shouldCallComposers = true;
-            } else {
-                foreach (Arr::wrap($views) as $view) {
-                    $this->shouldCallComposers[$this->normalizeName($view)] = true;
+            foreach (Arr::wrap($views) as $view) {
+                if (str_contains($view, '*')) {
+                    $this->shouldCallComposers = true;
+
+                    break;
                 }
+
+                $this->shouldCallComposers[$this->normalizeName($view)] = true;
             }
         }
 

--- a/src/Illuminate/View/Concerns/ManagesEvents.php
+++ b/src/Illuminate/View/Concerns/ManagesEvents.php
@@ -33,7 +33,7 @@ trait ManagesEvents
     public function creator($views, $callback)
     {
         if (is_array($this->shouldCallCreators)) {
-            if ($views == '*') {
+            if (is_string($views) && str_contains($views, '*')) {
                 $this->shouldCallCreators = true;
             } else {
                 foreach (Arr::wrap($views) as $view) {
@@ -78,7 +78,7 @@ trait ManagesEvents
     public function composer($views, $callback)
     {
         if (is_array($this->shouldCallComposers)) {
-            if ($views == '*') {
+            if (is_string($views) && str_contains($views, '*')) {
                 $this->shouldCallComposers = true;
             } else {
                 foreach (Arr::wrap($views) as $view) {

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -215,6 +215,27 @@ class ViewFactoryTest extends TestCase
         $factory->callCreator($view);
     }
 
+    public function testCallCreatorsDoesDispatchEventsWhenIsNecessaryUsingNamespacedWildcards()
+    {
+        $factory = $this->getFactory();
+        $factory->getDispatcher()
+            ->shouldReceive('listen')
+            ->with('creating: namespaced::*', m::type(Closure::class))
+            ->once();
+
+        $factory->getDispatcher()
+            ->shouldReceive('dispatch')
+            ->with('creating: namespaced::my-package-view', m::type('array'))
+            ->once();
+
+        $view = m::mock(View::class);
+        $view->shouldReceive('name')->once()->andReturn('namespaced::my-package-view');
+
+        $factory->creator('namespaced::*', fn () => true);
+
+        $factory->callCreator($view);
+    }
+
     public function testCallCreatorsDoesDispatchEventsWhenIsNecessaryUsingWildcards()
     {
         $factory = $this->getFactory();
@@ -286,6 +307,27 @@ class ViewFactoryTest extends TestCase
         $view->shouldReceive('name')->twice()->andReturn('name');
 
         $factory->composer('name', fn () => true);
+
+        $factory->callComposer($view);
+    }
+
+    public function testCallComposersDoesDispatchEventsWhenIsNecessaryUsingNamespacedWildcards()
+    {
+        $factory = $this->getFactory();
+        $factory->getDispatcher()
+            ->shouldReceive('listen')
+            ->with('composing: namespaced::*', m::type(Closure::class))
+            ->once();
+
+        $factory->getDispatcher()
+            ->shouldReceive('dispatch')
+            ->with('composing: namespaced::my-package-view', m::type('array'))
+            ->once();
+
+        $view = m::mock(View::class);
+        $view->shouldReceive('name')->once()->andReturn('namespaced::my-package-view');
+
+        $factory->composer('namespaced::*', fn () => true);
 
         $factory->callComposer($view);
     }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -337,6 +337,27 @@ class ViewFactoryTest extends TestCase
         $factory->callComposer($view);
     }
 
+    public function testCallComposerDoesDispatchEventsWhenIsNecessaryAndUsingTheArrayFormat()
+    {
+        $factory = $this->getFactory();
+        $factory->getDispatcher()
+            ->shouldReceive('listen')
+            ->with('composing: name', m::type(Closure::class))
+            ->once();
+
+        $factory->getDispatcher()
+            ->shouldReceive('dispatch')
+            ->with('composing: name', m::type('array'))
+            ->once();
+
+        $view = m::mock(View::class);
+        $view->shouldReceive('name')->twice()->andReturn('name');
+
+        $factory->composer(['name'], fn () => true);
+
+        $factory->callComposer($view);
+    }
+
     public function testCallComposersDoesDispatchEventsWhenIsNecessaryUsingNamespacedWildcards()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -379,7 +379,7 @@ class ViewFactoryTest extends TestCase
         $view = m::mock(View::class);
         $view->shouldReceive('name')->once()->andReturn('namespaced::my-package-view');
 
-        $factory->composer(['namespaced::*', 'welcome'] , fn () => true);
+        $factory->composer(['namespaced::*', 'welcome'], fn () => true);
 
         $factory->callComposer($view);
     }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -236,6 +236,32 @@ class ViewFactoryTest extends TestCase
         $factory->callCreator($view);
     }
 
+    public function testCallCreatorsDoesDispatchEventsWhenIsNecessaryUsingNamespacedNestedWildcards()
+    {
+        $factory = $this->getFactory();
+        $factory->getDispatcher()
+            ->shouldReceive('listen')
+            ->with('creating: namespaced::*', m::type(Closure::class))
+            ->once();
+
+        $factory->getDispatcher()
+            ->shouldReceive('listen')
+            ->with('creating: welcome', m::type(Closure::class))
+            ->once();
+
+        $factory->getDispatcher()
+            ->shouldReceive('dispatch')
+            ->with('creating: namespaced::my-package-view', m::type('array'))
+            ->once();
+
+        $view = m::mock(View::class);
+        $view->shouldReceive('name')->once()->andReturn('namespaced::my-package-view');
+
+        $factory->creator(['namespaced::*', 'welcome'], fn () => true);
+
+        $factory->callCreator($view);
+    }
+
     public function testCallCreatorsDoesDispatchEventsWhenIsNecessaryUsingWildcards()
     {
         $factory = $this->getFactory();
@@ -328,6 +354,32 @@ class ViewFactoryTest extends TestCase
         $view->shouldReceive('name')->once()->andReturn('namespaced::my-package-view');
 
         $factory->composer('namespaced::*', fn () => true);
+
+        $factory->callComposer($view);
+    }
+
+    public function testCallComposersDoesDispatchEventsWhenIsNecessaryUsingNamespacedNestedWildcards()
+    {
+        $factory = $this->getFactory();
+        $factory->getDispatcher()
+            ->shouldReceive('listen')
+            ->with('composing: namespaced::*', m::type(Closure::class))
+            ->once();
+
+        $factory->getDispatcher()
+            ->shouldReceive('listen')
+            ->with('composing: welcome', m::type(Closure::class))
+            ->once();
+
+        $factory->getDispatcher()
+            ->shouldReceive('dispatch')
+            ->with('composing: namespaced::my-package-view', m::type('array'))
+            ->once();
+
+        $view = m::mock(View::class);
+        $view->shouldReceive('name')->once()->andReturn('namespaced::my-package-view');
+
+        $factory->composer(['namespaced::*', 'welcome'] , fn () => true);
 
         $factory->callComposer($view);
     }


### PR DESCRIPTION
This pull request fixes https://github.com/laravel/framework/issues/44634, by calling creators and composers when `*` is present.