### PR TITLE
feat: add support for nullable passwords for users

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -44,7 +44,7 @@ trait Authenticatable
     /**
      * Get the password for the user.
      *
-     * @return string
+     * @return string|null
      */
     public function getAuthPassword()
     {

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -155,7 +155,7 @@ class DatabaseUserProvider implements UserProvider
     public function validateCredentials(UserContract $user, array $credentials)
     {
         return $this->hasher->check(
-            $credentials['password'], $user->getAuthPassword()
+            $credentials['password'], (string) $user->getAuthPassword()
         );
     }
 }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -151,7 +151,7 @@ class EloquentUserProvider implements UserProvider
     {
         $plain = $credentials['password'];
 
-        return $this->hasher->check($plain, $user->getAuthPassword());
+        return $this->hasher->check($plain, (string) $user->getAuthPassword());
     }
 
     /**

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -47,7 +47,7 @@ class GenericUser implements UserContract
     /**
      * Get the password for the user.
      *
-     * @return string
+     * @return string|null
      */
     public function getAuthPassword()
     {

--- a/src/Illuminate/Contracts/Auth/Authenticatable.php
+++ b/src/Illuminate/Contracts/Auth/Authenticatable.php
@@ -21,7 +21,7 @@ interface Authenticatable
     /**
      * Get the password for the user.
      *
-     * @return string
+     * @return string|null
      */
     public function getAuthPassword();
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -471,7 +471,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        return $hasher->check($value, $guard->user()->getAuthPassword());
+        return $hasher->check($value, (string) $guard->user()->getAuthPassword());
     }
 
     /**

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -160,4 +160,17 @@ class AuthDatabaseUserProviderTest extends TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testCredentialValidationWithNullablePassword()
+    {
+        $conn = m::mock(Connection::class);
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->once()->with('plain', null)->andReturn(false);
+        $provider = new DatabaseUserProvider($conn, $hasher, 'foo');
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn(null);
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+
+        $this->assertFalse($result);
+    }
 }

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -140,6 +140,18 @@ class AuthEloquentUserProviderTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testCredentialValidationWithNullablePassword()
+    {
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->once()->with('plain', null)->andReturn(false);
+        $provider = new EloquentUserProvider($hasher, 'foo');
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthPassword')->once()->andReturn(null);
+        $result = $provider->validateCredentials($user, ['password' => 'plain']);
+
+        $this->assertFalse($result);
+    }
+
     public function testModelsCanBeCreated()
     {
         $hasher = m::mock(Hasher::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This adds support for passwords that are `null` in the database. We are currently doing this, however it results in `strlen()` deprecation notices when the hash is checked.

If this isn't the correct way to handle this, and Laravel isn't intended to have nullable passwords, we can just overload `getAuthPassword()` on our user class. 👍🏻