### PR TITLE
[9.x] Remove argument assignment for console

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -13,7 +13,6 @@ use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
-use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -94,14 +94,6 @@ class Application extends SymfonyApplication implements ApplicationContract
             $input = $input ?: new ArgvInput
         );
 
-        if (! is_null($commandName)) {
-            try {
-                $input->bind($this->find($commandName)->getDefinition());
-            } catch (ExceptionInterface) {
-                // ...
-            }
-        }
-
         $this->events->dispatch(
             new CommandStarting(
                 $commandName, $input, $output = $output ?: new BufferedConsoleOutput


### PR DESCRIPTION
This PR reverts https://github.com/laravel/framework/pull/44662 by @bert-w. It seems this doesn't exactly works as expected because incorrect arguments are assigned: https://github.com/laravel/framework/issues/44877. I spent a great deal today looking into a fix but always managed to run into failing integration tests. Since this part of Laravel is too brittle it seemed to me to be the best choice to revert the PR to get back to the state it was instead of having a half baked implementation.

If we ever want to pursue this we'll need to make sure that the arguments of the input doesn't contains the command name as the issue in https://github.com/laravel/framework/issues/44877 describes.