### PR TITLE
[10.x] Validate objects with & without PHP attributes

### DIFF
--- a/src/Illuminate/Contracts/Validation/Factory.php
+++ b/src/Illuminate/Contracts/Validation/Factory.php
@@ -7,13 +7,13 @@ interface Factory
     /**
      * Create a new Validator instance.
      *
-     * @param  array  $data
+     * @param  array|object  $data
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
      * @return \Illuminate\Contracts\Validation\Validator
      */
-    public function make(array $data, array $rules, array $messages = [], array $customAttributes = []);
+    public function make(array|object $data, array $rules, array $messages = [], array $customAttributes = []);
 
     /**
      * Register a custom validator extension.

--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -3,13 +3,13 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Contracts\Validation\Validator|\Illuminate\Validation\Validator make(array $data, array $rules, array $messages = [], array $customAttributes = [])
+ * @method static \Illuminate\Contracts\Validation\Validator|\Illuminate\Validation\Validator make(array|object $data,array $rules, array $messages = [], array $customAttributes = [])
  * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
  * @method static void extend(string $rule, \Closure|string $extension, string $message = null)
  * @method static void extendImplicit(string $rule, \Closure|string $extension, string $message = null)
  * @method static void replacer(string $rule, \Closure|string $replacer)
- * @method static array validate(array $data, array $rules, array $messages = [], array $customAttributes = [])
+ * @method static array validate(array|object $data, array $rules, array $messages = [], array $customAttributes = [])
  *
  * @see \Illuminate\Validation\Factory
  */

--- a/src/Illuminate/Validation/Assert.php
+++ b/src/Illuminate/Validation/Assert.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Illuminate\Validation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Assert
+{
+    /**
+     * @var array The rules to be applied to the property.
+     */
+    public readonly array $rules;
+
+    /**
+     * @param array $rules
+     */
+    public function __construct(array $rules)
+    {
+        $this->rules = $rules;
+    }
+}

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -96,13 +96,13 @@ class Factory implements FactoryContract
     /**
      * Create a new Validator instance.
      *
-     * @param  array  $data
+     * @param  array|object  $data
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
      * @return \Illuminate\Validation\Validator
      */
-    public function make(array $data, array $rules, array $messages = [], array $customAttributes = [])
+    public function make(array|object $data, array $rules, array $messages = [], array $customAttributes = [])
     {
         $validator = $this->resolve(
             $data, $rules, $messages, $customAttributes
@@ -132,7 +132,7 @@ class Factory implements FactoryContract
     /**
      * Validate the given data against the provided rules.
      *
-     * @param  array  $data
+     * @param  array|object  $data
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
@@ -140,7 +140,7 @@ class Factory implements FactoryContract
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function validate(array $data, array $rules, array $messages = [], array $customAttributes = [])
+    public function validate(array|object $data, array $rules, array $messages = [], array $customAttributes = [])
     {
         return $this->make($data, $rules, $messages, $customAttributes)->validate();
     }
@@ -148,13 +148,13 @@ class Factory implements FactoryContract
     /**
      * Resolve a new Validator instance.
      *
-     * @param  array  $data
+     * @param  array|object  $data
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
      * @return \Illuminate\Validation\Validator
      */
-    protected function resolve(array $data, array $rules, array $messages, array $customAttributes)
+    protected function resolve(array|object $data, array $rules, array $messages, array $customAttributes)
     {
         if (is_null($this->resolver)) {
             return new Validator($this->translator, $data, $rules, $messages, $customAttributes);

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -151,4 +151,18 @@ class ValidationFactoryTest extends TestCase
 
         $this->assertSame($container, $factory->setContainer($container)->getContainer());
     }
+
+    public function testMakeMethodCreatesValidValidatorForAnObject(): void
+    {
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator);
+
+        $object = new class {
+            public string $foo = 'bar';
+        };
+
+        $validator = $factory->make($object, ['foo' => 'required']);
+
+        $this->assertSame(['foo' => 'bar'], $validator->getData());
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -7524,6 +7524,48 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider dataProviderForAttributeRules
+     */
+    public function testItValidatesAgainstAssertAttribute(object $obj, array $rules, bool $expected): void
+    {
+        $sut = new Validator($this->getIlluminateArrayTranslator(), $obj, $rules,);
+
+        $this->assertSame($expected, $sut->passes());
+    }
+
+    public function dataProviderForAttributeRules(): array
+    {
+        return [
+            'object with valid properties' => [
+                'obj' => new class {
+                    #[\Illuminate\Validation\Assert(['required', 'email'])]
+                    private string $email = 'user@site.com';
+                },
+                'rules' => [],
+                'expected' => true,
+            ],
+            'object with invalid properties' => [
+                'obj' => new class {
+                    #[\Illuminate\Validation\Assert(['required', 'email'])]
+                    private string $email = 'invalidEmail';
+                },
+                'rules' => [],
+                'expected' => false,
+            ],
+            'rules array overrides Assert attribute' => [
+                'obj' => new class {
+                    #[\Illuminate\Validation\Assert(['required', 'email'])]
+                    private string $email = 'invalidEmail';
+                },
+                'rules' => [
+                    'email' => 'required',
+                ],
+                'expected' => true,
+            ],
+        ];
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);


### PR DESCRIPTION
This PR provides a new feature to the Validator class. It allows object validation against a set of assertions. Asserts can be added by using a PHP attribute.

## Usage

#### Using the Assert attribute

Add the `Assert` attribute to a property of a class. The attribute takes an array of rules as a parameter.

```php
class User
{
    #[\Illuminate\Validation\Assert(['required', 'email'])]
    public string $email;
}

$user = new User();
$user->email = 'invalid-email';

$validator = \Illuminate\Support\Facades\Validator::make($user, []);

$validator->fails(); // true
```

#### Override Assert attributes

The `Assert` attributes could be overridden by the classic rules array:

```php
class User
{
    #[\Illuminate\Validation\Assert(['required', 'email'])]
    public string $email;
}

$user = new User();
$user->email = 'invalid-email';

$validator = \Illuminate\Support\Facades\Validator::make($user, [
    'email' => ['required'],
]);

$validator->fails(); // false
```

#### Validate objects

The new implementation allows object validation against the classic rules array without the need to add the `Assert` attribute to the object.

```php
class User
{
    public string $email;
}

$user = new User();
$user->email = 'invalid-email';

$validator = \Illuminate\Support\Facades\Validator::make($user, [
    'email' => ['required', 'email'],
]);

$validator->fails(); // true
```

---


## Thinking out loud

This is a **draft**, it would be nice to have some feedback on the implementation.

- Should the rules parameter of the `Validator` be optional?
- The `parseData` method uses getters if they are available, how will this affect the usage with Models?
- Still not sure about the naming, is `Assert` suitable for that functionality? 
