### PR TITLE
[9.x] Remove `__sleep()` & `__wakeup()` from SerializesModels trait.

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -10,44 +10,6 @@ trait SerializesModels
     use SerializesAndRestoresModelIdentifiers;
 
     /**
-     * Prepare the instance for serialization.
-     *
-     * @return array
-     */
-    public function __sleep()
-    {
-        $properties = (new ReflectionClass($this))->getProperties();
-
-        foreach ($properties as $property) {
-            $property->setValue($this, $this->getSerializedPropertyValue(
-                $this->getPropertyValue($property)
-            ));
-        }
-
-        return array_values(array_filter(array_map(function ($p) {
-            return $p->isStatic() ? null : $p->getName();
-        }, $properties)));
-    }
-
-    /**
-     * Restore the model after serialization.
-     *
-     * @return void
-     */
-    public function __wakeup()
-    {
-        foreach ((new ReflectionClass($this))->getProperties() as $property) {
-            if ($property->isStatic()) {
-                continue;
-            }
-
-            $property->setValue($this, $this->getRestoredPropertyValue(
-                $this->getPropertyValue($property)
-            ));
-        }
-    }
-
-    /**
      * Prepare the instance values for serialization.
      *
      * @return array


### PR DESCRIPTION
This PR removes support for the `__sleep()` & `__wakeup()` methods in the `SerializesModels` trait, since they have become irrelevant in Laravel 9.x as the minimum requirements are PHP 8.0. In this version of PHP the `__serialize()` method will be called instead of the `__sleep()` method and the `__unserialize()` method will be called instead of the `__wakeup()` method.

I believe the reason why both magic methods were still present in this trait was to keep supporting PHP 7.3 in Laravel 8.x.

[Documentation reference](https://www.php.net/manual/en/language.oop5.magic.php#object.serialize)