### PR TITLE
[9.x] Allow route group method to be chained

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -159,7 +159,7 @@ class RouteRegistrar
      * Create a route group with shared attributes.
      *
      * @param  \Closure|string  $callback
-     * @return void
+     * @return $this
      */
     public function group($callback)
     {

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -164,6 +164,8 @@ class RouteRegistrar
     public function group($callback)
     {
         $this->router->group($this->attributes, $callback);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -387,6 +387,8 @@ class Router implements BindingRegistrar, RegistrarContract
 
             array_pop($this->groupStack);
         }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -373,7 +373,7 @@ class Router implements BindingRegistrar, RegistrarContract
      *
      * @param  array  $attributes
      * @param  \Closure|array|string  $routes
-     * @return void
+     * @return $this
      */
     public function group(array $attributes, $routes)
     {

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -430,6 +430,26 @@ class RouteRegistrarTest extends TestCase
         $this->seeResponse('hello', Request::create('bar/baz', 'GET'));
     }
 
+    public function testRouteGroupChaining()
+    {
+        $this->router
+            ->group([], function ($router) {
+                $router->get('foo', function () {
+                    return 'hello';
+                });
+            })
+            ->group([], function ($router) {
+                $router->get('bar', function () {
+                    return 'goodbye';
+                });
+            });
+
+        $routeCollection = $this->router->getRoutes();
+
+        $this->assertInstanceOf(\Illuminate\Routing\Route::class, $routeCollection->match(Request::create('foo', 'GET')));
+        $this->assertInstanceOf(\Illuminate\Routing\Route::class, $routeCollection->match(Request::create('bar', 'GET')));
+    }
+
     public function testRegisteringNonApprovedAttributesThrows()
     {
         $this->expectException(BadMethodCallException::class);


### PR DESCRIPTION
This allows the `group` method to be chain called when defining routing. An example of where this would be useful:

```php
// In RouteServiceProvider
Route::middleware('web')
    ->domain('foo.example.com')
    ->group(base_path('routes/common.php')
    ->group(base_path('routes/foo.php');

Route::middleware('web')
    ->domain('bar.example.com')
    ->group(base_path('routes/common.php')
    ->group(base_path('routes/bar.php');
```