### PR TITLE
[9.x] New 'valueKey' method to return only model key value from builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -644,6 +644,16 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get a single primary key value from the first result of a query.
+     *
+     * @return mixed
+     */
+    public function valueKey()
+    {
+        return $this->value($this->model->getQualifiedKeyName());
+    }
+
+    /**
      * Get a single column's value from the first result of a query if it's the sole matching record.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $column

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -353,6 +353,26 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey('bar')->valueOrFail('column');
     }
 
+    public function testValueKeyMethodWithModelFound()
+    {
+        $builder = m::mock(Builder::class.'[value,first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        $builder->shouldReceive('value')->once()->with('foo_table.foo')->andReturn('baz');
+        $builder->shouldReceive('first')->with('foo_table.foo')->andReturn('baz');
+        $this->assertSame('baz', $builder->valueKey());
+    }
+
+    public function testValueKeyMethodWithModelNotFound()
+    {
+        $builder = m::mock(Builder::class.'[value,first]', [$this->getMockQueryBuilder()]);
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        $builder->shouldReceive('value')->once()->with('foo_table.foo')->andReturn(null);
+        $builder->shouldReceive('first')->with('foo_table.foo')->andReturn(null);
+        $this->assertNull($builder->valueKey());
+    }
+
     public function testChunkWithLastChunkComplete()
     {
         $builder = m::mock(Builder::class.'[forPage,get]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
It's nice being able to do `Model::value('id')` but what would be even nicer would be to not have to specify the key name at all: `Model::valueKey()`