### PR TITLE
Implement everyDayExcept method for scheduling

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -315,14 +315,14 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run every day except for those specified.
      *
-     * @param array|int $days
+     * @param  array|int  $days
      * @return $this
      */
     public function everyDayExcept($days)
     {
         $days = is_array($days) ? $days : func_get_args();
 
-        return $this->days(join(',', array_diff(range(0,6), $days)));
+        return $this->days(join(',', array_diff(range(0, 6), $days)));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -313,6 +313,19 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every day except for those specified.
+     *
+     * @param array|int $days
+     * @return $this
+     */
+    public function everyDayExcept($days)
+    {
+        $days = is_array($days) ? $days : func_get_args();
+
+        return $this->days(join(',', array_diff(range(0,6), $days)));
+    }
+
+    /**
      * Schedule the event to run only on Mondays.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -140,6 +140,12 @@ class FrequencyTest extends TestCase
         $this->assertSame('* * * * 6,0', $this->event->weekends()->getExpression());
     }
 
+    public function testEveryDayExcept()
+    {
+        $this->assertSame('* * * * 0,2,3,4,5,6', $this->event->everyDayExcept(1)->getExpression());
+        $this->assertSame('* * * * 0,1,3,4,6', $this->event->everyDayExcept([2, 5])->getExpression());
+    }
+
     public function testSundays()
     {
         $this->assertSame('* * * * 0', $this->event->sundays()->getExpression());


### PR DESCRIPTION
I have implemented a method called `->everyDayExcept($days)` for adding schedules where every day of the week is needed other that a specific day, or set of days.

My motivation for this is a common requirement where task is run daily, but then does additional work on a weekly basis. When the weekly version of this task is run, one does not want to run the daily version, hence `everyDayExcept()` to exclude the day where the weekly task is run.