### PR TITLE
[9.x] Fix condition in AsPivot::hasTimestampAttributes()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -222,7 +222,10 @@ trait AsPivot
      */
     public function hasTimestampAttributes($attributes = null)
     {
-        return array_key_exists($this->getCreatedAtColumn(), $attributes ?? $this->attributes);
+        $attributes ??= $this->attributes;
+
+        return array_key_exists($this->getCreatedAtColumn(), $attributes) &&
+            array_key_exists($this->getUpdatedAtColumn(), $attributes);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -29,9 +29,9 @@ class DatabaseEloquentPivotTest extends TestCase
         $connection->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
         $parent->getConnection()->getQueryGrammar()->shouldReceive('getDateFormat')->andReturn('Y-m-d H:i:s');
         $parent->setDateFormat('Y-m-d H:i:s');
-        $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar', 'created_at' => '2015-09-12'], 'table', true);
+        $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar', 'created_at' => '2015-09-12', 'updated_at' => '2015-09-12'], 'table', true);
 
-        $this->assertEquals(['foo' => 'bar', 'created_at' => '2015-09-12 00:00:00'], $pivot->getAttributes());
+        $this->assertEquals(['foo' => 'bar', 'created_at' => '2015-09-12 00:00:00', 'updated_at' => '2015-09-12 00:00:00'], $pivot->getAttributes());
         $this->assertSame('connection', $pivot->getConnectionName());
         $this->assertSame('table', $pivot->getTable());
         $this->assertTrue($pivot->exists);
@@ -91,19 +91,25 @@ class DatabaseEloquentPivotTest extends TestCase
         $parent = m::mock(Model::class.'[getConnectionName,getDates]');
         $parent->shouldReceive('getConnectionName')->andReturn('connection');
         $parent->shouldReceive('getDates')->andReturn([]);
-        $pivot = DatabaseEloquentPivotTestDateStub::fromAttributes($parent, ['foo' => 'bar', 'created_at' => 'foo'], 'table');
+        $pivot = DatabaseEloquentPivotTestDateStub::fromAttributes($parent, ['foo' => 'bar', 'created_at' => 'foo', 'updated_at' => 'bar'], 'table');
         $this->assertTrue($pivot->timestamps);
+
+        $pivot = DatabaseEloquentPivotTestDateStub::fromAttributes($parent, ['foo' => 'bar', 'created_at' => 'foo'], 'table');
+        $this->assertFalse($pivot->timestamps);
 
         $pivot = DatabaseEloquentPivotTestDateStub::fromAttributes($parent, ['foo' => 'bar'], 'table');
         $this->assertFalse($pivot->timestamps);
     }
 
-    public function testTimestampPropertyIsTrueWhenCreatingFromRawAttributes()
+    public function testTimestampPropertyIsSetWhenCreatingFromRawAttributes()
     {
         $parent = m::mock(Model::class.'[getConnectionName,getDates]');
         $parent->shouldReceive('getConnectionName')->andReturn('connection');
-        $pivot = Pivot::fromRawAttributes($parent, ['foo' => 'bar', 'created_at' => 'foo'], 'table');
+        $pivot = Pivot::fromRawAttributes($parent, ['foo' => 'bar', 'created_at' => 'foo', 'updated_at' => 'bar'], 'table');
         $this->assertTrue($pivot->timestamps);
+
+        $pivot = Pivot::fromRawAttributes($parent, ['foo' => 'bar', 'created_at' => 'foo'], 'table');
+        $this->assertFalse($pivot->timestamps);
     }
 
     public function testKeysCanBeSetProperly()


### PR DESCRIPTION
## Description

When the pivot table only has a `created_at` column but not a  `updated_at` column,  the `updated_at` column will appear in the SQL query generated by executing `attach()`.

## Example Scenario

### Post model
```php
public function tags()
{
    return $this
        ->belongsToMany(
            Tag::class,
            'post_tag',
            foreignPivotKey: 'post_id',
            relatedPivotKey: 'tag_id'
        )
        ->using(PostTagPivot::class)
        ->withPivot('created_at');
}
```

### PostTagPivot model
```php
class PostTagPivot extends Pivot
{
    protected $table = 'post_tag';

    public $timestamps = false;

    protected $casts = [
        'created_at' => 'timestamp',
    ];
}
```

### Function call
```php
$post->tags()->attach($tag)
```

get the error as the following:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'updated_at' in 'field list' (SQL: insert into `post_tag` (`post_id`, `tag_id`, `created_at`, `updated_at`) values (1, 22, 2022-12-14 09:32:31, 2022-12-14 09:32:31))
```