### PR TITLE
[9.x] Handle SQLite without `ENABLE_DBSTAT_VTAB` enabled

### DIFF
--- a/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+++ b/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Command;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\SqlServerConnection;
 use Illuminate\Support\Arr;
@@ -151,11 +152,15 @@ abstract class DatabaseInspectionCommand extends Command
      */
     protected function getSqliteTableSize(ConnectionInterface $connection, string $table)
     {
-        $result = $connection->selectOne('SELECT SUM(pgsize) AS size FROM dbstat WHERE name=?', [
-            $table,
-        ]);
+        try {
+            $result = $connection->selectOne('SELECT SUM(pgsize) AS size FROM dbstat WHERE name=?', [
+                $table,
+            ]);
 
-        return Arr::wrap((array) $result)['size'];
+            return Arr::wrap((array) $result)['size'];
+        } catch (QueryException $e) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #44860

PHP 7.4 and onwards no longer bundles SQLite. If PHP is built against a version of SQLite which is missing the `ENABLE_DBSTAT_VTAB` option then currently `db:show` will break. We'll now return nothing.