### PR TITLE
[9.x] Add raw content property for mailables

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1655,6 +1655,10 @@ class Mailable implements MailableContract, Renderable
             $this->markdown($content->markdown);
         }
 
+        if ($content->raw) {
+            $this->html($content->raw);
+        }
+
         foreach ($content->with as $key => $value) {
             $this->with($key, $value);
         }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -1655,8 +1655,8 @@ class Mailable implements MailableContract, Renderable
             $this->markdown($content->markdown);
         }
 
-        if ($content->raw) {
-            $this->html($content->raw);
+        if ($content->htmlString) {
+            $this->html($content->htmlString);
         }
 
         foreach ($content->with as $key => $value) {

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -39,7 +39,7 @@ class Content
     public $markdown;
 
     /**
-     * The raw html of the message
+     * The raw html of the message.
      *
      * @var string|null
      */

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -39,11 +39,11 @@ class Content
     public $markdown;
 
     /**
-     * The raw html of the message.
+     * The pre-rendered HTML of the message.
      *
      * @var string|null
      */
-    public $raw;
+    public $htmlString;
 
     /**
      * The message's view data.
@@ -60,18 +60,18 @@ class Content
      * @param  string|null  $text
      * @param  string|null  $markdown
      * @param  array  $with
-     * @param  string|null  $raw
+     * @param  string|null  $htmlString
      *
      * @named-arguments-supported
      */
-    public function __construct(string $view = null, string $html = null, string $text = null, $markdown = null, array $with = [], string $raw = null)
+    public function __construct(string $view = null, string $html = null, string $text = null, $markdown = null, array $with = [], string $htmlString = null)
     {
         $this->view = $view;
         $this->html = $html;
         $this->text = $text;
         $this->markdown = $markdown;
         $this->with = $with;
-        $this->raw = $raw;
+        $this->htmlString = $htmlString;
     }
 
     /**
@@ -125,14 +125,14 @@ class Content
     }
 
     /**
-     * Set the raw html for the message.
+     * Set the pre-rendered HTML for the message.
      *
      * @param  string  $html
      * @return $this
      */
-    public function raw(string $html)
+    public function htmlString(string $html)
     {
-        $this->raw = $html;
+        $this->htmlString = $html;
 
         return $this;
     }

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -59,19 +59,19 @@ class Content
      * @param  string|null  $html
      * @param  string|null  $text
      * @param  string|null  $markdown
-     * @param  string|null  $raw
      * @param  array  $with
+     * @param  string|null  $raw
      *
      * @named-arguments-supported
      */
-    public function __construct(string $view = null, string $html = null, string $text = null, string $markdown = null, string $raw = null, array $with = [])
+    public function __construct(string $view = null, string $html = null, string $text = null, $markdown = null, array $with = [], string $raw = null)
     {
         $this->view = $view;
         $this->html = $html;
         $this->text = $text;
         $this->markdown = $markdown;
-        $this->raw = $raw;
         $this->with = $with;
+        $this->raw = $raw;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailables/Content.php
+++ b/src/Illuminate/Mail/Mailables/Content.php
@@ -39,6 +39,13 @@ class Content
     public $markdown;
 
     /**
+     * The raw html of the message
+     *
+     * @var string|null
+     */
+    public $raw;
+
+    /**
      * The message's view data.
      *
      * @var array
@@ -52,16 +59,18 @@ class Content
      * @param  string|null  $html
      * @param  string|null  $text
      * @param  string|null  $markdown
+     * @param  string|null  $raw
      * @param  array  $with
      *
      * @named-arguments-supported
      */
-    public function __construct(string $view = null, string $html = null, string $text = null, $markdown = null, array $with = [])
+    public function __construct(string $view = null, string $html = null, string $text = null, string $markdown = null, string $raw = null, array $with = [])
     {
         $this->view = $view;
         $this->html = $html;
         $this->text = $text;
         $this->markdown = $markdown;
+        $this->raw = $raw;
         $this->with = $with;
     }
 
@@ -111,6 +120,19 @@ class Content
     public function markdown(string $view)
     {
         $this->markdown = $view;
+
+        return $this;
+    }
+
+    /**
+     * Set the raw html for the message.
+     *
+     * @param  string  $html
+     * @return $this
+     */
+    public function raw(string $html)
+    {
+        $this->raw = $html;
 
         return $this;
     }


### PR DESCRIPTION
This is a follow up from https://github.com/laravel/framework/pull/44696#issuecomment-1288210815. 

This PR introduces a new property and method on the mailable content class to supply a raw html string.

```php
public function content() {
    return new Content(
        raw: 'raw html string'
    );
}
```

The classic mailable approach already has this feature.
```php
public function build() {
    return $this->html('raw html string');
}
```