### PR TITLE
[9.x] Adds `response()->ok()`

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -117,6 +117,18 @@ class ResponseFactory implements FactoryContract
     }
 
     /**
+     * Create a new "ok" response.
+     *
+     * @param  mixed  $content
+     * @param  array  $headers
+     * @return \Illuminate\Http\Response
+     */
+    public function ok(mixed $content = '', array $headers = [])
+    {
+        return $this->make($content, 200, $headers);
+    }
+
+    /**
      * Create a new streamed response instance.
      *
      * @param  \Closure  $callback

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -9,6 +9,42 @@ use Orchestra\Testbench\TestCase;
 
 class ResponseTest extends TestCase
 {
+    public function testResponseOk()
+    {
+        Route::get('/response', function () {
+            return response()->ok();
+        });
+
+        $this->get('/response')
+            ->assertOk()
+            ->assertContent('');
+    }
+
+    public function testResponseOkWithContent()
+    {
+        Route::get('/response', function () {
+            return response()->ok('Hello World');
+        });
+
+        $this->get('/response')
+            ->assertOk()
+            ->assertContent('Hello World');
+    }
+
+    public function testResponseOkWithHeaders()
+    {
+        Route::get('/response', function () {
+            return response()->ok('Hello World', [
+                'X-Example' => 'X-Value',
+            ]);
+        });
+
+        $this->get('/response')
+            ->assertOk()
+            ->assertContent('Hello World')
+            ->assertHeader('X-Example', 'X-Value');
+    }
+
     public function testResponseWithInvalidJsonThrowsException()
     {
         $this->expectException('InvalidArgumentException');


### PR DESCRIPTION
I've always found confusing the away of returning an **typed `Illuminate\Http\Response` instance** with empty 200 status code in Laravel. While I understand that `200` is the default status code, and there is a couple of ways of making this possible, none of the existing ways looks clear to me.

```php
return response('');
return response('', 200);
return response(status: 200); // This one is actually OKish...
```

This pull request introduces an `Response::ok()` method, that can be used in this very simple way:

```php
public function something(Request $request): Response
{
    // $request->user()

    return response()->ok();
}
```

Of course, this combines well with the `assertOk()` response test method, as the route can be tested as such:

```php
it('works', function () {
    $this->get('/something')->assertOk();
});
```