### PR TITLE
Populate attributes on new instance after foreign attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -50,8 +50,10 @@ abstract class HasOneOrMany extends Relation
      */
     public function make(array $attributes = [])
     {
-        return tap($this->related->newInstance($attributes), function ($instance) {
+        return tap($this->related->newInstance(), function ($instance) use ($attributes) {
             $this->setForeignAttributesForCreate($instance);
+
+            $instance->fill($attributes);
         });
     }
 
@@ -214,9 +216,11 @@ abstract class HasOneOrMany extends Relation
     public function firstOrNew(array $attributes = [], array $values = [])
     {
         if (is_null($instance = $this->where($attributes)->first())) {
-            $instance = $this->related->newInstance(array_merge($attributes, $values));
+            $instance = $this->related->newInstance();
 
             $this->setForeignAttributesForCreate($instance);
+
+            $instance->fill(array_merge($attributes, $values));
         }
 
         return $instance;
@@ -316,8 +320,10 @@ abstract class HasOneOrMany extends Relation
      */
     public function create(array $attributes = [])
     {
-        return tap($this->related->newInstance($attributes), function ($instance) {
+        return tap($this->related->newInstance(), function ($instance) use ($attributes) {
             $this->setForeignAttributesForCreate($instance);
+
+            $instance->fill($attributes);
 
             $instance->save();
         });


### PR DESCRIPTION
I am submitting this feature request after encountering an issue where I was assuming the foreign model had been already associated in my mutator methods.

For example, let's say I have the following code:

`$child = $parent->children()->make($attributes)`

I might have one attribute called `last_name` that I want to set by default to the parent's last name. However, at the moment of initializing the new Child model, the parent is not yet associated.

Up until now, I have been resorting to doing the following:

`$child = $parent->children()->make()->fill($attributes)`