### PR TITLE
[9.x] Decouple database component from console component

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -20,7 +20,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrator
@@ -735,9 +734,15 @@ class Migrator
      */
     protected function write($component, ...$arguments)
     {
-        with(new $component(
-            $this->output ?: new NullOutput()
-        ))->render(...$arguments);
+        if ($this->output && class_exists($component)) {
+            (new $component($this->output))->render(...$arguments);
+        } else {
+            foreach ($arguments as $argument) {
+                if (is_callable($argument)) {
+                    $argument();
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Hi,

I'm using https://github.com/illuminate/database as standalone dependency and since @nunomaduro improved the console output this component have a hard dependency toward https://github.com/illuminate/console (It is impossible to run migrations without it).

There was already some work to handle the absence of output but it does not handle the absence of the `View\Components`: https://github.com/illuminate/database/commit/8e5c9a3979c6f5a41d9307865063db75ec5168f8

This PR tryies to decouple furthermore by checking if the `View\Components` classes exist... Else the callbacks passed as args are executed (this is mandatory as some of them do critical work).

Thanks for your work :-) 
