### PR TITLE
[9.x] Tweak title to match the test name in TrimStringsTest

### DIFF
--- a/tests/Http/Middleware/TrimStringsTest.php
+++ b/tests/Http/Middleware/TrimStringsTest.php
@@ -106,13 +106,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '﻿​﻿This title contains a zero-width non-breakable space at the end​',
+            'title' => '﻿​﻿This title contains a combination of zero-width non-breakable space and zero-widh spaces characters at the begining and the end​',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width non-breakable space at the end', $req->title);
+            $this->assertEquals('This title contains a combination of zero-width non-breakable space and zero-widh spaces characters at the begining and the end', $req->title);
         });
     }
 }


### PR DESCRIPTION
Just a tweak so that the test content actually matches the test name & description.