### PR TITLE
[9.x]  Allow to pass base64 key to `env:encrypt` command

### DIFF
--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -74,7 +74,9 @@ class EnvironmentEncryptCommand extends Command
 
         $keyPassed = $key !== null;
 
+        $keyPassedIsBase64 = false;
         if ($keyPassed) {
+            $keyPassedIsBase64 = $this->isBase64Encoded($this->option('key'));
             $key = $this->parseKey($this->option('key'));
         }
 
@@ -115,7 +117,7 @@ class EnvironmentEncryptCommand extends Command
 
         $this->components->info('Environment successfully encrypted.');
 
-        $this->components->twoColumnDetail('Key', ($keyPassed ? $key : 'base64:'.base64_encode($key)));
+        $this->components->twoColumnDetail('Key', ($keyPassed && ! $keyPassedIsBase64 ? $key : 'base64:'.base64_encode($key)));
         $this->components->twoColumnDetail('Cipher', $cipher);
         $this->components->twoColumnDetail('Encrypted file', $encryptedFile);
 
@@ -135,5 +137,16 @@ class EnvironmentEncryptCommand extends Command
         }
 
         return $key;
+    }
+
+    /**
+     * Checks if passed key is base64 encoded.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isBase64Encoded(string $key)
+    {
+        return Str::startsWith($key, 'base64:');
     }
 }

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -74,12 +74,6 @@ class EnvironmentEncryptCommand extends Command
 
         $keyPassed = $key !== null;
 
-        $keyPassedIsBase64 = false;
-        if ($keyPassed) {
-            $keyPassedIsBase64 = $this->isBase64Encoded($this->option('key'));
-            $key = $this->parseKey($this->option('key'));
-        }
-
         $environmentFile = $this->option('env')
                             ? base_path('.env').'.'.$this->option('env')
                             : $this->laravel->environmentFilePath();
@@ -103,7 +97,7 @@ class EnvironmentEncryptCommand extends Command
         }
 
         try {
-            $encrypter = new Encrypter($key, $cipher);
+            $encrypter = new Encrypter($this->parseKey($key), $cipher);
 
             $this->files->put(
                 $encryptedFile,
@@ -117,7 +111,7 @@ class EnvironmentEncryptCommand extends Command
 
         $this->components->info('Environment successfully encrypted.');
 
-        $this->components->twoColumnDetail('Key', ($keyPassed && ! $keyPassedIsBase64 ? $key : 'base64:'.base64_encode($key)));
+        $this->components->twoColumnDetail('Key', ($keyPassed ? $key : 'base64:'.base64_encode($key)));
         $this->components->twoColumnDetail('Cipher', $cipher);
         $this->components->twoColumnDetail('Encrypted file', $encryptedFile);
 
@@ -137,16 +131,5 @@ class EnvironmentEncryptCommand extends Command
         }
 
         return $key;
-    }
-
-    /**
-     * Checks if passed key is base64 encoded.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    protected function isBase64Encoded(string $key)
-    {
-        return Str::startsWith($key, 'base64:');
     }
 }

--- a/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
+++ b/src/Illuminate/Foundation/Console/EnvironmentEncryptCommand.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'env:encrypt')]
@@ -73,6 +74,10 @@ class EnvironmentEncryptCommand extends Command
 
         $keyPassed = $key !== null;
 
+        if ($keyPassed) {
+            $key = $this->parseKey($this->option('key'));
+        }
+
         $environmentFile = $this->option('env')
                             ? base_path('.env').'.'.$this->option('env')
                             : $this->laravel->environmentFilePath();
@@ -115,5 +120,20 @@ class EnvironmentEncryptCommand extends Command
         $this->components->twoColumnDetail('Encrypted file', $encryptedFile);
 
         $this->newLine();
+    }
+
+    /**
+     * Parse the encryption key.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function parseKey(string $key)
+    {
+        if (Str::startsWith($key, $prefix = 'base64:')) {
+            $key = base64_decode(Str::after($key, $prefix));
+        }
+
+        return $key;
     }
 }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -122,7 +122,23 @@ class EnvironmentEncryptCommandTest extends TestCase
             ->with(base_path('.env.encrypted'), m::any());
     }
 
-    public function testItEncryptsWithGivenGeneratedBase64Key()
+    public function testItEncryptsWithGivenKeyAndDisplaysIt()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $this->artisan('env:encrypt', ['--key' => $key = 'ANvVbPbE0tWMHpUySh6liY4WaCmAYKXP'])
+            ->expectsOutputToContain('Environment successfully encrypted')
+            ->expectsOutputToContain($key)
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
+    }
+
+    public function testItEncryptsWithGivenGeneratedBase64KeyAndDisplaysIt()
     {
         $this->filesystem->shouldReceive('exists')
             ->once()
@@ -135,6 +151,7 @@ class EnvironmentEncryptCommandTest extends TestCase
 
         $this->artisan('env:encrypt', ['--key' => 'base64:'.base64_encode($key)])
             ->expectsOutputToContain('Environment successfully encrypted')
+            ->expectsOutputToContain('base64:'.base64_encode($key))
             ->expectsOutputToContain('.env.encrypted')
             ->assertExitCode(0);
     }

--- a/tests/Integration/Console/EnvironmentEncryptCommandTest.php
+++ b/tests/Integration/Console/EnvironmentEncryptCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Console;
 
+use Illuminate\Encryption\Encrypter;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
 use Mockery as m;
@@ -119,5 +120,22 @@ class EnvironmentEncryptCommandTest extends TestCase
 
         $this->filesystem->shouldHaveReceived('put')
             ->with(base_path('.env.encrypted'), m::any());
+    }
+
+    public function testItEncryptsWithGivenGeneratedBase64Key()
+    {
+        $this->filesystem->shouldReceive('exists')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('exists')
+            ->once()
+            ->andReturn(false);
+
+        $key = Encrypter::generateKey('AES-256-CBC');
+
+        $this->artisan('env:encrypt', ['--key' => 'base64:'.base64_encode($key)])
+            ->expectsOutputToContain('Environment successfully encrypted')
+            ->expectsOutputToContain('.env.encrypted')
+            ->assertExitCode(0);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The idea is described in https://github.com/laravel/framework/issues/45155

The thing is that it is not possible now to reuse automatically generated _base64_ key by `env:encrypt` (when `--key` option is not passed) for further encryptions of .env file:

```
php artisan env:encrypt --env=staging --force --key=base64:74yqwbohnT2S9UFILYaDv73lZTqiDBeUDvyWHT6V0pw=
>    ERROR  Unsupported cipher or incorrect key length. Supported ciphers are: aes-128-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm.
```

And you would like to reuse the same encryption key between developers working on the same project and who needs to modify the .env (e.g. staging, production, etc.) files.

Fixes https://github.com/laravel/framework/issues/45155