### PR TITLE
[9.x] Translation for validation format message

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -449,11 +449,11 @@ trait FormatsMessages
         }
 
         if (is_bool($value)) {
-            return $value ? __('validation.true') : __('validation.false');
+            return $value ? $this->translator->get('validation.true') : $this->translator->get('validation.false');
         }
 
         if (is_null($value)) {
-            return __('validation.empty');
+            return $this->translator->get('validation.empty');
         }
 
         return (string) $value;

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -449,11 +449,11 @@ trait FormatsMessages
         }
 
         if (is_bool($value)) {
-            return $value ? 'true' : 'false';
+            return $value ? __('validation.true') : __('validation.false');
         }
 
         if (is_null($value)) {
-            return 'empty';
+            return __('validation.empty');
         }
 
         return (string) $value;


### PR DESCRIPTION
Add translation for words empty, true, false in the validation format message

Linked to

- https://github.com/laravel/framework/issues/45225
- https://github.com/laravel/laravel/pull/6047