### PR TITLE
[9.x] Fix aliasing with cursor pagination

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -427,10 +427,9 @@ trait BuildsQueries
 
         if (! is_null($columns)) {
             foreach ($columns as $column) {
-                if (($position = stripos($column, ' as ')) !== false) {
-                    $as = substr($column, $position, 4);
-
-                    [$original, $alias] = explode($as, $column);
+                if (($position = strripos($column, ' as ')) !== false) {
+                    $original = substr($column, 0, $position);
+                    $alias = substr($column, $position + 4);
 
                     if ($parameter === $alias || $builder->getGrammar()->wrap($parameter) === $alias) {
                         return $original;


### PR DESCRIPTION
This fixes an issue if  "as" is present in cursor pagination alias for casting a column value.

Example :
```

 \App\User::selectRaw('cast(created_at as DATE) as foo')->orderBy('foo')->cursorPaginate(1)->toArray();
```