### PR TITLE
Fix SerializesAndRestoresModelIdentifiers trait with model repository

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -577,6 +578,10 @@ class Mailable implements MailableContract, Renderable
      */
     public function to($address, $name = null)
     {
+        if (! $this->locale && $address instanceof HasLocalePreference) {
+            $this->locale($address->preferredLocale());
+        }
+
         return $this->setAddress($address, $name, 'to');
     }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -103,6 +104,10 @@ trait SerializesAndRestoresModelIdentifiers
      */
     public function restoreModel($value)
     {
+        if (!$value->id) {
+            return Container::getInstance()->make($value->class);
+        }
+
         return $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
         )->useWritePdo()->firstOrFail()->load($value->relations ?? []);

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -95,6 +95,11 @@ class SendingMailWithLocaleTest extends TestCase
         $this->assertStringContainsString('esm',
             app('mailer')->getSymfonyTransport()->messages()[0]->toString()
         );
+
+        $mailable = new Mailable;
+        $mailable->to($recipient);
+
+        $this->assertSame($recipient->email_locale, $mailable->locale);
     }
 
     public function testLocaleIsSentWithSelectedLocaleOverridingModelPreferredLocale()

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Queue;
 
+use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -328,6 +329,14 @@ class ModelSerializationTest extends TestCase
         unserialize($serialized);
 
         $this->assertTrue(true);
+    }
+
+    public function testItCanUnserializeModelRepository()
+    {
+        $userRepository = Container::getInstance()->make(ModelSerializationTestUser::class);
+
+        $serialized = serialize(new ModelSerializationTestClass($userRepository));
+        unserialize($serialized);
     }
 }
 


### PR DESCRIPTION
Hi,

Currently, the trait "SerializesAndRestoresModelIdentifiers" via "SerializesModels" doesn't support model repository like that:

```
<?php

namespace App\Mail;

use App\Models\Group;
use Illuminate\Bus\Queueable;
use Illuminate\Container\Container;
use Illuminate\Mail\Mailable;
use Illuminate\Queue\SerializesModels;

class UserInvitation extends Mailable
{
    use Queueable, SerializesModels;

    protected readonly Group $groupRepository;

    /**
     * Create a new message instance.
     *
     * @return void
     */
    public function __construct() {
        $this->groupRepository = Container::getInstance()->make(Group::class);
    }
}
```

This PR fix that.