### PR TITLE
Works on fixing incorrect resource name and parameters 🕸

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -334,9 +334,13 @@ class Router implements BindingRegistrar, RegistrarContract
                 ->each(function ($groupStack) use ($registrar, $controller, $options) {
                     $name = explode("/", $groupStack["prefix"])[1];
 
-                    return (new PendingResourceRegistration($registrar, "/", $controller, $options))
-                        ->names($name)
-                        ->parameters([null => $name]);
+                    if(str_ends_with($name, "s")) {
+                        $name = substr($name, 0, -1);
+                    }
+
+                    return (new PendingResourceRegistration(
+                        $registrar, "/", $controller, $options
+                    ))->names($name)->parameters([null => $name]);
                 });
 
             return;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -327,6 +327,20 @@ class Router implements BindingRegistrar, RegistrarContract
         } else {
             $registrar = new ResourceRegistrar($this);
         }
+        
+        if ($name == "/") {
+            collect($this->getGroupStack())
+                ->filter(fn ($groupStack) => array_key_exists("prefix", $groupStack))
+                ->each(function ($groupStack) use ($registrar, $controller, $options) {
+                    $name = explode("/", $groupStack["prefix"])[1];
+
+                    return (new PendingResourceRegistration($registrar, "/", $controller, $options))
+                        ->names($name)
+                        ->parameters([null => $name]);
+                });
+
+            return;
+        }
 
         return new PendingResourceRegistration(
             $registrar, $name, $controller, $options


### PR DESCRIPTION
**This PR continues the working of my old closed [PR](https://github.com/laravel/framework/pull/44715)**

As I said before, I did not use `ControllerName` to guess the resource `name` and `parameters`, also @taylorotwell did not prefer that way, so I decided to use `getGroupStack` method to get the `prefix` value, and then use it in the resource `name` and `parameters`