### PR TITLE
[9.x] fix deprecation in is_file function

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -536,7 +536,7 @@ class Filesystem
      */
     public function isFile($file)
     {
-        return is_file($file);
+        return is_string($file) && is_file($file);
     }
 
     /**


### PR DESCRIPTION

Hello, I saw this warning in my application and I am sending a PR to correct it.

What I did was make sure that the given `$filename` is a string before calling the `is_file `function

`is_file(): Passing null to parameter #1 ($filename) of type string is deprecated in /app/vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php on line 539`

![image](https://user-images.githubusercontent.com/41749399/206221760-5e57d09e-90bc-41d2-9091-ea2bd831f621.png)
