### PR TITLE
[9.x] Add `missing` method to `View/ComponentAttributeBag`

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -77,7 +77,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function missing($key)
     {
-        return !$this->has($key, $this->attributes);
+        return ! $this->has($key, $this->attributes);
     }
 
     /**

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -70,7 +70,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
-     * Determine if a given attribute does not exist in the attribute array.
+     * Determine if a given attribute is missing from the attribute array.
      *
      * @param  string  $key
      * @return bool

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -70,6 +70,17 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
+     * Determine if a given attribute does not exist in the attribute array.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        return !$this->has($key, $this->attributes);
+    }
+
+    /**
      * Only include the given attribute from the attribute array.
      *
      * @param  mixed  $keys

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -94,4 +94,14 @@ class ViewComponentAttributeBagTest extends TestCase
             'test-extract-2' => 'defaultValue',
         ]));
     }
+
+    public function testAttibuteExistence()
+    {
+        $bag = new ComponentAttributeBag(['name' => 'test']);
+
+        $this->assertTrue((bool) $bag->has('name'));
+        $this->assertFalse((bool) $bag->missing('name'));
+        $this->assertFalse((bool) $bag->has('class'));
+        $this->assertTrue((bool) $bag->missing('class'));
+    }
 }


### PR DESCRIPTION
Simple quality-of-life/legibility improvement for checking if an attribute is *missing* from the `ComponentAttributeBag`.

```diff
- if ($override instanceof ComponentAttributeBag && !$override->has('class')) {
+ if ($override instanceof ComponentAttributeBag && $override->missing('class')) {
  return $base;
}
```