### PR TITLE
[9.x] Add a new function `onlyTrashed`

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -183,7 +183,7 @@ trait DatabaseRule
     }
 
     /**
-     * Do not ignore soft deleted models during the existence check.
+     * Only include soft deleted models during the existence check.
      *
      * @param  string  $deletedAtColumn
      * @return $this

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -183,6 +183,19 @@ trait DatabaseRule
     }
 
     /**
+     * Do not ignore soft deleted models during the existence check.
+     *
+     * @param  string  $deletedAtColumn
+     * @return $this
+     */
+    public function onlyTrashed($deletedAtColumn = 'deleted_at')
+    {
+        $this->whereNotNull($deletedAtColumn);
+
+        return $this;
+    }
+
+    /**
      * Register a custom query callback.
      *
      * @param  \Closure  $callback

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -234,6 +234,17 @@ class ValidationExistsRuleTest extends TestCase
         $this->assertSame('exists:table,NULL,softdeleted_at,"NULL"', (string) $rule);
     }
 
+    public function testItOnlyTrashedSoftDeletes()
+    {
+        $rule = new Exists('table');
+        $rule->onlyTrashed();
+        $this->assertSame('exists:table,NULL,deleted_at,"NOT_NULL"', (string) $rule);
+
+        $rule = new Exists('table');
+        $rule->onlyTrashed('softdeleted_at');
+        $this->assertSame('exists:table,NULL,softdeleted_at,"NOT_NULL"', (string) $rule);
+    }
+
     protected function createSchema()
     {
         $this->schema('default')->create('users', function ($table) {

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -92,6 +92,17 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->withoutTrashed('softdeleted_at');
         $this->assertSame('unique:table,NULL,NULL,id,softdeleted_at,"NULL"', (string) $rule);
     }
+
+    public function testItOnlyTrashedSoftDeletes()
+    {
+        $rule = new Unique('table');
+        $rule->onlyTrashed();
+        $this->assertSame('unique:table,NULL,NULL,id,deleted_at,"NOT_NULL"', (string) $rule);
+
+        $rule = new Unique('table');
+        $rule->onlyTrashed('softdeleted_at');
+        $this->assertSame('unique:table,NULL,NULL,id,softdeleted_at,"NOT_NULL"', (string) $rule);
+    }
 }
 
 class EloquentModelStub extends Model


### PR DESCRIPTION
This PR introduces an "onlyTrashed" validation rule in `Exists` and `Unique`.

For example, we want a user to be able to create a new row in the database user, but we want to search in the database where the `deleted_at` is not null.
And the same since the same function is in the same trait `SoftDeletes`

Usage:

```php
Validator::make(
    [
        'name' => 'Michael Nabil',
    ],
    [
        'name' => [
            'required', 
            Rule::exists('users')->where('id', $this->id)->onlyTrashed(),  
            Rule::unique('users')->where('id', $this->id)->onlyTrashed(),  // Or
        ],
    ]
);
```