### PR TITLE
[9.x] Http client - allow to provide closure as "throwif" condition

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -607,6 +607,7 @@ class PendingRequest
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
      * @param  callable|bool  $condition
+     * @param  callable|null  $throwCallback
      * @return $this
      */
     public function throwIf($condition)
@@ -615,7 +616,7 @@ class PendingRequest
             $this->throwIfCallback = $condition;
         }
 
-        return $condition ? $this->throw() : $this;
+        return $condition ? $this->throw(func_get_args()[1] ?? null) : $this;
     }
 
     /**
@@ -808,7 +809,9 @@ class PendingRequest
                             throw $exception;
                         }
 
-                        if ($this->throwCallback && ($this->throwIfCallback === null || call_user_func($this->throwIfCallback, $response))) {
+                        if ($this->throwCallback &&
+                            ($this->throwIfCallback === null ||
+                             call_user_func($this->throwIfCallback, $response))) {
                             $response->throw($this->throwCallback);
                         }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -106,6 +106,13 @@ class PendingRequest
     protected $throwCallback;
 
     /**
+     * A callback to check if an exception should be thrown when a server or client error occurs.
+     *
+     * @var \Closure
+     */
+    protected $throwIfCallback;
+
+    /**
      * The number of times to try the request.
      *
      * @var int
@@ -599,11 +606,15 @@ class PendingRequest
     /**
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
-     * @param  bool  $condition
+     * @param  \Closure|bool  $condition
      * @return $this
      */
     public function throwIf($condition)
     {
+        if (is_callable($condition)) {
+            $this->throwIfCallback = $condition;
+        }
+
         return $condition ? $this->throw() : $this;
     }
 
@@ -797,7 +808,7 @@ class PendingRequest
                             throw $exception;
                         }
 
