### PR TITLE
Adds `getExcept` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -689,6 +689,23 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Execute the query as a "select" statement.
+     *
+     * @param  array  $except
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
+    public function getExcept(array $except)
+    {
+        $table = $this->getModel()->getTable();
+        $columns = $this->getModel()->getConnection()->getSchemaBuilder()
+            ->getColumnListing($table);
+
+        $columns = array_diff($columns, $except);
+
+        return $this->get($columns);
+    }
+
+    /**
      * Get the hydrated models without eager loading.
      *
      * @param  array|string  $columns

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -697,10 +697,10 @@ class Builder implements BuilderContract
     public function getExcept(array $except)
     {
         $table = $this->getModel()->getTable();
-        $columns = $this->getModel()->getConnection()->getSchemaBuilder()
+        $allColumns = $this->getModel()->getConnection()->getSchemaBuilder()
             ->getColumnListing($table);
 
-        $columns = array_diff($columns, $except);
+        $columns = array_diff($allColumns, $except);
 
         return $this->get($columns);
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2640,6 +2640,20 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Execute the query as a "select" statement.
+     *
+     * @param  array  $except
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
+    public function getExcept(array $except)
+    {
+        $allColumns = $this->getConnection()->getSchemaBuilder()->getColumnListing($this->from);
+        $columns = array_diff($allColumns, $except);
+
+        return $this->get($columns);
+    }
+
+    /**
      * Run the query as a "select" statement against the connection.
      *
      * @return array


### PR DESCRIPTION
This PR adds the ability to get the columns except we provide to the method, and I think this method is IMPORTANT something in some cases, and to illustrate that let's take a glance over these examples.

## BEFORE this PR gets merged

This code returns all columns except `created_at` and `updated_at`.

```PHP
use App\Models\User;

return User::get(['name', 'email', 'email_verified_at', 'status']);
```

The previous code is quite bad and gets worse if we have more columns. **I've faced the same problem before and this is what makes me Introduce this method**

## AFTER this PR gets merged

This code does the same thing that the previous code does but in an elegant way.

```PHP
use App\Models\User;

return User::getExcept(['created_at', 'updated_at']);
```

**I do not have a good annotation description for this method, so anyone who has a good one can leave a preview.**
