### PR TITLE
[9.x] Add `response()->accepted()`

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -24,6 +24,15 @@ interface ResponseFactory
     public function noContent($status = 204, array $headers = []);
 
     /**
+     * Create a new "accepted" response.
+     *
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\Response
+     */
+    public function accepted($status = 202, array $headers = []);
+
+    /**
      * Create a new response for a given view.
      *
      * @param  string|array  $view

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -70,6 +70,18 @@ class ResponseFactory implements FactoryContract
     }
 
     /**
+     * Create a new "accepted" response.
+     *
+     * @param  mixed  $content
+     * @param  array  $headers
+     * @return \Illuminate\Http\Response
+     */
+    public function accepted(mixed $content = '', array $headers = [])
+    {
+        return $this->make($content, 202, $headers);
+    }
+
+    /**
      * Create a new response for a given view.
      *
      * @param  string|array  $view

--- a/tests/Integration/Http/ResponseTest.php
+++ b/tests/Integration/Http/ResponseTest.php
@@ -9,6 +9,42 @@ use Orchestra\Testbench\TestCase;
 
 class ResponseTest extends TestCase
 {
+    public function testResponseAccepted()
+    {
+        Route::get('/response', function () {
+            return response()->accepted();
+        });
+
+        $this->get('/response')
+            ->assertStatus(202)
+            ->assertContent('');
+    }
+
+    public function testResponseAcceptedWithContent()
+    {
+        Route::get('/response', function () {
+            return response()->accepted('Hello World');
+        });
+
+        $this->get('/response')
+            ->assertStatus(202)
+            ->assertContent('Hello World');
+    }
+
+    public function testResponseAcceptedWithHeaders()
+    {
+        Route::get('/response', function () {
+            return response()->accepted('Hello World', [
+                'X-Example' => 'X-Value',
+            ]);
+        });
+
+        $this->get('/response')
+            ->assertStatus(202)
+            ->assertContent('Hello World')
+            ->assertHeader('X-Example', 'X-Value');
+    }
+
     public function testResponseWithInvalidJsonThrowsException()
     {
         $this->expectException('InvalidArgumentException');


### PR DESCRIPTION
Whenever I dispatch a job from the controller. I returned 202 as [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202) suggested.
```
public function something(Request $request): Response
{
    PatiendDataImportingJob::dispatch($media);

    return response()->noContent(202);
}
```

So, I have to return `noContent` with the 202 code. But it would make a lot more sense If we could do something like
```
  return response()->accepted();
  or
  return response()->processing();
```