### PR TITLE
Make RouteRegistrar Macroable

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Reflector;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
 /**
@@ -30,7 +31,9 @@ use InvalidArgumentException;
  */
 class RouteRegistrar
 {
-    use CreatesRegularExpressionRouteConstraints;
+    use CreatesRegularExpressionRouteConstraints, Macroable {
+        __call as macroCall;
+    }
 
     /**
      * The router instance.
@@ -240,6 +243,10 @@ class RouteRegistrar
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         if (in_array($method, $this->passthru)) {
             return $this->registerRoute($method, ...$parameters);
         }


### PR DESCRIPTION
Currently it is possible to add Macro to the `\Illuminate\Routing\Router`. One of the downside while doing is that some methods must follow a given order. Here an example:

```php
Router::macro('forOrganisation', function (Closure $callback) {
    Route::group([
        'prefix' => '{organisation}',
        'middleware' => SetDefaultOrganisation::class,
    ], $callback);
});
```

now you can do the following:

```php
Route::forOrganisation(function () {
    Route::get('/members', OrganisationMembersController::class);
})->middleware('can:manage-members');
```

But what currently is not possible is:
```php
Route::middleware('can:manage-members')->forOrganisation(function () {
    Route::get('/members', OrganisationMembersController::class);
});
```

The reason while the second example is not possible is because the `middleware` method returns an object of `RouteRegistrar`, which doesn't has the Macroable Trait.

With this PR it is possible to do the second example as well, after you register the Macro for the `RouteRegistrar` too.
And in my opinion the second example is more readable.