### PR TITLE
Align method visibility in HandlesAuthorization

### DIFF
--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -36,7 +36,7 @@ trait HandlesAuthorization
      * @param  ?int  $code
      * @return \Illuminate\Auth\Access\Response
      */
-    public function denyWithStatus($status, $message = null, $code = null)
+    protected function denyWithStatus($status, $message = null, $code = null)
     {
         return Response::denyWithStatus($status, $message, $code);
     }
@@ -48,7 +48,7 @@ trait HandlesAuthorization
      * @param  ?int  $code
      * @return \Illuminate\Auth\Access\Response
      */
-    public function denyAsNotFound($message = null, $code = null)
+    protected function denyAsNotFound($message = null, $code = null)
     {
         return Response::denyWithStatus(404, $message, $code);
     }


### PR DESCRIPTION
Not sure why these two methods are public while their regular counterparts (`deny` / `allow`) are protected.