### PR TITLE
[9.x] Allow passing closure to rescue `$report` parameter

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -711,7 +711,7 @@ if (! function_exists('rescue')) {
      *
      * @param  callable  $callback
      * @param  mixed  $rescue
-     * @param  bool  $report
+     * @param  bool|callable  $report
      * @return mixed
      */
     function rescue(callable $callback, $rescue = null, $report = true)

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -719,7 +719,7 @@ if (! function_exists('rescue')) {
         try {
             return $callback();
         } catch (Throwable $e) {
-            if ($report) {
+            if (value($report)) {
                 report($e);
             }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -719,7 +719,7 @@ if (! function_exists('rescue')) {
         try {
             return $callback();
         } catch (Throwable $e) {
-            if (value($report)) {
+            if (value($report, $e)) {
                 report($e);
             }
 


### PR DESCRIPTION
Allow closures to be pass in `rescue` function for `$report` paramter so we can conditionally report the error base on the exception type or etc ... (if accepted i'll add tests later)

```php

rescue(fn() => 'error', fn() => 'rescue', function(Throwable $e){
    return $e instanceof SomeException;
});

```