### PR TITLE
Include Eloquent Model Database name in model:show command

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -103,7 +103,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
             $model->getConnection()->getTablePrefix().$model->getTable(),
             $this->getAttributes($model),
             $this->getRelations($model),
-            $this->getObservers($model),
+            $model->getConnection()->getDatabaseName(),
         );
     }
 
@@ -267,13 +267,14 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
      * @param  \Illuminate\Support\Collection  $observers
+     * @param  string  $$databaseName
      * @return void
      */
-    protected function display($class, $database, $table, $attributes, $relations, $observers)
+    protected function display($class, $database, $table, $attributes, $relations, $observers, $databaseName)
     {
         $this->option('json')
-            ? $this->displayJson($class, $database, $table, $attributes, $relations, $observers)
-            : $this->displayCli($class, $database, $table, $attributes, $relations, $observers);
+            ? $this->displayJson($class, $database, $table, $attributes, $relations, $observers, $databaseName)
+            : $this->displayCli($class, $database, $table, $attributes, $relations, $observers, $databaseName);
     }
 
     /**
@@ -285,9 +286,10 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
      * @param  \Illuminate\Support\Collection  $observers
+     * @param  string  $databaseName
      * @return void
      */
-    protected function displayJson($class, $database, $table, $attributes, $relations, $observers)
+    protected function displayJson($class, $database, $table, $attributes, $relations, $observers, $databaseName)
     {
         $this->output->writeln(
             collect([
@@ -297,6 +299,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 'attributes' => $attributes,
                 'relations' => $relations,
                 'observers' => $observers,
+                'databaseName' => $databaseName,
             ])->toJson()
         );
     }
@@ -310,14 +313,16 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
      * @param  \Illuminate\Support\Collection  $observers
+     * @param  string  $databaseName
      * @return void
      */
-    protected function displayCli($class, $database, $table, $attributes, $relations, $observers)
+    protected function displayCli($class, $database, $table, $attributes, $relations, $observers, $databaseName)
     {
         $this->newLine();
 
         $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
-        $this->components->twoColumnDetail('Database', $database);
+        $this->components->twoColumnDetail('connection', $database);
+        $this->components->twoColumnDetail('database name', $databaseName);
         $this->components->twoColumnDetail('Table', $table);
 
         $this->newLine();


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR builds on the new `artisan model:show` command to show the database name of the Model. It could be handy to see on the Model information as it's not always obvious the name of the database of a Model.

It handles cases where multiple databases connection are used.

![image](https://user-images.githubusercontent.com/34031333/202196428-ecdf29d8-77f6-46bf-aa8a-54987dffe1af.png)


