### PR TITLE
[9.x] Improves `queue:work` command output

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -204,15 +204,13 @@ class WorkCommand extends Command
      */
     protected function writeOutput(Job $job, $status)
     {
-        $jobId = $this->output->isVerbose()
-             ? sprintf(' <fg=gray>%s</>', $job->getJobId())
-             : '';
-
         $this->output->write(sprintf(
             '  <fg=gray>%s</> %s%s',
             Carbon::now()->format('Y-m-d H:i:s'),
             $job->resolveName(),
-            $jobId,
+            $this->output->isVerbose()
+                ? sprintf(' <fg=gray>%s</>', $job->getJobId())
+                : ''
         ));
 
         if ($status == 'starting') {

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Terminal;
 use function Termwind\terminal;
 
 #[AsCommand(name: 'queue:work')]
@@ -81,13 +82,6 @@ class WorkCommand extends Command
     protected $latestStartedAt;
 
     /**
-     * Holds the status of the last processed job, if any.
-     *
-     * @var string|null
-     */
-    protected $latestStatus;
-
-    /**
      * Create a new queue work command.
      *
      * @param  \Illuminate\Queue\Worker  $worker
@@ -126,9 +120,11 @@ class WorkCommand extends Command
         // connection being run for the queue operation currently being executed.
         $queue = $this->getQueue($connection);
 
-        $this->components->info(
-            sprintf('Processing jobs from the [%s] %s.', $queue, str('queue')->plural(explode(',', $queue)))
-        );
+        if (Terminal::hasSttyAvailable()) {
+            $this->components->info(
+                sprintf('Processing jobs from the [%s] %s.', $queue, str('queue')->plural(explode(',', $queue)))
+            );
+        }
 
         return $this->runWorker(
             $connection, $queue
@@ -208,28 +204,39 @@ class WorkCommand extends Command
      */
     protected function writeOutput(Job $job, $status)
     {
+        $jobId = $this->output->isVerbose()
+             ? sprintf(' <fg=gray>%s</>', $job->getJobId())
+             : '';
+
+        $this->output->write(sprintf(
+            '  <fg=gray>%s</> %s%s',
+            Carbon::now()->format('Y-m-d H:i:s'),
+            $job->resolveName(),
+            $jobId,
+        ));
+
         if ($status == 'starting') {
             $this->latestStartedAt = microtime(true);
-            $this->latestStatus = $status;
 
-            $formattedStartedAt = Carbon::now()->format('Y-m-d H:i:s');
+            $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
+                $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0
+            ) - 33, 0);
 
-            return $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
-        }
+            $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
 
-        if ($this->latestStatus && $this->latestStatus != 'starting') {
-            $formattedStartedAt = Carbon::createFromTimestamp($this->latestStartedAt)->format('Y-m-d H:i:s');
-
-            $this->output->write("  <fg=gray>{$formattedStartedAt}</> {$job->resolveName()}");
+            return $this->output->writeln(' <fg=yellow;options=bold>RUNNING</>');
         }
 
         $runTime = number_format((microtime(true) - $this->latestStartedAt) * 1000, 2).'ms';
-        $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - mb_strlen($runTime) - 31, 0);
+
+        $dots = max(terminal()->width() - mb_strlen($job->resolveName()) - (
+            $this->output->isVerbose() ? (mb_strlen($job->getJobId()) + 1) : 0
+        ) - mb_strlen($runTime) - 31, 0);
 
         $this->output->write(' '.str_repeat('<fg=gray>.</>', $dots));
         $this->output->write(" <fg=gray>$runTime</>");
 
-        $this->output->writeln(match ($this->latestStatus = $status) {
+        $this->output->writeln(match ($status) {
             'success' => ' <fg=green;options=bold>DONE</>',
             'released_after_exception' => ' <fg=yellow;options=bold>FAIL</>',
             default => ' <fg=red;options=bold>FAIL</>',

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -173,9 +173,7 @@ class Listener
     public function runProcess(Process $process, $memory)
     {
         $process->run(function ($type, $line) {
-            if (! str($line)->contains('Processing jobs from the')) {
-                $this->handleWorkerOutput($type, $line);
-            }
+            $this->handleWorkerOutput($type, $line);
         });
 
         // Once we have run the job we'll go check if the memory limit has been exceeded


### PR DESCRIPTION
This pull request proposes three changes to the `queue:work` command output:

1. Print the job ID when the verbose flag `-v` flag is used. (docs: [#8345](https://github.com/laravel/docs/pull/8345))
<img width="1343" alt="Screenshot 2022-11-16 at 15 51 26" src="https://user-images.githubusercontent.com/5457236/202228345-cd38ed79-23e5-4207-852d-04757fd8dd90.png">

2. Output a new line, each time a queue job starts, fixing: https://github.com/laravel/horizon/issues/1216, and https://github.com/laravel/framework/pull/44838. This change is necessary, as in programs and situations like Horizon, multiple `queue:work` commands output is send to the same channel.
<img width="1343" alt="Screenshot 2022-11-16 at 15 53 10" src="https://user-images.githubusercontent.com/5457236/202228779-82abe468-1f9f-4cec-8dcf-a72a3f2e97d1.png">

3. Finally, it only displays the message `Processing jobs from the...`, if the process owns the output. This change is necessary, as in programs and situations like Horizon, or `queue:listen`, that information is not necessary or is displayed up-front, before creating the workers.

<img width="934" alt="Screenshot 2022-11-16 at 15 58 35" src="https://user-images.githubusercontent.com/5457236/202230490-db877c88-1775-495e-8285-6a2e308bb0c1.png">