### PR TITLE
[9.x] Fix expectations for output assertions in `PendingCommand` 🧪

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -419,6 +419,8 @@ class PendingCommand
 
         foreach ($this->test->expectedOutputSubstrings as $i => $text) {
             $mock->shouldReceive('doWrite')
+                ->atLeast()
+                ->times(0)
                 ->withArgs(fn ($output) => str_contains($output, $text))
                 ->andReturnUsing(function () use ($i) {
                     unset($this->test->expectedOutputSubstrings[$i]);
@@ -427,6 +429,8 @@ class PendingCommand
 
         foreach ($this->test->unexpectedOutput as $output => $displayed) {
             $mock->shouldReceive('doWrite')
+                ->atLeast()
+                ->times(0)
                 ->ordered()
                 ->with($output, Mockery::any())
                 ->andReturnUsing(function () use ($output) {
@@ -436,6 +440,8 @@ class PendingCommand
 
         foreach ($this->test->unexpectedOutputSubstrings as $text => $displayed) {
             $mock->shouldReceive('doWrite')
+                 ->atLeast()
+                 ->times(0)
                  ->withArgs(fn ($output) => str_contains($output, $text))
                  ->andReturnUsing(function () use ($text) {
                      $this->test->unexpectedOutputSubstrings[$text] = true;


### PR DESCRIPTION
## About

Because of missing expectations, test results show the warning instead of the success message if the test passes:
```php
This test did not perform any assertions
```

This PR fixes behavior of `expectsOutputToContain`, `doesntExpectOutputToContain` and `doesntExpectOutput` assertions to be counted as assertion.