### PR TITLE
[9.x] Fix argument name of `Enumerable::countBy`

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1168,7 +1168,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  (callable(TValue, TKey): mixed)|string|null  $countBy
      * @return static<array-key, int>
      */
-    public function countBy($callback = null);
+    public function countBy($countBy = null);
 
     /**
      * Zip the collection together with one or more arrays.


### PR DESCRIPTION
I think that `Enumerable::countBy()` argument is `$countBy`, not `$callback`.

`Collection::countBy()`
https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/Collection.php#L1626-L1635

`LazyCollection::countBy()`
https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/LazyCollection.php#L266-L293

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
