### PR TITLE
[9.x] cache repository put methond should pass correct ttl to putmany method

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -197,7 +197,7 @@ class Repository implements ArrayAccess, CacheContract
     public function put($key, $value, $ttl = null)
     {
         if (is_array($key)) {
-            return $this->putMany($key, $value);
+            return $this->putMany($key, $ttl);
         }
 
         if ($ttl === null) {

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -148,8 +148,8 @@ class CacheRepositoryTest extends TestCase
     public function testPuttingMultipleItemsInCache()
     {
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1);
-        $repo->put(['foo' => 'bar', 'bar' => 'baz'], 1);
+        $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 10);
+        $repo->put(['foo' => 'bar', 'bar' => 'baz'], 1, 10);
     }
 
     public function testSettingMultipleItemsInCacheArray()


### PR DESCRIPTION
look like the put mtthod inside cache repository class does not pass the correct ttl to the put many method 

thank you
