### PR TITLE
[9.x] Allow disabling checks for expired views

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -172,7 +172,7 @@ abstract class ServiceProvider
                 }
             }
 
-            $view->addNamespace($namespace, $path);
+            $view->addNamespace($namespace, realpath($path) ?: $path);
         });
     }
 

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -31,17 +31,26 @@ class CompilerEngine extends PhpEngine
     protected $compiledOrNotExpired = [];
 
     /**
+     * Flag to check expired views.
+     *
+     * @var bool
+     */
+    protected $checkExpiredViews = true;
+
+    /**
      * Create a new compiler engine instance.
      *
      * @param  \Illuminate\View\Compilers\CompilerInterface  $compiler
      * @param  \Illuminate\Filesystem\Filesystem|null  $files
+     * @param  bool  $checkExpiredViews
      * @return void
      */
-    public function __construct(CompilerInterface $compiler, Filesystem $files = null)
+    public function __construct(CompilerInterface $compiler, Filesystem $files = null, $checkExpiredViews = true)
     {
         parent::__construct($files ?: new Filesystem);
 
         $this->compiler = $compiler;
+        $this->checkExpiredViews = $checkExpiredViews;
     }
 
     /**
@@ -58,7 +67,7 @@ class CompilerEngine extends PhpEngine
         // If this given view has expired, which means it has simply been edited since
         // it was last compiled, we will re-compile the views so we can evaluate a
         // fresh copy of the view. We'll pass the compiler the path of the view.
-        if (! isset($this->compiledOrNotExpired[$path]) && $this->compiler->isExpired($path)) {
+        if ($this->checkExpiredViews && ! isset($this->compiledOrNotExpired[$path]) && $this->compiler->isExpired($path)) {
             $this->compiler->compile($path);
         }
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -161,7 +161,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeEngine($resolver)
     {
         $resolver->register('blade', function () {
-            $compiler = new CompilerEngine($this->app['blade.compiler'], $this->app['files']);
+            $compiler = new CompilerEngine($this->app['blade.compiler'], $this->app['files'], $this->app['config']['view.check_compiled'] ?? true);
 
             $this->app->terminating(static function () use ($compiler) {
                 $compiler->forgetCompiledOrNotExpired();

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -55,8 +55,20 @@ class ViewCompilerEngineTest extends TestCase
         $engine->get(__DIR__.'/fixtures/foo.php');
     }
 
-    protected function getEngine()
+    public function testViewsAreNotRecompiledIfWeDoNotWantThemRecompiled()
     {
-        return new CompilerEngine(m::mock(CompilerInterface::class), new Filesystem);
+        $engine = $this->getEngine(false);
+        $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/basic.php');
+        $engine->getCompiler()->shouldReceive('isExpired')->never();
+        $engine->getCompiler()->shouldReceive('compile')->never();
+        $results = $engine->get(__DIR__.'/fixtures/foo.php');
+
+        $this->assertSame('Hello World
+', $results);
+    }
+
+    protected function getEngine($checkExpiredViews = true)
+    {
+        return new CompilerEngine(m::mock(CompilerInterface::class), new Filesystem, $checkExpiredViews);
     }
 }


### PR DESCRIPTION
One of the changes @nunomaduro made in #44487 reminded me of a similar PR (#31206) I'd done about 2 years ago that was merged and then reverted due to a reported edge case bug.

The reported bug was that the `view:cache` was not correctly caching registered vendor views. I wish I'd have looked closer 2 years ago, because I've been testing all day, and everything seems to be working well to me, and I can't find any noticeable change in the framework that would've changed this behavior.

With that said, this is a resubmission of that original PR (#31206), with essentially no changes.  This change takes Nuno's optimization on compiled views a step further. The root of the problem is the `$this->compiler->isExpired($path)` method is a relatively expensive call, and it can get called a **large** number of times if:

1. you have a large number of views/components necessary for the page rendering
2. you render the same view/components multiple times on the page 

So the goal is to avoid unnecessary calls to `isExpired()`. Nuno's change in #44487 solves scenario 2 by building up a local cache of file paths already compiled, and then checking for the path value in the array on subsequent calls.  The changes in this PR actually solve both scenarios because you can now explicitly tell the `CompilerEngine` to never check if the path is expired and to assume the file is compiled validly.  This is intended to be a ***production only*** feature, and will only work if you run `php artisan view:cache` as part of your deployment.

So to start, could I first get a little confirmation from others that vendor registered views are being compiling with `artisan view:cache`. After that the PR should be good to review.

Check out the previous PR for the performance improvement data.