### PR TITLE
[9.x] Show error if key:generate artisan command fails

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -90,7 +90,9 @@ class KeyGenerateCommand extends Command
             return false;
         }
 
-        $this->writeNewEnvironmentFileWith($key);
+        if (! $this->writeNewEnvironmentFileWith($key)) {
+            return false;
+        }
 
         return true;
     }
@@ -99,15 +101,25 @@ class KeyGenerateCommand extends Command
      * Write a new environment file with the given key.
      *
      * @param  string  $key
-     * @return void
+     * @return bool
      */
     protected function writeNewEnvironmentFileWith($key)
     {
-        file_put_contents($this->laravel->environmentFilePath(), preg_replace(
+        $replaced = preg_replace(
             $this->keyReplacementPattern(),
             'APP_KEY='.$key,
-            file_get_contents($this->laravel->environmentFilePath())
-        ));
+            $input = file_get_contents($this->laravel->environmentFilePath())
+        );
+
+        if ($replaced === $input || $replaced === null) {
+            $this->error('No APP_KEY found in your .env file. Cannot set automatically.');
+
+            return false;
+        }
+
+        file_put_contents($this->laravel->environmentFilePath(), $replaced);
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -112,7 +112,7 @@ class KeyGenerateCommand extends Command
         );
 
         if ($replaced === $input || $replaced === null) {
-            $this->error('No APP_KEY found in your .env file. Cannot set automatically.');
+            $this->error('Unable to set application key. No APP_KEY variable was found in the .env file.');
 
             return false;
         }


### PR DESCRIPTION
This PR changes that if the `artisan key:generate` fails, an error message is shown.

This is most common when the `.env` file is missing an `APP_KEY=`  empty placeholder. In this case, the `preg_replace` call will return the input as-is. If that happened, an error is shown instead of showing the incorrect `Application key set successfully.`

Fixes #44917 