### PR TITLE
Use `array_is_list` to determine if it is list

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -410,9 +410,7 @@ class Arr
      */
     public static function isAssoc(array $array)
     {
-        $keys = array_keys($array);
-
-        return array_keys($keys) !== $keys;
+        return ! self::isList($array);
     }
 
     /**
@@ -425,7 +423,7 @@ class Arr
      */
     public static function isList($array)
     {
-        return ! self::isAssoc($array);
+        return array_is_list($array);
     }
 
     /**


### PR DESCRIPTION
In this PR `Arr::isAssoc()` and `Arr::isList()` refactored to use `array_is_list` function which introduced in php 8.0.