### PR TITLE
[9.x] Include Eloquent Model Database name in model:show command to distinguish between connection and database names

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -103,7 +103,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
             $model->getConnection()->getTablePrefix().$model->getTable(),
             $this->getAttributes($model),
             $this->getRelations($model),
-            $this->getObservers($model),
+            $model->getConnection()->getDatabaseName(),
         );
     }
 
@@ -267,13 +267,14 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
      * @param  \Illuminate\Support\Collection  $observers
+     * @param  string  $$databaseName
      * @return void
      */
-    protected function display($class, $database, $table, $attributes, $relations, $observers)
+    protected function display($class, $database, $table, $attributes, $relations, $observers, $databaseName)
     {
         $this->option('json')
-            ? $this->displayJson($class, $database, $table, $attributes, $relations, $observers)
-            : $this->displayCli($class, $database, $table, $attributes, $relations, $observers);
+            ? $this->displayJson($class, $database, $table, $attributes, $relations, $observers, $databaseName)
+            : $this->displayCli($class, $database, $table, $attributes, $relations, $observers, $databaseName);
     }
 
     /**
@@ -285,9 +286,10 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
      * @param  \Illuminate\Support\Collection  $observers
+     * @param  string  $databaseName
      * @return void
      */
-    protected function displayJson($class, $database, $table, $attributes, $relations, $observers)
+    protected function displayJson($class, $database, $table, $attributes, $relations, $observers, $databaseName)
     {
         $this->output->writeln(
             collect([
@@ -297,6 +299,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 'attributes' => $attributes,
                 'relations' => $relations,
                 'observers' => $observers,
+                'databaseName' => $databaseName,
             ])->toJson()
         );
     }
@@ -310,14 +313,16 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
      * @param  \Illuminate\Support\Collection  $observers
+     * @param  string  $databaseName
      * @return void
      */
-    protected function displayCli($class, $database, $table, $attributes, $relations, $observers)
+    protected function displayCli($class, $database, $table, $attributes, $relations, $observers, $databaseName)
     {
         $this->newLine();
 
         $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
-        $this->components->twoColumnDetail('Database', $database);
+        $this->components->twoColumnDetail('connection', $database);
+        $this->components->twoColumnDetail('database name', $databaseName);
         $this->components->twoColumnDetail('Table', $table);
 
         $this->newLine();

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -322,7 +322,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
         $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
         $this->components->twoColumnDetail('connection', $database);
-        $this->components->twoColumnDetail('database name', $databaseName);
+        $this->components->twoColumnDetail('databaseName', $databaseName);
         $this->components->twoColumnDetail('Table', $table);
 
         $this->newLine();

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -103,6 +103,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
             $model->getConnection()->getTablePrefix().$model->getTable(),
             $this->getAttributes($model),
             $this->getRelations($model),
+            $this->getObservers($model),
             $model->getConnection()->getDatabaseName(),
         );
     }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -267,7 +267,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
      * @param  \Illuminate\Support\Collection  $observers
-     * @param  string  $$databaseName
+     * @param  string  $databaseName
      * @return void
      */
     protected function display($class, $database, $table, $attributes, $relations, $observers, $databaseName)
@@ -321,8 +321,8 @@ class ShowModelCommand extends DatabaseInspectionCommand
         $this->newLine();
 
         $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
-        $this->components->twoColumnDetail('connection', $database);
-        $this->components->twoColumnDetail('databaseName', $databaseName);
+        $this->components->twoColumnDetail('Connection', $database);
+        $this->components->twoColumnDetail('DatabaseName', $databaseName);
         $this->components->twoColumnDetail('Table', $table);
 
         $this->newLine();


### PR DESCRIPTION
@taylorotwell actually this is fixing for "capitalization" on PR #44967 and I did it because of confusing between database name and connection name.
This PR builds on the new `artisan model:show` command to show the database name of the Model. It could be handy to see on the Model information as it's not always obvious the name of the database of a Model.

It handles cases where multiple databases connection are used.

_________

It is originally called the connection name as database, see bellow.
![image](https://user-images.githubusercontent.com/34031333/202366535-24bf9654-ea99-4fb6-bdfc-aa550ffe4a8d.png)

But this PR is differentiate between database name and connection name
![image](https://user-images.githubusercontent.com/34031333/202368315-3e9161d6-aac4-4f6f-bc5f-b76065003e69.png)

