### PR TITLE
[9.x] Allow customised implementation of the `SendQueuedMailable` job

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -258,7 +258,7 @@ class Mailable implements MailableContract, Renderable
      */
     protected function newQueuedJob()
     {
-        return (new SendQueuedMailable($this))
+        return Container::getInstance()->make(SendQueuedMailable::class, ['mailable' => $this])
                     ->through(array_merge(
                         method_exists($this, 'middleware') ? $this->middleware() : [],
                         $this->middleware ?? []


### PR DESCRIPTION
# What?

Allow us to bind a different implementation of the built-in `SendQueuedMailable` job.

For example...

```php
app()->bind(\Illuminate\Mail\SendQueuedMailable::class, function($app, $params) {
    return new \App\Jobs\SendQueuedMailable($params['mailable']);
});
```

# Why?

We have a lot of emails that we send by implementing `ShouldQueue` on the Mailable class. In all instances, we would like to use our own implementation of the `handle()` method of the built-in `SendQueuedMailable` job, which will enable us to handle exceptions in a more granular manner.

For example, most of our emails have a `backoff()` strategy and a `retryUntil()` value. Sometimes, we receive an exception via our 3rd party email provider which we know means the email is never going to be sent, so there is no point retrying it. We would just like to permanently fail that job at that point.

Something like...
```php
    /**
     * Execute the job.
     *
     * @return void
     */
    public function handle(MailFactory $factory)
    {
        try {
            $this->mailable->send($factory);
        } catch (\Exception $e) {
            if (Str::contains($e->getMessage(), 'Permanent failure')) {
                $this->fail();
            }
        }
    }
```

I know we could use our own job to do this, but it requires our team to always remember to dispatch the custom job, rather than just calling `send()` on the Mailable.

