### PR TITLE
[9.x] Makes TestResponse::assertSessionHasNoErrors() report 

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1344,13 +1344,13 @@ class TestResponse implements ArrayAccess
         PHPUnit::assertFalse(
             $hasErrors,
             'Session has unexpected errors: '.PHP_EOL.PHP_EOL.
-            json_encode((function () use($hasErrors) {
+            json_encode((function () use ($hasErrors) {
                 $errors = [];
 
                 $sessionErrors = $this->session()->get('errors');
                 if ($hasErrors && is_a($sessionErrors, ViewErrorBag::class)) {
                     foreach ($sessionErrors->getBags() as $bag => $messages) {
-                        if(!is_a($messages, MessageBag::class)) {
+                        if (! is_a($messages, MessageBag::class)) {
                             continue;
                         }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1348,13 +1348,12 @@ class TestResponse implements ArrayAccess
                 $errors = [];
 
                 $sessionErrors = $this->session()->get('errors');
+
                 if ($hasErrors && is_a($sessionErrors, ViewErrorBag::class)) {
                     foreach ($sessionErrors->getBags() as $bag => $messages) {
-                        if (! is_a($messages, MessageBag::class)) {
-                            continue;
+                        if (is_a($messages, MessageBag::class)) {
+                            $errors[$bag] = $messages->all();
                         }
-
-                        $errors[$bag] = $messages->all();
                     }
                 }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -4,6 +4,7 @@ namespace Illuminate\Testing;
 
 use ArrayAccess;
 use Closure;
+use Illuminate\Contracts\Support\MessageBag;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -15,6 +16,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Testing\Assert as PHPUnit;
 use Illuminate\Testing\Constraints\SeeInOrder;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -1339,12 +1341,25 @@ class TestResponse implements ArrayAccess
     {
         $hasErrors = $this->session()->has('errors');
 
-        $errors = $hasErrors ? $this->session()->get('errors')->all() : [];
-
         PHPUnit::assertFalse(
             $hasErrors,
             'Session has unexpected errors: '.PHP_EOL.PHP_EOL.
-            json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+            json_encode((function () use($hasErrors) {
+                $errors = [];
+
+                $sessionErrors = $this->session()->get('errors');
+                if ($hasErrors && is_a($sessionErrors, ViewErrorBag::class)) {
+                    foreach ($sessionErrors->getBags() as $bag => $messages) {
+                        if(!is_a($messages, MessageBag::class)) {
+                            continue;
+                        }
+
+                        $errors[$bag] = $messages->all();
+                    }
+                }
+
+                return $errors;
+            })(), JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
         );
 
         return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -1838,8 +1838,6 @@ class TestResponseTest extends TestCase
 
     public function testAssertSessionHasNoErrors()
     {
-        $this->expectException(AssertionFailedError::class);
-
         app()->instance('session.store', $store = new Store('test-session', new ArraySessionHandler(1)));
 
         $store->put('errors', $errorBag = new ViewErrorBag);
@@ -1850,9 +1848,20 @@ class TestResponseTest extends TestCase
             ],
         ]));
 
+        $errorBag->put('some-other-bag', new MessageBag([
+            'bar' => [
+                'bar is required',
+            ],
+        ]));
+
         $response = TestResponse::fromBaseResponse(new Response());
 
-        $response->assertSessionHasNoErrors();
+        try {
+            $response->assertSessionHasNoErrors();
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('foo is required', $e->getMessage());
+            $this->assertStringContainsString('bar is required', $e->getMessage());
+        }
     }
 
     public function testAssertSessionHas()


### PR DESCRIPTION
Makes TestResponse::assertSessionHasNoErrors() assertion exception show all errors from all bags. Previously it only did show those from the "default" bag only. 

Meaning that when a bag, other than the default, has validation errors, the errors did not show up at all. It showed us an empty array.
