### PR TITLE
[9.x] Fix HasAttributes::getMutatedAttributes for classes with constructor args

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2145,25 +2145,26 @@ trait HasAttributes
      */
     public function getMutatedAttributes()
     {
-        $class = static::class;
-
-        if (! isset(static::$mutatorCache[$class])) {
-            static::cacheMutatedAttributes($class);
+        if (! isset(static::$mutatorCache[static::class])) {
+            static::cacheMutatedAttributes($this);
         }
 
-        return static::$mutatorCache[$class];
+        return static::$mutatorCache[static::class];
     }
 
     /**
      * Extract and cache all the mutated attributes of a class.
      *
-     * @param  string  $class
+     * @param  mixed  $classOrInstance
      * @return void
      */
-    public static function cacheMutatedAttributes($class)
+    public static function cacheMutatedAttributes($classOrInstance)
     {
+        $reflectionClass = new ReflectionClass($classOrInstance);
+        $class = $reflectionClass->getName();
+
         static::$getAttributeMutatorCache[$class] =
-            collect($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($class))
+            collect($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($classOrInstance))
                     ->mapWithKeys(function ($match) {
                         return [lcfirst(static::$snakeAttributes ? Str::snake($match) : $match) => true];
                     })->all();

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2155,13 +2155,14 @@ trait HasAttributes
     /**
      * Extract and cache all the mutated attributes of a class.
      *
-     * @param  mixed  $classOrInstance
+     * @param  object|string  $classOrInstance
      * @return void
      */
     public static function cacheMutatedAttributes($classOrInstance)
     {
-        $reflectionClass = new ReflectionClass($classOrInstance);
-        $class = $reflectionClass->getName();
+        $reflection = new ReflectionClass($classOrInstance);
+
+        $class = $reflection->getName();
 
         static::$getAttributeMutatorCache[$class] =
             collect($attributeMutatorMethods = static::getAttributeMarkedMutatorMethods($classOrInstance))

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -29,7 +29,8 @@ class HasAttributesWithoutConstructor
 
     public function someAttribute(): Attribute
     {
-        return new Attribute(function () {});
+        return new Attribute(function () {
+        });
     }
 }
 

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Concerns\HasAttributes;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseConcernsHasAttributesTest extends TestCase
+{
+    public function testWithoutConstructor()
+    {
+        $instance = new HasAttributesWithoutConstructor();
+        $attributes = $instance->getMutatedAttributes();
+        $this->assertEquals(['some_attribute'], $attributes);
+    }
+
+    public function testWithConstructorArguments()
+    {
+        $instance = new HasAttributesWithConstructorArguments(null);
+        $attributes = $instance->getMutatedAttributes();
+        $this->assertEquals(['some_attribute'], $attributes);
+    }
+}
+
+class HasAttributesWithoutConstructor
+{
+    use HasAttributes;
+
+    public function someAttribute(): Attribute
+    {
+        return new Attribute(function () {});
+    }
+}
+
+class HasAttributesWithConstructorArguments extends HasAttributesWithoutConstructor
+{
+    public function __construct($someValue)
+    {
+    }
+}


### PR DESCRIPTION
Commit e0c2620b57be6416820ea7ca8e46fd2f71d2fe35 (PR #40022) caused `HasAttribute::getMutatedAttributes` to break when the trait is used on a class that has required constructor arguments.

The other introspective methods use the current instance of the class to do their magic instead of instantiating a new instance. This could be done for `getMutatedAttributes` as well, and this PR does that.