### PR TITLE
Add helper methods to `Schedule` to test against jobs and commands

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -13,7 +13,9 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Support\Arr;
 use Illuminate\Support\ProcessUtils;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
 
@@ -363,5 +365,39 @@ class Schedule
         }
 
         return $this->dispatcher;
+    }
+
+    /**
+     * Find if artisan command with given cron expression scheduled.
+     *
+     * @param  string  $command
+     * @param  string  $expression
+     * @return bool
+     */
+    public function hasCommand(string $command, string $expression): bool
+    {
+        $event = Arr::first(
+            $this->events,
+            fn (Event $item) => Str::after($item->command, "'artisan' ") === $command && $item->getExpression() === $expression
+        );
+
+        return ! is_null($event);
+    }
+
+    /**
+     * Find if job class with given cron expression scheduled.
+     *
+     * @param  string  $job
+     * @param  string  $expression
+     * @return bool
+     */
+    public function hasJob(string $job, string $expression): bool
+    {
+        $event = Arr::first(
+            $this->events,
+            fn (Event $item) => $item->description === $job && $item->getExpression() === $expression
+        );
+
+        return ! is_null($event);
     }
 }

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -147,6 +147,26 @@ class ConsoleEventSchedulerTest extends TestCase
         $events = $schedule->events();
         $this->assertSame('Asia/Tokyo', $events[0]->timezone);
     }
+
+    public function testHasCommandWithCommandAndExpression()
+    {
+        $schedule = $this->schedule;
+        $schedule->command(ConsoleCommandStub::class);
+
+        $this->assertTrue($schedule->hasCommand('foo:bar', '* * * * *'));
+        $this->assertFalse($schedule->hasCommand('foo:bar', '0 0 * * *'));
+        $this->assertFalse($schedule->hasCommand('foo:baz', '* * * * *'));
+    }
+
+    public function testHasCommandWithJobAndExpression()
+    {
+        $schedule = $this->schedule;
+        $schedule->job(ConsoleCommandStub::class);
+
+        $this->assertTrue($schedule->hasJob(ConsoleCommandStub::class, '* * * * *'));
+        $this->assertFalse($schedule->hasJob(ConsoleCommandStub::class, '0 0 * * *'));
+        $this->assertFalse($schedule->hasJob(FooClassStub::class, '* * * * *'));
+    }
 }
 
 class FooClassStub


### PR DESCRIPTION
This PR adds 2 public methods to `Illuminate\Console\Scheduling\Schedule` to test if a given job/command with a given expression is scheduled. Comes in handy on unit tests. 

Assuming we have a job `CheckProductAvailability` which we schedule to run daily.

```php
$schedule->job(CheckProductAvailability::class)->daily();
```

In units tested with the new `hasJob` method, we can test against this scheduled job.

```php
$this->assertTrue(
  app(Schedule::class)->hasJob(CheckProductAvailability::class, '0 0 * * *')
);
```

Testing against command is also easy:

```php
$schedule->command('foo:bar')->daily();

// test case
$this->assertTrue(
  app(Schedule::class)->hasCommand('foo:bar', '0 0 * * *')
);
```

`Schedule` is macroable, we can also add these methods as local macros, but I think makes sense to have them on the class directly, makes it easier to test