### PR TITLE
[9.x] Allow queueable notifications to set `maxExceptions`

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -51,6 +51,13 @@ class SendQueuedNotifications implements ShouldQueue
     public $timeout;
 
     /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions;
+
+    /**
      * Indicates if the job should be encrypted.
      *
      * @var bool
@@ -72,6 +79,7 @@ class SendQueuedNotifications implements ShouldQueue
         $this->notifiables = $this->wrapNotifiables($notifiables);
         $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
         $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;
+        $this->maxExceptions = property_exists($notification, 'maxExceptions') ? $notification->maxExceptions : null;
         $this->afterCommit = property_exists($notification, 'afterCommit') ? $notification->afterCommit : null;
         $this->shouldBeEncrypted = $notification instanceof ShouldBeEncrypted;
     }

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -52,6 +52,18 @@ class NotificationSendQueuedNotificationTest extends TestCase
 
         $this->assertStringContainsString($serializedNotifiable, $serialized);
     }
+
+    public function testNotificationCanSetMaxExceptions()
+    {
+        $notifiable = new NotifiableUser;
+        $notification = new class {
+            public $maxExceptions = 23;
+        };
+
+        $job = new SendQueuedNotifications($notifiable, $notification);
+
+        $this->assertEquals(23, $job->maxExceptions);
+    }
 }
 
 class NotifiableUser extends Model


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adds the ability for queued notifications to utilize [maxExceptions](https://laravel.com/docs/9.x/queues#max-exceptions). 

Particularly useful for notifications that might have a lot of `$tries` or a long `retryUntil()` because of rate limiting or some custom middleware, but don't want to keep retrying if there's some bug or an error from a third party notification channel service.