### PR TITLE
Add morph helper to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Http\Concerns;
 
-use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Concerns;
 
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Date;
@@ -360,6 +362,29 @@ trait InteractsWithInput
         }
 
         return $enumClass::tryFrom($this->input($key));
+    }
+
+    /**
+     * Retrieve input from the request as a morphed eloquent model instance.
+     *
+     * @param  string  $morphable
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function morph($morphable)
+    {
+        $id = $morphable.'_id';
+        $type = $morphable.'_type';
+        if ($this->isNotFilled($id) || $this->isNotFilled($type)) {
+            return null;
+        }
+
+        /** @var class-string<\Illuminate\Database\Eloquent\Model>|null $class */
+        $class = Relation::getMorphedModel($this->input($type));
+        if (! $class) {
+            return null;
+        }
+
+        return $class::find($this->input($id));
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Http;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Route;
@@ -644,6 +645,27 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(TestEnum::test, $request->enum('valid_enum_value', TestEnum::class));
 
         $this->assertNull($request->enum('invalid_enum_value', TestEnum::class));
+    }
+
+    public function testMorphMethod()
+    {
+        Relation::$morphMap['ExistingMap'] = MorphModelMock::class;
+        $request = Request::create('/', 'GET', [
+            'something' => null,
+
+            'invalid_id' => 9999,
+            'invalid_type' => 'NonExistingMap',
+
+            'valid_id' => 1,
+            'valid_type' => 'ExistingMap',
+        ]);
+
+        $this->assertNull($request->morph('something'));
+        $this->assertNull($request->morph('invalid'));
+
+        $morph = $request->morph('valid');
+        $this->assertNotNull($morph);
+        $this->assertSame(1, $morph->id);
     }
 
     public function testArrayAccess()

--- a/tests/Http/MorphModelMock.php
+++ b/tests/Http/MorphModelMock.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\Http;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MorphModelMock
+{
+    public static function find($id) {
+        return tap(new class extends Model{}, fn($model) => $model->id = $id);
+    }
+}

--- a/tests/Http/MorphModelMock.php
+++ b/tests/Http/MorphModelMock.php
@@ -8,6 +8,6 @@ class MorphModelMock
 {
     public static function find($id)
     {
-        return tap(new class extends Model {}, fn($model) => $model->id = $id);
+        return tap(new class extends Model {}, fn ($model) => $model->id = $id);
     }
 }

--- a/tests/Http/MorphModelMock.php
+++ b/tests/Http/MorphModelMock.php
@@ -8,6 +8,6 @@ class MorphModelMock
 {
     public static function find($id)
     {
-        return tap(new class extends Model{}, fn($model) => $model->id = $id);
+        return tap(new class extends Model {}, fn($model) => $model->id = $id);
     }
 }

--- a/tests/Http/MorphModelMock.php
+++ b/tests/Http/MorphModelMock.php
@@ -6,7 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class MorphModelMock
 {
-    public static function find($id) {
+    public static function find($id)
+    {
         return tap(new class extends Model{}, fn($model) => $model->id = $id);
     }
 }


### PR DESCRIPTION
This PR adds a new `morph` request helper.

**Usage**
```php
$contactable = request()->morph('contactable');

\\ $contactable is now an instance of the given morph.
```
The `morph` helper looks if `{$key}_id` and `{$key}_type` exists in the request and tries to instanciate a model instance with the given data.
If the fields aren't present or the model was not found it returns `null`.

**Why do I think this is usefull?**
Lately I had to deal a lot with morph models in an REST-API and I had to go the hard way like this:
```php
$id = request()->input('contactable_id');
$type = request()->input('contactable_type');

$contactable = null;
$class = Relation::getMorphedModel($type);
if ($class) {
  $contactable = $class::find($this->input($id))
}
```
This has to be done in multiple controllers so I extracted it and then I thought, maybe others have the same requirements so lets create a PR :)