### PR TITLE
Fixed Lack of Memory when failing a job with wrong variable passed on the method fail()

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->integer('total_jobs');
             $table->integer('pending_jobs');
             $table->integer('failed_jobs');
-            $table->longtext('failed_job_ids');
+            $table->longText('failed_job_ids');
             $table->mediumText('options')->nullable();
             $table->integer('cancelled_at')->nullable();
             $table->integer('created_at');

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->integer('total_jobs');
             $table->integer('pending_jobs');
             $table->integer('failed_jobs');
-            $table->text('failed_job_ids');
+            $table->longtext('failed_job_ids');
             $table->mediumText('options')->nullable();
             $table->integer('cancelled_at')->nullable();
             $table->integer('created_at');

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -43,8 +43,15 @@ trait InteractsWithQueue
      */
     public function fail($exception = null)
     {
-        if ($this->job) {
-            $this->job->fail($exception);
+        //Check if $exception is an instance of \Throwable or if it is null
+        if($exception instanceof \Throwable || is_null($exception)){
+            //If it is, then we can use the fail() method
+            if ($this->job) {
+                return $this->job->fail($exception);
+            }
+        } else {
+            //If it is not, then we throw an exception
+            throw new \Exception('The fail() method requires an instance of \Throwable');
         }
     }
 

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\Job as JobContract;
+use InvalidArgumentException;
+use Throwable;
 
 trait InteractsWithQueue
 {
@@ -43,15 +45,12 @@ trait InteractsWithQueue
      */
     public function fail($exception = null)
     {
-        //Check if $exception is an instance of \Throwable or if it is null
-        if($exception instanceof \Throwable || is_null($exception)){
-            //If it is, then we can use the fail() method
+        if ($exception instanceof Throwable || is_null($exception)) {
             if ($this->job) {
                 return $this->job->fail($exception);
             }
         } else {
-            //If it is not, then we throw an exception
-            throw new \Exception('The fail() method requires an instance of \Throwable');
+            throw new InvalidArgumentException('The fail method requires an instance of Throwable.');
         }
     }
 


### PR DESCRIPTION
Added validation to ensure that the $exception is a Throwable instance or is null, because if we pass another type of variable in the fail() method, the fail method enters an infinite loop until the php process crashes due to lack of memory