### PR TITLE
[9.x] Reduce amount of iterations when searching a view in paths.

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -45,9 +45,9 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Create a new file view loader instance.
      *
-     * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  array  $paths
-     * @param  array|null  $extensions
+     * @param \Illuminate\Filesystem\Filesystem $files
+     * @param array $paths
+     * @param array|null $extensions
      * @return void
      */
     public function __construct(Filesystem $files, array $paths, array $extensions = null)
@@ -63,7 +63,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Get the fully qualified location of the view.
      *
-     * @param  string  $name
+     * @param string $name
      * @return string
      */
     public function find($name)
@@ -82,7 +82,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Get the path to a template with a named path.
      *
-     * @param  string  $name
+     * @param string $name
      * @return string
      */
     protected function findNamespacedView($name)
@@ -95,7 +95,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Get the segments of a template with a named path.
      *
-     * @param  string  $name
+     * @param string $name
      * @return array
      *
      * @throws \InvalidArgumentException
@@ -108,7 +108,7 @@ class FileViewFinder implements ViewFinderInterface
             throw new InvalidArgumentException("View [{$name}] has an invalid name.");
         }
 
-        if (! isset($this->hints[$segments[0]])) {
+        if (!isset($this->hints[$segments[0]])) {
             throw new InvalidArgumentException("No hint path defined for [{$segments[0]}].");
         }
 
@@ -118,17 +118,17 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Find the given view in the list of paths.
      *
-     * @param  string  $name
-     * @param  array  $paths
+     * @param string $name
+     * @param array $paths
      * @return string
      *
      * @throws \InvalidArgumentException
      */
     protected function findInPaths($name, $paths)
     {
-        foreach ((array) $paths as $path) {
-            foreach ($this->getPossibleViewFiles($name) as $file) {
-                if ($this->files->exists($viewPath = $path.'/'.$file)) {
+        foreach ($this->getPossibleViewFiles($name) as $file) {
+            foreach ((array)$paths as $path) {
+                if ($this->files->exists($viewPath = $path . '/' . $file)) {
                     return $viewPath;
                 }
             }
@@ -140,18 +140,18 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Get an array of possible view files.
      *
-     * @param  string  $name
+     * @param string $name
      * @return array
      */
     protected function getPossibleViewFiles($name)
     {
-        return array_map(fn ($extension) => str_replace('.', '/', $name).'.'.$extension, $this->extensions);
+        return array_map(fn($extension) => str_replace('.', '/', $name) . '.' . $extension, $this->extensions);
     }
 
     /**
      * Add a location to the finder.
      *
-     * @param  string  $location
+     * @param string $location
      * @return void
      */
     public function addLocation($location)
@@ -162,7 +162,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Prepend a location to the finder.
      *
-     * @param  string  $location
+     * @param string $location
      * @return void
      */
     public function prependLocation($location)
@@ -173,7 +173,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Resolve the path.
      *
-     * @param  string  $path
+     * @param string $path
      * @return string
      */
     protected function resolvePath($path)
@@ -184,13 +184,13 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Add a namespace hint to the finder.
      *
-     * @param  string  $namespace
-     * @param  string|array  $hints
+     * @param string $namespace
+     * @param string|array $hints
      * @return void
      */
     public function addNamespace($namespace, $hints)
     {
-        $hints = (array) $hints;
+        $hints = (array)$hints;
 
         if (isset($this->hints[$namespace])) {
             $hints = array_merge($this->hints[$namespace], $hints);
@@ -202,13 +202,13 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Prepend a namespace hint to the finder.
      *
-     * @param  string  $namespace
-     * @param  string|array  $hints
+     * @param string $namespace
+     * @param string|array $hints
      * @return void
      */
     public function prependNamespace($namespace, $hints)
     {
-        $hints = (array) $hints;
+        $hints = (array)$hints;
 
         if (isset($this->hints[$namespace])) {
             $hints = array_merge($hints, $this->hints[$namespace]);
@@ -220,19 +220,19 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Replace the namespace hints for the given namespace.
      *
-     * @param  string  $namespace
-     * @param  string|array  $hints
+     * @param string $namespace
+     * @param string|array $hints
      * @return void
      */
     public function replaceNamespace($namespace, $hints)
     {
-        $this->hints[$namespace] = (array) $hints;
+        $this->hints[$namespace] = (array)$hints;
     }
 
     /**
      * Register an extension with the view finder.
      *
-     * @param  string  $extension
+     * @param string $extension
      * @return void
      */
     public function addExtension($extension)
@@ -247,7 +247,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Returns whether or not the view name has any hint information.
      *
-     * @param  string  $name
+     * @param string $name
      * @return bool
      */
     public function hasHintInformation($name)
@@ -278,7 +278,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Set the active view paths.
      *
-     * @param  array  $paths
+     * @param array $paths
      * @return $this
      */
     public function setPaths($paths)

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -127,7 +127,7 @@ class FileViewFinder implements ViewFinderInterface
     protected function findInPaths($name, $paths)
     {
         foreach ($this->getPossibleViewFiles($name) as $file) {
-            foreach ((array)$paths as $path) {
+            foreach ((array) $paths as $path) {
                 if ($this->files->exists($viewPath = $path.'/'.$file)) {
                     return $viewPath;
                 }

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -45,9 +45,9 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Create a new file view loader instance.
      *
-     * @param \Illuminate\Filesystem\Filesystem $files
-     * @param array $paths
-     * @param array|null $extensions
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  array  $paths
+     * @param  array|null  $extensions
      * @return void
      */
     public function __construct(Filesystem $files, array $paths, array $extensions = null)
@@ -63,7 +63,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Get the fully qualified location of the view.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     public function find($name)
@@ -82,7 +82,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Get the path to a template with a named path.
      *
-     * @param string $name
+     * @param  string  $name
      * @return string
      */
     protected function findNamespacedView($name)
@@ -95,7 +95,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Get the segments of a template with a named path.
      *
-     * @param string $name
+     * @param  string  $name
      * @return array
      *
      * @throws \InvalidArgumentException
@@ -108,7 +108,7 @@ class FileViewFinder implements ViewFinderInterface
             throw new InvalidArgumentException("View [{$name}] has an invalid name.");
         }
 
-        if (!isset($this->hints[$segments[0]])) {
+        if (! isset($this->hints[$segments[0]])) {
             throw new InvalidArgumentException("No hint path defined for [{$segments[0]}].");
         }
 
@@ -118,8 +118,8 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Find the given view in the list of paths.
      *
-     * @param string $name
-     * @param array $paths
+     * @param  string  $name
+     * @param  array  $paths
      * @return string
      *
      * @throws \InvalidArgumentException
@@ -128,7 +128,7 @@ class FileViewFinder implements ViewFinderInterface
     {
         foreach ($this->getPossibleViewFiles($name) as $file) {
             foreach ((array)$paths as $path) {
-                if ($this->files->exists($viewPath = $path . '/' . $file)) {
+                if ($this->files->exists($viewPath = $path.'/'.$file)) {
                     return $viewPath;
                 }
             }
@@ -140,18 +140,18 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Get an array of possible view files.
      *
-     * @param string $name
+     * @param  string  $name
      * @return array
      */
     protected function getPossibleViewFiles($name)
     {
-        return array_map(fn($extension) => str_replace('.', '/', $name) . '.' . $extension, $this->extensions);
+        return array_map(fn ($extension) => str_replace('.', '/', $name).'.'.$extension, $this->extensions);
     }
 
     /**
      * Add a location to the finder.
      *
-     * @param string $location
+     * @param  string  $location
      * @return void
      */
     public function addLocation($location)
@@ -162,7 +162,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Prepend a location to the finder.
      *
-     * @param string $location
+     * @param  string  $location
      * @return void
      */
     public function prependLocation($location)
@@ -173,7 +173,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Resolve the path.
      *
-     * @param string $path
+     * @param  string  $path
      * @return string
      */
     protected function resolvePath($path)
@@ -184,13 +184,13 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Add a namespace hint to the finder.
      *
-     * @param string $namespace
-     * @param string|array $hints
+     * @param  string  $namespace
+     * @param  string|array  $hints
      * @return void
      */
     public function addNamespace($namespace, $hints)
     {
-        $hints = (array)$hints;
+        $hints = (array) $hints;
 
         if (isset($this->hints[$namespace])) {
             $hints = array_merge($this->hints[$namespace], $hints);
@@ -202,13 +202,13 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Prepend a namespace hint to the finder.
      *
-     * @param string $namespace
-     * @param string|array $hints
+     * @param  string  $namespace
+     * @param  string|array  $hints
      * @return void
      */
     public function prependNamespace($namespace, $hints)
     {
-        $hints = (array)$hints;
+        $hints = (array) $hints;
 
         if (isset($this->hints[$namespace])) {
             $hints = array_merge($hints, $this->hints[$namespace]);
@@ -220,19 +220,19 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Replace the namespace hints for the given namespace.
      *
-     * @param string $namespace
-     * @param string|array $hints
+     * @param  string  $namespace
+     * @param  string|array  $hints
      * @return void
      */
     public function replaceNamespace($namespace, $hints)
     {
-        $this->hints[$namespace] = (array)$hints;
+        $this->hints[$namespace] = (array) $hints;
     }
 
     /**
      * Register an extension with the view finder.
      *
-     * @param string $extension
+     * @param  string  $extension
      * @return void
      */
     public function addExtension($extension)
@@ -247,7 +247,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Returns whether or not the view name has any hint information.
      *
-     * @param string $name
+     * @param  string  $name
      * @return bool
      */
     public function hasHintInformation($name)
@@ -278,7 +278,7 @@ class FileViewFinder implements ViewFinderInterface
     /**
      * Set the active view paths.
      *
-     * @param array $paths
+     * @param  array  $paths
      * @return $this
      */
     public function setPaths($paths)

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -37,9 +37,6 @@ class ViewFileViewFinderTest extends TestCase
         $finder = $this->getFinder();
         $finder->addLocation(__DIR__.'/nested');
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.css')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.html')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/nested/foo.blade.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/nested/foo.blade.php', $finder->find('foo'));
@@ -69,9 +66,6 @@ class ViewFileViewFinderTest extends TestCase
         $finder = $this->getFinder();
         $finder->addNamespace('foo', [__DIR__.'/foo', __DIR__.'/bar']);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.blade.php')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.css')->andReturn(false);
-        $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.html')->andReturn(false);
         $finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/bar/bar/baz.blade.php')->andReturn(true);
 
         $this->assertEquals(__DIR__.'/bar/bar/baz.blade.php', $finder->find('foo::bar.baz'));


### PR DESCRIPTION
Hello Everyone,

I've noticed the following method `Illuminate\View\FileViewFinder::findInPaths()`. This function is used to determine if a given name relates to a view. When it does the path is returned, else a `InvalidArgumentException` is thrown.

This process involves 3 loops. The first loop iterates over every configured view path, the second loop appends supported file extensions to the given name, the third loop validates if a view exists. According to my calculations this will result in a total of max 16 iterations per view path the max total iterations will double.

![Current iteration count](https://user-images.githubusercontent.com/88203507/196717334-eab58e64-a90f-4ff7-a5da-aac846cf9b4f.png)

### My Calculation 
amount of view paths * amount of extensions * amount of files to validate

**Amount of view paths**
count of paths defined in the config at view.paths

**Amount of extensions**
when appending file extensions to the name we iterate over all supported file extensions

**Amount of files to validate**
size of the results from “amount of extensions”


### Suggested Change
With this PR the nesting of the `Illuminate\View\FileViewFinder::findInPaths()` method is changed. This will reduce the amount of total iterations but doesn’t change the behavior. We start by generating possible view file names (4 iterations). The next step is to iterate over the configured view paths (1 - *). 

This halves the number of iterations when a single view path is configured (from 16 to 8 iterations). When the number of view paths grows this number will change (at 7 paths from 112 to 32 iterations).

![New iteration count](https://user-images.githubusercontent.com/88203507/196717808-60cbb59a-4f98-4fb4-84c3-08eb42bad4fe.png)

### My Calculation 
amount of file names * amount of view paths + iterations for generating the file names

**Amount of file names**
An array containing possible file names

**Amount of view paths** 
count of paths defined in the config at view.paths

**Iterations for generating the file names**
When generating the `Amount of file names` array a array_map is used.  So it iterates over something..  

### Expected impact
None, the methods behavior is the same. The performance impact is really low shouldn't be noticeable.  

You can find me in the discord server username: _bromano