### PR TITLE
[9.x] Added updateBlanks function for models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1038,7 +1038,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
-        $attributes = collect($attributes)
+        $attributes = (new Collection($attributes))
             ->filter(fn ($value, $key) => Arr::has($this->attributesToArray(), $key))
             ->reject(fn ($value, $key) => filled($this->$key))
             ->toArray();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1026,6 +1026,32 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
+     * Update only the missing values of the model in the database.
+     *
+     * @param  array  $attributes
+     * @param  array  $options
+     * @return bool  $quietly
+     * @return bool
+     */
+    public function updateMissing(array $attributes = [], array $options = [])
+    {
+        if (! $this->exists) {
+            return false;
+        }
+
+        $attributes = collect($attributes)
+            ->filter(fn ($value, $key) => Arr::has($this->attributesToArray(), $key))
+            ->reject(fn ($value, $key) => filled($this->$key))
+            ->toArray();
+
+        if (empty($attributes)) {
+            return false;
+        }
+
+        return $this->fill($attributes)->save($options);
+    }
+
+    /**
      * Increment a column's value by a given amount without raising any events.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1026,13 +1026,13 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
     }
 
     /**
-     * Update only the missing values of the model in the database.
+     * Update only the blank (missing) values of the model in the database.
      *
      * @param  array  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function updateMissing(array $attributes = [], array $options = [])
+    public function updateBlanks(array $attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1030,7 +1030,6 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      *
      * @param  array  $attributes
      * @param  array  $options
-     * @return bool  $quietly
      * @return bool
      */
     public function updateMissing(array $attributes = [], array $options = [])

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -49,7 +49,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withMiddleware(callable $middleware)
  * @method static \Illuminate\Http\Client\PendingRequest beforeSending(callable $callback)
  * @method static \Illuminate\Http\Client\PendingRequest throw(callable|null $callback = null)
- * @method static \Illuminate\Http\Client\PendingRequest throwIf(callable|bool $condition, callable|null $throwCallback)
+ * @method static \Illuminate\Http\Client\PendingRequest throwIf(callable|bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest throwUnless(bool $condition)
  * @method static \Illuminate\Http\Client\PendingRequest dump()
  * @method static \Illuminate\Http\Client\PendingRequest dd()

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -46,14 +46,14 @@ class EloquentUpdateTest extends DatabaseTestCase
         $this->assertCount(0, TestUpdateModel1::all());
     }
 
-    public function testUpdateMissing()
+    public function testUpdateBlanks()
     {
         $record = TestUpdateModel1::create([
             'name' => 'John',
             'title' => null,
         ]);
 
-        $record->updateMissing([
+        $record->updateBlanks([
             'name' => 'Jane',
             'title' => 'Mr.',
         ]);

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -49,17 +49,17 @@ class EloquentUpdateTest extends DatabaseTestCase
     public function testUpdateMissing()
     {
         $record = TestUpdateModel1::create([
-            'name' => 'LTKort',
+            'name' => 'John',
             'title' => null,
         ]);
 
         $record->updateMissing([
-            'name' => 'Marshmallow',
+            'name' => 'Jane',
             'title' => 'Mr.',
         ]);
 
-        $this->assertSame('LTKort', $record->name);
-        $this->assertNotEmpty($record->title);
+        $this->assertSame('John', $record->name);
+        $this->assertSame('Mr.', $record->title);
     }
 
     public function testUpdateWithLimitsAndOrders()

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -46,6 +46,22 @@ class EloquentUpdateTest extends DatabaseTestCase
         $this->assertCount(0, TestUpdateModel1::all());
     }
 
+    public function testUpdateMissing()
+    {
+        $record = TestUpdateModel1::create([
+            'name' => 'LTKort',
+            'title' => null,
+        ]);
+
+        $record->updateMissing([
+            'name' => 'Marshmallow',
+            'title' => 'Mr.',
+        ]);
+
+        $this->assertSame('LTKort', $record->name);
+        $this->assertNotEmpty($record->title);
+    }
+
     public function testUpdateWithLimitsAndOrders()
     {
         if ($this->driver === 'sqlsrv') {


### PR DESCRIPTION
Regarding the discussion #45230 

You can update a model with an array that only fills the fields that do not have a value, 

So for example I have user model that has these fields;
| id | first_name | last_name | email                |  
|----|------------|-----------|----------------------|
| 1  |            | Kort      | lars@marshmallow.dev |  

And I have an array like; 
```php
 $form_data = [
    'first_name' => 'Lars',
    'last_name' => 'Ananas',
    'phone_number' => '1234567890',
];
```

If you call the `$user->update($form_data)` function with the data, it will overwrite the last_name & give an error on phone_number.

So now I propose a function like `$user->updateBlanks($form_data)`.
Which will check if the attributes exists in the model & updates only the values of the empty keys. Which will result in:
| id | first_name | last_name | email                |  
|----|------------|-----------|----------------------|
| 1  | Lars      | Kort      | lars@marshmallow.dev |  

In addition I'm working on a `$user->fillBlanks()`, which will only fill the fields & not save them:
[Added fillBlanks #45272 ](https://github.com/laravel/framework/pull/45272). 
I'm not sure about the locations of the functions, which are now located in `Illuminate\Database\Eloquent\Model.php`
