### PR TITLE
[9.x] Add whenMissing() method to InteractsWithInput trait 

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -225,6 +225,27 @@ trait InteractsWithInput
     }
 
     /**
+     * Apply the callback if the request is missing the given input item key.
+     *
+     * @param  string  $key
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return $this|mixed
+     */
+    public function whenMissing($key, callable $callback, callable $default = null)
+    {
+        if ($this->missing($key)) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        if ($default) {
+            return $default();
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the given input key is an empty string for "has".
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -452,6 +452,41 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->missing('foo.baz'));
     }
 
+    public function testWhenMissingMethod()
+    {
+        $request = Request::create('/', 'GET', ['bar' => null]);
+
+        $name = $age = $city = $foo = $bar = true;
+
+        $request->whenMissing('name', function ($value) use (&$name) {
+            $name = 'Taylor';
+        });
+
+        $request->whenMissing('age', function ($value) use (&$age) {
+            $age = '';
+        });
+
+        $request->whenMissing('city', function ($value) use (&$city) {
+            $city = null;
+        });
+
+        $request->whenMissing('foo', function () use (&$foo) {
+            $foo = false;
+        });
+
+        $request->whenMissing('bar', function () use (&$bar) {
+            $bar = 'test';
+        }, function () use (&$bar) {
+            $bar = true;
+        });
+
+        $this->assertSame('Taylor', $name);
+        $this->assertSame('', $age);
+        $this->assertNull($city);
+        $this->assertFalse($foo);
+        $this->assertTrue($bar);
+    }
+
     public function testHasAnyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);


### PR DESCRIPTION
The `InteractsWithInput` methods `has()` and `filled()` both have a syntactic sugar method `whenHas()` and `whenFilled()` that accepts a callback to avoid adding `if's`.

This PR adds the method `whenMissing()` that is basically the opposite of `whenHas()`.

Today I was working on a middleware that takes care of both mappings and default fields. That looked something like this:

```php
$request->mergeWhenMissing([
    'type' => 'default',
]);
```

However, sometimes you need to add a little more than just the additional fields. Could be something like notifying a 3rd part service that this part of the API is still getting used:

```php
if ($request->whenMissing('type') {
    $this->deprecated('type');

    $request->merge(['type' => 'default']);
}
```

I just think it's a nice little syntactic sugar. 