### PR TITLE
[10.x] Solved the problem of incorrect parameter definition.

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Auth\Access;
 
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 
 trait AuthorizesRequests

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Auth\Access;
 
 use Illuminate\Contracts\Auth\Access\Gate;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 
 trait AuthorizesRequests
@@ -85,7 +84,7 @@ trait AuthorizesRequests
     {
         $model = is_array($model) ? implode(',', $model) : $model;
 
-        $automaticParameterDetection = Route::getCurrentRoute()->parameterNames ?: Str::snake(class_basename($model));
+        $automaticParameterDetection = app()->has('request') ? app('request')->route()->parameterNames : Str::snake(class_basename($model));
 
         $parameter = $parameter ?: $automaticParameterDetection;
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -84,7 +84,9 @@ trait AuthorizesRequests
     {
         $model = is_array($model) ? implode(',', $model) : $model;
 
-        $parameter = $parameter ?: (Route::getCurrentRoute()->parameterNames ?: Str::snake(class_basename($model)));
+        $automaticParameterDetection = Route::getCurrentRoute()->parameterNames ?: Str::snake(class_basename($model));
+
+        $parameter = $parameter ?: $automaticParameterDetection;
 
         $parameter = $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -88,7 +88,7 @@ trait AuthorizesRequests
 
         $parameter = $parameter ?: $automaticParameterDetection;
 
-        $parameter = $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
+        $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
 
         $middleware = [];
 

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -84,9 +84,9 @@ trait AuthorizesRequests
     {
         $model = is_array($model) ? implode(',', $model) : $model;
 
-        $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
+        $parameter = $parameter ?: (Route::getCurrentRoute()->parameterNames ?: Str::snake(class_basename($model)));
 
-        $parameter = $parameter ?: Str::snake(class_basename($model));
+        $parameter = $parameter = is_array($parameter) ? implode(',', $parameter) : $parameter;
 
         $middleware = [];
 


### PR DESCRIPTION
My edits will help Laravel auto-detect the parameter correctly

```php
// api.php
Route::apiResource('accounts', 'Account\TestAccountController');
```
```php
class TestAccountController extends Controller {
   public function __construct()
   {
      $this->authorizeResource(TestAccount::class);
   }
      
   public function show(TestAccount $account)
   {
      return $account;
      // "message": "This action is unauthorized.",
      // "exception": "Symfony\\Component\\HttpKernel\\Exception\\AccessDeniedHttpException",
   }
}
```
```php
class AuthServiceProvider extends ServiceProvider {
   public function boot()
   {
      Gate::before(
         function (User $user, string $action, array $options) {
            // FOR TEST

            dd($action, $options);
            // return
            // "view"
            // [ ]       <- this problem (POLICY NOT RUN)
         }
      );
   }
}
```

If you do that, then everything works as it should. But the problem is auto-detect!

```php
class TestAccountController extends Controller {
   public function __construct()
   {
      $this->authorizeResource(TestAccount::class, 'account');
   }
```
My edits will help Laravel auto-detect the parameter correctly -> Laravel listens to the parameter specified in Route

```php
// before (It doesn't work for this example)
Str::snake(class_basename($model))
// after (Laravel listens to the parameter specified in Route)
Route::getCurrentRoute()->parameterNames
```
Please see what I have done in the file!