### PR TITLE
[9.x] Allow set command description via `AsCommand` attribute

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -79,7 +79,11 @@ class Command extends SymfonyCommand
         // Once we have constructed the command, we'll set the description and other
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
-        $this->setDescription((string) $this->description);
+        if (! isset($this->description)) {
+            $this->setDescription((string) static::getDefaultDescription());
+        } else {
+            $this->setDescription((string) $this->description);
+        }
 
         $this->setHelp((string) $this->help);
 


### PR DESCRIPTION
Currently, if we use the `AsCommand` attribute, it will not be set to `$description` of the class, because Laravel command overrides this property.

This PR will allow us to use `AsCommand` to set the description of the command class.

ExampleCommand.php using `AsCommand`:

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;
use Symfony\Component\Console\Attribute\AsCommand;

#[AsCommand('example', 'This is an example command')]
class ExampleCommand extends Command
{
    // 
}

```

**Before the PR**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/9979458/204246420-5d59fa3e-dd8b-4f81-b861-3d1e7d0ec7a2.png">

**After the PR**

<img width="822" alt="image" src="https://user-images.githubusercontent.com/9979458/204246887-5f69a180-2213-456d-8933-7874eacebbfa.png">

Thanks.