### PR TITLE
[9.x] Add "lowercase" validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1054,19 +1054,6 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute is lowercase.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @param  array<int, int|string>  $parameters
-     * @return bool
-     */
-    public function validateLowercase($attribute, $value, $parameters)
-    {
-        return Str::lower($value) === $value;
-    }
-
-    /**
      * Validate that an attribute is less than another attribute.
      *
      * @param  string  $attribute
@@ -1169,6 +1156,19 @@ trait ValidatesAttributes
         }
 
         return $this->getSize($attribute, $value) <= $this->getSize($attribute, $comparedToValue);
+    }
+
+    /**
+     * Validate that an attribute is lowercase.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateLowercase($attribute, $value, $parameters)
+    {
+        return Str::lower($value) === $value;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1054,6 +1054,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is lowercase.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateLowercase($attribute, $value, $parameters)
+    {
+        return Str::lower($value) === $value;
+    }
+
+    /**
      * Validate that an attribute is less than another attribute.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1803,6 +1803,33 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testLowercase()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'lower' => 'lowercase',
+            'mixed' => 'MixedCase',
+            'upper' => 'UPPERCASE',
+            'lower_multibyte' => 'carácter multibyte',
+            'mixed_multibyte' => 'carÁcter multibyte',
+            'upper_multibyte' => 'CARÁCTER MULTIBYTE',
+        ], [
+            'lower' => 'lowercase',
+            'mixed' => 'lowercase',
+            'upper' => 'lowercase',
+            'lower_multibyte' => 'lowercase',
+            'mixed_multibyte' => 'lowercase',
+            'upper_multibyte' => 'lowercase',
+        ]);
+
+        $this->assertSame([
+            'mixed',
+            'upper',
+            'mixed_multibyte',
+            'upper_multibyte',
+        ], $v->messages()->keys());
+    }
+
     public function testLessThan()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR introduces a "lowercase" validation rule.

We have a current want for this rule to create some standardised data formatting without changing the case on the user silently.

For example, we want a user to be able to create a database user, but we want to force the user to lowercase.

## Usage

```php
Validator::make(['name' => 'Admin'], ['name' => 'required|string|lowercase']);
```

I don't have a real usecase for an "uppercase" rule, so I did not include it. If we want it for consistency, I can follow up with one (or someone else is welcome to add it).

Documentation: https://github.com/laravel/docs/pull/8332