### PR TITLE
[9.x] fix foreach loop in Str::is method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -353,19 +353,19 @@ class Str
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param  string|iterable<string>  $pattern
+     * @param  string|iterable<string>  $patterns
      * @param  string  $value
      * @return bool
      */
-    public static function is($pattern, $value)
+    public static function is($patterns, $value)
     {
         $value = (string) $value;
 
-        if (! is_iterable($pattern)) {
-            $pattern = [$pattern];
+        if (! is_iterable($patterns)) {
+            $patterns = [$patterns];
         }
 
-        foreach ($pattern as $pattern) {
+        foreach ($patterns as $pattern) {
             $pattern = (string) $pattern;
 
             // If the given value is an exact match we can of course return true right


### PR DESCRIPTION
There is a typo in foreach loop for the pattern variable which modifies the pattern value probably unintentionally. It's a small fix for that.