### PR TITLE
[9.x] Fix `php artisan serve` with `PHP_CLI_SERVER_WORKERS` > `1`

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -289,7 +289,7 @@ class ServeCommand extends Command
     protected function getDateFromLine($line)
     {
         $regex = env('PHP_CLI_SERVER_WORKERS', 1) > 1
-            ? '/^\[\d+]\s\[(.*)]/'
+            ? '/^\[\d+]\s\[([a-zA-Z0-9: ]+)\]/'
             : '/^\[([^\]]+)\]/';
 
         preg_match($regex, $line, $matches);


### PR DESCRIPTION
I checked it against php 8.0 and php 8.1 with laravel 9.32 and in both scenarios I receive an `InvalidFormatException`. 

It turned out that `(.*)` seems to catch nested brackets. This PR restricts the allowed characters.

References https://github.com/laravel/framework/pull/44204


```diff
 $line = '[13804] [Fri Nov 11 16:37:08 2022] [::1]:64202 Accepted'; 

- preg_match('/^\[\d+]\s\[(.*)]/', $line, $matches);
+ preg_match('/^\[\d+]\s\[([a-zA-Z0-9: ]+)]/', $line, $matches);

 var_dump($matches);
``` 

```diff
 array(2) {
   [0]=>
   string(40) "[13804] [Fri Nov 11 16:37:08 2022] [::1]"
   [1]=>
-  string(30) "Fri Nov 11 16:37:08 2022] [::1"
+  string(24) "Fri Nov 11 16:37:08 2022"
 }
``` 