### PR TITLE
Vite application manager

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Vite.php
+++ b/src/Illuminate/Contracts/Foundation/Vite.php
@@ -137,6 +137,7 @@ interface Vite extends Htmlable
     /**
      * Get a unique hash representing the current manifest, or null if there is no manifest.
      *
+     * @param  string|null  $buildDirectory
      * @return string|null
      */
     public function manifestHash($buildDirectory = null);

--- a/src/Illuminate/Contracts/Foundation/Vite.php
+++ b/src/Illuminate/Contracts/Foundation/Vite.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation;
+
+use Illuminate\Contracts\Support\Htmlable;
+
+interface Vite extends Htmlable
+{
+    /**
+     * Apply configuration to the Vite instance.
+     *
+     * @param  array  $config
+     * @return $this
+     */
+    public function configure($config);
+
+    /**
+     * Get the preloaded assets.
+     *
+     * @return array
+     */
+    public function preloadedAssets();
+
+    /**
+     * Get the Content Security Policy nonce applied to all generated tags.
+     *
+     * @return string|null
+     */
+    public function cspNonce();
+
+    /**
+     * Generate or set a Content Security Policy nonce to apply to all generated tags.
+     *
+     * @param  string|null  $nonce
+     * @return string
+     */
+    public function useCspNonce($nonce = null);
+
+    /**
+     * Use the given key to detect integrity hashes in the manifest.
+     *
+     * @param  string|false  $key
+     * @return $this
+     */
+    public function useIntegrityKey($key);
+
+    /**
+     * Set the Vite entry points.
+     *
+     * @param  array  $entryPoints
+     * @return $this
+     */
+    public function withEntryPoints($entryPoints);
+
+    /**
+     * Set the filename for the manifest file.
+     *
+     * @param  string  $filename
+     * @return $this
+     */
+    public function useManifestFilename($filename);
+
+    /**
+     * Get the Vite "hot" file path.
+     *
+     * @return string
+     */
+    public function hotFile();
+
+    /**
+     * Set the Vite "hot" file path.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function useHotFile($path);
+
+    /**
+     * Set the Vite build directory.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function useBuildDirectory($path);
+
+    /**
+     * Use the given callback to resolve attributes for script tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return $this
+     */
+    public function useScriptTagAttributes($attributes);
+
+    /**
+     * Use the given callback to resolve attributes for style tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return $this
+     */
+    public function useStyleTagAttributes($attributes);
+
+    /**
+     * Use the given callback to resolve attributes for preload tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return $this
+     */
+    public function usePreloadTagAttributes($attributes);
+
+    /**
+     * Generate Vite tags for an entrypoint.
+     *
+     * @param  string|string[]  $entrypoints
+     * @param  string|null  $buildDirectory
+     * @return \Illuminate\Support\HtmlString
+     *
+     * @throws \Exception
+     */
+    public function __invoke($entrypoints, $buildDirectory = null);
+
+    /**
+     * Generate React refresh runtime script.
+     *
+     * @return \Illuminate\Support\HtmlString|void
+     */
+    public function reactRefresh();
+
+    /**
+     * Get the URL for an asset.
+     *
+     * @param  string  $asset
+     * @param  string|null  $buildDirectory
+     * @return string
+     */
+    public function asset($asset, $buildDirectory = null);
+
+    /**
+     * Get a unique hash representing the current manifest, or null if there is no manifest.
+     *
+     * @return string|null
+     */
+    public function manifestHash($buildDirectory = null);
+
+    /**
+     * Determine if the HMR server is running.
+     *
+     * @return bool
+     */
+    public function isRunningHot();
+}

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -12,7 +12,6 @@ use Illuminate\Foundation\Console\CliDumper;
 use Illuminate\Foundation\Http\HtmlDumper;
 use Illuminate\Foundation\MaintenanceModeManager;
 use Illuminate\Foundation\Precognition;
-use Illuminate\Foundation\Vite;
 use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\AggregateServiceProvider;
