### PR TITLE
[9.x] Prevents booting of providers when running `env:encrypt`

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -146,7 +146,7 @@ class Kernel implements KernelContract
         $this->commandStartedAt = Carbon::now();
 
         try {
-            if ($input->getFirstArgument() === 'env:decrypt') {
+            if (in_array($input->getFirstArgument(), ['env:encrypt', 'env:decrypt'], true)) {
                 $this->bootstrapWithoutBootingProviders();
             }
 
@@ -327,7 +327,7 @@ class Kernel implements KernelContract
      */
     public function call($command, array $parameters = [], $outputBuffer = null)
     {
-        if ($command === 'env:decrypt') {
+        if (in_array($command, ['env:encrypt', 'env:decrypt'], true)) {
             $this->bootstrapWithoutBootingProviders();
         }
 


### PR DESCRIPTION
This PR resolves https://github.com/laravel/telescope/issues/1262

When running `env:encrypt` with the `--env` option, the command is run as if in that environment and is booted using the associated environment file. 

For example, `php artisan env:encrypt --env=staging" runs the command using the environment variables from `.env.staging`.

This can cause an issue if a service provider relies on a resource which is only accessible in that environment.

In the case of the issue above, it was Telescope attempting to register the Redis watcher for a cluster only accessible in the staging envrionment. Trying to run the command locally results in an exception being thrown.

To resolve the issue, I've prevented providers from booting when running the `env:encrypt` using the same approach as #44654 
