### PR TITLE
added isNumeric method

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -1177,6 +1177,14 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Check if the specified value is numeric.
+     * @return bool
+     */
+    public function isNumeric()
+    {
+        return is_numeric($this->value);
+    }
+    /**
      * Get the underlying string value as a Carbon instance.
      *
      * @param  string|null  $format

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1179,4 +1179,13 @@ class SupportStringableTest extends TestCase
 
         $this->stringable('not a date')->toDate();
     }
+
+    public function testIsNumeric()
+    {
+        $this->assertTrue($this->stringable('123')->isNumeric());
+        $this->assertTrue($this->stringable('123.45')->isNumeric());
+        $this->assertTrue($this->stringable(123)->isNumeric());
+        $this->assertFalse($this->stringable('123,45')->isNumeric());
+        $this->assertFalse($this->stringable('foo')->isNumeric());
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Sometimes we need to check whether the value we give is numeric or not.

```php
   str("123 333 A")->isNumeric() // bool: false
   str("123-333")->replace("-", "")->isNumeric() // bool: true
```
