### PR TITLE
[9.x] add method performCommit

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -42,15 +42,7 @@ trait ManagesTransactions
             }
 
             try {
-                if ($this->transactions == 1) {
-                    $this->getPdo()->commit();
-                }
-
-                $this->transactions = max(0, $this->transactions - 1);
-
-                if ($this->afterCommitCallbacksShouldBeExecuted()) {
-                    $this->transactionsManager?->commit($this->getName());
-                }
+                $this->performCommit();
             } catch (Throwable $e) {
                 $this->handleCommitTransactionException(
                     $e, $currentAttempt, $attempts
@@ -188,6 +180,20 @@ trait ManagesTransactions
      */
     public function commit()
     {
+        $this->performCommit();
+
+        $this->fireConnectionEvent('committed');
+    }
+
+    /**
+     * Perform a commit within the database.
+     *
+     * @return void
+     *
+     * @throws \Throwable
+     */
+    protected function performCommit()
+    {
         if ($this->transactions == 1) {
             $this->getPdo()->commit();
         }
@@ -197,8 +203,6 @@ trait ManagesTransactions
         if ($this->afterCommitCallbacksShouldBeExecuted()) {
             $this->transactionsManager?->commit($this->getName());
         }
-
-        $this->fireConnectionEvent('committed');
     }
 
     /**


### PR DESCRIPTION
Hello. 

I proposed an additional event (committing #44608) in laravel, but the PR was closed. Maybe then we can at least move the commit logic into one protected method? It will greatly simplify the application logic for me.

Thanks
