### PR TITLE
[9.x] skip tests that require gmp ext if not enabled

### DIFF
--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -59,7 +59,7 @@ class EloquentModelCustomCastingTest extends TestCase
     }
 
     /**
-     * Tests...
+     * @requires extension gmp
      */
     public function testSavingCastedAttributesToDatabase()
     {
@@ -97,6 +97,9 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->assertInstanceOf(GMP::class, $model->amount);
     }
 
+    /**
+     * @requires extension gmp
+     */
     public function testInvalidArgumentExceptionOnInvalidValue()
     {
         /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
@@ -115,6 +118,9 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->assertSame('address_line_two_value', $model->address->lineTwo);
     }
 
+    /**
+     * @requires extension gmp
+     */
     public function testInvalidArgumentExceptionOnNull()
     {
         /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */
@@ -133,6 +139,9 @@ class EloquentModelCustomCastingTest extends TestCase
         $this->assertSame('address_line_two_value', $model->address->lineTwo);
     }
 
+    /**
+     * @requires extension gmp
+     */
     public function testModelsWithCustomCastsCanBeConvertedToArrays()
     {
         /** @var \Illuminate\Tests\Integration\Database\CustomCasts $model */


### PR DESCRIPTION
Tests on `Illuminate\Tests\Integration\Database\EloquentModelCustomCastingTest` fail with the following error message:

```
Error: Call to undefined function Illuminate\Tests\Integration\Database\gmp_init()
```