### PR TITLE
make DB select work in migration pretend mode

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -403,10 +403,6 @@ class Connection implements ConnectionInterface
     public function select($query, $bindings = [], $useReadPdo = true)
     {
         return $this->run($query, $bindings, function ($query, $bindings) use ($useReadPdo) {
-            if ($this->pretending()) {
-                return [];
-            }
-
             // For select statements, we'll simply execute the query and return an array
             // of the database result set. Each element in the array will be a single
             // row from the database table, and will either be an array or objects.

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -458,7 +458,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection();
         $queries = $connection->pretend(function ($connection) {
-            $connection->select('foo bar', ['baz']);
+            $connection->update('foo bar', ['baz']);
         });
         $this->assertSame('foo bar', $queries[0]['query']);
         $this->assertEquals(['baz'], $queries[0]['bindings']);


### PR DESCRIPTION
Allows to launch Laravel database migrations that read database in pretend mode without errors
The more detailed description is in in issue that this fixes: https://github.com/laravel/framework/issues/45050
