### PR TITLE
Add callback to resolve custom mutex name of schedule events

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -157,6 +157,13 @@ class Event
     public $exitCode;
 
     /**
+     * The mutex name resolver callback.
+     *
+     * @var \Closure|null
+     */
+    public $createMutexNameCallback;
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
@@ -935,7 +942,26 @@ class Event
      */
     public function mutexName()
     {
+        $createMutexNameUsing = $this->createMutexNameCallback;
+
+        if (! is_null($createMutexNameUsing) && is_callable($createMutexNameUsing)) {
+            return $createMutexNameUsing($this);
+        }
+
         return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->command);
+    }
+
+    /**
+     * Set the mutex name resolver callback.
+     *
+     * @param  \Closure $callback
+     * @return $this
+     */
+    public function createMutexNameUsing(Closure $callback)
+    {
+        $this->createMutexNameCallback = $callback;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -954,7 +954,7 @@ class Event
     /**
      * Set the mutex name resolver callback.
      *
-     * @param  \Closure $callback
+     * @param  \Closure  $callback
      * @return $this
      */
     public function createMutexNameUsing(Closure $callback)

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Console\Scheduling;
 
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -93,5 +94,19 @@ class EventTest extends TestCase
         $event->dailyAt('10:15');
 
         $this->assertSame('10:15:00', $event->nextRunDate()->toTimeString());
+    }
+
+    public function testCustomMutexName()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->description('Fancy command description');
+
+        $this->assertSame('framework/schedule-eeb46c93d45e928d62aaf684d727e213b7094822', $event->mutexName());
+
+        $event->createMutexNameUsing(function (Event $event) {
+            return Str::slug($event->description);
+        });
+
+        $this->assertSame('fancy-command-description', $event->mutexName());
     }
 }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -101,7 +101,7 @@ class EventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->description('Fancy command description');
 
-        $this->assertSame('framework/schedule-eeb46c93d45e928d62aaf684d727e213b7094822', $event->mutexName());
+        $this->assertSame('framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822', $event->mutexName());
 
         $event->createMutexNameUsing(function (Event $event) {
             return Str::slug($event->description);


### PR DESCRIPTION
Hello 👋

we have created schedule tasks monitoring and history module, we are passing uuid to every schedule task (this uuid is different on every server every time) to identify specific runs.

We are using `withoutOverlapping` and `onOneServer` but we had some issues since mutex name of scheduled tasks are generated from full command string. This may be okay for hardcoded scheduled tasks in kernel but not so good for dynamically created scheduled tasks (ie via database) while attaching different parameters to commands. (We want to share mutex / lock between those cron runs on multiple servers.)

I have added simple method to allow developers to use custom defined mutex name of each of scheduled tasks.

This could be done by using `preventOverlapsUsing` and creating new implementation of `Illuminate\Console\Scheduling\EventMutex` interface, however this is not really necessary since we do not want to change logic how mutex is created, forgotten etc. We just want to change name of mutex (key).

This can be also used for blocking one scheduled command until other command is finished.

Example usage:

```
$schedule->command('do-something', ['--uuid' => 'b4d5f926-e1b5-4285-b068-cf1d623a0635'])
         ->description('Do something important.')
         ->everyFiveMinutes()
         ->onOneServer()
         ->withoutOverlapping()
         ->createMutexNameUsing(fn (Event $event) => 'schedule-task-'.sha1($event->description));
```

