### PR TITLE
Account for `preventAccessingMissingAttributes` in `Mailable::normalizeRecipient()`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -442,6 +442,24 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Execute a callback without triggering a missing attribute exception.
+     *
+     * @param  callable  $callback
+     * @return mixed
+     */
+    public static function ignoringMissingAttributes(callable $callback)
+    {
+        $preventsAccessingMissingAttributes = static::preventsAccessingMissingAttributes();
+
+        try {
+            static::preventAccessingMissingAttributes(false);
+            return $callback();
+        } finally {
+            static::preventAccessingMissingAttributes($preventsAccessingMissingAttributes);
+        }
+    }
+
+    /**
      * Execute a callback without broadcasting any model events for all model types.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -730,6 +731,8 @@ class Mailable implements MailableContract, Renderable
             return (object) ['email' => $recipient->getAddress(), 'name' => $recipient->getName()];
         } elseif ($recipient instanceof Mailables\Address) {
             return (object) ['email' => $recipient->address, 'name' => $recipient->name];
+        } elseif ($recipient instanceof Model) {
+            return $recipient::ignoringMissingAttributes(fn() => (object) $recipient->only(['name', 'email']));
         }
 
         return $recipient;


### PR DESCRIPTION
This PR is a potential fix for #44558 and provides an escape hatch for the `preventAccessingMissingAttributes()` function when needed. 

That said, this will result in potential silent bugs. Given this code:

```php
$users = User::select('name', 'mail')->get(); // Note the missing 'e'
Mail::to($users)->send(...);
```

Right now, if you turn on `Model::preventsAccessingMissingAttributes()`, this code will trigger an exception. After this PR, it will silently fail. I think there's an argument to be made for both sides, here…

I'm going to leave this as draft for discussion in #44558 until we come to an consensus there.