### PR TITLE
[9.x] Improve missing attributes functionality

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -451,7 +451,7 @@ trait HasAttributes
         // Here we will determine if the model base class itself contains this given key
         // since we don't want to treat any of those methods as relationships because
         // they are all intended as helper methods and none of these are relations.
-        if (method_exists($this, $key)) {
+        if (method_exists(self::class, $key)) {
             return $throwMissingAttributeExceptionIfApplicable($key);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -443,7 +443,7 @@ trait HasAttributes
 
         // Define wrapper so we can always call this function even though the related method does not exist.
         $throwMissingAttributeExceptionIfApplicable = function ($key) {
-            if(method_exists($this, 'throwMissingAttributeExceptionIfApplicable')) {
+            if (method_exists($this, 'throwMissingAttributeExceptionIfApplicable')) {
                 return $this->throwMissingAttributeExceptionIfApplicable($key);
             }
         };

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -441,7 +441,7 @@ trait HasAttributes
             return $this->getAttributeValue($key);
         }
 
-        // Define wrapper so we can always call this function even though the related method does not exist.
+        // Define wrapper so we can always call this function even though the related method might not exist.
         $throwMissingAttributeExceptionIfApplicable = function ($key) {
             if (method_exists($this, 'throwMissingAttributeExceptionIfApplicable')) {
                 return $this->throwMissingAttributeExceptionIfApplicable($key);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -441,16 +441,23 @@ trait HasAttributes
             return $this->getAttributeValue($key);
         }
 
+        // Define wrapper so we can always call this function even though the related method does not exist.
+        $throwMissingAttributeExceptionIfApplicable = function ($key) {
+            if(method_exists($this, 'throwMissingAttributeExceptionIfApplicable')) {
+                return $this->throwMissingAttributeExceptionIfApplicable($key);
+            }
+        };
+
         // Here we will determine if the model base class itself contains this given key
         // since we don't want to treat any of those methods as relationships because
         // they are all intended as helper methods and none of these are relations.
-        if (method_exists($this, $key) && method_exists($this, 'throwMissingAttributeExceptionIfApplicable')) {
-            return $this->throwMissingAttributeExceptionIfApplicable($key);
+        if (method_exists($this, $key)) {
+            return $throwMissingAttributeExceptionIfApplicable($key);
         }
 
         return $this->isRelation($key) || $this->relationLoaded($key)
                     ? $this->getRelationValue($key)
-                    : $this->throwMissingAttributeExceptionIfApplicable($key);
+                    : $throwMissingAttributeExceptionIfApplicable($key);
     }
 
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -460,7 +460,6 @@ trait HasAttributes
                     : $throwMissingAttributeExceptionIfApplicable($key);
     }
 
-
     /**
      * Get a plain attribute (not a relationship).
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/RestrictsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/RestrictsAttributes.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Database\Eloquent\MissingAttributeException;
+
+trait RestrictsAttributes
+{
+    /**
+     * Indicates if an exception should be thrown instead of silently discarding non-fillable attributes.
+     *
+     * @var bool
+     */
+    protected static $modelsShouldPreventSilentlyDiscardingAttributes = false;
+
+    /**
+     * The callback that is responsible for handling discarded attribute violations.
+     *
+     * @var callable|null
+     */
+    protected static $discardedAttributeViolationCallback;
+
+    /**
+     * Indicates if an exception should be thrown when trying to access a missing attribute on a retrieved model.
+     *
+     * @var bool
+     */
+    protected static $modelsShouldPreventAccessingMissingAttributes = false;
+
+    /**
+     * The callback that is responsible for handling missing attribute violations.
+     *
+     * @var callable|null
+     */
+    protected static $missingAttributeViolationCallback;
+
+    /**
+     * Determine if discarding guarded attribute fills is disabled.
+     *
+     * @return bool
+     */
+    public static function preventsSilentlyDiscardingAttributes()
+    {
+        return static::$modelsShouldPreventSilentlyDiscardingAttributes;
+    }
+
+    /**
+     * Determine if accessing missing attributes is disabled.
+     *
+     * @return bool
+     */
+    public static function preventsAccessingMissingAttributes()
+    {
+        return static::$modelsShouldPreventAccessingMissingAttributes;
+    }
+
+    /**
+     * Prevent non-fillable attributes from being silently discarded.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function preventSilentlyDiscardingAttributes($value = true)
+    {
+        static::$modelsShouldPreventSilentlyDiscardingAttributes = $value;
+    }
+
+    /**
+     * Register a callback that is responsible for handling discarded attribute violations.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public static function handleDiscardedAttributeViolationUsing(?callable $callback)
+    {
+        static::$discardedAttributeViolationCallback = $callback;
+    }
+
+    /**
+     * Prevent accessing missing attributes on retrieved models.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public static function preventAccessingMissingAttributes($value = true)
+    {
+        static::$modelsShouldPreventAccessingMissingAttributes = $value;
+    }
+
+    /**
+     * Register a callback that is responsible for handling lazy loading violations.
+     *
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public static function handleMissingAttributeViolationUsing(?callable $callback)
+    {
+        static::$missingAttributeViolationCallback = $callback;
+    }
+
+    /**
+     * Either throw a missing attribute exception or return null depending on Eloquent's configuration.
+     *
+     * @param  string  $key
+     * @return null
+     *
+     * @throws \Illuminate\Database\Eloquent\MissingAttributeException
+     */
+    protected function throwMissingAttributeExceptionIfApplicable($key)
+    {
+        if (static::preventsAccessingMissingAttributes() &&
+            $this->exists &&
+            ! $this->wasRecentlyCreated) {
+            if (isset(static::$missingAttributeViolationCallback)) {
+                return call_user_func(static::$missingAttributeViolationCallback, $this, $key);
+            }
+
+            throw new MissingAttributeException($this, $key);
+        }
+
+        return null;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/RestrictsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/RestrictsAttributes.php
@@ -108,7 +108,7 @@ trait RestrictsAttributes
      */
     protected function throwMissingAttributeExceptionIfApplicable($key)
     {
-        if (static::preventsAccessingMissingAttributes() &&
+        if (self::preventsAccessingMissingAttributes() &&
             $this->exists &&
             ! $this->wasRecentlyCreated) {
             if (isset(static::$missingAttributeViolationCallback)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -32,6 +32,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
+        Concerns\RestrictsAttributes,
         ForwardsCalls;
 
     /**
@@ -173,34 +174,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @var callable|null
      */
     protected static $lazyLoadingViolationCallback;
-
-    /**
-     * Indicates if an exception should be thrown instead of silently discarding non-fillable attributes.
-     *
-     * @var bool
-     */
-    protected static $modelsShouldPreventSilentlyDiscardingAttributes = false;
-
-    /**
-     * The callback that is responsible for handling discarded attribute violations.
-     *
-     * @var callable|null
-     */
-    protected static $discardedAttributeViolationCallback;
-
-    /**
-     * Indicates if an exception should be thrown when trying to access a missing attribute on a retrieved model.
-     *
-     * @var bool
-     */
-    protected static $modelsShouldPreventAccessingMissingAttributes = false;
-
-    /**
-     * The callback that is responsible for handling missing attribute violations.
-     *
-     * @var callable|null
-     */
-    protected static $missingAttributeViolationCallback;
 
     /**
      * Indicates if broadcasting is currently enabled.
@@ -431,50 +404,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function handleLazyLoadingViolationUsing(?callable $callback)
     {
         static::$lazyLoadingViolationCallback = $callback;
-    }
-
-    /**
-     * Prevent non-fillable attributes from being silently discarded.
-     *
-     * @param  bool  $value
-     * @return void
-     */
-    public static function preventSilentlyDiscardingAttributes($value = true)
-    {
-        static::$modelsShouldPreventSilentlyDiscardingAttributes = $value;
-    }
-
-    /**
-     * Register a callback that is responsible for handling discarded attribute violations.
-     *
-     * @param  callable|null  $callback
-     * @return void
-     */
-    public static function handleDiscardedAttributeViolationUsing(?callable $callback)
-    {
-        static::$discardedAttributeViolationCallback = $callback;
-    }
-
-    /**
-     * Prevent accessing missing attributes on retrieved models.
-     *
-     * @param  bool  $value
-     * @return void
-     */
-    public static function preventAccessingMissingAttributes($value = true)
-    {
-        static::$modelsShouldPreventAccessingMissingAttributes = $value;
-    }
-
-    /**
-     * Register a callback that is responsible for handling lazy loading violations.
-     *
-     * @param  callable|null  $callback
-     * @return void
-     */
-    public static function handleMissingAttributeViolationUsing(?callable $callback)
-    {
-        static::$missingAttributeViolationCallback = $callback;
     }
 
     /**
@@ -2165,26 +2094,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     public static function preventsLazyLoading()
     {
         return static::$modelsShouldPreventLazyLoading;
-    }
-
-    /**
-     * Determine if discarding guarded attribute fills is disabled.
-     *
-     * @return bool
-     */
-    public static function preventsSilentlyDiscardingAttributes()
-    {
-        return static::$modelsShouldPreventSilentlyDiscardingAttributes;
-    }
-
-    /**
-     * Determine if accessing missing attributes is disabled.
-     *
-     * @return bool
-     */
-    public static function preventsAccessingMissingAttributes()
-    {
-        return static::$modelsShouldPreventAccessingMissingAttributes;
     }
 
     /**


### PR DESCRIPTION
This is an improvement for the recently merged https://github.com/laravel/framework/pull/44283.

The following changes are included:

1. I got an error in my own project because I was using the `HasAttributes` trait for a custom class. However, the following piece of code makes a call to the properties `$this->exists` and `$this->wasRecentlyCreated` first which did not exist in my implementation, therefore throwing an "Undefined property" ErrorException:

https://github.com/laravel/framework/blob/0702f556f72745f34570fbdfa8e37b8ea0b7ffa5/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L465-L478

That if-statement has now been reordered to first call the `static::preventsAccessingMissingAttributes()`, and since this is `false` by default the code will work correctly.

2. I moved all associated code to a new concern so this functionality becomes slightly more scoped instead of being added to the 2k+ lines monsterclass `HasAttributes`.
3. I updated a couple calls in the Model class where these functions were used, so it can now work without the trait.