@@ -33,15 +32,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
     protected $providers = [
         FormRequestServiceProvider::class,
         ParallelTestingServiceProvider::class,
-    ];
-
-    /**
-     * The singletons to register into the container.
-     *
-     * @var array
-     */
-    public $singletons = [
-        Vite::class => Vite::class,
+        ViteServiceProvider::class,
     ];
 
     /**

--- a/src/Illuminate/Foundation/Providers/ViteServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ViteServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Foundation\Providers;
+
+use Illuminate\Contracts\Foundation\Vite;
+use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Foundation\ViteManager;
+use Illuminate\Support\ServiceProvider;
+
+class ViteServiceProvider extends ServiceProvider implements DeferrableProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton('vite', fn ($app) => new ViteManager($app));
+        $this->app->singleton('vite.app', fn ($app) => $app['vite']->app());
+        $this->app->bind(Vite::class, 'vite.app');
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['vite', 'vite.app', Vite::class];
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ViteServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ViteServiceProvider.php
@@ -2,8 +2,9 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use Illuminate\Contracts\Foundation\Vite;
+use Illuminate\Contracts\Foundation\Vite as ViteContract;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Foundation\Vite;
 use Illuminate\Foundation\ViteManager;
 use Illuminate\Support\ServiceProvider;
 
@@ -18,6 +19,7 @@ class ViteServiceProvider extends ServiceProvider implements DeferrableProvider
     {
         $this->app->singleton('vite', fn ($app) => new ViteManager($app));
         $this->app->singleton('vite.app', fn ($app) => $app['vite']->app());
+        $this->app->bind(ViteContract::class, 'vite.app');
         $this->app->bind(Vite::class, 'vite.app');
     }
 
@@ -28,6 +30,6 @@ class ViteServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function provides()
     {
-        return ['vite', 'vite.app', Vite::class];
+        return ['vite', 'vite.app', ViteContract::class, Vite::class];
     }
 }

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -112,8 +112,7 @@ class Vite implements ViteContract
             'usePreloadTagAttributes' => 'tag_attributes.preload',
         ];
 
-        collect($methods)->filter(fn (ReflectionMethod $method) =>
-            ! $method->isStatic()
+        collect($methods)->filter(fn (ReflectionMethod $method) => ! $method->isStatic()
             && $method->getName() !== $currentMethod
             && preg_match('/^(use|with)/', $method->getName())
         )->each(function (ReflectionMethod $method) use ($config, $methodKeyMap) {

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -3,13 +3,16 @@
 namespace Illuminate\Foundation;
 
 use Exception;
-use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Foundation\Vite as ViteContract;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use ReflectionClass;
+use ReflectionMethod;
 
-class Vite implements Htmlable
+class Vite implements ViteContract
 {
     use Macroable;
 
@@ -91,6 +94,38 @@ class Vite implements Htmlable
     protected static $manifests = [];
 
     /**
+     * Apply configuration to the Vite instance.
+     *
+     * @param  array  $config
+     * @return $this
+     */
+    public function configure($config)
+    {
+        $class = new ReflectionClass($this);
+        $methods = $class->getMethods(ReflectionMethod::IS_PUBLIC);
+        $currentMethod = __FUNCTION__;
+
+        $methodKeyMap = [
+            'useCspNonce' => 'nonce',
+            'useScriptTagAttributes' => 'tag_attributes.script',
+            'useStyleTagAttributes' => 'tag_attributes.style',
+            'usePreloadTagAttributes' => 'tag_attributes.preload',
+        ];
+
+        collect($methods)->filter(fn (ReflectionMethod $method) =>
+            ! $method->isStatic()
+            && $method->getName() !== $currentMethod
+            && preg_match('/^(use|with)/', $method->getName())
+        )->each(function (ReflectionMethod $method) use ($config, $methodKeyMap) {
+            $key = $methodKeyMap[$method->getName()]
+                ?? str($method->getName())->after('use')->after('with')->snake()->value();
+            Arr::has($config, $key) && $method->invoke($this, Arr::get($config, $key));
+        });
+
+        return $this;
+    }
+
+    /**
      * Get the preloaded assets.
      *
      * @return array
@@ -113,7 +148,7 @@ class Vite implements Htmlable
     /**
      * Generate or set a Content Security Policy nonce to apply to all generated tags.
      *
-     * @param  ?string  $nonce
+     * @param  string|null  $nonce
      * @return string
      */
     public function useCspNonce($nonce = null)

