### PR TITLE
[9.x] Add `uppercase` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1172,6 +1172,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is uppercase.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateUppercase($attribute, $value, $parameters)
+    {
+        return Str::upper($value) === $value;
+    }
+
+    /**
      * Validate the MIME type of a file is an image MIME type.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1830,6 +1830,33 @@ class ValidationValidatorTest extends TestCase
         ], $v->messages()->keys());
     }
 
+    public function testUppercase()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'lower' => 'lowercase',
+            'mixed' => 'MixedCase',
+            'upper' => 'UPPERCASE',
+            'lower_multibyte' => 'carácter multibyte',
+            'mixed_multibyte' => 'carÁcter multibyte',
+            'upper_multibyte' => 'CARÁCTER MULTIBYTE',
+        ], [
+            'lower' => 'uppercase',
+            'mixed' => 'uppercase',
+            'upper' => 'uppercase',
+            'lower_multibyte' => 'uppercase',
+            'mixed_multibyte' => 'uppercase',
+            'upper_multibyte' => 'uppercase',
+        ]);
+
+        $this->assertSame([
+            'lower',
+            'mixed',
+            'lower_multibyte',
+            'mixed_multibyte',
+        ], $v->messages()->keys());
+    }
+
     public function testLessThan()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR introduces an "uppercase" validation rule.

We have a current want for this rule to create some standardized data formatting without changing the case on the user silently.

For example, we want a user to be able to create a database user, but we want to force the user to uppercase.

Usage:

```php
Validator::make(['name' => 'ADMIN'], ['name' => ['required', 'string', 'uppercase']);
```

I don't have a real use case for an "uppercase" rule, so I did not include it. If we want it for consistency, I can follow up with one (or someone else is welcome to add it).

Documentation: https://github.com/laravel/docs/pull/8336