### PR TITLE
[9.x] Prevent model serialization on sync connection.

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -19,6 +19,10 @@ trait SerializesAndRestoresModelIdentifiers
      */
     protected function getSerializedPropertyValue($value)
     {
+        if (isset($this->connection) && $this->connection === 'sync') {
+            return $value;
+        }
+
         if ($value instanceof QueueableCollection) {
             return (new ModelIdentifier(
                 $value->getQueueableClass(),


### PR DESCRIPTION
It prevents additional queries from being made by **not** serializing models that are meant to be executed synchronously.

It might not be a big optimization but it can help reduce the request execution time, especially when the properties are `QueueableCollection`s or `QueueableEntity`s that have many loaded relations.