### PR TITLE
Pass `$maxExceptions` from mailable to underlying job when queuing

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -27,18 +27,18 @@ class SendQueuedMailable
     public $tries;
 
     /**
-     * Get the number of times to attempt a job after an exception.
-     *
-     * @return int|null
-     */
-    public $maxExceptions;
-
-    /**
      * The number of seconds the job can run before timing out.
      *
      * @var int
      */
     public $timeout;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @return int|null
+     */
+    public $maxExceptions;
 
     /**
      * Indicates if the job should be encrypted.
@@ -57,8 +57,8 @@ class SendQueuedMailable
     {
         $this->mailable = $mailable;
         $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
-        $this->maxExceptions = $mailable->maxExceptions ?? null;
         $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
+        $this->maxExceptions = property_exists($mailable, 'maxExceptions') ? $mailable->maxExceptions : null;
         $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
         $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;
     }

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -27,6 +27,13 @@ class SendQueuedMailable
     public $tries;
 
     /**
+     * Get the number of times to attempt a job after an exception.
+     *
+     * @return int|null
+     */
+    public $maxExceptions;
+
+    /**
      * The number of seconds the job can run before timing out.
      *
      * @var int
@@ -50,6 +57,7 @@ class SendQueuedMailable
     {
         $this->mailable = $mailable;
         $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
+        $this->maxExceptions = $mailable->maxExceptions ?? null;
         $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
         $this->afterCommit = property_exists($mailable, 'afterCommit') ? $mailable->afterCommit : null;
         $this->shouldBeEncrypted = $mailable instanceof ShouldBeEncrypted;


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Normal job that is processed by a queue can have `$maxExceptions` set to any number.
Mailables that ShouldQueue are missing this options, because of this it is complicated to build RateLimited mailable which would stop on nth unhandled exception, but would retry unlimited times (retryUntil method works perfectly on mailables).

https://laravel.com/docs/9.x/queues#max-exceptions