### PR TITLE
[9.x] Add a new way for the `Date` validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -64,8 +64,8 @@ class Date implements Rule, DataAwareRule, ValidatorAwareRule
             return static::default();
         }
 
-        if (!is_callable($callback) && !$callback instanceof static) {
-            throw new InvalidArgumentException('The given callback should be callable or an instance of ' . static::class);
+        if (! is_callable($callback) && ! $callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of '.static::class);
         }
 
         static::$defaultCallback = $callback;

--- a/src/Illuminate/Validation/Rules/Date.php
+++ b/src/Illuminate/Validation/Rules/Date.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidatorAwareRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Traits\Conditionable;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+
+class Date implements Rule, DataAwareRule, ValidatorAwareRule
+{
+    use Conditionable, Macroable;
+
+    /**
+     * An array of custom rules that will be merged into the validation rules.
+     *
+     * @var array
+     */
+    protected $customRules = [];
+
+    /**
+     * The error message after validation, if any.
+     *
+     * @var array
+     */
+    protected $messages = [];
+
+    /**
+     * The data under validation.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * The validator performing the validation.
+     *
+     * @var \Illuminate\Validation\Validator
+     */
+    protected $validator;
+
+    /**
+     * The callback that will generate the "default" version of the date rule.
+     *
+     * @var string|array|callable|null
+     */
+    public static $defaultCallback;
+
+    /**
+     * Set the default callback to be used for determining the file default rules.
+     *
+     * If no arguments are passed, the default file rule configuration will be returned.
+     *
+     * @param  static|callable|null  $callback
+     * @return static|null
+     */
+    public static function defaults($callback = null)
+    {
+        if (is_null($callback)) {
+            return static::default();
+        }
+
+        if (!is_callable($callback) && !$callback instanceof static) {
+            throw new InvalidArgumentException('The given callback should be callable or an instance of ' . static::class);
+        }
+
+        static::$defaultCallback = $callback;
+    }
+
+    /**
+     * Get the default configuration of the file rule.
+     *
+     * @return static
+     */
+    public static function default()
+    {
+        $file = is_callable(static::$defaultCallback)
+            ? call_user_func(static::$defaultCallback)
+            : static::$defaultCallback;
+
+        return $file instanceof Rule ? $file : new self();
+    }
+
+    /**
+     * Set date format.
+     *
+     * @param  string  $format
+     * @return $this
+     */
+    public function dateFormat($format)
+    {
+        $this->format = $format;
+
+        return $this->rules(['date_format:'.$format]);
+    }
+
+    /**
+     * Date after date.
+     *
+     * @param  \Illuminate\Support\Facades\Date|string  $date
+     * @return $this
+     */
+    public function after($filed)
+    {
+        return $this->rules(['after:'.$filed]);
+    }
+
+    /**
+     * Date before date.
+     *
+     * @param  \Illuminate\Support\Facades\Date|string  $date
+     * @return $this
+     */
+    public function before($filed)
+    {
+        return $this->rules(['before:'.$filed]);
+    }
+
+    /**
+     * After or equal the date.
+     *
+     * @param  \Illuminate\Support\Facades\Date|string  $date
+     * @return $this
+     */
+    public function afterOrEqual($date)
+    {
+        return $this->rules(['after_or_equal:'.$date]);
+    }
+
+    /**
+     * Before or equal date.
+     *
+     * @param  \Illuminate\Support\Facades\Date|string  $date
+     * @return $this
+     */
+    public function beforeOrEqual($date)
+    {
+        return $this->rules(['before_or_equal:'.$date]);
+    }
+
+    /**
+     * The equal date.
+     *
+     * @param  \Illuminate\Support\Facades\Date|string  $date
+     * @return $this
+     */
+    public function dateEqual($date)
+    {
+        return $this->rules(['date_equal:'.$date]);
+    }
+
+    /**
+     * Specify additional validation rules that should be merged with the default rules during validation.
+     *
+     * @param  string|array  $rules
+     * @return $this
+     */
+    public function rules($rules)
+    {
+        $this->customRules = array_merge($this->customRules, Arr::wrap($rules));
+
+        return $this;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->messages = [];
+
+        $validator = Validator::make(
+            $this->data,
+            [$attribute => array_merge(['date'], $this->customRules)],
+            $this->validator->customMessages,
+            $this->validator->customAttributes
+        );
+
+        if ($validator->fails()) {
+            return $this->fail($validator->messages()->all());
+        }
+
+        return true;
+    }
+
+    /**
+     * Add the given failures and return false.
+     *
+     * @param  array|string  $messages
+     * @return bool
+     */
+    protected function fail($messages)
+    {
+        $messages = collect(Arr::wrap($messages))->map(function ($message) {
+            return $this->validator->getTranslator()->get($message);
+        })->all();
+
+        $this->messages = array_merge($this->messages, $messages);
+
+        return false;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Set the current validator.
+     *
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @return $this
+     */
+    public function setValidator($validator)
+    {
+        $this->validator = $validator;
+
+        return $this;
+    }
+
+    /**
+     * Set the current data under validation.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}

--- a/tests/Validation/ValidationDateRuleTest.php
+++ b/tests/Validation/ValidationDateRuleTest.php
@@ -131,7 +131,7 @@ class ValidationDateRuleTest extends TestCase
             resolve('translator'),
             [
                 'end_date' => now()->addWeek(),
-                'start_date' => now()
+                'start_date' => now(),
             ],
             [
                 'end_date' => Date::default()->before('start_date'),
@@ -155,14 +155,14 @@ class ValidationDateRuleTest extends TestCase
             resolve('translator'),
             [
                 'end_date' => now()->addWeek(),
-                'start_date' => now()
+                'start_date' => now(),
             ],
             [
                 'end_date' => Date::default()->beforeOrEqual('start_date'),
                 'start_date' => Date::default()->after('tomorrow'),
             ]
         );
-        
+
         $this->assertTrue($v->fails());
         $this->assertSame(
             [

--- a/tests/Validation/ValidationDateRuleTest.php
+++ b/tests/Validation/ValidationDateRuleTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rules\Date;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+
+class ValidationDateRuleTest extends TestCase
+{
+    public function testValidationPassesWhenPassingCorrectDate()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'birth_date' => '25-07-2000',
+            ],
+            [
+                'birth_date' => Date::default(),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    public function testValidationPassesWhenPassingInstanceOfDate()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'birth_date' => now(),
+            ],
+            [
+                'birth_date' => Date::default(),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    public function testValidationFailsWhenProvidingDifferentType()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'birth_date' => '10',
+            ],
+            [
+                'birth_date' => Date::default(),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertSame(['birth_date' => ['validation.date']], $v->messages()->toArray());
+    }
+
+    public function testValidationFailsWhenProvidingNull()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'birth_date' => null,
+            ],
+            [
+                'birth_date' => Date::default(),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertSame(['birth_date' => ['validation.date']], $v->messages()->toArray());
+    }
+
+    public function testValidationFailsWhenProvidingAfter()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'birth_date' => now(),
+            ],
+            [
+                'birth_date' => Date::default()->after('tomorrow'),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertSame(['birth_date' => ['validation.after']], $v->messages()->toArray());
+    }
+
+    public function testValidationFailsWhenProvidingBefore()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'birth_date' => now(),
+            ],
+            [
+                'birth_date' => Date::default()->before('tomorrow'),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+        $this->assertEmpty($v->messages()->toArray());
+    }
+
+    public function testValidationFailsWhenProvidingAfterOrEqual()
+    {
+        $todayDate = date('m/d/Y');
+
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'birth_date' => now()->addWeek(),
+            ],
+            [
+                'birth_date' => Date::default()->afterOrEqual($todayDate),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+        $this->assertEmpty($v->messages()->toArray());
+    }
+
+    public function testValidationFailsWhenProvidingBeforeAntherFailed()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'end_date' => now()->addWeek(),
+                'start_date' => now()
+            ],
+            [
+                'end_date' => Date::default()->before('start_date'),
+                'start_date' => Date::default()->after('tomorrow'),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertSame(
+            [
+                'end_date' => ['validation.before'],
+                'start_date' => ['validation.after'],
+            ],
+            $v->messages()->toArray()
+        );
+    }
+
+    public function testValidationFailsWhenProvidingBeforeOrEqual()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'end_date' => now()->addWeek(),
+                'start_date' => now()
+            ],
+            [
+                'end_date' => Date::default()->beforeOrEqual('start_date'),
+                'start_date' => Date::default()->after('tomorrow'),
+            ]
+        );
+        
+        $this->assertTrue($v->fails());
+        $this->assertSame(
+            [
+                'end_date' => ['validation.before_or_equal'],
+                'start_date' => ['validation.after'],
+            ],
+            $v->messages()->toArray()
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $container = Container::getInstance();
+
+        $container->bind('translator', function () {
+            return new Translator(
+                new ArrayLoader,
+                'en'
+            );
+        });
+
+        Facade::setFacadeApplication($container);
+
+        (new ValidationServiceProvider($container))->register();
+    }
+
+    protected function tearDown(): void
+    {
+        Container::setInstance(null);
+
+        Facade::clearResolvedInstances();
+
+        Facade::setFacadeApplication(null);
+
+        Date::$defaultCallback = null;
+    }
+}


### PR DESCRIPTION
This PR adds a new Date validation rule that will make sure the provided data for the date

```php
validator(
    ['birth_date' => now()],
    ['birth_date' => [Date::default()->after('tomorrow')]]
)->validate();
```

It is the best way for the date validation