### PR TITLE
Cache PDO in RefreshDatabase trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -4,10 +4,13 @@ namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
+use Illuminate\Support\Facades\DB;
 
 trait RefreshDatabase
 {
     use CanConfigureMigrationCommands;
+
+    public static \PDO $cachedPdo;
 
     /**
      * Define hooks to migrate the database before and after each test.
@@ -16,6 +19,12 @@ trait RefreshDatabase
      */
     public function refreshDatabase()
     {
+        if (static::$cachedPdo) {
+            DB::setPdo(static::$cachedPdo);
+        } else {
+            static::$cachedPdo = DB::getPdo();
+        }
+
         $this->beforeRefreshingDatabase();
 
         $this->usingInMemoryDatabase()


### PR DESCRIPTION
This caches the PDO object in the `RefreshDatabase` trait for tests.

Originally, I implemented this for my own tests to fix the ["too many connections"](https://github.com/laravel/framework/issues/18471) error which can occur if a database other than in-memory SQLite is used in the tests. But I noticed that this also substantially sped up my tests, too. I have 1152 feature tests and most of these use the database. With the default `RefreshDatabase` trait, these finish after an average 62 seconds. With the updated trait, the tests finish in an average 41 seconds, which is 65 % of the previous time!

This also may make the change from https://github.com/laravel/framework/pull/22569 obsolete but I left the diconnect there because it had no noticable negative effect on the runtime.