### PR TITLE
Change order of "find loop" in the Illuminate\View\FileViewFinder::findInPaths() method.

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -126,8 +126,8 @@ class FileViewFinder implements ViewFinderInterface
      */
     protected function findInPaths($name, $paths)
     {
-        foreach ((array) $paths as $path) {
-            foreach ($this->getPossibleViewFiles($name) as $file) {
+        foreach ($this->getPossibleViewFiles($name) as $file) {
+            foreach((array) $paths as $path) {
                 if ($this->files->exists($viewPath = $path.'/'.$file)) {
                     return $viewPath;
                 }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -37,9 +37,6 @@ class ViewFileViewFinderTest extends TestCase
         $finder = $this->getFinder();
         $finder->addLocation(__DIR__.'/nested');
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.css')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.html')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/nested/foo.blade.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/nested/foo.blade.php', $finder->find('foo'));
@@ -69,9 +66,6 @@ class ViewFileViewFinderTest extends TestCase
         $finder = $this->getFinder();
         $finder->addNamespace('foo', [__DIR__.'/foo', __DIR__.'/bar']);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.blade.php')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.css')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.html')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/bar/bar/baz.blade.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/bar/bar/baz.blade.php', $finder->find('foo::bar.baz'));


### PR DESCRIPTION
Hello Everyone,

I've noticed the following method `Illuminate\View\FileViewFinder::findInPaths()`. This function is used to determine if a given name relates to a view. When it does the path is returned, else a `InvalidArgumentException` is thrown.

This process involves 3 loops. The first loop iterates over every configured view path, the second loop appends supported file extensions to the given name, the third loop validates if a view exists. According to my calculations this will result in a total of max 16 iterations per view path the max total iterations will double.

![Current iteration count](https://user-images.githubusercontent.com/88203507/196717334-eab58e64-a90f-4ff7-a5da-aac846cf9b4f.png)

### My Calculation 
amount of view paths * amount of extensions * amount of files to validate

**Amount of view paths**
count of paths defined in the config at view.paths

**Amount of extensions**
when appending file extensions to the name we iterate over all supported file extensions

**Amount of files to validate**
size of the results from “amount of extensions”


### Suggested Change
With this PR the nesting of the `Illuminate\View\FileViewFinder::findInPaths()` method is changed. This will reduce the amount of total iterations but doesn’t change the behavior. We start by generating possible view file names (4 iterations). The next step is to iterate over the configured view paths (1 - *). 

This halves the number of iterations when a single view path is configured (from 16 to 8 iterations). When the number of view paths grows this number will change (at 7 paths from 112 to 32 iterations).

![New iteration count](https://user-images.githubusercontent.com/88203507/196717808-60cbb59a-4f98-4fb4-84c3-08eb42bad4fe.png)

### My Calculation 
amount of file names * amount of view paths + iterations for generating the file names

**Amount of file names**
An array containing possible file names

**Amount of view paths** 
count of paths defined in the config at view.paths

**Iterations for generating the file names**
When generating the `Amount of file names` array a array_map is used.  So it iterates over something..  

### Expected impact
None, the methods behavior is the same. The performance impact is really low shouldn't be noticeable.  

You can find me in the discord server username: _bromano