### PR TITLE
[9.x] Add touchQuietly convenience method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -44,6 +44,17 @@ trait HasTimestamps
     }
 
     /**
+     * Update the model's update timestamp without raising any events.
+     *
+     * @param  string|null  $attribute
+     * @return bool
+     */
+    public function touchQuietly($attribute = null)
+    {
+        return static::withoutEvents(fn () => $this->touch($attribute));
+    }
+
+    /**
      * Update the creation and update timestamps.
      *
      * @return $this


### PR DESCRIPTION
This PR proposes the addition of a `touchQuietly()` method to update the model's update timestamp without raising any events.