### PR TITLE
[9.x] Update database version check for lock popping for PlanetScale

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -261,7 +261,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         if (Str::of($databaseVersion)->contains('MariaDB')) {
             $databaseEngine = 'mariadb';
             $databaseVersion = Str::before(Str::after($databaseVersion, '5.5.5-'), '-');
-        } elseif (Str::of($databaseVersion)->contains('vitess') || Str::of($databaseVersion)->contains('PlanetScale')) {
+        } elseif (Str::of($databaseVersion)->contains(['vitess', 'PlanetScale'])) {
             $databaseEngine = 'vitess';
             $databaseVersion = Str::before($databaseVersion, '-');
         }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -261,7 +261,7 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue
         if (Str::of($databaseVersion)->contains('MariaDB')) {
             $databaseEngine = 'mariadb';
             $databaseVersion = Str::before(Str::after($databaseVersion, '5.5.5-'), '-');
-        } elseif (Str::of($databaseVersion)->contains('vitess')) {
+        } elseif (Str::of($databaseVersion)->contains('vitess') || Str::of($databaseVersion)->contains('PlanetScale')) {
             $databaseEngine = 'vitess';
             $databaseVersion = Str::before($databaseVersion, '-');
         }


### PR DESCRIPTION
PlanetScale (Vitess) does not support `SKIP LOCKED`.

This issue was addressed previously in #44027 however PlanetScale seems to have changed their version string suffix from `-vitess` to `-PlanetScale`.

```
> DB::connection()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION)
= "8.0.23-PlanetScale"
```