### PR TITLE
[9.x] Add method missingAll to request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -225,6 +225,21 @@ trait InteractsWithInput
     }
 
     /**
+     * Determine if the request is missing all given input item key.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function missingAll($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $input = $this->all();
+
+        return ! Arr::hasAny($input, $keys);
+    }
+
+    /**
      * Apply the callback if the request is missing the given input item key.
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -455,19 +455,26 @@ class HttpRequestTest extends TestCase
     public function testMissingAllMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
-        $this->assertFalse($request->missingAll('city'));  
-        $this->assertFalse($request->missingAll('name', 'email'));
-        $this->assertFalse($request->missingAll(['name', 'age']));
+        $this->assertFalse($request->missingAll('name'));
+        $this->assertFalse($request->missingAll('age'));
+        $this->assertFalse($request->missingAll('city'));
+        $this->assertTrue($request->missingAll('foo'));
+        $this->assertTrue($request->missingAll('foo', 'email'));
+        $this->assertTrue($request->missingAll(['foo', 'email']));
 
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
-        $this->assertTrue($request->missingAll('foo'));
-        $this->assertTrue($request->missingAll('foo', 'bar'));
-        $this->assertTrue($request->missingAll(['year', 'location']));
+        $this->assertFalse($request->missingAll('name', 'email'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar', 'bar']]);
+        $this->assertFalse($request->missingAll('foo'));
+
+        $request = Request::create('/', 'GET', ['foo' => '', 'bar' => null]);
+        $this->assertFalse($request->missingAll('foo'));
+        $this->assertFalse($request->missingAll('bar'));
 
         $request = Request::create('/', 'GET', ['foo' => ['bar' => null, 'baz' => '']]);
-        $this->assertFalse($request->missingAll(['foo.bar','foo.foo']));
-        $this->assertTrue($request->missingAll(['foo.barz','foot.barz2']));
-        $this->assertTrue($request->missingAll(['bar.foo.deep','barz.foo.deep']));
+        $this->assertFalse($request->missingAll('foo.bar'));
+        $this->assertFalse($request->missingAll('foo.baz'));
     }
 
     public function testWhenMissingMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -452,6 +452,24 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->missing('foo.baz'));
     }
 
+    public function testMissingAllMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
+        $this->assertFalse($request->missingAll('city'));  
+        $this->assertFalse($request->missingAll('name', 'email'));
+        $this->assertFalse($request->missingAll(['name', 'age']));
+
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
+        $this->assertTrue($request->missingAll('foo'));
+        $this->assertTrue($request->missingAll('foo', 'bar'));
+        $this->assertTrue($request->missingAll(['year', 'location']));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar' => null, 'baz' => '']]);
+        $this->assertFalse($request->missingAll(['foo.bar','foo.foo']));
+        $this->assertTrue($request->missingAll(['foo.barz','foot.barz2']));
+        $this->assertTrue($request->missingAll(['bar.foo.deep','barz.foo.deep']));
+    }
+
     public function testWhenMissingMethod()
     {
         $request = Request::create('/', 'GET', ['bar' => null]);


### PR DESCRIPTION
This PR adds the method missingAll()

I think it should be a good idea to add a method to check if all params are missing, since missing() returns true even if there is a present param.

```php
if($request->missingAll(['name','email'])) {

}
```

it adds syntactic sugar. 