### PR TITLE
Use the full url provided by laravel mix hot file

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -39,7 +39,7 @@ class Mix
             }
 
             if (Str::startsWith($url, ['http://', 'https://'])) {
-                return new HtmlString(Str::after($url, ':').$path);
+                return new HtmlString($url.$path);
             }
 
             return new HtmlString("//localhost:8080{$path}");


### PR DESCRIPTION
If laravel mix hot module reloading is used on a laravel application running on https, the mix helper uses a protocol-less path to pull in the asset. As the default hmr server is not https and protocol-less mix path will try loading in the assets through https the assets are not being loaded.

This update will ensure that the mix helper always uses the correct hmr server setup by laravel mix, i.e. if a https hmr config is setup the mix helper will use https and the files will load in correctly.

One issue that could arise from this change is that if you are running a laravel server on https and the hmr server is not you could get a mixed content warning but I think that's a better alternative to the asset not being loaded in at all.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
