### PR TITLE
[9.x] Accept body in getJson() method of MakesHttpRequests.php

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -317,11 +317,12 @@ trait MakesHttpRequests
      *
      * @param  string  $uri
      * @param  array  $headers
+     * @param  array  $body
      * @return \Illuminate\Testing\TestResponse
      */
-    public function getJson($uri, array $headers = [])
+    public function getJson($uri, array $headers = [], array $body = [])
     {
-        return $this->json('GET', $uri, [], $headers);
+        return $this->json('GET', $uri, $body, $headers);
     }
 
     /**


### PR DESCRIPTION
The getJson() method of  MakesHttpRequests.php doesn't accept a body. That method is widely used when doing tests for api routes. It is interesting to accept a body although being a get method especially for API calls which get a list of resources but filtered with multiple filters, which you can pass them through the body when the filter information is too big to include it in the url.