### PR TITLE
Fixed bug on Job Batchs Table

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->integer('total_jobs');
             $table->integer('pending_jobs');
             $table->integer('failed_jobs');
-            $table->longtext('failed_job_ids');
+            $table->longText('failed_job_ids');
             $table->mediumText('options')->nullable();
             $table->integer('cancelled_at')->nullable();
             $table->integer('created_at');

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->integer('total_jobs');
             $table->integer('pending_jobs');
             $table->integer('failed_jobs');
-            $table->text('failed_job_ids');
+            $table->longtext('failed_job_ids');
             $table->mediumText('options')->nullable();
             $table->integer('cancelled_at')->nullable();
             $table->integer('created_at');


### PR DESCRIPTION
If the batch has more than 1000 errors the function Bus::findBatch() fails because the database cuts down the words when reach is limit and then the seventh argument returns null because can't be json decoded.