### PR TITLE
Remove comma from mail template

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -39,7 +39,7 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards'),<br>
+@lang('Regards')<br>
 {{ config('app.name') }}
 @endif
 

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -39,7 +39,7 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards')<br>
+@lang('Regards,')<br>
 {{ config('app.name') }}
 @endif
 


### PR DESCRIPTION
Some languages, like Japanese, don't put comma at the end of sentence. For example:

![image](https://user-images.githubusercontent.com/7894265/197921885-0d6e1307-79c2-42ed-9c53-45b2026230e1.png)

But Laravel mail template including comma outside of @lang section like below.

`@lang('Regards'),<br>`

This should be

`@lang('Regards,')<br>`
or
`@lang('Regards')<br>`

With this fix, you can translate Mail notification with LANG.json file without having this end-comma problem. Further more, it helps Devs to create Laravel app to support multi-languages easily. (Just make as many lang.json files as you want and swap them in config/app.php 'locale' => 'yourLang' )
