### PR TITLE
[9.x] Adds new ucwords method to the Str and Stringable classes

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1212,6 +1212,17 @@ class Str
     }
 
     /**
+     * Makes the first character of each word in a string uppercase.
+     *
+     * @param $string
+     * @return string
+     */
+    public static function ucwords($string)
+    {
+        return collect(explode(' ', $string))->map(fn ($word) => static::ucfirst($word))->join(' ');
+    }
+
+    /**
      * Get the number of words a string contains.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1214,7 +1214,7 @@ class Str
     /**
      * Makes the first character of each word in a string uppercase.
      *
-     * @param $string
+     * @param  string  $string
      * @return string
      */
     public static function ucwords($string)

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -881,6 +881,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Makes the first character of each word in a string uppercase.
+     *
+     * @param $string
+     * @return string
+     */
+    public static function ucwords($string)
+    {
+        return new static(Str::ucwords($string));
+    }
+
+    /**
      * Execute the given callback if the string contains a given substring.
      *
      * @param  string|iterable<string>  $needles

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -883,12 +883,11 @@ class Stringable implements JsonSerializable
     /**
      * Makes the first character of each word in a string uppercase.
      *
-     * @param $string
      * @return string
      */
-    public static function ucwords($string)
+    public function ucwords()
     {
-        return new static(Str::ucwords($string));
+        return new static(Str::ucwords($this->value));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -779,6 +779,14 @@ class SupportStrTest extends TestCase
         $this->assertSame(['Öffentliche', 'Überraschungen'], Str::ucsplit('ÖffentlicheÜberraschungen'));
     }
 
+    public function testUcwords()
+    {
+        $this->assertSame('Laravel', Str::ucwords('laravel'));
+        $this->assertSame('Laravel Framework', Str::ucwords('laravel framework'));
+        $this->assertSame('Мама', Str::ucwords('мама'));
+        $this->assertSame('Мама Мыла Раму', Str::ucwords('мама мыла раму'));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -193,6 +193,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame(['He_llo_', 'World'], $this->stringable('He_llo_World')->ucsplit()->toArray());
     }
 
+    public function testUcwordsOnStringable()
+    {
+        $this->assertSame('Laravel', $this->stringable('laravel')->ucwords()->value());
+        $this->assertSame('Laravel Framework', $this->stringable('laravel framework')->ucwords()->value());
+        $this->assertSame('Мама', $this->stringable('мама')->ucwords()->value());
+        $this->assertSame('Мама Мыла Раму', $this->stringable('мама мыла раму')->ucwords()->value());
+    }
+
     public function testWhenEndsWith()
     {
         $this->assertSame('Tony Stark', (string) $this->stringable('tony stark')->whenEndsWith('ark', function ($stringable) {


### PR DESCRIPTION
This PR adds a new `ucwords` method to the Str helper function, and also a chainable `ucwords()` method to the Stringable class.

Rather than utilising the PHP core `ucwords` function, I've chosen to hook in to the existing `ucfirst` method, which takes into account other characters such as the Cyrillic characters, meaning we're able to offer the same functionality for more languages, in the same way Laravel already does.

I was recently working on a personal project, and I found myself wanting to chain a ucwords method to the end of a string manipulation. Obviously this can be achieved by wrapping the existing code within the PHP function, but this PR will allow us to maintain the chainable nature of the new Stringables available in Laravel.

This should allow users to utilise the functionality of ucwords now while keeping the fluent syntax Laravel is known for.