### PR TITLE
[9.x] Dynamic Attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -633,7 +633,13 @@ trait HasAttributes
      */
     public function hasDynamicAttribute($key)
     {
-        return array_key_exists($key, static::$dynamicAttributeMutatorCache[get_class($this)]);
+        $class = get_class($this);
+
+        if (! isset(static::$dynamicAttributeMutatorCache[$class])) {
+            return static::$dynamicAttributeMutatorCache[$class][$key] = false;
+        }
+
+        return array_key_exists($key, static::$dynamicAttributeMutatorCache[$class]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -633,13 +633,7 @@ trait HasAttributes
      */
     public function hasDynamicAttribute($key)
     {
-        $class = get_class($this);
-
-        if (! isset(static::$dynamicAttributeMutatorCache[$class])) {
-            return static::$dynamicAttributeMutatorCache[$class][$key] = false;
-        }
-
-        return array_key_exists($key, static::$dynamicAttributeMutatorCache[$class]);
+        return isset($key, static::$dynamicAttributeMutatorCache[get_class($this)][$key]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -633,7 +633,7 @@ trait HasAttributes
      */
     public function hasDynamicAttribute($key)
     {
-        return isset($key, static::$dynamicAttributeMutatorCache[get_class($this)][$key]);
+        return isset(static::$dynamicAttributeMutatorCache[get_class($this)][$key]);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithCastedAttributesTest.php
@@ -23,6 +23,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model1->shouldReceive('getAttribute')->with('parent_key')->andReturn(1);
         $model1->shouldReceive('getAttribute')->with('foo')->passthru();
         $model1->shouldReceive('hasGetMutator')->andReturn(false);
+        $model1->shouldReceive('hasDynamicGetMutator')->andReturn(false);
         $model1->shouldReceive('hasAttributeMutator')->andReturn(false);
         $model1->shouldReceive('getCasts')->andReturn([]);
         $model1->shouldReceive('getRelationValue', 'relationLoaded', 'relationResolver', 'setRelation', 'isRelation')->passthru();
@@ -31,6 +32,7 @@ class DatabaseEloquentBelongsToManyWithCastedAttributesTest extends TestCase
         $model2->shouldReceive('getAttribute')->with('parent_key')->andReturn(2);
         $model2->shouldReceive('getAttribute')->with('foo')->passthru();
         $model2->shouldReceive('hasGetMutator')->andReturn(false);
+        $model1->shouldReceive('hasDynamicGetMutator')->andReturn(false);
         $model2->shouldReceive('hasAttributeMutator')->andReturn(false);
         $model2->shouldReceive('getCasts')->andReturn([]);
         $model2->shouldReceive('getRelationValue', 'relationLoaded', 'relationResolver', 'setRelation', 'isRelation')->passthru();


### PR DESCRIPTION
This PR will allow to set Dynamic Attributes to Models, this attributes can be added at runtime.

Example:
```php
use Illuminate\Database\Eloquent\Casts\Attribute;

trait HasMedia
{
    public static function bootHasMedia()
    {
        foreach (static::$mediaList as $mediaName) {
            static::registerDynamicAttribute(
                $mediaName . '_url',
                // $this is bounded to the model instance
                Attribute::get(fn () => asset($this->{$mediaName . "_path"}))
            );
        }
    }
}
```
This works exactly as a "Attribute" return-type marked function in the Model class.