### PR TITLE
[9.x] Fix mailable content html

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1644,7 +1644,7 @@ class Mailable implements MailableContract, Renderable
         }
 
         if ($content->html) {
-            $this->view($content->html);
+            $this->html($content->html);
         }
 
         if ($content->text) {


### PR DESCRIPTION
The alternative mailable syntax introduced in https://github.com/laravel/framework/pull/44462#issue-1396874380 currently does not work when using html.

```php
// the classic approach still works as expected
public function build() {
    return $this->html('html string');
}
```

The following results in throws an InvalidArgumentException `View [html string] not found.`

```php
// with the new alternative mailable syntax
public function content() {
    return new Content(
        html: 'html string',
    );
}
```