### PR TITLE
Avoid registering multiple event listeners

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -94,7 +94,9 @@ class Dispatcher implements DispatcherContract
             if (str_contains($event, '*')) {
                 $this->setupWildcardListen($event, $listener);
             } else {
-                $this->listeners[$event][] = $listener;
+                if (!in_array($listener, Arr::get($this->listeners, $event, []))) {
+                    $this->listeners[$event][] = $listener;
+                }
             }
         }
     }


### PR DESCRIPTION
When adding listeners dynamically in a queue worker

To simulate what will happen if you register events dynamically with queues, you can simply register events in a loop and the same issue will occur.
 
```php
for ($i = 0; $i < 5; $i++) {
    Event::listen($event, $listener);
}
```
The problem with events registers multiple times is that the listener also will fire multiple times. 


<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
