### PR TITLE
Fixes incorrect resource name and parameters

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -332,9 +332,9 @@ class Router implements BindingRegistrar, RegistrarContract
             $controllerName = last(explode("\\", $controller));
             $name = explode("controller", strtolower($controllerName))[0];
 
-            return new PendingResourceRegistration(
-                $registrar, "{$name}s", $controller, $options
-            );
+            return (new PendingResourceRegistration(
+                $registrar, "/", $controller, $options
+            ))->names("{$name}s")->parameters([null => $name]);
         }
 
         return new PendingResourceRegistration(

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -327,6 +327,15 @@ class Router implements BindingRegistrar, RegistrarContract
         } else {
             $registrar = new ResourceRegistrar($this);
         }
+        
+       if($name == "/") {
+            $controllerName = last(explode("\\", $controller));
+            $name = explode("controller", strtolower($controllerName))[0];
+
+            return new PendingResourceRegistration(
+                $registrar, "{$name}s", $controller, $options
+            );
+        }
 
         return new PendingResourceRegistration(
             $registrar, $name, $controller, $options


### PR DESCRIPTION
## BEFORE this PR gets merged

I was working on a project and I wanted to add a new route to the `resource` routes like so,

```PHP
Route::resource('users', UserController::class);
Route::delete('/users/multi_delete', [UserController::class, 'multiDelete'])->name('users.multiDelete');
```

The result was as shown in the next figure

![before_prefix](https://user-images.githubusercontent.com/48416569/197539651-6c0cbe91-bd27-49d6-826b-2a5b128959f8.png)

But I was would like to use the `prefix` route method to be more clear like so,

```PHP
Route::prefix('users')->group(function () {
    Route::resource('/', UserController::class);
    Route::delete('/multi_delete', [UserController::class, 'multiDelete'])->name('users.multiDelete');
});
```

The result was as shown in the next figure

![before-fixing-issue](https://user-images.githubusercontent.com/48416569/197557273-c247e297-7313-4acd-bfe2-0f030decad97.png)

As we noticed, the resource routes with **NULL** segments and incorrect routes names.

## AFTER this PR gets merged

![after-fixing-issue](https://user-images.githubusercontent.com/48416569/197557351-201b7a9e-f7dc-4240-9579-96e240fc76f0.png)

The issue is solved now 🎉

> In fact, I tried to use `getGroupStack` method, but I realized that its a painful way because it returns an array with every `middleware`, `prefix`, `name`...etc in the route file and there is no distinctive key to catch the prefix that I need, so I decide to guess the routes segments and names with the given controller name.

