### PR TITLE
[10.x] Add Route::json() method

### DIFF
--- a/src/Illuminate/Routing/JsonController.php
+++ b/src/Illuminate/Routing/JsonController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Contracts\Routing\ResponseFactory;
+
+class JsonController extends Controller
+{
+    /**
+     * The response factory implementation.
+     *
+     * @var \Illuminate\Contracts\Routing\ResponseFactory
+     */
+    protected $response;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $response
+     * @return void
+     */
+    public function __construct(ResponseFactory $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Invoke the controller method.
+     *
+     * @param  array  $args
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(...$args)
+    {
+        $routeParameters = array_filter($args, function ($key) {
+            return ! in_array($key, ['data', 'status', 'headers', 'options']);
+        }, ARRAY_FILTER_USE_KEY);
+
+        $args['data'] = array_merge($args['data'], $routeParameters);
+
+        return $this->response->json(
+            $args['data'],
+            $args['status'],
+            $args['headers'],
+            $args['options']
+        );
+    }
+
+    /**
+     * Execute an action on the controller.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function callAction($method, $parameters)
+    {
+        return $this->{$method}(...$parameters);
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -302,7 +302,7 @@ class Router implements BindingRegistrar, RegistrarContract
                     'data' => is_array($data) ? $data : $data->toArray(),
                     'status' => is_array($status) ? 200 : $status,
                     'headers' => is_array($status) ? $status : $headers,
-                    'options' => $options
+                    'options' => $options,
                 ]);
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -289,7 +289,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * Register a new route that returns json.
      *
      * @param  string  $uri
-     * @param  array  $data
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @param  int|array  $status
      * @param  array  $headers
      * @param  int  $options
@@ -299,7 +299,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\JsonController')
                 ->setDefaults([
-                    'data' => $data,
+                    'data' => is_array($data) ? $data : $data->toArray(),
                     'status' => is_array($status) ? 200 : $status,
                     'headers' => is_array($status) ? $status : $headers,
                     'options' => $options

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -286,6 +286,27 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Register a new route that returns json.
+     *
+     * @param  string  $uri
+     * @param  array  $data
+     * @param  int|array  $status
+     * @param  array  $headers
+     * @param  int  $options
+     * @return \Illuminate\Routing\Route
+     */
+    public function json($uri, $data = [], $status = 200, array $headers = [], $options = 0)
+    {
+        return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\JsonController')
+                ->setDefaults([
+                    'data' => $data,
+                    'status' => is_array($status) ? 200 : $status,
+                    'headers' => is_array($status) ? $status : $headers,
+                    'options' => $options
+                ]);
+    }
+
+    /**
      * Register a new route with the given verbs.
      *
      * @param  array|string  $methods

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -21,6 +21,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 302)
  * @method static \Illuminate\Routing\Route substituteBindings(\Illuminate\Support\Facades\Route $route)
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [], int|array $status = 200, array $headers = [])
+ * @method static \Illuminate\Routing\Route json(string $uri, array $data = [], int|array $status = 200, array $headers = [], int $options = 0)
  * @method static \Illuminate\Routing\RouteRegistrar as(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method static \Illuminate\Routing\RouteRegistrar domain(string $value)

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -21,7 +21,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 302)
  * @method static \Illuminate\Routing\Route substituteBindings(\Illuminate\Support\Facades\Route $route)
  * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [], int|array $status = 200, array $headers = [])
- * @method static \Illuminate\Routing\Route json(string $uri, array $data = [], int|array $status = 200, array $headers = [], int $options = 0)
+ * @method static \Illuminate\Routing\Route json(string $uri, \Illuminate\Contracts\Support\Arrayable|array $data = [], int|array $status = 200, array $headers = [], int $options = 0)
  * @method static \Illuminate\Routing\RouteRegistrar as(string $value)
  * @method static \Illuminate\Routing\RouteRegistrar controller(string $controller)
  * @method static \Illuminate\Routing\RouteRegistrar domain(string $value)

--- a/tests/Integration/Routing/RouteJsonTest.php
+++ b/tests/Integration/Routing/RouteJsonTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+
+class RouteJsonTest extends TestCase
+{
+    public function testRouteJson()
+    {
+        Route::json('route', $json = ['foo' => 'bar']);
+
+        $this->assertSame(json_encode($json), $this->get('/route')->getContent());
+        $this->assertSame(200, $this->get('/route')->status());
+    }
+
+    public function testRouteJsonWithStatus()
+    {
+        Route::json('route', $json = ['foo' => 'bar'], 418);
+
+        $this->assertSame(418, $this->get('/route')->status());
+    }
+
+    public function testRouteJsonWithHeaders()
+    {
+        Route::json('route', $json = ['foo' => 'bar'], 418, ['Framework' => 'Laravel']);
+
+        $this->assertSame('Laravel', $this->get('/route')->headers->get('Framework'));
+    }
+
+    public function testRouteJsonOverloadingStatusWithHeaders()
+    {
+        Route::json('route', $json = ['foo' => 'bar'], ['Framework' => 'Laravel']);
+
+        $this->assertSame('Laravel', $this->get('/route')->headers->get('Framework'));
+    }
+
+    public function testRouteJsonWithOptions()
+    {
+        Route::json('route', $json = ['float' => 8.0], 418, ['Framework' => 'Laravel'], JSON_PRESERVE_ZERO_FRACTION);
+
+        $this->assertSame(json_encode($json, JSON_PRESERVE_ZERO_FRACTION), $this->get('/route')->getContent());
+        $this->assertSame(JSON_PRESERVE_ZERO_FRACTION, $this->get('/route')->getEncodingOptions());
+    }
+}


### PR DESCRIPTION
This PR adds a new `Route::json()` method making it possible to register a new route that returns json.

Before:
```php
Route::get('/', function() {
    return response()->json(['foo' => 'bar']);
});
```

After:
```php
Route::json('/', ['foo' => 'bar']);
```

Arguments that can be passed are:
1. The route
2. The data (\Illuminate\Contracts\Support\Arrayable|array)
3. A status code
4. Headers
5. Options

Long version:
```php
Route::json('/', ['foo' => 'bar'], 418, ['Framework' => 'Laravel'], JSON_PRESERVE_ZERO_FRACTION);
```