### PR TITLE
Improved error logging for unmatched routes and route not found

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -41,7 +41,10 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException;
+        throw new NotFoundHttpException(sprintf(
+            'The route %s could not be found.',
+            $request->path()
+        ));
     }
 
     /**
@@ -101,24 +104,26 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             }))->bind($request);
         }
 
-        $this->methodNotAllowed($methods, $request->method());
+        $this->methodNotAllowed($request, $methods, $request->method());
     }
 
     /**
      * Throw a method not allowed HTTP exception.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  array  $others
      * @param  string  $method
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
      */
-    protected function methodNotAllowed(array $others, $method)
+    protected function methodNotAllowed($request, array $others, $method)
     {
         throw new MethodNotAllowedHttpException(
             $others,
             sprintf(
-                'The %s method is not supported for this route. Supported methods: %s.',
+                'The %s method is not supported for route %s. Supported methods: %s.',
+                $request->path(),
                 $method,
                 implode(', ', $others)
             )


### PR DESCRIPTION

This change adds some improved error messages so that so that poor client uses can be identified via sentry logging.

The change targets the following:
* handleMatchedRoute's NotFoundHttpException
* methodNotAllowed's MethodNotAllowedHttpException
