### PR TITLE
[9.x] Use Macroable in Session facade

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -7,12 +7,15 @@ use Illuminate\Contracts\Session\Session;
 use Illuminate\Support\Arr;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\ViewErrorBag;
 use SessionHandlerInterface;
 use stdClass;
 
 class Store implements Session
 {
+    use Macroable;
+
     /**
      * The session ID.
      *

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -59,6 +59,10 @@ namespace Illuminate\Support\Facades;
  * @method static void setHandler(\SessionHandlerInterface $handler)
  * @method static bool handlerNeedsRequest()
  * @method static void setRequestOnHandler(\Illuminate\Http\Request $request)
+ * @method static void macro(string $name, object|callable $macro)
+ * @method static void mixin(object $mixin, bool $replace = true)
+ * @method static bool hasMacro(string $name)
+ * @method static void flushMacros()
  *
  * @see \Illuminate\Session\SessionManager
  */


### PR DESCRIPTION
I found myself wanting to add a macro to encapsulate a session getter I was using in a few different places but noticed the Session facade is not using the Macroable trait like other facades do.

Do you see any issues with just importing the Macroable trait directly in the Session class?