### PR TITLE
Corrects insertGetId method's return type

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3253,7 +3253,7 @@ class Builder implements BuilderContract
      *
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return int|string
      */
     public function insertGetId(array $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -13,7 +13,7 @@ class PostgresProcessor extends Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return int|string
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -25,7 +25,7 @@ class Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return int|string
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -15,7 +15,7 @@ class SqlServerProcessor extends Processor
      * @param  string  $sql
      * @param  array  $values
      * @param  string|null  $sequence
-     * @return int
+     * @return int|string
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {


### PR DESCRIPTION
Just a small addition to Builder class documentation.
I believe it should be this way, because the method returns the value of the primary key, which can also be a string.