### PR TITLE
[9.x] Solved the problem of incorrect parameter definition.

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -84,9 +84,11 @@ trait AuthorizesRequests
     {
         $model = is_array($model) ? implode(',', $model) : $model;
 
-        $parameter = $parameter ?: (Route::getCurrentRoute()->parameterNames ?: Str::snake(class_basename($model)));
+        $automaticParameterDetection = Route::getCurrentRoute()->parameterNames ?: Str::snake(class_basename($model));
 
-        $parameter = $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
+        $parameter = $parameter ?: $automaticParameterDetection;
+
+        $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
 
         $middleware = [];
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Auth\Access;
 
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 
 trait AuthorizesRequests

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -84,7 +84,7 @@ trait AuthorizesRequests
     {
         $model = is_array($model) ? implode(',', $model) : $model;
 
-        $automaticParameterDetection = app('request')->route()->parameterNames ?? Str::snake(class_basename($model));
+        $automaticParameterDetection = app()->has('request') ? app('request')->route()->parameterNames : Str::snake(class_basename($model));
 
         $parameter = $parameter ?: $automaticParameterDetection;
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Auth\Access;
 
 use Illuminate\Contracts\Auth\Access\Gate;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 
 trait AuthorizesRequests
@@ -85,7 +84,7 @@ trait AuthorizesRequests
     {
         $model = is_array($model) ? implode(',', $model) : $model;
 
-        $automaticParameterDetection = Route::getCurrentRoute()->parameterNames ?: Str::snake(class_basename($model));
+        $automaticParameterDetection = app('request')->route()->parameterNames ?? Str::snake(class_basename($model));
 
         $parameter = $parameter ?: $automaticParameterDetection;
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -84,9 +84,9 @@ trait AuthorizesRequests
     {
         $model = is_array($model) ? implode(',', $model) : $model;
 
-        $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
+        $parameter = $parameter ?: (Route::getCurrentRoute()->parameterNames ?: Str::snake(class_basename($model)));
 
-        $parameter = $parameter ?: Str::snake(class_basename($model));
+        $parameter = $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
 
         $middleware = [];
 


### PR DESCRIPTION
By default, the parameter should listen to the route parameter, not the model name.  Documentation [Authorizing Resource Controllers](https://laravel.com/docs/9.x/authorization#authorizing-resource-controllers) recommends specifying the parameter initially. The second parameter is optional. Ларавел will figure it out for you. In 99% of cases it works. I was lucky to be in the 1%. Below is a complete description of the problem.
