### PR TITLE
Return 500 http error, instead of 200, when dotenv fails to load

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -104,6 +104,7 @@ class LoadEnvironmentVariables
         $output->writeln($e->getMessage());
 
         http_response_code(500);
+
         exit(1);
     }
 }

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -103,6 +103,7 @@ class LoadEnvironmentVariables
         $output->writeln('The environment file is invalid!');
         $output->writeln($e->getMessage());
 
+        http_response_code(500);
         exit(1);
     }
 }


### PR DESCRIPTION
When dotenv fails, the response on http is always 200.

Because of 200 response, alerts might not be triggered, and data will be cached with whatever laravel decides to output.
