### PR TITLE
[10.x] Drop DBAL v2 and bump v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "require-dev": {
         "ably/ably-php": "^1.0",
         "aws/aws-sdk-php": "^3.235.5",
-        "doctrine/dbal": "^2.13.3|^3.1.4",
+        "doctrine/dbal": "^3.5.1",
         "fakerphp/faker": "^1.9.2",
         "guzzlehttp/guzzle": "^7.5",
         "league/flysystem-aws-s3-v3": "^3.0",
@@ -147,7 +147,7 @@
         "ably/ably-php": "Required to use the Ably broadcast driver (^1.0).",
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage, and SES mail driver (^3.235.5).",
         "brianium/paratest": "Required to run tests in parallel (^6.0).",
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.4).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "filp/whoops": "Required for friendly error pages in development (^2.14.3).",
         "guzzlehttp/guzzle": "Required to use the HTTP Client and the ping methods on schedules (^7.5).",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -35,7 +35,7 @@
         }
     },
     "suggest": {
-        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.13.3|^3.1.4).",
+        "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "illuminate/console": "Required to use the database commands (^10.0).",
         "illuminate/events": "Required to use the observers with Eloquent (^10.0).",

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -63,30 +63,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
                 'DROP TABLE users',
-                'CREATE TABLE users (name VARCHAR(255) NOT NULL COLLATE BINARY, age INTEGER NOT NULL)',
-                'INSERT INTO users (name, age) SELECT name, age FROM __temp__users',
-                'DROP TABLE __temp__users',
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
-                'DROP TABLE users',
-                'CREATE TABLE users (age VARCHAR(255) NOT NULL COLLATE BINARY, first_name VARCHAR(255) NOT NULL)',
-                'INSERT INTO users (first_name, age) SELECT name, age FROM __temp__users',
-                'DROP TABLE __temp__users',
-            ],
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
-                'DROP TABLE users',
-                'CREATE TABLE users (name VARCHAR(255) NOT NULL COLLATE BINARY, age INTEGER NOT NULL)',
-                'INSERT INTO users (name, age) SELECT name, age FROM __temp__users',
-                'DROP TABLE __temp__users',
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
-                'DROP TABLE users',
-                'CREATE TABLE users (first_name VARCHAR(255) NOT NULL, age VARCHAR(255) NOT NULL COLLATE BINARY)',
-                'INSERT INTO users (first_name, age) SELECT name, age FROM __temp__users',
-                'DROP TABLE __temp__users',
-            ],
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name, age FROM users',
-                'DROP TABLE users',
                 'CREATE TABLE users (name VARCHAR(255) NOT NULL COLLATE "BINARY", age INTEGER NOT NULL)',
                 'INSERT INTO users (name, age) SELECT name, age FROM __temp__users',
                 'DROP TABLE __temp__users',
@@ -121,13 +97,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT age FROM users',
                 'DROP TABLE users',
-                'CREATE TABLE users (age INTEGER NOT NULL COLLATE RTRIM)',
-                'INSERT INTO users (age) SELECT age FROM __temp__users',
-                'DROP TABLE __temp__users',
-            ],
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT age FROM users',
-                'DROP TABLE users',
                 'CREATE TABLE users (age INTEGER NOT NULL COLLATE "RTRIM")',
                 'INSERT INTO users (age) SELECT age FROM __temp__users',
                 'DROP TABLE __temp__users',
@@ -139,13 +108,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $queries = $blueprint2->toSql($this->db->connection(), new SQLiteGrammar);
 
         $expected = [
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT age FROM users',
-                'DROP TABLE users',
-                'CREATE TABLE users (age INTEGER NOT NULL COLLATE NOCASE)',
-                'INSERT INTO users (age) SELECT age FROM __temp__users',
-                'DROP TABLE __temp__users',
-            ],
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT age FROM users',
                 'DROP TABLE users',
@@ -171,13 +133,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $queries = $blueprint->toSql($this->db->connection(), new SQLiteGrammar);
 
         $expected = [
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
-                'DROP TABLE users',
-                'CREATE TABLE users (name CHAR(50) NOT NULL COLLATE BINARY)',
-                'INSERT INTO users (name) SELECT name FROM __temp__users',
-                'DROP TABLE __temp__users',
-            ],
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
                 'DROP TABLE users',
@@ -278,14 +233,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
                 'DROP TABLE users',
-                'CREATE TABLE users (name VARCHAR(255) DEFAULT NULL COLLATE BINARY)',
-                'INSERT INTO users (name) SELECT name FROM __temp__users',
-                'DROP TABLE __temp__users',
-                'alter table `users` add unique `users_name_unique`(`name`)',
-            ],
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
-                'DROP TABLE users',
                 'CREATE TABLE users (name VARCHAR(255) DEFAULT NULL COLLATE "BINARY")',
                 'INSERT INTO users (name) SELECT name FROM __temp__users',
                 'DROP TABLE __temp__users',
@@ -302,14 +249,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $queries = $blueprintPostgres->toSql($this->db->connection(), new PostgresGrammar);
 
         $expected = [
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
-                'DROP TABLE users',
-                'CREATE TABLE users (name VARCHAR(255) DEFAULT NULL COLLATE BINARY)',
-                'INSERT INTO users (name) SELECT name FROM __temp__users',
-                'DROP TABLE __temp__users',
-                'alter table "users" add constraint "users_name_unique" unique ("name")',
-            ],
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
                 'DROP TABLE users',
@@ -332,14 +271,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
                 'DROP TABLE users',
-                'CREATE TABLE users (name VARCHAR(255) DEFAULT NULL COLLATE BINARY)',
-                'INSERT INTO users (name) SELECT name FROM __temp__users',
-                'DROP TABLE __temp__users',
-                'create unique index "users_name_unique" on "users" ("name")',
-            ],
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
-                'DROP TABLE users',
                 'CREATE TABLE users (name VARCHAR(255) DEFAULT NULL COLLATE "BINARY")',
                 'INSERT INTO users (name) SELECT name FROM __temp__users',
                 'DROP TABLE __temp__users',
@@ -356,14 +287,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $queries = $blueprintSqlServer->toSql($this->db->connection(), new SqlServerGrammar);
 
         $expected = [
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
-                'DROP TABLE users',
-                'CREATE TABLE users (name VARCHAR(255) DEFAULT NULL COLLATE BINARY)',
-                'INSERT INTO users (name) SELECT name FROM __temp__users',
-                'DROP TABLE __temp__users',
-                'create unique index "users_name_unique" on "users" ("name")',
-            ],
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
                 'DROP TABLE users',
@@ -390,14 +313,6 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $queries = $blueprintMySql->toSql($this->db->connection(), new MySqlGrammar);
 
         $expected = [
-            [
-                'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
-                'DROP TABLE users',
-                'CREATE TABLE users (name VARCHAR(255) DEFAULT NULL COLLATE BINARY)',
-                'INSERT INTO users (name) SELECT name FROM __temp__users',
-                'DROP TABLE __temp__users',
-                'alter table `users` add unique `index1`(`name`)',
-            ],
             [
                 'CREATE TEMPORARY TABLE __temp__users AS SELECT name FROM users',
                 'DROP TABLE users',


### PR DESCRIPTION
This PR removes support for the now unmaintained DBAL v2 version for the upcoming Laravel v10 release. It also bumps v3 so we can remove some workarounds in our tests when matching schema builder queries.