### PR TITLE
[9.x] Fix pure enums validation

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -34,12 +34,12 @@ class Enum implements Rule
      */
     public function passes($attribute, $value)
     {
-        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type) || ! method_exists($this->type, 'tryFrom')) {
-            return false;
-        }
-
         if ($value instanceof $this->type) {
             return true;
+        }
+
+        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type) || ! method_exists($this->type, 'tryFrom')) {
+            return false;
         }
 
         try {

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -52,6 +52,21 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertFalse($v->fails());
     }
 
+    public function testvalidationPassesWhenPassingInstanceOfPureEnum()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => PureEnum::one,
+            ],
+            [
+                'status' => new Enum(PureEnum::class),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
     public function testValidationFailsWhenProvidingNoExistingCases()
     {
         $v = new Validator(


### PR DESCRIPTION
There was a problem when passing `UnitEnum` instance to the Enum rule, not `BackedEnum`. `UnitEnum` doesn't have `tryFrom` method, but in the first condition there is a check that such method exists.
Basically, what we should do is just swap first condition with the second. If `$value instanceof $this->type` is true, it is surely enum, no matter Backed or not.