### PR TITLE
Strip key, secret and token from root config options on aws clients

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -265,7 +265,7 @@ class FilesystemManager implements FactoryContract
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
-        return Arr::except($config, ['key', 'secret', 'token']);
+        return Arr::except($config, ['token']);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -265,7 +265,7 @@ class FilesystemManager implements FactoryContract
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
-        return $config;
+        return Arr::except($config, ['key', 'secret', 'token']);
     }
 
     /**

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -253,7 +253,7 @@ class MailManager implements FactoryContract
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
-        return $config;
+        return Arr::except($config, ['key', 'secret', 'token']);
     }
 
     /**

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -253,7 +253,7 @@ class MailManager implements FactoryContract
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 
-        return Arr::except($config, ['key', 'secret', 'token']);
+        return Arr::except($config, ['token']);
     }
 
     /**

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -24,7 +24,7 @@ class SqsConnector implements ConnectorInterface
 
         return new SqsQueue(
             new SqsClient(
-                Arr::except($config, ['key', 'secret', 'token'])
+                Arr::except($config, ['token'])
             ),
             $config['queue'],
             $config['prefix'] ?? '',

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -23,7 +23,9 @@ class SqsConnector implements ConnectorInterface
         }
 
         return new SqsQueue(
-            new SqsClient($config),
+            new SqsClient(
+                Arr::except($config, ['key', 'secret', 'token'])
+            ),
             $config['queue'],
             $config['prefix'] ?? '',
             $config['suffix'] ?? '',


### PR DESCRIPTION
Fixes #44977

Related to https://github.com/aws/aws-sdk-php/issues/2567