### PR TITLE
Add docblock deprecated method in `InteractsWithInput`

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -311,6 +311,7 @@ trait InteractsWithInput
      * @param  string  $key
      * @param  mixed  $default
      * @return \Illuminate\Support\Stringable
+     *
      * @deprecated use string
      */
     public function str($key, $default = null)

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -311,6 +311,7 @@ trait InteractsWithInput
      * @param  string  $key
      * @param  mixed  $default
      * @return \Illuminate\Support\Stringable
+     * @deprecated use string
      */
     public function str($key, $default = null)
     {

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -152,7 +152,6 @@ namespace Illuminate\Support\Facades;
  * @method static array keys()
  * @method static array all(array|mixed|null $keys = null)
  * @method static mixed input(string|null $key = null, mixed $default = null)
- * @method static \Illuminate\Support\Stringable str(string $key, mixed $default = null)
  * @method static \Illuminate\Support\Stringable string(string $key, mixed $default = null)
  * @method static bool boolean(string|null $key = null, bool $default = false)
  * @method static int integer(string $key, int $default = 0)


### PR DESCRIPTION
The function `str` is calling function `string` and makes the same functionality