### PR TITLE
[9.x] Prevent increment/decrement on non-existing models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -946,14 +946,14 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  float|int  $amount
      * @param  array  $extra
      * @param  string  $method
-     * @return int
+     * @return int|false
      */
     protected function incrementOrDecrement($column, $amount, $extra, $method)
     {
         $query = $this->newQueryWithoutRelationships();
 
         if (! $this->exists) {
-            return $query->{$method}($column, $amount, $extra);
+            return false;
         }
 
         $this->{$column} = $this->isClassDeviable($column)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -921,7 +921,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $extra
      * @return int
      */
-    protected function increment($column, $amount = 1, array $extra = [])
+    public function increment($column, $amount = 1, array $extra = [])
     {
         return $this->incrementOrDecrement($column, $amount, $extra, 'increment');
     }
@@ -934,7 +934,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      * @param  array  $extra
      * @return int
      */
-    protected function decrement($column, $amount = 1, array $extra = [])
+    public function decrement($column, $amount = 1, array $extra = [])
     {
         return $this->incrementOrDecrement($column, $amount, $extra, 'decrement');
     }
@@ -2310,10 +2310,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement'])) {
-            return $this->$method(...$parameters);
-        }
-
         if ($resolver = (static::$relationResolvers[get_class($this)][$method] ?? null)) {
             return $resolver($this);
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1896,6 +1896,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertNull($replicated->updated_at);
     }
 
+    public function testIncrementOnNonExistingItemReturnsFalse()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
+        $model->exists = false;
+
+        $model->shouldReceive('newQueryWithoutRelationships')->andReturnNull();
+
+        $this->assertFalse($model->publicIncrement('foo', 1));
+
+        $this->assertFalse($model->publicDecrement('foo', 1));
+    }
+
     public function testIncrementOnExistingModelCallsQueryAndSetsAttribute()
     {
         $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
@@ -2644,6 +2656,11 @@ class EloquentModelStub extends Model
     public function publicIncrement($column, $amount = 1, $extra = [])
     {
         return $this->increment($column, $amount, $extra);
+    }
+
+    public function publicDecrement($column, $amount = 1, $extra = [])
+    {
+        return $this->decrement($column, $amount, $extra);
     }
 
     public function publicIncrementQuietly($column, $amount = 1, $extra = [])

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -112,7 +112,7 @@ class EloquentUpdateTest extends DatabaseTestCase
             'counter' => 0,
         ])->delete();
 
-        TestUpdateModel3::increment('counter');
+        TestUpdateModel3::query()->increment('counter');
 
         $models = TestUpdateModel3::withoutGlobalScopes()->orderBy('id')->get();
         $this->assertEquals(1, $models[0]->counter);


### PR DESCRIPTION
This fixes the issue as described here: https://github.com/laravel/framework/issues/45043

Calling `increment` or `decrement` on a non-existing Eloquent model previously defaulted to executing it on a new query, effectively running the incrementation on the complete table (e.g. `UPDATE users SET value = value + 1`). This will unintentionally change the whole table. Furthermore, there were no tests that described a use case for this previous implementation, so I have added a test to explicitly disallow this behaviour.

Note: this probably needs a documentation section right after https://laravel.com/docs/9.x/eloquent#upserts named "Increment / Decrement". There is currently no mention of this functionality in the docs, only at https://laravel.com/docs/9.x/queries#increment-and-decrement which is the query builder itself.