### PR TITLE
[9.x] Address Dynamic Relation Resolver inconsiency issue with extended Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -541,7 +541,7 @@ trait HasAttributes
         }
 
         return method_exists($this, $key) ||
-            $this->relationResolver(static::class, $key);
+               $this->relationResolver(static::class, $key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -541,7 +541,7 @@ trait HasAttributes
         }
 
         return method_exists($this, $key) ||
-            (static::$relationResolvers[get_class($this)][$key] ?? null);
+            $this->relationResolver(static::class, $key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -70,6 +70,26 @@ trait HasRelationships
     }
 
     /**
+     * Return a dynamic relation resolver if defined or inherited, null otherwise
+     *
+     * @param  string  $class
+     * @param  string  $key
+     * @return mixed
+     */
+    public function relationResolver($class, $key)
+    {
+        if ($resolver = static::$relationResolvers[$class][$key] ?? null) {
+            return $resolver;
+        }
+
+        if($parent = get_parent_class($class)) {
+            return $this->relationResolver($parent, $key);
+        }
+
+        return null;
+    }
+
+    /**
      * Define a one-to-one relationship.
      *
      * @param  string  $related

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -70,7 +70,7 @@ trait HasRelationships
     }
 
     /**
-     * Return a dynamic relation resolver if defined or inherited, null otherwise
+     * Return a dynamic relation resolver if defined or inherited, null otherwise.
      *
      * @param  string  $class
      * @param  string  $key
@@ -82,7 +82,7 @@ trait HasRelationships
             return $resolver;
         }
 
-        if($parent = get_parent_class($class)) {
+        if ($parent = get_parent_class($class)) {
             return $this->relationResolver($parent, $key);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -55,22 +55,7 @@ trait HasRelationships
     protected static $relationResolvers = [];
 
     /**
-     * Define a dynamic relation resolver.
-     *
-     * @param  string  $name
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public static function resolveRelationUsing($name, Closure $callback)
-    {
-        static::$relationResolvers = array_replace_recursive(
-            static::$relationResolvers,
-            [static::class => [$name => $callback]]
-        );
-    }
-
-    /**
-     * Return a dynamic relation resolver if defined or inherited, null otherwise.
+     * Get the dynamic relation resolver if defined or inherited, or return null.
      *
      * @param  string  $class
      * @param  string  $key
@@ -87,6 +72,21 @@ trait HasRelationships
         }
 
         return null;
+    }
+
+    /**
+     * Define a dynamic relation resolver.
+     *
+     * @param  string  $name
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function resolveRelationUsing($name, Closure $callback)
+    {
+        static::$relationResolvers = array_replace_recursive(
+            static::$relationResolvers,
+            [static::class => [$name => $callback]]
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2314,7 +2314,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return $this->$method(...$parameters);
         }
 
-        if ($resolver = (static::$relationResolvers[get_class($this)][$method] ?? null)) {
+        if ($resolver = ($this->relationResolver(static::class, $method))) {
             return $resolver($this);
         }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -25,7 +25,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model1->shouldReceive('hasGetMutator')->andReturn(false);
         $model1->shouldReceive('hasAttributeMutator')->andReturn(false);
         $model1->shouldReceive('getCasts')->andReturn([]);
-        $model1->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation', 'isRelation')->passthru();
+        $model1->shouldReceive('getRelationValue', 'relationLoaded', 'relationResolver', 'setRelation', 'isRelation')->passthru();
 
         $model2 = m::mock(Model::class);
         $model2->shouldReceive('getAttribute')->with('parent_key')->andReturn(2);
@@ -33,7 +33,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model2->shouldReceive('hasGetMutator')->andReturn(false);
         $model2->shouldReceive('hasAttributeMutator')->andReturn(false);
         $model2->shouldReceive('getCasts')->andReturn([]);
-        $model2->shouldReceive('getRelationValue', 'relationLoaded', 'setRelation', 'isRelation')->passthru();
+        $model2->shouldReceive('getRelationValue', 'relationLoaded', 'relationResolver', 'setRelation', 'isRelation')->passthru();
 
         $result1 = (object) [
             'pivot' => (object) [


### PR DESCRIPTION
This PR aims to address the inconsistency issues with child Eloquent Models not inheriting their parents' dynamically registered relations, an issue which I attempted to explain in detail in #44741.

I have also added an in-line comment with an alternative approach to implementing the `relationResolver()` method.