### PR TITLE
[9.x] Added `Auth::userOrFail()` function

### DIFF
--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -69,8 +69,7 @@ class RequestGuard implements Guard
     {
         $user = $this->user();
 
-        if (!$user)
-        {
+        if (!$user) {
             throw new UnauthorizedException();
         }
 

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\UnauthorizedException;
 
 class RequestGuard implements Guard
 {
@@ -57,6 +58,23 @@ class RequestGuard implements Guard
         return $this->user = call_user_func(
             $this->callback, $this->request, $this->getProvider()
         );
+    }
+
+    /**
+     * Get the currently authenticated user.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public function userOrFail()
+    {
+        $user = $this->user();
+
+        if (!$user)
+        {
+            throw new UnauthorizedException();
+        }
+
+        return $this->user();
     }
 
     /**

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -64,12 +64,14 @@ class RequestGuard implements Guard
      * Get the currently authenticated user.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable
+     *
+     * @throws \Illuminate\Validation\UnauthorizedException
      */
     public function userOrFail()
     {
         $user = $this->user();
 
-        if (!$user) {
+        if (! $user) {
             throw new UnauthorizedException();
         }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Illuminate\Support\Timebox;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\UnauthorizedException;
 use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
@@ -174,6 +175,24 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         }
 
         return $this->user;
+    }
+
+    /**
+     * Get the currently authenticated user or creates an error response.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @throws \Illuminate\Validation\UnauthorizedException
+     */
+    public function userOrFail()
+    {
+        $user = $this->user();
+
+        if (!$user)
+        {
+            throw new UnauthorizedException();
+        }
+
+        return $this->user();
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -187,8 +187,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         $user = $this->user();
 
-        if (!$user)
-        {
+        if (!$user) {
             throw new UnauthorizedException();
         }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -181,13 +181,14 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * Get the currently authenticated user or creates an error response.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable
+     *
      * @throws \Illuminate\Validation\UnauthorizedException
      */
     public function userOrFail()
     {
         $user = $this->user();
 
-        if (!$user) {
+        if (! $user) {
             throw new UnauthorizedException();
         }
 

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
+use Illuminate\Validation\UnauthorizedException;
 
 class TokenGuard implements Guard
 {
@@ -87,6 +88,24 @@ class TokenGuard implements Guard
         }
 
         return $this->user = $user;
+    }
+
+    /**
+     * Get the currently authenticated user or creates an error response.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @throws \Illuminate\Validation\UnauthorizedException
+     */
+    public function userOrFail()
+    {
+        $user = $this->user();
+
+        if (!$user)
+        {
+            throw new UnauthorizedException();
+        }
+
+        return $this->user();
     }
 
     /**

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -100,8 +100,7 @@ class TokenGuard implements Guard
     {
         $user = $this->user();
 
-        if (!$user)
-        {
+        if (!$user) {
             throw new UnauthorizedException();
         }
 

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -94,13 +94,14 @@ class TokenGuard implements Guard
      * Get the currently authenticated user or creates an error response.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable
+     *
      * @throws \Illuminate\Validation\UnauthorizedException
      */
     public function userOrFail()
     {
         $user = $this->user();
 
-        if (!$user) {
+        if (! $user) {
             throw new UnauthorizedException();
         }
 

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -29,6 +29,7 @@ interface Guard
      * Get the currently authenticated user or creates an error response.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable
+     *
      * @throws \Illuminate\Validation\UnauthorizedException
      */
     public function userOrFail();

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -26,6 +26,14 @@ interface Guard
     public function user();
 
     /**
+     * Get the currently authenticated user or creates an error response.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @throws \Illuminate\Validation\UnauthorizedException
+     */
+    public function userOrFail();
+
+    /**
      * Get the ID for the currently authenticated user.
      *
      * @return int|string|null

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -10,6 +10,7 @@ use RuntimeException;
  * @method static \Illuminate\Auth\AuthManager provider(string $name, \Closure $callback)
  * @method static \Illuminate\Contracts\Auth\Authenticatable loginUsingId(mixed $id, bool $remember = false)
  * @method static \Illuminate\Contracts\Auth\Authenticatable|null user()
+ * @method static \Illuminate\Contracts\Auth\Authenticatable userOrFail()
  * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard guard(string|null $name = null)
  * @method static \Illuminate\Contracts\Auth\UserProvider|null createUserProvider(string $provider = null)
  * @method static \Symfony\Component\HttpFoundation\Response|null onceBasic(string $field = 'email',array $extraConditions = [])


### PR DESCRIPTION
I propose to have a `Auth::userOrFail()` method. Returning only the current user but never not null. Instead it throws a UnauthorizedException.

With `Auth::user()` you always have to check if there is a user. In every route and where every you use it. Often this is already checked by a guarded route. This can be solved by userOrFail() similar to firstOrFail() an other ...OrFail() methodes we already have.

Please let me now if this PR needs improvement.