### PR TITLE
[9.x] Update nick-(invision/fields)/retry to fixNode.js deprecations

### DIFF
--- a/.github/workflows/databases.yml
+++ b/.github/workflows/databases.yml
@@ -39,7 +39,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -82,7 +82,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -125,7 +125,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -169,7 +169,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -211,7 +211,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -30,7 +30,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
           REDIS_LIBS: liblz4-dev, liblzf-dev, libzstd-dev
 
       - name: Set Minimum PHP 8.0 Versions
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -69,7 +69,7 @@ jobs:
         if: matrix.php >= 8
 
       - name: Set Minimum PHP 8.1 Versions
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -77,7 +77,7 @@ jobs:
         if: matrix.php >= 8.1
 
       - name: Set Minimum PHP 8.2 Versions
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -85,7 +85,7 @@ jobs:
         if: matrix.php >= 8.2
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -138,7 +138,7 @@ jobs:
           coverage: none
 
       - name: Set Minimum PHP 8.0 Versions
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -146,7 +146,7 @@ jobs:
         if: matrix.php >= 8
 
       - name: Set Minimum PHP 8.2 Versions
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -154,7 +154,7 @@ jobs:
         if: matrix.php >= 8.2
 
       - name: Install dependencies
-        uses: nick-invision/retry@v1
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 5


### PR DESCRIPTION
Same as https://github.com/laravel/framework/pull/45020, remove the Node.js 12 deprecation warnings when running actions.

The `nick-invision` has also been moved to `nick-fields`, due to [changing of ownership](https://github.com/nick-fields/retry#ownership).