### PR TITLE
Add method to be able to override the exception context format

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -300,9 +300,9 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
-     * Create the context for logging by default format.
+     * Create the context array for logging the given exception.
      *
-     * @param  \Throwable $e
+     * @param  \Throwable  $e
      * @return array
      */
     protected function buildExceptionContext(Throwable $e)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -333,7 +333,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * Create the context for logging by default format.
      *
-     * @param \Throwable $e
+     * @param  \Throwable $e
      * @return array
      */
     protected function buildContext(Throwable $e)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -268,7 +268,7 @@ class Handler implements ExceptionHandlerContract
             $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
         );
 
-        $context = $this->buildContext($e);
+        $context = $this->buildExceptionContext($e);
 
         method_exists($logger, $level)
             ? $logger->{$level}($e->getMessage(), $context)
@@ -300,6 +300,21 @@ class Handler implements ExceptionHandlerContract
     }
 
     /**
+     * Create the context for logging by default format.
+     *
+     * @param  \Throwable $e
+     * @return array
+     */
+    protected function buildExceptionContext(Throwable $e)
+    {
+        return array_merge(
+            $this->exceptionContext($e),
+            $this->context(),
+            ['exception' => $e]
+        );
+    }
+
+    /**
      * Get the default exception context variables for logging.
      *
      * @param  \Throwable  $e
@@ -328,21 +343,6 @@ class Handler implements ExceptionHandlerContract
         } catch (Throwable $e) {
             return [];
         }
-    }
-
-    /**
-     * Create the context for logging by default format.
-     *
-     * @param  \Throwable $e
-     * @return array
-     */
-    protected function buildContext(Throwable $e)
-    {
-        return array_merge(
-            $this->exceptionContext($e),
-            $this->context(),
-            ['exception' => $e]
-        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -268,11 +268,7 @@ class Handler implements ExceptionHandlerContract
             $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
         );
 
-        $context = array_merge(
-            $this->exceptionContext($e),
-            $this->context(),
-            ['exception' => $e]
-        );
+        $context = $this->buildContext($e);
 
         method_exists($logger, $level)
             ? $logger->{$level}($e->getMessage(), $context)
@@ -332,6 +328,21 @@ class Handler implements ExceptionHandlerContract
         } catch (Throwable $e) {
             return [];
         }
+    }
+
+    /**
+     * Create the context for logging by default format.
+     *
+     * @param \Throwable $e
+     * @return array
+     */
+    protected function buildContext(Throwable $e)
+    {
+        return array_merge(
+            $this->exceptionContext($e),
+            $this->context(),
+            ['exception' => $e]
+        );
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR extracted 1 protected methods to Illuminate\Foundation\Exceptions\Handler to override exception context format in downstream.

Currently if you need to customize context format of an exception, you would need to override the whole report method and do it there.

Adding this method allows us to customize context format of an exception by simply implementing the method in the applications Handler class. This is not a breaking change.

Example:

```php
    // override
    protected function buildContext(Throwable $e): array
    {
        return [
            'exception' => [
                'origin' => $e,
                'context' => [
                    'common' => $this->context(),
                    'specific' => $this->exceptionContext($e),
                ],
            ],
        ];
    }
```

