### PR TITLE
Enforce lazyLoading Prevention to be strict via flag

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -391,12 +391,9 @@ class Builder implements BuilderContract
     {
         $instance = $this->newModelInstance();
 
-        return $instance->newCollection(array_map(function ($item) use ($items, $instance) {
+        return $instance->newCollection(array_map(function ($item) use ($instance) {
             $model = $instance->newFromBuilder($item);
-
-            if (count($items) > 1) {
-                $model->preventsLazyLoading = Model::preventsLazyLoading();
-            }
+            $model->preventsLazyLoading = Model::preventsLazyLoading();
 
             return $model;
         }, $items));

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -391,9 +391,16 @@ class Builder implements BuilderContract
     {
         $instance = $this->newModelInstance();
 
-        return $instance->newCollection(array_map(function ($item) use ($instance) {
+        return $instance->newCollection(array_map(function ($item) use ($instance, $items) {
             $model = $instance->newFromBuilder($item);
-            $model->preventsLazyLoading = Model::preventsLazyLoading();
+
+            if (count($items) > 1) {
+                $model->preventsLazyLoading = Model::preventsLazyLoading();
+            }
+
+            if (Model::preventsLazyLoadingStrict()) {
+                $model->preventsLazyLoading = Model::preventsLazyLoadingStrict();
+            }
 
             return $model;
         }, $items));

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -168,6 +168,15 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     protected static $modelsShouldPreventLazyLoading = false;
 
     /**
+     * Indicates whether lazy loading should be restricted on all models.
+     *
+     * Strict mode will allow no exceptions to that rule
+     *
+     * @var bool
+     */
+    protected static $modelsShouldPreventLazyLoadingStrict = false;
+
+    /**
      * The callback that is responsible for handling lazy loading violations.
      *
      * @var callable|null
@@ -404,9 +413,9 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  bool  $shouldBeStrict
      * @return void
      */
-    public static function shouldBeStrict(bool $shouldBeStrict = true)
+    public static function shouldBeStrict(bool $shouldBeStrict = true, bool $enforceStrictness = false) :void
     {
-        static::preventLazyLoading($shouldBeStrict);
+        static::preventLazyLoading(toggle: $shouldBeStrict, strict: $enforceStrictness);
         static::preventSilentlyDiscardingAttributes($shouldBeStrict);
         static::preventAccessingMissingAttributes($shouldBeStrict);
     }
@@ -414,12 +423,19 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     /**
      * Prevent model relationships from being lazy loaded.
      *
-     * @param  bool  $value
+     * @param  bool  $toggle
      * @return void
      */
-    public static function preventLazyLoading($value = true)
+    public static function preventLazyLoading(bool $toggle = true, bool $strict = false) :void
     {
-        static::$modelsShouldPreventLazyLoading = $value;
+        static::$modelsShouldPreventLazyLoading = $toggle;
+        if ($strict && $toggle) {
+            static::$modelsShouldPreventLazyLoadingStrict = $toggle;
+        }
+        if (!$toggle) {
+            static::$modelsShouldPreventLazyLoadingStrict = $toggle;
+        }
+
     }
 
     /**
@@ -2165,6 +2181,16 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function preventsLazyLoading()
     {
         return static::$modelsShouldPreventLazyLoading;
+    }
+
+    /**
+     * Determine if lazy loading is strict disabled.
+     *
+     * @return bool
+     */
+    public static function preventsLazyLoadingStrict()
+    {
+        return static::$modelsShouldPreventLazyLoadingStrict;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2156,6 +2156,18 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
 
+    public function testLazyLoadingPrevention()
+    {
+
+        $builder = new Builder($this->getMockQueryBuilder());
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        Model::preventLazyLoading();
+        $instance = $builder->first();
+        $this->assertTrue($instance->preventsLazyLoading);
+
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2156,18 +2156,6 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
 
-    public function testLazyLoadingPrevention()
-    {
-
-        $builder = new Builder($this->getMockQueryBuilder());
-        $model = $this->getMockModel();
-        $builder->setModel($model);
-        Model::preventLazyLoading();
-        $instance = $builder->first();
-        $this->assertTrue($instance->preventsLazyLoading);
-
-    }
-
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2101,6 +2101,16 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('primary', $pivot->taxonomy);
     }
 
+    public function testLazyLoadingPreventionWorksAsExpectedForSingleModels()
+    {
+
+        Model::preventLazyLoading();
+        $user = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $this->assertFalse($user->preventsLazyLoading);
+        $user->refresh();
+        $this->assertTrue($user->preventsLazyLoading);
+    }
+
     /**
      * Helpers...
      */

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
@@ -2109,6 +2110,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertFalse($user->preventsLazyLoading);
         $user->refresh();
         $this->assertTrue($user->preventsLazyLoading);
+
+        // revert ll prevention for other tests
+        Model::preventLazyLoading(false);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2585,6 +2585,59 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($user->getOriginal('name'));
         $this->assertNull($user->getAttribute('name'));
     }
+
+
+
+    public function lazyLoadingPreventionToggleDataProvider() :array
+    {
+        return [
+            'disabled' => [
+                'toggle' => false,
+                'strict' => false,
+                'preventsLazy' => false,
+                'preventsLazyStrict' => false
+            ],
+            'enabled soft mode' => [
+                'toggle' => true,
+                'strict' => false,
+                'preventsLazy' => true,
+                'preventsLazyStrict' => false
+            ],
+            'enabled strict mode' => [
+                'toggle' => true,
+                'strict' => true,
+                'preventsLazy' => true,
+                'preventsLazyStrict' => true
+            ]
+        ];
+    }
+
+    /** @dataProvider lazyLoadingPreventionToggleDataProvider */
+    public function testLazyLoadiingPreventionToggles(bool $toggle, bool $strict, bool $preventsLazy, bool $preventsStrict) :void
+    {
+
+        Model::preventLazyLoading(false);
+        self::assertFalse(Model::preventsLazyLoading());
+        self::assertFalse(Model::preventsLazyLoadingStrict());
+
+        Model::preventLazyLoading(toggle: $toggle, strict: $strict);
+
+        self::assertEquals($preventsLazy, Model::preventsLazyLoading());
+        self::assertEquals($preventsStrict, Model::preventsLazyLoadingStrict());
+
+        Model::preventLazyLoading(false);
+        self::assertFalse(Model::preventsLazyLoading());
+        self::assertFalse(Model::preventsLazyLoadingStrict());
+
+        Model::shouldBeStrict(shouldBeStrict: $toggle, enforceStrictness: $strict);
+
+        self::assertEquals($preventsLazy, Model::preventsLazyLoading());
+        self::assertEquals($preventsStrict, Model::preventsLazyLoadingStrict());
+
+        // revert ll prevention for other tests
+        Model::preventLazyLoading(false);
+
+    }
 }
 
 class EloquentTestObserverStub

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2613,7 +2613,7 @@ class DatabaseEloquentModelTest extends TestCase
     }
 
     /** @dataProvider lazyLoadingPreventionToggleDataProvider */
-    public function testLazyLoadiingPreventionToggles(bool $toggle, bool $strict, bool $preventsLazy, bool $preventsStrict) :void
+    public function testLazyLoadingPreventionToggles(bool $toggle, bool $strict, bool $preventsLazy, bool $preventsStrict) :void
     {
 
         Model::preventLazyLoading(false);
@@ -2636,6 +2636,8 @@ class DatabaseEloquentModelTest extends TestCase
 
         // revert ll prevention for other tests
         Model::preventLazyLoading(false);
+        // revert strictness for other tests
+        Model::shouldBeStrict(false);
 
     }
 }


### PR DESCRIPTION
As stated in the doc https://laravel.com/docs/9.x/eloquent-relationships#preventing-lazy-loading

Model::preventLazyLoading() should prevent lazy loading.

A change introduced in https://github.com/laravel/framework/commit/f26816df096b873c5ec7220bc3aa7634e3e8c4fa changes that behavior and ejects the lazy-loading prevention when there is only one model queried.

This current behavior should not be altered thus in this PR a second parameter is introduced to 

Model::preventLazyLoading()
and
Model::shouldBeStrict()

to indicate that lazyLoadingPrevention will be enforced.

(imho the expected behavior and more matching to the documentation of those methods)
