### PR TITLE
Option to stop serve command if environment file has changed.

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -104,7 +104,7 @@ class ServeCommand extends Command
 
             $isEnvironmentChanged = filemtime($environmentFile) > $environmentLastModified;
 
-            if (!$this->option('no-reload') &&
+            if (! $this->option('no-reload') &&
                 $hasEnvironment &&
                 $isEnvironmentChanged) {
                 $environmentLastModified = filemtime($environmentFile);

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -102,9 +102,11 @@ class ServeCommand extends Command
                 clearstatcache(false, $environmentFile);
             }
 
-            if (! $this->option('no-reload') &&
+            $isEnvironmentChanged = filemtime($environmentFile) > $environmentLastModified;
+
+            if (!$this->option('no-reload') &&
                 $hasEnvironment &&
-                filemtime($environmentFile) > $environmentLastModified) {
+                $isEnvironmentChanged) {
                 $environmentLastModified = filemtime($environmentFile);
 
                 $this->newLine();
@@ -116,6 +118,16 @@ class ServeCommand extends Command
                 $this->serverRunningHasBeenDisplayed = false;
 
                 $process = $this->startProcess($hasEnvironment);
+            }
+
+            if ($this->option('exit-on-update') &&
+                $hasEnvironment &&
+                $isEnvironmentChanged) {
+                $this->newLine();
+
+                $this->components->info('Environment modified. Stopping server...');
+
+                $process->stop(5);
             }
 
             usleep(500 * 1000);


### PR DESCRIPTION
Idea came while using Sail - when updating environment file, `serve` command restarts underlying php server and most of the values are getting picked up after update. But for example `APP_ENV` change is not picked up by restarted server. Underlying command is not restarted, and it is seems that it is passing original `APP_ENV` value.

This change unlocks ability, to stop server process and exit command if environment file has been updated. Then Sail supervisor will start fresh `serve` command with updated environment file.


I will make PR to Sail repository to start serve command with new option if this will be merged.
