### PR TITLE
[9.x] Fixes blade not forgetting compiled views on `view:clear`

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -70,6 +70,10 @@ class ViewClearCommand extends Command
             throw new RuntimeException('View path not found.');
         }
 
+        $this->laravel['view.engine.resolver']
+            ->resolve('blade')
+            ->forgetCompiledOrNotExpired();
+
         foreach ($this->files->glob("{$path}/*") as $view) {
             $this->files->delete($view);
         }


### PR DESCRIPTION
This pull request addresses Spatie's Permission package test suite, as they need to run the `view:clear` at runtime between assertions.

https://github.com/spatie/laravel-permission/actions/runs/3276093280/jobs/5391731843