### PR TITLE
[9.x] Add news `report_if` and `report_unless` helpers functions

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -681,6 +681,38 @@ if (! function_exists('report')) {
     }
 }
 
+if (! function_exists('report_if')) {
+    /**
+     * Report an exception if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  \Throwable|string  $exception
+     * @return void
+     */
+    function report_if($boolean, $exception)
+    {
+        if ($boolean) {
+            report($exception);
+        }
+    }
+}
+
+if (! function_exists('report_unless')) {
+    /**
+     * Report an exception unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  \Throwable|string  $exception
+     * @return void
+     */
+    function report_unless($boolean, $exception)
+    {
+        if (! $boolean) {
+            report($exception);
+        }
+    }
+}
+
 if (! function_exists('request')) {
     /**
      * Get an instance of the current request or an input item from the request.


### PR DESCRIPTION
This PR is to add the ability to report functions with some condition.

Ex:

```php
class WelcomeController
{
    public function index(): View
    {
        if(! Auth::user()->isAdmin()){
            report('Is route need permission user');
        }
        
        // OR
         if(Auth::user()->isUser()){
            report('Is route need permission admin');
        }

        // Your code

        return view('welcome');
    }
}
```

After PR:
```php
class WelcomeController
{
    public function index(): View
    {
        report_if(Auth::user()->isAdmin(), 'Is route need permission admin');
        
        // OR
        report_unless(Auth::user()->isAdmin(), 'Is route need permission user');

        // Your code

        return view('welcome');
    }
}
```