### PR TITLE
[9.x] Make `migrate` command isolated

### DIFF
--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -8,18 +8,18 @@ use Illuminate\Contracts\Cache\Factory as Cache;
 class CacheCommandMutex implements CommandMutex
 {
     /**
-     * The cache store that should be used.
-     *
-     * @var string|null
-     */
-    public $store = null;
-
-    /**
      * The cache factory implementation.
      *
      * @var \Illuminate\Contracts\Cache\Factory
      */
     public $cache;
+
+    /**
+     * The cache store that should be used.
+     *
+     * @var string|null
+     */
+    public $store = null;
 
     /**
      * Create a new command mutex.

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -24,9 +24,9 @@ class CacheCommandMutex implements CommandMutex
     public $cache;
 
     /**
-     * Create a new command mutex
+     * Create a new command mutex.
      *
-     * @param \Illuminate\Contracts\Cache\Factory $cache
+     * @param  \Illuminate\Contracts\Cache\Factory  $cache
      */
     public function __construct(Cache $cache)
     {
@@ -50,7 +50,7 @@ class CacheCommandMutex implements CommandMutex
     }
 
     /**
-     * @param Command $command
+     * @param  Command  $command
      * @return string
      */
     protected function commandMutexName($command): string
@@ -61,7 +61,7 @@ class CacheCommandMutex implements CommandMutex
     /**
      * Specify the cache store that should be used.
      *
-     * @param string|null $store
+     * @param  string|null  $store
      * @return $this
      */
     public function useStore($store): static

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Illuminate\Console;
 
 use Carbon\CarbonInterval;
@@ -33,6 +31,12 @@ class CacheCommandMutex implements CommandMutex
         $this->cache = $cache;
     }
 
+    /**
+     * Attempt to obtain a command mutex for the given command.
+     *
+     * @param  \Illuminate\Console\Command  $command
+     * @return bool
+     */
     public function create($command)
     {
         return $this->cache->store($this->store)->add(
@@ -42,13 +46,12 @@ class CacheCommandMutex implements CommandMutex
         );
     }
 
