### PR TITLE
[10.x] Update SQL Server to FETCH and OFFSET for queries that do not include an order by

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -47,7 +47,7 @@ class SqlServerGrammar extends Grammar
     public function compileSelect(Builder $query)
     {
         // An ORDER BY clause is required for offset to work
-        if($query->offset && empty($query->orders)){
+        if ($query->offset && empty($query->orders)) {
             $query->orders[] = ['sql' => '(SELECT 0)'];
         }
 
@@ -309,7 +309,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileLimit(Builder $query, $limit)
     {
-        if($limit && $query->offset > 0){
+        if ($limit && $query->offset > 0) {
             return "fetch next {$limit} rows only";
         }
 
@@ -325,7 +325,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileOffset(Builder $query, $offset)
     {
-        if($offset){
+        if ($offset) {
             return "offset {$offset} rows";
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -20,6 +20,25 @@ class SqlServerGrammar extends Grammar
     ];
 
     /**
+     * The components that make up a select clause.
+     *
+     * @var string[]
+     */
+    protected $selectComponents = [
+        'aggregate',
+        'columns',
+        'from',
+        'joins',
+        'wheres',
+        'groups',
+        'havings',
+        'orders',
+        'offset',
+        'limit',
+        'lock',
+    ];
+
+    /**
      * Compile a select query into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -27,26 +46,12 @@ class SqlServerGrammar extends Grammar
      */
     public function compileSelect(Builder $query)
     {
-        if (! $query->offset) {
-            return parent::compileSelect($query);
+        // An ORDER BY clause is required for offset to work
+        if($query->offset && empty($query->orders)){
+            $query->orders[] = ['sql' => '(SELECT 0)'];
         }
 
-        if (is_null($query->columns)) {
-            $query->columns = ['*'];
-        }
-
-        $components = $this->compileComponents($query);
-
-        if (! empty($components['orders'])) {
-            return parent::compileSelect($query)." offset {$query->offset} rows fetch next {$query->limit} rows only";
-        }
-
-        // If an offset is present on the query, we will need to wrap the query in
-        // a big "ANSI" offset syntax block. This is very nasty compared to the
-        // other database systems but is necessary for implementing features.
-        return $this->compileAnsiOffset(
-            $query, $components
-        );
+        return parent::compileSelect($query);
     }
 
     /**
@@ -236,69 +241,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Create a full ANSI offset clause for the query.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $components
-     * @return string
-     */
-    protected function compileAnsiOffset(Builder $query, $components)
-    {
-        // An ORDER BY clause is required to make this offset query work, so if one does
-        // not exist we'll just create a dummy clause to trick the database and so it
-        // does not complain about the queries for not having an "order by" clause.
-        if (empty($components['orders'])) {
-            $components['orders'] = 'order by (select 0)';
-        }
-
-        // We need to add the row number to the query so we can compare it to the offset
-        // and limit values given for the statements. So we will add an expression to
-        // the "select" that will give back the row numbers on each of the records.
-        $components['columns'] .= $this->compileOver($components['orders']);
-
-        unset($components['orders']);
-
-        if ($this->queryOrderContainsSubquery($query)) {
-            $query->bindings = $this->sortBindingsForSubqueryOrderBy($query);
-        }
-
-        // Next we need to calculate the constraints that should be placed on the query
-        // to get the right offset and limit from our query but if there is no limit
-        // set we will just handle the offset only since that is all that matters.
-        $sql = $this->concatenate($components);
-
-        return $this->compileTableExpression($sql, $query);
-    }
-
-    /**
-     * Compile the over statement for a table expression.
-     *
-     * @param  string  $orderings
-     * @return string
-     */
-    protected function compileOver($orderings)
-    {
-        return ", row_number() over ({$orderings}) as row_num";
-    }
-
-    /**
-     * Determine if the query's order by clauses contain a subquery.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return bool
-     */
-    protected function queryOrderContainsSubquery($query)
-    {
-        if (! is_array($query->orders)) {
-            return false;
-        }
-
-        return Arr::first($query->orders, function ($value) {
-            return $this->isExpression($value['column'] ?? null);
-        }, false) !== false;
-    }
-
-    /**
      * Move the order bindings to be after the "select" statement to account for an order by subquery.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -309,20 +251,6 @@ class SqlServerGrammar extends Grammar
         return Arr::sort($query->bindings, function ($bindings, $key) {
             return array_search($key, ['select', 'order', 'from', 'join', 'where', 'groupBy', 'having', 'union', 'unionOrder']);
         });
-    }
-
-    /**
-     * Compile a common table expression for a query.
-     *
-     * @param  string  $sql
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return string
-     */
-    protected function compileTableExpression($sql, $query)
-    {
-        $constraint = $this->compileRowConstraint($query);
-
-        return "select * from ({$sql}) as temp_table where row_num {$constraint} order by row_num";
     }
 
     /**
@@ -381,6 +309,10 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileLimit(Builder $query, $limit)
     {
+        if($limit && $query->offset > 0){
+            return "fetch next {$limit} rows only";
+        }
+
         return '';
     }
 
@@ -393,6 +325,10 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileOffset(Builder $query, $offset)
     {
+        if($offset){
+            return "offset {$offset} rows";
+        }
+
         return '';
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3502,19 +3502,18 @@ SQL;
         $this->assertSame('select top 10 * from [users]', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
-        $builder->select('*')->from('users')->skip(10);
-        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11 order by row_num', $builder->toSql());
+        $builder->select('*')->from('users')->skip(10)->orderBy('email', 'desc');
+        $this->assertSame('select * from [users] order by [email] desc offset 10 rows', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->take(10);
-        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
+        $this->assertSame('select * from [users] order by (SELECT 0) offset 10 rows fetch next 10 rows only', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(11)->take(10)->orderBy('email', 'desc');
         $this->assertSame('select * from [users] order by [email] desc offset 11 rows fetch next 10 rows only', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
-        $subQueryBuilder = $this->getSqlServerBuilder();
         $subQuery = function ($query) {
             return $query->select('created_at')->from('logins')->where('users.name', 'nameBinding')->whereColumn('user_id', 'users.id')->limit(1);
         };


### PR DESCRIPTION
## Overview

SQL Server 2012 introduced the fetch and offset feature.

Laravel started using FETCH and OFFSET in 2021 -- but only when you include an order by. 
See PR: https://github.com/laravel/framework/pull/39863

Laravel also only officially supports 2017 and up: 
https://laravel.com/docs/9.x/database#introduction

This PR updates the query builder to also use FETCH and OFFSET for queries that do not include an order by.

Others have voiced support for this PR: 
https://www.reddit.com/r/laravel/comments/ypooqe

This update improves the speed by 33% and requires less execution steps!
https://gist.github.com/dunhamjared/cb40bbf294ed6f8e48bd60010a31b4f3

## Changes

- Updated `row_number()` logic to match the current use of `OFFSET/FETCH`
- Consolidated the `OFFSET/FETCH` logic into built in functions
- Ordered the `$selectComponents` in the correct order for SQL Server

## Example

Currently, if you include an order by, it uses offset and fetch:

```php
$builder->select('*')->from('users')->skip(11)->take(10)->orderBy('email', 'desc');
```

```sql
select * from [users] order by [email] desc offset 11 rows fetch next 10 rows only
```

However, if order by is not included, it falls back to the old method of offsetting the results:

```php
$builder->select('*')->from('users')->skip(10)->take(10);
```

```sql
select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num
```

This PR would instead produce:

```sql
select * from [users] order by (SELECT 0) offset 10 rows fetch next 10 rows only
```

## Edge cases 

- There could be people that actually use the `row_num` in their applications when order by is not used, so this could be considered a breaking change. 
