### PR TITLE
Make success message of migration creation similar to other makers

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -114,7 +114,7 @@ class MigrateMakeCommand extends BaseCommand
             $file = pathinfo($file, PATHINFO_FILENAME);
         }
 
-        $this->components->info(sprintf('Created migration [%s].', $file));
+        $this->components->info(sprintf('Migration [%s] created successfully.', $file));
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -117,6 +117,7 @@ class ModelMakeCommand extends GeneratorCommand
         $this->call('make:migration', [
             'name' => "create_{$table}_table",
             '--create' => $table,
+            '--fullpath' => true,
         ]);
     }
 


### PR DESCRIPTION
The success message pattern of creating a migration is different from other entity related classes. 

Generally it's not a noticeable issue. But when we run `make:model {name} -a`, it creates bunch of classes and the message looks odd in that situation. Also, it doesn't display the file path like others in `make:model {name} -a`.

This tiny PR will make the message pattern similar with other makers.

**Current success message:**
![image](https://user-images.githubusercontent.com/439612/202264736-78f31c1d-5bbe-4ca3-b8f1-6351e62a6763.png)

**This PR will make it:**
![image](https://user-images.githubusercontent.com/439612/202265249-3cded14d-1144-4973-8196-2dca400f2e0b.png)

