### PR TITLE
[9.x] Allow toggle off of public property and method injection

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -76,6 +76,11 @@ abstract class Component
     protected static $constructorParametersCache = [];
 
     /**
+     * @var bool
+     */
+    protected static $shouldInjectPublic = true;
+
+    /**
      * Get the view / view contents that represent the component.
      *
      * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
@@ -209,6 +214,13 @@ abstract class Component
     public function data()
     {
         $this->attributes = $this->attributes ?: $this->newAttributeBag();
+
+        if (! static::$shouldInjectPublic) {
+            return [
+                'componentName' => $this->componentName,
+                'attributes' => $this->attributes,
+            ];
+        }
 
         return array_merge($this->extractPublicProperties(), $this->extractPublicMethods());
     }

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -76,9 +76,18 @@ abstract class Component
     protected static $constructorParametersCache = [];
 
     /**
+     * Indicates whether public properties should be injected on all models.
+     *
      * @var bool
      */
-    protected static $shouldInjectPublic = true;
+    protected static $componentShouldInjectPublicProperties = true;
+
+    /**
+     * Indicates whether public methods should be injected on all models.
+     *
+     * @var bool
+     */
+    protected static $componentShouldInjectPublicMethods = true;
 
     /**
      * Get the view / view contents that represent the component.
@@ -215,14 +224,20 @@ abstract class Component
     {
         $this->attributes = $this->attributes ?: $this->newAttributeBag();
 
-        if (! static::$shouldInjectPublic) {
-            return [
-                'componentName' => $this->componentName,
-                'attributes' => $this->attributes,
-            ];
+        $data =[
+            'componentName' => $this->componentName,
+            'attributes' => $this->attributes,
+        ];
+
+        if (static::$componentShouldInjectPublicProperties) {
+            $data = array_merge($data, $this->extractPublicProperties());
         }
 
-        return array_merge($this->extractPublicProperties(), $this->extractPublicMethods());
+        if (static::$componentShouldInjectPublicMethods) {
+            $data = array_merge($data, $this->extractPublicMethods());
+        }
+
+        return $data;
     }
 
     /**
@@ -334,6 +349,8 @@ abstract class Component
     protected function ignoredMethods()
     {
         return array_merge([
+            'componentName',
+            'attributes',
             'data',
             'render',
             'resolveView',
@@ -466,5 +483,27 @@ abstract class Component
     public static function resolveComponentsUsing($resolver)
     {
         static::$componentsResolver = $resolver;
+    }
+
+    /**
+     * Prevent public properties from being injected.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function preventPublicPropertyInjection($value = true)
+    {
+        static::$componentShouldInjectPublicProperties = !$value;
+    }
+
+    /**
+     * Prevent public methods from being injected.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function preventPublicMethodInjection($value = true)
+    {
+        static::$componentShouldInjectPublicMethods = !$value;
     }
 }

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -224,7 +224,7 @@ abstract class Component
     {
         $this->attributes = $this->attributes ?: $this->newAttributeBag();
 
-        $data =[
+        $data = [
             'componentName' => $this->componentName,
             'attributes' => $this->attributes,
         ];
@@ -493,7 +493,7 @@ abstract class Component
      */
     public static function preventPublicPropertyInjection($value = true)
     {
-        static::$componentShouldInjectPublicProperties = !$value;
+        static::$componentShouldInjectPublicProperties = ! $value;
     }
 
     /**
@@ -504,6 +504,6 @@ abstract class Component
      */
     public static function preventPublicMethodInjection($value = true)
     {
-        static::$componentShouldInjectPublicMethods = !$value;
+        static::$componentShouldInjectPublicMethods = ! $value;
     }
 }

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -76,14 +76,14 @@ abstract class Component
     protected static $constructorParametersCache = [];
 
     /**
-     * Indicates whether public properties should be injected on all models.
+     * Indicates whether public properties should be injected on all components.
      *
      * @var bool
      */
     protected static $componentShouldInjectPublicProperties = true;
 
     /**
-     * Indicates whether public methods should be injected on all models.
+     * Indicates whether public methods should be injected on all components.
      *
      * @var bool
      */
@@ -486,7 +486,7 @@ abstract class Component
     }
 
     /**
-     * Prevent public properties from being injected.
+     * Prevent public properties from being injected into the component view.
      *
      * @param  bool  $value
      * @return void
@@ -497,7 +497,7 @@ abstract class Component
     }
 
     /**
-     * Prevent public methods from being injected.
+     * Prevent public methods from being injected into the component view.
      *
      * @param  bool  $value
      * @return void


### PR DESCRIPTION
The components currently use reflection to automatically include all public properties and public methods in the component's rendered view.  This change allows developers to toggle this functionality off.

While I definitely value a lot of the magic that Laravel puts into the framework, when it's easy to be explicit I prefer to be explicit. We currently **never** use `public` properties on our components and force all data to be explicitly passed.  This change would allow us to enforce this a little more.

I would also guess there's a small performance benefit by avoiding all the reflection, Collection methods, and loops, but it would depend on the number of components rendered per request. I don't have any data to back this up, purely "a priori".