### PR TITLE
[9.x] Add $encoding parameter to `substr` method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1125,6 +1125,7 @@ class Str
      * @param  string  $string
      * @param  int  $start
      * @param  int|null  $length
+     * @param  string  $encoding
      * @return string
      */
     public static function substr($string, $start, $length = null, $encoding = 'UTF-8')

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1127,9 +1127,9 @@ class Str
      * @param  int|null  $length
      * @return string
      */
-    public static function substr($string, $start, $length = null)
+    public static function substr($string, $start, $length = null, $encoding = 'UTF-8')
     {
-        return mb_substr($string, $start, $length, 'UTF-8');
+        return mb_substr($string, $start, $length, $encoding);
     }
 
     /**


### PR DESCRIPTION
Support custom encoding for the `substr` method, the same thing applied for the `mask` method on https://github.com/laravel/framework/blob/9.x/src/Illuminate/Support/Str.php#L573