### PR TITLE
Add forgetUser() method to GuardHelpers

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -96,6 +96,16 @@ trait GuardHelpers
     }
 
     /**
+     * Forget the user.
+     *
+     * @return void
+     */
+    public function forgetUser()
+    {
+        $this->user = null;
+    }
+
+    /**
      * Get the user provider used by the guard.
      *
      * @return \Illuminate\Contracts\Auth\UserProvider

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -56,6 +56,7 @@ use RuntimeException;
  * @method static \Illuminate\Auth\SessionGuard setRequest(\Symfony\Component\HttpFoundation\Request $request)
  * @method static \Illuminate\Support\Timebox getTimebox()
  * @method static \Illuminate\Contracts\Auth\Authenticatable authenticate()
+ * @method static void forgetUser()
  * @method static \Illuminate\Contracts\Auth\UserProvider getProvider()
  * @method static void setProvider(\Illuminate\Contracts\Auth\UserProvider $provider)
  * @method static void macro(string $name, object|callable $macro)

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -588,6 +588,14 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->once(['foo']));
     }
 
+    public function testForgetUserSetsUserToNull()
+    {
+        $user = m::mock(Authenticatable::class);
+        $guard = $this->getGuard()->setUser($user);
+        $guard->forgetUser();
+        $this->assertNull($guard->getUser());
+    }
+
     protected function getGuard()
     {
         [$session, $provider, $request, $cookie, $timebox] = $this->getMocks();


### PR DESCRIPTION
This is helpful for unit tests. There are situations where you need to perform an action as a logged in user and then run tests as a non-logged in user and ensure behavior is as you wish it to behave. In particular I needed this because TokenGuard has no other way to log out.