### PR TITLE
[9.x] Auto fix docblock changes

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,6 +47,8 @@ jobs:
 
     name: Facade DocBlocks
 
+    if: ${{ github.repository_owner == 'laravel' && (github.ref_name == 'master' || github.ref_name == '9.x') }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -65,5 +67,11 @@ jobs:
           max_attempts: 5
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
-      - name: Lint facade docblocks
-        run: php -f bin/facades.php -- --lint
+      - name: Update facade docblocks
+        run: php -f bin/facades.php
+
+      - name: Commit facade docblocks
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update facade docblocks
+          file_pattern: src/

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,7 +47,7 @@ jobs:
 
     name: Facade DocBlocks
 
-    if: ${{ github.repository_owner == 'laravel' && (github.ref_name == 'master' || github.ref_name == '9.x') }}
+    if: ${{ github.repository_owner == 'laravel' && github.event_name == 'push' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Right now, builds on 9.x are failing because a PR was merged without updating docblocks. This is because of the new Facade DocBlocks job that was merged here: https://github.com/laravel/framework/pull/45154. Because of this all new PR's will now fail.

I don't think it's feasible that we keep this linting job as people will not update these docblocks themselves. Instead we should automate this. This new PR changes the job to only run on the Laravel organization and on the latest stable branches so not on PR's. People can change code as they want and when it gets merged, this GHA will automatically update DocBlocks accordingly. 

This PR removes the GHA for PR's but I think it's a good thing as contributors now will not have to worry anymore about these changes/failures.