### PR TITLE
[9.x] Throw meaningful exception when broadcast connection not configured

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -245,6 +245,10 @@ class BroadcastManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
+        if (is_null($config)) {
+            throw new InvalidArgumentException("Broadcast connection [{$name}] is not defined.");
+        }
+
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
         }


### PR DESCRIPTION
Currently, when you configure your application to use a broadcasting driver that is not configured, it throws an exception because it's unable to read the `driver` key from `null`.

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/4411748/198047891-d1887c5b-516a-4c00-954e-f3d4de47704d.png">

Other managers, like the [CacheManager](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Cache/CacheManager.php#L97-L99) and [LogManager](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Log/LogManager.php#L206-L208), each check if the `$config` is null and throw a meaningful exception describing what is wrong. This PR adds the same logic to the BroadcastManager, so the resulting exception is:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/4411748/198048631-204e3fdd-985a-4683-bc4b-20161cb9b3af.png">
