### PR TITLE
[9.x] Update InteractsWithQueue::$job PHPDoc

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -9,7 +9,7 @@ trait InteractsWithQueue
     /**
      * The underlying queue job instance.
      *
-     * @var \Illuminate\Contracts\Queue\Job
+     * @var \Illuminate\Contracts\Queue\Job|null
      */
     public $job;
 


### PR DESCRIPTION
`$job` is null until `setJob()` is called.

This change will help to fix the PHPStan errors of the form `Call to function is_null() with Illuminate\Contracts\Queue\Job will always evaluate to false.`.