### PR TITLE
[9.x] Allow BusFake to use custom BusRepository

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Bus\BatchRepository;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Support\Testing\Fakes\BusFake;
@@ -44,9 +45,9 @@ class Bus extends Facade
      * @param  array|string  $jobsToFake
      * @return \Illuminate\Support\Testing\Fakes\BusFake
      */
-    public static function fake($jobsToFake = [])
+    public static function fake($jobsToFake = [], BatchRepository $batchRepository = null)
     {
-        static::swap($fake = new BusFake(static::getFacadeRoot(), $jobsToFake));
+        static::swap($fake = new BusFake(static::getFacadeRoot(), $jobsToFake, $batchRepository));
 
         return $fake;
     }

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -43,6 +43,7 @@ class Bus extends Facade
      * Replace the bound instance with a fake.
      *
      * @param  array|string  $jobsToFake
+     * @param  \Illuminate\Bus\BatchRepository|null  $batchRepository
      * @return \Illuminate\Support\Testing\Fakes\BusFake
      */
     public static function fake($jobsToFake = [], BatchRepository $batchRepository = null)

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Testing\Fakes;
 
 use Closure;
+use Illuminate\Bus\BatchRepository;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Support\Arr;
@@ -75,13 +76,14 @@ class BusFake implements QueueingDispatcher
      *
      * @param  \Illuminate\Contracts\Bus\QueueingDispatcher  $dispatcher
      * @param  array|string  $jobsToFake
+     * @param  BatchRepository|null  $jobsToFake
      * @return void
      */
-    public function __construct(QueueingDispatcher $dispatcher, $jobsToFake = [])
+    public function __construct(QueueingDispatcher $dispatcher, $jobsToFake = [], BatchRepository $batchRepository = null)
     {
         $this->dispatcher = $dispatcher;
         $this->jobsToFake = Arr::wrap($jobsToFake);
-        $this->batchRepository = new BatchRepositoryFake;
+        $this->batchRepository = $batchRepository ?: new BatchRepositoryFake;
     }
 
     /**

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Support;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
+use Illuminate\Support\Testing\Fakes\BatchRepositoryFake;
 use Illuminate\Support\Testing\Fakes\BusFake;
 use Mockery as m;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
@@ -26,6 +27,20 @@ class SupportTestingBusFakeTest extends TestCase
     {
         parent::tearDown();
         m::close();
+    }
+
+    public function testItUsesCustomBusRepository()
+    {
+        $busRepository = new BatchRepositoryFake;
+
+        $fake = new BusFake(m::mock(QueueingDispatcher::class), [], $busRepository);
+
+        $this->assertNull($fake->findBatch('non-existent-batch'));
+
+        $batch = $fake->batch([])->dispatch();
+
+        $this->assertSame($batch, $fake->findBatch($batch->id));
+        $this->assertSame($batch, $busRepository->find($batch->id));
     }
 
     public function testAssertDispatched()


### PR DESCRIPTION
As described in PR name, allow BusFake to use custom BusRepository. This is useful in tests where we use `Bus::fake()` and later in code we use `resolve(BusRepository::class)->find(...)`.

Before this change that test would fail since Bus::fake() is creating always new BusRepository so using `resolve(BusRepository::class)->find(...)` will not use `BatchRepositoryFake` and throw error that it cant find batch in unit tests.

Usage:

```
$myBusRepository = new BatchRepositoryFake;

Bus::fake([JobsToFake::class], $myBusRepository);


// either bind $myBusRepository to \Illuminate\Bus\BatchRepository interface or send as constructor param to user defined class

app()->bind(\Illuminate\Bus\BatchRepository::class, $myBusRepository);


...
$myTestedService->method(); // this method calls  -> resolve(BatchRepository::class)->find(...)  -> correctly found fake batch
```