### PR TITLE
[9.x] Fix deprecation warning when comparing a password against a `NULL` database password

### DIFF
--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -19,13 +19,13 @@ abstract class AbstractHasher
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      */
     public function check($value, $hashedValue, array $options = [])
     {
-        if (strlen($hashedValue) === 0) {
+        if (is_null($hashedValue)) {
             return false;
         }
 

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -10,7 +10,7 @@ class Argon2IdHasher extends ArgonHasher
      * Check the given plain value against a hash.
      *
      * @param  string  $value
-     * @param  string  $hashedValue
+     * @param  string|null  $hashedValue
      * @param  array  $options
      * @return bool
      *
@@ -22,7 +22,7 @@ class Argon2IdHasher extends ArgonHasher
             throw new RuntimeException('This password does not use the Argon2id algorithm.');
         }
 
-        if (strlen($hashedValue) === 0) {
+        if (is_null($hashedValue)) {
             return false;
         }
 

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -10,6 +10,26 @@ use RuntimeException;
 
 class HasherTest extends TestCase
 {
+    public function testEmptyHashedValueReturnsFalse()
+    {
+        $hasher = new BcryptHasher();
+        $this->assertTrue($hasher->check('password', ''));
+        $hasher = new ArgonHasher();
+        $this->assertTrue($hasher->check('password', ''));
+        $hasher = new Argon2IdHasher();
+        $this->assertTrue($hasher->check('password', ''));
+    }
+
+    public function testNullHashedValueReturnsFalse()
+    {
+        $hasher = new BcryptHasher();
+        $this->assertTrue($hasher->check('password', null));
+        $hasher = new ArgonHasher();
+        $this->assertTrue($hasher->check('password', null));
+        $hasher = new Argon2IdHasher();
+        $this->assertTrue($hasher->check('password', null));
+    }
+
     public function testBasicBcryptHashing()
     {
         $hasher = new BcryptHasher;


### PR DESCRIPTION
This used to be dealt with via a `strlen(null)` check added in this commit 
https://github.com/laravel/framework/commit/a36f1fe931abd07460f49875491ee066e319a64a
@GrahamCampbell I'd appreciate if you could cast your eye over this change.

`strlen(null)` used to return 0 as shown in [this PHP docs comment](https://www.php.net/manual/en/function.strlen.php#:~:text=%3C%3Fphp%20strlen(null)%3B%20%3F%3E%20will%20return%200), however since PHP 8.0, passing null to strlen() has been deprecated.

I think this check has always been a null check as passing an empty string as the second parameter to `password_verify()` has always been permitted and throws no level of warning or error. 

To be on the safe side I have also added tests for when `$hashedValue` is passed in as an empty string.

We're are seeing a lot of deprecation notices as in our system it is possible for users to have a NULL password in the database until they have activated their account and setup a password.