### PR TITLE
[9.x] Fixed 404 internal message output error in production

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -35,14 +35,7 @@ class ModelNotFoundException extends RecordsNotFoundException
     {
         $this->model = $model;
         $this->ids = Arr::wrap($ids);
-
-        $this->message = "No query results for model [{$model}]";
-
-        if (count($this->ids) > 0) {
-            $this->message .= ' '.implode(', ', $this->ids);
-        } else {
-            $this->message .= '.';
-        }
+        $this->message = $this->message($model);
 
         return $this;
     }
@@ -65,5 +58,21 @@ class ModelNotFoundException extends RecordsNotFoundException
     public function getIds()
     {
         return $this->ids;
+    }
+
+    /**
+     * Get the message text.
+     *
+     * @return string
+     */
+    protected function message($model)
+    {
+        if (config('app.debug')) {
+            $ids = count($this->ids) > 0 ? ' '.implode(', ', $this->ids) : '.';
+
+            return __('No query results for model [:model]:ids', compact('model', 'ids'));
+        }
+
+        return __('Not Found');
     }
 }

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -364,6 +364,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testFindOrFailMethod()
     {
+        $this->app['config']->set('app.debug', true);
+
         $this->expectException(ModelNotFoundException::class);
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10');
 
@@ -378,6 +380,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testFindOrFailMethodWithMany()
     {
+        $this->app['config']->set('app.debug', true);
+
         $this->expectException(ModelNotFoundException::class);
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
 
@@ -392,8 +396,26 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
     public function testFindOrFailMethodWithManyUsingCollection()
     {
+        $this->app['config']->set('app.debug', true);
+
         $this->expectException(ModelNotFoundException::class);
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest\Tag] 10, 11');
+
+        $post = Post::create(['title' => Str::random()]);
+
+        Tag::create(['name' => Str::random()]);
+
+        $post->tags()->attach(Tag::all());
+
+        $post->tags()->findOrFail(new Collection([10, 11]));
+    }
+
+    public function testFindOrFailMethodWithManyUsingCollectionWhenDebugIsFalse()
+    {
+        $this->app['config']->set('app.debug', false);
+
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('Not Found');
 
         $post = Post::create(['title' => Str::random()]);
 


### PR DESCRIPTION
## Current state

Laravel always returns a reference to the model despite changing the `APP_DEBUG` option (`true` or `false`).

![image](https://user-images.githubusercontent.com/10347617/200006640-c0b4d9b6-1486-44bb-9c14-4a397c5d3f7f.png)

### `APP_DEBUG = false`

![image](https://user-images.githubusercontent.com/10347617/200007213-7b62d1c8-2de4-40d0-83f2-9664d3866a34.png)

## After fix

### `APP_DEBUG = true`

![image](https://user-images.githubusercontent.com/10347617/200007370-8eccc5b6-b582-4481-86f6-1902a83b4771.png)

### Additional functionality

The text of the message may be subject to translation:

```php
__('No query results for model [:model]:ids', [...])
__('Not Found')
```