### PR TITLE
correct grammar mistakes 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -435,7 +435,7 @@ trait HasRelationships
     {
         $instance = $this->newRelatedInstance($related);
 
-        // Here we will gather up the morph type and ID for the relationship so that we
+        // Here we will gather the morph type and ID for the relationship so that we
         // can properly query the intermediate table of a relation. Finally, we will
         // get the table and create the relationship instances for the developers.
         [$type, $id] = $this->getMorphs($name, $type, $id);


### PR DESCRIPTION
This phrase is redundant. Consider using gather. 

Example: 

Incorrect:  Please, gather up the documentation and let's go. 
Correct:  Please, gather the documentation and let's go. 