### PR TITLE
[9.x] Fix factory breaking when trying to determine whether a relation is empty

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Enumerable;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -329,7 +330,7 @@ abstract class Factory
             $model->save();
 
             foreach ($model->getRelations() as $name => $items) {
-                if ($items->isEmpty()) {
+                if ($items instanceof Enumerable && $items->isEmpty()) {
                     $model->unsetRelation($name);
                 }
             }

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -364,6 +364,24 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(1, $role->users);
     }
 
+    public function test_relation_can_be_loaded_before_model_is_created()
+    {
+        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->createOne();
+
+        $post = FactoryTestPostFactory::new()
+            ->for($user, 'user')
+            ->afterMaking(function (FactoryTestPost $post) {
+                $post->load('user');
+            })
+            ->createOne();
+
+        $this->assertTrue($post->relationLoaded('user'));
+        $this->assertTrue($post->user->is($user));
+
+        $this->assertCount(1, FactoryTestUser::all());
+        $this->assertCount(1, FactoryTestPost::all());
+    }
+
     public function test_belongs_to_many_relationship_with_existing_model_instances()
     {
         $roles = FactoryTestRoleFactory::times(3)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/laravel/framework/pull/45118. When a model's singular relation is loaded before the model is stored (e.g. in a `afterMaking` callback). The factory will try to call `isEmpty()` on it which will cause an error.

```
BadMethodCallException : Call to undefined method App\Models\OtherModel::isEmpty()
```