### PR TITLE
[9.x] Mailable : fixes strict comparison with int value

### DIFF
--- a/src/Illuminate/Mail/Mailables/Envelope.php
+++ b/src/Illuminate/Mail/Mailables/Envelope.php
@@ -364,6 +364,6 @@ class Envelope
      */
     public function hasMetadata(string $key, string $value)
     {
-        return isset($this->metadata[$key]) && $this->metadata[$key] === $value;
+        return isset($this->metadata[$key]) && (string) $this->metadata[$key] === $value;
     }
 }


### PR DESCRIPTION
This PR fixes the case when we set metadata with an integer value :

```php

    // ExampleMail.php
    public function envelope(): Envelope
    {
        return new Envelope(
            from: 'hello@world.com',
            subject: 'Laravel',
            metadata: [
                'mailable_id' => 1,
            ],
        );
    }

    // ExampleMailTest.php
    public function test_mail_is_correct(): void
    {
        $mailable = new Mail();

        $mailable->assertHasMetadata('mailable_id', 1); // With this fix, it returns true
    }
```
