### PR TITLE
[9.x ] Updated Mailable to prevent duplicated recipients

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -689,6 +689,11 @@ class Mailable implements MailableContract, Renderable
             ];
         }
 
+        $this->{$property} = collect($this->{$property})
+            ->unique('address')
+            ->values()
+            ->all();
+
         return $this;
     }
 

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -71,7 +71,7 @@ class MailMailableTest extends TestCase
         $mailable->assertHasTo('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->to(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
+        $mailable->to(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -149,7 +149,7 @@ class MailMailableTest extends TestCase
         $mailable->assertHasCc('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->cc(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
+        $mailable->cc(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -238,7 +238,7 @@ class MailMailableTest extends TestCase
         $mailable->assertHasBcc('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->bcc(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
+        $mailable->bcc(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -327,7 +327,7 @@ class MailMailableTest extends TestCase
         $mailable->assertHasReplyTo('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->replyTo(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
+        $mailable->replyTo(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -405,7 +405,7 @@ class MailMailableTest extends TestCase
         $mailable->assertFrom('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->from(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
+        $mailable->from(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableTestUserStub2]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
@@ -1018,7 +1018,7 @@ class MailableTestUserStub
     public $email = 'taylor@laravel.com';
 }
 
-class MailableDumbUserStud
+class MailableTestUserStub2
 {
     public $name = 'Laravel Framework';
     public $email = 'contact@laravel.com';

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -74,7 +74,6 @@ class MailMailableTest extends TestCase
         $mailable->to(collect([new MailableTestUserStub, new MailableTestUserStub]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
-            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
         ], $mailable->to);
         $this->assertTrue($mailable->hasTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
@@ -151,7 +150,6 @@ class MailMailableTest extends TestCase
         $mailable = new WelcomeMailableStub;
         $mailable->cc(collect([new MailableTestUserStub, new MailableTestUserStub]));
         $this->assertEquals([
-            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
         ], $mailable->cc);
         $this->assertTrue($mailable->hasCc(new MailableTestUserStub));
@@ -241,7 +239,6 @@ class MailMailableTest extends TestCase
         $mailable->bcc(collect([new MailableTestUserStub, new MailableTestUserStub]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
-            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
         ], $mailable->bcc);
         $this->assertTrue($mailable->hasBcc(new MailableTestUserStub));
         $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
@@ -330,7 +327,6 @@ class MailMailableTest extends TestCase
         $mailable->replyTo(collect([new MailableTestUserStub, new MailableTestUserStub]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
-            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
         ], $mailable->replyTo);
         $this->assertTrue($mailable->hasReplyTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
@@ -407,7 +403,6 @@ class MailMailableTest extends TestCase
         $mailable = new WelcomeMailableStub;
         $mailable->from(collect([new MailableTestUserStub, new MailableTestUserStub]));
         $this->assertEquals([
-            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
         ], $mailable->from);
         $this->assertTrue($mailable->hasFrom(new MailableTestUserStub));

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -71,9 +71,10 @@ class MailMailableTest extends TestCase
         $mailable->assertHasTo('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->to(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $mailable->to(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
         ], $mailable->to);
         $this->assertTrue($mailable->hasTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
@@ -148,9 +149,10 @@ class MailMailableTest extends TestCase
         $mailable->assertHasCc('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->cc(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $mailable->cc(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
         ], $mailable->cc);
         $this->assertTrue($mailable->hasCc(new MailableTestUserStub));
         $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
@@ -236,9 +238,10 @@ class MailMailableTest extends TestCase
         $mailable->assertHasBcc('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->bcc(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $mailable->bcc(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
         ], $mailable->bcc);
         $this->assertTrue($mailable->hasBcc(new MailableTestUserStub));
         $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
@@ -324,9 +327,10 @@ class MailMailableTest extends TestCase
         $mailable->assertHasReplyTo('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->replyTo(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $mailable->replyTo(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
         ], $mailable->replyTo);
         $this->assertTrue($mailable->hasReplyTo(new MailableTestUserStub));
         $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
@@ -401,9 +405,10 @@ class MailMailableTest extends TestCase
         $mailable->assertFrom('taylor@laravel.com');
 
         $mailable = new WelcomeMailableStub;
-        $mailable->from(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $mailable->from(collect([new MailableTestUserStub, new MailableTestUserStub, new MailableDumbUserStud()]));
         $this->assertEquals([
             ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Laravel Framework', 'address' => 'contact@laravel.com'],
         ], $mailable->from);
         $this->assertTrue($mailable->hasFrom(new MailableTestUserStub));
         $this->assertTrue($mailable->hasFrom('taylor@laravel.com'));
@@ -1011,6 +1016,12 @@ class MailableTestUserStub
 {
     public $name = 'Taylor Otwell';
     public $email = 'taylor@laravel.com';
+}
+
+class MailableDumbUserStud
+{
+    public $name = 'Laravel Framework';
+    public $email = 'contact@laravel.com';
 }
 
 class MailTestAttachable implements Attachable


### PR DESCRIPTION
As discussed on #45042 these changes prevent the use of duplicated recipients in the `to`, `from`, `cc`, `bcc` and `replyTo` properties of the mailable.