### PR TITLE
Add hasAttribute method to Eloquent Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -268,7 +268,7 @@ trait HasAttributes
     /**
      * Check if model has a given attribute.
      *
-     * @param  string $key
+     * @param  string  $key
      * @return bool
      */
     public function hasAttribute($key)
@@ -465,7 +465,7 @@ trait HasAttributes
             return;
         }
 
-        if($this->hasAttribute($key)) {
+        if ($this->hasAttribute($key)) {
             return $this->getAttributeValue($key);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -266,6 +266,40 @@ trait HasAttributes
     }
 
     /**
+     * Check if model has a given attribute.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function hasAttribute($key)
+    {
+        // If the attribute exists in the attribute array or has a "get" mutator we will
+        // return the attribute's value. Otherwise, we will proceed as if the developers
+        // are asking for a relationship's value. This covers both types of values.
+        if (array_key_exists($key, $this->attributes)) {
+            return true;
+        }
+
+        if (array_key_exists($key, $this->casts)) {
+            return true;
+        }
+
+        if ($this->hasGetMutator($key)) {
+            return true;
+        }
+
+        if ($this->hasAttributeMutator($key)) {
+            return true;
+        }
+
+        if ($this->isClassCastable($key)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Add the casted attributes to the attributes array.
      *
      * @param  array  $attributes
@@ -431,14 +465,7 @@ trait HasAttributes
             return;
         }
 
-        // If the attribute exists in the attribute array or has a "get" mutator we will
-        // get the attribute's value. Otherwise, we will proceed as if the developers
-        // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes) ||
-            array_key_exists($key, $this->casts) ||
-            $this->hasGetMutator($key) ||
-            $this->hasAttributeMutator($key) ||
-            $this->isClassCastable($key)) {
+        if($this->hasAttribute($key)) {
             return $this->getAttributeValue($key);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -273,9 +273,6 @@ trait HasAttributes
      */
     public function hasAttribute($key)
     {
-        // If the attribute exists in the attribute array or has a "get" mutator we will
-        // return the attribute's value. Otherwise, we will proceed as if the developers
-        // are asking for a relationship's value. This covers both types of values.
         if (array_key_exists($key, $this->attributes)) {
             return true;
         }
@@ -465,6 +462,9 @@ trait HasAttributes
             return;
         }
 
+        // If the attribute exists in the attribute array or has a "get" mutator we will
+        // return the attribute's value. Otherwise, we will proceed as if the developers
+        // are asking for a relationship's value. This covers both types of values.
         if ($this->hasAttribute($key)) {
             return $this->getAttributeValue($key);
         }

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -20,6 +20,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
     {
         $relation = $this->getRelation();
         $model1 = m::mock(Model::class);
+        $model1->shouldReceive('hasAttribute')->passthru();
         $model1->shouldReceive('getAttribute')->with('parent_key')->andReturn(1);
         $model1->shouldReceive('getAttribute')->with('foo')->passthru();
         $model1->shouldReceive('hasGetMutator')->andReturn(false);
@@ -28,6 +29,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model1->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation', 'isRelation')->passthru();
 
         $model2 = m::mock(Model::class);
+        $model2->shouldReceive('hasAttribute')->passthru();
         $model2->shouldReceive('getAttribute')->with('parent_key')->andReturn(2);
         $model2->shouldReceive('getAttribute')->with('foo')->passthru();
         $model2->shouldReceive('hasGetMutator')->andReturn(false);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3097,9 +3097,9 @@ class EloquentModelWithAttributeMutator extends Model
 
     public function firstName(): Attribute
     {
-        return Attribute::make(function (){
+        return Attribute::make(function () {
             return 'Taylor';
-        },function ($value){
+        }, function ($value) {
             return $value;
         });
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEncryptedCollection;
 use Illuminate\Database\Eloquent\Casts\AsStringable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MassAssignmentException;
@@ -371,6 +372,49 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['project' => 'laravel'], $model->only('project'));
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only('first_name', 'last_name'));
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
+    }
+
+    public function testHasAttributeWithAttributes()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'Taylor';
+        $model->last_name = 'Otwell';
+
+        $this->assertTrue($model->hasAttribute('first_name'));
+        $this->assertTrue($model->hasAttribute('last_name'));
+        $this->assertFalse($model->hasAttribute('project'));
+    }
+
+    public function testHasAttributeWithCasts()
+    {
+        $model = new EloquentModelStub;
+
+        $this->assertTrue($model->hasAttribute('castedFloat'));
+        $this->assertFalse($model->hasAttribute('project'));
+    }
+
+    public function testHasAttributeWithGetMutators()
+    {
+        $model = new EloquentModelGetMutatorsStub();
+
+        $this->assertTrue($model->hasAttribute('first_name'));
+        $this->assertFalse($model->hasAttribute('project'));
+    }
+
+    public function testHasAttributeWithAttributeMutators()
+    {
+        $model = new EloquentModelWithAttributeMutator();
+
+        $this->assertTrue($model->hasAttribute('first_name'));
+        $this->assertFalse($model->hasAttribute('project'));
+    }
+
+    public function testHasAttributeWithCastableCast()
+    {
+        $model = new EloquentModelCastingStub();
+
+        $this->assertTrue($model->hasAttribute('asarrayobjectAttribute'));
+        $this->assertFalse($model->hasAttribute('project'));
     }
 
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
@@ -3045,6 +3089,20 @@ class EloquentModelWithUpdatedAtNull extends Model
 {
     protected $table = 'stub';
     const UPDATED_AT = null;
+}
+
+class EloquentModelWithAttributeMutator extends Model
+{
+    protected $table = 'stub';
+
+    public function firstName(): Attribute
+    {
+        return Attribute::make(function (){
+            return 'Taylor';
+        },function ($value){
+            return $value;
+        });
+    }
 }
 
 class UnsavedModel extends Model


### PR DESCRIPTION
Hello Laravel Team,

With Laravel's new strict ``` Model::preventAccessingMissingAttributes``` Eloquent configuration, there are some problems with 3rd party packages when these packages want to access optional attributes.

To prevent ``` MissingAttributeException```, it would be handy to have a central way to check if an Eloquent Model attribute exists or not.

This PR introduces a new ```hasAttribute(string $key): bool``` method on Eloquent models to check if a model has an attribute configured. This also could be archived in the 3rd party package code. But I think it would be helpful if this gets added to the core. So it will be aligned with upcoming new framework features.