### PR TITLE
[9.x] Translate Based on Object Property

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -889,11 +889,11 @@ if (! function_exists('trans')) {
      * Translate the given message.
      *
      * @param  string|null  $key
-     * @param  array  $replace
+     * @param  mixed  $replace
      * @param  string|null  $locale
      * @return \Illuminate\Contracts\Translation\Translator|string|array|null
      */
-    function trans($key = null, $replace = [], $locale = null)
+    function trans($key = null, $replace = null, $locale = null)
     {
         if (is_null($key)) {
             return app('translator');
@@ -924,11 +924,11 @@ if (! function_exists('__')) {
      * Translate the given message.
      *
      * @param  string|null  $key
-     * @param  array  $replace
+     * @param  mixed  $replace
      * @param  string|null  $locale
      * @return string|array|null
      */
-    function __($key = null, $replace = [], $locale = null)
+    function __($key = null, $replace = null, $locale = null)
     {
         if (is_null($key)) {
             return $key;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -99,12 +99,12 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * Get the translation for the given key.
      *
      * @param  string  $key
-     * @param  array  $replace
+     * @param  mixed  $replace
      * @param  string|null  $locale
      * @param  bool  $fallback
      * @return string|array
      */
-    public function get($key, array $replace = [], $locale = null, $fallback = true)
+    public function get($key, mixed $replace = null, $locale = null, $fallback = true)
     {
         $locale = $locale ?: $this->locale;
 
@@ -188,10 +188,10 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * @param  string  $group
      * @param  string  $locale
      * @param  string  $item
-     * @param  array  $replace
+     * @param  mixed  $replace
      * @return string|array|null
      */
-    protected function getLine($namespace, $group, $locale, $item, array $replace)
+    protected function getLine($namespace, $group, $locale, $item, mixed $replace)
     {
         $this->load($namespace, $group, $locale);
 
@@ -212,14 +212,16 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      * Make the place-holder replacements on a line.
      *
      * @param  string  $line
-     * @param  array  $replace
+     * @param  mixed  $replace
      * @return string
      */
-    protected function makeReplacements($line, array $replace)
+    protected function makeReplacements($line, mixed $replace)
     {
         if (empty($replace)) {
             return $line;
         }
+
+        $replace = is_object($replace) ? (array) $replace : $replace;
 
         $shouldReplace = [];
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Translation;
 
+use stdClass;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Collection;
 use Illuminate\Translation\MessageSelector;
@@ -63,6 +64,19 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals(['foo' => 'foo', 'baz' => 'breeze bar', 'qux' => ['tree bar', 'breeze bar', 'beep' => ['rock' => 'tree bar']]], $t->get('foo::bar', ['foo' => 'bar'], 'en'));
         $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
         $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesObjectItem()
+    {
+        $stdClass = new stdClass;
+        $stdClass->name = 'foo';
+        $stdClass->email = 'bar';
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :name' => 'foo :name']);
+        $this->assertSame('foo foo', $t->get('foo :name', $stdClass));
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :email' => 'foo :email']);
+        $this->assertSame('foo bar', $t->get('foo :email', $stdClass));
     }
 
     public function testGetMethodForNonExistingReturnsSameKey()

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Tests\Translation;
 
-use stdClass;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Support\Collection;
 use Illuminate\Translation\MessageSelector;
 use Illuminate\Translation\Translator;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class TranslationTranslatorTest extends TestCase
 {


### PR DESCRIPTION
## What

This PR introduces the capability to pass an entire object to the translator to make translations based on property bind.

## Why

In some cases we need to translate something based on a property of an object, so it is easier to pass the object to the translator to be able to do the translation based on the property.

## Example:

```php
//before this PR

@lang('Welcome, :name!', ['name' => $user->name])
```
```php
//with the proposal of this PR

@lang('Welcome, :name!', $user)
```
