### PR TITLE
[9.x] Update Vite mock to return empty array for preloadedAssets

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -135,6 +135,10 @@ trait InteractsWithContainer
             {
                 return $this;
             }
+
+            public function preloadedAssets() {
+                return [];
+            }
         });
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -136,7 +136,8 @@ trait InteractsWithContainer
                 return $this;
             }
 
-            public function preloadedAssets() {
+            public function preloadedAssets()
+            {
                 return [];
             }
         });

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -37,6 +37,14 @@ class InteractsWithContainerTest extends TestCase
         $this->assertSame($this, $instance);
     }
 
+    public function testWithoutViteReturnsEmptyArrayForPreloadedAssets(): void
+    {
+        $instance = $this->withoutVite();
+
+        $this->assertSame([], app(Vite::class)->preloadedAssets());
+        $this->assertSame($this, $instance);
+    }
+
     public function testWithoutMixBindsEmptyHandlerAndReturnsInstance()
     {
         $instance = $this->withoutMix();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

**TL;DR**

The Vite mock that is used when using `$this->withoutVite()` inside tests uses `__call` to proxy all method calls that aren't explicitly defined to return an empty string.

This conflicts with the `\Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class` middleware which expects this to be an empty array.


**Long Version**

I recently created a new Laravel project and installed Breeze.
I'm using Vue and Inertia and bootstrapped this through Breeze.

We've been writing tests as we've gone and this has all worked fine locally.

Today, I added a CI workflow for our project, via GitHub Actions, and got failures.

I was not installing and building assets, and it was failing due to a missing Vite manifest.

I added `$this->withoutVite()` to the base `TestCase.php` and then saw failures due to the `\Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class` middleware as the assets were not coming through as an empty array but an empty string.

Looking under the hood, the mock that exists in the `InteractsWithContainer`, I can see that this will be due to `__call` forcing a string to return.

I've added a test to the `InteractsWithContainerTest` that highlights the issue.