### PR TITLE
[9.x] Fix `InteractsWithContainer::withoutMix`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Closure;
 use Illuminate\Foundation\Mix;
 use Illuminate\Foundation\Vite;
+use Illuminate\Support\HtmlString;
 use Mockery;
 
 trait InteractsWithContainer
@@ -186,7 +187,7 @@ trait InteractsWithContainer
         }
 
         $this->swap(Mix::class, function () {
-            return '';
+            return new HtmlString('');
         });
 
         return $this;

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -49,7 +49,7 @@ class InteractsWithContainerTest extends TestCase
     {
         $instance = $this->withoutMix();
 
-        $this->assertSame('', mix('path/to/asset.png'));
+        $this->assertSame('', (string) mix('path/to/asset.png'));
         $this->assertSame($this, $instance);
     }
 


### PR DESCRIPTION
2nd PR, with a fixed test

_____


Original `mix()` returns `HtmlString` instance, fake-mix should return the same in case if a developer uses `toHtml()` explicitly. Example:

```php
mix('asset.css')->toHtml()
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
