### PR TITLE
[9.x] fix `Observer attribute changes ignored when using increment()` #45163

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -971,7 +971,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         return tap($this->setKeysForSaveQuery($query)->{$method}($column, $amount, $extra), function () use ($column) {
             $this->fireModelEvent('updated', false);
-
             $this->syncOriginalAttribute($column);
         });
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -966,9 +966,10 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
-        return tap($this->setKeysForSaveQuery($query)->{$method}($column, $amount, $extra), function () use ($column) {
-            $this->syncChanges();
+        $this->syncChanges();
+        $extra = array_merge($extra, $this->changes);
 
+        return tap($this->setKeysForSaveQuery($query)->{$method}($column, $amount, $extra), function () use ($column) {
             $this->fireModelEvent('updated', false);
 
             $this->syncOriginalAttribute($column);


### PR DESCRIPTION
fixing `Observer attribute changes ignored when using increment()` by sync changes and appends them to $extra array before applying the changes
