### PR TITLE
[9.x] Improve assertSeeText and assertDontSeeText test methods

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -621,11 +621,11 @@ class TestResponse implements ArrayAccess
 
         $values = $escape ? array_map('e', ($value)) : $value;
 
-        tap(strip_tags($this->getContent()), function ($content) use ($values) {
-            foreach ($values as $value) {
-                PHPUnit::assertStringContainsString((string) $value, $content);
-            }
-        });
+        $content = strip_tags($this->getContent());
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringContainsString((string) $value, $content);
+        }
 
         return $this;
     }
@@ -679,11 +679,11 @@ class TestResponse implements ArrayAccess
 
         $values = $escape ? array_map('e', ($value)) : $value;
 
-        tap(strip_tags($this->getContent()), function ($content) use ($values) {
-            foreach ($values as $value) {
-                PHPUnit::assertStringNotContainsString((string) $value, $content);
-            }
-        });
+        $content = strip_tags($this->getContent());
+
+        foreach ($values as $value) {
+            PHPUnit::assertStringNotContainsString((string) $value, $content);
+        }
 
         return $this;
     }


### PR DESCRIPTION
When you use `assertSee` test method and fail the test, you get a message like below.

```bash
  ' contains "Hello, Taylor.".

  at tests/Feature/ExampleTest.php:20
     16▕     {
     17▕         $response = $this->get('/');
     18▕
     19▕         $response->assertStatus(200)
  ➜  20▕             ->assertSee('Hello, Taylor.');
```

This is ok.
But meanwhile if you use `assertSeeText` and fail the test, you get a message like below.

```bash
  ' contains "Hello, Taylor.".

  at vendor/laravel/framework/src/Illuminate/Support/helpers.php:306
    302▕         if (is_null($callback)) {
    303▕             return new HigherOrderTapProxy($value);
    304▕         }
    305▕
  ➜ 306▕         $callback($value);
    307▕
    308▕         return $value;
    309▕     }
    310▕ }
```

This is not so helpful or just confusing.
To solve this, we can just forget about nice helper function `tap` and use the old-fashioned way.
By doing so, we can get the same error message as `assertSee`.
The same applies to `assertDontSeeText`.
