### PR TITLE
[9.x] chore(LockableFile): correct the return type of write()

### DIFF
--- a/src/Illuminate/Filesystem/LockableFile.php
+++ b/src/Illuminate/Filesystem/LockableFile.php
@@ -101,7 +101,7 @@ class LockableFile
      * Write to the file.
      *
      * @param  string  $contents
-     * @return string
+     * @return $this
      */
     public function write($contents)
     {


### PR DESCRIPTION
This is a chore correction.

At LockableFile.php:140, I think there is a miss if "@return string" but you are returning $this object.
In my editor, at FileStore.php:114 it gives me a problem: Expected type 'object'. Found 'string'.intelephense(1006)
So I think it's better to correct it.

```php
<?php
$file->truncate()
    ->write($this->expiration($seconds).serialize($value))
    ->close();
```

Best Regard,