### PR TITLE
[9.x] Introduced flag without-interactive-output

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -250,13 +250,13 @@ class WorkCommand extends Command
             return;
         }
 
-        if (! $useLineBreak) {
-            $this->output->write($output);
+        if ($useLineBreak) {
+            $this->output->writeln($output);
 
             return;
         }
 
-        $this->output->writeln($output);
+        $this->output->write($output);
     }
 
     /**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -252,6 +252,7 @@ class WorkCommand extends Command
 
         if (! $useLineBreak) {
             $this->output->write($output);
+
             return;
         }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -39,7 +39,8 @@ class WorkCommand extends Command
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=1 : Number of times to attempt a job before logging it failed}';
+                            {--tries=1 : Number of times to attempt a job before logging it failed}
+                            {--without-interactive-output : Interactive output will not be printed, only logging}';
 
     /**
      * The name of the console command.

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -238,8 +238,10 @@ class WorkCommand extends Command
     }
 
     /**
-     * @param string $output
-     * @param bool $useLine
+     * Writes the interactive output.
+     *
+     * @param  string  $output
+     * @param  bool  $useLineBreak
      * @return void
      */
     protected function writePrettyOutput($output, $useLineBreak = false)
@@ -248,7 +250,7 @@ class WorkCommand extends Command
             return;
         }
 
-        if (!$useLineBreak) {
+        if (! $useLineBreak) {
             $this->output->write($output);
             return;
         }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -226,9 +226,9 @@ class WorkCommand extends Command
         }
 
         $runTime = number_format((microtime(true) - $this->latestStartedAt) * 1000, 2).'ms';
-        $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - mb_strlen($runTime) - 31, 0);
+        $dots = max(terminal()->width() - mb_strlen($runTime) - 8, 0);
 
-        $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
+        $this->output->write('  '.str_repeat('<fg=gray>.</>', $dots));
         $this->output->write(" <fg=gray>$runTime</>");
 
         $this->output->writeln(match ($this->latestStatus = $status) {

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -214,15 +214,15 @@ class WorkCommand extends Command
 
             $formattedStartedAt = Carbon::now()->format('Y-m-d H:i:s');
 
-            $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
-            $this->output->newLine();
+            $this->output->writeln("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
+
             return;
         }
 
         if ($this->latestStatus && $this->latestStatus != 'starting') {
             $formattedStartedAt = Carbon::createFromTimestamp($this->latestStartedAt)->format('Y-m-d H:i:s');
 
-            $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
+            $this->output->writeln("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
         }
 
         $runTime = number_format((microtime(true) - $this->latestStartedAt) * 1000, 2).'ms';

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -214,7 +214,9 @@ class WorkCommand extends Command
 
             $formattedStartedAt = Carbon::now()->format('Y-m-d H:i:s');
 
-            return $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
+            $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
+            $this->output->newLine();
+            return;
         }
 
         if ($this->latestStatus && $this->latestStatus != 'starting') {


### PR DESCRIPTION
We have a DataDog logs parsing issues, because when it was added without a new line, we should have to change our Logger monolog format, something like this:
`'format' => "\n%channel%.%level_name%: %message% %context% %extra%\n", // New line before`

I think that others also have the same issue.
I fixed it into this PR.
