### PR TITLE
[9.x] Call object's dump method when passed to global dump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
         "aws/aws-sdk-php": "^3.235.5",
         "doctrine/dbal": "^2.13.3|^3.1.4",
         "fakerphp/faker": "^1.9.2",
+        "funkjedi/composer-include-files": "^1.1",
         "guzzlehttp/guzzle": "^7.5",
         "league/flysystem-aws-s3-v3": "^3.0",
         "league/flysystem-ftp": "^3.0",
@@ -134,7 +135,10 @@
     "extra": {
         "branch-alias": {
             "dev-master": "9.x-dev"
-        }
+        },
+        "include_files": [
+            "src/Illuminate/Support/helpers.php"
+        ]
     },
     "suggest": {
         "ext-bcmath": "Required to use the multiple_of validation rule.",
@@ -174,7 +178,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "funkjedi/composer-include-files": true
         }
     },
     "minimum-stability": "dev",

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support;
 use CachingIterator;
 use Countable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Contracts\Support\Jsonable;
 use IteratorAggregate;
 use JsonSerializable;
@@ -17,7 +18,7 @@ use Traversable;
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  * @extends \IteratorAggregate<TKey, TValue>
  */
-interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
+interface Enumerable extends Arrayable, Countable, Dumpable, IteratorAggregate, Jsonable, JsonSerializable
 {
     /**
      * Create a new collection instance if the value isn't one already.

--- a/src/Illuminate/Contracts/Support/Dumpable.php
+++ b/src/Illuminate/Contracts/Support/Dumpable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Dumpable
+{
+    /**
+     * Dump the object and end the script.
+     *
+     * @return never
+     */
+    public function dd();
+
+    /**
+     * Dump the object.
+     *
+     * @return mixed
+     */
+    public function dump();
+}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -8,6 +8,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Database\Concerns\BuildsQueries;
 use Illuminate\Database\Concerns\ExplainsQueries;
 use Illuminate\Database\ConnectionInterface;
