### PR TITLE
[9.x] Add `assertRedirectToRoute` to `TestResponse`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -291,6 +291,33 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert whether the response is redirecting to a given route.
+     *
+     * @param  string|null  $name
+     * @param  mixed  $parameters
+     * @return $this
+     */
+    public function assertRedirectToRoute($name = null, $parameters = [])
+    {
+        if (! is_null($name)) {
+            $uri = route($name, $parameters);
+        }
+
+        PHPUnit::assertTrue(
+            $this->isRedirect(),
+            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
+        );
+
+        $request = Request::create($this->headers->get('Location'));
+
+        PHPUnit::assertEquals(
+            app('url')->to($uri), $request->fullUrl()
+        );
+
+        return $this;
+    }
+
+    /**
      * Asserts that the response contains the given header and equals the optional value.
      *
      * @param  string  $headerName

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -253,6 +253,33 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert whether the response is redirecting to a given route.
+     *
+     * @param  string|null  $name
+     * @param  mixed  $parameters
+     * @return $this
+     */
+    public function assertRedirectToRoute($name = null, $parameters = [])
+    {
+        if (! is_null($name)) {
+            $uri = route($name, $parameters);
+        }
+
+        PHPUnit::assertTrue(
+            $this->isRedirect(),
+            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
+        );
+
+        $request = Request::create($this->headers->get('Location'));
+
+        PHPUnit::assertEquals(
+            app('url')->to($uri), $request->fullUrl()
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert whether the response is redirecting to a given signed route.
      *
      * @param  string|null  $name
@@ -286,33 +313,6 @@ class TestResponse implements ArrayAccess
                 app('url')->to($uri), $expectedUri
             );
         }
-
-        return $this;
-    }
-
-    /**
-     * Assert whether the response is redirecting to a given route.
-     *
-     * @param  string|null  $name
-     * @param  mixed  $parameters
-     * @return $this
-     */
-    public function assertRedirectToRoute($name = null, $parameters = [])
-    {
-        if (! is_null($name)) {
-            $uri = route($name, $parameters);
-        }
-
-        PHPUnit::assertTrue(
-            $this->isRedirect(),
-            $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
-        );
-
-        $request = Request::create($this->headers->get('Location'));
-
-        PHPUnit::assertEquals(
-            app('url')->to($uri), $request->fullUrl()
-        );
 
         return $this;
     }

--- a/tests/Testing/AssertRedirectToRouteTest.php
+++ b/tests/Testing/AssertRedirectToRouteTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Tests\Testing;
+
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Facade;
+use Orchestra\Testbench\TestCase;
+
+class AssertRedirectToRouteTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Contracts\Routing\Registrar
+     */
+    private $router;
+
+    /**
+     * @var \Illuminate\Routing\UrlGenerator
+     */
+    private $urlGenerator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->router = $this->app->make(Registrar::class);
+
+        $this->router
+            ->get('named-route')
+            ->name('named-route');
+
+        $this->router
+            ->get('named-route-with-param/{param}')
+            ->name('named-route-with-param');
+
+        $this->urlGenerator = $this->app->make(UrlGenerator::class);
+    }
+
+    public function testAssertRedirectToRouteWithRouteName()
+    {
+        $this->router->get('test-route', function () {
+            return new RedirectResponse($this->urlGenerator->route('named-route'));
+        });
+
+        $this->get('test-route')
+            ->assertRedirectToRoute('named-route');
+    }
+
+    public function testAssertRedirectToRouteWithRouteNameAndParams()
+    {
+        $this->router->get('test-route', function () {
+            return new RedirectResponse($this->urlGenerator->route('named-route-with-param', 'hello'));
+        });
+
+        $this->router->get('test-route-with-extra-param', function () {
+            return new RedirectResponse($this->urlGenerator->route('named-route-with-param', [
+                'param' => 'foo',
+                'extra' => 'another',
+            ]));
+        });
+
+        $this->get('test-route')
+            ->assertRedirectToRoute('named-route-with-param', 'hello');
+
+        $this->get('test-route-with-extra-param')
+            ->assertRedirectToRoute('named-route-with-param', [
+                'param' => 'foo',
+                'extra' => 'another',
+            ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Facade::setFacadeApplication(null);
+    }
+}


### PR DESCRIPTION
`Illuminate\Testing\TestResponse` has several helpers to assert the response has a redirect of various types. There is `assertRedirect(string $uri = null)`, `assertRedirectContains(string $uri)`, and `assertRedirectToSignedRoute(string $name = null, array $parameters = [])`.

This PR add a missing assertion `assertRedirectToRoute`, which in theory does not differ much from `assertRedirectToSignedRoute`.

Used as the following:

```php
$this->get('test-route')
    ->assertRedirectToRoute('named-route');
```

and in case of passing parameters we use it as the following:

```php
$this->get('test-route')
    ->assertRedirectToRoute('named-route-with-param', 'hello');

$this->get('test-route-with-extra-param')
    ->assertRedirectToRoute('named-route-with-param', [
        'param' => 'foo',
        'extra' => 'another',
    ]);
```
