### PR TITLE
Make prevent lazy loading behave as expected

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -391,12 +391,9 @@ class Builder implements BuilderContract
     {
         $instance = $this->newModelInstance();
 
-        return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
+        return $instance->newCollection(array_map(function ($item) use ($instance) {
             $model = $instance->newFromBuilder($item);
-
-            if (count($items) > 1) {
-                $model->preventsLazyLoading = Model::preventsLazyLoading();
-            }
+            $model->preventsLazyLoading = Model::preventsLazyLoading();
 
             return $model;
         }, $items));

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2156,6 +2156,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
 
+    public function testLazyLoadingPrevention()
+    {
+
+        $builder = new Builder($this->getMockQueryBuilder());
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        Model::preventLazyLoading();
+        $instance = $builder->first();
+        $this->assertTrue($instance->preventsLazyLoading);
+
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2156,18 +2156,6 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
 
-    public function testLazyLoadingPrevention()
-    {
-
-        $builder = new Builder($this->getMockQueryBuilder());
-        $model = $this->getMockModel();
-        $builder->setModel($model);
-        Model::preventLazyLoading();
-        $instance = $builder->first();
-        $this->assertTrue($instance->preventsLazyLoading);
-
-    }
-
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2101,6 +2101,16 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('primary', $pivot->taxonomy);
     }
 
+    public function testLazyLoadingPreventionWorksAsExpectedForSingleModels()
+    {
+
+        Model::preventLazyLoading();
+        $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $this->assertFalse($user->preventsLazyLoading);
+        $user->refresh();
+        $this->assertTrue($user->preventsLazyLoading);
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
As stated in the doc https://laravel.com/docs/9.x/eloquent-relationships#preventing-lazy-loading

Model::preventLazyLoading() should prevent lazy loading.

A change introduced in https://github.com/laravel/framework/commit/f26816df096b873c5ec7220bc3aa7634e3e8c4fa changes that behavior and ejects the lazy-loading prevention when there is only one model queried.

While the current implentation will not lead to N+1 problem performance impact it still:

- is unexpected behavior by name
  -  " i explicitly forbid lazy loading. it should always throw an exception when attempted " 
- is unexpected behavior in regards of documented behavior
  - "After preventing lazy loading, Eloquent will throw a Illuminate\Database\LazyLoadingViolationException exception when your application attempts to lazy load **any** Eloquent relationship."
- to my knowledge might degrade performance since i.e. database connection must be re-established

the current implentation shouldn't be triggered via ::preventLazyLoading (if at all). If an option as currently implented should exist it should be triggerd by maybe a method ::migitateNPlusOneQueryIssuesByPreventingLAzyLoadingWhenThereIsMoreThanOnItemInTheQueryResult() ... or something like that... dunno... naming is hard :)