### PR TITLE
Add sort option for schedule:list

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -155,22 +155,23 @@ class ScheduleListCommand extends Command
     /**
      * Sorts the events by due date if option set.
      *
-     * @param  \Illuminate\Support\Collection $events
+     * @param  \Illuminate\Support\Collection  $events
      * @return \Illuminate\Support\Collection
      */
     private function sortEvents(\Illuminate\Support\Collection $events, DateTimeZone $timezone): \Illuminate\Support\Collection
     {
-        if (!$this->option('sort')) {
+        if (! $this->option('sort')) {
             return $events;
         }
+
         return $events->sortBy(fn ($event) => $this->getNextDueDate($event, $timezone));
     }
 
     /**
-     * Get the next due date for an event
+     * Get the next due date for an event.
      *
-     * @param Event $event
-     * @param DateTimeZone $timezone
+     * @param  Event  $event
+     * @param  DateTimeZone  $timezone
      * @return Carbon
      */
     private function getNextDueDate(\Illuminate\Console\Scheduling\Event $event, DateTimeZone $timezone): Carbon

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -52,6 +52,30 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }
 
+    public function testDisplayScheduleWithSort()
+    {
+        $this->schedule->command(FooCommand::class)->quarterly();
+        $this->schedule->command('inspire')->twiceDaily(14, 18);
+        $this->schedule->command('foobar', ['a' => 'b'])->everyMinute();
+        $this->schedule->job(FooJob::class)->everyMinute();
+        $this->schedule->command('inspire')->cron('0 9,17 * * *');
+        $this->schedule->command('inspire')->cron("0 10\t* * *");
+
+        $this->schedule->call(fn () => '')->everyMinute();
+        $closureLineNumber = __LINE__ - 1;
+        $closureFilePath = __FILE__;
+
+        $this->artisan(ScheduleListCommand::class)
+            ->assertSuccessful()
+            ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now')
+            ->expectsOutput('  0 9,17  * *      *  php artisan inspire ......... Next Due: 9 hours from now')
+            ->expectsOutput('  0 10    * *      *  php artisan inspire ........ Next Due: 10 hours from now')
+            ->expectsOutput('  0 14,18 * *      *  php artisan inspire ........ Next Due: 14 hours from now')
+            ->expectsOutput('  0 0     1 1-12/3 *  php artisan foo:command .... Next Due: 3 months from now');
+    }
+
     public function testDisplayScheduleInVerboseMode()
     {
         $this->schedule->command(FooCommand::class)->everyMinute();

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -65,7 +65,7 @@ class ScheduleListCommandTest extends TestCase
         $closureLineNumber = __LINE__ - 1;
         $closureFilePath = __FILE__;
 
-        $this->artisan(ScheduleListCommand::class)
+        $this->artisan(ScheduleListCommand::class, ['-s' => true])
             ->assertSuccessful()
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -65,7 +65,7 @@ class ScheduleListCommandTest extends TestCase
         $closureLineNumber = __LINE__ - 1;
         $closureFilePath = __FILE__;
 
-        $this->artisan(ScheduleListCommand::class, ['-s' => true])
+        $this->artisan(ScheduleListCommand::class, ['--next' => true])
             ->assertSuccessful()
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')


### PR DESCRIPTION
Currently, in order to see what schedule task will be run next, one needs to run schedule:list and eyeball the list to find the relevant ones. This PR adds an option to sort the list by the next due date.

#### Standard Usage:
```
php artisan schedule:list

  0    *   * * *    php artisan command-one .......... Next Due: 55 minutes from now
  15   *   * * *    php artisan command-three ........ Next Due: 10 minutes from now
  17   *   * * *    php artisan command-two .......... Next Due: 12 minutes from now
```

#### Sort by next due:
```
php artisan schedule:list --next

  15   *   * * *    php artisan command-three ........ Next Due: 10 minutes from now
  17   *   * * *    php artisan command-two .......... Next Due: 12 minutes from now
  0    *   * * *    php artisan command-one .......... Next Due: 55 minutes from now
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
