### PR TITLE
[9.x] Revert PR #44613

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -84,7 +84,7 @@ class VerifyEmail extends Notification
             'verification.verify',
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
             [
-                $notifiable->getKeyName() => $notifiable->getKey(),
+                'id' => $notifiable->getKey(),
                 'hash' => sha1($notifiable->getEmailForVerification()),
             ]
         );


### PR DESCRIPTION
The previous PR #44613 is a breaking change. Changing the route parameter name is unrelated to the ORM!

My registration page is now crashed because of this change, and I've to override the fortify route file and change the `{id}` to `{user_id}`, so it will fit this PR! That doesn't make sense.

Here is my comment: https://github.com/laravel/framework/pull/44613#issuecomment-1285688441