### PR TITLE
[9.x] Add collect key parameter to replicate the behavior of Response::collect method

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -854,11 +854,12 @@ trait EnumeratesValues
     /**
      * Collect the values into a collection.
      *
+     * @param  string|null  $key
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
-    public function collect()
+    public function collect($key = null)
     {
-        return new Collection($this->all());
+        return Collection::make(is_null($key) ? $this->all() : $this->get($key));
     }
 
     /**

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -857,9 +857,9 @@ trait EnumeratesValues
      * @param  string|null  $key
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
-    public function collect($key = null)
+    public function collect($key = null, $default = null)
     {
-        return Collection::make(is_null($key) ? $this->all() : $this->get($key));
+        return Collection::make(is_null($key) ? $this->all() : $this->get($key, $default));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5426,6 +5426,28 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testCollectWithKey($collection)
+    {
+        $data = $collection::make([
+            'a' => [
+                1,
+                2,
+                3,
+            ],
+        ])->collect('a');
+
+        $this->assertInstanceOf(Collection::class, $data);
+
+        $this->assertSame([
+            1,
+            2,
+            3,
+        ], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testUndot($collection)
     {
         $data = $collection::make([


### PR DESCRIPTION
The `Illuminate\Http\Client\Response::collect` method makes it really easy to convert a json object to a collection object. It would be very convenient to have a similar functionality in the collection class itself however the collect method does not accept an argument. 

Given this data structure

```
{
    "results": [1,2,3],
    "meta": [1,2,3]
}
```

To access the sub keys as a collection you'd need to do this:

```
$data = Http::get()->collect();
$results = collect($data->get('results'));
$meta = collect($data->get('meta'));
```

But with this PR you can simply do this:

```
$data = Http::get()->collect();
$results = $data->collect('results');
```

I recognize that you could do this
```
$response = Http::get();
$results = $response->collect('results');
```

However when used in this context it makes it not so convenient since you can't cache a response object

```
public function templates(): Collection
{
    return collect($this->getTemplates()->get('templates'))->mapInto(Template::class);
}

public function upsells(): Collection
{
    return collect($this->getTemplates()->get('upsells'))->mapInto(Upsell::class);
}

protected function getTemplates(): Collection
{
    return cache()->remember(
        key:'templates',
        ttl: now()->addMinutes(10),
        callback: fn () => Http::asJson()->get('endpoint')->collect()
    );
}
```