### PR TITLE
[9.x] Add Policies to Model Show Command

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -402,7 +402,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
         if ($policies->count()) {
             foreach ($policies as $policy) {
                 $this->components->twoColumnDetail(
-                    '<fg=gray>Policy</>',
+                    'Policy',
                     sprintf('%s', $policy)
                 );
             }


### PR DESCRIPTION
This PR adds registered policies to the `artisan model:show` command.  This can be useful to see what policies are registered on a model.

<img width="788" alt="Screen Shot 2022-11-30 at 10 09 29 PM" src="https://user-images.githubusercontent.com/17038330/204963751-5d037d80-4dd3-4c09-ab2a-f26967624e85.png">
