### PR TITLE
Support custom field names when using explicit route model binding

### DIFF
--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -55,9 +55,9 @@ class RouteBinding
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>
      */
-    public static function forModel($container, $class, $callback = null)
+    public static function forModel($container, $class, $callback = null, $routeParameter = null)
     {
-        return function ($value) use ($container, $class, $callback) {
+        return function ($value) use ($container, $class, $callback, $routeParameter) {
             if (is_null($value)) {
                 return;
             }
@@ -66,8 +66,11 @@ class RouteBinding
             // method on the model instance. If we cannot retrieve the models we'll
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
+            
+            $route = $container->make(Route::class);
+            $field = $route->bindingFieldFor($routeParameter);
 
-            if ($model = $instance->resolveRouteBinding($value)) {
+            if ($model = $instance->resolveRouteBinding($value, $field)) {
                 return $model;
             }
 

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -51,6 +51,7 @@ class RouteBinding
      * @param  \Illuminate\Container\Container  $container
      * @param  string  $class
      * @param  \Closure|null  $callback
+     * @param  string|null  $routeParameter
      * @return \Closure
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException<\Illuminate\Database\Eloquent\Model>

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -66,7 +66,7 @@ class RouteBinding
             // method on the model instance. If we cannot retrieve the models we'll
             // throw a not found exception otherwise we will return the instance.
             $instance = $container->make($class);
-            
+
             $route = $container->make(Route::class);
             $field = $route->bindingFieldFor($routeParameter);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1134,7 +1134,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function model($key, $class, Closure $callback = null)
     {
-        $this->bind($key, RouteBinding::forModel($this->container, $class, $callback));
+        $this->bind($key, RouteBinding::forModel($this->container, $class, $callback, $key));
     }
 
     /**


### PR DESCRIPTION
Consider the following code snippet:


```php
Route::model('tenant', Tenant::class);

Route::get('/{tenant:subdomain}/show', fn (Tenant $tenant) => response($tenant->name));
```

Currently, it will try to resolve the Tenant using the `id` field, ignoring the custom `subdomain` field specified.

This pull requests fixes this behaviour to be the same as the implicit model binding behaviour, which resolves the model using the custom field name.

Fixes #33079