### PR TITLE
`dropForeignIdFor` method in `Blueprint` class should drop foreign key constraints along with column as well.

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -401,7 +401,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * Attempt to authenticate a user with credentials and additional callbacks.
      *
      * @param  array  $credentials
-     * @param  array|callable  $callbacks
+     * @param  array|callable|null  $callbacks
      * @param  bool  $remember
      * @return bool
      */

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -74,6 +74,9 @@ trait Batchable
      * @param  int  $failedJobs
      * @param  array  $failedJobIds
      * @param  array  $options
+     * @param  \Carbon\CarbonImmutable  $createdAt
+     * @param  \Carbon\CarbonImmutable|null  $cancelledAt
+     * @param  \Carbon\CarbonImmutable|null  $finishedAt
      * @return array{0: $this, 1: \Illuminate\Support\Testing\BatchFake}
      */
     public function withFakeBatch(string $id = '',

--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -180,6 +180,7 @@ if (! function_exists('value')) {
      * Return the default value of the given value.
      *
      * @param  mixed  $value
+     * @param  mixed  $args
      * @return mixed
      */
     function value($value, ...$args)

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -44,7 +44,7 @@ class ScheduleWorkCommand extends Command
     {
         $this->components->info('Running schedule tasks every minute.');
 
-        [$lastExecutionStartedAt, $keyOfLastExecutionWithOutput, $executions] = [null, null, []];
+        [$lastExecutionStartedAt, $executions] = [null, []];
 
         while (true) {
             usleep(100 * 1000);

--- a/src/Illuminate/Database/Concerns/CompilesJsonPaths.php
+++ b/src/Illuminate/Database/Concerns/CompilesJsonPaths.php
@@ -35,7 +35,7 @@ trait CompilesJsonPaths
         $value = preg_replace("/([\\\\]+)?\\'/", "''", $value);
 
         $jsonPath = collect(explode($delimiter, $value))
-            ->map(fn ($segment) =>  $this->wrapJsonPathSegment($segment))
+            ->map(fn ($segment) => $this->wrapJsonPathSegment($segment))
             ->join('.');
 
         return "'$".(str_starts_with($jsonPath, '[') ? '' : '.').$jsonPath."'";

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -414,7 +414,7 @@ class Blueprint
     }
 
     /**
-     * Indicate that the given foreign key should be dropped.
+     * Indicate that the given foreign key should be dropped along with column.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @param  string|null  $column
@@ -425,6 +425,7 @@ class Blueprint
         if (is_string($model)) {
             $model = new $model;
         }
+
         $this->dropForeign([$column ?: $model->getForeignKey()]);
         return $this->dropColumn([$column?:$model->getForeignKey()]);;
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -425,8 +425,8 @@ class Blueprint
         if (is_string($model)) {
             $model = new $model;
         }
-
-        return $this->dropForeign([$column ?: $model->getForeignKey()]);
+        $this->dropForeign([$column ?: $model->getForeignKey()]);
+        return $this->dropColumn([$column?:$model->getForeignKey()]);;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/src/Illuminate/Foundation/Http/Middleware/HandlePrecognitiveRequests.php
@@ -12,7 +12,7 @@ use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherCon
 class HandlePrecognitiveRequests
 {
     /**
-     *The container instance.
+     * The container instance.
      *
      * @var \Illuminate\Container\Container
      */

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -681,6 +681,38 @@ if (! function_exists('report')) {
     }
 }
 
+if (! function_exists('report_if')) {
+    /**
+     * Report an exception if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  \Throwable|string  $exception
+     * @return void
+     */
+    function report_if($boolean, $exception)
+    {
+        if ($boolean) {
+            report($exception);
+        }
+    }
+}
+
+if (! function_exists('report_unless')) {
+    /**
+     * Report an exception unless the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  \Throwable|string  $exception
+     * @return void
+     */
+    function report_unless($boolean, $exception)
+    {
+        if (! $boolean) {
+            report($exception);
+        }
+    }
+}
+
 if (! function_exists('request')) {
     /**
      * Get an instance of the current request or an input item from the request.

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -25,7 +25,8 @@ class ListenCommand extends Command
                             {--queue= : The queue to listen on}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=1 : Number of times to attempt a job before logging it failed}';
+                            {--tries=1 : Number of times to attempt a job before logging it failed}
+                            {--rest=0 : Number of seconds to rest between jobs}';
 
     /**
      * The name of the console command.
@@ -120,7 +121,8 @@ class ListenCommand extends Command
             $this->option('timeout'),
             $this->option('sleep'),
             $this->option('tries'),
-            $this->option('force')
+            $this->option('force'),
+            $this->option('rest')
         );
     }
 

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -24,9 +24,9 @@ class ListenCommand extends Command
                             {--memory=128 : The memory limit in megabytes}
                             {--queue= : The queue to listen on}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--rest=0 : Number of seconds to rest between jobs}
                             {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=1 : Number of times to attempt a job before logging it failed}
-                            {--rest=0 : Number of seconds to rest between jobs}';
+                            {--tries=1 : Number of times to attempt a job before logging it failed}';
 
     /**
      * The name of the console command.
@@ -114,15 +114,15 @@ class ListenCommand extends Command
                 : $this->option('delay');
 
         return new ListenerOptions(
-            $this->option('name'),
-            $this->option('env'),
-            $backoff,
-            $this->option('memory'),
-            $this->option('timeout'),
-            $this->option('sleep'),
-            $this->option('tries'),
-            $this->option('force'),
-            $this->option('rest')
+            name: $this->option('name'),
+            environment: $this->option('env'),
+            backoff: $backoff,
+            memory: $this->option('memory'),
+            timeout: $this->option('timeout'),
+            sleep: $this->option('sleep'),
+            rest: $this->option('rest'),
+            maxTries: $this->option('tries'),
+            force: $this->option('force')
         );
     }
 

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -88,6 +88,9 @@ class Listener
 
         while (true) {
             $this->runProcess($process, $options->memory);
+            if($options->rest) {
+                sleep($options->rest);
+            }
         }
     }
 

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -88,7 +88,7 @@ class Listener
 
         while (true) {
             $this->runProcess($process, $options->memory);
-            if($options->rest) {
+            if ($options->rest) {
                 sleep($options->rest);
             }
         }

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -88,6 +88,7 @@ class Listener
 
         while (true) {
             $this->runProcess($process, $options->memory);
+
             if ($options->rest) {
                 sleep($options->rest);
             }

--- a/src/Illuminate/Queue/ListenerOptions.php
+++ b/src/Illuminate/Queue/ListenerOptions.php
@@ -22,12 +22,13 @@ class ListenerOptions extends WorkerOptions
      * @param  int  $sleep
      * @param  int  $maxTries
      * @param  bool  $force
+     * @param  int  $rest
      * @return void
      */
-    public function __construct($name = 'default', $environment = null, $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1, $force = false)
+    public function __construct($name = 'default', $environment = null, $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1, $force = false, $rest = 0)
     {
         $this->environment = $environment;
 
-        parent::__construct($name, $backoff, $memory, $timeout, $sleep, $maxTries, $force);
+        parent::__construct($name, $backoff, $memory, $timeout, $sleep, $maxTries, $force, false, 0, 0, $rest);
     }
 }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -321,6 +321,16 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Determine if a given string is a valid ULID.
+     *
+     * @return bool
+     */
+    public function isUlid()
+    {
+        return Str::isUlid($this->value);
+    }
+
+    /**
      * Determine if the given string is empty.
      *
      * @return bool

--- a/tests/Database/DatabaseEloquentWithCastsTest.php
+++ b/tests/Database/DatabaseEloquentWithCastsTest.php
@@ -15,7 +15,7 @@ class DatabaseEloquentWithCastsTest extends TestCase
         $db = new DB;
 
         $db->addConnection([
-            'driver'   => 'sqlite',
+            'driver' => 'sqlite',
             'database' => ':memory:',
         ]);
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -587,7 +587,7 @@ class HttpRequestTest extends TestCase
 
     public function testBooleanMethod()
     {
-        $request = Request::create('/', 'GET', ['with_trashed' => 'false', 'download' => true, 'checked' => 1, 'unchecked' => '0', 'with_on' => 'on', 'with_yes'=> 'yes']);
+        $request = Request::create('/', 'GET', ['with_trashed' => 'false', 'download' => true, 'checked' => 1, 'unchecked' => '0', 'with_on' => 'on', 'with_yes' => 'yes']);
         $this->assertTrue($request->boolean('checked'));
         $this->assertTrue($request->boolean('download'));
         $this->assertFalse($request->boolean('unchecked'));
@@ -605,8 +605,8 @@ class HttpRequestTest extends TestCase
             'zero_padded' => '078',
             'space_padded' => ' 901',
             'nan' => 'nan',
-            'mixed'=> '1ab',
-            'underscore_notation'=> '2_000',
+            'mixed' => '1ab',
+            'underscore_notation' => '2_000',
         ]);
         $this->assertSame(123, $request->integer('int'));
         $this->assertSame(456, $request->integer('raw_int'));
@@ -627,8 +627,8 @@ class HttpRequestTest extends TestCase
             'zero_padded' => '0.78',
             'space_padded' => ' 90.1',
             'nan' => 'nan',
-            'mixed'=> '1.ab',
-            'scientific_notation'=> '1e3',
+            'mixed' => '1.ab',
+            'scientific_notation' => '1e3',
         ]);
         $this->assertSame(1.23, $request->float('float'));
         $this->assertSame(45.6, $request->float('raw_float'));

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -110,7 +110,7 @@ class EloquentWhereHasTest extends DatabaseTestCase
         };
 
         return [
-            'Find user with post.public = true'  => $callbackArray(true),
+            'Find user with post.public = true' => $callbackArray(true),
             'Find user with post.public = false' => $callbackArray(false),
         ];
     }

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -57,10 +57,10 @@ class NotificationDatabaseChannelTest extends TestCase
         $notifiable = m::mock();
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
-            'id'        => 1,
-            'type'      => 'MONTHLY',
-            'data'      => ['invoice_id' => 1],
-            'read_at'   => null,
+            'id' => 1,
+            'type' => 'MONTHLY',
+            'data' => ['invoice_id' => 1],
+            'read_at' => null,
             'something' => 'else',
         ]);
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -54,11 +54,10 @@ class QueueDatabaseQueueUnitTest extends TestCase
             return $uuid;
         });
 
-        $queue = $this->getMockBuilder(
-            DatabaseQueue::class)->onlyMethods(
-            ['currentTime'])->setConstructorArgs(
-            [$database = m::mock(Connection::class), 'table', 'default']
-        )->getMock();
+        $queue = $this->getMockBuilder(DatabaseQueue::class)
+            ->onlyMethods(['currentTime'])
+            ->setConstructorArgs([$database = m::mock(Connection::class), 'table', 'default'])
+            ->getMock();
         $queue->expects($this->any())->method('currentTime')->willReturn('time');
         $queue->setContainer($container = m::spy(Container::class));
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -994,9 +994,9 @@ class SupportArrTest extends TestCase
         Arr::forget($array, 1);
         $this->assertEquals(['name' => 'hAz', 2 => 'bAz'], $array);
 
-        $array = [2 => [1 =>'products', 3 => 'users']];
+        $array = [2 => [1 => 'products', 3 => 'users']];
         Arr::forget($array, 2.3);
-        $this->assertEquals([2 => [1 =>'products']], $array);
+        $this->assertEquals([2 => [1 => 'products']], $array);
     }
 
     public function testWrap()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -326,7 +326,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('500-dollar-bill', Str::slug('500-$-bill', '-', 'en', ['$' => 'dollar']));
         $this->assertSame('500-dollar-bill', Str::slug('500$--bill', '-', 'en', ['$' => 'dollar']));
         $this->assertSame('500-dollar-bill', Str::slug('500-$--bill', '-', 'en', ['$' => 'dollar']));
-        $this->assertSame('أحمد-في-المدرسة', Str::slug('أحمد@المدرسة', '-', null, ['@' =>'في']));
+        $this->assertSame('أحمد-في-المدرسة', Str::slug('أحمد@المدرسة', '-', null, ['@' => 'في']));
     }
 
     public function testStrStart()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -39,6 +39,12 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('2cdc7039-65a6-4ac7-8e5d-d554a98')->isUuid());
     }
 
+    public function testIsUlid()
+    {
+        $this->assertTrue($this->stringable('01GJSNW9MAF792C0XYY8RX6QFT')->isUlid());
+        $this->assertFalse($this->stringable('01GJSNW9MAF-792C0XYY8RX6ssssss-QFT')->isUlid());
+    }
+
     public function testIsJson()
     {
         $this->assertTrue($this->stringable('1')->isJson());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4736,7 +4736,7 @@ class ValidationValidatorTest extends TestCase
     {
         // ['users'] -> if users is not empty it must be validated as array
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]], ['users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]], ['users.*.name' => 'required|string']);
         $v->sometimes(['users'], 'array', function ($i, $item) {
             return $item !== null;
         });
@@ -4744,7 +4744,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['users'] -> if users is null no rules will be applied
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['users' => null], ['users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['users' => null], ['users.*.name' => 'required|string']);
         $v->sometimes(['users'], 'array', function ($i, $item) {
             return (bool) $item;
         });
@@ -4752,7 +4752,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['company.users'] -> if users is not empty it must be validated as array
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name' => 'required|string']);
         $v->sometimes(['company.users'], 'array', function ($i, $item) {
             return $item->users !== null;
         });
@@ -4760,7 +4760,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['company.users'] -> if users is null no rules will be applied
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['company' => ['users' => null]], ['company'=> 'required', 'company.users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['company' => ['users' => null]], ['company' => 'required', 'company.users.*.name' => 'required|string']);
         $v->sometimes(['company.users'], 'array', function ($i, $item) {
             return (bool) $item->users;
         });
@@ -4768,7 +4768,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['company.*'] -> if users is not empty it must be validated as array
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name' => 'required|string']);
         $v->sometimes(['company.*'], 'array', function ($i, $item) {
             return $item !== null;
         });
@@ -4776,7 +4776,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['company.*'] -> if users is null no rules will be applied
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['company' => ['users' => null]], ['company'=> 'required', 'company.users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['company' => ['users' => null]], ['company' => 'required', 'company.users.*.name' => 'required|string']);
         $v->sometimes(['company.*'], 'array', function ($i, $item) {
             return (bool) $item;
         });
@@ -4784,7 +4784,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['users.*'] -> all nested array items in users must be validated as array
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]], ['users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]], ['users.*.name' => 'required|string']);
         $v->sometimes(['users.*'], 'array', function ($i, $item) {
             return (bool) $item;
         });
@@ -4792,7 +4792,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['company.users.*'] -> all nested array items in users must be validated as array
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name' => 'required|string']);
         $v->sometimes(['company.users.*'], 'array', function () {
             return true;
         });
@@ -4800,7 +4800,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['company.*.*'] -> all nested array items in users must be validated as array
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name'=> 'required|string']);
+        $v = new Validator($trans, ['company' => ['users' => [['name' => 'Taylor'], ['name' => 'Abigail']]]], ['company.users.*.name' => 'required|string']);
         $v->sometimes(['company.*.*'], 'array', function ($i, $item) {
             return true;
         });
@@ -4905,7 +4905,7 @@ class ValidationValidatorTest extends TestCase
 
         // ['attendee.*'] -> if attendee name is set, all other fields will be required as well
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['attendee' => ['name' => 'Taylor', 'title' => 'Creator of Laravel', 'type' => 'Developer']], ['attendee.*'=> 'string']);
+        $v = new Validator($trans, ['attendee' => ['name' => 'Taylor', 'title' => 'Creator of Laravel', 'type' => 'Developer']], ['attendee.*' => 'string']);
         $v->sometimes(['attendee.*'], 'required', function ($i, $item) {
             return (bool) $item;
         });

--- a/types/Database/Eloquent/ModelNotFoundException.php
+++ b/types/Database/Eloquent/ModelNotFoundException.php
@@ -6,10 +6,10 @@ use function PHPStan\Testing\assertType;
 /** @var ModelNotFoundException<User> $exception */
 $exception = new ModelNotFoundException();
 
- assertType('array<int, int|string>', $exception->getIds());
- assertType('class-string<User>', $exception->getModel());
+assertType('array<int, int|string>', $exception->getIds());
+assertType('class-string<User>', $exception->getModel());
 
- $exception->setModel(User::class, 1);
- $exception->setModel(User::class, [1]);
- $exception->setModel(User::class, '1');
- $exception->setModel(User::class, ['1']);
+$exception->setModel(User::class, 1);
+$exception->setModel(User::class, [1]);
+$exception->setModel(User::class, '1');
+$exception->setModel(User::class, ['1']);

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -286,7 +286,7 @@ assertType(
         }
     )
 );
-assertType('Illuminate\Support\Collection<int, User>|void', $collection->when(fn () =>'Taylor', function ($collection, $name) {
+assertType('Illuminate\Support\Collection<int, User>|void', $collection->when(fn () => 'Taylor', function ($collection, $name) {
     assertType('Illuminate\Support\Collection<int, User>', $collection);
     assertType('string', $name);
 }));


### PR DESCRIPTION
```https://github.com/laravel/framework/compare/9.x...anilkumarthakur60:framework:patch-1```


```
   public function dropForeignIdFor($model, $column = null)
    {
        if (is_string($model)) {
            $model = new $model;
        }

        $this->dropForeign([$column ?: $model->getForeignKey()]);
        return $this->dropColumn([$column ?: $model->getForeignKey()]);
    }
```

