### PR TITLE
[9.x] Improve input argument parsing for commands

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -95,10 +95,9 @@ class Application extends SymfonyApplication implements ApplicationContract
         );
 
         try {
-            // Use command's input definition to properly parse the arguments.
             $input->bind($this->find($commandName)->getDefinition());
         } catch (ExceptionInterface) {
-            // Ignore invalid options/arguments for now.
+            // ...
         }
 
         $this->events->dispatch(

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -13,6 +13,7 @@ use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -92,6 +93,13 @@ class Application extends SymfonyApplication implements ApplicationContract
         $commandName = $this->getCommandName(
             $input = $input ?: new ArgvInput
         );
+
+        try {
+            // Use command's input definition to properly parse the arguments.
+            $input->bind($this->find($commandName)->getDefinition());
+        } catch (ExceptionInterface) {
+            // Ignore invalid options/arguments for now.
+        }
 
         $this->events->dispatch(
             new CommandStarting(


### PR DESCRIPTION
I noticed that whenever I would listen to the `CommandStarting`/`CommandFinished` events, there was some functionality missing with the `input` property on this event (`\Symfony\Component\Console\Input\InputInterface`). It appears that the input definition is not loaded at all and it causes the `getArguments()`/`getOptions()` functions to be empty. So the following code would never work:

```php
// Keep track of called commands and their arguments.
Event::listen(function (CommandStarting $event) {
    Log::info('starting ' . $event->command);
    Log::info($event->input->getOptions()); // Always `[]` even though the command has options.
    Log::info($event->input->getArguments()); // Always `[]` even though the command has arguments.
});
```

Therefore I've added a few lines of code to `Illuminate\Console\Application` to load the input definition directly from the command that is being called. The `catch` block around calling `$input->bind()` appears to be a common thing judging by the occurrences in the Symfony codebase, I'm not sure why this is necessary.

I've also just noticed by looking at this application structure, that Laravel is basically overriding some Symfony events (which DO work properly). Laravel calls its own `CommandStarting`/`CommandFinished` events while there already is existing code in Symfony that uses their own (for instance https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Console/Application.php#L1006 and https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Console/Application.php#L1034). However, the Symfony commands cannot be listened to because there apparently is no event dispatcher attached in the Laravel override so these events are never sent.

I'm not sure of the downsides of my addition so I've submitted this as a draft. Someone with more knowledge about the bootstrapping logic should have a look at this.