### PR TITLE
[9.x] Apply global scopes when refreshing model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1688,7 +1688,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         }
 
         $this->setRawAttributes(
-            $this->setKeysForSelectQuery($this->newQueryWithoutScopes())
+            $this->setKeysForSelectQuery($this->newQuery())
                 ->useWritePdo()
                 ->firstOrFail()
                 ->attributes

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\EloquentModelRefreshTest;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
@@ -23,8 +24,9 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
     public function testItRefreshesModelExcludedByGlobalScope()
     {
-        $post = Post::create(['title' => 'mohamed']);
+        $this->expectException(ModelNotFoundException::class);
 
+        $post = Post::create(['title' => 'mohamed']);
         $post->refresh();
     }
 
@@ -36,6 +38,7 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
         $this->assertFalse($post->trashed());
 
+        $this->expectException(ModelNotFoundException::class);
         $post->refresh();
 
         $this->assertTrue($post->trashed());


### PR DESCRIPTION
As discussed on #45091 this PR changes the `refresh` method to apply the `global scopes` when calling `refresh` on a model. This made some tests fail, so I updated those.

Another approach that can be done if this is not the expected behaviour and I can work on it is to add an optional parameter on `refresh` that defaults to `false` but when set to `true` it will apply the `global scopes` when refreshing or to create a new method `refreshWithScopes` per example.

Let me know your thoughts on this.
