### PR TITLE
Add `--rest` option to `queue:listen`

### DIFF
--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -25,7 +25,8 @@ class ListenCommand extends Command
                             {--queue= : The queue to listen on}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=1 : Number of times to attempt a job before logging it failed}';
+                            {--tries=1 : Number of times to attempt a job before logging it failed}
+                            {--rest=0 : Number of seconds to rest between jobs}';
 
     /**
      * The name of the console command.
@@ -120,7 +121,8 @@ class ListenCommand extends Command
             $this->option('timeout'),
             $this->option('sleep'),
             $this->option('tries'),
-            $this->option('force')
+            $this->option('force'),
+            $this->option('rest')
         );
     }
 

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -88,6 +88,9 @@ class Listener
 
         while (true) {
             $this->runProcess($process, $options->memory);
+            if($options->rest) {
+                sleep($options->rest);
+            }
         }
     }
 

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -88,7 +88,7 @@ class Listener
 
         while (true) {
             $this->runProcess($process, $options->memory);
-            if($options->rest) {
+            if ($options->rest) {
                 sleep($options->rest);
             }
         }

--- a/src/Illuminate/Queue/ListenerOptions.php
+++ b/src/Illuminate/Queue/ListenerOptions.php
@@ -22,12 +22,13 @@ class ListenerOptions extends WorkerOptions
      * @param  int  $sleep
      * @param  int  $maxTries
      * @param  bool  $force
+     * @param  int  $rest
      * @return void
      */
-    public function __construct($name = 'default', $environment = null, $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1, $force = false)
+    public function __construct($name = 'default', $environment = null, $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1, $force = false, $rest = 0)
     {
         $this->environment = $environment;
 
-        parent::__construct($name, $backoff, $memory, $timeout, $sleep, $maxTries, $force);
+        parent::__construct($name, $backoff, $memory, $timeout, $sleep, $maxTries, $force, false, 0, 0, $rest);
     }
 }


### PR DESCRIPTION
When running the `queue:listen` command as a daemon one might want to wait between jobs for a short time, just to make sure that one can dispatch a lot of jobs, without them overwhelming a 3rd party API or a rate-limited service.

To that effect, I've made the following changes:
+ `sleep()` if there was a rest option
+ Add `rest` to the `ListenerOptions`
+ Add `--rest` to the `ListenCommand` and store the value in the `ListenerOptions`

Since I'm quite unsure how this could be tested, I have not prepared / written any test cases. Sorry for that!