-    public function exists($command)
-    {
-        return $this->cache->store($this->store)->has(
-            $this->commandMutexName($command)
-        );
-    }
-
+    /**
+     * Release the mutex for the given command.
+     *
+     * @param  \Illuminate\Console\Command  $command
+     * @return bool
+     */
     public function release($command)
     {
         return $this->cache->store($this->store)->forget(
@@ -57,10 +60,23 @@ class CacheCommandMutex implements CommandMutex
     }
 
     /**
-     * @param  Command  $command
+     * Determine if a command mutex exists for the given command.
+     *
+     * @param  \Illuminate\Console\Command  $command
+     * @return bool
+     */
+    public function exists($command)
+    {
+        return $this->cache->store($this->store)->has(
+            $this->commandMutexName($command)
+        );
+    }
+
+    /**
+     * @param  \Illuminate\Console\Command  $command
      * @return string
      */
-    protected function commandMutexName($command): string
+    protected function commandMutexName($command)
     {
         return 'framework'.DIRECTORY_SEPARATOR.'command-'.$command->getName();
     }
@@ -71,7 +87,7 @@ class CacheCommandMutex implements CommandMutex
      * @param  string|null  $store
      * @return $this
      */
-    public function useStore($store): static
+    public function useStore($store)
     {
         $this->store = $store;
 

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -47,19 +47,6 @@ class CacheCommandMutex implements CommandMutex
     }
 
     /**
-     * Release the mutex for the given command.
-     *
-     * @param  \Illuminate\Console\Command  $command
-     * @return bool
-     */
-    public function release($command)
-    {
-        return $this->cache->store($this->store)->forget(
-            $this->commandMutexName($command)
-        );
-    }
-
-    /**
      * Determine if a command mutex exists for the given command.
      *
      * @param  \Illuminate\Console\Command  $command
@@ -68,6 +55,19 @@ class CacheCommandMutex implements CommandMutex
     public function exists($command)
     {
         return $this->cache->store($this->store)->has(
+            $this->commandMutexName($command)
+        );
+    }
+
+    /**
+     * Release the mutex for the given command.
+     *
+     * @param  \Illuminate\Console\Command  $command
+     * @return bool
+     */
+    public function forget($command)
+    {
+        return $this->cache->store($this->store)->forget(
             $this->commandMutexName($command)
         );
     }

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Console;
+
+use Carbon\CarbonInterval;
+use Illuminate\Contracts\Cache\Factory as Cache;
+
+class CacheCommandMutex implements CommandMutex
+{
+    public string|null $store = null;
+
+    public Cache $cache;
+
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function create(Command $command): bool
+    {
+        return $this->cache->store($this->store)->add(
+            $this->commandMutexName($command),
+            true,
+            CarbonInterval::hour(),
+        );
+    }
+
+    public function exists(Command $command): bool
+    {
+        return $this->cache->store($this->store)->has(
+            $this->commandMutexName($command)
+        );
+    }
+
+    protected function commandMutexName(Command $command): string
+    {
+        return 'framework'.DIRECTORY_SEPARATOR.'command-'.$command->getName();
+    }
+    public function useStore(string|null $store): static
+    {
+        $this->store = $store;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -49,6 +49,13 @@ class CacheCommandMutex implements CommandMutex
         );
     }
 
+    public function release($command)
+    {
+        return $this->cache->store($this->store)->forget(
+            $this->commandMutexName($command)
+        );
+    }
+
     /**
      * @param  Command  $command
      * @return string

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -9,16 +9,31 @@ use Illuminate\Contracts\Cache\Factory as Cache;
 
 class CacheCommandMutex implements CommandMutex
 {
-    public string|null $store = null;
+    /**
+     * The cache store that should be used.
+     *
+     * @var string|null
+     */
+    public $store = null;
 
-    public Cache $cache;
+    /**
+     * The cache factory implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Factory
+     */
+    public $cache;
 
+    /**
+     * Create a new command mutex
+     *
+     * @param \Illuminate\Contracts\Cache\Factory $cache
+     */
     public function __construct(Cache $cache)
     {
         $this->cache = $cache;
     }
 
-    public function create(Command $command): bool
+    public function create($command)
     {
         return $this->cache->store($this->store)->add(
             $this->commandMutexName($command),
@@ -27,18 +42,29 @@ class CacheCommandMutex implements CommandMutex
         );
     }
 
-    public function exists(Command $command): bool
+    public function exists($command)
     {
         return $this->cache->store($this->store)->has(
             $this->commandMutexName($command)
         );
     }
 
-    protected function commandMutexName(Command $command): string
+    /**
+     * @param Command $command
+     * @return string
+     */
+    protected function commandMutexName($command): string
     {
         return 'framework'.DIRECTORY_SEPARATOR.'command-'.$command->getName();
     }
-    public function useStore(string|null $store): static
+
+    /**
+     * Specify the cache store that should be used.
+     *
+     * @param string|null $store
+     * @return $this
+     */
+    public function useStore($store): static
     {
         $this->store = $store;
 

--- a/src/Illuminate/Console/CacheCommandMutex.php
+++ b/src/Illuminate/Console/CacheCommandMutex.php
@@ -42,7 +42,9 @@ class CacheCommandMutex implements CommandMutex
         return $this->cache->store($this->store)->add(
             $this->commandMutexName($command),
             true,
-            CarbonInterval::hour(),
+            method_exists($command, 'isolationExpiresAt')
+                    ? $command->isolationExpiresAt()
+                    : CarbonInterval::hour(),
         );
     }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -123,7 +123,8 @@ class Command extends SymfonyCommand
             'isolated',
             null,
             InputOption::VALUE_OPTIONAL,
-            'Do not run the command if another instance of the command is already running'
+            'Do not run the command if another instance of the command is already running',
+            false
         ));
     }
 
