### PR TITLE
[9.x] Use type casting instead

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -352,7 +352,7 @@ trait InteractsWithInput
      */
     public function integer($key, $default = 0)
     {
-        return intval($this->input($key, $default));
+        return (int) $this->input($key, $default);
     }
 
     /**
@@ -364,7 +364,7 @@ trait InteractsWithInput
      */
     public function float($key, $default = 0.0)
     {
-        return floatval($this->input($key, $default));
+        return (float) $this->input($key, $default);
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1139,7 +1139,7 @@ class Stringable implements JsonSerializable
      */
     public function toInteger()
     {
-        return intval($this->value);
+        return (int) $this->value;
     }
 
     /**
@@ -1149,7 +1149,7 @@ class Stringable implements JsonSerializable
      */
     public function toFloat()
     {
-        return floatval($this->value);
+        return (float) $this->value;
     }
 
     /**

--- a/src/Illuminate/Support/Timebox.php
+++ b/src/Illuminate/Support/Timebox.php
@@ -24,7 +24,7 @@ class Timebox
 
         $result = $callback($this);
 
-        $remainder = intval($microseconds - ((microtime(true) - $start) * 1000000));
+        $remainder = (int) ($microseconds - ((microtime(true) - $start) * 1000000));
 
         if (! $this->earlyReturn && $remainder > 0) {
             $this->usleep($remainder);

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -134,7 +134,7 @@ class UrlSigningTest extends TestCase
     {
         Route::get('/foo/{id}', function (Request $request, $id) {
             return $request->hasValidSignature()
-                && intval($id) === 1
+                && (int) $id === 1
                 && $request->has('paramEmpty')
                 && $request->has('paramEmptyString')
                 && $request->query('paramWithValue') === 'value'


### PR DESCRIPTION
Type castings `(int)` & `(float)` can be used instead to reduce cognitive load and ensure that the way we cast is unified.