### PR TITLE
[9.x] Allow report helper to take additional context

### DIFF
--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -10,11 +10,12 @@ interface ExceptionHandler
      * Report or log an exception.
      *
      * @param  \Throwable  $e
+     * @param  array  $context
      * @return void
      *
      * @throws \Throwable
      */
-    public function report(Throwable $e);
+    public function report(Throwable $e, array $context);
 
     /**
      * Determine if the exception should be reported.

--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -15,7 +15,7 @@ interface ExceptionHandler
      *
      * @throws \Throwable
      */
-    public function report(Throwable $e, array $context);
+    public function report(Throwable $e, array $context = []);
 
     /**
      * Determine if the exception should be reported.

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -269,7 +269,7 @@ class Handler implements ExceptionHandlerContract
             $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
         );
 
-        $context = array_merge($this->buildExceptionContext($e), $context];
+        $context = array_merge($this->buildExceptionContext($e), $context);
 
         method_exists($logger, $level)
             ? $logger->{$level}($e->getMessage(), $context)

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -235,11 +235,12 @@ class Handler implements ExceptionHandlerContract
      * Report or log an exception.
      *
      * @param  \Throwable  $e
+     * @param  array  $context
      * @return void
      *
      * @throws \Throwable
      */
-    public function report(Throwable $e)
+    public function report(Throwable $e, array $context = [])
     {
         $e = $this->mapException($e);
 
@@ -268,7 +269,7 @@ class Handler implements ExceptionHandlerContract
             $this->levels, fn ($level, $type) => $e instanceof $type, LogLevel::ERROR
         );
 
-        $context = $this->buildExceptionContext($e);
+        $context = array_merge($this->buildExceptionContext($e), $context];
 
         method_exists($logger, $level)
             ? $logger->{$level}($e->getMessage(), $context)

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -88,11 +88,12 @@ trait InteractsWithExceptionHandling
              * Report or log an exception.
              *
              * @param  \Throwable  $e
+             * @param  array  $context
              * @return void
              *
              * @throws \Exception
              */
-            public function report(Throwable $e)
+            public function report(Throwable $e, array $context = [])
             {
                 //
             }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -669,15 +669,16 @@ if (! function_exists('report')) {
      * Report an exception.
      *
      * @param  \Throwable|string  $exception
+     * @param  array  $context
      * @return void
      */
-    function report($exception)
+    function report($exception, array $context = [])
     {
         if (is_string($exception)) {
             $exception = new Exception($exception);
         }
 
-        app(ExceptionHandler::class)->report($exception);
+        app(ExceptionHandler::class)->report($exception, $context);
     }
 }
 


### PR DESCRIPTION
This PR allows `report` helper to take additional context when needed for an exception. 

Also created this PR https://github.com/orchestral/testbench-core/pull/89 to support this one for the pipelines

Usage:

`
report($e, ['foo' => 'some bar to put out the fire quickly']);
`