@@ -26,7 +27,7 @@ use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 
-class Builder implements BuilderContract
+class Builder implements BuilderContract, Dumpable
 {
     use BuildsQueries, ExplainsQueries, ForwardsCalls, Macroable {
         __call as macroCall;

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\HandlerStack;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
@@ -24,7 +25,7 @@ use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 use Symfony\Component\VarDumper\VarDumper;
 
-class PendingRequest
+class PendingRequest implements Dumpable
 {
     use Conditionable, Macroable;
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -5,6 +5,7 @@ namespace Illuminate\Http;
 use ArrayAccess;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Session\SymfonySessionDecorator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  * @method array validateWithBag(string $errorBag, array $rules, ...$params)
  * @method bool hasValidSignature(bool $absolute = true)
  */
-class Request extends SymfonyRequest implements Arrayable, ArrayAccess
+class Request extends SymfonyRequest implements Arrayable, ArrayAccess, Dumpable
 {
     use Concerns\CanBePrecognitive,
         Concerns\InteractsWithContentTypes,

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Closure;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
@@ -10,7 +11,7 @@ use Illuminate\Support\Traits\Tappable;
 use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 
-class Stringable implements JsonSerializable
+class Stringable implements Dumpable, JsonSerializable
 {
     use Conditionable, Macroable, Tappable;
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,12 +1,14 @@
 <?php
 
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Str;
+use Symfony\Component\VarDumper\VarDumper;
 
 if (! function_exists('append_config')) {
     /**
@@ -95,6 +97,50 @@ if (! function_exists('class_uses_recursive')) {
         }
 
         return array_unique($results);
+    }
+}
+
+if (! function_exists('dd')) {
+    /**
+     * Dump the given value(s) and end script exection.
+     *
+     * @return never
+     */
+    function dd(...$vars): void
+    {
+        foreach ($vars as $var) {
+            if ($var instanceof Dumpable) {
+                $var->dd();
+            } else {
+                VarDumper::dump($var);
+            }
+        }
+
+        exit(1);
+    }
+}
+
+if (! function_exists('dump')) {
+    /**
+     * Dump the given values and return them.
+     *
+     * @return mixed
+     */
+    function dump(...$vars): mixed
+    {
+        foreach ($vars as $var) {
+            if ($var instanceof Dumpable) {
+                $var->dump();
+            } else {
+                VarDumper::dump($var);
+            }
+        }
+
+        if (count($vars) === 1) {
+            return Arr::first($vars);
+        }
+
+        return $vars;
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -102,19 +102,13 @@ if (! function_exists('class_uses_recursive')) {
 
 if (! function_exists('dd')) {
     /**
-     * Dump the given value(s) and end script exection.
+     * Dump the given values and end script execution.
      *
      * @return never
      */
     function dd(...$vars): void
     {
-        foreach ($vars as $var) {
-            if ($var instanceof Dumpable) {
-                $var->dd();
-            } else {
-                VarDumper::dump($var);
-            }
-        }
+        dump($vars);
 
         exit(1);
     }
@@ -136,6 +130,8 @@ if (! function_exists('dump')) {
             }
         }
 
+        // If only one argument was passed, return it. This matches
+        // the behavior of Symfony's `dump` function.
         if (count($vars) === 1) {
             return Arr::first($vars);
         }

--- a/src/Illuminate/Testing/Fluent/AssertableJson.php
+++ b/src/Illuminate/Testing/Fluent/AssertableJson.php
@@ -4,13 +4,14 @@ namespace Illuminate\Testing\Fluent;
 
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\Traits\Tappable;
 use Illuminate\Testing\AssertableJsonString;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class AssertableJson implements Arrayable
+class AssertableJson implements Arrayable, Dumpable
 {
     use Concerns\Has,
         Concerns\Matching,

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -4,6 +4,7 @@ namespace Illuminate\Testing;
 
 use ArrayAccess;
 use Closure;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Contracts\Support\MessageBag;
 use Illuminate\Contracts\View\View;
 use Illuminate\Cookie\CookieValuePrefix;
@@ -30,7 +31,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * @mixin \Illuminate\Http\Response
  */
-class TestResponse implements ArrayAccess
+class TestResponse implements ArrayAccess, Dumpable
 {
     use Tappable, Macroable {
         __call as macroCall;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use ArrayAccess;
 use ArrayIterator;
 use Countable;
+use Illuminate\Contracts\Support\Dumpable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Env;
 use Illuminate\Support\Optional;
@@ -18,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 use stdClass;
+use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
 
 class SupportHelpersTest extends TestCase
@@ -921,6 +923,28 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testDumpDumpable()
+    {
+        VarDumper::setHandler(function ($val) {
+            echo "called VarDumper with [$val]";
+        });
+
+        $this->expectOutputString('dumped');
+
+        dump(new SupportTestDumpable());
+    }
+
+    public function testDumpRegularValue()
+    {
+        VarDumper::setHandler(function ($val) {
+            echo "called VarDumper with [$val]";
+        });
+
+        $this->expectOutputString('called VarDumper with [42]');
+
+        dump(42);
+    }
 }
 
 trait SupportTestTraitOne
@@ -1003,5 +1027,23 @@ class SupportTestCountable implements Countable
     public function count(): int
     {
         return 0;
+    }
+}
+
+class SupportTestDumpable implements Dumpable
+{
+    public function dd()
+    {
+        echo "dd'ed";
+    }
+
+    public function dump()
+    {
+        echo 'dumped';
+    }
+
+    public function __toString()
+    {
+        return "This shouldn't be getting called";
     }
 }


### PR DESCRIPTION
Many Laravel classes have `dump` and `dd` methods.

It would be nice if these methods would be called when an object of this sort is passed to `dd` or `dump`, instead of the default behavior (which can get pretty ugly, especially with things like QueryBuilder, see screenshot below).

**Screenshot**
<img width="1536" alt="Screen Shot 2022-11-25 at 11 18 14 AM" src="https://user-images.githubusercontent.com/33736292/204028883-d3ed98ab-2d24-4047-9956-ccc97813e010.png">

 This would be especially useful when passing multiple values to the dump methods, i.e.
```php
dump($query1, $query2); // I still want nice output here
```

This PR adds a new contract, `Dumpable`, which requires the presence of the `dump` and `dd` methods on the implementing class. It also adds a new set of `dump` and `dd` functions which replace Symfony's while still being completely backwards compatible.

**Note:**
In order to get Composer to load `Illuminate\Support\helpers.php` before `vendor/symfony/var-dumper/Resources/functions/dump.php` while running tests, I had to install [`funkjedi/composer-include-files`](https://github.com/funkjedi/composer-include-files) (in require-dev only, hope that's ok). In a real application this will probably work out of the box, since both functions will be loaded by Composer, and "L" comes before "S".

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