-                        if ($this->throwCallback) {
+                        if ($this->throwCallback && ($this->throwIfCallback === null || call_user_func($this->throwIfCallback, $response))) {
                             $response->throw($this->throwCallback);
                         }
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -606,7 +606,7 @@ class PendingRequest
     /**
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
-     * @param  \Closure|bool  $condition
+     * @param  callable|bool  $condition
      * @return $this
      */
     public function throwIf($condition)

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -330,17 +330,14 @@ class Response implements ArrayAccess
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
      * @param  \Closure|bool  $condition
+     * @param  \Closure|null  $throwCallback
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
     public function throwIf($condition)
     {
-        if (is_callable($condition)) {
-            $condition = call_user_func($condition, $this);
-        }
-
-        return $condition ? $this->throw() : $this;
+        return value($condition, $this) ? $this->throw(func_get_args()[1] ?? null) : $this;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -329,13 +329,17 @@ class Response implements ArrayAccess
     /**
      * Throw an exception if a server or client error occurred and the given condition evaluates to true.
      *
-     * @param  bool  $condition
+     * @param  \Closure|bool  $condition
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
     public function throwIf($condition)
     {
+        if (is_callable($condition)) {
+            $condition = call_user_func($condition, $this);
+        }
+
         return $condition ? $this->throw() : $this;
     }
 

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -49,7 +49,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\PendingRequest beforeSending(callable $callback)
  * @method static \Illuminate\Http\Client\PendingRequest throw(callable|null $callback = null)
- * @method static \Illuminate\Http\Client\PendingRequest throwIf(bool $condition)
+ * @method static \Illuminate\Http\Client\PendingRequest throwIf(callable|bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest throwUnless(bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -49,7 +49,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\PendingRequest beforeSending(callable $callback)
  * @method static \Illuminate\Http\Client\PendingRequest throw(callable|null $callback = null)
- * @method static \Illuminate\Http\Client\PendingRequest throwIf(callable|bool $condition)
+ * @method static \Illuminate\Http\Client\PendingRequest throwIf(callable|bool $condition, callable|null $throwCallback)
  * @method static \Illuminate\Http\Client\PendingRequest throwUnless(bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1503,6 +1503,8 @@ class HttpClientTest extends TestCase
 
         $exception = null;
 
+        $hitThrowCallback = false;
+
         try {
             $this->factory
                 ->throwIf(function ($response) {
@@ -1510,6 +1512,12 @@ class HttpClientTest extends TestCase
                     $this->assertSame(403, $response->status());
 
                     return true;
+                }, function ($response, $e) use (&$hitThrowCallback) {
+                    $this->assertInstanceOf(Response::class, $response);
+                    $this->assertSame(403, $response->status());
+
+                    $this->assertInstanceOf(RequestException::class, $e);
+                    $hitThrowCallback = true;
                 })
                 ->get('http://foo.com/get');
         } catch (RequestException $e) {
@@ -1518,6 +1526,7 @@ class HttpClientTest extends TestCase
 
         $this->assertNotNull($exception);
         $this->assertInstanceOf(RequestException::class, $exception);
+        $this->assertTrue($hitThrowCallback);
     }
 
     public function testRequestExceptionIsNotThrownIfTheThrowIfClosureOnThePendingRequestReturnsFalse()
@@ -1526,16 +1535,21 @@ class HttpClientTest extends TestCase
             '*' => $this->factory->response(['error'], 403),
         ]);
 
+        $hitThrowCallback = false;
+
         $response = $this->factory
             ->throwIf(function ($response) {
                 $this->assertInstanceOf(Response::class, $response);
                 $this->assertSame(403, $response->status());
 
                 return false;
+            }, function ($response, $e) use (&$hitThrowCallback) {
+                $hitThrowCallback = true;
             })
             ->get('http://foo.com/get');
 
         $this->assertSame(403, $response->status());
+        $this->assertFalse($hitThrowCallback);
     }
 
     public function testRequestExceptionIsThrownWithCallbackIfThePendingRequestIsSetToThrowOnFailure()
@@ -1654,11 +1668,18 @@ class HttpClientTest extends TestCase
 
         $exception = null;
 
+        $hitThrowCallback = false;
+
         try {
             $this->factory->get('http://foo.com/api')->throwIf(function ($response) {
                 $this->assertSame(400, $response->status());
 
                 return true;
+            }, function ($response, $e) use (&$hitThrowCallback) {
+                $this->assertSame(400, $response->status());
+                $this->assertInstanceOf(RequestException::class, $e);
+
+                $hitThrowCallback = true;
             });
         } catch (RequestException $e) {
             $exception = $e;
@@ -1666,6 +1687,7 @@ class HttpClientTest extends TestCase
 
         $this->assertNotNull($exception);
         $this->assertInstanceOf(RequestException::class, $exception);
+        $this->assertTrue($hitThrowCallback);
     }
 
     public function testRequestExceptionIsNotThrownIfConditionClosureIsNotSatisfied()
@@ -1674,13 +1696,18 @@ class HttpClientTest extends TestCase
             '*' => $this->factory::response(['result' => ['foo' => 'bar']], 400),
         ]);
 
+        $hitThrowCallback = false;
+
         $response = $this->factory->get('http://foo.com/api')->throwIf(function ($response) {
             $this->assertSame(400, $response->status());
 
             return false;
+        }, function ($response, $e) use (&$hitThrowCallback) {
+            $hitThrowCallback = true;
         });
 
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
+        $this->assertFalse($hitThrowCallback);
     }
 
     public function testItCanEnforceFaking()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1495,6 +1495,49 @@ class HttpClientTest extends TestCase
         $this->assertSame(403, $response->status());
     }
 
+    public function testRequestExceptionIsThrownIfTheThrowIfClosureOnThePendingRequestReturnsTrue()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory
+                ->throwIf(function ($response) {
+                    $this->assertInstanceOf(Response::class, $response);
+                    $this->assertSame(403, $response->status());
+
+                    return true;
+                })
+                ->get('http://foo.com/get');
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
+    public function testRequestExceptionIsNotThrownIfTheThrowIfClosureOnThePendingRequestReturnsFalse()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $response = $this->factory
+            ->throwIf(function ($response) {
+                $this->assertInstanceOf(Response::class, $response);
+                $this->assertSame(403, $response->status());
+
+                return false;
+            })
+            ->get('http://foo.com/get');
+
+        $this->assertSame(403, $response->status());
+    }
+
     public function testRequestExceptionIsThrownWithCallbackIfThePendingRequestIsSetToThrowOnFailure()
     {
         $this->factory->fake([
@@ -1599,6 +1642,43 @@ class HttpClientTest extends TestCase
         ]);
 
         $response = $this->factory->get('http://foo.com/api')->throwIf(false);
+
+        $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
+    }
+
+    public function testRequestExceptionIsThrowIfConditionClosureIsSatisfied()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('', 400),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api')->throwIf(function ($response) {
+                $this->assertSame(400, $response->status());
+
+                return true;
+            });
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
+    public function testRequestExceptionIsNotThrownIfConditionClosureIsNotSatisfied()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['result' => ['foo' => 'bar']], 400),
+        ]);
+
+        $response = $this->factory->get('http://foo.com/api')->throwIf(function ($response) {
+            $this->assertSame(400, $response->status());
+
+            return false;
+        });
 
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
     }


### PR DESCRIPTION
Currently, the `throwIf` method on the Http `PendingRequest`/`Response` only allows a boolean. This means you can not let it behave differently based on what the failed response actually is. To make this possible, this PR adds the option to provide a closure which will be executed with the $response as an argument. This allows you to inspect the response before determining if you want to throw an exception or not.

```php
Http::throwIf(fn ($response) => $response->status() !== 404)->get('https://laravel.com/foo');

Http::get('https://laravel.com/foo')->throwIf(fn ($response) => $response->status() !== 404);
```