### PR TITLE
Specify the table's primary key as a UUID or a ULID

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1514,6 +1514,17 @@ class Blueprint
     }
 
     /**
+     * Specify the primary key for the table as UUID.
+     *
+     * @param  string  $column
+     * @return void
+     */
+    public function uuidPrimary($column = 'id')
+    {
+        return $this->uuid($column)->primary();
+    }
+
+    /**
      * Add nullable columns for a polymorphic table using UUIDs.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1525,6 +1525,18 @@ class Blueprint
     }
 
     /**
+     * Specify the primary key for the table as ULID.
+     *
+     * @param  string  $column
+     * @param  int|null  $length
+     * @return void
+     */
+    public function ulidPrimary($column = 'id', $length = 26)
+    {
+        return $this->ulid($column, $length)->primary();
+    }
+
+    /**
      * Add nullable columns for a polymorphic table using UUIDs.
      *
      * @param  string  $name

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1057,6 +1057,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `uuid` char(36) not null', $statements[0]);
     }
 
+    public function testAddingUuidAsPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->uuidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` add `id` char(36) not null', $statements[0]);
+        $this->assertSame('alter table `users` add primary key `users_id_primary`(`id`)', $statements[1]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1068,6 +1068,17 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add primary key `users_id_primary`(`id`)', $statements[1]);
     }
 
+    public function testAddingUlidAsPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table `users` add `id` char(26) not null', $statements[0]);
+        $this->assertSame('alter table `users` add primary key `users_id_primary`(`id`)', $statements[1]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -875,6 +875,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "uuid" uuid not null', $statements[0]);
     }
 
+    public function testAddingUuidAsPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->uuidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table "users" add column "id" uuid not null', $statements[0]);
+        $this->assertSame('alter table "users" add primary key ("id")', $statements[1]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -886,6 +886,17 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add primary key ("id")', $statements[1]);
     }
 
+    public function testAddingUlidAsPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table "users" add column "id" char(26) not null', $statements[0]);
+        $this->assertSame('alter table "users" add primary key ("id")', $statements[1]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -711,6 +711,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "uuid" varchar not null', $statements[0]);
     }
 
+    public function testAddingUuidAsPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->uuidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" varchar not null', $statements[0]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -721,6 +721,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add column "id" varchar not null', $statements[0]);
     }
 
+    public function testAddingUlidAsPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table "users" add column "id" varchar not null', $statements[0]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -761,6 +761,17 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add constraint "users_id_primary" primary key ("id")', $statements[1]);
     }
 
+    public function testAddingUlidAsPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->ulidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table "users" add "id" nchar(26) not null', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "users_id_primary" primary key ("id")', $statements[1]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -750,6 +750,17 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('alter table "users" add "uuid" uniqueidentifier not null', $statements[0]);
     }
 
+    public function testAddingUuidAsPrimaryKey()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->uuidPrimary();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(2, $statements);
+        $this->assertSame('alter table "users" add "id" uniqueidentifier not null', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "users_id_primary" primary key ("id")', $statements[1]);
+    }
+
     public function testAddingForeignUuid()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This PR adds two new methods to specify the table's primary key as a UUID or a ULID.

#### Before
```php
$table->uuid('id')->primary();
// OR
$table->ulid('id')->primary();
```

#### After
```php
$table->uuidPrimary();
// OR
$table->ulidPrimary();
```

If this PR would merge, I suggest reflecting it on the UUID/ULID section of the docs, where it instructs the user to ensure the model has an adequate primary key column.


#### References
[UUID & ULID Keys](https://laravel.com/docs/9.x/eloquent#uuid-and-ulid-keys)
>  Of course, you should ensure that the model has a [UUID equivalent primary key column](https://laravel.com/docs/9.x/migrations#column-method-uuid):