### PR TITLE
[9.x] Prevent test issues with relations with the $touches property

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -328,24 +328,14 @@ abstract class Factory
 
             $model->save();
 
-            $this->removeEmptyRelations($model);
+            foreach ($model->getRelations() as $name => $items) {
+                if ($items->isEmpty()) {
+                    $model->unsetRelation($name);
+                }
+            }
+
             $this->createChildren($model);
         });
-    }
-
-    /**
-     * Remove the empty relations to avoid issues with touch when testing.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return void
-     */
-    protected function removeEmptyRelations(Model $model)
-    {
-        foreach ($model->getRelations() as $name => $items) {
-            if ($items->isEmpty()) {
-                $model->unsetRelation($name);
-            }
-        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -334,7 +334,7 @@ abstract class Factory
     }
 
     /**
-     * Remove the empty relations to avoid issues with touch when testing
+     * Remove the empty relations to avoid issues with touch when testing.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return void

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -328,8 +328,24 @@ abstract class Factory
 
             $model->save();
 
+            $this->removeEmptyRelations($model);
             $this->createChildren($model);
         });
+    }
+
+    /**
+     * Remove the empty relations to avoid issues with touch when testing
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    protected function removeEmptyRelations(Model $model)
+    {
+        foreach ($model->getRelations() as $name => $items) {
+            if ($items->isEmpty()) {
+                $model->unsetRelation($name);
+            }
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -356,6 +356,14 @@ class DatabaseEloquentFactoryTest extends TestCase
         unset($_SERVER['__test.role.creating-role'], $_SERVER['__test.role.creating-user']);
     }
 
+    public function test_belongs_to_many_relationship_related_models_set_on_instance_when_touching_owner()
+    {
+        $user = FactoryTestUserFactory::new()->create();
+        $role = FactoryTestRoleFactory::new()->hasAttached($user, [], 'users')->create();
+
+        $this->assertCount(1, $role->users);
+    }
+
     public function test_belongs_to_many_relationship_with_existing_model_instances()
     {
         $roles = FactoryTestRoleFactory::times(3)
@@ -912,6 +920,8 @@ class FactoryTestRoleFactory extends Factory
 class FactoryTestRole extends Eloquent
 {
     protected $table = 'roles';
+
+    protected $touches = ['users'];
 
     public function users()
     {


### PR DESCRIPTION
As discussed on #45064 this is a change that will prevent the issue of an empty relationship when testing models with the `$touches` property defined.

TBH IDK if this is the expected behaviour so if this is not the best solution, feel free to close the PR or let me know what should I change so the PR can be accepted.
