### PR TITLE
[8.x] Fix email verification request

### DIFF
--- a/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
+++ b/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php
@@ -14,13 +14,13 @@ class EmailVerificationRequest extends FormRequest
      */
     public function authorize()
     {
-        if (! hash_equals((string) $this->route('id'),
-                          (string) $this->user()->getKey())) {
+        if (! hash_equals((string) $this->user()->getKey(),
+                          (string) $this->route('id'))) {
             return false;
         }
 
-        if (! hash_equals((string) $this->route('hash'),
-                          sha1($this->user()->getEmailForVerification()))) {
+        if (! hash_equals(sha1($this->user()->getEmailForVerification()),
+                          (string) $this->route('hash'))) {
             return false;
         }
 


### PR DESCRIPTION
This PR is a redo of https://github.com/laravel/framework/pull/45226

For `hash_equals()` to effectively prevent timing attacks, the known value must be the first parameter, and the user supplied input must be the second parameter. Laravel currently does this the other way around in email verification requests, defeating the purpose of using `hash_equals()` over `===`.

This is the only instance in the framework (that I could find) where the parameter order is incorrect.