### PR TITLE
Add `after` method to collections

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1146,6 +1146,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Slice the array after the given value.
+     *
+     * @param  TValue  $value
+     * @param  int|null  $length
+     * @param  bool  $strict
+     * @return static
+     */
+    public function after($value, $length = null, $strict = true)
+    {
+        return $this->slice($this->search($value, $strict), $length);
+    }
+
+    /**
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1125,6 +1125,19 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Slice the array after the given value.
+     *
+     * @param  TValue  $value
+     * @param  int|null  $length
+     * @param  bool  $strict
+     * @return static
+     */
+    public function after($value, $length = null, $strict = true)
+    {
+        return $this->slice($this->search($value, $strict), $length);
+    }
+
+    /**
      * Split a collection into a certain number of groups.
      *
      * @param  int  $numberOfGroups

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4549,6 +4549,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testAfter($collection)
+    {
+        $data = new $collection(['tiny', 'small', 'medium', 'large', 'huge']);
+        $this->assertEquals(['small', 'medium', 'large', 'huge'], $data->after('small')->values()->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testAfterLength($collection)
+    {
+        $data = new $collection(['tiny', 'small', 'medium', 'large', 'huge']);
+        $this->assertEquals(['small', 'medium'], $data->after('small', 2)->values()->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSliceOffset($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);


### PR DESCRIPTION
This pull request adds an `after` method to `Collection` and `LazyCollection`. This method returns a sliced collection after the given value.

```php
$value = 'large'; // Selecting "large+" in filters

$sizes = collect(['small', 'medium', 'large', 'huge'])
    ->after($value); // ['large', 'huge']

$categories = AircraftCategory::query()
    ->whereIn('size', $sizes)
    ->pluck('id')
```