### PR TITLE
[9.x] Fix schedule:list crash when call() is given class-string

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -225,11 +225,9 @@ class ScheduleListCommand extends Command
         }
 
         if (is_array($callback)) {
-            if (is_string($callback[0])) {
-                return sprintf('%s::%s', $callback[0], $callback[1]);
-            }
+            $className = is_string($callback[0]) ? $callback[0] : $callback[0]::class;
 
-            return sprintf('%s::%s', $callback[0]::class, $callback[1]);
+            return sprintf('%s::%s', $className, $callback[1]);
         }
 
         return sprintf('%s::__invoke', $callback::class);

--- a/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleListCommand.php
@@ -220,7 +220,15 @@ class ScheduleListCommand extends Command
             );
         }
 
+        if (is_string($callback)) {
+            return $callback;
+        }
+
         if (is_array($callback)) {
+            if (is_string($callback[0])) {
+                return sprintf('%s::%s', $callback[0], $callback[1]);
+            }
+
             return sprintf('%s::%s', $callback[0]::class, $callback[1]);
         }
 

--- a/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
+++ b/tests/Integration/Console/Scheduling/ScheduleListCommandTest.php
@@ -36,6 +36,8 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->job(FooJob::class)->everyMinute();
         $this->schedule->command('inspire')->cron('0 9,17 * * *');
         $this->schedule->command('inspire')->cron("0 10\t* * *");
+        $this->schedule->call(FooCall::class)->everyMinute();
+        $this->schedule->call([FooCall::class, 'fooFunction'])->everyMinute();
 
         $this->schedule->call(fn () => '')->everyMinute();
         $closureLineNumber = __LINE__ - 1;
@@ -49,6 +51,8 @@ class ScheduleListCommandTest extends TestCase
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
             ->expectsOutput('  0 9,17  * *      *  php artisan inspire ......... Next Due: 9 hours from now')
             ->expectsOutput('  0 10    * *      *  php artisan inspire ........ Next Due: 10 hours from now')
+            ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall::fooFunction  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now');
     }
 
@@ -60,6 +64,8 @@ class ScheduleListCommandTest extends TestCase
         $this->schedule->job(FooJob::class)->everyMinute();
         $this->schedule->command('inspire')->cron('0 9,17 * * *');
         $this->schedule->command('inspire')->cron("0 10\t* * *");
+        $this->schedule->call(FooCall::class)->everyMinute();
+        $this->schedule->call([FooCall::class, 'fooFunction'])->everyMinute();
 
         $this->schedule->call(fn () => '')->everyMinute();
         $closureLineNumber = __LINE__ - 1;
@@ -69,6 +75,8 @@ class ScheduleListCommandTest extends TestCase
             ->assertSuccessful()
             ->expectsOutput('  * *     * *      *  php artisan foobar a='.ProcessUtils::escapeArgument('b').' ... Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Illuminate\Tests\Integration\Console\Scheduling\FooJob  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall  Next Due: 1 minute from now')
+            ->expectsOutput('  * *     * *      *  Closure at: Illuminate\Tests\Integration\Console\Scheduling\FooCall::fooFunction  Next Due: 1 minute from now')
             ->expectsOutput('  * *     * *      *  Closure at: '.$closureFilePath.':'.$closureLineNumber.'  Next Due: 1 minute from now')
             ->expectsOutput('  0 9,17  * *      *  php artisan inspire ......... Next Due: 9 hours from now')
             ->expectsOutput('  0 10    * *      *  php artisan inspire ........ Next Due: 10 hours from now')
@@ -105,4 +113,15 @@ class FooCommand extends Command
 
 class FooJob
 {
+}
+
+class FooCall
+{
+    public function __invoke(): void
+    {
+    }
+
+    public function fooFunction(): void
+    {
+    }
 }


### PR DESCRIPTION
When creating schedule of the form:

```php
$this->schedule->call(FooCall::class);
$this->schedule->call([FooCall::class, 'fooFunction']);
```

Then the `ScheduleListCommand::getClosureLocation()` method would crash with:

```
TypeError

Cannot use "::class" on value of type string
```

This PR fixes it by adding checks for string `$callback` and returning that string instead of adding `::class` to it.

Tests for both single string and array callable syntax included.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
