### PR TITLE
[9.x] Improved error logging for unauthenticated routes

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -80,7 +80,11 @@ class Authenticate implements AuthenticatesRequests
     protected function unauthenticated($request, array $guards)
     {
         throw new AuthenticationException(
-            'Unauthenticated.', $guards, $this->redirectTo($request)
+            sprintf(
+                'Unauthenticated route %s %s',
+                $request->method(), $request->path()
+            )
+            , $guards, $this->redirectTo($request)
         );
     }
 

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -83,8 +83,7 @@ class Authenticate implements AuthenticatesRequests
             sprintf(
                 'Unauthenticated route %s %s',
                 $request->method(), $request->path()
-            )
-            , $guards, $this->redirectTo($request)
+            ), $guards, $this->redirectTo($request)
         );
     }
 

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -39,7 +39,7 @@ class AuthenticateMiddlewareTest extends TestCase
     public function testDefaultUnauthenticatedThrows()
     {
         $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated.');
+        $this->expectExceptionMessage('Unauthenticated route GET /path/to');
 
         $this->registerAuthDriver('default', false);
 
@@ -84,7 +84,7 @@ class AuthenticateMiddlewareTest extends TestCase
     public function testMultipleDriversUnauthenticatedThrows()
     {
         $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Unauthenticated.');
+        $this->expectExceptionMessage('Unauthenticated route GET /path/to');
 
         $this->registerAuthDriver('default', false);
 
@@ -183,6 +183,8 @@ class AuthenticateMiddlewareTest extends TestCase
     protected function authenticate(...$guards)
     {
         $request = m::mock(Request::class);
+        $request->shouldReceive('method')->andReturn('GET');
+        $request->shouldReceive('path')->andReturn('/path/to');
 
         $nextParam = null;
 


### PR DESCRIPTION
This change aims to improve observability through error reporting. 

When the Authenticate middleware throws a AuthenticationException it sends the method and path in the exception message.
