### PR TITLE
[10.x] Date Casts returns wrong data with an impact to data consistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1346,7 +1346,7 @@ trait HasAttributes
             $date = false;
         }
 
-        return $date ?: Date::parse($value);
+        return $date ?: Date::make($value) ?: $value;
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -113,6 +113,17 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertArrayNotHasKey('immutable_date_field', $user->getDirty());
         $this->assertArrayNotHasKey('immutable_datetime_field', $user->getDirty());
     }
+
+    public function testDatesCanBeEmptyOrNull()
+    {
+        $user = TestModel1::make([
+            'date_field' => '',
+            'datetime_field' => null,
+        ]);
+
+        $this->assertSame(null, $user->toArray()['date_field']);
+        $this->assertSame(null, $user->toArray()['datetime_field']);
+    }
 }
 
 class TestModel1 extends Model


### PR DESCRIPTION
This PR fixes the Bug in #44628.

## Given

Imagine you have a model with a custom cast property to date. The code below will demonstrate it:

```php
class Foo extends \Illuminate\Database\Eloquent\Model {
  protected $guarded = [];
  protected $casts = ['something' => 'datetime:Y-m-d\TH:i',];
}

$foo = new Foo(['something' => '']);
```

## Expectation

I expect that I convert my model to an array or to json and the property `something` that has an empty string as a value, will be empty after conversion.

```php
dump([$foo, $foo->something, $foo->toJson()]);
```

The output I expect is:
```
[
  Foo {#2298
    something: "",
  },
  null,
  "{"something":""}",
]
```

## Bug

Instead of getting an empty value, I got the current datetime in my castable property, which is clearly wrong and manipulates the integrity of my data. The least expectation will be, that an empty field will get a random datetime, instead of an empty value

Let us add a dump to the given code above:

```php
dump([$foo, $foo->something, $foo->toJson()]);
```

The output is:
```
[
  Foo {#2298
    something: "",
  },
  Illuminate\Support\Carbon @1666016419 {#2294
    value: "2022-10-17 14:20:19",
  },
  "{"something":"2022-10-17T14:20"}",
]
```

## Solution

instead of using `Carbon::parse()` which always returns an instance of it self and in case it fails, it returns now (https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Traits/Creator.php#L211).
We switch to the more safe method `Carbon::make()`, which returns the value we gave in, when it is not possible to transform into datatime. https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Traits/Creator.php#L899-L919