### PR TITLE
[9.x] Add streamed content test assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -573,6 +573,19 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the given string matches the streamed response content.
+     *
+     * @param  $value
+     * @return $this
+     */
+    public function assertStreamedContent($value)
+    {
+        PHPUnit::assertSame($value, $this->streamedContent());
+
+        return $this;
+    }
+
+    /**
      * Assert that the given string or array of strings are contained within the response.
      *
      * @param  string|array  $value

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -234,6 +234,29 @@ class TestResponseTest extends TestCase
         }
     }
 
+    public function testAssertStreamedContent()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new StreamedResponse)->setContent('expected response data')
+        );
+
+        $this->assertStreamedContent('expected response data');
+
+        try {
+            $response->assertStreamedContent('expected');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
+        }
+
+        try {
+            $response->assertStreamedContent('expected response data with extra');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
+        }
+    }
+
     public function testAssertSee()
     {
         $response = $this->makeMockResponse([

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class TestResponseTest extends TestCase
 {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -238,10 +238,15 @@ class TestResponseTest extends TestCase
     public function testAssertStreamedContent()
     {
         $response = TestResponse::fromBaseResponse(
-            (new StreamedResponse)->setContent('expected response data')
+            new StreamedResponse(function () {
+                $stream = fopen('php://memory', 'r+');
+                fwrite($stream, 'expected response data');
+                rewind($stream);
+                fpassthru($stream);
+            })
         );
 
-        $this->assertStreamedContent('expected response data');
+        $response->assertStreamedContent('expected response data');
 
         try {
             $response->assertStreamedContent('expected');


### PR DESCRIPTION
[This PR](https://github.com/laravel/framework/pull/45288#event-8030702892) of mine was merged but then reverted because the tests were broken (sorry!). This PR fixes the tests.

```
❯ ./bin/test.sh -- --filter=TestResponseTest
Ensuring docker is running
Ensuring services are running
laravel-framework_redis_1 is up-to-date
laravel-framework_mysql_1 is up-to-date
laravel-framework_memcached_1 is up-to-date
laravel-framework_dynamodb_1 is up-to-date
Running tests
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.26
Configuration: /data/phpunit.xml.dist

...............................................................  63 / 138 ( 45%)
............................................................... 126 / 138 ( 91%)
............                                                    138 / 138 (100%)

Time: 00:00.236, Memory: 100.50 MB

OK (138 tests, 395 assertions)
```