### PR TITLE
Do not invoke Attribute method if it has parameters

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2187,7 +2187,8 @@ trait HasAttributes
             $returnType = $method->getReturnType();
 
             if ($returnType instanceof ReflectionNamedType &&
-                $returnType->getName() === Attribute::class) {
+                $returnType->getName() === Attribute::class &&
+                $method->getParameters() === []) {
                 $method->setAccessible(true);
 
                 if (is_callable($method->invoke($instance)->get)) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In some cases Model may has helper Attribute method with some parameters. This pr suggests to isolate such helper methods from being invoked while building array of attributes.