### PR TITLE
[9.x] Allow faking connection errors in HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -37,7 +37,7 @@ class Response implements ArrayAccess
     /**
      * The transfer stats for the request.
      *
-     * \GuzzleHttp\TransferStats|null
+     * @var \GuzzleHttp\TransferStats|null
      */
     public $transferStats;
 

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Http\Client;
 
-use Closure;
 use Illuminate\Support\Traits\Macroable;
 use OutOfBoundsException;
 

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Client\Factory;
 
 /**
  * @method static \GuzzleHttp\Promise\PromiseInterface response($body = null, $status = 200, $headers = [])
+ * @method static callable error(string $message = '', array $handlerContext = [])
  * @method static \Illuminate\Http\Client\PendingRequest accept(string $contentType)
  * @method static \Illuminate\Http\Client\PendingRequest acceptJson()
  * @method static \Illuminate\Http\Client\PendingRequest asForm()


### PR DESCRIPTION
## Purpose

This PR brings the ability to fake connection/networking errors when HTTP requests are made.

## Why this is useful

Until now, we could fake HTTP responses, both successful or failed (4xx/5xx). But there is no way to test how the HTTP client or our application behaves when there is a networking error, e.g. a host that could not be resolved, a connection timeout, an SSL error, etc.

In fact, there are currently no tests that assert the `ConnectionFailed` event is dispatched, or that the `retry` method catches the `ConnectionException`.

### Example use-case

I have some jobs that make API calls to a server that might be down or timeouts. When that happens, I need to notify someone.
Of course, I could do that before, but there was no easy way to test that case.

```php
class ExampleJob implements ShouldQueue
{
    public function handle()
    {
        rescue(
            fn () => Http::get('https://aws.example.com')),
            fn ($e) => Notification::send($developers, new AwsIsDownAgain($e->getMessage())),
        );
    }
}

public function test_aws_is_down()
{
    Http::fake(['aws.example.com' => Http::error('down')]);
    Notification::fake([AwsIsDownAgain::class]);

    Bus::dispatch(new ExampleJob());

    Http::assertSent(fn ($request, $response) => $response instanceof ConnectionException);
    Notification::assertSentTo($developers, fn (AwsIsDownAgain $notification) => $notification->message === 'down');
}
```

## Usage

The new `Http::error()` method accepts two optional parameters: an error message, and an array with the (cURL) handler context.

```php
Http::fake([
    'error.example.com' => Http::error(),
    'expired.example.com' => Http::error('Could not resolve host: expired.example.com'),
    'timeout.example.com' => Http::error('Connection timed out after 42 milliseconds', ['errno' => 28]),
]);
```

This method works with all the common features of the HTTP client:
- Concurent requests using `HTTP::pool()`
- Dispatching `RequestSending` and `ConnectionFailed` events
- Faking response sequences using `Http::sequence()` and `Http::fakeSequence()`
- Inspecting requests using `assertSent()`, `assertNotSent()`, etc.
- Recording requests / exceptions using `Http::recorded()`

### Simple requests

Inside your tests, making a request will still throw a `ConnectionException`, but it will not actually send the request.

```php
public function test_the_domain_expired()
{
    Http::fake([
        'expired.example.com' => Http::error('Could not resolve host: expired.example.com'),
    ]);

    $this->expectException(ConnectionException::class);
    $this->expectExceptionMessage('Could not resolve host: expired.example.com');

    Http::get('https://expired.example.com');
}
```

### Concurrent requests

When using `Http::pool()`, the response instance will be a `Http\Client\ConnectionException` instead of a `Http\Client\Response`.

```php
public function test_aws_is_down()
{
    Http::fake([
        'us-east-1.amazon.com' => Http::response('us-east-1 is up'),
        'us-east-2.amazon.com' => Http::error('us-east-2 is down'),
    ]);

    [$usEast1, $usEast2] = Http::pool(fn (Pool $pool) => [
        $pool->get('us-east-1.amazon.com'),
        $pool->get('us-east-2.amazon.com'),
    ]);

   $this->assertInstanceOf(Response::class, $usEast1);
   $this->assertEquals('us-east-1 is up', $usEast1->body());

   $this->assertInstanceOf(ConnectionException::class, $usEast2);
   $this->assertEquals('us-east-2 is down', $usEast2->getMessage());
}
```

### Events

```php
public function test_events()
{
    Event::fake();

    Http::fake(['error.example.com' => Http::error()]);

    rescue(fn () => Http::get('https://error.example.com'));

    Event::assertDispatched(RequestSending::class);
    Event::assertDispatched(ConnectionFailed::class);
    Event::assertNotDispatched(ResponseReceived::class);
}
```

### Faking response sequences

```php
public function test_sequences()
{
    Http::fake(['example.com' => Http::sequence()
        ->push('Hello world')
        ->pushError('Connection failed'),
    ]);

    $response = Http::get('example.com');

    $this->assertEquals('Hello world', $response->body());

    $this->expectException(ConnectionException::class);
    $this->expectExceptionMessage('Connection failed');

    Http::get('example.com');
}
```

### Inspecting requests

When asserting requests that throws connection errors, the `Http::assert*()` methods receive a `Http\Client\ConnectionException` instead of a `Http\Client\Response`.

```php
public function test_inspections()
{
    Http::fake(['error.example.com' => Http::error('Connection failed')]);

    rescue(fn () => Http::get('https://error.example.com'));

    Http::assertSentCount(1);

    Http::assertSent(function (Request $request, ConnectionException $response) {
        return $request->url() === 'https://error.example.com'
            && $response->getMessage() === 'Connection failed';
    });
}
```