### PR TITLE
[9.x] Adds template fragments to Blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -21,6 +21,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesConditionals,
         Concerns\CompilesEchos,
         Concerns\CompilesErrors,
+        Concerns\CompilesFragments,
         Concerns\CompilesHelpers,
         Concerns\CompilesIncludes,
         Concerns\CompilesInjections,

--- a/src/Illuminate/View/Compilers/Concerns/CompilesFragments.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesFragments.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesFragments
+{
+    /**
+     * Compile the fragment statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileFragment($expression)
+    {
+        $this->lastFragment = trim($expression, "()'\" ");
+
+        return "<?php \$__env->startFragment{$expression}; ?>";
+    }
+
+    /**
+     * Compile the end-fragment statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndfragment()
+    {
+        return '<?php echo $__env->stopFragment(); ?>';
+    }
+}

--- a/src/Illuminate/View/Concerns/ManagesFragments.php
+++ b/src/Illuminate/View/Concerns/ManagesFragments.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\View\Concerns;
+
+use InvalidArgumentException;
+
+trait ManagesFragments
+{
+    /**
+     * All of the finished, captured fragments.
+     *
+     * @var array
+     */
+    protected $fragments = [];
+
+    /**
+     * The stack of in-progress fragments.
+     *
+     * @var array
+     */
+    protected $fragmentStack = [];
+
+    /**
+     * Start injecting content into a fragment.
+     *
+     * @param  string  $fragment
+     * @return void
+     */
+    public function startFragment($fragment)
+    {
+        if (ob_start()) {
+            $this->fragmentStack[] = $fragment;
+        }
+    }
+
+    /**
+     * Stop injecting content into a fragment.
+     *
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function stopFragment()
+    {
+        if (empty($this->fragmentStack)) {
+            throw new InvalidArgumentException('Cannot end a fragment without first starting one.');
+        }
+
+        $last = array_pop($this->fragmentStack);
+
+        $this->fragments[$last] = ob_get_clean();
+
+        return $this->fragments[$last];
+    }
+
+    /**
+     * Get the contents of a fragment.
+     *
+     * @param  string  $name
+     * @param  string|null  $default
+     * @return mixed
+     */
+    public function getFragment($name, $default = null)
+    {
+        return $this->getFragments()[$name] ?? $default;
+    }
+
+    /**
+     * Get the entire array of fragments.
+     *
+     * @return array
+     */
+    public function getFragments()
+    {
+        return $this->fragments;
+    }
+
+    /**
+     * Flush all of the fragments.
+     *
+     * @return void
+     */
+    public function flushFragments()
+    {
+        $this->fragments = [];
+        $this->fragmentStack = [];
+    }
+}

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -16,6 +16,7 @@ class Factory implements FactoryContract
     use Macroable,
         Concerns\ManagesComponents,
         Concerns\ManagesEvents,
+        Concerns\ManagesFragments,
         Concerns\ManagesLayouts,
         Concerns\ManagesLoops,
         Concerns\ManagesStacks,
@@ -481,6 +482,7 @@ class Factory implements FactoryContract
         $this->flushSections();
         $this->flushStacks();
         $this->flushComponents();
+        $this->flushFragments();
     }
 
     /**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -130,6 +130,19 @@ class View implements ArrayAccess, Htmlable, ViewContract
     }
 
     /**
+     * Get the evaluated contents of the fragment.
+     *
+     * @param string $fragment
+     * @return string
+     */
+    public function fragment(string $fragment)
+    {
+        return $this->render(function () use ($fragment) {
+            return $this->factory->getFragment($fragment);
+        });
+    }
+
+    /**
      * Get the evaluated contents of the view.
      *
      * @return string

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -132,10 +132,10 @@ class View implements ArrayAccess, Htmlable, ViewContract
     /**
      * Get the evaluated contents of the fragment.
      *
-     * @param string $fragment
+     * @param  string  $fragment
      * @return string
      */
-    public function fragment(string $fragment)
+    public function fragment($fragment)
     {
         return $this->render(function () use ($fragment) {
             return $this->factory->getFragment($fragment);

--- a/tests/View/Blade/BladeFragmentTest.php
+++ b/tests/View/Blade/BladeFragmentTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeFragmentTest extends AbstractBladeTestCase
+{
+    public function testFragmentStartsAreCompiled()
+    {
+        $this->assertSame('<?php $__env->startFragment(\'foo\'); ?>', $this->compiler->compileString('@fragment(\'foo\')'));
+        $this->assertSame('<?php $__env->startFragment(name(foo)); ?>', $this->compiler->compileString('@fragment(name(foo))'));
+    }
+
+    public function testEndFragmentsAreCompiled()
+    {
+        $this->assertSame('<?php echo $__env->stopFragment(); ?>', $this->compiler->compileString('@endfragment'));
+    }
+}

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -543,7 +543,7 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
         $factory->startFragment('foo');
         echo 'hi';
-        $this->assertSame('hi',  $factory->stopFragment());
+        $this->assertSame('hi', $factory->stopFragment());
     }
 
     public function testBasicSectionHandling()

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -538,6 +538,14 @@ class ViewFactoryTest extends TestCase
         $this->assertSame('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo', $view));
     }
 
+    public function testBasicFragmentHandling()
+    {
+        $factory = $this->getFactory();
+        $factory->startFragment('foo');
+        echo 'hi';
+        $this->assertSame('hi',  $factory->stopFragment());
+    }
+
     public function testBasicSectionHandling()
     {
         $factory = $this->getFactory();


### PR DESCRIPTION
Hello everyone! This PR adds fragments to Blade, suggested in #44468.


Working with frontend frameworks that use the html over-the-wire concept such as Turbo, Unpoly, Htmx or Pjax, sometimes when handling a request we have to return  **just a fragment of a view** to replace a portion of the DOM.

- [HTMX Fragments](https://htmx.org/essays/template-fragments/)
- [Unpoly Fragments](https://unpoly.com/up.link)
- [Turbo Frames](https://turbo.hotwired.dev/handbook/frames/)


Adding this feature will allow developers to return said fragment from a controller **without having to create a component** and split the view in several files.


As mentioned in the original discussion there are several implementations of this feature in other backend template engines, [here's a detailed list](https://htmx.org/essays/template-fragments/).

Although this can be extracted to a package I think it would be a nice addition to the framework.


## Usage
```PHP
// UserController.php

public function updateStatus() 
{
    // Business logic

    // This will only return the content inside the fragment named actions.
    return view('users.profile', $data)->fragment('actions');
}

```

```HTML
<!-- resources/views/users/profile.blade.php -->

<!-- Example using HTMX.js -->

<div>
    First Name {{ $firstName }}
    Last Name: {{ $lastName }}

    @fragment('actions')
        <div hx-target="this">
            @if($enabled)
                <button hx-patch="/mark-as-disabled">Mark as Disabled</button>
            @else
                <button hx-patch="/mark-as-enabled">Mark as Enabled</button>
            @endif
        </div>
    @endfragment
</div>
```
