### PR TITLE
[9.x] use static data providers in tests

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -570,7 +570,7 @@ class AuthAccessGateTest extends TestCase
     /**
      * @return array
      */
-    public function notCallableDataProvider()
+    public static function notCallableDataProvider()
     {
         return [
             [1],
@@ -1051,7 +1051,7 @@ class AuthAccessGateTest extends TestCase
         $this->assertEquals($expectedHasValue, $gate->has($abilitiesToCheck));
     }
 
-    public function hasAbilitiesTestDataProvider()
+    public static function hasAbilitiesTestDataProvider()
     {
         $abilities = ['foo' => 'foo', 'bar' => 'bar'];
         $noAbilities = [];

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -322,7 +322,7 @@ class BroadcasterTest extends TestCase
         $this->assertEquals($shouldMatch, $this->broadcaster->channelNameMatchesPattern($channel, $pattern));
     }
 
-    public function channelNameMatchPatternProvider()
+    public static function channelNameMatchPatternProvider()
     {
         return [
             ['something', 'something', true],

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -44,7 +44,7 @@ class UsePusherChannelsNamesTest extends TestCase
         );
     }
 
-    public function channelsProvider()
+    public static function channelsProvider()
     {
         $prefixesInfos = [
             ['prefix' => 'private-', 'guarded' => true],

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -448,7 +448,7 @@ class BusBatchTest extends TestCase
     /**
      * @return array
      */
-    public function serializedOptions()
+    public static function serializedOptions()
     {
         $options = [1, 2];
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -27,7 +27,7 @@ class CacheRepositoryTest extends TestCase
     {
         parent::setUp();
 
-        Carbon::setTestNow(Carbon::parse($this->getTestDate()));
+        Carbon::setTestNow(Carbon::parse(self::getTestDate()));
     }
 
     protected function tearDown(): void

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -261,12 +261,12 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function dataProviderTestGetSeconds()
+    public static function dataProviderTestGetSeconds()
     {
         return [
-            [Carbon::parse($this->getTestDate())->addMinutes(5)],
-            [(new DateTime($this->getTestDate()))->modify('+5 minutes')],
-            [(new DateTimeImmutable($this->getTestDate()))->modify('+5 minutes')],
+            [Carbon::parse(self::getTestDate())->addMinutes(5)],
+            [(new DateTime(self::getTestDate()))->modify('+5 minutes')],
+            [(new DateTimeImmutable(self::getTestDate()))->modify('+5 minutes')],
             [new DateInterval('PT5M')],
             [300],
         ];
@@ -438,7 +438,7 @@ class CacheRepositoryTest extends TestCase
         return $repository;
     }
 
-    protected function getTestDate()
+    protected static function getTestDate()
     {
         return '2030-07-25 12:13:14 UTC';
     }

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -45,7 +45,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function mySqlConnectProvider()
+    public static function mySqlConnectProvider()
     {
         return [
             ['mysql:host=foo;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
@@ -112,7 +112,7 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
-    public function provideSearchPaths()
+    public static function provideSearchPaths()
     {
         return [
             'all-lowercase' => [

--- a/tests/Database/DatabaseMySqlSchemaStateTest.php
+++ b/tests/Database/DatabaseMySqlSchemaStateTest.php
@@ -33,7 +33,7 @@ class DatabaseMySqlSchemaStateTest extends TestCase
         self::assertEquals($expectedVariables, $variables);
     }
 
-    public function provider(): Generator
+    public static function provider(): Generator
     {
         yield 'default' => [
             ' --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}"', [

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -23,7 +23,7 @@ class HttpJsonResponseTest extends TestCase
         $this->assertSame('bar', $response->getData()->foo);
     }
 
-    public function setAndRetrieveDataProvider()
+    public static function setAndRetrieveDataProvider()
     {
         return [
             'Jsonable data' => [new JsonResponseTestJsonableObject],
@@ -85,7 +85,7 @@ class HttpJsonResponseTest extends TestCase
         new JsonResponse(['data' => $data], 200, [], JSON_PARTIAL_OUTPUT_ON_ERROR);
     }
 
-    public function jsonErrorDataProvider()
+    public static function jsonErrorDataProvider()
     {
         // Resources can't be encoded
         $resource = tmpfile();

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -89,7 +89,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($expected, $request->segment($segment, 'default'));
     }
 
-    public function segmentProvider()
+    public static function segmentProvider()
     {
         return [
             ['', 1, 'default'],
@@ -111,7 +111,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $request->segments());
     }
 
-    public function segmentsProvider()
+    public static function segmentsProvider()
     {
         return [
             ['', []],
@@ -1012,7 +1012,7 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($payload, $data);
     }
 
-    public function getPrefersCases()
+    public static function getPrefersCases()
     {
         return [
             ['application/json', ['json'], 'json'],

--- a/tests/Integration/Console/CommandSchedulingTest.php
+++ b/tests/Integration/Console/CommandSchedulingTest.php
@@ -95,7 +95,7 @@ class CommandSchedulingTest extends TestCase
         $this->assertLogged('before', 'handled', 'after');
     }
 
-    public function executionProvider()
+    public static function executionProvider()
     {
         return [
             'Foreground' => [false],

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -87,7 +87,7 @@ class EloquentWhereHasTest extends DatabaseTestCase
         $this->assertEquals($userOrWhereHas->first()->id, $query->first()->id);
     }
 
-    public function dataProviderWhereRelationCallback()
+    public static function dataProviderWhereRelationCallback()
     {
         $callbackArray = function ($value) {
             $callbackEloquent = function (EloquentBuilder $builder) use ($value) {

--- a/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlConnectionTest.php
@@ -46,7 +46,7 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         );
     }
 
-    public function floatComparisonsDataProvider()
+    public static function floatComparisonsDataProvider()
     {
         return [
             [0.2, '=', true],
@@ -88,7 +88,7 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         $this->assertSame(! $expected, DB::table(self::TABLE)->whereNotNull(self::JSON_COL.'->'.$key)->exists());
     }
 
-    public function jsonWhereNullDataProvider()
+    public static function jsonWhereNullDataProvider()
     {
         return [
             'key not exists' => [true, 'invalid'],
@@ -138,7 +138,7 @@ class DatabaseMySqlConnectionTest extends MySqlTestCase
         $this->assertSame($count, DB::table(self::TABLE)->whereJsonContainsKey($column)->count());
     }
 
-    public function jsonContainsKeyDataProvider()
+    public static function jsonContainsKeyDataProvider()
     {
         return [
             'string key' => [4, 'json_col->foo'],

--- a/tests/Integration/Database/Postgres/DatabasePostgresConnectionTest.php
+++ b/tests/Integration/Database/Postgres/DatabasePostgresConnectionTest.php
@@ -46,7 +46,7 @@ class DatabasePostgresConnectionTest extends PostgresTestCase
         $this->assertSame(! $expected, DB::table('json_table')->whereNotNull("json_col->$key")->exists());
     }
 
-    public function jsonWhereNullDataProvider()
+    public static function jsonWhereNullDataProvider()
     {
         return [
             'key not exists' => [true, 'invalid'],
@@ -107,7 +107,7 @@ class DatabasePostgresConnectionTest extends PostgresTestCase
         $this->assertSame($count, DB::table('json_table')->whereJsonContainsKey($column)->count());
     }
 
-    public function jsonContainsKeyDataProvider()
+    public static function jsonContainsKeyDataProvider()
     {
         return [
             'string key' => [4, 'json_col->foo'],

--- a/tests/Integration/Database/SqlServer/DatabaseSqlServerConnectionTest.php
+++ b/tests/Integration/Database/SqlServer/DatabaseSqlServerConnectionTest.php
@@ -42,7 +42,7 @@ class DatabaseSqlServerConnectionTest extends SqlServerTestCase
         $this->assertSame($count, DB::table('json_table')->whereJsonContainsKey($column)->count());
     }
 
-    public function jsonContainsKeyDataProvider()
+    public static function jsonContainsKeyDataProvider()
     {
         return [
             'string key' => [4, 'json_col->foo'],

--- a/tests/Integration/Database/Sqlite/DatabaseSqliteConnectionTest.php
+++ b/tests/Integration/Database/Sqlite/DatabaseSqliteConnectionTest.php
@@ -54,7 +54,7 @@ class DatabaseSqliteConnectionTest extends DatabaseTestCase
         $this->assertSame($count, DB::table('json_table')->whereJsonContainsKey($column)->count());
     }
 
-    public function jsonContainsKeyDataProvider()
+    public static function jsonContainsKeyDataProvider()
     {
         return [
             'string key' => [4, 'json_col->foo'],

--- a/tests/Integration/Queue/CustomPayloadTest.php
+++ b/tests/Integration/Queue/CustomPayloadTest.php
@@ -18,7 +18,7 @@ class CustomPayloadTest extends TestCase
         return [QueueServiceProvider::class];
     }
 
-    public function websites()
+    public static function websites()
     {
         yield ['laravel.com'];
 

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -27,7 +27,7 @@ class MailManagerTest extends TestCase
         $this->app['mail.manager']->mailer('custom_smtp');
     }
 
-    public function emptyTransportConfigDataProvider()
+    public static function emptyTransportConfigDataProvider()
     {
         return [
             [null], [''], [' '],

--- a/tests/Routing/RouteUriTest.php
+++ b/tests/Routing/RouteUriTest.php
@@ -20,7 +20,7 @@ class RouteUriTest extends TestCase
     /**
      * @return array
      */
-    public function uriProvider()
+    public static function uriProvider()
     {
         return [
             [

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -571,7 +571,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
-    public function providerRouteParameters()
+    public static function providerRouteParameters()
     {
         return [
             [['test' => 123]],
@@ -600,7 +600,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com:8080/foo?test=123', $url->route('foo', $parameters));
     }
 
-    public function provideParametersAndExpectedMeaningfulExceptionMessages()
+    public static function provideParametersAndExpectedMeaningfulExceptionMessages()
     {
         return [
             'Missing parameters "one", "two" and "three"' => [

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -45,7 +45,7 @@ class ConfigurationUrlParserTest extends TestCase
         ], (new ConfigurationUrlParser)->parseConfiguration('some-particular-alias://null'));
     }
 
-    public function databaseUrls()
+    public static function databaseUrls()
     {
         return [
             'simple URL' => [

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5464,7 +5464,7 @@ class SupportCollectionTest extends TestCase
      *
      * @return array
      */
-    public function collectionClassProvider()
+    public static function collectionClassProvider()
     {
         return [
             [Collection::class],

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -892,7 +892,7 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('From $_SERVER', env('foo'));
     }
 
-    public function providesPregReplaceArrayData()
+    public static function providesPregReplaceArrayData()
     {
         $pointerArray = ['Taylor', 'Otwell'];
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -849,7 +849,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals(3, Str::wordCount('МАМА МЫЛА РАМУ', 'абвгдеёжзийклмнопрстуфхцчшщъыьэюяАБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ'));
     }
 
-    public function validUuidList()
+    public static function validUuidList()
     {
         return [
             ['a0a2a2d2-0b87-4a18-83f2-2529882be2de'],
@@ -865,7 +865,7 @@ class SupportStrTest extends TestCase
         ];
     }
 
-    public function invalidUuidList()
+    public static function invalidUuidList()
     {
         return [
             ['not a valid uuid so we can test this'],
@@ -881,7 +881,7 @@ class SupportStrTest extends TestCase
         ];
     }
 
-    public function strContainsProvider()
+    public static function strContainsProvider()
     {
         return [
             ['Taylor', 'ylo', true, true],
@@ -900,7 +900,7 @@ class SupportStrTest extends TestCase
         ];
     }
 
-    public function strContainsAllProvider()
+    public static function strContainsAllProvider()
     {
         return [
             ['Taylor Otwell', ['taylor', 'otwell'], false, false],
@@ -938,7 +938,7 @@ class SupportStrTest extends TestCase
         $this->assertSame($expected, Str::transliterate($value));
     }
 
-    public function specialCharacterProvider(): array
+    public static function specialCharacterProvider(): array
     {
         return [
             ['ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ', 'abcdefghijklmnopqrstuvwxyz'],

--- a/tests/Testing/Concerns/TestDatabasesTest.php
+++ b/tests/Testing/Concerns/TestDatabasesTest.php
@@ -76,7 +76,7 @@ class TestDatabasesTest extends TestCase
         tap($method)->setAccessible(true)->invoke($instance, $database);
     }
 
-    public function databaseUrls()
+    public static function databaseUrls()
     {
         return [
             [

--- a/tests/Testing/ParallelTestingTest.php
+++ b/tests/Testing/ParallelTestingTest.php
@@ -86,7 +86,7 @@ class ParallelTestingTest extends TestCase
         $this->assertSame('1', (string) $parallelTesting->token());
     }
 
-    public function callbacks()
+    public static function callbacks()
     {
         return [
             ['setUpProcess'],

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -17,7 +17,7 @@ class TranslationMessageSelectorTest extends TestCase
         $this->assertEquals($expected, $selector->choose($id, $number, 'en'));
     }
 
-    public function chooseTestData()
+    public static function chooseTestData()
     {
         return [
             ['first', 'first', 1],

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2728,7 +2728,7 @@ class ValidationValidatorTest extends TestCase
         }
     }
 
-    public function multipleOfDataProvider()
+    public static function multipleOfDataProvider()
     {
         return [
             [0, 0, false], // zero (same)
@@ -3455,7 +3455,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function validUrls()
+    public static function validUrls()
     {
         return [
             ['aaa://fully.qualified.domain/path'],
@@ -3702,7 +3702,7 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
-    public function invalidUrls()
+    public static function invalidUrls()
     {
         return [
             ['aslsdlks'],
@@ -3739,7 +3739,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals($outcome, $v->passes());
     }
 
-    public function activeUrlDataProvider()
+    public static function activeUrlDataProvider()
     {
         return [
             'Invalid Url' => [
@@ -6694,7 +6694,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function validUuidList()
+    public static function validUuidList()
     {
         return [
             ['a0a2a2d2-0b87-4a18-83f2-2529882be2de'],
@@ -6710,7 +6710,7 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
-    public function invalidUuidList()
+    public static function invalidUuidList()
     {
         return [
             ['not a valid uuid so we can test this'],
@@ -6726,7 +6726,7 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
-    public function providesPassingExcludeIfData()
+    public static function providesPassingExcludeIfData()
     {
         return [
             [
@@ -6962,7 +6962,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame($expectedValidatedData, $validator->validated());
     }
 
-    public function providesFailingExcludeIfData()
+    public static function providesFailingExcludeIfData()
     {
         return [
             [
@@ -7076,7 +7076,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame($expectedMessages, $validator->messages()->toArray());
     }
 
-    public function providesPassingExcludeData()
+    public static function providesPassingExcludeData()
     {
         return [
             [

--- a/tests/View/Blade/BladeEchoHandlerTest.php
+++ b/tests/View/Blade/BladeEchoHandlerTest.php
@@ -70,7 +70,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         eval(Str::of($this->compiler->compileString($blade))->remove(['<?php', '?>']));
     }
 
-    public function handlerLogicDataProvider()
+    public static function handlerLogicDataProvider()
     {
         return [
             ['{{$exampleObject}}'],
@@ -97,7 +97,7 @@ class BladeEchoHandlerTest extends AbstractBladeTestCase
         $this->assertSame($expectedOutput, $output);
     }
 
-    public function nonStringableDataProvider()
+    public static function nonStringableDataProvider()
     {
         return [
             ['{{"foo" . "bar"}}', 'foobar'],

--- a/tests/View/Blade/BladeForeachStatementsTest.php
+++ b/tests/View/Blade/BladeForeachStatementsTest.php
@@ -107,7 +107,7 @@ test
         $this->compiler->compileString($string);
     }
 
-    public function invalidForeachStatementsDataProvider()
+    public static function invalidForeachStatementsDataProvider()
     {
         return [
             ['@foreach'],

--- a/tests/View/Blade/BladeForelseStatementsTest.php
+++ b/tests/View/Blade/BladeForelseStatementsTest.php
@@ -95,7 +95,7 @@ tag empty
         $this->compiler->compileString($string);
     }
 
-    public function invalidForelseStatementsDataProvider()
+    public static function invalidForelseStatementsDataProvider()
     {
         return [
             ['@forelse'],

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -140,7 +140,7 @@ class ViewBladeCompilerTest extends TestCase
     /**
      * @return array
      */
-    public function appendViewPathDataProvider()
+    public static function appendViewPathDataProvider()
     {
         return [
             'No PHP blocks' => [

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -146,7 +146,7 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertFalse($finder->hasHintInformation('::foo.bar'));
     }
 
-    public function pathsProvider()
+    public static function pathsProvider()
     {
         return [
             ['incorrect_path', 'incorrect_path'],


### PR DESCRIPTION
Upcoming PHPUnit 10 deprecates usage of non-static data providers (see https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09). This PR makes all data providers `static` so PHPUnit 10 won't complain when it is released 🚀 
