### PR TITLE
[9.x] Skip absent provider classes while bootstraping

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Closure;
+use Error;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Contracts\Foundation\CachesConfiguration;
@@ -683,7 +684,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
         // application instance automatically for the developer. This is simply
         // a more convenient way of specifying your service provider classes.
         if (is_string($provider)) {
-            $provider = $this->resolveProvider($provider);
+            try {
+                $provider = $this->resolveProvider($provider);
+            } catch (Error) {
+                return;
+            }
         }
 
         $provider->register();

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation;
 
+use Error;
 use Exception;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Filesystem\Filesystem;
@@ -141,7 +142,11 @@ class ProviderRepository
         $manifest = $this->freshManifest($providers);
 
         foreach ($providers as $provider) {
-            $instance = $this->createProvider($provider);
+            try {
+                $instance = $this->createProvider($provider);
+            } catch (Error) {
+                continue;
+            }
 
             // When recompiling the service manifest, we will spin through each of the
             // providers and check if it's a deferred provider or not. If so we'll
@@ -205,6 +210,6 @@ class ProviderRepository
      */
     public function createProvider($provider)
     {
-        return new $provider($this->app);
+        return $this->app->resolveProvider($provider);
     }
 }


### PR DESCRIPTION
### Problem:
Currently, if a none existent service provider gets registered it prevents the framework to boot up with vague errors.

For example, if we have something like `auth()->user()` in the `App\Exception\Handler@report` method, we will see an error like below which tells us something very strange about the "hash" class.
```
PHP Fatal error:  Uncaught ReflectionException: Class "hash" does not exist in .../vendor/laravel/framework/src
/Illuminate/Container/Container.php:875
...
...
```

In fact, is so vague that there is no good answer for it on the stackOverFlow or Laracasts forums.

https://laracasts.com/discuss/channels/envoyer/uncaught-reflectionexception-class-hash-does-not-exist-in-envoyer-deploy
https://stackoverflow.com/questions/62825914/laravel-7-class-hash-does-not-exist

The framework currently just assumes all the providers exist and there is no clear plan to deal with the absent providers.
![image](https://user-images.githubusercontent.com/6961695/202696958-a07cdb61-3a21-4cd8-9b10-291c0fc59414.png)


### Why a provider can be absent?
- One reason is switching between git branches and introduce in providers in `config/app.php` but `vendor` folder is not updated accordingly by running `composer install`.
- Running `composer install --no-dev` on the server and if we have something like below, it can lead to registering an absent provider since the environment can be set to `staging` or something not equal to the string: "production".
```php
if ($this->app->environment() !== 'production') {
      $this->app->register(IdeHelperServiceProvider::class); // a dev-only provider.
}
```

### Why this error is shown?
The root cause is that when the bootstrap phase is happening and the `registerProviders` bails with an `Error` exception, the deferrable providers and the following `bootProviders` do not get run, and the `HashServiceProvider` is a deferrable one.

So when is execution flow goes to the `Handler` class to deal with the `ErrorExceotion` and there is a call to `auth()->user()` it can not access the lazy `hash` binding.


You can easily reproduce it in a plain laravel installation:
```php
public function register()
{
     $this->app->register('hello!');    // in  AppServiceProvider
}
```
and and `  auth()->user();   ` to `Handler@register`
```php
public function register()
{
        auth()->user();        // in App\Exceptions\Handler
        $this->reportable(function (Throwable $e) { });
}
```

### Solution:
- Is it better to silently skip the absent providers to let the rest of the framework boot up?
- We can have a different `try/catch` to handle the exception that happened during the boot phase separately from the exception during handling the application code.

![image](https://user-images.githubusercontent.com/6961695/202697871-0e9fed17-88df-416e-9a52-3a64473a69eb.png)
