### PR TITLE
[9.x] Fixed errors occurring when encrypted cookies has been tampered with

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -229,10 +229,24 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     protected function validPayload($payload)
     {
-        return is_array($payload) && isset($payload['iv'], $payload['value'], $payload['mac']) &&
-            strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length(strtolower($this->cipher));
-    }
+        if (!is_array($payload)) {
+            return false;
+        }
 
+        // Required values, must be strings
+        foreach (['iv', 'value', 'mac'] as $item) {
+            if (!isset($payload[$item]) || !is_string($payload[$item])) {
+                return false;
+            }
+        }
+
+        // Optional, but has to be string if present
+        if (isset($payload['tag']) && !is_string($payload['tag'])) {
+            return false;
+        }
+
+        return strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length(strtolower($this->cipher));
+    }
     /**
      * Determine if the MAC for the given payload is valid.
      *

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -233,14 +233,12 @@ class Encrypter implements EncrypterContract, StringEncrypter
             return false;
         }
 
-        // Required values, must be strings
         foreach (['iv', 'value', 'mac'] as $item) {
             if (! isset($payload[$item]) || ! is_string($payload[$item])) {
                 return false;
             }
         }
 
-        // Optional, but has to be string if present
         if (isset($payload['tag']) && ! is_string($payload['tag'])) {
             return false;
         }

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -229,24 +229,25 @@ class Encrypter implements EncrypterContract, StringEncrypter
      */
     protected function validPayload($payload)
     {
-        if (!is_array($payload)) {
+        if (! is_array($payload)) {
             return false;
         }
 
         // Required values, must be strings
         foreach (['iv', 'value', 'mac'] as $item) {
-            if (!isset($payload[$item]) || !is_string($payload[$item])) {
+            if (! isset($payload[$item]) || ! is_string($payload[$item])) {
                 return false;
             }
         }
 
         // Optional, but has to be string if present
-        if (isset($payload['tag']) && !is_string($payload['tag'])) {
+        if (isset($payload['tag']) && ! is_string($payload['tag'])) {
             return false;
         }
 
         return strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length(strtolower($this->cipher));
     }
+
     /**
      * Determine if the MAC for the given payload is valid.
      *

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -204,4 +204,27 @@ class EncrypterTest extends TestCase
         $this->assertTrue(Encrypter::supported($key, 'aes-128-CBC'));
         $this->assertTrue(Encrypter::supported($key, 'aes-128-cbc'));
     }
+
+    public function provideTamperedData()
+    {
+        return [
+            [['iv' => ['value_in_array'], 'value' => '', 'mac' => '']],
+            [['iv' => '', 'value' => '', 'mac' => '']],
+            [['iv' => '', 'value' => ['value_in_array'], 'mac' => '']],
+            [['iv' => '', 'value' => '', 'mac' => ['value_in_array']]],
+            [['iv' => '', 'value' => '', 'mac' => ['value_in_array'], 'tag' => ['value_in_array']]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTamperedData
+     */
+    public function testTamperedPayloadWillGetRejected($payload)
+    {
+        $this->expectException(DecryptException::class);
+        $this->expectExceptionMessage('The payload is invalid.');
+
+        $enc = new Encrypter(str_repeat('x', 16));
+        $enc->decrypt(base64_encode(json_encode($payload)));
+    }
 }


### PR DESCRIPTION
Dear maintainers,

we have faced several errors, while receiving seemingly malicious requests with tampered cookie data. 
`ErrorException: hash_equals(): Expected user_string to be a string, array given`
`ErrorException: base64_decode() expects parameter 1 to be string, array given`
`ErrorException: Array to string conversion`

After investigation, we came to a conclusion, that the validation of encrypted payload is insufficient, i.e. not checking if the value is scalar. In this PR I have extended the validation and added a test to cover the case.

As per requirement I send the PR to 9.x branch, but I would greatly appreciate it the fix would be backported to version 8.x. I can not estimate if this poses a significant security threat, yet I am concerned, that this behavior can be abused in some way.