### PR TITLE
[9.x] Move HasFactory to Model class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
@@ -32,7 +33,8 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
-        ForwardsCalls;
+        ForwardsCalls,
+        HasFactory;
 
     /**
      * The connection name for the model.

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -2,10 +2,8 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class {{ class }} extends Model
 {
-    use HasFactory;
 }

--- a/tests/Database/Fixtures/Models/Money/Price.php
+++ b/tests/Database/Fixtures/Models/Money/Price.php
@@ -2,17 +2,14 @@
 
 namespace Illuminate\Tests\Database\Fixtures\Models\Money;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Tests\Database\Fixtures\Factories\Money\PriceFactory;
 
 class Price extends Model
 {
-    use HasFactory;
-
     protected $table = 'prices';
 
-    public static function factory()
+    public static function newFactory()
     {
         return PriceFactory::new();
     }


### PR DESCRIPTION
This pull request moves the `HasFactory` trait into the Model class directly, meaning all models will by default have the `factory` method available.

## For
The advantage of moving the `HasFactory` trait into the model is that many people wants this on all their models and making it added by default means we don't have to think about adding it and bloat our models with code we deem a standard.

By looking at the model stub, we can clearly see that Laravel already see the `HasFactory` trait as a standard, as it is included in the stub by default, so why not completely embrace it and just add it to the model class? 

The trait simply adds two new methods into the model, so even for people that do not wanna use this trait, it won't affect site performance, as they do not hook into any events etc.

## Against
Some people deem model factories as something that should only be used in tests, and therefore they do not want this trait added in their models as they do not want test code mixed together with production code. Making this change will not make them able to opt-out of the trait (when using the`Model` class).


## Alternative solution
An alternative way this could be done is via a macro on the `Builder` class. Either adding this macro via a call in a service provider or as a separate package. This would give people the power of choosing if they want the method to be available or not.
However it does add the overhead of a macro in a situation where it can be easily solved without.