### PR TITLE
[9.x] Add assertDatabaseEmpty helper

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -69,7 +69,7 @@ trait InteractsWithDatabase
     }
 
     /**
-     * Assert table has no entries.
+     * Assert that the given table has no entries.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  string|null  $connection

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -69,6 +69,22 @@ trait InteractsWithDatabase
     }
 
     /**
+     * Assert table has no entries.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDatabaseEmpty($table, $connection = null)
+    {
+        $this->assertThat(
+            $this->getTable($table), new CountInDatabase($this->getConnection($connection, $table), 0)
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert the given record has been "soft deleted".
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $table

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -134,6 +134,14 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseCount(new ProductStub, 1);
     }
 
+    public function testAssertDatabaseEmpty()
+    {
+        $this->mockCountBuilder(0);
+
+        $this->assertDatabaseEmpty(ProductStub::class);
+        $this->assertDatabaseEmpty(new ProductStub);
+    }
+
     public function testAssertTableEntriesCountWrong()
     {
         $this->expectException(ExpectationFailedException::class);


### PR DESCRIPTION
This PR adds a new testing helper `assertDatabaseEmpty` which checks if a specific table has `no entires`.

**Why do we need it?**

When testing against the database you often `also` need to check if a table is empty `before` or `after` a specific action:

```php
    // Assert
    $this->assertDatabaseCount(MyModel::class, 0);

    // Act
    // Call a specific action or request

    // Assert
    $this->assertDatabaseCount(MyModel::class, 1);
````

This new testing helper is a bit shorter to write, descriptive, and better to read:

```php
    // Assert
    $this->assertDatabaseEmpty(MyModel::class);

    // Act
    // Call a specific action or request

    // Assert
    $this->assertDatabaseCount(MyModel::class, 1);
````


