### PR TITLE
[10.x] Add the PresentIf validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -473,6 +473,24 @@ trait ReplacesAttributes
     }
 
     /**
+     * Replace all place-holders for the present_if rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replacePresentIf($message, $attribute, $rule, $parameters)
+    {
+        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
+
+        $parameters[0] = $this->getDisplayableAttribute($parameters[0]);
+
+        return str_replace([':other', ':value'], $parameters, $message);
+    }
+
+    /**
      * Replace all place-holders for the prohibited_if rule.
      *
      * @param  string  $message

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1509,6 +1509,31 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute exists even if not filled when another attribute has a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validatePresentIf($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'present_if');
+
+        if (! Arr::has($this->data, $parameters[0])) {
+            return false;
+        }
+
+        [$values, $other] = $this->parseDependentRuleParameters($parameters);
+
+        if (in_array($other, $values, is_bool($other) || is_null($other))) {
+            return $this->validatePresent($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute passes a regular expression check.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -9,6 +9,7 @@ use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\NotIn;
+use Illuminate\Validation\Rules\PresentIf;
 use Illuminate\Validation\Rules\ProhibitedIf;
 use Illuminate\Validation\Rules\RequiredIf;
 use Illuminate\Validation\Rules\Unique;
@@ -114,6 +115,17 @@ class Rule
     public static function excludeIf($callback)
     {
         return new ExcludeIf($callback);
+    }
+
+    /**
+     * Get a present_if constraint builder instance.
+     *
+     * @param  callable|bool  $callback
+     * @return \Illuminate\Validation\Rules\PresentIf
+     */
+    public static function presentIf($callback)
+    {
+        return new PresentIf($callback);
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/PresentIf.php
+++ b/src/Illuminate/Validation/Rules/PresentIf.php
@@ -17,7 +17,7 @@ class PresentIf
     /**
      * Create a new present validation rule based on a condition.
      *
-     * @param Closure|bool  $condition
+     * @param  Closure|bool  $condition
      * @return void
      *
      * @throws InvalidArgumentException

--- a/src/Illuminate/Validation/Rules/PresentIf.php
+++ b/src/Illuminate/Validation/Rules/PresentIf.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Closure;
+use InvalidArgumentException;
+
+class PresentIf
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var Closure|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new present validation rule based on a condition.
+     *
+     * @param Closure|bool  $condition
+     * @return void
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($condition)
+    {
+        if ($condition instanceof Closure || is_bool($condition)) {
+            $this->condition = $condition;
+        } else {
+            throw new InvalidArgumentException('The provided condition must be a callable or boolean.');
+        }
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'present' : '';
+        }
+
+        return $this->condition ? 'present' : '';
+    }
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -725,7 +725,8 @@ class Validator implements ValidatorContract
             return $this->isImplicit($rule);
         }
 
-        return $this->validatePresent($attribute, $value) ||
+        return $rule === 'PresentIf' ||
+               $this->validatePresent($attribute, $value) ||
                $this->isImplicit($rule);
     }
 

--- a/tests/Validation/ValidationPresentIfTest.php
+++ b/tests/Validation/ValidationPresentIfTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Exception;
+use Illuminate\Validation\Rules\PresentIf;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ValidationPresentIfTest extends TestCase
+{
+    public function testItFormatsAStringVersionOfTheRule()
+    {
+        $rule = new PresentIf(function () {
+            return true;
+        });
+
+        $this->assertSame('present', (string) $rule);
+
+        $rule = new PresentIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new PresentIf(true);
+
+        $this->assertSame('present', (string) $rule);
+
+        $rule = new PresentIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+
+    public function testItOnlyAcceptsBooleanAndCallableAsArguments()
+    {
+        $rule = new PresentIf(false);
+
+        $rule = new PresentIf(true);
+
+        foreach ([1, 1.1, 'phpinfo', new stdClass] as $condition) {
+            try {
+                $rule = new PresentIf($condition);
+                $this->fail('The ProhibitedIf constructor must not accept '.gettype($condition));
+            } catch (InvalidArgumentException $exception) {
+                $this->assertEquals('The provided condition must be a callable or boolean.', $exception->getMessage());
+            }
+        }
+    }
+
+    public function testItIsNotSerializable()
+    {
+        $this->expectException(Exception::class);
+
+        $rule = serialize(new PresentIf(function () {
+            return true;
+        }));
+    }
+}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1483,6 +1483,44 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
     }
 
+    public function testPresentIf()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => 'kim'], ['last' => 'present_if:first,kim']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => 'kim', 'last' => 'bouchouaram'], ['last' => 'present_if:first,kim']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'present_if:first,taylor,kim']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => 'taylor', 'last' => 'otwell'], ['last' => 'present_if:first,taylor,kim']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['first' => 'kim', 'last' => null], ['last' => 'present_if:first,kim']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => true], ['bar' => 'present_if:foo,false']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => true], ['bar' => 'present_if:foo,true']);
+        $this->assertTrue($v->fails());
+
+        // error message when passed multiple values (prohibited_if:foo,bar,baz)
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.present_if' => 'The :attribute field must be present when :other is :value.'], 'en');
+        $v = new Validator($trans, ['first' => 'kim'], ['last' => 'present_if:first,kim']);
+        $this->assertFalse($v->passes());
+        $this->assertSame('The last field must be present when first is kim.', $v->messages()->first('last'));
+    }
+
     public function testProhibited()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Like the `required_if` and `prohibited_if` validation rules I would like to add the `present_if` validation rule.

This rule allows you to conditionally constrain an attribute to be present.

I also added the `PresentIf` rule class.

This PR only adds features so it is backwards compatible.

PR for documentation: `TODO`
PR for translation: `TODO`