### PR TITLE
[9.x] Updated maintenance mode to be able to pre-render views usin…

### DIFF
--- a/src/Illuminate/Contracts/Foundation/MaintenanceMode.php
+++ b/src/Illuminate/Contracts/Foundation/MaintenanceMode.php
@@ -5,6 +5,21 @@ namespace Illuminate\Contracts\Foundation;
 interface MaintenanceMode
 {
     /**
+     * Marks the application in "pre-maintenance" mode so views can be pre-render checking for maintenance mode.
+     *
+     * @param  bool  $prerender
+     * @return void
+     */
+    public function prerenderMaintenance(bool $prerender): void;
+
+    /**
+     * Determine if the application needs to pre-render views for maintenance mode.
+     *
+     * @return bool
+     */
+    public function needsPrerender(): bool;
+
+    /**
      * Take the application down for maintenance.
      *
      * @param  array  $payload

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1128,7 +1128,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isDownForMaintenance()
     {
-        return $this->maintenanceMode()->active();
+        return $this->maintenanceMode()->needsPrerender() || $this->maintenanceMode()->active();
     }
 
     /**

--- a/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/CacheBasedMaintenanceMode.php
@@ -5,9 +5,12 @@ namespace Illuminate\Foundation;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Foundation\MaintenanceMode;
+use Illuminate\Foundation\Concerns\HasPrerenderMode;
 
 class CacheBasedMaintenanceMode implements MaintenanceMode
 {
+    use HasPrerenderMode;
+
     /**
      * The cache factory.
      *

--- a/src/Illuminate/Foundation/Concerns/HasPrerenderMode.php
+++ b/src/Illuminate/Foundation/Concerns/HasPrerenderMode.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Foundation\Concerns;
+
+trait HasPrerenderMode
+{
+    /**
+     * The flag to set if the maintenance needs to pre-render a view.
+     *
+     * @var bool
+     */
+    protected $prerender = false;
+
+    /**
+     * Marks the application in "pre-maintenance" mode so views can be pre-render checking for maintenance mode.
+     *
+     * @param  bool  $prerender
+     * @return void
+     */
+    public function prerenderMaintenance(bool $prerender): void
+    {
+        $this->prerender = $prerender;
+    }
+
+    /**
+     * Determine if the application needs to pre-render views for maintenance mode.
+     *
+     * @return bool
+     */
+    public function needsPrerender(): bool
+    {
+        return $this->prerender;
+    }
+}

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -130,6 +130,7 @@ class DownCommand extends Command
      */
     protected function prerenderView()
     {
+        $this->laravel->maintenanceMode()->prerenderMaintenance(true);
         (new RegisterErrorViewPaths)();
 
         return view($this->option('render'), [

--- a/src/Illuminate/Foundation/FileBasedMaintenanceMode.php
+++ b/src/Illuminate/Foundation/FileBasedMaintenanceMode.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Foundation;
 
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
+use Illuminate\Foundation\Concerns\HasPrerenderMode;
 
 class FileBasedMaintenanceMode implements MaintenanceModeContract
 {
+    use HasPrerenderMode;
+
     /**
      * Take the application down for maintenance.
      *

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -390,7 +390,7 @@ trait CompilesConditionals
      */
     protected function compileMaintenance()
     {
-        return "<?php if(app()->isDownForMaintenance()): ?>";
+        return '<?php if(app()->isDownForMaintenance()): ?>';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -382,4 +382,24 @@ trait CompilesConditionals
     {
         return '<?php $__env->stopPush(); endif; ?>';
     }
+
+    /**
+     * Compile the maintenance statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileMaintenance()
+    {
+        return "<?php if(app()->isDownForMaintenance()): ?>";
+    }
+
+    /**
+     * Compile the end-maintenance statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndMaintenance()
+    {
+        return '<?php endif; ?>';
+    }
 }

--- a/tests/View/Blade/BladeMaintenanceStatementsTest.php
+++ b/tests/View/Blade/BladeMaintenanceStatementsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeMaintenanceStatementsTest extends AbstractBladeTestCase
+{
+    public function testMaintenanceStatementsAreCompiled()
+    {
+        $string = '@maintenance
+breeze
+@else
+boom
+@endmaintenance';
+        $expected = "<?php if(app()->isDownForMaintenance()): ?>
+breeze
+<?php else: ?>
+boom
+<?php endif; ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladeMaintenanceStatementsTest.php
+++ b/tests/View/Blade/BladeMaintenanceStatementsTest.php
@@ -11,11 +11,11 @@ breeze
 @else
 boom
 @endmaintenance';
-        $expected = "<?php if(app()->isDownForMaintenance()): ?>
+        $expected = '<?php if(app()->isDownForMaintenance()): ?>
 breeze
 <?php else: ?>
 boom
-<?php endif; ?>";
+<?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
As discussed on #45033 when pre-rendering custom views for Maintenance mode, the app is not set to maintenance when the Framework renders the view. This PR updates this behaviour by adding a flag to check if the maintenance mode needs pre-render and if so, the isDownForMaintenance will return true when pre-rendering those custom views.

This PR also includes a new Blade directive maintenance that can be used instead of the isDownForMaintenance method, so instead of doing:

```
@extends('errors::minimal')

@if(App::isDownForMaintenance())
    @section('title', __('Down for Maintenance'))
    @section('code', '503')
    @section('message', __('Down for Maintenance'))
@else
    @section('title', __('Service Unavailable'))
    @section('code', '503')
    @section('message', __('Service Unavailable'))
@endif
```

We can do:

```
@extends('errors::minimal')

@maintenance
    @section('title', __('Down for Maintenance'))
    @section('code', '503')
    @section('message', __('Down for Maintenance'))
@else
    @section('title', __('Service Unavailable'))
    @section('code', '503')
    @section('message', __('Service Unavailable'))
@endmaintenance
```