### PR TITLE
[9.x] Validate uuid before route binding query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -44,6 +44,24 @@ trait HasUuids
     }
 
     /**
+     * Retrieve the model for a bound value.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveRouteBinding($value, $field = null)
+    {
+        if (in_array($this->getRouteKeyName(), $this->uniqueIds())) {
+            if (! Str::isUuid($value)) {
+                throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+            }
+        }
+
+        return parent::resolveRouteBinding($value);
+    }
+
+    /**
      * Get the auto-incrementing key type.
      *
      * @return string
@@ -69,23 +87,5 @@ trait HasUuids
         }
 
         return $this->incrementing;
-    }
-
-    /**
-     * Retrieve the model for a bound value.
-     *
-     * @param  mixed  $value
-     * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
-    public function resolveRouteBinding($value, $field = null)
-    {
-        if (in_array($this->getRouteKeyName(), $this->uniqueIds())) {
-            if (! Str::isUuid($value)) {
-                throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-            }
-        }
-
-        return parent::resolveRouteBinding($value);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -66,6 +66,7 @@ trait HasUuids
 
     /**
      * Throw ModelNotFoundException unless value is a uuid.
+     *
      * @param  mixed  $value
      * @return void
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -53,11 +53,11 @@ trait HasUuids
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
-        if($field && in_array($field, $this->uniqueIds())){
+        if ($field && in_array($field, $this->uniqueIds())) {
             $this->throwNotFoundUnlessUuid($value);
         }
 
-        if(!$field && in_array($this->getRouteKeyName(), $this->uniqueIds())){
+        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds())) {
             $this->throwNotFoundUnlessUuid($value);
         }
 
@@ -65,8 +65,9 @@ trait HasUuids
     }
 
     /**
-     * Throw ModelNotFoundException unless value is a uuid
-     *
+     * Throw ModelNotFoundException unless value is a uuid.
+     * @param  mixed  $value
+     * @return void
      */
     protected function throwNotFoundUnlessUuid($value)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
 
 trait HasUuids
@@ -68,5 +69,23 @@ trait HasUuids
         }
 
         return $this->incrementing;
+    }
+
+    /**
+     * Retrieve the model for a bound value.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveRouteBinding($value, $field = null)
+    {
+        if (in_array($this->getRouteKeyName(), $this->uniqueIds())) {
+            if (!Str::isUuid($value)) {
+                throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+            }
+        }
+
+        return parent::resolveRouteBinding($value);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -81,7 +81,7 @@ trait HasUuids
     public function resolveRouteBinding($value, $field = null)
     {
         if (in_array($this->getRouteKeyName(), $this->uniqueIds())) {
-            if (!Str::isUuid($value)) {
+            if (! Str::isUuid($value)) {
                 throw (new ModelNotFoundException)->setModel(get_class($this), $value);
             }
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -53,13 +53,26 @@ trait HasUuids
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
-        if (in_array($this->getRouteKeyName(), $this->uniqueIds())) {
-            if (! Str::isUuid($value)) {
-                throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-            }
+        if($field && in_array($field, $this->uniqueIds())){
+            $this->throwNotFoundUnlessUuid($value);
+        }
+
+        if(!$field && in_array($this->getRouteKeyName(), $this->uniqueIds())){
+            $this->throwNotFoundUnlessUuid($value);
         }
 
         return parent::resolveRouteBindingQuery($query, $value, $field);
+    }
+
+    /**
+     * Throw ModelNotFoundException unless value is a uuid
+     *
+     */
+    protected function throwNotFoundUnlessUuid($value)
+    {
+        if (! Str::isUuid($value)) {
+            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -53,28 +53,15 @@ trait HasUuids
      */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
-        if ($field && in_array($field, $this->uniqueIds())) {
-            $this->throwNotFoundUnlessUuid($value);
+        if ($field && in_array($field, $this->uniqueIds()) && ! Str::isUuid($value)) {
+            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
         }
 
-        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds())) {
-            $this->throwNotFoundUnlessUuid($value);
+        if (! $field && in_array($this->getRouteKeyName(), $this->uniqueIds()) && ! Str::isUuid($value)) {
+            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
         }
 
         return parent::resolveRouteBindingQuery($query, $value, $field);
-    }
-
-    /**
-     * Throw ModelNotFoundException unless value is a uuid.
-     *
-     * @param  mixed  $value
-     * @return void
-     */
-    protected function throwNotFoundUnlessUuid($value)
-    {
-        if (! Str::isUuid($value)) {
-            throw (new ModelNotFoundException)->setModel(get_class($this), $value);
-        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasUuids.php
@@ -46,11 +46,12 @@ trait HasUuids
     /**
      * Retrieve the model for a bound value.
      *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Relations\Relation  $query
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return \Illuminate\Database\Eloquent\Model|null
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function resolveRouteBinding($value, $field = null)
+    public function resolveRouteBindingQuery($query, $value, $field = null)
     {
         if (in_array($this->getRouteKeyName(), $this->uniqueIds())) {
             if (! Str::isUuid($value)) {
@@ -58,7 +59,7 @@ trait HasUuids
             }
         }
 
-        return parent::resolveRouteBinding($value);
+        return parent::resolveRouteBindingQuery($query, $value, $field);
     }
 
     /**

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -4,12 +4,10 @@ namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
 use Orchestra\Testbench\TestCase;
 
@@ -238,7 +236,7 @@ PHP);
         $user = ImplicitBindingUser::create(['name' => 'Dries']);
         $comment = ImplicitBindingComment::create([
             'slug' => 'slug',
-            'user_id' => $user->id
+            'user_id' => $user->id,
         ]);
 
         config(['app.key' => str_repeat('a', 32)]);

--- a/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
+++ b/tests/Integration/Routing/ImplicitModelRouteBindingTest.php
@@ -51,6 +51,7 @@ class ImplicitModelRouteBindingTest extends TestCase
         $this->beforeApplicationDestroyed(function () {
             Schema::dropIfExists('users');
             Schema::dropIfExists('posts');
+            Schema::dropIfExists('comments');
         });
     }
 


### PR DESCRIPTION
This pull request overrides the resolveRouteBinding method in the HasUuids trait to ensure the given URI segment is a valid UUID before passing it to the database.

This check is necessary when using a Postgres database with the UUID datatype as passing anything other then a valid UUID will throw a QueryException. This check is also useful more generally to avoid unnecessary database queries.