### PR TITLE
Update Password facade docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Auth\PasswordBroker;
 /**
  * @method static mixed reset(array $credentials, \Closure $callback)
  * @method static string sendResetLink(array $credentials, \Closure $callback = null)
- * @method static \Illuminate\Contracts\Auth\CanResetPassword getUser(array $credentials)
+ * @method static \Illuminate\Contracts\Auth\CanResetPassword|null getUser(array $credentials)
  * @method static string createToken(\Illuminate\Contracts\Auth\CanResetPassword $user)
  * @method static void deleteToken(\Illuminate\Contracts\Auth\CanResetPassword $user)
  * @method static bool tokenExists(\Illuminate\Contracts\Auth\CanResetPassword $user, string $token)


### PR DESCRIPTION
The Password facade docblock is missing a possible **null** return type for the `getUser` method which is giving false positive when running Larastan.

See https://github.com/nunomaduro/larastan/issues/1449#issuecomment-1316944966 for more details
