### PR TITLE
[9.x] Add Str::in() helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -351,6 +351,18 @@ class Str
     }
 
     /**
+     * Determine if a given string matches any of the given values.
+     *
+     * @param  string  $value
+     * @param  array  $sequence
+     * @return bool
+     */
+    public static function in($value, array $options = [])
+    {
+        return in_array($value, $options);
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -280,6 +280,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given string matches any of the given values.
+     *
+     * @param  array  $options
+     * @return bool
+     */
+    public function in(array $options = [])
+    {
+        return Str::in($this->value, $options);
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|iterable<string>  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -358,6 +358,15 @@ class SupportStrTest extends TestCase
         $this->assertEquals('foo-bar-baz', Str::wrap('-bar-', 'foo', 'baz'));
     }
 
+    public function testIn()
+    {
+        $this->assertTrue(Str::in('foo', ['foo']));
+        $this->assertTrue(Str::in('foo', ['foo', 'bar']));
+        $this->assertFalse(Str::in('foo', ['bar']));
+        $this->assertFalse(Str::in('foo', ['bar', 'baz']));
+        $this->assertFalse(Str::in('foo', [' foo']));
+    }
+
     public function testIs()
     {
         $this->assertTrue(Str::is('/', '/'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -702,6 +702,15 @@ class SupportStringableTest extends TestCase
         $this->assertSame('abcbbc', (string) $this->stringable('abcbbcbc')->finish('bc'));
     }
 
+    public function testIn()
+    {
+        $this->assertTrue($this->stringable('foo')->in(['foo']));
+        $this->assertTrue($this->stringable('foo')->in(['foo', 'bar']));
+        $this->assertFalse($this->stringable('foo')->in(['bar']));
+        $this->assertFalse($this->stringable('foo')->in(['bar', 'baz']));
+        $this->assertFalse($this->stringable('foo')->in([' foo']));
+    }
+
     public function testIs()
     {
         $this->assertTrue($this->stringable('/')->is('/'));


### PR DESCRIPTION
This adds the `Str::in()` helper that will determine whether the given value is contained within the provided array of options. This expands upon the existing `Str::is()` helper and is consistent with other parts of the framework like the `whereIn()` Eloquent and DB methods.

While it's certainly possible to simply use `in_array()` in your code, I find myself reaching for this when using fluent strings where I am performing other operations first. Being able to chain `in()` on to the end of this transformation string would be helpful.