### PR TITLE
[9.x] Fix `whenPivotLoaded(As)` api resource methods when using Eloquent strict mode

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -291,7 +291,7 @@ trait ConditionallyLoadsAttributes
         }
 
         return $this->when(
-            $this->resource->$accessor &&
+            isset($this->resource->$accessor) &&
             ($this->resource->$accessor instanceof $table ||
             $this->resource->$accessor->getTable() === $table),
             ...[$value, $default]

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -450,7 +450,10 @@ class ResourceTest extends TestCase
 
         Route::get('/', function () {
             $post = new Post(['id' => 5]);
-            (function () { $this->exists = true; $this->wasRecentlyCreated = false; })->bindTo($post)();
+            (function () {
+                $this->exists = true;
+                $this->wasRecentlyCreated = false;
+            })->bindTo($post)();
 
             return new PostResourceWithOptionalPivotRelationship($post);
         });

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
 use Illuminate\Http\Exceptions\PostTooLargeException;
 use Illuminate\Http\Request;
@@ -439,6 +440,30 @@ class ResourceTest extends TestCase
                 'subscription' => [
                     'foo' => 'bar',
                 ],
+            ],
+        ]);
+    }
+
+    public function testResourceDoesNotThrowErrorWhenUsingEloquentStrictModeAndCheckingOptionalPivotRelationship()
+    {
+        Model::shouldBeStrict(true);
+
+        Route::get('/', function () {
+            $post = new Post(['id' => 5]);
+            (function () { $this->exists = true; $this->wasRecentlyCreated = false; })->bindTo($post)();
+
+            return new PostResourceWithOptionalPivotRelationship($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'id' => 5,
             ],
         ]);
     }


### PR DESCRIPTION
When the "Prevent accessing missing attributes on retrieved models" feature of Eloquent strict mode is enabled, the code `$this->resource->$accessor` will cause an unwanted exception. Using `isset` method fixes this.
