### PR TITLE
[9.x] Use the LARAVEL_ENV_ENCRYPTION_KEY to encrypt when it is present

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -69,7 +69,7 @@ class EnvironmentEncryptCommand extends Command
     {
         $cipher = $this->option('cipher') ?: 'AES-256-CBC';
 
-        $key = $this->option('key');
+        $key = $this->option('key') ?: Env::get('LARAVEL_ENV_ENCRYPTION_KEY');
 
         $keyPassed = $key !== null;
 

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Env;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'env:encrypt')]

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -70,6 +70,27 @@ class EnvironmentEncryptCommandTest extends TestCase
 
     public function testItGeneratesTheCorrectFileWhenNotUsingEnvironment()
     {
+        putenv('LARAVEL_ENV_ENCRYPTION_KEY=ponmlkjihgfedcbaponmlkjihgfedcba');
+
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('get');
+
+        $this->artisan('env:encrypt')
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+
+        $this->filesystem->shouldHaveReceived('put')
+            ->with(base_path('.env.encrypted'), m::any());
+    }
+
+    ////
+    public function testItGeneratesTheCorrectFileWithKeyFromEnvironment()
+    {
         $this->filesystem->shouldReceive('exists')
             ->once()
             ->andReturn(true)

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -70,8 +70,6 @@ class EnvironmentEncryptCommandTest extends TestCase
 
     public function testItGeneratesTheCorrectFileWhenNotUsingEnvironment()
     {
-        putenv('LARAVEL_ENV_ENCRYPTION_KEY=ponmlkjihgfedcbaponmlkjihgfedcba');
-
         $this->filesystem->shouldReceive('exists')
             ->once()
             ->andReturn(true)
@@ -88,9 +86,10 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->with(base_path('.env.encrypted'), m::any());
     }
 
-    ////
     public function testItGeneratesTheCorrectFileWithKeyFromEnvironment()
     {
+        putenv('LARAVEL_ENV_ENCRYPTION_KEY=ponmlkjihgfedcbaponmlkjihgfedcba');
+
         $this->filesystem->shouldReceive('exists')
             ->once()
             ->andReturn(true)


### PR DESCRIPTION
Use the `LARAVEL_ENV_ENCRYPTION_KEY` to encrypt when it is present.

The functionality is already there on `env:decrypt` but not on `env:encrypt`

Thanks!