### PR TITLE
[9.x] Testing: Allow users to determine the schema file used when migrating the database for tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
+++ b/src/Illuminate/Foundation/Testing/Traits/CanConfigureMigrationCommands.php
@@ -20,10 +20,10 @@ trait CanConfigureMigrationCommands
             '--drop-views' => $this->shouldDropViews(),
             '--drop-types' => $this->shouldDropTypes(),
         ])->when($seeder,
-            fn(Collection $collection) => $collection->put('--seeder', $seeder),
-            fn(Collection $collection) => $collection->put('--seed', $this->shouldSeed())
+            fn (Collection $collection) => $collection->put('--seeder', $seeder),
+            fn (Collection $collection) => $collection->put('--seed', $this->shouldSeed())
         )->when($dump,
-            fn(Collection $collection) => $collection->put('--schema-path', $dump)
+            fn (Collection $collection) => $collection->put('--schema-path', $dump)
         )->toArray();
     }
 
@@ -70,6 +70,7 @@ trait CanConfigureMigrationCommands
     /**
      * Determine the specific schema dump path that should be used when refreshing the database.
      * Otherwise laravel will use the default dump as per your connection name.
+     *
      * @return mixed
      */
     protected function dump()

--- a/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
+++ b/tests/Foundation/Testing/Traits/CanConfigureMigrationCommandsTest.php
@@ -75,6 +75,19 @@ class CanConfigureMigrationCommandsTest extends TestCase
         $this->traitObject->dropTypes = true;
 
         $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
+
+        $expected = [
+            '--drop-views' => false,
+            '--drop-types' => false,
+            '--seed' => false,
+            '--schema-path' => 'database/schema/mysql-schema.dump',
+        ];
+
+        $this->traitObject->dropViews = false;
+        $this->traitObject->dropTypes = false;
+        $this->traitObject->dump = 'database/schema/mysql-schema.dump';
+
+        $this->assertEquals($expected, $migrateFreshUsingReflection->invoke($this->traitObject));
     }
 }
 
@@ -85,4 +98,6 @@ class CanConfigureMigrationCommandsTestMockClass
     public $dropViews = false;
 
     public $dropTypes = false;
+
+    public $dump = false;
 }


### PR DESCRIPTION
If you are running tests, chances are that you are using a different database connection for your tests than your normal connection. In fact, the default phpunit.xml file provided by Laravel already switches to a "testing" connection. However, if you are [squashing migrations](https://laravel.com/docs/9.x/migrations#squashing-migrations) you will provably want to use the same schema file as in your normal database, rather than using a copied file with the name of the testing connection (for instance: testing-schema.dump).

This PR adds the option to easily choose your desired schema file when running tests which require running migrations. The way to specify the file, is exactly the same as the one used to indicate that you want to seed the database before each test, or to specify the database seeder: https://laravel.com/docs/9.x/database-testing#running-seeders. So, you just need to add a `protected $dump = 'database/schema/mysql-schema.dump';` property in your testCase class.

The PR also updates the CanConfigureMigrationCommandsTest, to ensure that functionality works well. In addition, this new functionality is being documented in a PR I'm creating after this in the [Laravel docs project](https://github.com/laravel/docs). I will be adding the PR link in the comments.
