### PR TITLE
Add support for eager loading specific columns to withWhereHas

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -165,7 +165,7 @@ trait QueriesRelationships
      */
     public function withWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
-        return $this->whereHas($relation, $callback, $operator, $count)
+        return $this->whereHas(Str::before($relation, ':'), $callback, $operator, $count)
             ->with($callback ? [$relation => fn ($query) => $callback($query)] : $relation);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -494,6 +494,17 @@ class DatabaseEloquentModelTest extends TestCase
         $closure($builder);
     }
 
+    public function testWithWhereHasWithSpecificColumns()
+    {
+        $model = new EloquentModelWithWhereHasStub;
+        $instance = $model->newInstance()->newQuery()->withWhereHas('foo:diaa,fares');
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('select')->once()->with(['diaa', 'fares']);
+        $this->assertNotNull($instance->getEagerLoads()['foo']);
+        $closure = $instance->getEagerLoads()['foo'];
+        $closure($builder);
+    }
+
     public function testWithMethodCallsQueryBuilderCorrectlyWithArray()
     {
         $result = EloquentModelWithStub::with(['foo', 'bar']);
@@ -2855,6 +2866,14 @@ class EloquentModelWithStub extends Model
         $mock->shouldReceive('with')->once()->with(['foo', 'bar'])->andReturn('foo');
 
         return $mock;
+    }
+}
+
+class EloquentModelWithWhereHasStub extends Model
+{
+    public function foo()
+    {
+        return $this->hasMany(EloquentModelStub::class);
     }
 }
 


### PR DESCRIPTION
Hi,
`withWhereHas()` didn't work as expected when I tried to eager load specific columns the same way that we are doing using `with('user:id,first_name,last_name')` and it gave me the following error:
`Call to undefined method Employee::user:id,first_name,last_name()`

This PR adds support for eager loading specific columns to `withWhereHas()`, so it is now consistent with `with()` method and works as expected:
`withWhereHas('user:id,first_name,last_name')`

Please let me know if anything is needed ☺️ 
