### PR TITLE
[9.x] Fix (widen) PHPDoc parameter typehint for `EnumeratesValues::reject()`

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -765,7 +765,7 @@ trait EnumeratesValues
     /**
      * Create a collection of all elements that do not pass a given truth test.
      *
-     * @param  (callable(TValue, TKey): bool)|bool  $callback
+     * @param  (callable(TValue, TKey): bool)|bool|TValue  $callback
      * @return static
      */
     public function reject($callback = true)

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -855,6 +855,7 @@ assertType('Illuminate\Support\Collection<int, mixed>', $collection->make(['stri
 assertType('Illuminate\Support\Collection<int, mixed>', $collection->make(['string' => 'string'])->pluck('string', 'string'));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject());
+assertType('Illuminate\Support\Collection<int, User>', $collection->reject(new User));
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject(function ($user) {
     assertType('User', $user);
 


### PR DESCRIPTION
_Re-attempt of https://github.com/laravel/framework/pull/45137._

In my tests I often use `Collection::reject()` to select a random value from an enum _except_ for a specific value. Consider this example:

```php
$notAdminRole = Collection::make(Role::cases())
    ->reject(Role::Admin)
    ->random();
```

However, the PHPDoc parameter type hint for `EnumeratesValues::reject()` doesn't "allow" this (which triggers errors in PHPStan) – even though this use case is specifically covered in the tests:

https://github.com/laravel/framework/blob/9.x/tests/Support/SupportCollectionTest.php#L3803