### PR TITLE
[9.x] Add method to remove a middleware from a group

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1000,6 +1000,30 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * @param  string $group
+     * @param  string $middleware
+     * @return $this
+     */
+    public function removeMiddlewareFromGroup($group, $middleware)
+    {
+        if (! $this->hasMiddlewareGroup($group)) {
+            return $this;
+        }
+
+        $reversedMiddlewaresArray = array_flip($this->middlewareGroups[$group]);
+
+        if (! array_key_exists($middleware, $reversedMiddlewaresArray)) {
+            return $this;
+        }
+
+        $middlewareKey = $reversedMiddlewaresArray[$middleware];
+
+        unset($this->middlewareGroups[$group][$middlewareKey]);
+
+        return $this;
+    }
+
+    /**
      * Flush the router's middleware groups.
      *
      * @return $this

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1000,6 +1000,8 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Remove the given middleware from the specified group.
+     *
      * @param  string  $group
      * @param  string  $middleware
      * @return $this

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1000,8 +1000,8 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * @param  string $group
-     * @param  string $middleware
+     * @param  string  $group
+     * @param  string  $middleware
      * @return $this
      */
     public function removeMiddlewareFromGroup($group, $middleware)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1020,6 +1020,33 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('users.index', $this->getRoute()->getName());
     }
 
+    public function testCanRemoveMiddlewareFromGroup()
+    {
+        $this->router->pushMiddlewareToGroup('web', 'test-middleware');
+
+        $this->assertEquals(['test-middleware'], $this->router->getMiddlewareGroups()['web']);
+
+        $this->router->removeMiddlewareFromGroup('web', 'test-middleware');
+
+        $this->assertEquals([], $this->router->getMiddlewareGroups()['web']);
+    }
+
+    public function testCanRemoveMiddlewareFromGroupNotRegisteredMiddleware()
+    {
+        $this->router->middlewareGroup('web', []);
+
+        $this->router->removeMiddlewareFromGroup('web', 'different-test-middleware');
+
+        $this->assertEquals([], $this->router->getMiddlewareGroups()['web']);
+    }
+
+    public function testCanRemoveMiddlewareFromGroupNotRegisteredGroup()
+    {
+        $this->router->removeMiddlewareFromGroup('web', ['test-middleware']);
+
+        $this->assertEquals([], $this->router->getMiddlewareGroups());
+    }
+
     /**
      * Get the last route registered with the router.
      *

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1020,11 +1020,32 @@ class RouteRegistrarTest extends TestCase
         $this->assertSame('users.index', $this->getRoute()->getName());
     }
 
-    public function testCanRemoveMiddlewareFromGroup()
+    public function testPushMiddlewareToGroup()
+    {
+        $this->router->middlewareGroup('web', []);
+        $this->router->pushMiddlewareToGroup('web', 'test-middleware');
+
+        $this->assertEquals(['test-middleware'], $this->router->getMiddlewareGroups()['web']);
+    }
+
+    public function testPushMiddlewareToGroupUnregisteredGroup()
     {
         $this->router->pushMiddlewareToGroup('web', 'test-middleware');
 
         $this->assertEquals(['test-middleware'], $this->router->getMiddlewareGroups()['web']);
+    }
+
+    public function testPushMiddlewareToGroupDuplicatedMiddleware()
+    {
+        $this->router->pushMiddlewareToGroup('web', 'test-middleware');
+        $this->router->pushMiddlewareToGroup('web', 'test-middleware');
+
+        $this->assertEquals(['test-middleware'], $this->router->getMiddlewareGroups()['web']);
+    }
+
+    public function testCanRemoveMiddlewareFromGroup()
+    {
+        $this->router->pushMiddlewareToGroup('web', 'test-middleware');
 
         $this->router->removeMiddlewareFromGroup('web', 'test-middleware');
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -1052,7 +1052,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals([], $this->router->getMiddlewareGroups()['web']);
     }
 
-    public function testCanRemoveMiddlewareFromGroupNotRegisteredMiddleware()
+    public function testCanRemoveMiddlewareFromGroupNotUnregisteredMiddleware()
     {
         $this->router->middlewareGroup('web', []);
 
@@ -1061,7 +1061,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals([], $this->router->getMiddlewareGroups()['web']);
     }
 
-    public function testCanRemoveMiddlewareFromGroupNotRegisteredGroup()
+    public function testCanRemoveMiddlewareFromGroupUnregisteredGroup()
     {
         $this->router->removeMiddlewareFromGroup('web', ['test-middleware']);
 


### PR DESCRIPTION
On Magic Test, I need to [dynamically register a middleware](https://github.com/magic-test/magic-test-laravel/blob/master/src/MagicTestServiceProvider.php:29) and in some situations that middleware needs to also be removed.   

The current way is rebinding the middleware in the container to an implementation that doesn't really do anything. I think having the ability to remove it from a group is a cleaner way to do it, and since you can already rebind dependencies on the container I don't think it'd be a problem.

P.S: this PR also includes some tests for `pushMiddlewareToGroup`, in case it isn't accepted I can send it on a separate PR.
Also: I wasn't sure if I should use types or not on this PR since it is aimed at v9, but I can add them if necessary. 👍 