### PR TITLE
[9.x] Add `assertBadRequest` to the `TestResponse`.

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -156,6 +156,16 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has a bad request status code.
+     *
+     * @return $this
+     */
+    public function assertBadRequest()
+    {
+        return $this->assertStatus(400);
+    }
+
+    /**
      * Assert that the response has a 422 status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -564,6 +564,22 @@ class TestResponseTest extends TestCase
         $response->assertUnauthorized();
     }
 
+    public function testAssertBadRequest()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Expected response status code');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertBadRequest();
+    }
+
     public function testAssertUnprocessable()
     {
         $statusCode = 500;


### PR DESCRIPTION
This PR adds the `assertBadRequest` to the `TestResponse` class.

This will allow to use:

```php
$response->assertBadRequest();
```

instead of:

```php
$response->assertStatus(400);
```

This one was also submitted in the past by @michael-rubel on https://github.com/laravel/framework/pull/43047.