### PR TITLE
fix getInstance in Container for better performance

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1379,11 +1379,11 @@ class Container implements ArrayAccess, ContainerContract
      */
     public static function getInstance()
     {
-        if (is_null(static::$instance)) {
-            static::$instance = new static;
+        if (isset(static::$instance)) {
+            return static::$instance;
         }
 
-        return static::$instance;
+        return static::$instance = new static;
     }
 
     /**


### PR DESCRIPTION
reasons:

isset is faster than is_null
Because the "instance" property is returned at the first opportunity, it improves performance