### PR TITLE
[9.x] Checksums for filesystem disks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "fruitcake/php-cors": "^1.2",
         "laravel/serializable-closure": "^1.2.2",
         "league/commonmark": "^2.2",
-        "league/flysystem": "^3.0.16",
+        "league/flysystem": "^3.8.0",
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.62.1",
         "nunomaduro/termwind": "^1.13",

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -556,6 +556,24 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Get the checksum for a file.
+     *
+     * @return string|false string checksum or false on error
+     *
+     * @throws UnableToProvideChecksum
+     */
+    public function checksum(string $path, array $options = []): string|false
+    {
+        try {
+            return $this->driver->checksum($path, $options);
+        } catch (UnableToProvideChecksum $e) {
+            throw_if($this->throwsExceptions(), $e);
+
+            return false;
+        }
+    }
+
+    /**
      * Get the mime-type of a given file.
      *
      * @param  string  $path
@@ -841,24 +859,6 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         return true;
-    }
-
-    /**
-     * Get the checksum for a file.
-     *
-     * @return string|false string checksum or false on error
-     *
-     * @throws UnableToProvideChecksum
-     */
-    public function checksum(string $path, array $options = []): string|false
-    {
-        try {
-            return $this->driver->checksum($path, $options);
-        } catch (UnableToProvideChecksum $e) {
-            throw_if($this->throwsExceptions(), $e);
-
-            return false;
-        }
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -558,7 +558,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     /**
      * Get the checksum for a file.
      *
-     * @return string|false string checksum or false on error
+     * @return string|false
      *
      * @throws UnableToProvideChecksum
      */

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -24,6 +24,7 @@ use League\Flysystem\UnableToCreateDirectory;
 use League\Flysystem\UnableToDeleteDirectory;
 use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\UnableToMoveFile;
+use League\Flysystem\UnableToProvideChecksum;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToSetVisibility;
@@ -840,6 +841,17 @@ class FilesystemAdapter implements CloudFilesystemContract
         }
 
         return true;
+    }
+
+    public function checksum(string $path, array $options = []): string|false
+    {
+        try {
+            return $this->driver->checksum($path, $options);
+        } catch (UnableToProvideChecksum $e) {
+            throw_if($this->throwsExceptions(), $e);
+
+            return false;
+        }
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -843,6 +843,13 @@ class FilesystemAdapter implements CloudFilesystemContract
         return true;
     }
 
+    /**
+     * Get the checksum for a file.
+     *
+     * @return string|false string checksum or false on error
+     *
+     * @throws UnableToProvideChecksum
+     */
     public function checksum(string $path, array $options = []): string|false
     {
         try {

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -571,4 +571,13 @@ class FilesystemAdapterTest extends TestCase
 
         $this->assertEquals('https://example.org/images/picture.jpeg', $filesystemAdapter->url('picture.jpeg'));
     }
+
+    public function testGetChecksum()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem, $this->adapter);
+        $filesystemAdapter->write('path.txt', 'contents of file');
+
+        $this->assertEquals('730bed78bccf58c2cfe44c29b71e5e6b', $filesystemAdapter->checksum('path.txt'));
+        $this->assertEquals('a5c3556d', $filesystemAdapter->checksum('path.txt', ['checksum_algo' => 'crc32']));
+    }
 }


### PR DESCRIPTION
Flysystem 3.8 has shipped a new capability; file checksums. This PR exposes this that functionality for Laravel ⚡️

Discussion point: This method is not added to the Filesystem interface as it would be a breaking change. Flysystem had the same problem, where the method was added to the interface using a docblock annotation, which could help with IDE discovery.