### PR TITLE
Customizable blade component tag prefix

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -152,6 +152,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $compilesComponentTags = true;
 
     /**
+     * The prefix for component tags.
+     *
+     * @var string
+     */
+    protected $componentTagPrefix = 'x';
+
+    /**
      * Compile the view at the given path.
      *
      * @param  string|null  $path
@@ -861,5 +868,26 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function withoutComponentTags()
     {
         $this->compilesComponentTags = false;
+    }
+
+    /**
+     * Get the "prefix" for component tags.
+     *
+     * @return string
+     */
+    public function getComponentTagPrefix()
+    {
+        return $this->componentTagPrefix;
+    }
+
+    /**
+     * Set the "prefix" for component tags.
+     *
+     * @param $prefix
+     * @return void
+     */
+    public function setComponentTagPrefix($prefix)
+    {
+        $this->componentTagPrefix = $prefix;
     }
 }

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -103,10 +103,12 @@ class ComponentTagCompiler
      */
     protected function compileOpeningTags(string $value)
     {
+        $prefix = $this->blade->getComponentTagPrefix();
+
         $pattern = "/
             <
                 \s*
-                x[-\:]([\w\-\:\.]*)
+                {$prefix}[-\:]([\w\-\:\.]*)
                 (?<attributes>
                     (?:
                         \s+
@@ -163,10 +165,12 @@ class ComponentTagCompiler
      */
     protected function compileSelfClosingTags(string $value)
     {
+        $prefix = $this->blade->getComponentTagPrefix();
+
         $pattern = "/
             <
                 \s*
-                x[-\:]([\w\-\:\.]*)
+                {$prefix}[-\:]([\w\-\:\.]*)
                 \s*
                 (?<attributes>
                     (?:
@@ -435,7 +439,9 @@ class ComponentTagCompiler
      */
     protected function compileClosingTags(string $value)
     {
-        return preg_replace("/<\/\s*x[-\:][\w\-\:\.]*\s*>/", ' @endComponentClass##END-COMPONENT-CLASS##', $value);
+        $prefix = $this->blade->getComponentTagPrefix();
+
+        return preg_replace("/<\/\s*{$prefix}[-\:][\w\-\:\.]*\s*>/", ' @endComponentClass##END-COMPONENT-CLASS##', $value);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -452,10 +452,12 @@ class ComponentTagCompiler
      */
     public function compileSlots(string $value)
     {
+        $prefix = $this->blade->getComponentTagPrefix();
+
         $pattern = "/
             <
                 \s*
-                x[\-\:]slot
+                {$prefix}[\-\:]slot
                 (?:\:(?<inlineName>\w+(?:-\w+)*))?
                 (?:\s+(:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?
                 (?<attributes>

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -106,6 +106,30 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
     }
 
+    public function testComponentTagPrefixCanBeCustomized()
+    {
+        $this->mockViewFactory();
+
+        $blade = m::mock(BladeCompiler::class)->makePartial();
+        $blade->shouldReceive('getComponentTagPrefix')->andReturn('laravel');
+
+        $result = $this->compiler(['alert' => TestAlertComponent::class], [], $blade)->compileTags('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><x-alert /></div>');
+        $this->assertEquals('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><x-alert /></div>', $result);
+
+        $result = $this->compiler(['alert' => TestAlertComponent::class], [], $blade)->compileTags('<div><laravel-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><laravel-alert /></div>');
+        $this->assertEquals("<div>##BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestAlertComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); ?>\n".
+            "@endComponentClass##END-COMPONENT-CLASS####BEGIN-COMPONENT-CLASS##@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag && \$constructor = (new ReflectionClass(Illuminate\Tests\View\Blade\TestAlertComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+            '@endComponentClass##END-COMPONENT-CLASS##</div>', trim($result));
+    }
+
     public function testBasicComponentWithEmptyAttributesParsing()
     {
         $this->mockViewFactory();


### PR DESCRIPTION
This pull request allows developers to customize the component tag prefix Laravel uses to identify blade components.

In my projects, I have a Laravel backend with a Vue frontend. For my Vue components, I use the `x-` prefix. When I tried to use these components in a Blade file, I received `InvalidArgumentException: Unable to locate a class or view for component [header].`

I have resolved the issue using `Blade::withoutComponentTags()` in a service provider. It would be nice to have the option to use blade components in the future, so this pull request adds a `Blade::setComponentTagPrefix($prefix)` option to the Blade compiler. I've added a test case to verify that the `ComponentTagCompiler` uses the prefix. It should be sufficient but shout if I need to add more tests (and what you'd like tested).

```php
Blade::setComponentTagPrefix("blade"); // <blade-component-name />
```

This issue could be resolved by "just using a different prefix for your Vue components"; but alas, I'm stubborn, and don't want to. And that was a good enough reason for me to write the code & this PR.

Let me know what you think!