### PR TITLE
[9.x] Add a generator for canonical URLs

### DIFF
--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -64,7 +64,8 @@ class RoutingServiceProvider extends ServiceProvider
             return new UrlGenerator(
                 $routes, $app->rebinding(
                     'request', $this->requestRebinder()
-                ), $app['config']['app.asset_url']
+                ), $app['config']['app.asset_url'],
+                $app['config']['app.url'],
             );
         });
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -118,7 +118,7 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  string|null  $assetRoot
      * @return void
      */
-    public function __construct(RouteCollectionInterface $routes, Request $request, $assetRoot = null)
+    public function __construct(RouteCollectionInterface $routes, Request $request, $assetRoot = nully)
     {
         $this->routes = $routes;
         $this->assetRoot = $assetRoot;
@@ -200,7 +200,7 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  bool|null  $secure
      * @return string
      */
-    public function to($path, $extra = [], $secure = null)
+    public function to($path, $extra = [], $secure = null, ?string $root)
     {
         // First we will check if the URL is already a valid URL. If it is we will not
         // try to generate a new one but will simply return the URL as is, which is
@@ -216,7 +216,7 @@ class UrlGenerator implements UrlGeneratorContract
         // Once we have the scheme we will compile the "tail" by collapsing the values
         // into a single string delimited by slashes. This just makes it convenient
         // for passing the array of parameters to this URL as a list of segments.
-        $root = $this->formatRoot($this->formatScheme($secure));
+        $root ??= $this->formatRoot($this->formatScheme($secure));
 
         [$path, $query] = $this->extractQueryString($path);
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -251,7 +251,7 @@ class UrlGenerator implements UrlGeneratorContract
         $uri ??= $this->request->getRequestUri();
         $domain ??= $this->appRoot ?: $this->formatRoot($this->formatScheme());
 
-        return $this->to($path, root: $domain);
+        return $this->to($uri, root: $domain);
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -36,7 +36,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * The app root URL.
      */
-    protected $appRoot;
+    protected string $appRoot;
 
     /**
      * The asset root URL.

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -36,7 +36,7 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * The app root URL.
      */
-    protected string $appRoot;
+    protected ?string $appRoot;
 
     /**
      * The asset root URL.

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -34,6 +34,11 @@ class UrlGenerator implements UrlGeneratorContract
     protected $request;
 
     /**
+     * The app root URL.
+     */
+    protected $appRoot;
+
+    /**
      * The asset root URL.
      *
      * @var string
@@ -118,10 +123,11 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  string|null  $assetRoot
      * @return void
      */
-    public function __construct(RouteCollectionInterface $routes, Request $request, $assetRoot = nully)
+    public function __construct(RouteCollectionInterface $routes, Request $request, $assetRoot = null, ?string $appRoot = null)
     {
         $this->routes = $routes;
         $this->assetRoot = $assetRoot;
+        $this->appRoot = $appRoot;
 
         $this->setRequest($request);
     }
@@ -235,6 +241,17 @@ class UrlGenerator implements UrlGeneratorContract
     public function secure($path, $parameters = [])
     {
         return $this->to($path, $parameters, true);
+    }
+
+    /**
+     * Generate the canonical URL.
+     */
+    public function canonical(?string $uri = null, ?string $domain = null): string
+    {
+        $uri ??= $this->request->getRequestUri();
+        $domain ??= $this->appRoot ?: $this->formatRoot($this->formatScheme());
+
+        return $this->to($path, root: $domain);
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -200,7 +200,7 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  bool|null  $secure
      * @return string
      */
-    public function to($path, $extra = [], $secure = null, ?string $root)
+    public function to($path, $extra = [], $secure = null, ?string $root = null)
     {
         // First we will check if the URL is already a valid URL. If it is we will not
         // try to generate a new one but will simply return the URL as is, which is

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -933,6 +933,22 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('https://foo.com/other/page?b=3', $url->canonical('other/page?b=3'));
         $this->assertSame('https://foo.com/my/page', $url->canonical($request->path()));
     }
+
+    public function testCanonicalGenerationWithCustomDomain()
+    {
+        $request = Request::create('http://www.foo.com/my/page?a=1');
+
+        $url = new UrlGenerator(
+            new RouteCollection,
+            $request,
+            appRoot: 'https://foo.com',
+        );
+
+        $this->assertSame('http://foo.net/my/page?a=1', $url->canonical(domain: 'http://foo.net'));
+        $this->assertSame('http://foo.net/other/page', $url->canonical('other/page', 'http://foo.net'));
+        $this->assertSame('http://foo.net/other/page?b=3', $url->canonical('other/page?b=3', 'http://foo.net'));
+        $this->assertSame('http://foo.net/my/page', $url->canonical($request->path(), 'http://foo.net'));
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -925,7 +925,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $url = new UrlGenerator(
             new RouteCollection,
             $request,
-            appUrl: 'https://foo.com',
+            appRoot: 'https://foo.com',
         );
 
         $this->assertSame('https://foo.com/my/page?a=1', $url->canonical());

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -902,7 +902,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertTrue($url2->hasValidSignature($request));
         $this->assertFalse($url->hasValidSignature($request));
     }
-    
+
     public function testCanonicalGeneration()
     {
         $request = Request::create('http://www.foo.com/my/page?a=1');
@@ -917,7 +917,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/other/page?b=3', $url->canonical('other/page?b=3'));
         $this->assertSame('http://www.foo.com/my/page', $url->canonical($request->path()));
     }
-    
+
     public function testCanonicalGenerationWithConfiguredDomain()
     {
         $request = Request::create('http://www.foo.com/my/page?a=1');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -902,6 +902,37 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertTrue($url2->hasValidSignature($request));
         $this->assertFalse($url->hasValidSignature($request));
     }
+    
+    public function testCanonicalGeneration()
+    {
+        $request = Request::create('http://www.foo.com/my/page?a=1');
+
+        $url = new UrlGenerator(
+            new RouteCollection,
+            $request,
+        );
+
+        $this->assertSame('http://www.foo.com/my/page?a=1', $url->canonical());
+        $this->assertSame('http://www.foo.com/other/page', $url->canonical('other/page'));
+        $this->assertSame('http://www.foo.com/other/page?b=3', $url->canonical('other/page?b=3'));
+        $this->assertSame('http://www.foo.com/my/page', $url->canonical($request->path()));
+    }
+    
+    public function testCanonicalGenerationWithConfiguredDomain()
+    {
+        $request = Request::create('http://www.foo.com/my/page?a=1');
+
+        $url = new UrlGenerator(
+            new RouteCollection,
+            $request,
+            appUrl: 'https://foo.com',
+        );
+
+        $this->assertSame('https://foo.com/my/page?a=1', $url->canonical());
+        $this->assertSame('https://foo.com/other/page', $url->canonical('other/page'));
+        $this->assertSame('https://foo.com/other/page?b=3', $url->canonical('other/page?b=3'));
+        $this->assertSame('https://foo.com/my/page', $url->canonical($request->path()));
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable


### PR DESCRIPTION
This adds a method for canonical links to the URLGenerator class.

```php
<link rel="canonical" href="{{url()->canonical()}}">
```

It will generate URLs to the current resource, but on the `app.url` root, which is the de facto canonical root already used in emails.

```php
Config::set('app.url', 'http://example.com');

// reqeust url: https://www.example.net/some/path?page=999
url()->canonical(); // returns 'http://example.com/some/path?page=999'
```

### Options

When the same page is available on multiple paths, one can manually specify the canonical one. In this case we will only canonicize the domain name.

```php
Config::set('app.url', 'http://example.com');

// reqeust url: https://www.example.net/some/path?page=999
url()->canonical('custom/path'); // returns 'http://example.com/custom/path'
```

The domain can also be specified in the code for some projects where different sections should have different canonical domains:

```php
// reqeust url: https://www.example.net/some/path?page=999
url()->canonical(domain: 'http://example.org');  // http://example.org/some/path?page=999
```

### Side effects and implementation details

This PR also adds an optional `root` argument to `URL::to()` as that felt the easiest way to accomplish this. This might also be useful for other uses.

I noticed that Laravel [is moving towards](https://github.com/laravel/framework/pull/44545) native PHP types, so I declared native types for the **new** things that I added. Please let me know if something about types and/or newer PHP features should be done differently on Laravel PRs.