### PR TITLE
[9.x] UpCommand::handle must return int

### DIFF
--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -66,5 +66,7 @@ class UpCommand extends Command
 
             return 1;
         }
+
+        return 0;
     }
 }


### PR DESCRIPTION
This method must return an integer. This causes issues with classes that override the UpCommand and return parent::handle()