### PR TITLE
Add valuesRecursive Collection method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1589,7 +1589,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     {
         $values = is_null($values) ? new static($this->items) : $values;
 
-        foreach ($values as $key => $row){
+        foreach ($values as $key => $row) {
             if (is_array($row) || $row instanceof Enumerable) {
                 $values[$key] = $this->valuesRecursive(new static($row))->values()->all();
             }

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1585,6 +1585,17 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         return new static(array_values($this->items));
     }
 
+    public function valuesRecursive($values = null){
+        $values = is_null($values) ? new static($this->items) : $values;
+
+        foreach ($values as $key => $row){
+            if(is_array($row) || $row instanceof Enumerable)
+                $values[$key] = $this->valuesRecursive(new static($row))->values()->all();
+        }
+
+        return (new static($values instanceof Enumerable ? $values->values() : array_values($values)))->values();
+    }
+
     /**
      * Zip the collection together with one or more arrays.
      *

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1585,12 +1585,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         return new static(array_values($this->items));
     }
 
-    public function valuesRecursive($values = null){
+    public function valuesRecursive($values = null)
+    {
         $values = is_null($values) ? new static($this->items) : $values;
 
         foreach ($values as $key => $row){
-            if(is_array($row) || $row instanceof Enumerable)
+            if (is_array($row) || $row instanceof Enumerable) {
                 $values[$key] = $this->valuesRecursive(new static($row))->values()->all();
+            }
         }
 
         return (new static($values instanceof Enumerable ? $values->values() : array_values($values)))->values();

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1535,6 +1535,17 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         });
     }
 
+    public function valuesRecursive($values = null){
+        return new static(function () {
+            foreach ($this as $row) {
+                if(is_array($row) || $row instanceof Enumerable) {
+                    $row = $this->passthru("valuesRecursive", ["values" => collect($row)])->values()->all();
+                }
+                yield $row;
+            }
+        });
+    }
+
     /**
      * Zip the collection together with one or more arrays.
      *

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1535,11 +1535,12 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         });
     }
 
-    public function valuesRecursive($values = null){
+    public function valuesRecursive($values = null)
+    {
         return new static(function () {
             foreach ($this as $row) {
-                if(is_array($row) || $row instanceof Enumerable) {
-                    $row = $this->passthru("valuesRecursive", ["values" => collect($row)])->values()->all();
+                if (is_array($row) || $row instanceof Enumerable) {
+                    $row = $this->passthru('valuesRecursive', ['values' => collect($row)])->values()->all();
                 }
                 yield $row;
             }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1189,6 +1189,86 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([0 => 'a', 1 => 'b', 2 => 'c'], $data->values()->all());
     }
 
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testValuesRecursiveWithArray($collection)
+    {
+        $c = new $collection([
+            "a" => [
+                "x" => 1,
+                "y" => [
+                    "0"
+                ]
+            ],
+            "b" => 1
+        ]);
+
+        $this->assertEquals([
+            [
+                1,
+                [
+                    "0"
+                ]
+            ],
+            1
+        ], $c->valuesRecursive()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testValuesRecursiveWithCollection($collection)
+    {
+        $c = new $collection([
+            "a" => new $collection([
+                "x" => 1,
+                "y" => new $collection([
+                    "0"
+                ])
+            ]),
+            "b" => 1
+        ]);
+
+        $this->assertEquals([
+            [
+                1,
+                [
+                    "0"
+                ]
+            ],
+            1
+        ], $c->valuesRecursive()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testValuesRecursiveWithArrayAndCollection($collection)
+    {
+        $c = new $collection([
+            "a" => [
+                "x" => 1,
+                "y" => new $collection([
+                    "0"
+                ])
+            ],
+            "b" => 1
+        ]);
+
+        $this->assertEquals([
+            [
+                1,
+                [
+                    "0"
+                ]
+            ],
+            1
+        ], $c->valuesRecursive()->all());
+    }
+
+
     /**
      * @dataProvider collectionClassProvider
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1199,10 +1199,10 @@ class SupportCollectionTest extends TestCase
             'a' => [
                 'x' => 1,
                 'y' => [
-                    '0'
-                ]
+                    '0',
+                ],
             ],
-            'b' => 1
+            'b' => 1,
         ]);
 
         $this->assertEquals([
@@ -1210,9 +1210,9 @@ class SupportCollectionTest extends TestCase
                 1,
                 [
                     '0'
-                ]
+                ],
             ],
-            1
+            1,
         ], $c->valuesRecursive()->all());
     }
 
@@ -1225,7 +1225,7 @@ class SupportCollectionTest extends TestCase
             'a' => new $collection([
                 'x' => 1,
                 'y' => new $collection([
-                    '0'
+                    '0',
                 ])
             ]),
             'b' => 1,
@@ -1235,7 +1235,7 @@ class SupportCollectionTest extends TestCase
             [
                 1,
                 [
-                    '0'
+                    '0',
                 ]
             ],
             1,
@@ -1251,7 +1251,7 @@ class SupportCollectionTest extends TestCase
             'a' => [
                 'x' => 1,
                 'y' => new $collection([
-                    '0'
+                    '0',
                 ])
             ],
             'b' => 1,
@@ -1261,8 +1261,8 @@ class SupportCollectionTest extends TestCase
             [
                 1,
                 [
-                    '0'
-                ]
+                    '0',
+                ],
             ],
             1,
         ], $c->valuesRecursive()->all());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1196,20 +1196,20 @@ class SupportCollectionTest extends TestCase
     public function testValuesRecursiveWithArray($collection)
     {
         $c = new $collection([
-            "a" => [
-                "x" => 1,
-                "y" => [
-                    "0"
+            'a' => [
+                'x' => 1,
+                'y' => [
+                    '0'
                 ]
             ],
-            "b" => 1
+            'b' => 1
         ]);
 
         $this->assertEquals([
             [
                 1,
                 [
-                    "0"
+                    '0'
                 ]
             ],
             1
@@ -1222,23 +1222,23 @@ class SupportCollectionTest extends TestCase
     public function testValuesRecursiveWithCollection($collection)
     {
         $c = new $collection([
-            "a" => new $collection([
-                "x" => 1,
-                "y" => new $collection([
-                    "0"
+            'a' => new $collection([
+                'x' => 1,
+                'y' => new $collection([
+                    '0'
                 ])
             ]),
-            "b" => 1
+            'b' => 1,
         ]);
 
         $this->assertEquals([
             [
                 1,
                 [
-                    "0"
+                    '0'
                 ]
             ],
-            1
+            1,
         ], $c->valuesRecursive()->all());
     }
 
@@ -1248,23 +1248,23 @@ class SupportCollectionTest extends TestCase
     public function testValuesRecursiveWithArrayAndCollection($collection)
     {
         $c = new $collection([
-            "a" => [
-                "x" => 1,
-                "y" => new $collection([
-                    "0"
+            'a' => [
+                'x' => 1,
+                'y' => new $collection([
+                    '0'
                 ])
             ],
-            "b" => 1
+            'b' => 1,
         ]);
 
         $this->assertEquals([
             [
                 1,
                 [
-                    "0"
+                    '0'
                 ]
             ],
-            1
+            1,
         ], $c->valuesRecursive()->all());
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I added the `valuesRecursive` to `Collection` and `LazyCollection` classes. This method will allow developers to reset indexes recursively through multidimensional colletions, like so:

```php
collect([
    "a" => [
        "x" => 1,
        "y" => [
             "0"
          ]
      ],
      "b" => 1
])->valuesRecursive();

/* Will return 
[
    [
        1,
        [
            "0"
        ]
    ],
    1
]
*/
```


It will not break any current features, as it is completely new method, which does not interfere with any other Collection methods.
