### PR TITLE
[9.x] Improve facade script

### DIFF
--- a/bin/facades.php
+++ b/bin/facades.php
@@ -352,7 +352,11 @@ function isInternal($method)
  */
 function isDeprecated($method)
 {
-    return ! is_string($method) && $method->isDeprecated();
+    if (is_string($method)) {
+        return false;
+    }
+
+    return $method->isDeprecated() || resolveDocTags($method->getDocComment(), '@deprecated')->isNotEmpty();
 }
 
 /**

--- a/bin/facades.php
+++ b/bin/facades.php
@@ -31,6 +31,7 @@ resolveFacades($finder)->each(function ($facade) use ($linting) {
         ->flatMap(fn ($class) => [$class, ...resolveDocMixins($class)])
         ->flatMap(resolveMethods(...))
         ->reject(isMagic(...))
+        ->reject(isInternal(...))
         ->reject(isDeprecated(...))
         ->reject(fulfillsBuiltinInterface(...))
         ->reject(fn ($method) => conflictsWithFacade($facade, $method))
@@ -326,6 +327,21 @@ function resolveDocMixins($class)
 function isMagic($method)
 {
     return Str::startsWith(is_string($method) ? $method : $method->getName(), '__');
+}
+
+/**
+ * Determine if the method is marked as @internal.
+ *
+ * @param  \ReflectionMethod|string  $method
+ * @return bool
+ */
+function isInternal($method)
+{
+    if (is_string($method)) {
+        return false;
+    }
+
+    return resolveDocTags($method->getDocComment(), '@internal')->isNotEmpty();
 }
 
 /**

--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -29,7 +29,6 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
  * @method static void assertNothingSentTo(mixed $notifiable)
  * @method static void assertSentTimes(string $notification, int $expectedCount)
  * @method static void assertCount(int $expectedCount)
- * @method static void assertTimesSent(int $expectedCount, string $notification)
  * @method static \Illuminate\Support\Collection sent(mixed $notifiable, string $notification, callable|null $callback = null)
  * @method static bool hasSent(mixed $notifiable, string $notification)
  * @method static array sentNotifications()

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static \Illuminate\Http\RedirectResponse home(int $status = 302)
  * @method static \Illuminate\Http\RedirectResponse back(int $status = 302, array $headers = [], mixed $fallback = false)
  * @method static \Illuminate\Http\RedirectResponse refresh(int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse guest(string $path, int $status = 302, array $headers = [], bool|null $secure = null)

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -95,7 +95,6 @@ namespace Illuminate\Support\Facades;
  * @method static void setFormat(string|null $format, string|string[] $mimeTypes)
  * @method static string|null getRequestFormat(string|null $default = 'html')
  * @method static void setRequestFormat(string|null $format)
- * @method static string|null getContentType()
  * @method static string|null getContentTypeFormat()
  * @method static void setDefaultLocale(string $locale)
  * @method static string getDefaultLocale()

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -66,7 +66,6 @@ namespace Illuminate\Support\Facades;
  * @method static bool getHttpMethodParameterOverride()
  * @method static bool hasPreviousSession()
  * @method static void setSession(\Symfony\Component\HttpFoundation\Session\SessionInterface $session)
- * @method static void setSessionFactory(callable(): SessionInterface $factory)
  * @method static array getClientIps()
  * @method static string|null getClientIp()
  * @method static string getScriptName()


### PR DESCRIPTION
- Removes `@internal` methods from facade docblocks
- Correctly filters `@deprecated` userland methods.