### PR TITLE
[9.x] Created the Clock facade to implement PSR-20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.62.1",
         "nunomaduro/termwind": "^1.13",
+        "psr/clock": "^1.0",
         "psr/container": "^1.1.1|^2.0.1",
         "psr/log": "^1.0|^2.0|^3.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1339,6 +1339,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             'cache' => [\Illuminate\Cache\CacheManager::class, \Illuminate\Contracts\Cache\Factory::class],
             'cache.store' => [\Illuminate\Cache\Repository::class, \Illuminate\Contracts\Cache\Repository::class, \Psr\SimpleCache\CacheInterface::class],
             'cache.psr6' => [\Symfony\Component\Cache\Adapter\Psr16Adapter::class, \Symfony\Component\Cache\Adapter\AdapterInterface::class, \Psr\Cache\CacheItemPoolInterface::class],
+            'clock' => [\Illuminate\Support\Clock::class],
             'config' => [\Illuminate\Config\Repository::class, \Illuminate\Contracts\Config\Repository::class],
             'cookie' => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
             'db' => [\Illuminate\Database\DatabaseManager::class, \Illuminate\Database\ConnectionResolverInterface::class],

--- a/src/Illuminate/Support/Clock.php
+++ b/src/Illuminate/Support/Clock.php
@@ -23,6 +23,7 @@ class Clock implements ClockInterface
      *
      * @param  \DateTimeZone  $timezone
      * @return \DateTimeImmutable
+     *
      * @throws \Exception
      */
     public function withTimezone(DateTimeZone $timezone): DateTimeImmutable

--- a/src/Illuminate/Support/Clock.php
+++ b/src/Illuminate/Support/Clock.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Psr\Clock\ClockInterface;
+
+class Clock implements ClockInterface
+{
+    /**
+     * Returns the current time as a DateTimeImmutable Object.
+     *
+     * @return \DateTimeImmutable
+     */
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+
+    /**
+     * Returns the current time with the given timezone as a DateTimeImmutable Object.
+     *
+     * @param  \DateTimeZone  $timezone
+     * @return \DateTimeImmutable
+     * @throws \Exception
+     */
+    public function withTimezone(DateTimeZone $timezone): DateTimeImmutable
+    {
+        return new DateTimeImmutable('now', $timezone);
+    }
+
+    /**
+     * Creates a DateTimeImmutable Object based in the given format, datetime and timezone.
+     *
+     * @param  string  $format
+     * @param  string  $datetime
+     * @param  \DateTimeZone|null  $timezone
+     * @return \DateTimeImmutable|false
+     */
+    public function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null)
+    {
+        return DateTimeImmutable::createFromFormat($format, $datetime, $timezone);
+    }
+}

--- a/src/Illuminate/Support/Facades/Clock.php
+++ b/src/Illuminate/Support/Facades/Clock.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * @method static \DateTimeImmutable now()
+ * @method static \DateTimeImmutable withTimezone(\DateTimeZone $timezone)
+ * @method static \DateTimeImmutable createFromFormat(string $format, string $datetime, ?\DateTimeZone $timezone = null)
+ *
+ * @see \Illuminate\Support\Clock
+ */
+class Clock extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'clock';
+    }
+}

--- a/tests/Support/ClockTest.php
+++ b/tests/Support/ClockTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Clock;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\TestCase;
+
+class ClockTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = new Container;
+        $container->instance('clock', new \Illuminate\Support\Clock());
+
+        Facade::setFacadeApplication($container);
+    }
+
+    public function testDateInstance()
+    {
+        $this->assertInstanceOf(DateTimeImmutable::class, Clock::now());
+        $this->assertInstanceOf(DateTimeImmutable::class, Clock::withTimezone(new DateTimeZone('Europe/London')));
+        $this->assertInstanceOf(DateTimeImmutable::class, Clock::createFromFormat('Y-m-d', '2022-11-28'));
+    }
+
+    public function testNowReturnsCorrectDateTime()
+    {
+        $clockNow = Clock::now();
+        $now = new DateTimeImmutable();
+        $this->assertTrue($clockNow->getTimestamp() === $now->getTimestamp());
+    }
+
+    public function testWithTimezoneReturnsCorrectDateTime()
+    {
+        $clockNow = Clock::withTimezone(new DateTimeZone('Europe/London'));
+        $now = new DateTimeImmutable('now', new DateTimeZone('Europe/London'));
+        $this->assertTrue($clockNow->getTimestamp() === $now->getTimestamp());
+    }
+
+    public function testCreateFromFormatReturnsCorrectDateTime()
+    {
+        $clockNow = Clock::createFromFormat('Y-m-d H:i:s', '2022-11-28 12:00:00');
+        $now = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2022-11-28 12:00:00');
+        $this->assertTrue($clockNow->getTimestamp() === $now->getTimestamp());
+    }
+
+    public function testCreateFromFormatShouldReturnFalseWithWrongFormat()
+    {
+        $this->assertFalse(Clock::createFromFormat('Y-m-d', '2022-11-28 12:00:00'));
+    }
+}


### PR DESCRIPTION
I know that `Laravel` already has ways to deal with dates on it, but since `PRS-20` was accepted some days ago I thought on working on a simple implementation of it as a `facade`.

This PR introduces the `Clock` facade that implements the `ClockInterface` from the `PSR` implementing the `now` method and also adds two other methods: `withTimezone` and `createFromFormat`.

IDK if this is something that you want to add to the framework and if this is not the correct way of trying to add a new feature to the framework I apologize, I'm starting now to get involved with contributing to it.