### PR TITLE
Add session directive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,10 @@ services:
       MYSQL_DATABASE: "forge"
       MYSQL_ROOT_HOST: "%"
     ports:
-      - "3306:3306"
+      - "3307:3307"
     restart: always
   redis:
     image: redis:5.0-alpine
     ports:
-      - "6379:6379"
+      - "6380:6380"
     restart: always

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -32,6 +32,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         Concerns\CompilesRawPhp,
         Concerns\CompilesStacks,
         Concerns\CompilesTranslations,
+        Concerns\CompilesSession,
         ReflectsClosures;
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesSession.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesSession.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\View\Compilers\Concerns;
+
+trait CompilesSession
+{
+    /**
+     * Compile the session statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileSession($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return '<?php if (session()->has('.$expression.')) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = session()->get('.$expression.'); ?>';
+    }
+
+    /**
+     * Compile the endsession statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEndsession($expression)
+    {
+        return '<?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif; ?>';
+    }
+}

--- a/tests/View/Blade/BladeSessionTest.php
+++ b/tests/View/Blade/BladeSessionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeSessionTest extends AbstractBladeTestCase
+{
+    public function testSessionIsCompiled()
+    {
+        $string = '
+@session(\'success\')
+    <span>{{ $message }}</span>
+@endsession';
+        $expected = '
+<?php if (session()->has(\'success\')) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = session()->get(\'success\'); ?>
+    <span><?php echo e($message); ?></span>
+<?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif; ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
With `@session` we can replace `if(session()->has('...'))`, which makes the code more readable.

For example:

```blade
<!-- Before -->
@if(session()->has('success'))
<div class="...">{{ session()->get('success') }}</div>
@endif

<!-- After -->
@session('success')
<div class="...">{{ $message }}</div>
@endsession
```