### PR TITLE
[9.x] Add sort routes by occurrence

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -121,8 +121,8 @@ class RouteListCommand extends Command
      */
     protected function getRoutes()
     {
-        $routes = collect($this->router->getRoutes())->map(function ($route) {
-            return $this->getRouteInformation($route);
+        $routes = collect($this->router->getRoutes())->map(function ($route, $occurrence) {
+            return $this->getRouteInformation($route, $occurrence);
         })->filter()->all();
 
         if (($sort = $this->option('sort')) !== null) {
@@ -142,9 +142,10 @@ class RouteListCommand extends Command
      * Get the route information for a given route.
      *
      * @param  \Illuminate\Routing\Route  $route
+     * @param  int  $occurrence
      * @return array
      */
-    protected function getRouteInformation(Route $route)
+    protected function getRouteInformation(Route $route, int $occurrence)
     {
         return $this->filterRoute([
             'domain' => $route->domain(),
@@ -154,6 +155,7 @@ class RouteListCommand extends Command
             'action' => ltrim($route->getActionName(), '\\'),
             'middleware' => $this->getMiddleware($route),
             'vendor' => $this->isVendorRoute($route),
+            'occurrence' => $occurrence,
         ]);
     }
 


### PR DESCRIPTION
I'd like to refactor my routes from one huge `web.php` file to multiple files (in a `web` subdirectory).

To ensure I'm making no mistakes, I exported the initial routes (`./artisan route:list --verbose > old.txt`) to be able to compare them against the refactored ones (`./artisan route:list --verbose > new.txt`).

Anyway, this does not protect me from unintentionally changing the order of the routes, which could cause serious bugs:
```php
Route::get('foo/{bar}', function () { return 'foo'; });
Route::get('foo/baz', function () { return 'foo/baz'; }); // This route is not reachable
```

In order to check the occurrence, this PR adds the possibility to sort by occurrence: `./artisan route:list --sort occurrence`