### PR TITLE
[9.x] Fixed `model:show` registering `getAttribute()` as a null accessor

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -155,7 +155,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                     || $method->getDeclaringClass()->getName() !== get_class($model)
             )
             ->mapWithKeys(function (ReflectionMethod $method) use ($model) {
-                if (preg_match('/^get(.*)Attribute$/', $method->getName(), $matches) === 1) {
+                if (preg_match('/^get(.+)Attribute$/', $method->getName(), $matches) === 1) {
                     return [Str::snake($matches[1]) => 'accessor'];
                 } elseif ($model->hasAttributeMutator($method->getName())) {
                     return [Str::snake($method->getName()) => 'attribute'];


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Some traits and models include a `getAttribute()` method which causes `model:show` to display the following null line:

![image](https://user-images.githubusercontent.com/4176520/197247278-9349524f-560e-4e5a-bb02-79b9b7148282.png)