@@ -160,7 +161,7 @@ class Command extends SymfonyCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($this instanceof Isolatable && $this->option('isolated') &&
+        if ($this instanceof Isolatable && $this->option('isolated') !== false &&
             ! $this->commandIsolationMutex()->create($this)) {
             $this->comment(sprintf(
                 'The [%s] command is already running.', $this->getName()
@@ -176,7 +177,7 @@ class Command extends SymfonyCommand
         try {
             return (int) $this->laravel->call([$this, $method]);
         } finally {
-            if ($this instanceof Isolatable && $this->option('isolated')) {
+            if ($this instanceof Isolatable && $this->option('isolated') !== false) {
                 $this->commandIsolationMutex()->forget($this);
             }
         }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\View\Components\Factory;
+use Illuminate\Contracts\Console\Isolated;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -139,6 +140,13 @@ class Command extends SymfonyCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if ($this instanceof Isolated && ! $this->laravel->get(CommandMutex::class)->create($this)) {
+            $this->info(sprintf(
+                "Skipping [%s], as command already running.", $this->getName()
+            ));
+            return self::SUCCESS;
+        }
+
         $method = method_exists($this, 'handle') ? 'handle' : '__invoke';
 
         return (int) $this->laravel->call([$this, $method]);

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -142,8 +142,9 @@ class Command extends SymfonyCommand
     {
         if ($this instanceof Isolated && ! $this->laravel->get(CommandMutex::class)->create($this)) {
             $this->info(sprintf(
-                "Skipping [%s], as command already running.", $this->getName()
+                'Skipping [%s], as command already running.', $this->getName()
             ));
+
             return self::SUCCESS;
         }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -90,12 +90,7 @@ class Command extends SymfonyCommand
         }
 
         if ($this instanceof Isolatable) {
-            $this->getDefinition()->addOption(new InputOption(
-                'isolated',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Do not run the command if another instance of the command is already running'
-            ));
+            $this->configureIsolation();
         }
     }
 
@@ -115,6 +110,21 @@ class Command extends SymfonyCommand
         // instances of these "InputArgument" and "InputOption" Symfony classes.
         $this->getDefinition()->addArguments($arguments);
         $this->getDefinition()->addOptions($options);
+    }
+
+    /**
+     * Configure the console command for isolation.
+     *
+     * @return void
+     */
+    protected function configureIsolation()
+    {
+        $this->getDefinition()->addOption(new InputOption(
+            'isolated',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Do not run the command if another instance of the command is already running'
+        ));
     }
 
     /**
@@ -156,7 +166,9 @@ class Command extends SymfonyCommand
                 'The [%s] command is already running.', $this->getName()
             ));
 
-            return self::SUCCESS;
+            return (int) (is_numeric($this->option('isolated'))
+                        ? $this->option('isolated')
+                        : self::SUCCESS);
         }
 
         $method = method_exists($this, 'handle') ? 'handle' : '__invoke';

--- a/src/Illuminate/Console/CommandMutex.php
+++ b/src/Illuminate/Console/CommandMutex.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Console;
+
+use DateTimeInterface;
+
+interface CommandMutex
+{
+    /**
+     * Attempt to obtain a command mutex for the given command
+     */
+    public function create(Command $command): bool;
+
+    public function exists(Command $command): bool;
+}

--- a/src/Illuminate/Console/CommandMutex.php
+++ b/src/Illuminate/Console/CommandMutex.php
@@ -7,9 +7,9 @@ namespace Illuminate\Console;
 interface CommandMutex
 {
     /**
-     * Attempt to obtain a command mutex for the given command
+     * Attempt to obtain a command mutex for the given command.
      *
-     * @param Command $command
+     * @param  Command  $command
      * @return bool
      */
     public function create($command);
@@ -17,7 +17,7 @@ interface CommandMutex
     /**
      * Determine if a command mutex exists for the given command.
      *
-     * @param Command $command
+     * @param  Command  $command
      * @return bool
      */
     public function exists($command);

--- a/src/Illuminate/Console/CommandMutex.php
+++ b/src/Illuminate/Console/CommandMutex.php
@@ -15,6 +15,14 @@ interface CommandMutex
     public function create($command);
 
     /**
+     * Release the mutex for the given command.
+     *
+     * @param Command $command
+     * @return bool
+     */
+    public function release($command);
+
+    /**
      * Determine if a command mutex exists for the given command.
      *
      * @param  Command  $command

--- a/src/Illuminate/Console/CommandMutex.php
+++ b/src/Illuminate/Console/CommandMutex.php
@@ -13,18 +13,18 @@ interface CommandMutex
     public function create($command);
 
     /**
-     * Release the mutex for the given command.
-     *
-     * @param  \Illuminate\Console\Command  $command
-     * @return bool
-     */
-    public function release($command);
-
-    /**
      * Determine if a command mutex exists for the given command.
      *
      * @param  \Illuminate\Console\Command  $command
      * @return bool
      */
     public function exists($command);
+
+    /**
+     * Release the mutex for the given command.
+     *
+     * @param  \Illuminate\Console\Command  $command
+     * @return bool
+     */
+    public function forget($command);
 }

--- a/src/Illuminate/Console/CommandMutex.php
+++ b/src/Illuminate/Console/CommandMutex.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Illuminate\Console;
 
 interface CommandMutex
@@ -9,7 +7,7 @@ interface CommandMutex
     /**
      * Attempt to obtain a command mutex for the given command.
      *
-     * @param  Command  $command
+     * @param  \Illuminate\Console\Command  $command
      * @return bool
      */
     public function create($command);
@@ -17,7 +15,7 @@ interface CommandMutex
     /**
      * Release the mutex for the given command.
      *
-     * @param Command $command
+     * @param  \Illuminate\Console\Command  $command
      * @return bool
      */
     public function release($command);
@@ -25,7 +23,7 @@ interface CommandMutex
     /**
      * Determine if a command mutex exists for the given command.
      *
-     * @param  Command  $command
+     * @param  \Illuminate\Console\Command  $command
      * @return bool
      */
     public function exists($command);

--- a/src/Illuminate/Console/CommandMutex.php
+++ b/src/Illuminate/Console/CommandMutex.php
@@ -4,14 +4,21 @@ declare(strict_types=1);
 
 namespace Illuminate\Console;
 
-use DateTimeInterface;
-
 interface CommandMutex
 {
     /**
      * Attempt to obtain a command mutex for the given command
+     *
+     * @param Command $command
+     * @return bool
      */
-    public function create(Command $command): bool;
+    public function create($command);
 
-    public function exists(Command $command): bool;
+    /**
+     * Determine if a command mutex exists for the given command.
+     *
+     * @param Command $command
+     * @return bool
+     */
+    public function exists($command);
 }

--- a/src/Illuminate/Contracts/Console/Isolatable.php
+++ b/src/Illuminate/Contracts/Console/Isolatable.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Contracts\Console;
 
-interface Isolated
+interface Isolatable
 {
+    //
 }

--- a/src/Illuminate/Contracts/Console/Isolated.php
+++ b/src/Illuminate/Contracts/Console/Isolated.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Illuminate\Contracts\Console;
 
 interface Isolated

--- a/src/Illuminate/Contracts/Console/Isolated.php
+++ b/src/Illuminate/Contracts/Console/Isolated.php
@@ -6,5 +6,4 @@ namespace Illuminate\Contracts\Console;
 
 interface Isolated
 {
-
 }

--- a/src/Illuminate/Contracts/Console/Isolated.php
+++ b/src/Illuminate/Contracts/Console/Isolated.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Contracts\Console;
+
+interface Isolated
+{
+
+}

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Console\View\Components\Task;
+use Illuminate\Contracts\Console\Isolated;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\SchemaLoaded;
 use Illuminate\Database\Migrations\Migrator;
@@ -12,7 +12,7 @@ use Illuminate\Database\SqlServerConnection;
 use PDOException;
 use Throwable;
 
-class MigrateCommand extends BaseCommand
+class MigrateCommand extends BaseCommand implements Isolated
 {
     use ConfirmableTrait;
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Contracts\Console\Isolated;
+use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\SchemaLoaded;
 use Illuminate\Database\Migrations\Migrator;
@@ -12,7 +12,7 @@ use Illuminate\Database\SqlServerConnection;
 use PDOException;
 use Throwable;
 
-class MigrateCommand extends BaseCommand implements Isolated
+class MigrateCommand extends BaseCommand implements Isolatable
 {
     use ConfirmableTrait;
 

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -8,8 +8,8 @@ use Illuminate\Console\CacheCommandMutex;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Cache\Repository;
-use PHPUnit\Framework\TestCase;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
 class CacheCommandMutexTest extends TestCase
 {
@@ -39,7 +39,8 @@ class CacheCommandMutexTest extends TestCase
         $this->cacheRepository = m::mock(Repository::class);
         $this->cacheFactory->shouldReceive('store')->andReturn($this->cacheRepository);
         $this->mutex = new CacheCommandMutex($this->cacheFactory);
-        $this->command = new class extends Command {
+        $this->command = new class extends Command
+        {
             protected $name = 'command-name';
         };
     }

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\CacheCommandMutex;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Cache\Repository;
+use PHPUnit\Framework\TestCase;
+use Mockery as m;
+
+class CacheCommandMutexTest extends TestCase
+{
+    protected CacheCommandMutex $mutex;
+    protected Command $command;
+    protected Factory $cacheFactory;
+    protected Repository $cacheRepository;
+
+    protected function setUp(): void
+    {
+        $this->cacheFactory = m::mock(Factory::class);
+        $this->cacheRepository = m::mock(Repository::class);
+        $this->cacheFactory->shouldReceive('store')->andReturn($this->cacheRepository);
+        $this->mutex = new CacheCommandMutex($this->cacheFactory);
+        $this->command = new class extends Command {
+            protected $name = 'command-name';
+        };
+    }
+
+    public function testCanCreateMutex()
+    {
+        $this->cacheRepository->shouldReceive('add')
+            ->andReturn(true)
+            ->once();
+        $actual = $this->mutex->create($this->command);
+
+        $this->assertTrue($actual);
+    }
+
+    public function testCannotCreateMutexIfAlreadyExist()
+    {
+        $this->cacheRepository->shouldReceive('add')
+            ->andReturn(false)
+            ->once();
+        $actual = $this->mutex->create($this->command);
+
+        $this->assertFalse($actual);
+    }
+
+    public function testCanCreateMutexWithCustomConnection()
+    {
+        $this->cacheRepository->shouldReceive('getStore')
+            ->with('test')
+            ->andReturn($this->cacheRepository);
+        $this->cacheRepository->shouldReceive('add')
+            ->andReturn(false)
+            ->once();
+        $this->mutex->useStore('test');
+
+        $this->mutex->create($this->command);
+    }
+}

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -13,9 +13,24 @@ use Mockery as m;
 
 class CacheCommandMutexTest extends TestCase
 {
-    protected CacheCommandMutex $mutex;
-    protected Command $command;
-    protected Factory $cacheFactory;
+    /**
+     * @var CacheCommandMutex
+     */
+    protected $mutex;
+
+    /**
+     * @var Command
+     */
+    protected $command;
+
+    /**
+     * @var Factory
+     */
+    protected $cacheFactory;
+
+    /**
+     * @var Repository
+     */
     protected Repository $cacheRepository;
 
     protected function setUp(): void

--- a/tests/Console/CacheCommandMutexTest.php
+++ b/tests/Console/CacheCommandMutexTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\CacheCommandMutex;
@@ -14,24 +12,24 @@ use PHPUnit\Framework\TestCase;
 class CacheCommandMutexTest extends TestCase
 {
     /**
-     * @var CacheCommandMutex
+     * @var \Illuminate\Console\CacheCommandMutex
      */
     protected $mutex;
 
     /**
-     * @var Command
+     * @var \Illuminate\Console\Command
      */
     protected $command;
 
     /**
-     * @var Factory
+     * @var \Illuminate\Contracts\Cache\Factory
      */
     protected $cacheFactory;
 
     /**
-     * @var Repository
+     * @var \Illuminate\Contracts\Cache\Repository
      */
-    protected Repository $cacheRepository;
+    protected $cacheRepository;
 
     protected function setUp(): void
     {

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -8,10 +8,8 @@ use Illuminate\Console\Command;
 use Illuminate\Console\CommandMutex;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Isolated;
-use Mockery\LegacyMockInterface;
-use Mockery\MockInterface;
-use PHPUnit\Framework\TestCase;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -32,6 +30,7 @@ class CommandMutexTest extends TestCase
         $this->command = new class extends Command implements Isolated
         {
             public bool $ran = false;
+
             public function __invoke()
             {
                 $this->ran = true;
@@ -59,7 +58,6 @@ class CommandMutexTest extends TestCase
     public function testCannotRunIsolatedCommandIfBlocked()
     {
         $this->commandMutex->shouldReceive('create')->andReturn(false);
-
 
         $input = new ArrayInput([]);
         $output = new NullOutput;

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Illuminate\Tests\Console;
 
 use Illuminate\Console\Command;
@@ -83,7 +81,6 @@ class CommandMutexTest extends TestCase
 
         $this->assertEquals(2, $this->command->ran);
     }
-
 
     protected function runCommand()
     {

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -82,9 +82,18 @@ class CommandMutexTest extends TestCase
         $this->assertEquals(2, $this->command->ran);
     }
 
-    protected function runCommand()
+    public function testCanRunCommandAgainNonAutomated()
     {
-        $input = new ArrayInput([]);
+        $this->commandMutex->shouldNotHaveBeenCalled();
+
+        $this->runCommand(false);
+
+        $this->assertEquals(1, $this->command->ran);
+    }
+
+    protected function runCommand($withIsolated = true)
+    {
+        $input = new ArrayInput(['--isolated' => $withIsolated]);
         $output = new NullOutput;
         $this->command->run($input, $output);
     }

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Console;
 use Illuminate\Console\Command;
 use Illuminate\Console\CommandMutex;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Console\Isolated;
+use Illuminate\Contracts\Console\Isolatable;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -25,7 +25,7 @@ class CommandMutexTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->command = new class extends Command implements Isolated
+        $this->command = new class extends Command implements Isolatable
         {
             public $ran = 0;
 
@@ -47,7 +47,7 @@ class CommandMutexTest extends TestCase
         $this->commandMutex->shouldReceive('create')
             ->andReturn(true)
             ->once();
-        $this->commandMutex->shouldReceive('release')
+        $this->commandMutex->shouldReceive('forget')
             ->andReturn(true)
             ->once();
 
@@ -72,7 +72,7 @@ class CommandMutexTest extends TestCase
         $this->commandMutex->shouldReceive('create')
             ->andReturn(true)
             ->twice();
-        $this->commandMutex->shouldReceive('release')
+        $this->commandMutex->shouldReceive('forget')
             ->andReturn(true)
             ->twice();
 

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -8,6 +8,8 @@ use Illuminate\Console\Command;
 use Illuminate\Console\CommandMutex;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Isolated;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Mockery as m;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -15,9 +17,15 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class CommandMutexTest extends TestCase
 {
-    protected Command $command;
+    /**
+     * @var Command
+     */
+    protected $command;
 
-    protected CommandMutex $commandMutex;
+    /**
+     * @var CommandMutex
+     */
+    protected $commandMutex;
 
     protected function setUp(): void
     {

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Tests\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\CommandMutex;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Console\Isolated;
+use PHPUnit\Framework\TestCase;
+use Mockery as m;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CommandMutexTest extends TestCase
+{
+    protected Command $command;
+
+    protected CommandMutex $commandMutex;
+
+    protected function setUp(): void
+    {
+        $this->command = new class extends Command implements Isolated
+        {
+            public bool $ran = false;
+            public function __invoke()
+            {
+                $this->ran = true;
+            }
+        };
+
+        $this->commandMutex = m::mock(CommandMutex::class);
+
+        $container = Container::getInstance();
+        $container->instance(CommandMutex::class, $this->commandMutex);
+        $this->command->setLaravel($container);
+    }
+
+    public function testCanRunIsolatedCommandIfNotBlocked()
+    {
+        $this->commandMutex->shouldReceive('create')->andReturn(true);
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput;
+        $this->command->run($input, $output);
+
+        $this->assertTrue($this->command->ran);
+    }
+
+    public function testCannotRunIsolatedCommandIfBlocked()
+    {
+        $this->commandMutex->shouldReceive('create')->andReturn(false);
+
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput;
+        $this->command->run($input, $output);
+
+        $this->assertFalse($this->command->ran);
+    }
+}

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Console\CommandMutex;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\Events\SchemaLoaded;
@@ -149,6 +150,11 @@ class ApplicationDatabaseMigrationStub extends Application
 {
     public function __construct(array $data = [])
     {
+        $mutex = m::mock(CommandMutex::class);
+        $mutex->shouldReceive('create')->andReturn(true);
+        $mutex->shouldReceive('release')->andReturn(true);
+        $this->instance(CommandMutex::class, $mutex);
+
         foreach ($data as $abstract => $instance) {
             $this->instance($abstract, $instance);
         }


### PR DESCRIPTION
This PR makes the `migrate` command isolated which limits the migration command to only have one process active at once. Meaning two servers cannot both run `migrate` at the same time.

## Problem
When deploying on multiple servers at once, it needs to be decided which of these servers have the responsibility for running migrations, however this means that all the deployments to all the servers are not identical, to simplify deployments.

For example when using k8s, you would use something like `initContainers` for running things like migrations. However as this will happen on each replica it could result in two servers running the same migration at the same time, as there is no locking so only one server will run one migration. 

Other people talking about this issue
- https://github.com/laravel/framework/discussions/41559
- https://github.com/laravel/ideas/issues/1645
- https://github.com/laravel/ideas/issues/1970

## Solution
Make migrate command isolated. This could in theory still result in the command running twice in the same deployment, however not at the same time, so it won't cause any issues, it will however result in queries to the database to check if migrations are missing where we already know there are none missing.

This solution works by adding the `Isolated` interface to a command which marks the command as an isolated command and it will now only run on one server. This implementation would allow to easily make other commands run in isolated when needed.

```php
class MyCommand extends Command implements Isolated
{
   ...
}
```


An alternative solution could be to instead make this a flag called `isolated` so the user can choose when running the command to run it isolated or not. This solution could be added as a parameter available for all commands by default.
