### PR TITLE
[9.x] Allow custom `PathNormalizer` for filesystem

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/PathNormalizer.php
+++ b/src/Illuminate/Contracts/Filesystem/PathNormalizer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Contracts\Filesystem;
+
+use League\Flysystem\PathNormalizer as FlysystemPathNormalizer;
+
+interface PathNormalizer extends FlysystemPathNormalizer
+{
+}

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -325,7 +325,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function getCustomPathNormalizer()
     {
-        $pathNormalizerClass = $this->app['config']['filesystems.path_normalizer'];
+        $pathNormalizerClass = $this->app['config']['filesystems.path_normalizer'] ?? '';
 
         if (! class_exists($pathNormalizerClass)) {
             return null;

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -305,13 +305,33 @@ class FilesystemManager implements FactoryContract
             $adapter = new PathPrefixedAdapter($adapter, $config['prefix']);
         }
 
-        return new Flysystem($adapter, Arr::only($config, [
-            'directory_visibility',
-            'disable_asserts',
-            'temporary_url',
-            'url',
-            'visibility',
-        ]));
+        return new Flysystem(
+            $adapter,
+            Arr::only($config, [
+                'directory_visibility',
+                'disable_asserts',
+                'temporary_url',
+                'url',
+                'visibility',
+            ]),
+            $this->getCustomPathNormalizer()
+        );
+    }
+
+    /**
+     * Get the custom path normalizer.
+     *
+     * @return \Illuminate\Contracts\Filesystem\PathNormalizer|null
+     */
+    protected function getCustomPathNormalizer()
+    {
+        $pathNormalizerClass = $this->app['config']['filesystems.path_normalizer'];
+
+        if (! class_exists($pathNormalizerClass)) {
+            return null;
+        }
+
+        return new $pathNormalizerClass();
     }
 
     /**


### PR DESCRIPTION
Currently all filesystems use the default [WhitespacePathNormalizer](https://github.com/thephpleague/flysystem/blob/3.x/src/WhitespacePathNormalizer.php) provided by `thephpleague/flysystem`.

While this is mostly fine, it throws an exception for "funky" whitespaces.
Currently there is no general solution to alter this behavior to e.g. just remove this funky whitespaces.

This PR allows a custom `PathNormalizer` class to be defined in `filesystems` config.
The documentation for the new configuration option in the `laravel/laravel` repo could look something like:
```php
/*
|--------------------------------------------------------------------------
| Path Normalization
|--------------------------------------------------------------------------
|
| Here you may specify a custom path normalizer. It has to implement
| `\Illuminate\Contracts\Filesystem\PathNormalizer`.
|
*/

'path_normalizer' => null,
```

Here an example for a custom `PathNormalizer` that alters this behavior:
```php
<?php

namespace App\Filesystem;

use Illuminate\Contracts\Filesystem\PathNormalizer as PathNormalizerContract;
use League\Flysystem\WhitespacePathNormalizer;

class PathNormalizer extends WhitespacePathNormalizer implements PathNormalizerContract
{
    public function normalizePath(string $path): string
    {
        // Remove funky whitespaces.
        $path = preg_replace('#\p{C}+#u', '', $path);

        return parent::normalizePath($path);
    }
}
```

This exact behavior was also recently changed in Spaties popular `spatie/laravel-medialibrary` package:
https://github.com/spatie/laravel-medialibrary/pull/3105

Fixes #44244.
