### PR TITLE
Revert "[9.x] fix deprecation in is_file function"

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -536,7 +536,7 @@ class Filesystem
      */
     public function isFile($file)
     {
-        return is_string($file) && is_file($file);
+        return is_file($file);
     }
 
     /**


### PR DESCRIPTION
Reverts laravel/framework#45216

The docblock clearly states you can only pass a string. Like decided in the past, we won't be typecasting inside methods as this could lead to an exponential list of new PRs similar to this one.