### PR TITLE
[9.x] Prevents booting providers when running `env:decrypt`

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -24,7 +24,7 @@ class EnvironmentDecryptCommand extends Command
                     {--env= : The environment to be decrypted}
                     {--force : Overwrite the existing environment file}
                     {--filename= : Filename to write the decrypted file contents}
-                    {--path= : Path to write the decrypted file}';
+                    {--path= : Path to write the decrypted file contents}';
 
     /**
      * The name of the console command.
@@ -90,7 +90,7 @@ class EnvironmentDecryptCommand extends Command
         $encryptedFile = $environmentFile.'.encrypted';
 
         $path = $this->option('path') ?: base_path();
-        $filename = $path.($this->option('filename') ?: $environmentFile);
+        $filename = $path.($this->option('filename') ?: str_replace(base_path(), '', $environmentFile));
 
         if (Str::endsWith($filename, '.encrypted')) {
             $this->components->error('Invalid filename.');

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -23,7 +23,8 @@ class EnvironmentDecryptCommand extends Command
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be decrypted}
                     {--force : Overwrite the existing environment file}
-                    {--filename= : Where to write the decrypted file contents}';
+                    {--filename= : Filename to write the decrypted file contents}
+                    {--path= : Path to write the decrypted file}';
 
     /**
      * The name of the console command.
@@ -88,9 +89,8 @@ class EnvironmentDecryptCommand extends Command
 
         $encryptedFile = $environmentFile.'.encrypted';
 
-        $filename = $this->option('filename')
-                    ? base_path($this->option('filename'))
-                    : $environmentFile;
+        $path = $this->option('path') ?: base_path();
+        $filename = $path.($this->option('filename') ?: $environmentFile);
 
         if (Str::endsWith($filename, '.encrypted')) {
             $this->components->error('Invalid filename.');

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -24,7 +24,7 @@ class EnvironmentDecryptCommand extends Command
                     {--env= : The environment to be decrypted}
                     {--force : Overwrite the existing environment file}
                     {--filename= : Filename to write the decrypted file contents}
-                    {--path= : Path to write the decrypted file contents}';
+                    {--path= : Path to write the decrypted file}';
 
     /**
      * The name of the console command.

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -89,8 +89,9 @@ class EnvironmentDecryptCommand extends Command
 
         $encryptedFile = $environmentFile.'.encrypted';
 
-        $path = $this->option('path') ?: base_path();
-        $filename = $path.($this->option('filename') ?: str_replace(base_path(), '', $environmentFile));
+        $path = Str::finish($this->option('path') ?: base_path(), DIRECTORY_SEPARATOR);
+        $filename = ltrim($this->option('filename') ?: Str::replace(base_path(), '', $environmentFile), DIRECTORY_SEPARATOR);
+        $filename = Str::finish($path, '/').$filename;
 
         if (Str::endsWith($filename, '.encrypted')) {
             $this->components->error('Invalid filename.');

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -23,8 +23,8 @@ class EnvironmentDecryptCommand extends Command
                     {--cipher= : The encryption cipher}
                     {--env= : The environment to be decrypted}
                     {--force : Overwrite the existing environment file}
-                    {--filename= : Filename to write the decrypted file contents}
-                    {--path= : Path to write the decrypted file}';
+                    {--path= : Path to write the decrypted file}
+                    {--filename= : Filename of the decrypted file}';
 
     /**
      * The name of the console command.
@@ -150,6 +150,7 @@ class EnvironmentDecryptCommand extends Command
     protected function outputFilePath()
     {
         $path = Str::finish($this->option('path') ?: base_path(), DIRECTORY_SEPARATOR);
+
         $outputFile = $this->option('filename') ?: ('.env'.($this->option('env') ? '.'.$this->option('env') : ''));
         $outputFile = ltrim($outputFile, DIRECTORY_SEPARATOR);
 

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -91,7 +91,7 @@ class EnvironmentDecryptCommand extends Command
 
         $path = Str::finish($this->option('path') ?: base_path(), DIRECTORY_SEPARATOR);
         $filename = ltrim($this->option('filename') ?: Str::replace(base_path(), '', $environmentFile), DIRECTORY_SEPARATOR);
-        $filename = Str::finish($path, '/').$filename;
+        $filename = $path.$filename;
 
         if (Str::endsWith($filename, '.encrypted')) {
             $this->components->error('Invalid filename.');

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -105,7 +105,7 @@ class EnvironmentDecryptCommand extends Command
             return Command::FAILURE;
         }
 
-        if ($this->files->exists($environmentFile) && ! $this->option('force')) {
+        if ($this->files->exists($filename) && ! $this->option('force')) {
             $this->components->error('Environment file already exists.');
 
             return Command::FAILURE;

--- a/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentDecryptCommand.php
@@ -87,7 +87,7 @@ class EnvironmentDecryptCommand extends Command
                     ? base_path('.env').'.'.$this->option('env')
                     : $this->laravel->environmentFilePath()).'.encrypted';
 
-        $outputFile = $this->generateOutputFile();
+        $outputFile = $this->outputFilePath();
 
         if (Str::endsWith($outputFile, '.encrypted')) {
             $this->components->error('Invalid filename.');
@@ -142,10 +142,15 @@ class EnvironmentDecryptCommand extends Command
         return $key;
     }
 
-    protected function generateOutputFile()
+    /**
+     * Get the output file path that should be used for the command.
+     *
+     * @return string
+     */
+    protected function outputFilePath()
     {
         $path = Str::finish($this->option('path') ?: base_path(), DIRECTORY_SEPARATOR);
-        $outputFile = $this->option('filename') ?: '.env'.($this->option('env') ? '.'.$this->option('env') : '');
+        $outputFile = $this->option('filename') ?: ('.env'.($this->option('env') ? '.'.$this->option('env') : ''));
         $outputFile = ltrim($outputFile, DIRECTORY_SEPARATOR);
 
         return $path.$outputFile;

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -147,11 +147,7 @@ class Kernel implements KernelContract
 
         try {
             if ($input->getFirstArgument() === 'env:decrypt') {
-                $this->app->bootstrapWith(
-                    collect($this->bootstrappers())->reject(function ($bootstrapper) {
-                        return $bootstrapper === \Illuminate\Foundation\Bootstrap\BootProviders::class;
-                    })->all()
-                );
+                $this->bootstrapWithoutProviders($input->getFirstArgument());
             }
 
             $this->bootstrap();
@@ -331,6 +327,10 @@ class Kernel implements KernelContract
      */
     public function call($command, array $parameters = [], $outputBuffer = null)
     {
+        if ($command === 'env:decrypt') {
+            $this->bootstrapWithoutProviders();
+        }
+
         $this->bootstrap();
 
         return $this->getArtisan()->call($command, $parameters, $outputBuffer);
@@ -390,6 +390,20 @@ class Kernel implements KernelContract
 
             $this->commandsLoaded = true;
         }
+    }
+
+    /**
+     * Bootstrap the application without booting service providers.
+     *
+     * @return void
+     */
+    protected function bootstrapWithoutProviders()
+    {
+        $this->app->bootstrapWith(
+            collect($this->bootstrappers())->reject(function ($bootstrapper) {
+                return $bootstrapper === \Illuminate\Foundation\Bootstrap\BootProviders::class;
+            })->all()
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -146,6 +146,14 @@ class Kernel implements KernelContract
         $this->commandStartedAt = Carbon::now();
 
         try {
+            if ($input->getFirstArgument() === 'env:decrypt') {
+                $this->app->bootstrapWith(
+                    collect($this->bootstrappers())->reject(function ($bootstrapper) {
+                        return $bootstrapper === \Illuminate\Foundation\Bootstrap\BootProviders::class;
+                    })->all()
+                );
+            }
+
             $this->bootstrap();
 
             return $this->getArtisan()->run($input, $output);

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -147,7 +147,7 @@ class Kernel implements KernelContract
 
         try {
             if ($input->getFirstArgument() === 'env:decrypt') {
-                $this->bootstrapWithoutProviders();
+                $this->bootstrapWithoutBootingProviders();
             }
 
             $this->bootstrap();
@@ -328,7 +328,7 @@ class Kernel implements KernelContract
     public function call($command, array $parameters = [], $outputBuffer = null)
     {
         if ($command === 'env:decrypt') {
-            $this->bootstrapWithoutProviders();
+            $this->bootstrapWithoutBootingProviders();
         }
 
         $this->bootstrap();
@@ -397,7 +397,7 @@ class Kernel implements KernelContract
      *
      * @return void
      */
-    public function bootstrapWithoutProviders()
+    public function bootstrapWithoutBootingProviders()
     {
         $this->app->bootstrapWith(
             collect($this->bootstrappers())->reject(function ($bootstrapper) {

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -75,13 +75,6 @@ class Kernel implements KernelContract
     protected $commandStartedAt;
 
     /**
-     * Indicates whether the application should reboot.
-     *
-     * @var bool
-     */
-    protected $shouldReboot = false;
-
-    /**
      * The bootstrap classes for the application.
      *
      * @var string[]
@@ -155,9 +148,9 @@ class Kernel implements KernelContract
         try {
             if ($input->getFirstArgument() === 'env:decrypt') {
                 $this->bootstrapWithoutProviders();
-            } else {
-                $this->bootstrap();
             }
+
+            $this->bootstrap();
 
             return $this->getArtisan()->run($input, $output);
         } catch (Throwable $e) {
@@ -336,9 +329,9 @@ class Kernel implements KernelContract
     {
         if ($command === 'env:decrypt') {
             $this->bootstrapWithoutProviders();
-        } else {
-            $this->bootstrap();
         }
+
+        $this->bootstrap();
 
         return $this->getArtisan()->call($command, $parameters, $outputBuffer);
     }
@@ -386,7 +379,7 @@ class Kernel implements KernelContract
      */
     public function bootstrap()
     {
-        if (! $this->app->hasBeenBootstrapped() || $this->shouldReboot()) {
+        if (! $this->app->hasBeenBootstrapped()) {
             $this->app->bootstrapWith($this->bootstrappers());
         }
 
@@ -397,8 +390,6 @@ class Kernel implements KernelContract
 
             $this->commandsLoaded = true;
         }
-
-        $this->shouldReboot = false;
     }
 
     /**
@@ -413,20 +404,6 @@ class Kernel implements KernelContract
                 return $bootstrapper === \Illuminate\Foundation\Bootstrap\BootProviders::class;
             })->all()
         );
-
-        $this->bootstrap();
-
-        $this->shouldReboot = true;
-    }
-
-    /**
-     * Determine if the application should be rebooted.
-     *
-     * @return bool
-     */
-    protected function shouldReboot()
-    {
-        return $this->shouldReboot;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -147,7 +147,7 @@ class Kernel implements KernelContract
 
         try {
             if ($input->getFirstArgument() === 'env:decrypt') {
-                $this->bootstrapWithoutProviders($input->getFirstArgument());
+                $this->bootstrapWithoutProviders();
             }
 
             $this->bootstrap();

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -246,7 +246,7 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with('/tmp/.env.production', 'APP_NAME="Laravel Two"');
+            ->with('/tmp'.DIRECTORY_SEPARATOR.'.env.production', 'APP_NAME="Laravel Two"');
     }
 
     public function testItWritesTheEnvironmentFileCustomPathAndFilename()
@@ -264,12 +264,12 @@ class EnvironmentDecryptCommandTest extends TestCase
                     ->encrypt('APP_NAME="Laravel Two"')
             );
 
-        $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnopabcdefghijklmnop', '--filename' => '.env', '--path' => '/tmp/'])
+        $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnopabcdefghijklmnop', '--filename' => '.env', '--path' => '/tmp'])
             ->expectsOutputToContain('Environment successfully decrypted.')
             ->assertExitCode(0);
 
         $this->filesystem->shouldHaveReceived('put')
-            ->with('/tmp/.env', 'APP_NAME="Laravel Two"');
+            ->with('/tmp'.DIRECTORY_SEPARATOR.'.env', 'APP_NAME="Laravel Two"');
     }
 
     public function testItCannotOverwriteEncryptedFiles()

--- a/tests/Integration/Console/EnvironmentDecryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentDecryptCommandTest.php
@@ -226,6 +226,52 @@ class EnvironmentDecryptCommandTest extends TestCase
             ->with(base_path('.env'), 'APP_NAME="Laravel Two"');
     }
 
+    public function testItWritesTheEnvironmentFileCustomPath()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter('abcdefghijklmnopabcdefghijklmnop', 'AES-256-CBC'))
+                    ->encrypt('APP_NAME="Laravel Two"')
+            );
+
+        $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnopabcdefghijklmnop', '--path' => '/tmp'])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with('/tmp/.env.production', 'APP_NAME="Laravel Two"');
+    }
+
+    public function testItWritesTheEnvironmentFileCustomPathAndFilename()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get')
+            ->once()
+            ->andReturn(
+                (new Encrypter('abcdefghijklmnopabcdefghijklmnop', 'AES-256-CBC'))
+                    ->encrypt('APP_NAME="Laravel Two"')
+            );
+
+        $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnopabcdefghijklmnop', '--filename' => '.env', '--path' => '/tmp/'])
+            ->expectsOutputToContain('Environment successfully decrypted.')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with('/tmp/.env', 'APP_NAME="Laravel Two"');
+    }
+
     public function testItCannotOverwriteEncryptedFiles()
     {
         $this->artisan('env:decrypt', ['--env' => 'production', '--key' => 'abcdefghijklmnop', '--filename' => '.env.production.encrypted'])


### PR DESCRIPTION
This PR fixes an issue with the `env:decrypt` command which can occur when a service provider relies on the presence of a value in the environment file. 

For example, the Pusher broadcast driver relies on the API token set in the environment and that token doesn't exist until the environment file is decrypted. However, when running the command, the `BroadcastServiceProvider` is booted which attempts to instantiate Pusher and an exception is thrown.

This PR aims to resolve that issue by omitting `\Illuminate\Foundation\Bootstrap\BootProviders::class` from the kernel bootstrappers **only** when invoking the `env:decrypt` command.

This functionality has been added to both the `handle` and `call` methods.

As part of this, I have also added the option to decrypt a file to a different path.

```shell
php artisan env:decrypt --path=/tmp
```

Running the command above would result decrypting a file called `.env.encrypted` to `/tmp/.env`

Of course, you may combine this with the other options:

```shell
php artisan env:decrypt --env=production --filename=.env --path=/tmp
```

The above command will decrypt `.env.production.encrypted` to `/tmp/.env`
