### PR TITLE
Fix error with string seeds in inRandomOrder query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2273,10 +2273,10 @@ class Builder implements BuilderContract
     /**
      * Put the query's results in random order.
      *
-     * @param  string  $seed
+     * @param  int|null  $seed
      * @return $this
      */
-    public function inRandomOrder($seed = '')
+    public function inRandomOrder($seed = null)
     {
         return $this->orderByRaw($this->grammar->compileRandom($seed));
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -877,12 +877,12 @@ class Grammar extends BaseGrammar
     /**
      * Compile the random statement into SQL.
      *
-     * @param  string  $seed
+     * @param  int|null  $seed
      * @return string
      */
-    public function compileRandom($seed)
+    public function compileRandom($seed = null)
     {
-        return 'RANDOM()';
+        return 'RANDOM('.$seed.')';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -142,10 +142,10 @@ class MySqlGrammar extends Grammar
     /**
      * Compile the random statement into SQL.
      *
-     * @param  string  $seed
+     * @param  int|null  $seed
      * @return string
      */
-    public function compileRandom($seed)
+    public function compileRandom($seed = null)
     {
         return 'RAND('.$seed.')';
     }


### PR DESCRIPTION
**The error**

There's a bug when using string seeds with the method `->inRandomOrder()` and I think it's causing confusion to many Laravel developers.

For example, when implementing a pagination with the elements in random order, if you do not pass a seed to this method, you will end up with duplicated items, since these are randomized for every page load.

We can fix this behaviour by passing a seed to the `->inRandomOrder($seed)`. But the problems are:

- The seed argument is not specified in the documentation (this is not a bug, but would be an improvement).
- If you inspect the signature of the method, you can see that we are currently asking for a string: `* @param  string $seed`. Well, then when you use it like this `->inRandomOrder('foo')`, you will end up with the following error: `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'foo' in 'order clause' (SQL: select * from...`.

This error is happening because if you inspect the `MySqlGrammar` you will find that the string is ending in the query like this: `RAND(mystring)`.

```
public function compileRandom($seed)
{
   return 'RAND('.$seed.')';
}
```

**The fix**

At this point we can do two things:
1. Parse correctly the string and add the quotes to the final string
2. Force the seed to be and `int|null`

I personally think the second one is better but It would be a breaking change for some users? And also, because it's more close to the definition of `RAND()`, which only uses integer in the docs: https://dev.mysql.com/doc/refman/8.0/en/mathematical-functions.html#function_rand.

**Other resources**
- For example, other users facing this error and not understanding why, when a simple `foo` seed should work: https://laracasts.com/discuss/channels/laravel/pagination-random-data-without-repeating