### PR TITLE
Add insertGetIds method to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3270,8 +3270,7 @@ class Builder implements BuilderContract
      * Insert a new records and get the values of the result
      *
      * @param array $values
-     * @param string|null $sequence
-     *
+     * @param string|null $sequence     
      * @return array
      */
     public function insertGetIds(array $values, $sequence = null)
@@ -3280,7 +3279,7 @@ class Builder implements BuilderContract
             return [];
         }
 
-        if (!is_array(reset($values))) {
+        if (! is_array(reset($values))) {
             $values = [$values];
         } else {
             foreach ($values as $key => $value) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3265,12 +3265,12 @@ class Builder implements BuilderContract
 
         return $this->processor->processInsertGetId($this, $sql, $values, $sequence);
     }
-    
+
     /**
      * Insert a new records and get the values of the result.
      *
      * @param  array  $values
-     * @param  string|null  $sequence    
+     * @param  string|null  $sequence
      * @return array
      */
     public function insertGetIds(array $values, $sequence = null)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3267,10 +3267,10 @@ class Builder implements BuilderContract
     }
     
     /**
-     * Insert a new records and get the values of the result
+     * Insert a new records and get the values of the result.
      *
-     * @param array $values
-     * @param string|null $sequence     
+     * @param  array  $values
+     * @param  string|null  $sequence    
      * @return array
      */
     public function insertGetIds(array $values, $sequence = null)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3265,6 +3265,38 @@ class Builder implements BuilderContract
 
         return $this->processor->processInsertGetId($this, $sql, $values, $sequence);
     }
+    
+    /**
+     * Insert a new records and get the values of the result
+     *
+     * @param array $values
+     * @param string|null $sequence
+     *
+     * @return array
+     */
+    public function insertGetIds(array $values, $sequence = null)
+    {
+        if (empty($values)) {
+            return [];
+        }
+
+        if (!is_array(reset($values))) {
+            $values = [$values];
+        } else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+
+                $values[$key] = $value;
+            }
+        }
+
+        $this->applyBeforeQueryCallbacks();
+
+        return $this->connection->select(
+            $this->grammar->compileInsertGetId($this, $values, $sequence),
+            $this->cleanBindings(Arr::flatten($values, 1))
+        );
+    }
 
     /**
      * Insert new records into the table using a subquery.


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR proposes the addition of a insertGetIds() method to  query builder get values from inserted record result. By default returning id column, you can select any column you want, in certain cases you can get all the columns data by specifying '*'.
