### PR TITLE
[9.x] Add DatabaseBatchRepository to `provides()` in BusServiceProvider

### DIFF
--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -64,6 +64,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
             DispatcherContract::class,
             QueueingDispatcherContract::class,
             BatchRepository::class,
+            DatabaseBatchRepository::class,
         ];
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
In `archtechx/tenancy`, [we use DatabaseBatchRepository directly](https://github.com/archtechx/tenancy/blob/aa536529dfd11fbbca96ba51a937331bc098fea3/src/Bootstrappers/BatchTenancyBootstrapper.php#L30), so we inject DatabaseBatchRepository instead of the BatchRepository interface. But injecting DatabaseBatchRepository throws BindingResolutionException ("Unresolvable dependency..."). Adding DatabaseBatchRepository to `provides()` in BusServiceProvider solves the problem.

Also, BusServiceProvider binds a singleton to `DatabaseBatchRepository`, so `provides()` should include the service.