### PR TITLE
Outlook web dark mode email layout fix

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -33,7 +33,7 @@ width: 100% !important;
 
 <!-- Email Body -->
 <tr>
-<td class="body" width="100%" cellpadding="0" cellspacing="0">
+<td class="body" width="100%" cellpadding="0" cellspacing="0" style="border: hidden !important;">
 <table class="inner-body" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
 <!-- Body content -->
 <tr>


### PR DESCRIPTION
In the web version of outlook (outlook.office.com) there is a visible border inside the email template layout when dark mode is enabled, this small change will hide this border, since outlook comments out the style tag, it only works with inline code.

The change working in version: 9.x and 8.x, older versions not tested.

Email layout in dark mode outlook web:
![laravel_outlook_web_dark_email_layout](https://user-images.githubusercontent.com/88137868/202855665-9d89deb1-f906-444c-8f41-3037ef3fb2c5.jpg)

Email layout in dark mode outlook web (fixed)
![laravel_outlook_web_dark_email_layout_fixed](https://user-images.githubusercontent.com/88137868/202855666-51912611-ec69-4b96-a5f9-a5a93ea44310.jpg)
