### PR TITLE
[9.x] Add methodIs method to Illuminate\Http\Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -216,6 +216,19 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Determine if the request method matches a given pattern.
+     *
+     * @param  mixed  ...$patterns
+     * @return bool
+     */
+    public function methodIs(...$patterns)
+    {
+        $method = $this->method();
+
+        return collect($patterns)->contains(fn ($pattern) => Str::is($pattern, $method));
+    }
+
+    /**
      * Determine if the route name matches a given pattern.
      *
      * @param  mixed  ...$patterns

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -204,6 +204,31 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->routeIs('foo.foo'));
     }
 
+    public function testMethodIsMethod()
+    {
+        $request = Request::create('/', 'GET');
+        $this->assertTrue($request->methodIs('GET'));
+        $request = Request::create('/', 'HEAD');
+        $this->assertTrue($request->methodIs('HEAD'));
+        $request = Request::create('/', 'POST');
+        $this->assertTrue($request->methodIs('POST'));
+        $request = Request::create('/', 'PUT');
+        $this->assertTrue($request->methodIs('PUT'));
+        $request = Request::create('/', 'PATCH');
+        $this->assertTrue($request->methodIs('PATCH'));
+        $request = Request::create('/', 'DELETE');
+        $this->assertTrue($request->methodIs('DELETE'));
+        $request = Request::create('/', 'OPTIONS');
+        $this->assertTrue($request->methodIs('OPTIONS'));
+        $request = Request::create('/', 'GET');
+        $this->assertTrue($request->methodIs('GET', 'POST'));
+
+        $request = Request::create('/', 'GET');
+        $this->assertFalse($request->methodIs('HEAD'));
+        $request = Request::create('/', 'GET');
+        $this->assertFalse($request->methodIs('POST', 'PUT'));
+    }
+
     public function testRouteMethod()
     {
         $request = Request::create('/foo/bar');


### PR DESCRIPTION
This PR to the method which etermine if the request method matches a given pattern.


## before

```
if($request->method() === 'POST' || $request->method() === 'PUT') {
  // do someting
}
```


## after

```
if($request->methodIs('POST', 'PUT')) {
  // do someting
}
```