### PR TITLE
[9.x] Vite: ability to prevent preload tag generation from attribute resolver callback

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -476,7 +476,7 @@ class Vite implements Htmlable
             : $attributes;
 
         foreach ($this->preloadTagAttributesResolvers as $resolver) {
-            if (false === $resolvedAttributes = $resolver($src, $url, $chunk, $manifest)) {
+            if (false === ($resolvedAttributes = $resolver($src, $url, $chunk, $manifest))) {
                 return false;
             }
 

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -233,7 +233,7 @@ class Vite implements Htmlable
     /**
      * Use the given callback to resolve attributes for preload tags.
      *
-     * @param  (callable(string, string, ?array, ?array): array)|array  $attributes
+     * @param  (callable(string, string, ?array, ?array): array|false)|array|false  $attributes
      * @return $this
      */
     public function usePreloadTagAttributes($attributes)
@@ -351,8 +351,8 @@ class Vite implements Htmlable
      *
      * @param  string  $src
      * @param  string  $url
-     * @param  ?array  $chunk
-     * @param  ?array  $manifest
+     * @param  array|null  $chunk
+     * @param  array|null  $manifest
      * @return string
      */
     protected function makeTagForChunk($src, $url, $chunk, $manifest)
@@ -386,11 +386,15 @@ class Vite implements Htmlable
      * @param  string  $url
      * @param  array  $chunk
      * @param  array  $manifest
-     * @return string|null
+     * @return string
      */
     protected function makePreloadTagForChunk($src, $url, $chunk, $manifest)
     {
         $attributes = $this->resolvePreloadTagAttributes($src, $url, $chunk, $manifest);
+
+        if ($attributes === false) {
+            return '';
+        }
 
         $this->preloadedAssets[$url] = $this->parseAttributes(
             Collection::make($attributes)->forget('href')->all()
@@ -404,8 +408,8 @@ class Vite implements Htmlable
      *
      * @param  string  $src
      * @param  string  $url
-     * @param  ?array  $chunk
-     * @param  ?array  $manifest
+     * @param  array|null  $chunk
+     * @param  array|null  $manifest
      * @return array
      */
     protected function resolveScriptTagAttributes($src, $url, $chunk, $manifest)
@@ -426,8 +430,8 @@ class Vite implements Htmlable
      *
      * @param  string  $src
      * @param  string  $url
-     * @param  ?array  $chunk
-     * @param  ?array  $manifest
+     * @param  array|null  $chunk
+     * @param  array|null  $manifest
      * @return array
      */
     protected function resolveStylesheetTagAttributes($src, $url, $chunk, $manifest)
@@ -450,7 +454,7 @@ class Vite implements Htmlable
      * @param  string  $url
      * @param  array  $chunk
      * @param  array  $manifest
-     * @return array
+     * @return array|false
      */
     protected function resolvePreloadTagAttributes($src, $url, $chunk, $manifest)
     {
@@ -472,7 +476,11 @@ class Vite implements Htmlable
             : $attributes;
 
         foreach ($this->preloadTagAttributesResolvers as $resolver) {
-            $attributes = array_merge($attributes, $resolver($src, $url, $chunk, $manifest));
+            if (false === $resolvedAttributes = $resolver($src, $url, $chunk, $manifest)) {
+                return false;
+            }
+
+            $attributes = array_merge($attributes, $resolvedAttributes);
         }
 
         return $attributes;

--- a/src/Illuminate/Support/Facades/Vite.php
+++ b/src/Illuminate/Support/Facades/Vite.php
@@ -14,7 +14,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Foundation\Vite useBuildDirectory(string $path)
  * @method static \Illuminate\Foundation\Vite useScriptTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
  * @method static \Illuminate\Foundation\Vite useStyleTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
- * @method static \Illuminate\Foundation\Vite usePreloadTagAttributes((callable(string, string, ?array, ?array): array)|array $attributes)
+ * @method static \Illuminate\Foundation\Vite usePreloadTagAttributes((callable(string, string, ?array, ?array): array|false)|array|false $attributes)
  * @method static \Illuminate\Support\HtmlString|void reactRefresh()
  * @method static string asset(string $asset, string|null $buildDirectory = null)
  * @method static string|null manifestHash(string|null $buildDirectory = null)


### PR DESCRIPTION
This PR adds an ability to return `false` from preload tag attribute resolver to prevent tag generation.
For example, this is needed when adding chunks generated by [@vitejs/plugin-legacy
](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) to stop preloading unneeded scripts in modern browsers.
Current code to do so looks like this:
```php
Vite::withEntryPoints(['vite/legacy-polyfills-legacy', "resources/js/app-legacy.js", "resources/js/app.js"])
    ->useScriptTagAttributes(function ($src) {
        return Str::contains($src, '-legacy') ? ['type' => 'text/javascript', 'nomodule'] : [];
    })
    ->usePreloadTagAttributes(function ($src) {
        return Str::contains($src, '-legacy') ? ['rel' => 'dummy'] : [];
    });
```
Tag is still generating, but browsers omits it due to invalid `rel` attribute value.

With this PR, callback will look like this:
```php
->usePreloadTagAttributes(function ($src) {
    return Str::contains($src, '-legacy') ? false : [];
});
```
This will suppress preload tag generation for all scripts which name ends with "-legacy".