### PR TITLE
WIP: [9.x] Adding a "unixtime" Eloquant type and cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -107,6 +107,7 @@ trait HasAttributes
         'real',
         'string',
         'timestamp',
+        'unixtime',
     ];
 
     /**
@@ -292,6 +293,10 @@ trait HasAttributes
             // into an array without affecting how they are persisted into the storage.
             if (isset($attributes[$key]) && in_array($value, ['date', 'datetime', 'immutable_date', 'immutable_datetime'])) {
                 $attributes[$key] = $this->serializeDate($attributes[$key]);
+            }
+
+            if (isset($attributes[$key]) && $value == 'unixtime') {
+                $attributes[$key] = $this->serializeDateToInteger($attributes[$key]);
             }
 
             if (isset($attributes[$key]) && ($this->isCustomDateTimeCast($value) ||
@@ -773,6 +778,7 @@ trait HasAttributes
                 return $this->asDate($value);
             case 'datetime':
             case 'custom_datetime':
+            case 'unixtime':
                 return $this->asDateTime($value);
             case 'immutable_date':
                 return $this->asDate($value)->toImmutable();
@@ -1433,6 +1439,19 @@ trait HasAttributes
     }
 
     /**
+     * Prepare a date for integral serialization.
+     *
+     * @param  \DateTimeInterface  $date
+     * @return string
+     */
+    protected function serializeDateToInteger(DateTimeInterface $date)
+    {
+        return $date instanceof DateTimeImmutable ?
+            CarbonImmutable::instance($date)->timestamp :
+            Carbon::instance($date)->timestamp;
+    }
+
+    /**
      * Get the attributes that should be converted to dates.
      *
      * @return array
@@ -1512,7 +1531,7 @@ trait HasAttributes
      */
     protected function isDateCastable($key)
     {
-        return $this->hasCast($key, ['date', 'datetime', 'immutable_date', 'immutable_datetime']);
+        return $this->hasCast($key, ['date', 'datetime', 'immutable_date', 'immutable_datetime', 'unixtime']);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1198,6 +1198,17 @@ class Blueprint
     }
 
     /**
+     * Add a signed bigInteger for unix timestamps.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function unixtime($column)
+    {
+        return $this->bigInteger($column);
+    }
+
+    /**
      * Add a "deleted at" timestamp for the table.
      *
      * @param  string  $column


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

This PR adds the `$table->unixTime();` migration table method and `"unixtime"` cast to Models.

<!--
In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This doesn't break any existing features. `$table->timestamps();`, `"datetime"`, `"timestamp"`, etc. still behave as they did.

MySQL (and by extension, MariaDB) does not yet support [>2038-01-19 03:14:07 UTC](https://en.wikipedia.org/wiki/Year_2038_problem), and it is slowly but increasingly becoming a problem. Many developers have resorted to using `BIGINT` and writing their own casts (including myself) to store datetimes beyond 2038.

This PR adds a convenient migration table method and an Eloquent cast to make this easier out-of-the-box.