### PR TITLE
PendingDispatch can be dispatched manually

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingDispatch.php
+++ b/src/Illuminate/Foundation/Bus/PendingDispatch.php
@@ -25,7 +25,7 @@ class PendingDispatch
     protected $afterResponse = false;
     
     /**
-     * Indicates if the job has been already dispatched
+     * Indicates if the job has been already dispatched.
      *
      * @var bool
      */


### PR DESCRIPTION
The PendingDispatch was dispatched when it was destroyed, and it was not possible to retrieve the generated job ID (when using queues). This change allows dispatching the job like this, obtaining the new job ID:  
```$job_id = ProcessPodcast::dispatch()->onQueue('emails')->now();```

It should be backwards-compatible. The dispatch logic in the `__destruct` method has been moved to the new `dispatch` method, which executes the previous statements if the new property `dispatched` is `false`, the default value.
This property will only be changed to `true` when dispatched to ensure the job is not dispatched twice.

I have not found any other way to obtain the queued job ID without having to extend large parts of the framework, but there might be another way. If that is the case, please forgive me and close the request.

Thanks!

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
