### PR TITLE
[9.x] Add zero-width space to trimmed characters in TrimStrings middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -53,7 +53,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return preg_replace('~^[\s﻿]+|[\s﻿]+$~u', '', $value) ?? trim($value);
+        return preg_replace('~^[\s﻿​]+|[\s﻿​]+$~u', '', $value) ?? trim($value);
     }
 
     /**

--- a/tests/Http/Middleware/TrimStringsTest.php
+++ b/tests/Http/Middleware/TrimStringsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Illuminate\Tests\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\TrimStrings;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class TrimStringsTest extends TestCase
+{
+    /**
+     * Test no zero-width space character returns the same string
+     */
+    public function test_no_zero_width_space_character_returns_the_same_string()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => 'This title does not contains any zero-width space'
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title does not contains any zero-width space', $req->title);
+        });
+    }
+
+    /**
+     * Test leading zero-width space character is trimmed [ZWSP]
+     */
+    public function test_leading_zero_width_space_character_is_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => '​This title contains a zero-width space at the begining'
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a zero-width space at the begining', $req->title);
+        });
+    }
+
+    /**
+     * Test trailing zero-width space character is trimmed [ZWSP]
+     */
+    public function test_trailing_zero_width_space_character_is_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => 'This title contains a zero-width space at the end​'
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a zero-width space at the end', $req->title);
+        });
+    }
+
+    /**
+     * Test leading zero-width non-breakable space character is trimmed [ZWNBSP]
+     */
+    public function test_leading_zero_width_non_breakable_space_character_is_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => '﻿This title contains a zero-width non-breakable space at the begining'
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a zero-width non-breakable space at the begining', $req->title);
+        });
+    }
+
+    /**
+     * Test leading multiple zero-width non-breakable space characters are trimmed [ZWNBSP]
+     */
+    public function test_leading_multiple_zero_width_non_breakable_space_characters_are_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => '﻿﻿This title contains a zero-width non-breakable space at the begining'
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a zero-width non-breakable space at the begining', $req->title);
+        });
+    }
+
+    /**
+     * Test a combination of leading and trailing zero-width non-breakable space and zero-width space characters are trimmed [ZWNBSP], [ZWSP]
+     */
+    public function test_combination_of_leading_and_trailing_zero_width_non_breakable_space_and_zero_width_space_characters_are_trimmed()
+    {
+        $request = new Request;
+
+        $request->merge([
+            'title' => '﻿​﻿This title contains a zero-width non-breakable space at the end​'
+        ]);
+
+        $middleware = new TrimStrings;
+
+        $middleware->handle($request, function ($req) {
+            $this->assertEquals('This title contains a zero-width non-breakable space at the end', $req->title);
+        });
+    }
+}


### PR DESCRIPTION
I had a weird bug recently when adding a job to the queue when the content had a zero-width space present somewhere.

The bug I had was: `Unable to JSON encode payload. Error code: 5`

It took me a while to corner this issue to a zero-width space present in a user firstname.

I was wondering also if would be interesting to add a middleware to actually remove those characters also from within the fields instead of just the side. I am willing to create another pull request if that need can benefit more people.

Github does not show the diff, so here is a visual diff:

**Before**  
![image](https://user-images.githubusercontent.com/2213846/201346692-9f16d6be-b661-470b-8faa-31ae8d31b7d7.png)

**After**  
![image](https://user-images.githubusercontent.com/2213846/201346759-edc3f3cb-cd61-4553-b0ed-6aa1bb47234a.png)
