### PR TITLE
Add isolation levels to SQL Server Connector

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -38,9 +38,10 @@ class SqlServerConnector extends Connector implements ConnectorInterface
 
     /**
      * Set the connection transaction isolation level.
-     * Full details on transaction isolation levels here: https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16
+     * Full details on transaction isolation levels here:
+     * https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16
      *
-     * @param \PDO $connection
+     * @param  \PDO  $connection
      * @param  array  $config
      * @return void
      */

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -29,7 +29,30 @@ class SqlServerConnector extends Connector implements ConnectorInterface
     {
         $options = $this->getOptions($config);
 
-        return $this->createConnection($this->getDsn($config), $config, $options);
+        $connection = $this->createConnection($this->getDsn($config), $config, $options);
+
+        $this->configureIsolationLevel($connection, $config);
+
+        return $connection;
+    }
+
+    /**
+     * Set the connection transaction isolation level.
+     * Full details on isolation levels here: https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16
+     *
+     * @param \PDO $connection
+     * @param  array  $config
+     * @return void
+     */
+    protected function configureIsolationLevel($connection, array $config): void
+    {
+        if (! isset($config['isolation_level'])) {
+            return;
+        }
+
+        $connection->prepare(
+            "SET TRANSACTION ISOLATION LEVEL {$config['isolation_level']}"
+        )->execute();
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -38,7 +38,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
 
     /**
      * Set the connection transaction isolation level.
-     * Full details on isolation levels here: https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16
+     * Full details on transaction isolation levels here: https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16
      *
      * @param \PDO $connection
      * @param  array  $config

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -38,14 +38,14 @@ class SqlServerConnector extends Connector implements ConnectorInterface
 
     /**
      * Set the connection transaction isolation level.
-     * Full details on transaction isolation levels here:
-     * https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql.
+     *
+     * https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql
      *
      * @param  \PDO  $connection
      * @param  array  $config
      * @return void
      */
-    protected function configureIsolationLevel($connection, array $config): void
+    protected function configureIsolationLevel($connection, array $config)
     {
         if (! isset($config['isolation_level'])) {
             return;

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -39,7 +39,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
     /**
      * Set the connection transaction isolation level.
      * Full details on transaction isolation levels here:
-     * https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16
+     * https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql.
      *
      * @param  \PDO  $connection
      * @param  array  $config


### PR DESCRIPTION
Extending this concept to the SqlServer Connector

- https://github.com/laravel/ideas/issues/2228
- https://github.com/laravel/framework/pull/33783/commits/bdf7699f7238865a8f23af51d6c01269cd120ab4

we currently ran into the situation where we need to set the transaction isolation level for SqlServer.

We implemented it and thought maybe it makes sense to bring that into laravel core, as laravel currently lacks that possibility, whereas Doctrine provides that possibility.

We currently configure it in database.php

```
return [
    'connections' => [
          'default' => [
                ...
               'host' => env('DB_HOST'),
               ...
               'isolation_level' => env('DB_ISOLATION_LEVEL', 'REPEATABLE READ'),
              ....
            ]
      ]
];
```




This ha been added already for the MySql connector and so I am following the same concept for the MsSQL connector.

