### PR TITLE
Added missing docblock params and parameter types to Str::slug and Str::wrap

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1012,9 +1012,10 @@ class Str
      * @param  string  $title
      * @param  string  $separator
      * @param  string|null  $language
+     * @param  array<string, string> $dictionary
      * @return string
      */
-    public static function slug($title, $separator = '-', $language = 'en', $dictionary = ['@' => 'at'])
+    public static function slug(string $title, string $separator = '-', ?string $language = 'en', array $dictionary = ['@' => 'at'])
     {
         $title = $language ? static::ascii($title, $language) : $title;
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -341,11 +341,12 @@ class Str
     /**
      * Wrap the string with the given strings.
      *
+     * @param  string  $value
      * @param  string  $before
      * @param  string|null  $after
      * @return string
      */
-    public static function wrap($value, $before, $after = null)
+    public static function wrap(string $value, string $before, ?string $after = null)
     {
         return $before.$value.($after ??= $before);
     }


### PR DESCRIPTION
I've noticed Str::slug method is updated recently and the custom implementation that I was using started to give extra warnings on Larastan. So I decided to check the class and a small fix for missing docblock params and added types to parameters.

