### PR TITLE
Improve setAttribute Mutators return consistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1046,7 +1046,7 @@ trait HasAttributes
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return mixed
+     * @return $this
      */
     protected function setAttributeMarkedMutatedAttributeValue($key, $value)
     {
@@ -1068,6 +1068,8 @@ trait HasAttributes
         } else {
             unset($this->attributeCastCache[$key]);
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This change returns the current object from `setAttributeMarkedMutatedAttributeValue` which allows using `$model->setAttribute('key', 'value')->save()` when using Attribute Mutators. As far as I can tell the setAttribute is otherwise intended to return `$this` and only returns `mixed` (in phpdoc) since it is unknown what is returned in a custom mutator function via `setMutatedAttributeValue`.

Since `setAttributeMarkedMutatedAttributeValue` currently returns `void` this change should have no impact on anything else.
