### PR TITLE
[9.x] Fixes regression from #44662

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -94,10 +94,12 @@ class Application extends SymfonyApplication implements ApplicationContract
             $input = $input ?: new ArgvInput
         );
 
-        try {
-            $input->bind($this->find($commandName)->getDefinition());
-        } catch (ExceptionInterface) {
-            // ...
+        if (! is_null($commandName)) {
+            try {
+                $input->bind($this->find($commandName)->getDefinition());
+            } catch (ExceptionInterface) {
+                // ...
+            }
         }
 
         $this->events->dispatch(


### PR DESCRIPTION
Bug introduced in #44662 where `Application::find()` only accepts `string` while `Application::getCommandName()` can return `string|null`.

As a result calling `php artisan --version` now going to fail.

https://github.com/orchestral/testbench-core/actions/runs/3382197389/jobs/5618137040

![CleanShot 2022-11-03 at 11 50 12](https://user-images.githubusercontent.com/172966/199645935-68527241-554f-4b1d-9b10-1ff8a4457de8.png)

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>