### PR TITLE
Fixes malformed resource names and parameters 🐛🕸

### DIFF
--- a/src/Illuminate/Routing/Exceptions/MalformedResourceException.php
+++ b/src/Illuminate/Routing/Exceptions/MalformedResourceException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Routing\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class MalformedResourceException extends HttpException
+{
+    /**
+     * Create a new exception instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct(403, 'Malformed resource names and parameters.');
+    }
+}


### PR DESCRIPTION
This PR continues working on #44715 and #44742, and also solves issues that @dennisprudlo suggested on #44742.

## BEFORE this PR gets merged

- The first scenario, if the developer writes an empty resource name or `/` only like so,

```PHP
Route::resource('', CommentController::class);

// OR

Route::resource('/', CommentController::class);
```

The resource routes will be malformed as shown in the next figure

![before-fixing-slash-issue](https://user-images.githubusercontent.com/48416569/199178601-c18f5ba3-8bc0-4a74-ac84-0ea6f1d5517a.png)

- The second scenario, and according to @dennisprudlo comment, if the developer wants to limit resource routes like so,

```PHP
Route::resource('comments', CommentController::class)->only('index');
```

The previous scenario will not be working perfectly according to my previous PR solution.

- The third scenario, if the developer wants to insert a `prefix` method before the `resource` method like so,

```PHP
Route::prefix('comments')->group(function () {
    Route::resource('/', CommentController::class);
    Route::delete('/multi_delete', [CommentController::class, 'multiDelete'])->name('comments.multiDelete');
});
```

The result was as shown in the next figure

![before-fixing-names-parameters-issue](https://user-images.githubusercontent.com/48416569/199178985-539fa926-8485-4abd-883d-708236db1c9b.png)

## AFTER this PR gets merged

**All the previously mentioned issues will be solved as shown in the next figures 🎉**

### Fixing empty and `/` issue

![after-fixing-slash-issue](https://user-images.githubusercontent.com/48416569/199179192-15120e99-1227-4e21-b6c5-3244e8356ae4.png)

### Fixing resource names and parameters issue

![after-fixing-names-parameters-issue](https://user-images.githubusercontent.com/48416569/199179341-752573d2-dd83-4800-adcf-d76fc32c1dff.png)

### Limits the resource routes

![after-fixing-names-parameters-issue-with-only-method](https://user-images.githubusercontent.com/48416569/199179415-f916cb61-a69e-47bc-9d87-d431b3626e55.png)
