### PR TITLE
[9.x] Added `ContainsWith` and `DoesntContainsWith` in validate rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -707,4 +707,22 @@ trait ReplacesAttributes
 
         return str_replace(':values', implode(', ', $parameters), $message);
     }
+
+    /**
+     * Replace all place-holders for the contains_with rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceContainsWith($message, $attribute, $rule, $parameters)
+    {
+        foreach ($parameters as &$parameter) {
+            $parameter = $this->getDisplayableValue($attribute, $parameter);
+        }
+
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -725,4 +725,22 @@ trait ReplacesAttributes
 
         return str_replace(':values', implode(', ', $parameters), $message);
     }
+
+    /**
+     * Replace all place-holders for the doesnt_contains_with rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array<int,string>  $parameters
+     * @return string
+     */
+    protected function replaceDoesntContainsWith($message, $attribute, $rule, $parameters)
+    {
+        foreach ($parameters as &$parameter) {
+            $parameter = $this->getDisplayableValue($attribute, $parameter);
+        }
+
+        return str_replace(':values', implode(', ', $parameters), $message);
+    }
 }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2064,6 +2064,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the attribute contains with a given substring.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateContainsWith($attribute, $value, $parameters)
+    {
+        return Str::contains($value, $parameters);
+    }
+
+    /**
      * Validate the attribute does not end with a given substring.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -2077,6 +2077,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the attribute does not contains with a given substring.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateDoesntContainsWith($attribute, $value, $parameters)
+    {
+        return ! Str::contains($value, $parameters);
+    }
+
+    /**
      * Validate the attribute does not end with a given substring.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Rule.php
+++ b/src/Illuminate/Validation/Rule.php
@@ -4,7 +4,9 @@ namespace Illuminate\Validation;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Validation\Rules\Contains;
 use Illuminate\Validation\Rules\Dimensions;
+use Illuminate\Validation\Rules\DoesntContains;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\ExcludeIf;
 use Illuminate\Validation\Rules\Exists;
@@ -96,6 +98,36 @@ class Rule
         }
 
         return new NotIn(is_array($values) ? $values : func_get_args());
+    }
+
+    /**
+     * Get an contains constraint builder instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
+     * @return \Illuminate\Validation\Rules\In
+     */
+    public static function contains($values)
+    {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        return new Contains(is_array($values) ? $values : func_get_args());
+    }
+
+    /**
+     * Get an doesnt_contains constraint builder instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable|array|string  $values
+     * @return \Illuminate\Validation\Rules\In
+     */
+    public static function doesntContains($values)
+    {
+        if ($values instanceof Arrayable) {
+            $values = $values->toArray();
+        }
+
+        return new DoesntContains(is_array($values) ? $values : func_get_args());
     }
 
     /**

--- a/src/Illuminate/Validation/Rules/Contains.php
+++ b/src/Illuminate/Validation/Rules/Contains.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class Contains
+{
+    /**
+     * The name of the rule.
+     *
+     * @var string
+     */
+    protected $rule = 'contains_with';
+
+    /**
+     * The accepted values.
+     *
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * Create a new in rule instance.
+     *
+     * @param  array  $values
+     * @return void
+     */
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     *
+     * @see \Illuminate\Validation\ValidationRuleParser::parseParameters
+     */
+    public function __toString()
+    {
+        $values = array_map(function ($value) {
+            return '"'.str_replace('"', '""', $value).'"';
+        }, $this->values);
+
+        return $this->rule.':'.implode(',', $values);
+    }
+}

--- a/src/Illuminate/Validation/Rules/DoesntContains.php
+++ b/src/Illuminate/Validation/Rules/DoesntContains.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class DoesntContains
+{
+    /**
+     * The name of the rule.
+     *
+     * @var string
+     */
+    protected $rule = 'doesnt_contains_with';
+
+    /**
+     * The accepted values.
+     *
+     * @var array
+     */
+    protected $values;
+
+    /**
+     * Create a new in rule instance.
+     *
+     * @param  array  $values
+     * @return void
+     */
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     *
+     * @see \Illuminate\Validation\ValidationRuleParser::parseParameters
+     */
+    public function __toString()
+    {
+        $values = array_map(function ($value) {
+            return '"'.str_replace('"', '""', $value).'"';
+        }, $this->values);
+
+        return $this->rule.':'.implode(',', $values);
+    }
+}

--- a/tests/Validation/ValidationContainsRuleTest.php
+++ b/tests/Validation/ValidationContainsRuleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Contains;
+use PHPUnit\Framework\TestCase;
+
+class ValidationContainsRuleTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = new Contains(['Laravel', 'Framework', 'PHP']);
+
+        $this->assertSame('contains_with:"Laravel","Framework","PHP"', (string) $rule);
+
+        $rule = Rule::contains([1, 2, 3, 4]);
+
+        $this->assertSame('contains_with:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::contains(collect([1, 2, 3, 4]));
+
+        $this->assertSame('contains_with:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::contains('1', '2', '3', '4');
+
+        $this->assertSame('contains_with:"1","2","3","4"', (string) $rule);
+    }
+}

--- a/tests/Validation/ValidationDoesntContainsRuleTest.php
+++ b/tests/Validation/ValidationDoesntContainsRuleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\DoesntContains;
+use PHPUnit\Framework\TestCase;
+
+class ValidationDoesntContainsRuleTest extends TestCase
+{
+    public function testItCorrectlyFormatsAStringVersionOfTheRule()
+    {
+        $rule = new DoesntContains(['Laravel', 'Framework', 'PHP']);
+
+        $this->assertSame('doesnt_contains_with:"Laravel","Framework","PHP"', (string) $rule);
+
+        $rule = Rule::doesntContains([1, 2, 3, 4]);
+
+        $this->assertSame('doesnt_contains_with:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::doesntContains(collect([1, 2, 3, 4]));
+
+        $this->assertSame('doesnt_contains_with:"1","2","3","4"', (string) $rule);
+
+        $rule = Rule::doesntContains('1', '2', '3', '4');
+
+        $this->assertSame('doesnt_contains_with:"1","2","3","4"', (string) $rule);
+    }
+}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2312,6 +2312,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateContainsWith()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'some bad word f***'], ['x' => 'contains_with:f***,s***']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'some word'], ['x' => 'contains_with:f***,s***']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateString()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2323,6 +2323,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateDoesntContainsWith()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'some word'], ['x' => 'doesnt_contains_with:other words']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'some word'], ['x' => 'doesnt_contains_with:word']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateString()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR adds the ability to check if the string contains the given values, and I think this validation is important and makes the validation easier and we will not resort to using something else such as Regex.

```php
$request->validate([
    'comment' => ['required', 'contains_with:f***,s***'],
    'note' => ['required', Rule::contains(['f***', 's***'])],
]);
```

```php
$request->validate([
    'comment' => ['required', 'doesnt_contains_with:other words'],
    'note' => ['required', Rule::doesntContains(['other words'])],
]);
```