### PR TITLE
[9.x] Create new `schema:load` Artisan command

### DIFF
--- a/src/Illuminate/Database/Console/LoadCommand.php
+++ b/src/Illuminate/Database/Console/LoadCommand.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Events\SchemaLoaded;
+use Illuminate\Database\SqlServerConnection;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'schema:load')]
+class LoadCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'schema:load
+                {--database= : The database connection to use}
+                {--path= : The path to the schema dump file}
+                {--drop-views : Drop all tables and views}
+                {--drop-types : Drop all tables and types (Postgres only)}
+                {--force : Force the operation to run when in production}
+                {--prune : Delete schema file after loading}
+        ';
+
+    /**
+     * The name of the console command.
+     *
+     * This name is used to identify the command during lazy loading.
+     *
+     * @var string|null
+     *
+     * @deprecated
+     */
+    protected static $defaultName = 'schema:load';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Load the given database schema';
+
+    /**
+     * Create a new schema load command instance.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @return void
+     */
+    public function __construct(
+        protected ConnectionResolverInterface $resolver,
+        protected Dispatcher $dispatcher,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return 1;
+        }
+
+        $connection = $this->resolver->connection($database = $this->option('database'));
+
+        if ($connection instanceof SqlServerConnection) {
+            $this->components->warn('Incompatible database connection.');
+
+            return;
+        }
+
+        if (is_null($path = $this->path($connection))) {
+            $this->components->warn('No schema file found.');
+
+            return;
+        }
+
+        $this->ensureCleanDatabase($connection);
+
+        $this->components->info('Loading database schema.');
+
+        $this->components->task($path, function () use ($connection, $path) {
+            $connection->getSchemaState()->handleOutputUsing(function ($type, $buffer) {
+                $this->output->write($buffer);
+            })->load($path);
+        });
+
+        $this->newLine();
+
+        $this->dispatcher->dispatch(new SchemaLoaded($connection, $path));
+
+        $info = 'Database schema loaded';
+
+        if ($this->option('prune')) {
+            (new Filesystem)->delete($path);
+
+            $info .= ' and pruned';
+        }
+
+        $this->components->info($info.' successfully.');
+    }
+
+    /**
+     * Ensure database is clean to prevent errors when loading schema.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     */
+    protected function ensureCleanDatabase(Connection $connection): void
+    {
+        if (! $connection->getSchemaBuilder()->hasTable(config('database.migrations'))) {
+            return;
+        }
+
+        $this->newLine();
+
+        $this->components->task('Dropping all tables', fn () => $this->callSilent('db:wipe', array_filter([
+            '--database' => $this->option('database'),
+            '--drop-views' => $this->option('drop-views'),
+            '--drop-types' => $this->option('drop-types'),
+            '--force' => true,
+        ])) == 0);
+
+        $this->newLine();
+    }
+
+    /**
+     * Get the path to the stored schema for the given connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return string|null
+     */
+    protected function path(Connection $connection): ?string
+    {
+        return collect([
+            $this->option('path'),
+            $this->laravel->databasePath('schema/'.$connection->getName().'-schema.dump'),
+            $this->laravel->databasePath('schema/'.$connection->getName().'-schema.sql'),
+        ])->filter(fn ($file) => file_exists($file))
+            ->first();
+    }
+}

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database;
 
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\Migrations\FreshCommand;
 use Illuminate\Database\Console\Migrations\InstallCommand;
