### PR TITLE
[9.x] Add source file to Collection's dd method output

### DIFF
--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -56,12 +56,17 @@ trait ResolvesDumpSource
         $sourceKey = null;
 
         foreach ($trace as $traceKey => $traceFile) {
-            if (isset($traceFile['file']) && str_ends_with(
-                $traceFile['file'],
-                'dump.php'
-            )) {
-                $sourceKey = $traceKey + 1;
+            if (! isset($traceFile['file'])) {
+                continue;
+            }
 
+            if (str_ends_with($traceFile['file'], 'dump.php')) {
+                $sourceKey = $traceKey + 1;
+                break;
+            }
+
+            if (str_ends_with($traceFile['file'], 'EnumeratesValues.php')) {
+                $sourceKey = $traceKey + 4;
                 break;
             }
         }

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -30,6 +30,16 @@ trait ResolvesDumpSource
     ];
 
     /**
+     * All of the trace names and its keys..
+     *
+     * @var array<string, int>
+     */
+    protected static $traceNames = [
+        'dump.php' => 1,
+        'EnumeratesValues.php' => 4,
+    ];
+
+    /**
      * The source resolver.
      *
      * @var (callable(): (array{0: string, 1: string, 2: int|null}|null))|null|false
@@ -60,13 +70,14 @@ trait ResolvesDumpSource
                 continue;
             }
 
-            if (str_ends_with($traceFile['file'], 'dump.php')) {
-                $sourceKey = $traceKey + 1;
-                break;
+            foreach($this->traceNames as $name => $key) {
+                if (str_ends_with($traceFile['file'], $name)) {
+                    $sourceKey = $traceKey + $key;
+                    break;
+                }
             }
 
-            if (str_ends_with($traceFile['file'], 'EnumeratesValues.php')) {
-                $sourceKey = $traceKey + 4;
+            if (! is_null($sourceKey)) {
                 break;
             }
         }

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -35,8 +35,8 @@ trait ResolvesDumpSource
      * @var array<string, int>
      */
     protected static $traceNames = [
-        'dump.php' => 1,
-        'EnumeratesValues.php' => 4,
+        'symfony/var-dumper/Resources/functions/dump.php' => 1,
+        'Illuminate/Collection/Traits/EnumeratesValues.php' => 4,
     ];
 
     /**
@@ -70,8 +70,11 @@ trait ResolvesDumpSource
                 continue;
             }
 
-            foreach ($this->traceNames as $name => $key) {
-                if (str_ends_with($traceFile['file'], $name)) {
+            foreach (self::$traceNames as $name => $key) {
+                if (str_ends_with(
+                    $traceFile['file'],
+                    str_replace('/', DIRECTORY_SEPARATOR, $name)
+                )) {
                     $sourceKey = $traceKey + $key;
                     break;
                 }

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -30,7 +30,7 @@ trait ResolvesDumpSource
     ];
 
     /**
-     * All of the trace names and its keys..
+     * All of the trace names and its keys.
      *
      * @var array<string, int>
      */
@@ -70,7 +70,7 @@ trait ResolvesDumpSource
                 continue;
             }
 
-            foreach($this->traceNames as $name => $key) {
+            foreach ($this->traceNames as $name => $key) {
                 if (str_ends_with($traceFile['file'], $name)) {
                     $sourceKey = $traceKey + $key;
                     break;

--- a/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
+++ b/src/Illuminate/Foundation/Concerns/ResolvesDumpSource.php
@@ -36,7 +36,7 @@ trait ResolvesDumpSource
      */
     protected static $traceNames = [
         'symfony/var-dumper/Resources/functions/dump.php' => 1,
-        'Illuminate/Collection/Traits/EnumeratesValues.php' => 4,
+        'Illuminate/Collections/Traits/EnumeratesValues.php' => 4,
     ];
 
     /**


### PR DESCRIPTION
This pull request further extends #44211 by @nunomaduro to work on `Collection` by adding the source file/line to the `dd` output of the `Collection` class method.

After using the improved `dd`, I found it odd that `Collection` class `dd` method did not give the same output as the current improved `dd` function. The workaround was to wrap the collection variable with `dd` instead of using the built in `dd` method of `Collection` class.