### PR TITLE
[10.x] Resolve component dependencies via render method

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -76,13 +76,6 @@ abstract class Component
     protected static $constructorParametersCache = [];
 
     /**
-     * Get the view / view contents that represent the component.
-     *
-     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
-     */
-    abstract public function render();
-
-    /**
      * Resolve the component instance with the given data.
      *
      * @param  array  $data
@@ -94,15 +87,7 @@ abstract class Component
             return call_user_func(static::$componentsResolver, static::class, $data);
         }
 
-        $parameters = static::extractConstructorParameters();
-
-        $dataKeys = array_keys($data);
-
-        if (empty(array_diff($parameters, $dataKeys))) {
-            return new static(...array_intersect_key($data, array_flip($parameters)));
-        }
-
-        return Container::getInstance()->make(static::class, $data);
+        return new static(...array_intersect_key($data, array_flip(static::extractConstructorParameters())));
     }
 
     /**
@@ -132,7 +117,7 @@ abstract class Component
      */
     public function resolveView()
     {
-        $view = $this->render();
+        $view = app()->call([$this, 'render']);
 
         if ($view instanceof ViewContract) {
             return $view;


### PR DESCRIPTION
This is a breaking change resubmission of #44796. Taylor voiced concern over giving users this toggling ability due to uncertainty in could cause in 3rd party packages. This PR omits the toggle and resolves dependencies on the `render()` method rather than on the constructor for all components. IMO, this is better behavior and addresses some of the issues outlined below.

For example, let's say you have a `UserCard` component that has simple output for anonymous users, and a fancy output for registered ones.

```php
class UserCard extends Component
{
    public function __construct(
        protected User|null $user = null,
        protected string $name = null,
        protected string $email = null,
    ) {}

    public function render()
    {
        $user = $this->user;
        $name = $this->name;
        $email = $this->email;

        return view('components/user-card', compact('user', 'name', 'email');
    }
}
```

and the view looks something like this:

```blade
<div id="user.card">
    @if(! is_null($user))
         //fancy output
    @else
        //plain output
    @endif
</div>
```

If we call the component via `<x-user-card name="Andy" email="andy@email.com"></x-user-card>`, we might think we'd get the plain output, but Laravel dependency injects an empty `User` into our component, making it not null, and rendering the fancy output.  Yes, this can be handled, but I believe it's an annoyance that can be avoided.

---

This also gives us the ability to use native PHP to enforce required parameters. Let's say we have a `ProductCard` component.

```php
class ProductCard extends Component
{
    public function __construct(
        protected Product $product,
    ) {}
}
```

Without this PR, you could make a `<x-product-card>`, and barring any view errors, you might not know that you forgot to pass a required parameter, because Laravel will have automatically injected an empty `Product` in for you.

### Precedence

There is also precedence for this switch, as Jobs are handled the same way.  Jobs do not do any dependency injection via the constructor, but rather via the `handle()` method. This gives the developer better control over how to build their Job, but still gives them the easy DI that we're used to.