### PR TITLE
[9.x] Recompiles views when necessary

### DIFF
--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\View\Engines;
 
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\ViewException;

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -70,7 +70,7 @@ class CompilerEngine extends PhpEngine
         try {
             $results = $this->evaluatePath($this->compiler->getCompiledPath($path), $data);
         } catch (ViewException $e) {
-            if (! $e->getPrevious() instanceof FileNotFoundException) {
+            if (! str($e->getMessage())->contains(['No such file or directory', 'File does not exist at path'])) {
                 throw $e;
             }
 
@@ -83,9 +83,9 @@ class CompilerEngine extends PhpEngine
             $results = $this->evaluatePath($this->compiler->getCompiledPath($path), $data);
         }
 
-        array_pop($this->lastCompiled);
-
         $this->compiledOrNotExpired[$path] = true;
+
+        array_pop($this->lastCompiled);
 
         return $results;
     }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -2,9 +2,12 @@
 
 namespace Illuminate\Tests\View;
 
+use Exception;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
+use Illuminate\View\ViewException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -55,8 +58,174 @@ class ViewCompilerEngineTest extends TestCase
         $engine->get(__DIR__.'/fixtures/foo.php');
     }
 
-    protected function getEngine()
+    public function testViewsAreRecompiledWhenCompiledViewIsMissing()
     {
-        return new CompilerEngine(m::mock(CompilerInterface::class), new Filesystem);
+        $compiled = __DIR__.'/fixtures/basic.php';
+        $path = __DIR__.'/fixtures/foo.php';
+
+        $files = m::mock(Filesystem::class);
+        $engine = $this->getEngine($files);
+
+        $files->shouldReceive('getRequire')
+            ->once()
+            ->with($compiled, [])
+            ->andReturn('compiled-content');
+
+        $files->shouldReceive('getRequire')
+            ->once()
+            ->with($compiled, [])
+            ->andThrow(new FileNotFoundException(
+                "File does not exist at path {$path}."
+            ));
+
+        $files->shouldReceive('getRequire')
+            ->once()
+            ->with($compiled, [])
+            ->andReturn('compiled-content');
+
+        $engine->getCompiler()
+            ->shouldReceive('getCompiledPath')
+            ->times(3)
+            ->with($path)
+            ->andReturn($compiled);
+
+        $engine->getCompiler()
+            ->shouldReceive('isExpired')
+            ->once()
+            ->andReturn(true);
+
+        $engine->getCompiler()
+            ->shouldReceive('compile')
+            ->twice()
+            ->with($path);
+
+        $engine->get($path);
+        $engine->get($path);
+    }
+
+    public function testViewsAreRecompiledJustOnceWhenCompiledViewIsMissing()
+    {
+        $compiled = __DIR__.'/fixtures/basic.php';
+        $path = __DIR__.'/fixtures/foo.php';
+
+        $files = m::mock(Filesystem::class);
+        $engine = $this->getEngine($files);
+
+        $files->shouldReceive('getRequire')
+            ->once()
+            ->with($compiled, [])
+            ->andReturn('compiled-content');
+
+        $files->shouldReceive('getRequire')
+            ->once()
+            ->with($compiled, [])
+            ->andThrow(new FileNotFoundException(
+                "File does not exist at path {$path}."
+            ));
+
+        $files->shouldReceive('getRequire')
+            ->once()
+            ->with($compiled, [])
+            ->andThrow(new FileNotFoundException(
+                "File does not exist at path {$path}."
+            ));
+
+        $engine->getCompiler()
+            ->shouldReceive('getCompiledPath')
+            ->times(3)
+            ->with($path)
+            ->andReturn($compiled);
+
+        $engine->getCompiler()
+            ->shouldReceive('isExpired')
+            ->once()
+            ->andReturn(true);
+
+        $engine->getCompiler()
+            ->shouldReceive('compile')
+            ->twice()
+            ->with($path);
+
+        $engine->get($path);
+
+        $this->expectException(ViewException::class);
+        $this->expectExceptionMessage("File does not exist at path {$path}.");
+        $engine->get($path);
+    }
+
+    public function testViewsAreNotRecompiledOnRegularViewException()
+    {
+        $compiled = __DIR__.'/fixtures/basic.php';
+        $path = __DIR__.'/fixtures/foo.php';
+
+        $files = m::mock(Filesystem::class);
+        $engine = $this->getEngine($files);
+
+        $files->shouldReceive('getRequire')
+            ->once()
+            ->with($compiled, [])
+            ->andThrow(new Exception(
+                'Just an regular error...'
+            ));
+
+        $engine->getCompiler()
+            ->shouldReceive('isExpired')
+            ->once()
+            ->andReturn(false);
+
+        $engine->getCompiler()
+            ->shouldReceive('compile')
+            ->never();
+
+        $engine->getCompiler()
+            ->shouldReceive('getCompiledPath')
+            ->once()
+            ->with($path)
+            ->andReturn($compiled);
+
+        $this->expectException(ViewException::class);
+        $this->expectExceptionMessage('Just an regular error...');
+        $engine->get($path);
+    }
+
+    public function testViewsAreNotRecompiledIfTheyWereJustCompiled()
+    {
+        $compiled = __DIR__.'/fixtures/basic.php';
+        $path = __DIR__.'/fixtures/foo.php';
+
+        $files = m::mock(Filesystem::class);
+        $engine = $this->getEngine($files);
+
+        $files->shouldReceive('getRequire')
+            ->once()
+            ->with($compiled, [])
+            ->andThrow(new FileNotFoundException(
+                "File does not exist at path {$path}."
+            ));
+
+        $engine->getCompiler()
+            ->shouldReceive('isExpired')
+            ->once()
+            ->andReturn(true);
+
+        $engine->getCompiler()
+            ->shouldReceive('compile')
+            ->once()
+            ->with($path);
+
+        $engine->getCompiler()
+            ->shouldReceive('getCompiledPath')
+            ->once()
+            ->with($path)
+            ->andReturn($compiled);
+
+        $this->expectException(ViewException::class);
+        $this->expectExceptionMessage("File does not exist at path {$path}.");
+        $engine->get($path);
+    }
+
+    protected function getEngine($filesystem = null)
+    {
+        return new CompilerEngine(m::mock(CompilerInterface::class), $filesystem ?: new Filesystem);
     }
 }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\View;
 
-use Exception;
 use ErrorException;
+use Exception;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\CompilerInterface;


### PR DESCRIPTION
This pull request fixes an issue that may happen when deploying Laravel applications after https://github.com/laravel/framework/pull/44487. If the compiled views directory gets deleted via the `view:clear` command, while a worker is running, the worker does not handle correctly the fact that the compiled views may be missing.

```
php artisan view:clear
sleep 5 // If an queue job, that uses views, tries to re-send a job, it may face `File does not exist at path`...
php artisan queue:restart
```

To address this issue, we simply re-compile the given view if necessary.