### PR TITLE
[9.x] added missing docblock params to Str::wrap and Str::slug

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -341,6 +341,7 @@ class Str
     /**
      * Wrap the string with the given strings.
      *
+     * @param  string  $value
      * @param  string  $before
      * @param  string|null  $after
      * @return string
@@ -1012,6 +1013,7 @@ class Str
      * @param  string  $title
      * @param  string  $separator
      * @param  string|null  $language
+     * @param  array<string, string>  $dictionary
      * @return string
      */
     public static function slug($title, $separator = '-', $language = 'en', $dictionary = ['@' => 'at'])


### PR DESCRIPTION
I've noticed Str::slug method is updated and noticed missing docblocks in the class while checking.

