### PR TITLE
fix : dropForeignIdFor method in Blueprint.php

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -414,7 +414,7 @@ class Blueprint
     }
 
     /**
-     * Indicate that the given foreign key should be dropped.
+     * Indicate that the given foreign key and column should be dropped.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $model
      * @param  string|null  $column
@@ -426,7 +426,8 @@ class Blueprint
             $model = new $model;
         }
 
-        return $this->dropForeign([$column ?: $model->getForeignKey()]);
+         $this->dropForeign([$column ?: $model->getForeignKey()]);
+        return  $this->dropColumn($column ?: $model->getForeignKey());
     }
 
     /**


### PR DESCRIPTION
577b84d4d0371e8f1dee4756e608988698d87d70

```
    public function dropForeignIdFor($model, $column = null)
    {
        if (is_string($model)) {
            $model = new $model;
        }

         $this->dropForeign([$column ?: $model->getForeignKey()]);
        return  $this->dropColumn($column ?: $model->getForeignKey());
    }
```


previously  while adding new migation  for existing table that reference some other table  in the drop section  of migration it only drops the key constrained but not column  so each time to drop the column i have to add  
```

    public function up(): void
    {
        Schema::table('tableName', function (Blueprint $table) {
         
            $table->foreignIdFor(\App\Models\User::class)->constrained();
           
        });
    }


    public function down(): void
    {
        Schema::table('tableName', function (Blueprint $table) {
            $table->dropForeignIdFor(\App\Models\User::class);
           $table->dropColumn(['user_id']);


            //
        });
    }

```

this only drops the key constrained not column so to overcome this issue 
i have pf  with changes in #https://github.com/laravel/framework/pull/45134/commits/577b84d4d0371e8f1dee4756e608988698d87d70

