### PR TITLE
[9.x] Implementing `clear` method for collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -160,6 +160,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         return new static(Arr::collapse($this->items));
     }
 
+	/**
+	 * Clear all items in the collection.
+	 * 
+	 * @return $this
+	 */
+	public function clear()
+	{
+		$this->items = [];
+
+		return $this;
+	}
+
     /**
      * Determine if an item exists in the collection.
      *

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -204,6 +204,16 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
         });
     }
 
+	/**
+	 * Clear all items in the collection.
+	 * 
+	 * @return $this
+	 */
+	public function clear()
+	{
+        return $this->passthru('clear', []);
+	}
+
     /**
      * Determine if an item exists in the enumerable.
      *

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -5460,6 +5460,16 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testClear($collection)
+    {
+        $data = new $collection(['foo', 'bar', 'baz']);
+
+		$this->assertSame([], $data->clear()->toArray());
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array


### PR DESCRIPTION
Hello, I think `clear` method would be very useful for collections. The main reason we need this method is `readonly` properties, without internal clear method I guess It's impossible to clear readonly collection. There might be a ways to clear collection but I don't think It would be convinient as `clear` method.

It's my first contribution to a open source code base. Sorry if I have done something wrong.
