### PR TITLE
[9.x] De-couple Console component from framework

### DIFF
--- a/src/Illuminate/Console/View/Components/Component.php
+++ b/src/Illuminate/Console/View/Components/Component.php
@@ -81,12 +81,14 @@ abstract class Component
     protected function mutate($data, $mutators)
     {
         foreach ($mutators as $mutator) {
+            $mutator = new $mutator;
+
             if (is_iterable($data)) {
                 foreach ($data as $key => $value) {
-                    $data[$key] = app($mutator)->__invoke($value);
+                    $data[$key] = $mutator($value);
                 }
             } else {
-                $data = app($mutator)->__invoke($data);
+                $data = $mutator($data);
             }
         }
 

--- a/src/Illuminate/Console/View/Components/Mutators/EnsureRelativePaths.php
+++ b/src/Illuminate/Console/View/Components/Mutators/EnsureRelativePaths.php
@@ -12,7 +12,7 @@ class EnsureRelativePaths
      */
     public function __invoke($string)
     {
-        if (app()->has('path.base')) {
+        if (function_exists('app') && app()->has('path.base')) {
             $string = str_replace(base_path().'/', '', $string);
         }
 


### PR DESCRIPTION
This PR decouples the Console component further from the framework. https://github.com/laravel/framework/pull/43065 introduced the concept of mutators which are getting resolved through the container before they're invoked. But since none of these mutators have dependencies this isn't necessary. 

I've also added a check for the `app` function in the `EnsureRelativePaths` mutator so it's not invoked when called from outside the framework.

See https://github.com/laravel/framework/issues/44849