### PR TITLE
Unification ResetPassword email builder

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,11 +59,13 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
+        $resetUrl = $this->resetUrl($notifiable);
+
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+            return call_user_func(static::$toMailCallback, $notifiable, $resetUrl);
         }
 
-        return $this->buildMailMessage($this->resetUrl($notifiable));
+        return $this->buildMailMessage($resetUrl);
     }
 
     /**

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -106,7 +106,7 @@ class ForgotPasswordTest extends TestCase
                 ->line(__('If you did not request a password reset, no further action is required.'));
         });
 
-        ResetPassword::createUrlUsing(function ($notifiable, $token){
+        ResetPassword::createUrlUsing(function ($notifiable, $token) {
             return route('custom.password.reset', $token);
         });
 

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -107,7 +107,7 @@ class ForgotPasswordTest extends TestCase
         });
 
         ResetPassword::createUrlUsing(function ($notifiable, $token){
-            return  route('custom.password.reset', $token);
+            return route('custom.password.reset', $token);
         });
 
         UserFactory::new()->create();

--- a/tests/Integration/Auth/ForgotPasswordTest.php
+++ b/tests/Integration/Auth/ForgotPasswordTest.php
@@ -98,12 +98,16 @@ class ForgotPasswordTest extends TestCase
     {
         Notification::fake();
 
-        ResetPassword::toMailUsing(function ($notifiable, $token) {
+        ResetPassword::toMailUsing(function ($notifiable, $url) {
             return (new MailMessage)
                 ->subject(__('Reset Password Notification'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
-                ->action(__('Reset Password'), route('custom.password.reset', $token))
+                ->action(__('Reset Password'), $url)
                 ->line(__('If you did not request a password reset, no further action is required.'));
+        });
+
+        ResetPassword::createUrlUsing(function ($notifiable, $token){
+            return  route('custom.password.reset', $token);
         });
 
         UserFactory::new()->create();

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -105,7 +105,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
                 ->line(__('If you did not request a password reset, no further action is required.'));
         });
 
-        ResetPassword::createUrlUsing(function ($notifiable, $token){
+        ResetPassword::createUrlUsing(function ($notifiable, $token) {
             return route('custom.password.reset', $token);
         });
 

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -106,7 +106,7 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
         });
 
         ResetPassword::createUrlUsing(function ($notifiable, $token){
-            return  route('custom.password.reset', $token);
+            return route('custom.password.reset', $token);
         });
 
         UserFactory::new()->create();

--- a/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
+++ b/tests/Integration/Auth/ForgotPasswordWithoutDefaultRoutesTest.php
@@ -97,12 +97,16 @@ class ForgotPasswordWithoutDefaultRoutesTest extends TestCase
     {
         Notification::fake();
 
-        ResetPassword::toMailUsing(function ($notifiable, $token) {
+        ResetPassword::toMailUsing(function ($notifiable, $url) {
             return (new MailMessage)
                 ->subject(__('Reset Password Notification'))
                 ->line(__('You are receiving this email because we received a password reset request for your account.'))
-                ->action(__('Reset Password'), route('custom.password.reset', $token))
+                ->action(__('Reset Password'), $url)
                 ->line(__('If you did not request a password reset, no further action is required.'));
+        });
+
+        ResetPassword::createUrlUsing(function ($notifiable, $token){
+            return  route('custom.password.reset', $token);
         });
 
         UserFactory::new()->create();


### PR DESCRIPTION
Currently in VerifyEmail notification class: if you set toMailUsing and createUrlUsing handlers then when you call toMail - VerifyEmail first using your url handler and send his return to body creator.

But in ResetPassword createUrlUsing ignoring while using toMailUsing.

This changes will unificate both handlers