### PR TITLE
[9.x] Added generic typing to EnumeratesValues::flatMap method.

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -680,8 +680,11 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Map a collection and flatten the result by a single level.
      *
-     * @param  callable(TValue, TKey): mixed  $callback
-     * @return static<int, mixed>
+     * @template TFlatMapKey of array-key
+     * @template TFlatMapValue
+     *
+     * @param  callable(TValue, TKey): (\Illuminate\Support\Collection<TFlatMapKey, TFlatMapValue>|array<TFlatMapKey, TFlatMapValue>)  $callback
+     * @return static<TFlatMapKey, TFlatMapValue>
      */
     public function flatMap(callable $callback);
 

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -384,8 +384,11 @@ trait EnumeratesValues
     /**
      * Map a collection and flatten the result by a single level.
      *
-     * @param  callable(TValue, TKey): mixed  $callback
-     * @return static<int, mixed>
+     * @template TFlatMapKey of array-key
+     * @template TFlatMapValue
+     *
+     * @param  callable(TValue, TKey): (\Illuminate\Support\Collection<TFlatMapKey, TFlatMapValue>|array<TFlatMapKey, TFlatMapValue>)  $callback
+     * @return static<TFlatMapKey, TFlatMapValue>
      */
     public function flatMap(callable $callback)
     {

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -584,12 +584,12 @@ assertType('Illuminate\Support\Collection<string, int>', $collection::make(['str
         return ['string' => 1];
     }));
 
-assertType('Illuminate\Support\Collection<int, mixed>', $collection::make(['string'])
+assertType('Illuminate\Support\Collection<int, string>', $collection::make(['string'])
     ->flatMap(function ($string, $int) {
         assertType('string', $string);
         assertType('int', $int);
 
-        return 1;
+        return [0 => 'string'];
     }));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->mapInto(User::class));

--- a/types/Support/LazyCollection.php
+++ b/types/Support/LazyCollection.php
@@ -480,12 +480,12 @@ assertType('Illuminate\Support\LazyCollection<string, int>', $collection::make([
         return ['string' => 1];
     }));
 
-assertType('Illuminate\Support\LazyCollection<int, mixed>', $collection::make(['string'])
+assertType('Illuminate\Support\LazyCollection<int, string>', $collection::make(['string'])
     ->flatMap(function ($string, $int) {
         assertType('string', $string);
         assertType('int', $int);
 
-        return 1;
+        return [0 => 'string'];
     }));
 
 assertType('Illuminate\Support\LazyCollection<int, User>', $collection->mapInto(User::class));


### PR DESCRIPTION
Improves the generic typing of `EnumeratesValues` by providing them for the `flatMap()` method.

Using `flatMap` right now causes all type information to be lost, and explicitly states there will only be integer keys, when `collapse()` can produce both `string` and `int` keys thanks to it's use of `array_merge()`.

ref: https://github.com/nunomaduro/larastan/discussions/1427
