### PR TITLE
[9.x] Allow component DI through `render()`

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -76,11 +76,11 @@ abstract class Component
     protected static $constructorParametersCache = [];
 
     /**
-     * Get the view / view contents that represent the component.
+     * Toggle to resolve the via the constructor or the render method.
      *
-     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
+     * @var bool
      */
-    abstract public function render();
+    protected static $shouldResolveConstructor = true;
 
     /**
      * Resolve the component instance with the given data.
@@ -98,7 +98,7 @@ abstract class Component
 
         $dataKeys = array_keys($data);
 
-        if (empty(array_diff($parameters, $dataKeys))) {
+        if (! static::$shouldResolveConstructor || empty(array_diff($parameters, $dataKeys))) {
             return new static(...array_intersect_key($data, array_flip($parameters)));
         }
 
@@ -132,7 +132,7 @@ abstract class Component
      */
     public function resolveView()
     {
-        $view = $this->render();
+        $view = ! static::$shouldResolveConstructor ? app()->call([$this, 'render']) : $this->render();
 
         if ($view instanceof ViewContract) {
             return $view;

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -76,11 +76,11 @@ abstract class Component
     protected static $constructorParametersCache = [];
 
     /**
-     * Toggle to resolve the via the constructor or the render method.
+     * Indicates whether dependency injection should happen on the constructor or the render method.
      *
      * @var bool
      */
-    protected static $shouldResolveConstructor = true;
+    protected static $componentShouldResolveConstructor = true;
 
     /**
      * Resolve the component instance with the given data.
@@ -98,7 +98,7 @@ abstract class Component
 
         $dataKeys = array_keys($data);
 
-        if (! static::$shouldResolveConstructor || empty(array_diff($parameters, $dataKeys))) {
+        if (! static::$componentShouldResolveConstructor || empty(array_diff($parameters, $dataKeys))) {
             return new static(...array_intersect_key($data, array_flip($parameters)));
         }
 
@@ -132,7 +132,7 @@ abstract class Component
      */
     public function resolveView()
     {
-        $view = ! static::$shouldResolveConstructor ? app()->call([$this, 'render']) : $this->render();
+        $view = ! static::$componentShouldResolveConstructor ? app()->call([$this, 'render']) : $this->render();
 
         if ($view instanceof ViewContract) {
             return $view;
@@ -454,5 +454,16 @@ abstract class Component
     public static function resolveComponentsUsing($resolver)
     {
         static::$componentsResolver = $resolver;
+    }
+
+    /**
+     * Set whether dependencies should be resolved via the constructor or the render method.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function resolveConstructorDependencies($value = true)
+    {
+        static::$componentShouldResolveConstructor = $value;
     }
 }

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -143,6 +143,25 @@ class ComponentTest extends TestCase
         $this->assertSame('foo', $component->render());
     }
 
+    public function testResolveDependenciesWithContainerViaRenderMethod()
+    {
+        $this->viewFactory->shouldReceive('exists')->once()->andReturn(true);
+
+        $component = TestRenderResolvedViewComponent::resolve([]);
+        $component->resolveView();
+
+        $this->assertNull($component->dependency);
+        $this->assertSame($this->viewFactory, $component->renderDependency);
+        $this->assertNull($component->content);
+
+        $component = TestRenderResolvedViewComponent::resolve(['content' => 'foo']);
+        $component->resolveView();
+
+        $this->assertNull($component->dependency);
+        $this->assertSame($this->viewFactory, $component->renderDependency);
+        $this->assertSame('foo', $component->content);
+    }
+
     public function testResolveComponentsUsing()
     {
         $component = new TestInlineViewComponent;
@@ -396,5 +415,29 @@ class TestHtmlableReturningViewComponent extends Component
     public function render()
     {
         return new HtmlString("<p>Hello {$this->title}</p>");
+    }
+}
+
+class TestRenderResolvedViewComponent extends Component
+{
+    static $shouldResolveConstructor = false;
+
+    public $dependency;
+
+    public $renderDependency;
+
+    public $content;
+
+    public function __construct(FactoryContract $dependency = null, $content = null)
+    {
+        $this->dependency = $dependency;
+        $this->content = $content;
+    }
+
+    public function render(FactoryContract $renderDependency)
+    {
+        $this->renderDependency = $renderDependency;
+
+        return '';
     }
 }

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -420,7 +420,7 @@ class TestHtmlableReturningViewComponent extends Component
 
 class TestRenderResolvedViewComponent extends Component
 {
-    static $shouldResolveConstructor = false;
+    public static $shouldResolveConstructor = false;
 
     public $dependency;
 

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -420,7 +420,7 @@ class TestHtmlableReturningViewComponent extends Component
 
 class TestRenderResolvedViewComponent extends Component
 {
-    public static $shouldResolveConstructor = false;
+    public static $componentShouldResolveConstructor = false;
 
     public $dependency;
 


### PR DESCRIPTION
Currently the component will try to resolve dependencies that are passed via the constructor, which is not always ideal. This change allows you to specify on your component that you would like dependencies resolved on the `render()` method instead of the constructor.

For example, let's say you have a `UserCard` component that has simple output for anonymous users, and a fancy output for registered ones.

```php
class UserCard extends Component
{
    public function __construct(
        protected User|null $user = null,
        protected string $name = null,
        protected string $email = null,
    ) {}

    public function render()
    {
        $user = $this->user;
        $name = $this->name;
        $email = $this->email;

        return view('components/user-card', compact('user', 'name', 'email');
    }
}
```

and the view looks something like this:

```blade
<div id="user.card">
    @if(! is_null($user))
         //fancy output
    @else
        //plain output
    @endif
</div>
```

If we call the component via `<x-user-card name="Andy" email="andy@email.com"></x-user-card>`, we might think we'd get the plain output, but Laravel dependency injects an empty `User` into our component, making it not null, and rendering the fancy output.  Yes, this can be handled, but I believe it's an annoyance that can be avoided.

---

This also gives us the ability to use native PHP to enforce required parameters. Let's say we have a `ProductCard` component.

```php
class ProductCard extends Component
{
    public function __construct(
        protected Product $product,
    ) {}
}
```

Without this PR, you could make a `<x-product-card>`, and barring any view errors, you might not know that you forgot to pass a required parameter, because Laravel will have automatically injected an empty `Product` in for you.

### Precedence

There is also precedence for this switch, as Jobs are handled the same way.  Jobs do not do any dependency injection via the constructor, but rather via the `handle()` method. This gives the developer better control over how to build their Job, but still gives them the easy DI that we're used to.

### Future Thoughts

IMO, this is how components should behave by default. If there's interest, I'd love to send a PR through to 10.x as well.