### PR TITLE
Invariant docblocks

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -22,7 +22,7 @@ class EncryptCookies
     /**
      * The names of the cookies that should not be encrypted.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $except = [];
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -51,21 +51,21 @@ class Kernel implements KernelContract
     /**
      * The application's middleware stack.
      *
-     * @var array
+     * @var array<int, class-string|string>
      */
     protected $middleware = [];
 
     /**
      * The application's route middleware groups.
      *
-     * @var array
+     * @var array<string, array<int, class-string|string>>
      */
     protected $middlewareGroups = [];
 
     /**
      * The application's route middleware.
      *
-     * @var array
+     * @var array<string, class-string|string>
      */
     protected $routeMiddleware = [];
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -51,7 +51,7 @@ class Kernel implements KernelContract
     /**
      * The application's middleware stack.
      *
-     * @var array<int, class-string|string>
+     * @var array<int, string>
      */
     protected $middleware = [];
 

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -19,7 +19,7 @@ class PreventRequestsDuringMaintenance
     /**
      * The URIs that should be accessible while maintenance mode is enabled.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $except = [];
 

--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -16,7 +16,7 @@ class TrimStrings extends TransformsRequest
     /**
      * The attributes that should not be trimmed.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $except = [
         //

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -34,7 +34,7 @@ class VerifyCsrfToken
     /**
      * The URIs that should be excluded from CSRF verification.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $except = [];
 

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -11,7 +11,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The event handler mappings for the application.
      *
-     * @var array
+     * @var array<class-string, array<int, class-string>>
      */
     protected $listen = [];
 

--- a/src/Illuminate/Http/Middleware/TrustHosts.php
+++ b/src/Illuminate/Http/Middleware/TrustHosts.php
@@ -28,7 +28,7 @@ abstract class TrustHosts
     /**
      * Get the host patterns that should be trusted.
      *
-     * @return array
+     * @return array<int, string|null>
      */
     abstract public function hosts();
 

--- a/src/Illuminate/Http/Middleware/TrustProxies.php
+++ b/src/Illuminate/Http/Middleware/TrustProxies.php
@@ -10,7 +10,7 @@ class TrustProxies
     /**
      * The trusted proxies for the application.
      *
-     * @var array|string|null
+     * @var array<int, string>|string|null
      */
     protected $proxies;
 


### PR DESCRIPTION
There are some of core classes (http kernel, middlewares, providers) have only common array type described in docblocks `@var array`:
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php#L11-L16

when they are described with array key and value types in extended from core classes in `laravel/laravel` repository:
[https://github.com/laravel/laravel/blob/9.x/app/Providers/EventServiceProvider.php#L12-L17](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Providers/EventServiceProvider.php#L12-L17)

Another cases:
1. [https://github.com/laravel/framework/blob/9.x/src/Illuminate/Foundation/Http/Kernel.php#L51-L70](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Http/Kernel.php#L9-L55)
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Foundation/Http/Kernel.php#L51-L70

2. [https://github.com/laravel/laravel/blob/9.x/app/Http/Middleware/EncryptCookies.php#L9-L14](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Http/Middleware/EncryptCookies.php#L9-L14)
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Cookie/Middleware/EncryptCookies.php#L22-L27

3. [https://github.com/laravel/laravel/blob/9.x/app/Http/Middleware/PreventRequestsDuringMaintenance.php#L9-L14](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Http/Middleware/PreventRequestsDuringMaintenance.php#L9-L14)
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php#L19-L24

4. [https://github.com/laravel/laravel/blob/9.x/app/Http/Middleware/TrimStrings.php#L9-L14](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Http/Middleware/TrimStrings.php#L9-L14)
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php#L16-L21

5. [https://github.com/laravel/laravel/blob/9.x/app/Http/Middleware/VerifyCsrfToken.php#L9-L14](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Http/Middleware/VerifyCsrfToken.php#L9-L14)
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L34-L39

6. [https://github.com/laravel/laravel/blob/9.x/app/Http/Middleware/TrustHosts.php#L9-L14](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Http/Middleware/TrustHosts.php#L9-L14)
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Http/Middleware/TrustHosts.php#L28-L33

7. [https://github.com/laravel/laravel/blob/9.x/app/Http/Middleware/TrustProxies.php#L10-L15](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Http/Middleware/TrustProxies.php#L10-L15)
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Http/Middleware/TrustProxies.php#L10-L15

This PR suggests to make these doc blocks are invariant.

Sometimes, they are equal:
[https://github.com/laravel/laravel/blob/9.x/app/Providers/AuthServiceProvider.php#L10-L15](https://github.com/laravel/laravel/blob/88b2d177fcff54cc9356d29ba7d3b36efda800c6/app/Providers/AuthServiceProvider.php#L10-L15)
https://github.com/laravel/framework/blob/82fde9e0dc4f08f4c4db254b9449fd87652c40a6/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php#L10-L15