### PR TITLE
[9.x] add pullWithKey convenience method to Arr helper and collections

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -602,6 +602,23 @@ class Arr
     }
 
     /**
+     * Get a key-value pair from the array, and remove it.
+     *
+     * @param  array  $array
+     * @param  string|int  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public static function pullWithKey(&$array, $key, $default = null)
+    {
+        //as func_get_args() loses references, we can't pass
+        //spreaded func_get_args() here...
+        $value = static::pull($array, $key, $default);
+
+        return [$key => $value];
+    }
+
+    /**
      * Convert the array into a query string.
      *
      * @param  array  $array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -978,6 +978,22 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Get and remove a key-item pair from the collection.
+     *
+     * @template TPullDefault
+     *
+     * @param  TKey  $key
+     * @param  TPullDefault|(\Closure(): TPullDefault)  $default
+     * @return TValue|TPullDefault
+     */
+    public function pullWithKey($key, $default = null)
+    {
+        //as func_get_args() loses references, we can't pass
+        //spreaded func_get_args() here...
+        return collect(Arr::pullWithKey($this->items, $key, $default));
+    }
+
+    /**
      * Put an item in the collection by key.
      *
      * @param  TKey  $key

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -678,6 +678,32 @@ class SupportArrTest extends TestCase
         $this->assertSame('First', $first);
         $this->assertSame([1 => 'Second'], $array);
     }
+    
+    public function testPullWithKey()
+    {
+        $array = ['name' => 'Desk', 'price' => 100];
+        $nameKeyValue = Arr::pullWithKey($array, 'name');
+        $this->assertSame(['name' => 'Desk'], $nameKeyValue);
+        $this->assertSame(['price' => 100], $array);
+
+        // Only works on first level keys
+        $array = ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane'];
+        $nameKeyValue = Arr::pullWithKey($array, 'joe@example.com');
+        $this->assertSame(['joe@example.com' => 'Joe'], $nameKeyValue);
+        $this->assertSame(['jane@localhost' => 'Jane'], $array);
+
+        // Does not work for nested keys
+        $array = ['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']];
+        $nameKeyValue = Arr::pullWithKey($array, 'emails.joe@example.com');
+        $this->assertSame(['emails.joe@example.com' => null], $nameKeyValue);
+        $this->assertSame(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
+
+        // Works with int keys
+        $array = ['First', 'Second'];
+        $firstKeyValue = Arr::pullWithKey($array, 0);
+        $this->assertSame([0 => 'First'], $firstKeyValue);
+        $this->assertSame([1 => 'Second'], $array);
+    }
 
     public function testQuery()
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3794,6 +3794,62 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo', $value);
     }
 
+    public function testPullWithKeyRetrievesItemFromCollection()
+    {
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertSame([0 => 'foo'], $c->pullWithKey(0)->toArray());
+        $this->assertSame([1 => 'bar'], $c->pullWithKey(1)->toArray());
+
+        $c = new Collection(['foo', 'bar']);
+
+        $this->assertSame([-1 => null], $c->pullWithKey(-1)->toArray());
+        $this->assertSame([2 => null], $c->pullWithKey(2)->toArray());
+    }
+
+    public function testPullWithKeyRemovesItemFromCollection()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $c->pullWithKey(0);
+        $this->assertEquals([1 => 'bar'], $c->all());
+        $c->pullWithKey(1);
+        $this->assertEquals([], $c->all());
+    }
+
+    public function testPullWithKeyRemovesItemFromNestedCollection()
+    {
+        $nestedCollection = new Collection([
+            new Collection([
+                'value',
+                new Collection([
+                    'bar' => 'baz',
+                    'test' => 'value',
+                ]),
+            ]),
+            'bar',
+        ]);
+
+        $nestedCollection->pullWithKey('0.1.test');
+
+        $actualArray = $nestedCollection->toArray();
+        $expectedArray = [
+            [
+                'value',
+                ['bar' => 'baz'],
+            ],
+            'bar',
+        ];
+
+        $this->assertEquals($expectedArray, $actualArray);
+    }
+
+    public function testPullWithKeyReturnsDefault()
+    {
+        $c = new Collection([]);
+        $valueArray = $c->pullWithKey(0, 'foo')->toArray();
+        $this->assertSame([0 => 'foo'], $valueArray);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
Sometimes I have something like this:

```php
function store($attributes) {
  $value = Arr::pull($attributes, 'value', 0);
  $update = ['value' => $value];
  SomeModel::updateOrCreate($attributes, $update);
}

store([
  'foo_id' => 1,
  'bar_id' => 2,
  'period' => '2022-01-01',
  'value' => 123,
]);
```

With this small convenience `pullWithKey` method this could be a bit simpler:

```php
function store($attributes) {
  $update = Arr::pullWithKey($attributes, 'value', 0);
  SomeModel::updateOrCreate($attributes, $update);
}

store([
  'foo_id' => 1,
  'bar_id' => 2,
  'period' => '2022-01-01',
  'value' => 123,
]);
```