### PR TITLE
[9.x] Fix passing null to `assertRedirectToRoute`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -270,11 +270,13 @@ class TestResponse implements ArrayAccess
             $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
         );
 
-        $request = Request::create($this->headers->get('Location'));
+        if(! is_null($name)) {
+            $request = Request::create($this->headers->get('Location'));
 
-        PHPUnit::assertEquals(
-            app('url')->to($uri), $request->fullUrl()
-        );
+            PHPUnit::assertEquals(
+                app('url')->to($uri), $request->fullUrl()
+            );
+        }
 
         return $this;
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -270,7 +270,7 @@ class TestResponse implements ArrayAccess
             $this->statusMessageWithDetails('201, 301, 302, 303, 307, 308', $this->getStatusCode()),
         );
 
-        if(! is_null($name)) {
+        if (! is_null($name)) {
             $request = Request::create($this->headers->get('Location'));
 
             PHPUnit::assertEquals(

--- a/tests/Testing/AssertRedirectToRouteTest.php
+++ b/tests/Testing/AssertRedirectToRouteTest.php
@@ -75,10 +75,10 @@ class AssertRedirectToRouteTest extends TestCase
         $this->router->get('test-route', function () {
             return new RedirectResponse($this->urlGenerator->route('named-route'));
         });
-    
+
         $this->get('test-route')
             ->assertRedirectToRoute();
-    }    
+    }
 
     protected function tearDown(): void
     {

--- a/tests/Testing/AssertRedirectToRouteTest.php
+++ b/tests/Testing/AssertRedirectToRouteTest.php
@@ -70,6 +70,16 @@ class AssertRedirectToRouteTest extends TestCase
             ]);
     }
 
+    public function testAssertRedirectToRouteWithoutRouteName()
+    {
+        $this->router->get('test-route', function () {
+            return new RedirectResponse($this->urlGenerator->route('named-route'));
+        });
+    
+        $this->get('test-route')
+            ->assertRedirectToRoute();
+    }    
+
     protected function tearDown(): void
     {
         parent::tearDown();


### PR DESCRIPTION
A few days ago, I added this PR https://github.com/laravel/framework/pull/44926 which introduced a new assertion function called `assertRedirectToRoute`.

as noted by @gms8994 here I have forgot to check when passing `null` as the name for the route.

This PR should fix this, and include the test code which @gms8994 provided.
