### PR TITLE
[9.x] Add `bytesToHumanReadableSize` method

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -459,6 +459,17 @@ class Filesystem
     }
 
     /**
+     * Return the file size of a given file in a human readable format.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function humanReadableSize(string $path, int $precision = 2, ?string $locale = null): string
+    {
+        return bytesToHumanReadableSize($this->size($path), $precision, $locale);
+    }
+
+    /**
      * Get the file's last modification time.
      *
      * @param  string  $path

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -220,7 +220,36 @@ if (! function_exists('broadcast')) {
     }
 }
 
-if (! function_exists('cache')) {
+if (!function_exists('bytesToHumanReadableSize')) {
+    /**
+     * Format bytes number to human readable size in common units.
+     *
+     * @param  int  $bytes
+     * @param  int  $precision
+     * @param  string  $locale
+     * @return string
+     */
+    function bytesToHumanReadableSize(int $bytes, int $precision = 2, ?string $locale = null): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+        $bytes = max($bytes, 0);
+        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+        $pow = min($pow, count($units) - 1);
+        $bytes /= pow(1000, $pow);
+
+        $formattedValue = round($bytes, $precision);
+
+        if ($locale) {
+            $num = NumberFormatter::create($locale, NumberFormatter::DECIMAL);
+            return $num->format($formattedValue) . " " . $units[$pow];
+        }
+
+        return $formattedValue . " " . $units[$pow];
+    }
+}
+
+if (!function_exists('cache')) {
     /**
      * Get / set the specified cache value.
      *

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -10,6 +10,154 @@ use Orchestra\Testbench\TestCase;
 
 class FoundationHelpersTest extends TestCase
 {
+    public function testBytesToHumanReadableSize()
+    {
+        $this->assertEquals(
+            '0 B',
+            bytesToHumanReadableSize(0),
+        );
+
+        $this->assertEquals(
+            '1 B',
+            bytesToHumanReadableSize(1),
+        );
+
+        $this->assertEquals(
+            '10 B',
+            bytesToHumanReadableSize(10),
+        );
+
+        $this->assertEquals(
+            '1.23 KB',
+            bytesToHumanReadableSize(1234),
+        );
+
+        $this->assertEquals(
+            '12.35 KB',
+            bytesToHumanReadableSize(12345),
+        );
+
+        $this->assertEquals(
+            '123.46 KB',
+            bytesToHumanReadableSize(123456),
+        );
+
+        $this->assertEquals(
+            '1.23 MB',
+            bytesToHumanReadableSize(1234567),
+        );
+
+        $this->assertEquals(
+            '12.35 MB',
+            bytesToHumanReadableSize(12345678),
+        );
+
+        $this->assertEquals(
+            '123.46 MB',
+            bytesToHumanReadableSize(123456789),
+        );
+
+        $this->assertEquals(
+            '1.23 GB',
+            bytesToHumanReadableSize(1234567890),
+        );
+
+        $this->assertEquals(
+            '12.35 GB',
+            bytesToHumanReadableSize(12345678901),
+        );
+
+        $this->assertEquals(
+            '123.46 GB',
+            bytesToHumanReadableSize(123456789012),
+        );
+
+        $this->assertEquals(
+            '1.23 TB',
+            bytesToHumanReadableSize(1234567890123),
+        );
+
+        $this->assertEquals(
+            '1 KB',
+            bytesToHumanReadableSize(1234, 0),
+        );
+
+        $this->assertEquals(
+            '1.2 KB',
+            bytesToHumanReadableSize(1234, 1),
+        );
+
+        $this->assertEquals(
+            '1.234 KB',
+            bytesToHumanReadableSize(1234, 3),
+        );
+
+        $this->assertEquals(
+            '1.235 GB',
+            bytesToHumanReadableSize(1234567890, 3),
+        );
+
+        $this->assertEquals(
+            '1.2346 GB',
+            bytesToHumanReadableSize(1234567890, 4),
+        );
+
+        $this->assertEquals(
+            '1.23457 GB',
+            bytesToHumanReadableSize(1234567890, 5),
+        );
+
+        $this->assertEquals(
+            '1,2 KB',
+            bytesToHumanReadableSize(1234, 1, "pt-BR"),
+        );
+
+        $this->assertEquals(
+            '1,23 KB',
+            bytesToHumanReadableSize(1234, 2, "pt-BR"),
+        );
+
+        $this->assertEquals(
+            '1,234 KB',
+            bytesToHumanReadableSize(1234, 3, "pt-BR"),
+        );
+
+        $this->assertEquals(
+            '123,457 GB',
+            bytesToHumanReadableSize(123456789012, 3, "pt-BR"),
+        );
+
+        $this->assertEquals(
+            '123,457 GB',
+            bytesToHumanReadableSize(123456789012, 4, "pt-BR"),
+        );
+
+        $this->assertEquals(
+            '123,457 GB',
+            bytesToHumanReadableSize(123456789012, 5, "pt-BR"),
+        );
+
+        $this->assertEquals(
+            '123.46 GB',
+            bytesToHumanReadableSize(123456789012, 2, "nonexistent"),
+        );
+
+        $this->assertEquals(
+            '0 B',
+            bytesToHumanReadableSize(-1),
+        );
+
+        $this->assertEquals(
+            '0 B',
+            bytesToHumanReadableSize("-1"),
+        );
+
+        $this->assertEquals(
+            "1.23 KB",
+            bytesToHumanReadableSize("1234"),
+        );
+    }
+
     public function testRescue()
     {
         $this->assertEquals(


### PR DESCRIPTION
This PR adds the `bytesToHumanReadableSize` helper method to convert a number of bytes to a human readable string.
And, for convenience, adds the `humanReadableSize` method to `Filesystem`.


### Use case:
Right now the only way of getting a file size is using `Storage::size($file)` — and the response is a number that doesn't say much, like `12345678`.

With this PR proposed method, using `Storage::humanReadableSize($file)` would return `12.35 MB`. A way better way to represente the file size _(for humans, of course!)_

If more precision is required, the `bytesToHumanReadableSize` accepts the `precision` parameter. And if your target audience is not in US, this method also accepts the `locale` parameter.

```php
function bytesToHumanReadableSize(int $bytes, int $precision = 2, ?string $locale = null): string
````



### Discussion:
- Should we use `1000` or `1024` in `pow()`?
  - Results were validated with [gbmb.org](https://www.gbmb.org/bytes-to-kb), but I am not 100% sure of the calculation since byte conversion can be a little tricky.
  - The main calculation was _inspired_ by this [StackOverflow response.](https://stackoverflow.com/a/2510459/2225110)
- The `locale` parameter is _too much?_ Definitely important for me, but I don't know if this should be in core.
  - Is it safe to use `NumberFormatter`?
- I personally believe that if `precision` is not defined it should be `0` for KBs (1 KB, 2 KB, …), `1` for MBs (1.1 MB, 2.4 MB, …) and `2` for GB (1.43 GB, 4.14 GB, …), but am I am not sure since it can be understand as an inconsistency.