### PR TITLE
[9.x] Refactor use syntax sugar in belongsTo method in HasRelationships trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -206,9 +206,7 @@ trait HasRelationships
         // If no foreign key was supplied, we can use a backtrace to guess the proper
         // foreign key name by using the name of the relationship function, which
         // when combined with an "_id" should conventionally match the columns.
-        if (is_null($foreignKey)) {
-            $foreignKey = Str::snake($relation).'_'.$instance->getKeyName();
-        }
+        $foreignKey = $foreignKey ?: Str::snake($relation).'_'.$instance->getKeyName();
 
         // Once we have the foreign key names we'll just create a new Eloquent query
         // for the related models and return the relationship instance which will


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

With the greatest respect, I found an area where the belongsTo method in HasRelationships allows me to write shorter code.

$foreignKey of the default argument is null. So, I think this syntax run same behavior.
In addition, this syntax is also used by other methods such as hasOne, so it provides a sense of uniformity!

This is a result of null.
https://3v4l.org/lN6qY
