### PR TITLE
Added missing code to set locale from model preferred locale

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\Factory as Queue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -577,6 +578,10 @@ class Mailable implements MailableContract, Renderable
      */
     public function to($address, $name = null)
     {
+        if (! $this->locale && $address instanceof HasLocalePreference) {
+            $this->locale($address->preferredLocale());
+        }
+
         return $this->setAddress($address, $name, 'to');
     }
 

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -95,6 +95,11 @@ class SendingMailWithLocaleTest extends TestCase
         $this->assertStringContainsString('esm',
             app('mailer')->getSymfonyTransport()->messages()[0]->toString()
         );
+
+        $mailable = new Mailable;
+        $mailable->to($recipient);
+
+        $this->assertSame($recipient->email_locale, $mailable->locale);
     }
 
     public function testLocaleIsSentWithSelectedLocaleOverridingModelPreferredLocale()


### PR DESCRIPTION
Hi,

According to the documentation, it's possible to set the locale from a model like that: https://laravel.com/docs/9.x/mail#user-preferred-locales

It works great if you use the method `to` via `Illuminate\Support\Facades\Mail` class like in this example: https://laravel.com/docs/9.x/mail#sending-mail

But if you want to do the same inside a `lluminate\Mail\Mailable` class, it will not set the locale. Like this example:

```
<?php
 
namespace App\Mail;
 
use App\Models\Order;
use Illuminate\Bus\Queueable;
use Illuminate\Mail\Mailable;
use Illuminate\Mail\Mailables\Content;
use Illuminate\Queue\SerializesModels;
 
class OrderShipped extends Mailable
{
    use Queueable, SerializesModels;
 
    protected $order;
    protected $user;
 
    public function __construct(Order $order, User $user)
    {
        $this->to($user);
    }
}
```

This PR fix that.