### PR TITLE
[9.x] Inherit crossorigin attributes while preloading

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -440,12 +440,12 @@ class Vite implements Htmlable
             'as' => 'style',
             'href' => $url,
             'nonce' => $this->nonce ?? false,
-            ...Arr::only($this->resolveStylesheetTagAttributes($src, $url, $chunk, $manifest), 'crossorigin'),
+            'crossorigin' => $this->resolveStylesheetTagAttributes($src, $url, $chunk, $manifest)['crossorigin'] ?? false,
         ] : [
             'rel' => 'modulepreload',
             'href' => $url,
             'nonce' => $this->nonce ?? false,
-            ...Arr::only($this->resolveScriptTagAttributes($src, $url, $chunk, $manifest), 'crossorigin'),
+            'crossorigin' => $this->resolveScriptTagAttributes($src, $url, $chunk, $manifest)['crossorigin'] ?? false,
         ];
 
         $attributes = $this->integrityKey !== false

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Exception;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -439,10 +440,12 @@ class Vite implements Htmlable
             'as' => 'style',
             'href' => $url,
             'nonce' => $this->nonce ?? false,
+            ...Arr::only($this->resolveStylesheetTagAttributes($src, $url, $chunk, $manifest), 'crossorigin'),
         ] : [
             'rel' => 'modulepreload',
             'href' => $url,
             'nonce' => $this->nonce ?? false,
+            ...Arr::only($this->resolveScriptTagAttributes($src, $url, $chunk, $manifest), 'crossorigin'),
         ];
 
         $attributes = $this->integrityKey !== false

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation;
 
 use Exception;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;


### PR DESCRIPTION
"CORS"...the thing every developer wants to wake up and hear about 💆‍♂️


This PR improves upon the preloading functionality with Vite by having preload tags inherit the `crossorigin` attribute from their standard script / link tag counterpart.

If an app is adding a crossorigin attribute...

```php
Vite::useScriptTagAttributes([
    'crossorigin' => true,
]);
```

That results in the following HTML...


```html
<link rel="modulepreload" href="https://exmaple.com/build/assets/app.0b16cbf2.js">
<script type="module" src="https://exmaple.com/build/assets/app.0b16cbf2.js" crossorigin></script>
```

The trouble is that the two tags must have matching `crossorigin` tags, otherwise a double fetch is performed. To manually solve this, you can specify the crossorigin tag for preload tags...

```php
Vite::useScriptTagAttributes([
    'crossorigin' => true,
]);

Vite::usePreloadTagAttributes([
    'crossorigin' => true,
]);
```

After this PR, there is no need to manually specify the preload tag attribute for `crossorigin`, as it will be inherited from the `useScriptTagAttributes` setup.

This means that the following setup...

```php
Vite::useScriptTagAttributes([
    'crossorigin' => true,
]);
```

results in the following HTML...


```html
<link rel="modulepreload" href="https://exmaple.com/build/assets/app.0b16cbf2.js" crossorigin>
<script type="module" src="https://exmaple.com/build/assets/app.0b16cbf2.js" crossorigin></script>
```

where both tags have the same `crossorigin` attribute. A develop may still override the preload tag attribute for the `crossorigin` attribute, however I can't see any reason why you would ever want to do this.