@@ -117,7 +116,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
     protected function registerMigrateCommand()
     {
         $this->app->singleton(MigrateCommand::class, function ($app) {
-            return new MigrateCommand($app['migrator'], $app[Dispatcher::class]);
+            return new MigrateCommand($app['migrator']);
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DbCommand;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
+use Illuminate\Database\Console\LoadCommand;
 use Illuminate\Database\Console\MonitorCommand as DatabaseMonitorCommand;
 use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
@@ -140,6 +141,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'RouteClear' => RouteClearCommand::class,
         'RouteList' => RouteListCommand::class,
         'SchemaDump' => DumpCommand::class,
+        'SchemaLoad' => LoadCommand::class,
         'Seed' => SeedCommand::class,
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleList' => ScheduleListCommand::class,

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -2,8 +2,13 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Config\Repository as Config;
 use Illuminate\Console\CommandMutex;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Console\LoadCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\Events\SchemaLoaded;
 use Illuminate\Database\Migrations\Migrator;
@@ -11,6 +16,7 @@ use Illuminate\Foundation\Application;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -23,7 +29,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testBasicMigrationsCallMigratorWithProperArguments()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -42,33 +48,57 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testMigrationsCanBeRunWithStoredSchema()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
+        $console = m::mock(ConsoleApplication::class)->makePartial();
+        $console->__construct();
         $command->setLaravel($app);
-        $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(false);
-        $migrator->shouldReceive('resolveConnection')->andReturn($connection = m::mock(stdClass::class));
-        $connection->shouldReceive('getName')->andReturn('mysql');
+        $command->setApplication($console);
+
+        $params = [
+            $resolver = m::mock(ConnectionResolverInterface::class),
+            $dispatcher = m::mock(Dispatcher::class),
+        ];
+        $loadCommand = $this->getMockBuilder(LoadCommand::class)->onlyMethods(['callSilent'])->setConstructorArgs($params)->getMock();
+        $loadCommand->setLaravel($app);
+        $loadCommand->setApplication($console);
+        $loadCommand->ignoreValidationErrors();
+
+        $container = Container::setInstance(new Container);
+
+        $container->singleton('config', function () {
+            return new Config(['database.migrations' => 'migrations']);
+        });
+
+        $schemaPath = __DIR__.'/stubs/schema.sql';
+
         $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
             return $callback();
         });
-        $migrator->shouldReceive('deleteRepository')->once();
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('hasRunAnyMigrations')->andReturn(false);
+        $console->shouldReceive('find')->with('schema:load')->andReturn($loadCommand);
+        $resolver->shouldReceive('connection')->andReturn($connection = m::mock(Connection::class));
+        $connection->shouldReceive('getName')->andReturn('mysql');
+        $connection->shouldReceive('getSchemaBuilder')->andReturn($schemaBuilder = m::mock(stdClass::class));
+        $schemaBuilder->shouldReceive('hasTable')->with('migrations')->andReturn(true);
         $connection->shouldReceive('getSchemaState')->andReturn($schemaState = m::mock(stdClass::class));
         $schemaState->shouldReceive('handleOutputUsing')->andReturnSelf();
-        $schemaState->shouldReceive('load')->once()->with(__DIR__.'/stubs/schema.sql');
+        $schemaState->shouldReceive('load')->once()->with($schemaPath);
         $dispatcher->shouldReceive('dispatch')->once()->with(m::type(SchemaLoaded::class));
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
         $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
-        $migrator->shouldReceive('getNotes')->andReturn([]);
-        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
-        $this->runCommand($command, ['--schema-path' => __DIR__.'/stubs/schema.sql']);
+        $loadCommand->expects($this->once())->method('callSilent')->with($this->equalTo('db:wipe'), $this->equalTo(['--force' => true]));
+
+        $this->runCommand($command, ['--schema-path' => $schemaPath]);
     }
 
     public function testMigrationRepositoryCreatedWhenNecessary()
     {
-        $params = [$migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class)];
+        $params = [$migrator = m::mock(Migrator::class)];
         $command = $this->getMockBuilder(MigrateCommand::class)->onlyMethods(['callSilent'])->setConstructorArgs($params)->getMock();
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
@@ -88,7 +118,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheCommandMayBePretended()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -106,7 +136,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testTheDatabaseMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
@@ -124,7 +154,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 
     public function testStepMayBeSet()
     {
-        $command = new MigrateCommand($migrator = m::mock(Migrator::class), $dispatcher = m::mock(Dispatcher::class));
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
         $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello,

Currently any existing schema files are loaded by the `migrate`/`migrate:fresh` commands when creating a new database. However, I have a couple of  non-default connections that need their schema files to be loaded but *without performing any migrations on those connections*---which is not possible at the moment.

This PR plucks the schema loading logic out of the `migrate` command and creates the sister command to `schema:dump`---namely, it loads/restores a schema file for a given database, but *does not perform any migrations*.


Thanks!