### PR TITLE
[9.x] Replace model:show searched value with correct FQCN

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -89,7 +89,8 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
         try {
             $model = $this->laravel->make($class);
-            $class = ($class === get_class($model)) ? $class : get_class($model)." (searched: {$this->argument('model')})";
+
+            $class = get_class($model);
         } catch (BindingResolutionException $e) {
             return $this->components->error($e->getMessage());
         }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -89,7 +89,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
         try {
             $model = $this->laravel->make($class);
-            $class = ($class === get_class($model)) ? $class : get_class($model) . " (searched: {$this->argument('model')})";
+            $class = ($class === get_class($model)) ? $class : get_class($model)." (searched: {$this->argument('model')})";
         } catch (BindingResolutionException $e) {
             return $this->components->error($e->getMessage());
         }

--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -89,6 +89,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
 
         try {
             $model = $this->laravel->make($class);
+            $class = ($class === get_class($model)) ? $class : get_class($model) . " (searched: {$this->argument('model')})";
         } catch (BindingResolutionException $e) {
             return $this->components->error($e->getMessage());
         }


### PR DESCRIPTION
**Problem**
Currently, while using `php artisan model:show` the result features the name of the class in the exact way you wrote it. 

In PHP, class names as well as function/method names are case-insensitive, but it is considered good practice to them functions as they appear in their declaration. Therefore it makes sense to return the name of the class as intended, however, while drawing the developers attention to it.

**Proof of concept**
`php artisan model:show RUle` results in the following:
<img width="1269" alt="Screenshot 2022-12-01 at 17 59 55" src="https://user-images.githubusercontent.com/43651556/205100337-24518c0e-2028-408d-ab97-97ca1acf18ea.png">

**Explanation of work** 
This PR checks if the provided model name matches what would be returned and appends searched value while replacing the original with correct casing.

**Result**
Incorrect casing results in:
<img width="1280" alt="Screenshot 2022-12-01 at 17 58 52" src="https://user-images.githubusercontent.com/43651556/205100105-52c9f0b6-14e7-4870-a6e8-7085efff71b0.png">
Initially correct casing results in:
<img width="1259" alt="Screenshot 2022-12-01 at 18 00 38" src="https://user-images.githubusercontent.com/43651556/205100509-c8c3a17f-51b0-45c4-92ea-4896b96493ca.png">

