### PR TITLE
[9.x] Update HandleExceptions::$reservedMemory

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -17,7 +17,7 @@ class HandleExceptions
     /**
      * Reserved memory so that errors can be displayed properly on memory exhaustion.
      *
-     * @var string
+     * @var string|null
      */
     public static $reservedMemory;
 


### PR DESCRIPTION
`$reservedMemory` can be set to null (see `handleException()` for instance).

This change will help to fix the PHPStan errors of the form `Static property Illuminate\Foundation\Bootstrap\HandleExceptions::$reservedMemory (string) does not accept null.`.