### PR TITLE
Support '/' as a possible column name.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -202,7 +202,7 @@ trait GuardsAttributes
         }
 
         return $this->getGuarded() == ['*'] ||
-               ! empty(preg_grep('/^'.preg_quote($key).'$/i', $this->getGuarded())) ||
+               ! empty(preg_grep('/^'.preg_quote($key, '/').'$/i', $this->getGuarded())) ||
                ! $this->isGuardableColumn($key);
     }
 


### PR DESCRIPTION
Escape '/' when checking for guard-able column.

This might not be a popular thing, but we have a dynamic app, where some of the postgres columns have a "/" character in them. If you have such a column, calling the fill() method on the model with such column name results in an warning such as this:

```
PHP Warning:  preg_grep(): Unknown modifier '_' in .../GuardsAttributes.php on line ...
```

I figure that if Postgres supports such columns, Laravel/Eloquent should support this too.
