### PR TITLE
[9.x] Apply force flag when necessary

### DIFF
--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -157,7 +157,7 @@ class Listener
             "--memory={$options->memory}",
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
-            $options->force ? "--force" : null,
+            $options->force ? '--force' : null,
         ], function ($value) {
             return ! is_null($value);
         });

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -157,6 +157,7 @@ class Listener
             "--memory={$options->memory}",
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
+            $options->force ? "--force" : null,
         ], function ($value) {
             return ! is_null($value);
         });


### PR DESCRIPTION
This PR fix #44861. 

The `--force` flag was missing when it was needed on the Listener::createCommand function.