### PR TITLE
Make Vite::isRunningHot public

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -708,7 +708,7 @@ class Vite implements Htmlable
      *
      * @return bool
      */
-    protected function isRunningHot()
+    public function isRunningHot()
     {
         return is_file($this->hotFile());
     }


### PR DESCRIPTION
I am currently getting a lot of Content Security Policy errors when the Vite HMR server is running. It would be nice to be able to disable CSP rules when it is running. For example:

```
   public function shouldBeApplied(Request $request, Response $response): bool
    {
        if (Vite::isRunningHot()) {
            return false;
        }

        return parent::shouldBeApplied($request, $response);
    }
```

`is_file(Vite::hotFile())` can be called to achieve this, but it would be nicer if this method was public