### PR TITLE
[9.x] Update the changes that made within `updating` event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -966,8 +966,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
-        if (count($changes) !== count($this->getDirty())) {
-            $extra = array_merge($extra, array_diff_key($this->getDirty(), $changes));
+        if (count($changes) !== count($fillable = $this->getDirty())) {
+            $extra = array_merge($extra, array_diff_key($fillable, $changes));
         }
 
         $this->forceFill($extra);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -972,7 +972,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
 
         $this->forceFill($extra);
 
-        $columns = array_keys($extra) + [$column];
+        $columns = array_keys(array_diff_key($extra, $changes)) + [$column];
 
         return tap($this->setKeysForSaveQuery($query)->{$method}($column, $amount, $extra), function () use ($columns) {
             $this->syncChanges();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1925,7 +1925,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->publicIncrement('foo', 1, ['category' => 1]);
         $this->assertEquals(4, $model->foo);
         $this->assertEquals(1, $model->category);
-        $this->assertTrue($model->isDirty('category'));
+        $this->assertFalse($model->isDirty('category'));
     }
 
     public function testIncrementQuietlyOnExistingModelCallsQueryAndSetsAttributeAndIsQuiet()
@@ -1952,7 +1952,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->publicIncrementQuietly('foo', 1, ['category' => 1]);
         $this->assertEquals(4, $model->foo);
         $this->assertEquals(1, $model->category);
-        $this->assertTrue($model->isDirty('category'));
+        $this->assertFalse($model->isDirty('category'));
     }
 
     public function testDecrementQuietlyOnExistingModelCallsQueryAndSetsAttributeAndIsQuiet()
@@ -1979,7 +1979,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->publicDecrementQuietly('foo', 1, ['category' => 1]);
         $this->assertEquals(2, $model->foo);
         $this->assertEquals(1, $model->category);
-        $this->assertTrue($model->isDirty('category'));
+        $this->assertFalse($model->isDirty('category'));
     }
 
     public function testRelationshipTouchOwnersIsPropagated()


### PR DESCRIPTION
This PR is fixing this issue https://github.com/laravel/framework/issues/45163.

Here is what I've done as follows:
- Get the changes that were only made by model event `updating` and add them to the `$extra` variable.
- Sync the original attributes to both `[$column] + $extra` because it doesn't make sense that the `category` is still dirty even after reflecting it on SQL, and that's why I fixed the test assertions.

Please let me know what you think.