--- a/src/Illuminate/Foundation/ViteManager.php
+++ b/src/Illuminate/Foundation/ViteManager.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Illuminate\Contracts\Foundation\Vite as ViteContract;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Manager;
+use InvalidArgumentException;
+
+class ViteManager extends Manager implements ViteContract
+{
+    /**
+     * The registered app factory.
+     *
+     * @var (callable(string, ViteContract, array, Container): ViteContract)|null
+     */
+    protected $appFactory = null;
+
+    /**
+     * Get the default driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver()
+    {
+        return $this->config->get('vite.app', 'default');
+    }
+
+    /**
+     * Create a new driver instance.
+     *
+     * @param  string  $driver
+     * @return ViteContract
+     */
+    protected function createDriver($driver)
+    {
+        try {
+            return parent::createDriver($driver);
+        } catch (InvalidArgumentException) {
+            return $this->createApp($driver);
+        }
+    }
+
+    /**
+     * Create a new app instance.
+     *
+     * @param  string  $app
+     * @return ViteContract
+     */
+    protected function createApp($app)
+    {
+        return ($this->appFactory ?? function (string $app, ViteContract $vite, array $config) {
+            return $vite->configure($config);
+        })($app, new Vite, config("vite.apps.$app", []), $this->container);
+    }
+
+    /**
+     * Register an app factory callback.
+     *
+     * @param  callable(string, ViteContract, array, Container): ViteContract  $appFactory
+     * @return void
+     */
+    public function useAppFactory($appFactory)
+    {
+        $this->appFactory = $appFactory;
+    }
+
+    /**
+     * Get an app instance.
+     *
+     * @param  string|null  $app
+     * @return ViteContract
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function app($app = null)
+    {
+        return $this->driver($app);
+    }
+
+    /**
+     * Apply configuration to the Vite instance.
+     *
+     * @param  array  $config
+     * @return ViteContract
+     */
+    public function configure($config)
+    {
+        return $this->app()->configure($config);
+    }
+
+    /**
+     * Get the preloaded assets.
+     *
+     * @return array
+     */
+    public function preloadedAssets()
+    {
+        return $this->app()->preloadedAssets();
+    }
+
+    /**
+     * Get the Content Security Policy nonce applied to all generated tags.
+     *
+     * @return string|null
+     */
+    public function cspNonce()
+    {
+        return $this->app()->cspNonce();
+    }
+
+    /**
+     * Generate or set a Content Security Policy nonce to apply to all generated tags.
+     *
+     * @param  string|null  $nonce
+     * @return string
+     */
+    public function useCspNonce($nonce = null)
+    {
+        return $this->app()->useCspNonce($nonce);
+    }
+
+    /**
+     * Use the given key to detect integrity hashes in the manifest.
+     *
+     * @param  string|false  $key
+     * @return ViteContract
+     */
+    public function useIntegrityKey($key)
+    {
+        return $this->app()->useIntegrityKey($key);
+    }
+
+    /**
+     * Set the Vite entry points.
+     *
+     * @param  array  $entryPoints
+     * @return ViteContract
+     */
+    public function withEntryPoints($entryPoints)
+    {
+        return $this->app()->withEntryPoints($entryPoints);
+    }
+
+    /**
+     * Set the filename for the manifest file.
+     *
+     * @param  string  $filename
+     * @return ViteContract
+     */
+    public function useManifestFilename($filename)
+    {
+        return $this->app()->useManifestFilename($filename);
+    }
+
+    /**
+     * Get the Vite "hot" file path.
+     *
+     * @return string
+     */
+    public function hotFile(): string
+    {
+        return $this->app()->hotFile();
+    }
+
+    /**
+     * Set the Vite "hot" file path.
+     *
+     * @param  string  $path
+     * @return ViteContract
+     */
+    public function useHotFile($path)
+    {
+        return $this->app()->useHotFile($path);
+    }
+
+    /**
+     * Set the Vite build directory.
+     *
+     * @param  string  $path
+     * @return ViteContract
+     */
+    public function useBuildDirectory($path)
+    {
+        return $this->app()->useBuildDirectory($path);
+    }
+
+    /**
+     * Use the given callback to resolve attributes for script tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return ViteContract
+     */
+    public function useScriptTagAttributes($attributes)
+    {
+        return $this->app()->useScriptTagAttributes($attributes);
+    }
+
+    /**
+     * Use the given callback to resolve attributes for style tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return ViteContract
+     */
+    public function useStyleTagAttributes($attributes)
+    {
+        return $this->app()->useStyleTagAttributes($attributes);
+    }
+
+    /**
+     * Use the given callback to resolve attributes for preload tags.
+     *
+     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @return ViteContract
+     */
+    public function usePreloadTagAttributes($attributes)
+    {
+        return $this->app()->usePreloadTagAttributes($attributes);
+    }
+
+    /**
+     * Generate Vite tags for an entrypoint.
+     *
+     * @param  string|string[]  $entrypoints
+     * @param  string|null  $buildDirectory
+     * @return \Illuminate\Support\HtmlString
+     *
+     * @throws \Exception
+     */
+    public function __invoke($entrypoints, $buildDirectory = null)
+    {
+        return $this->app()->__invoke($entrypoints, $buildDirectory);
+    }
+
+    /**
+     * Generate React refresh runtime script.
+     *
+     * @return \Illuminate\Support\HtmlString|void
+     */
+    public function reactRefresh()
+    {
+        return $this->app()->reactRefresh();
+    }
+
+    /**
+     * Get the URL for an asset.
+     *
+     * @param  string  $asset
+     * @param  string|null  $buildDirectory
+     * @return string
+     */
+    public function asset($asset, $buildDirectory = null)
+    {
+        return $this->app()->asset($asset, $buildDirectory);
+    }
+
+    /**
+     * Get a unique hash representing the current manifest, or null if there is no manifest.
+     *
+     * @return string|null
+     */
+    public function manifestHash($buildDirectory = null)
+    {
+        return $this->app()->manifestHash($buildDirectory);
+    }
+
+    /**
+     * Determine if the HMR server is running.
+     *
+     * @return bool
+     */
+    public function isRunningHot()
+    {
+        return $this->app()->isRunningHot();
+    }
+
+    /**
+     * Get the Vite tag content as a string of HTML.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return $this->app()->toHtml();
+    }
+}

--- a/src/Illuminate/Foundation/ViteManager.php
+++ b/src/Illuminate/Foundation/ViteManager.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation;
 
 use Illuminate\Contracts\Foundation\Vite as ViteContract;
-use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Manager;
 use InvalidArgumentException;
 
@@ -12,7 +11,7 @@ class ViteManager extends Manager implements ViteContract
     /**
      * The registered app factory.
      *
-     * @var (callable(string, ViteContract, array, Container): ViteContract)|null
+     * @var (callable(\Illuminate\Contracts\Foundation\Vite, string, array, \Illuminate\Contracts\Container\Container): \Illuminate\Contracts\Foundation\Vite)|null
      */
     protected $appFactory = null;
 
@@ -30,7 +29,7 @@ class ViteManager extends Manager implements ViteContract
      * Create a new driver instance.
      *
      * @param  string  $driver
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     protected function createDriver($driver)
     {
@@ -45,19 +44,19 @@ class ViteManager extends Manager implements ViteContract
      * Create a new app instance.
      *
      * @param  string  $app
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     protected function createApp($app)
     {
-        return ($this->appFactory ?? function (string $app, ViteContract $vite, array $config) {
+        return ($this->appFactory ?? function (ViteContract $vite, string $app, array $config) {
             return $vite->configure($config);
-        })($app, new Vite, config("vite.apps.$app", []), $this->container);
+        })(new Vite, $app, config("vite.apps.$app", []), $this->container);
     }
 
     /**
      * Register an app factory callback.
      *
-     * @param  callable(string, ViteContract, array, Container): ViteContract  $appFactory
+     * @param  callable(\Illuminate\Contracts\Foundation\Vite, string, array, \Illuminate\Contracts\Container\Container): \Illuminate\Contracts\Foundation\Vite  $appFactory
      * @return $this
      */
     public function useAppFactory($appFactory)
@@ -71,7 +70,7 @@ class ViteManager extends Manager implements ViteContract
      * Get an app instance.
      *
      * @param  string|null  $app
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      *
      * @throws \InvalidArgumentException
      */
@@ -84,7 +83,7 @@ class ViteManager extends Manager implements ViteContract
      * Apply configuration to the Vite instance.
      *
      * @param  array  $config
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function configure($config)
     {
@@ -126,7 +125,7 @@ class ViteManager extends Manager implements ViteContract
      * Use the given key to detect integrity hashes in the manifest.
      *
      * @param  string|false  $key
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function useIntegrityKey($key)
     {
@@ -137,7 +136,7 @@ class ViteManager extends Manager implements ViteContract
      * Set the Vite entry points.
      *
      * @param  array  $entryPoints
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function withEntryPoints($entryPoints)
     {
@@ -148,7 +147,7 @@ class ViteManager extends Manager implements ViteContract
      * Set the filename for the manifest file.
      *
      * @param  string  $filename
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function useManifestFilename($filename)
     {
@@ -169,7 +168,7 @@ class ViteManager extends Manager implements ViteContract
      * Set the Vite "hot" file path.
      *
      * @param  string  $path
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function useHotFile($path)
     {
@@ -180,7 +179,7 @@ class ViteManager extends Manager implements ViteContract
      * Set the Vite build directory.
      *
      * @param  string  $path
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function useBuildDirectory($path)
     {
@@ -191,7 +190,7 @@ class ViteManager extends Manager implements ViteContract
      * Use the given callback to resolve attributes for script tags.
      *
      * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function useScriptTagAttributes($attributes)
     {
@@ -202,7 +201,7 @@ class ViteManager extends Manager implements ViteContract
      * Use the given callback to resolve attributes for style tags.
      *
      * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function useStyleTagAttributes($attributes)
     {
@@ -213,7 +212,7 @@ class ViteManager extends Manager implements ViteContract
      * Use the given callback to resolve attributes for preload tags.
      *
      * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
-     * @return ViteContract
+     * @return \Illuminate\Contracts\Foundation\Vite
      */
     public function usePreloadTagAttributes($attributes)
     {
@@ -259,6 +258,7 @@ class ViteManager extends Manager implements ViteContract
     /**
      * Get a unique hash representing the current manifest, or null if there is no manifest.
      *
+     * @param  string|null  $buildDirectory
      * @return string|null
      */
     public function manifestHash($buildDirectory = null)

--- a/src/Illuminate/Foundation/ViteManager.php
+++ b/src/Illuminate/Foundation/ViteManager.php
@@ -58,11 +58,13 @@ class ViteManager extends Manager implements ViteContract
      * Register an app factory callback.
      *
      * @param  callable(string, ViteContract, array, Container): ViteContract  $appFactory
-     * @return void
+     * @return $this
      */
     public function useAppFactory($appFactory)
     {
         $this->appFactory = $appFactory;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -2,19 +2,24 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Foundation\Vite as ViteContract;
+
 /**
+ * @method static void useAppFactory((callable(string, ViteContract, array, Container): ViteContract) $appResolver)
+ * @method static ViteContract app(string|null $app = null)
+ * @method static ViteContract configure(array $config)
  * @method static array preloadedAssets()
  * @method static string|null cspNonce()
- * @method static string useCspNonce(?string $nonce = null)
- * @method static \Illuminate\Foundation\Vite useIntegrityKey(string|false $key)
- * @method static \Illuminate\Foundation\Vite withEntryPoints(array $entryPoints)
- * @method static \Illuminate\Foundation\Vite useManifestFilename(string $filename)
+ * @method static string useCspNonce(string|null $nonce = null)
+ * @method static ViteContract useIntegrityKey(string|false $key)
+ * @method static ViteContract withEntryPoints(array $entryPoints)
+ * @method static ViteContract useManifestFilename(string $filename)
  * @method static string hotFile()
- * @method static \Illuminate\Foundation\Vite useHotFile(string $path)
- * @method static \Illuminate\Foundation\Vite useBuildDirectory(string $path)
- * @method static \Illuminate\Foundation\Vite useScriptTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
- * @method static \Illuminate\Foundation\Vite useStyleTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
- * @method static \Illuminate\Foundation\Vite usePreloadTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
+ * @method static ViteContract useHotFile(string $path)
+ * @method static ViteContract useBuildDirectory(string $path)
+ * @method static ViteContract useScriptTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
+ * @method static ViteContract useStyleTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
+ * @method static ViteContract usePreloadTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
  * @method static \Illuminate\Support\HtmlString|void reactRefresh()
  * @method static string asset(string $asset, string|null $buildDirectory = null)
  * @method static string|null manifestHash(string|null $buildDirectory = null)
@@ -25,7 +30,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Illuminate\Foundation\Vite
+ * @see \Illuminate\Foundation\ViteManager
  */
 class Vite extends Facade
 {
@@ -36,6 +41,6 @@ class Vite extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return \Illuminate\Foundation\Vite::class;
+        return 'vite';
     }
 }

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -5,7 +5,7 @@ namespace Illuminate\Support\Facades;
 use Illuminate\Contracts\Foundation\Vite as ViteContract;
 
 /**
- * @method static void useAppFactory((callable(string, ViteContract, array, Container): ViteContract) $appResolver)
+ * @method static \Illuminate\Foundation\ViteManager useAppFactory(callable(string, ViteContract, array, Container): ViteContract $appFactory)
  * @method static ViteContract app(string|null $app = null)
  * @method static ViteContract configure(array $config)
  * @method static array preloadedAssets()

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -2,33 +2,34 @@
 
 namespace Illuminate\Support\Facades;
 
-use Illuminate\Contracts\Foundation\Vite as ViteContract;
-
 /**
- * @method static \Illuminate\Foundation\ViteManager useAppFactory(callable(string, ViteContract, array, Container): ViteContract $appFactory)
- * @method static ViteContract app(string|null $app = null)
- * @method static ViteContract configure(array $config)
+ * @method static string getDefaultDriver()
+ * @method static \Illuminate\Foundation\ViteManager useAppFactory(callable(string, \Illuminate\Contracts\Foundation\Vite, array, \Illuminate\Contracts\Container\Container): \Illuminate\Contracts\Foundation\Vite $appFactory)
+ * @method static \Illuminate\Contracts\Foundation\Vite app(string|null $app = null)
+ * @method static \Illuminate\Contracts\Foundation\Vite configure(array $config)
  * @method static array preloadedAssets()
  * @method static string|null cspNonce()
  * @method static string useCspNonce(string|null $nonce = null)
- * @method static ViteContract useIntegrityKey(string|false $key)
- * @method static ViteContract withEntryPoints(array $entryPoints)
- * @method static ViteContract useManifestFilename(string $filename)
+ * @method static \Illuminate\Contracts\Foundation\Vite useIntegrityKey(string|false $key)
+ * @method static \Illuminate\Contracts\Foundation\Vite withEntryPoints(array $entryPoints)
+ * @method static \Illuminate\Contracts\Foundation\Vite useManifestFilename(string $filename)
  * @method static string hotFile()
- * @method static ViteContract useHotFile(string $path)
- * @method static ViteContract useBuildDirectory(string $path)
- * @method static ViteContract useScriptTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
- * @method static ViteContract useStyleTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
- * @method static ViteContract usePreloadTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
+ * @method static \Illuminate\Contracts\Foundation\Vite useHotFile(string $path)
+ * @method static \Illuminate\Contracts\Foundation\Vite useBuildDirectory(string $path)
+ * @method static \Illuminate\Contracts\Foundation\Vite useScriptTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
+ * @method static \Illuminate\Contracts\Foundation\Vite useStyleTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
+ * @method static \Illuminate\Contracts\Foundation\Vite usePreloadTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
  * @method static \Illuminate\Support\HtmlString|void reactRefresh()
  * @method static string asset(string $asset, string|null $buildDirectory = null)
- * @method static string|null manifestHash(string|null $buildDirectory = null)
+ * @method static string|null manifestHash(void $buildDirectory = null)
  * @method static bool isRunningHot()
  * @method static string toHtml()
- * @method static void macro(string $name, object|callable $macro)
- * @method static void mixin(object $mixin, bool $replace = true)
- * @method static bool hasMacro(string $name)
- * @method static void flushMacros()
+ * @method static mixed driver(string|null $driver = null)
+ * @method static \Illuminate\Foundation\ViteManager extend(string $driver, \Closure $callback)
+ * @method static array getDrivers()
+ * @method static \Illuminate\Contracts\Container\Container getContainer()
+ * @method static \Illuminate\Foundation\ViteManager setContainer(\Illuminate\Contracts\Container\Container $container)
+ * @method static \Illuminate\Foundation\ViteManager forgetDrivers()
  *
  * @see \Illuminate\Foundation\ViteManager
  */

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static string getDefaultDriver()
- * @method static \Illuminate\Foundation\ViteManager useAppFactory(callable(string, \Illuminate\Contracts\Foundation\Vite, array, \Illuminate\Contracts\Container\Container): \Illuminate\Contracts\Foundation\Vite $appFactory)
+ * @method static \Illuminate\Foundation\ViteManager useAppFactory(callable(\Illuminate\Contracts\Foundation\Vite, string, array, \Illuminate\Contracts\Container\Container): \Illuminate\Contracts\Foundation\Vite $appFactory)
  * @method static \Illuminate\Contracts\Foundation\Vite app(string|null $app = null)
  * @method static \Illuminate\Contracts\Foundation\Vite configure(array $config)
  * @method static array preloadedAssets()
@@ -21,7 +21,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Contracts\Foundation\Vite usePreloadTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
  * @method static \Illuminate\Support\HtmlString|void reactRefresh()
  * @method static string asset(string $asset, string|null $buildDirectory = null)
- * @method static string|null manifestHash(void $buildDirectory = null)
+ * @method static string|null manifestHash(string|null $buildDirectory = null)
  * @method static bool isRunningHot()
  * @method static string toHtml()
  * @method static mixed driver(string|null $driver = null)

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -59,9 +59,20 @@ trait CompilesHelpers
     {
         $arguments ??= '()';
 
-        $class = Vite::class;
+        return "<?php echo app('vite'){$arguments}; ?>";
+    }
 
-        return "<?php echo app('$class'){$arguments}; ?>";
+    /**
+     * Compile the "viteApp" statements into valid PHP.
+     *
+     * @param  ?string  $arguments
+     * @return string
+     */
+    protected function compileViteApp($arguments)
+    {
+        $arguments ??= '()';
+
+        return "<?php echo app('vite')->app{$arguments}->toHtml(); ?>";
     }
 
     /**
@@ -71,8 +82,6 @@ trait CompilesHelpers
      */
     protected function compileViteReactRefresh()
     {
-        $class = Vite::class;
-
-        return "<?php echo app('$class')->reactRefresh(); ?>";
+        return "<?php echo app('vite')->reactRefresh(); ?>";
     }
 }

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -1001,23 +1001,23 @@ class FoundationViteTest extends TestCase
 
         $vite = app(Vite::class)->configure($config);
 
-        $integrityKey = (new ReflectionObject($vite))->getProperty('integrityKey')->getValue($vite);
-        $entryPoints = (new ReflectionObject($vite))->getProperty('entryPoints')->getValue($vite);
-        $buildDirectory = (new ReflectionObject($vite))->getProperty('buildDirectory')->getValue($vite);
-        $manifestFilename = (new ReflectionObject($vite))->getProperty('manifestFilename')->getValue($vite);
-        $scriptTagAttributesResolvers = (new ReflectionObject($vite))->getProperty('scriptTagAttributesResolvers')->getValue($vite);
-        $styleTagAttributesResolvers = (new ReflectionObject($vite))->getProperty('styleTagAttributesResolvers')->getValue($vite);
-        $preloadTagAttributesResolvers = (new ReflectionObject($vite))->getProperty('preloadTagAttributesResolvers')->getValue($vite);
-
         $this->assertEquals($vite->cspNonce(), $config['nonce']);
-        $this->assertEquals($integrityKey, $config['integrity_key']);
-        $this->assertEquals($entryPoints, $config['entry_points']);
+        $this->assertEquals($this->getViteProperty($vite, 'integrityKey'), $config['integrity_key']);
+        $this->assertEquals($this->getViteProperty($vite, 'entryPoints'), $config['entry_points']);
         $this->assertEquals($vite->hotFile(), $config['hot_file']);
-        $this->assertEquals($buildDirectory, $config['build_directory']);
-        $this->assertEquals($manifestFilename, $config['manifest_filename']);
-        $this->assertEquals($scriptTagAttributesResolvers[0](), $config['tag_attributes']['script']);
-        $this->assertEquals($styleTagAttributesResolvers[0](), $config['tag_attributes']['style']);
-        $this->assertEquals($preloadTagAttributesResolvers[0](), $config['tag_attributes']['preload']);
+        $this->assertEquals($this->getViteProperty($vite, 'buildDirectory'), $config['build_directory']);
+        $this->assertEquals($this->getViteProperty($vite, 'manifestFilename'), $config['manifest_filename']);
+        $this->assertEquals($this->getViteProperty($vite, 'scriptTagAttributesResolvers')[0](), $config['tag_attributes']['script']);
+        $this->assertEquals($this->getViteProperty($vite, 'styleTagAttributesResolvers')[0](), $config['tag_attributes']['style']);
+        $this->assertEquals($this->getViteProperty($vite, 'preloadTagAttributesResolvers')[0](), $config['tag_attributes']['preload']);
+    }
+
+    protected function getViteProperty($vite, $propertyName)
+    {
+        $property = (new ReflectionObject($vite))->getProperty($propertyName);
+        $property->setAccessible(true);
+
+        return $property->getValue($vite);
     }
 
     protected function makeViteManifest($contents = null, $path = 'build')

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -983,6 +983,13 @@ class FoundationViteTest extends TestCase
         rmdir(public_path($buildDir));
     }
 
+    public function testItCreatesInstances()
+    {
+        $this->assertSame(ViteFacade::app(), ViteFacade::app());
+        $this->assertSame(ViteFacade::app('app1'), ViteFacade::app('app1'));
+        $this->assertNotSame(ViteFacade::app('app2'), ViteFacade::app('app3'));
+    }
+
     public function testItCanBeConfiguredWithArray()
     {
         $config = [

--- a/tests/Http/Middleware/VitePreloadingTest.php
+++ b/tests/Http/Middleware/VitePreloadingTest.php
@@ -21,7 +21,7 @@ class VitePreloadingTest extends TestCase
     public function testItDoesNotSetLinkTagWhenNoTagsHaveBeenPreloaded()
     {
         $app = new Container();
-        $app->instance(Vite::class, new class extends Vite
+        $app->instance('vite', new class extends Vite
         {
             protected $preloadedAssets = [];
         });
@@ -37,7 +37,7 @@ class VitePreloadingTest extends TestCase
     public function testItAddsPreloadLinkHeader()
     {
         $app = new Container();
-        $app->instance(Vite::class, new class extends Vite
+        $app->instance('vite', new class extends Vite
         {
             protected $preloadedAssets = [
                 'https://laravel.com/app.js' => [

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -11,10 +11,10 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
         $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
         $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
-        $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite'));
-        $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(); ?>', $this->compiler->compileString('@vite()'));
-        $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')(\'resources/js/app.js\'); ?>', $this->compiler->compileString('@vite(\'resources/js/app.js\')'));
-        $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')([\'resources/js/app.js\']); ?>', $this->compiler->compileString('@vite([\'resources/js/app.js\'])'));
-        $this->assertSame('<?php echo app(\'Illuminate\Foundation\Vite\')->reactRefresh(); ?>', $this->compiler->compileString('@viteReactRefresh'));
+        $this->assertSame('<?php echo app(\'vite\')(); ?>', $this->compiler->compileString('@vite'));
+        $this->assertSame('<?php echo app(\'vite\')(); ?>', $this->compiler->compileString('@vite()'));
+        $this->assertSame('<?php echo app(\'vite\')(\'resources/js/app.js\'); ?>', $this->compiler->compileString('@vite(\'resources/js/app.js\')'));
+        $this->assertSame('<?php echo app(\'vite\')([\'resources/js/app.js\']); ?>', $this->compiler->compileString('@vite([\'resources/js/app.js\'])'));
+        $this->assertSame('<?php echo app(\'vite\')->reactRefresh(); ?>', $this->compiler->compileString('@viteReactRefresh'));
     }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -15,6 +15,9 @@ class BladeHelpersTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo app(\'vite\')(); ?>', $this->compiler->compileString('@vite()'));
         $this->assertSame('<?php echo app(\'vite\')(\'resources/js/app.js\'); ?>', $this->compiler->compileString('@vite(\'resources/js/app.js\')'));
         $this->assertSame('<?php echo app(\'vite\')([\'resources/js/app.js\']); ?>', $this->compiler->compileString('@vite([\'resources/js/app.js\'])'));
+        $this->assertSame('<?php echo app(\'vite\')->app()->toHtml(); ?>', $this->compiler->compileString('@viteApp'));
+        $this->assertSame('<?php echo app(\'vite\')->app()->toHtml(); ?>', $this->compiler->compileString('@viteApp()'));
+        $this->assertSame('<?php echo app(\'vite\')->app(\'app\')->toHtml(); ?>', $this->compiler->compileString('@viteApp(\'app\')'));
         $this->assertSame('<?php echo app(\'vite\')->reactRefresh(); ?>', $this->compiler->compileString('@viteReactRefresh'));
     }
 }


### PR DESCRIPTION
Currently `Vite` helper is a singleton which mean that it may hold only one configuration at a time, allowing developer to customize only entry points and build directory per `__invoke` call. This may cause problems in multi-app configurations.

**Example**
In our project we use many SPAs within mainly legacy codebase. We manage our apps using Yarn workspaces. _Axios_, _Echo_ and _Ziggy_ configurations are shared between apps and stored in `resources/js/bootstrap.js` (`resources/js/app.js` entry point), as suggested by Laravel. This bootstrap code is injected into main page layout and accessible throughout the entire project and all its sub-apps.
The problem arose when it became necessary to debug specific app using `yarn dev` (`vite`) command to serve its assets. Vite can't serve multiple applications at once, so we need to use separate `hot` files for each application. But Laravel's `Vite` helper can only hold one configuration... so here we are.

**Reasoning**
- allow `Vite` helper to manage multiple app configurations;
- take app configuration out of Blade templates and store it in centralized location;
- add support for _app factory_ so new apps can be added without need to configure them separately;
- make it possible to configure default "app" for each environment separately via `VITE_APP` environment variable.

**Backward compatibility**
`Vite` facade, `Vite` helper injection and `@vite` Blade directive should work as before, but instead of resolving singleton from application's container, they will point to "default" entry from the `ViteManager`.
`Vite` contract has been added to allow `ViteManager` to implement it.

**Configuration**
There are 3 ways to configure Vite "apps":
1. `config/vite.php` file (should probably be added into `laravel/laravel` repo?):
```php
<?php

return [

    /*
    |--------------------------------------------------------------------------
    | Default Vite App
    |--------------------------------------------------------------------------
    */

    'app' => env('VITE_APP', 'default'),

    'apps' => [

        'default' => [
            'entry_points' => ['vite/legacy-polyfills-legacy', 'resources/js/app-legacy.js', 'resources/js/app.js'],
            'build_directory' => 'build',
        ],

        'myapp' => [
            'entry_points' => ['vite/legacy-polyfills-legacy', 'src/app-legacy.js', 'src/app.js'],
            'build_directory' => 'build/packages/myapp',
            'hot_file' => 'build/packages/myapp/hot',
        ],

    ],

];
```
2. Service provider's `boot` method:
```php
<?php

namespace App\Providers;

use Illuminate\Support\Facades\Vite;
use Illuminate\Support\ServiceProvider;
use Illuminate\Support\Str;

class ViteServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        Vite::withEntryPoints(['vite/legacy-polyfills-legacy', 'resources/js/app-legacy.js', 'resources/js/app.js'])
            ->useBuildDirectory('build');

        Vite::app('myapp')
            ->withEntryPoints(['vite/legacy-polyfills-legacy', 'src/app-legacy.js', 'src/app.js'])
            ->useBuildDirectory('build/packages/myapp')
            ->useHotFile(public_path('build/packages/myapp/hot'))
            ->useScriptTagAttributes(function (string $src) {
                return Str::contains($src, '-legacy') ? ['type' => 'text/javascript', 'nomodule'] : [];
            })
            ->usePreloadTagAttributes(function (string $src) {
                return Str::contains($src, '-legacy') ? ['rel' => 'dummy'] : [];
            });
    }
}
```
3. App factory:
```php
<?php

namespace App\Providers;

use Illuminate\Contracts\Foundation\Vite as ViteContract;
use Illuminate\Support\Facades\Vite;
use Illuminate\Support\ServiceProvider;
use Illuminate\Support\Str;

class ViteServiceProvider extends ServiceProvider
{
    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        Vite::useAppFactory(fn (ViteContract $vite, string $app, array $config) => $vite
            ->withEntryPoints(['vite/legacy-polyfills-legacy', 'src/app-legacy.js', 'src/app.js'])
            ->useBuildDirectory("build/packages/$app")
            ->useHotFile(public_path("build/packages/$app/hot"))
            ->useScriptTagAttributes(function (string $src) {
                return Str::contains($src, '-legacy') ? ['type' => 'text/javascript', 'nomodule'] : [];
            })
            ->usePreloadTagAttributes(function (string $src) {
                return Str::contains($src, '-legacy') ? ['rel' => 'dummy'] : [];
            })
            // amend/fall back to config entry for the app (if exists) from the "config/vite.php" file
            ->configure($config)
        );
    }
}
```

**Usage**
`@viteApp` directive should be used in Blade templates to enjoy the power of _multiappness_ to its fullest:
```blade
<!-- Shared bootstrap code -->
@viteApp

<!-- Example app -->
@viteApp('myapp')
```

**Testing**
I should probably add some tests for this feature, but I'm not good at it, so any help will be appreciated.
For now, I'll mark this PR as draft and try to write some tests.