### PR TITLE
[9.x] Fix `dispatchAfterResponse` in `PendingBatchFake` 🧪

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingBatchFake.php
@@ -36,4 +36,14 @@ class PendingBatchFake extends PendingBatch
     {
         return $this->bus->recordPendingBatch($this);
     }
+
+    /**
+     * Dispatch the batch after the response is sent to the browser.
+     *
+     * @return \Illuminate\Bus\Batch
+     */
+    public function dispatchAfterResponse()
+    {
+        return $this->bus->recordPendingBatch($this);
+    }
 }


### PR DESCRIPTION
## About

Usage of `dispatchAfterResponse` on `Bus::batch()` causes the error in tests:
```php
Call to a member function make() on null

./vendor/laravel/framework/src/Illuminate/Bus/PendingBatch.php:282
```

This PR fixes the error.