### PR TITLE
[9.x] Add Illuminate\Session\Store::setHandler()

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -733,6 +733,17 @@ class Store implements Session
     }
 
     /**
+     * Set the underlying session handler implementation.
+     *
+     * @param  \SessionHandlerInterface  $handler
+     * @return void
+     */
+    public function setHandler(SessionHandlerInterface $handler)
+    {
+        return $this->handler = $handler;
+    }
+
+    /**
      * Determine if the session handler needs a request.
      *
      * @return bool


### PR DESCRIPTION
This adds a simple setter for the handler used by `Illuminate\Session\Store`. The PR doesn't introduce any breaking changes.

The use case is that when you're changing database connections on the fly, the database session driver can run into issues where it tries to run queries on a DB connection that no longer exists.

The session-related middleware instantiates `Illuminate\Session\Store` for the database driver which uses `DatabaseSessionHandler` as the `$handler`. That class stores the connection and is used at the end of the request to write the session data. At that point, the connection that was injected initially may not exist anymore.

By adding the setter, I can reconstruct the `DatabaseSessionHandler` on the fly and make it use the correct DB connection: https://gist.github.com/stancl/eb6e210b553bf697c13f19ddaf80f539#file-sessiontenancybootstrapper-php-L18-L38

The addition will let me fix https://github.com/archtechx/tenancy/issues/547.