### PR TITLE
[9.x] Add nonce for preloaded assets

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -447,6 +447,10 @@ class Vite implements Htmlable
             ? array_merge($attributes, ['integrity' => $chunk[$this->integrityKey] ?? false])
             : $attributes;
 
+        $attributes = ! is_null($this->nonce)
+            ? array_merge($attributes, ['nonce' => $this->nonce])
+            : $attributes;
+
         foreach ($this->preloadTagAttributesResolvers as $resolver) {
             $attributes = array_merge($attributes, $resolver($src, $url, $chunk, $manifest));
         }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -438,17 +438,15 @@ class Vite implements Htmlable
             'rel' => 'preload',
             'as' => 'style',
             'href' => $url,
+            'nonce' => $this->nonce ?? false,
         ] : [
             'rel' => 'modulepreload',
             'href' => $url,
+            'nonce' => $this->nonce ?? false,
         ];
 
         $attributes = $this->integrityKey !== false
             ? array_merge($attributes, ['integrity' => $chunk[$this->integrityKey] ?? false])
-            : $attributes;
-
-        $attributes = ! is_null($this->nonce)
-            ? array_merge($attributes, ['nonce' => $this->nonce])
             : $attributes;
 
         foreach ($this->preloadTagAttributesResolvers as $resolver) {


### PR DESCRIPTION
In https://github.com/laravel/framework/pull/44096 support for preloading is added. However, the preloaded assets don't have the nonce attribute set, which breaks certain CSP-policies (for example when using `strict-dynamic` for scripts). This PR adds the nonce (if set) for preloaded assets.
