### PR TITLE
[9.x] Add streamed content test assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -573,6 +573,19 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the given string matches the streamed response content.
+     *
+     * @param  $value
+     * @return $this
+     */
+    public function assertStreamedContent($value)
+    {
+        PHPUnit::assertSame($value, $this->streamedContent());
+
+        return $this;
+    }
+
+    /**
      * Assert that the given string or array of strings are contained within the response.
      *
      * @param  string|array  $value

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -234,6 +234,29 @@ class TestResponseTest extends TestCase
         }
     }
 
+    public function testAssertStreamedContent()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new StreamedResponse)->setContent('expected response data')
+        );
+
+        $this->assertStreamedContent('expected response data');
+
+        try {
+            $response->assertStreamedContent('expected');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
+        }
+
+        try {
+            $response->assertStreamedContent('expected response data with extra');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
+        }
+    }
+
     public function testAssertSee()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
This PR adds an `assertStreamedContent()` assertion that allows `response()->streamDownload()` feature tests to be shortened from: 

```
$response = $this->get('/download')
    ->assertOk()
    ->assertDownload('foobar.txt');

$this->assertSame($response->streamedContent(), 'foobar');
```

To a more succinct:
```
$this->get('/download')
    ->assertOk()
    ->assertDownload('foobar.txt')
    ->assertStreamedContent('foobar');
```