### PR TITLE
[9.x] Improved error logging for unmatched routes and route not found

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -133,7 +133,6 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     /**
      * Throw a method not allowed HTTP exception.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  array  $others
      * @param  string  $method
      * @return void

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -136,7 +136,6 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      * @param  array  $others
      * @param  string  $method
      * @return void
-     * 
      * @deprecated use requestMethodNotAllowed
      *
      * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -104,7 +104,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             }))->bind($request);
         }
 
-        $this->methodNotAllowed($request, $methods, $request->method());
+        $this->requestMethodNotAllowed($request, $methods, $request->method());
     }
 
     /**
@@ -117,13 +117,37 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      *
      * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
      */
-    protected function methodNotAllowed($request, array $others, $method)
+    protected function requestMethodNotAllowed($request, array $others, $method)
     {
         throw new MethodNotAllowedHttpException(
             $others,
             sprintf(
                 'The %s method is not supported for route %s. Supported methods: %s.',
                 $request->path(),
+                $method,
+                implode(', ', $others)
+            )
+        );
+    }
+
+    /**
+     * Throw a method not allowed HTTP exception.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array  $others
+     * @param  string  $method
+     * @return void
+     * 
+     * @deprecated use requestMethodNotAllowed
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
+     */
+    protected function methodNotAllowed(array $others, $method)
+    {
+        throw new MethodNotAllowedHttpException(
+            $others,
+            sprintf(
+                'The %s method is not supported for this route. Supported methods: %s.',
                 $method,
                 implode(', ', $others)
             )

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -41,7 +41,10 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException;
+        throw new NotFoundHttpException(sprintf(
+            'The route %s could not be found.',
+            $request->path()
+        ));
     }
 
     /**
@@ -101,24 +104,26 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             }))->bind($request);
         }
 
-        $this->methodNotAllowed($methods, $request->method());
+        $this->methodNotAllowed($request, $methods, $request->method());
     }
 
     /**
      * Throw a method not allowed HTTP exception.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @param  array  $others
      * @param  string  $method
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
      */
-    protected function methodNotAllowed(array $others, $method)
+    protected function methodNotAllowed($request, array $others, $method)
     {
         throw new MethodNotAllowedHttpException(
             $others,
             sprintf(
-                'The %s method is not supported for this route. Supported methods: %s.',
+                'The %s method is not supported for route %s. Supported methods: %s.',
+                $request->path(),
                 $method,
                 implode(', ', $others)
             )


### PR DESCRIPTION
Recreating #45191 as it was closed a little too early for me to provide an update based on feedback. 

This change adds some improved error messages so that poor client usages (for example, older versions of mobile clients) can be identified via sentry logging etc. At the moment this is impossible to do without logging every request.

The change targets the following:
* handleMatchedRoute's NotFoundHttpException
* methodNotAllowed's MethodNotAllowedHttpException
