### PR TITLE
[9.x] Add `redirect_if` and `redirect_unless` helpers

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
 use Illuminate\Database\RecordsNotFoundException;
+use Illuminate\Http\Exceptions\HttpRedirectException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -99,6 +100,7 @@ class Handler implements ExceptionHandlerContract
         AuthorizationException::class,
         BackedEnumCaseNotFoundException::class,
         HttpException::class,
+        HttpRedirectException::class,
         HttpResponseException::class,
         ModelNotFoundException::class,
         MultipleRecordsFoundException::class,
@@ -362,6 +364,10 @@ class Handler implements ExceptionHandlerContract
 
         if ($e instanceof Responsable) {
             return $e->toResponse($request);
+        }
+
+        if ($e instanceof HttpRedirectException) {
+            return redirect()->to($e->getUri(), $e->getStatusCode(), $e->getHeaders(), $e->getSecure());
         }
 
         $e = $this->prepareException($this->mapException($e));

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -15,6 +15,7 @@ use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Foundation\Bus\PendingClosureDispatch;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
+use Illuminate\Http\Exceptions\HttpRedirectException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Routing\Router;
@@ -661,6 +662,42 @@ if (! function_exists('redirect')) {
         }
 
         return app('redirect')->to($to, $status, $headers, $secure);
+    }
+}
+
+if (! function_exists('redirect_if')) {
+    /**
+     * Redirect if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  string  $to
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool|null  $secure
+     * @throw \Illuminate\Http\Exceptions\HttpResponseException
+     */
+    function redirect_if($boolean, $to, $status = 302, $headers = [], $secure = null)
+    {
+        if ($boolean) {
+            throw new HttpRedirectException($to, $status, $headers, $secure);
+        }
+    }
+}
+
+if (! function_exists('redirect_unless')) {
+    /**
+     * Redirect if the given condition is false.
+     *
+     * @param  bool  $boolean
+     * @param  string  $to
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool|null  $secure
+     * @throw \Illuminate\Http\Exceptions\HttpResponseException
+     */
+    function redirect_unless($boolean, $to, $status = 302, $headers = [], $secure = null)
+    {
+        redirect_if(! $boolean, $to, $status, $headers, $secure);
     }
 }
 

--- a/src/Illuminate/Http/Exceptions/HttpRedirectException.php
+++ b/src/Illuminate/Http/Exceptions/HttpRedirectException.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Illuminate\Http\Exceptions;
+
+use RuntimeException;
+
+class HttpRedirectException extends RuntimeException
+{
+    /**
+     * The URL to redirect to.
+     *
+     * @var string
+     */
+    protected $uri;
+
+    /**
+     * The status code to use for the redirect.
+     *
+     * @var int
+     */
+    protected $statusCode;
+
+    /**
+     * The headers to send with the redirect.
+     *
+     * @var array
+     */
+    protected $headers = [];
+
+    /**
+     * Whether the redirect should be securedone.
+     *
+     * @var bool|null
+     */
+    protected $secure;
+
+    /**
+     * Create a new HTTP redirect exception instance.
+     *
+     * @param  string  $uri
+     * @param  int  $statusCode
+     * @param  array $headers
+     * @param  bool|null  $secure
+     * @return void
+     */
+    public function __construct($uri, $statusCode = 302, array $headers = [], $secure = null)
+    {
+        $this->uri = $uri;
+        $this->statusCode = $statusCode;
+        $this->headers = $headers;
+        $this->secure = $secure;
+    }
+
+    /**
+     * Get the uri.
+     *
+     * @return string
+     */
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     * Get the status code.
+     *
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * Get the headers.
+     *
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Get the secure flag.
+     *
+     * @return bool|null
+     */
+    public function getSecure()
+    {
+        return $this->secure;
+    }
+}

--- a/src/Illuminate/Http/Exceptions/HttpRedirectException.php
+++ b/src/Illuminate/Http/Exceptions/HttpRedirectException.php
@@ -39,7 +39,7 @@ class HttpRedirectException extends RuntimeException
      *
      * @param  string  $uri
      * @param  int  $statusCode
-     * @param  array $headers
+     * @param  array  $headers
      * @param  bool|null  $secure
      * @return void
      */


### PR DESCRIPTION
This PR introduces two new helpers:

- `redirect_if`
- `redirect_unless`

They are analogous to the `abort_if` and `abort_unless` helpers in that they'll only redirect if a truthy boolean is passed.

Both helpers can be used to refactor something like:

```php
public function meta(Server $server)
{
  if (! auth()->user()->hasPermission($server, 'server:meta')) {
    return redirect('/servers');
  }

  return view('meta');
}
```

Into something much nicer and modern:

```php
public function meta(Server $server)
{
  redirect_unless(auth()->user()->hasPermission($server, 'server:meta'), '/servers');

  return view('meta');
}
```

These methods work by throwing a new `HttpRedirectException` (similar to the `abort*` methods) and then handling this in the exceptions `Handler`.