### PR TITLE
[9.x] Add ability to set middleware based on notifiable instance and channel

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -211,17 +211,21 @@ class NotificationSender
                     $delay = $notification->withDelay($notifiable, $channel) ?? null;
                 }
 
+                $middleware = $notification->middleware ?? [];
+
+                if (method_exists($notification, 'middleware')) {
+                    $middleware = array_merge(
+                        $middleware,
+                        $notification->middleware($notifiable, $channel)
+                    );
+                }
+
                 $this->bus->dispatch(
                     (new SendQueuedNotifications($notifiable, $notification, [$channel]))
                             ->onConnection($notification->connection)
                             ->onQueue($queue)
                             ->delay(is_array($delay) ? ($delay[$channel] ?? null) : $delay)
-                            ->through(
-                                array_merge(
-                                    method_exists($notification, 'middleware') ? $notification->middleware() : [],
-                                    $notification->middleware ?? []
-                                )
-                            )
+                            ->through($middleware)
                 );
             }
         }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -215,8 +215,8 @@ class NotificationSender
 
                 if (method_exists($notification, 'middleware')) {
                     $middleware = array_merge(
-                        $middleware,
-                        $notification->middleware($notifiable, $channel)
+                        $notification->middleware($notifiable, $channel),
+                        $middleware
                     );
                 }
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -61,6 +61,49 @@ class NotificationSenderTest extends TestCase
 
         $sender->sendNow($notifiable, new DummyNotificationWithDatabaseVia);
     }
+
+    public function testItCanSendQueuedNotificationsThroughMiddleware()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->withArgs(function ($job) {
+                return $job->middleware[0] instanceof TestNotificationMiddleware;
+            });
+        $events = m::mock(EventDispatcher::class);
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, new DummyNotificationWithMiddleware);
+    }
+
+    public function testItCanSendQueuedMultiChannelNotificationsThroughDifferentMiddleware()
+    {
+        $notifiable = m::mock(Notifiable::class);
+        $manager = m::mock(ChannelManager::class);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->middleware[0] instanceof TestMailNotificationMiddleware;
+            });
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return $job->middleware[0] instanceof TestDatabaseNotificationMiddleware;
+            });
+        $bus->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($job) {
+                return empty($job->middleware);
+            });
+        $events = m::mock(EventDispatcher::class);
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->send($notifiable, new DummyMultiChannelNotificationWithConditionalMiddlware);
+    }
 }
 
 class DummyQueuedNotificationWithStringVia extends Notification implements ShouldQueue
@@ -108,5 +151,69 @@ class DummyNotificationWithDatabaseVia extends Notification
     public function via($notifiable)
     {
         return 'database';
+    }
+}
+
+class DummyNotificationWithMiddleware extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return 'mail';
+    }
+
+    public function middleware()
+    {
+        return [
+            new TestNotificationMiddleware
+        ];
+    }
+}
+
+class DummyMultiChannelNotificationWithConditionalMiddlware extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return [
+            'mail',
+            'database',
+            'broadcast',
+        ];
+    }
+
+    public function middleware($notifiable, $channel)
+    {
+        return match ($channel) {
+            'mail' => [new TestMailNotificationMiddleware],
+            'database' => [new TestDatabaseNotificationMiddleware],
+            default => []
+        };       
+    }
+}
+
+class TestNotificationMiddleware
+{
+    public function handle($command, $next)
+    {
+        return $next($command);
+    }
+}
+
+class TestMailNotificationMiddleware
+{
+    public function handle($command, $next)
+    {
+        return $next($command);
+    }
+}
+
+class TestDatabaseNotificationMiddleware
+{
+    public function handle($command, $next)
+    {
+        return $next($command);
     }
 }

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -166,7 +166,7 @@ class DummyNotificationWithMiddleware extends Notification implements ShouldQueu
     public function middleware()
     {
         return [
-            new TestNotificationMiddleware
+            new TestNotificationMiddleware,
         ];
     }
 }
@@ -190,7 +190,7 @@ class DummyMultiChannelNotificationWithConditionalMiddlware extends Notification
             'mail' => [new TestMailNotificationMiddleware],
             'database' => [new TestDatabaseNotificationMiddleware],
             default => []
-        };       
+        };
     }
 }
 


### PR DESCRIPTION
### Discussed in https://github.com/laravel/framework/discussions/44766

I want to apply middleware to my queueable notifications, but only for specific channels and/or users. For example; no middleware for database notifications, but apply a rate limiter to email and sms notifications - unless the notifiable is an admin.

My suggestion is to pass `$notifiable` and `$channel` to the `middleware()` method on queuable notifications, similar to how [withDelay](https://github.com/laravel/framework/pull/42239) works.

Now I can change my middleware stack depending on the notifiable and channel of each job instance.

```php

class ImportantNotification extends Notification implements ShouldQueue
{
    use Queueable;

    public function via($notifiable)
    {
        return [
            'email',
            'database',
            'broadcast',
        ];
    }

    public function middleware($notifiable, $channel)
    {
        if ($notifiable instance of User && $notifiable->isAdmin()) {
            return [];
        }

        if ($channel == 'email') {
            return [new RateLimited('mailgun')];
        }

        return [];
    }

    ...
}
```

```php
Notification::send($users, new ImportantNotification);
```