### PR TITLE
[9.x] Add isUlid in `Stringable`

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -321,7 +321,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Determine if a given string is a valid isUlid.
+     * Determine if a given string is a valid ULID.
      *
      * @return bool
      */

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -321,6 +321,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given string is a valid isUlid.
+     *
+     * @return bool
+     */
+    public function isUlid()
+    {
+        return Str::isUlid($this->value);
+    }
+
+    /**
      * Determine if the given string is empty.
      *
      * @return bool

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -39,6 +39,12 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98')->isUuid());
     }
 
+    public function testIsUlid()
+    {
+        $this->assertTrue($this->stringable('01GJSNW9MAF792C0XYY8RX6QFT')->isUlid());
+        $this->assertFalse($this->stringable('01GJSNW9MAF-792C0XYY8RX6ssssss-QFT')->isUlid());
+    }
+
     public function testIsJson()
     {
         $this->assertTrue($this->stringable('1')->isJson());


### PR DESCRIPTION
This PR is to add the ability to check if the string is Ulid.

Ex:

```php
str('01GJSNW9MAF792C0XYY8RX6QFT')->isUlid();
```