### PR TITLE
[9.x] Add CSP nonce to Vite reactRefresh inline script

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -575,10 +575,14 @@ class Vite implements Htmlable
             return;
         }
 
+        $attributes = $this->parseAttributes([
+            'nonce' => $this->cspNonce()
+        ]);
+
         return new HtmlString(
             sprintf(
                 <<<'HTML'
-                <script type="module">
+                <script type="module" %s>
                     import RefreshRuntime from '%s'
                     RefreshRuntime.injectIntoGlobalHook(window)
                     window.$RefreshReg$ = () => {}
@@ -586,6 +590,7 @@ class Vite implements Htmlable
                     window.__vite_plugin_react_preamble_installed__ = true
                 </script>
                 HTML,
+                implode(' ', $attributes),
                 $this->hotAsset('@react-refresh')
             )
         );

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -170,6 +170,25 @@ class FoundationViteTest extends TestCase
         );
     }
 
+    public function testReactRefreshWithNoNonce()
+    {
+        $this->makeViteHotFile();
+
+        $result = app(Vite::class)->reactRefresh();
+
+        $this->assertStringNotContainsString('nonce', $result);
+    }
+
+    public function testReactRefreshNonce()
+    {
+        $this->makeViteHotFile();
+
+        $nonce = ViteFacade::useCspNonce('expected-nonce');
+        $result = app(Vite::class)->reactRefresh();
+
+        $this->assertStringContainsString(sprintf('nonce="%s"', $nonce), $result);
+    }
+
     public function testItCanInjectIntegrityWhenPresentInManifest()
     {
         $buildDir = Str::random();


### PR DESCRIPTION
This PR adds the Laravel Vite CSP nonce to the inline javascript generated by the Blade directive `@reactRefresh` (`Vite::reactRefresh`).

This allows hot reloading to work for React projects where unsafe inline javascript is disabled via the CSP.