### PR TITLE
Correct PHPDoc for the HTTP-client transferStats property

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -37,7 +37,7 @@ class Response implements ArrayAccess
     /**
      * The transfer stats for the request.
      *
-     * \GuzzleHttp\TransferStats|null
+     * @var \GuzzleHttp\TransferStats|null
      */
     public $transferStats;
 


### PR DESCRIPTION
IDEs and analyzers are unable to determine the type of the property. Correcting the PHPDoc provides better feedback for developers. This is a simple change to a comment block and should not break anything.

Failed test not related to these PR changes, see #45251