### PR TITLE
[9.x] Add method missingAny to request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -225,6 +225,21 @@ trait InteractsWithInput
     }
 
     /**
+     * Determine if the request is missing any of the given inputs.
+     *
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public function missingAny($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $input = $this->all();
+
+        return ! Arr::hasAny($input, $keys);
+    }
+
+    /**
      * Apply the callback if the request is missing the given input item key.
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -487,6 +487,28 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($bar);
     }
 
+    public function testmissingAnyMethod()
+    {
+        $request = Request::create('/', 'GET', ['foo' => 'bar']);
+        $this->assertTrue($request->missingAny('name'));
+        $this->assertTrue($request->missingAny('age'));
+        $this->assertTrue($request->missingAny('city'));
+        $this->assertFalse($request->missingAny('foo'));
+        $this->assertTrue($request->missingAny('name', 'email'));
+        $this->assertTrue($request->missingAny(['name', 'email']));
+
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'forge@laravel.com']);
+        $this->assertFalse($request->missingAny('name', 'email'));
+        $this->assertTrue($request->missingAny('username', 'password'));
+        $this->assertTrue($request->missingAny(['username', 'password']));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar' => null, 'baz' => '']]);
+        $this->assertFalse($request->missingAny('foo.bar'));
+        $this->assertFalse($request->missingAny('foo.baz'));
+        $this->assertTrue($request->missingAny('foo.bax'));
+        $this->assertFalse($request->missingAny(['foo.bax', 'foo.baz']));
+    }
+
     public function testHasAnyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);


### PR DESCRIPTION
This PR adds the method missingAny() that is basically the contrary of hasAny()

Since Laravel has the methods `has`, `hasAny`, `whenHas`, and `missing`, `whenMissing`, I thought it was a good idea to add this method.

Before
```php
if(! $request->hasAny(['name','email'])) {

}
```

After

```php
if($request->missingAny(['name','email'])) {

}
```

it adds syntactic sugar. 