### PR TITLE
[10.x] Process DX Layer

### DIFF
--- a/src/Illuminate/Console/Contracts/ProcessResult.php
+++ b/src/Illuminate/Console/Contracts/ProcessResult.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Console\Contracts;
+
+interface ProcessResult
+{
+    /**
+     * Get the original command executed by the process.
+     *
+     * @return string
+     */
+    public function command();
+
+    /**
+     * Determine if the process was successful.
+     *
+     * @return bool
+     */
+    public function successful();
+
+    /**
+     * Get the exit code of the process.
+     *
+     * @return int
+     */
+    public function exitCode();
+
+    /**
+     * Get the standard output of the process.
+     *
+     * @return string
+     */
+    public function output();
+
+    /**
+     * Get the error output of the process.
+     *
+     * @return string
+     */
+    public function errorOutput();
+
+    /**
+     * Throw an exception if the process failed.
+     *
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function throw($callback = null);
+
+    /**
+     * Throw an exception if the process failed and the given condition is true.
+     *
+     * @param  bool  $condition
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function throwIf($condition, $callback = null);
+}

--- a/src/Illuminate/Console/Process/Exceptions/ProcessFailedException.php
+++ b/src/Illuminate/Console/Process/Exceptions/ProcessFailedException.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Console\Process\Exceptions;
 
-use Illuminate\Console\Contracts\ProcessResult;
+use Illuminate\Contracts\Console\Process\ProcessResult;
 use Symfony\Component\Console\Exception\RuntimeException;
 
 class ProcessFailedException extends RuntimeException
@@ -10,14 +10,14 @@ class ProcessFailedException extends RuntimeException
     /**
      * The process result instance.
      *
-     * @var \Illuminate\Console\Contracts\ProcessResult
+     * @var \Illuminate\Contracts\Console\Process\ProcessResult
      */
     public $result;
 
     /**
      * Create a new exception instance.
      *
-     * @param  \Illuminate\Console\Contracts\ProcessResult  $result
+     * @param  \Illuminate\Contracts\Console\Process\ProcessResult  $result
      * @return void
      */
     public function __construct(ProcessResult $result)

--- a/src/Illuminate/Console/Process/Exceptions/ProcessFailedException.php
+++ b/src/Illuminate/Console/Process/Exceptions/ProcessFailedException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Console\Process\Exceptions;
+
+use Illuminate\Console\Contracts\ProcessResult;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+class ProcessFailedException extends RuntimeException
+{
+    /**
+     * The process result instance.
+     *
+     * @var \Illuminate\Console\Contracts\ProcessResult
+     */
+    public $result;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  \Illuminate\Console\Contracts\ProcessResult  $result
+     * @return void
+     */
+    public function __construct(ProcessResult $result)
+    {
+        $this->result = $result;
+
+        parent::__construct(
+            sprintf('The process "%s" failed.', $result->command()),
+            $result->exitCode() ?? 1,
+        );
+    }
+}

--- a/src/Illuminate/Console/Process/Exceptions/ProcessTimedOutException.php
+++ b/src/Illuminate/Console/Process/Exceptions/ProcessTimedOutException.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Console\Process\Exceptions;
 
-use Illuminate\Console\Contracts\ProcessResult;
+use Illuminate\Contracts\Console\Process\ProcessResult;
 use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyTimeoutException;
 use Symfony\Component\Process\Exception\RuntimeException;
 
@@ -11,7 +11,7 @@ class ProcessTimedOutException extends RuntimeException
     /**
      * The process result instance.
      *
-     * @var \Illuminate\Console\Contracts\ProcessResult
+     * @var \Illuminate\Contracts\Console\Process\ProcessResult
      */
     public $result;
 
@@ -19,7 +19,7 @@ class ProcessTimedOutException extends RuntimeException
      * Create a new exception instance.
      *
      * @param  \Symfony\Component\Process\Exception\ProcessTimedOutException  $original
-     * @param  \Illuminate\Console\Contracts\ProcessResult  $result
+     * @param  \Illuminate\Contracts\Console\Process\ProcessResult  $result
      * @return void
      */
     public function __construct(SymfonyTimeoutException $original, ProcessResult $result)

--- a/src/Illuminate/Console/Process/Exceptions/ProcessTimedOutException.php
+++ b/src/Illuminate/Console/Process/Exceptions/ProcessTimedOutException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Console\Process\Exceptions;
+
+use Illuminate\Console\Contracts\ProcessResult;
+use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyTimeoutException;
+use Symfony\Component\Process\Exception\RuntimeException;
+
+class ProcessTimedOutException extends RuntimeException
+{
+    /**
+     * The process result instance.
+     *
+     * @var \Illuminate\Console\Contracts\ProcessResult
+     */
+    public $result;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  \Symfony\Component\Process\Exception\ProcessTimedOutException  $original
+     * @param  \Illuminate\Console\Contracts\ProcessResult  $result
+     * @return void
+     */
+    public function __construct(SymfonyTimeoutException $original, ProcessResult $result)
+    {
+        $this->result = $result;
+
+        parent::__construct($original->getMessage(), $original->getCode(), $original);
+    }
+}

--- a/src/Illuminate/Console/Process/Factory.php
+++ b/src/Illuminate/Console/Process/Factory.php
@@ -44,12 +44,12 @@ class Factory
     /**
      * Create a new fake process response for testing purposes.
      *
-     * @param  string  $output
-     * @param  string  $errorOutput
+     * @param  array|string  $output
+     * @param  array|string  $errorOutput
      * @param  int  $exitCode
      * @return \Illuminate\Console\Process\FakeProcessResult
      */
-    public function result(string $output = '', string $errorOutput = '', int $exitCode = 0)
+    public function result(array|string $output = '', array|string $errorOutput = '', int $exitCode = 0)
     {
         return new FakeProcessResult(
             output: $output,
@@ -66,6 +66,17 @@ class Factory
     public function describe()
     {
         return new FakeProcessDescription;
+    }
+
+    /**
+     * Begin describing a fake process sequence.
+     *
+     * @param  array  $processes
+     * @return \Illuminate\Console\Process\FakeProcessSequence
+     */
+    public function sequence(array $processes = [])
+    {
+        return new FakeProcessSequence($processes);
     }
 
     /**

--- a/src/Illuminate/Console/Process/Factory.php
+++ b/src/Illuminate/Console/Process/Factory.php
@@ -185,7 +185,7 @@ class Factory
             collect($this->recorded)->filter(function ($pair) use ($callback) {
                 return $callback($pair[0], $pair[1]);
             })->count() > 0,
-            'An expected external process was not invoked.'
+            'An expected process was not invoked.'
         );
 
         return $this;
@@ -222,7 +222,7 @@ class Factory
             collect($this->recorded)->filter(function ($pair) use ($callback) {
                 return $callback($pair[0], $pair[1]);
             })->count() === 0,
-            'An unexpected external process was invoked.'
+            'An unexpected process was invoked.'
         );
 
         return $this;
@@ -237,7 +237,7 @@ class Factory
     {
         PHPUnit::assertEmpty(
             $this->recorded,
-            'An unexpected external process was invoked.'
+            'An unexpected process was invoked.'
         );
 
         return $this;

--- a/src/Illuminate/Console/Process/Factory.php
+++ b/src/Illuminate/Console/Process/Factory.php
@@ -49,7 +49,7 @@ class Factory
      * @param  int  $exitCode
      * @return \Illuminate\Console\Process\FakeProcessResult
      */
-    public function result($output = '', $errorOutput = '', $exitCode = 0)
+    public function result(string $output = '', string $errorOutput = '', int $exitCode = 0)
     {
         return new FakeProcessResult(
             output: $output,
@@ -145,7 +145,7 @@ class Factory
      * @param  bool  $prevent
      * @return $this
      */
-    public function preventStrayProcesses($prevent = true)
+    public function preventStrayProcesses(bool $prevent = true)
     {
         $this->preventStrayProcesses = $prevent;
 
@@ -178,6 +178,25 @@ class Factory
         );
 
         return $this;
+    }
+
+    /**
+     * Assert that a process was recorded a given number of times matching a given truth test.
+     *
+     * @param  \Closure  $callback
+     * @param  int  $times
+     * @return $this
+     */
+    public function assertRanTimes(Closure $callback, int $times = 1)
+    {
+        $count = collect($this->recorded)->filter(function ($pair) use ($callback) {
+            return $callback($pair[0], $pair[1]);
+        })->count();
+
+        PHPUnit::assertSame(
+            $times, $count,
+            "An expected process ran {$count} times instead of {$times} times."
+        );
     }
 
     /**
@@ -219,7 +238,7 @@ class Factory
      * @param  callable  $callback
      * @return \Illuminate\Console\Process\Pool
      */
-    public function pool($callback)
+    public function pool(callable $callback)
     {
         return new Pool($this, $callback);
     }

--- a/src/Illuminate/Console/Process/Factory.php
+++ b/src/Illuminate/Console/Process/Factory.php
@@ -244,7 +244,7 @@ class Factory
     }
 
     /**
-     * Start a pool of processes and wait for them to finish executing.
+     * Start defining a pool of processes.
      *
      * @param  callable  $callback
      * @return \Illuminate\Console\Process\Pool
@@ -252,6 +252,18 @@ class Factory
     public function pool(callable $callback)
     {
         return new Pool($this, $callback);
+    }
+
+    /**
+     * Run a pool of processes and wait for them to finish executing.
+     *
+     * @param  callable  $callback
+     * @param  callable|null  $output
+     * @return \Illuminate\Console\Process\ProcessPoolResults
+     */
+    public function concurrently(callable $callback, ?callable $output)
+    {
+        return (new Pool($this, $callback))->start($output)->wait();
     }
 
     /**

--- a/src/Illuminate/Console/Process/Factory.php
+++ b/src/Illuminate/Console/Process/Factory.php
@@ -214,11 +214,22 @@ class Factory
     }
 
     /**
+     * Start a pool of processes and wait for them to finish executing.
+     *
+     * @param  callable  $callback
+     * @return \Illuminate\Console\Process\Pool
+     */
+    public function pool($callback)
+    {
+        return new Pool($this, $callback);
+    }
+
+    /**
      * Create a new pending process associated with this factory.
      *
      * @return \Illuminate\Console\Process\PendingProcess
      */
-    protected function newPendingProcess()
+    public function newPendingProcess()
     {
         return (new PendingProcess($this))->withFakeHandlers($this->fakeHandlers);
     }

--- a/src/Illuminate/Console/Process/Factory.php
+++ b/src/Illuminate/Console/Process/Factory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+class Factory
+{
+    /**
+     * Create a new pending process associated with this factory.
+     *
+     * @return \Illuminate\Console\Process\PendingProcess
+     */
+    protected function newPendingProcess()
+    {
+        return new PendingProcess($this);
+    }
+
+    /**
+     * Dynamically proxy methods to a new pending process instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->newPendingProcess()->{$method}(...$parameters);
+    }
+}

--- a/src/Illuminate/Console/Process/Factory.php
+++ b/src/Illuminate/Console/Process/Factory.php
@@ -2,8 +2,78 @@
 
 namespace Illuminate\Console\Process;
 
+use Closure;
+use Illuminate\Support\Traits\Macroable;
+
 class Factory
 {
+    use Macroable {
+        __call as macroCall;
+    }
+
+    /**
+     * The registered fake handler callbacks.
+     *
+     * @var array
+     */
+    protected $fakeHandlers = [];
+
+    /**
+     * Create a new fake process response for testing purposes.
+     *
+     * @param  string  $output
+     * @param  string  $errorOutput
+     * @param  int  $exitCode
+     * @return \Illuminate\Console\Process\FakeProcessResult
+     */
+    public function result($output = '', $errorOutput = '', $exitCode = 0)
+    {
+        return new FakeProcessResult(
+            output: $output,
+            errorOutput: $errorOutput,
+            exitCode: $exitCode,
+        );
+    }
+
+    /**
+     * Begin describing a fake process lifecycle.
+     *
+     * @return \Illuminate\Console\Process\FakeProcessDescription
+     */
+    public function describe()
+    {
+        return new FakeProcessDescription;
+    }
+
+    /**
+     * Indicate that the process factory should fake processes.
+     *
+     * @param  \Closure|array|null  $callback
+     * @return $this
+     */
+    public function fake(Closure|array $callback = null)
+    {
+        if (is_null($callback)) {
+            $this->fakeHandlers = ['*' => fn () => new FakeProcessResult];
+
+            return $this;
+        }
+
+        if ($callback instanceof Closure) {
+            $this->fakeHandlers = ['*' => $callback];
+
+            return $this;
+        }
+
+        foreach ($callback as $command => $handler) {
+            $this->fakeHandlers[is_numeric($command) ? '*' : $command] = $handler instanceof Closure
+                    ? $handler
+                    : fn () => $handler;
+        }
+
+        return $this;
+    }
+
     /**
      * Create a new pending process associated with this factory.
      *
@@ -11,7 +81,7 @@ class Factory
      */
     protected function newPendingProcess()
     {
-        return new PendingProcess($this);
+        return (new PendingProcess($this))->withFakeHandlers($this->fakeHandlers);
     }
 
     /**
@@ -23,6 +93,10 @@ class Factory
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         return $this->newPendingProcess()->{$method}(...$parameters);
     }
 }

--- a/src/Illuminate/Console/Process/Factory.php
+++ b/src/Illuminate/Console/Process/Factory.php
@@ -99,29 +99,6 @@ class Factory
     }
 
     /**
-     * Indicate that an exception should be thrown if any process is not faked.
-     *
-     * @param  bool  $prevent
-     * @return $this
-     */
-    public function preventStrayProcesses($prevent = true)
-    {
-        $this->preventStrayProcesses = $prevent;
-
-        return $this;
-    }
-
-    /**
-     * Determine if stray processes are being prevented.
-     *
-     * @return bool
-     */
-    public function preventingStrayProcesses()
-    {
-        return $this->preventStrayProcesses;
-    }
-
-    /**
      * Determine if the process factory has fake process handlers and is recording processes.
      *
      * @return bool
@@ -157,6 +134,29 @@ class Factory
         $this->recorded[] = $process;
 
         return $this;
+    }
+
+    /**
+     * Indicate that an exception should be thrown if any process is not faked.
+     *
+     * @param  bool  $prevent
+     * @return $this
+     */
+    public function preventStrayProcesses($prevent = true)
+    {
+        $this->preventStrayProcesses = $prevent;
+
+        return $this;
+    }
+
+    /**
+     * Determine if stray processes are being prevented.
+     *
+     * @return bool
+     */
+    public function preventingStrayProcesses()
+    {
+        return $this->preventStrayProcesses;
     }
 
     /**

--- a/src/Illuminate/Console/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Console/Process/FakeInvokedProcess.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Console\Process;
 
-use Illuminate\Console\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Contracts\Console\Process\InvokedProcess as InvokedProcessContract;
-use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyTimeoutException;
 use Symfony\Component\Process\Process;
 
 class FakeInvokedProcess implements InvokedProcessContract

--- a/src/Illuminate/Console/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Console/Process/FakeInvokedProcess.php
@@ -123,7 +123,8 @@ class FakeInvokedProcess implements InvokedProcessContract
                 : $this->remainingRunIterations;
 
         if ($this->remainingRunIterations === 0) {
-            while ($this->invokeOutputHandlerWithNextLineOfOutput()) {}
+            while ($this->invokeOutputHandlerWithNextLineOfOutput()) {
+            }
 
             return false;
         }
@@ -181,7 +182,6 @@ class FakeInvokedProcess implements InvokedProcessContract
         for ($i = $this->nextOutputIndex; $i < $outputCount; $i++) {
             if ($this->process->output[$i]['type'] === 'out') {
                 $output = $this->process->output[$i]['buffer'];
-
                 $this->nextOutputIndex = $i + 1;
 
                 break;
@@ -190,7 +190,7 @@ class FakeInvokedProcess implements InvokedProcessContract
             $this->nextOutputIndex = $i + 1;
         }
 
-        return $output ?? '';
+        return isset($output) ? $output : '';
     }
 
     /**
@@ -205,7 +205,6 @@ class FakeInvokedProcess implements InvokedProcessContract
         for ($i = $this->nextErrorOutputIndex; $i < $outputCount; $i++) {
             if ($this->process->output[$i]['type'] === 'err') {
                 $output = $this->process->output[$i]['buffer'];
-
                 $this->nextErrorOutputIndex = $i + 1;
 
                 break;
@@ -214,7 +213,7 @@ class FakeInvokedProcess implements InvokedProcessContract
             $this->nextErrorOutputIndex = $i + 1;
         }
 
-        return $output ?? '';
+        return isset($output) ? $output : '';
     }
 
     /**
@@ -233,7 +232,9 @@ class FakeInvokedProcess implements InvokedProcessContract
             return $this->predictProcessResult();
         }
 
-        while ($this->invokeOutputHandlerWithNextLineOfOutput()) {}
+        while ($this->invokeOutputHandlerWithNextLineOfOutput()) {
+            //
+        }
 
         $this->remainingRunIterations = 0;
 
@@ -249,7 +250,7 @@ class FakeInvokedProcess implements InvokedProcessContract
     public function waitUntil(callable $until)
     {
         while ($currentOutput = $this->invokeOutputHandlerWithNextLineOfOutput()) {
-            if ($until(...$currentOutput)) {
+            if ($until($currentOutput['type'], $currentOutput['buffer'])) {
                 return $this;
             }
         }

--- a/src/Illuminate/Console/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Console/Process/FakeInvokedProcess.php
@@ -242,27 +242,6 @@ class FakeInvokedProcess implements InvokedProcessContract
     }
 
     /**
-     * Wait for some given output from the process.
-     *
-     * @param  callable  $until
-     * @return $this
-     */
-    public function waitUntil(callable $until)
-    {
-        while ($currentOutput = $this->invokeOutputHandlerWithNextLineOfOutput()) {
-            if ($until($currentOutput['type'], $currentOutput['buffer'])) {
-                return $this;
-            }
-        }
-
-        // This process would essentially be running forever; therefore, throw...
-        throw new ProcessTimedOutException(
-            new SymfonyTimeoutException($this->process->toSymfonyProcess($this->command), 1),
-            $this->process->toProcessResult($this->command),
-        );
-    }
-
-    /**
      * Get the ultimate process result that wil be returned by this "process".
      *
      * @return \Illuminate\Contracts\Console\Process\ProcessResult

--- a/src/Illuminate/Console/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Console/Process/FakeInvokedProcess.php
@@ -223,7 +223,7 @@ class FakeInvokedProcess implements InvokedProcessContract
      * @param  callable|null  $output
      * @return \Illuminate\Console\Process\ProcessResult
      */
-    public function wait($output = null)
+    public function wait(callable $output = null)
     {
         $this->outputHandler = $output ?: $this->outputHandler;
 
@@ -246,7 +246,7 @@ class FakeInvokedProcess implements InvokedProcessContract
      * @param  callable  $until
      * @return $this
      */
-    public function waitUntil($until)
+    public function waitUntil(callable $until)
     {
         while ($currentOutput = $this->invokeOutputHandlerWithNextLineOfOutput()) {
             if ($until(...$currentOutput)) {
@@ -277,7 +277,7 @@ class FakeInvokedProcess implements InvokedProcessContract
      * @param  callable|null  $output
      * @return $this
      */
-    public function withOutputHandler($outputHandler)
+    public function withOutputHandler(?callable $outputHandler)
     {
         $this->outputHandler = $outputHandler;
 

--- a/src/Illuminate/Console/Process/FakeInvokedProcess.php
+++ b/src/Illuminate/Console/Process/FakeInvokedProcess.php
@@ -171,6 +171,46 @@ class FakeInvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Get the standard output for the process.
+     *
+     * @return string
+     */
+    public function output()
+    {
+        $this->latestOutput();
+
+        $output = [];
+
+        for ($i = 0; $i < $this->nextOutputIndex; $i++) {
+            if ($this->process->output[$i]['type'] === 'out') {
+                $output[] = $this->process->output[$i]['buffer'];
+            }
+        }
+
+        return rtrim(implode('', $output), "\n")."\n";
+    }
+
+    /**
+     * Get the error output for the process.
+     *
+     * @return string
+     */
+    public function errorOutput()
+    {
+        $this->latestErrorOutput();
+
+        $output = [];
+
+        for ($i = 0; $i < $this->nextErrorOutputIndex; $i++) {
+            if ($this->process->output[$i]['type'] === 'err') {
+                $output[] = $this->process->output[$i]['buffer'];
+            }
+        }
+
+        return rtrim(implode('', $output), "\n")."\n";
+    }
+
+    /**
      * Get the latest standard output for the process.
      *
      * @return string

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -61,9 +61,7 @@ class FakeProcessDescription
             return $this;
         }
 
-        if (strlen($output) > 0) {
-            $this->output[] = ['type' => 'out', 'buffer' => rtrim($output, "\n")."\n"];
-        }
+        $this->output[] = ['type' => 'out', 'buffer' => rtrim($output, "\n")."\n"];
 
         return $this;
     }
@@ -82,8 +80,40 @@ class FakeProcessDescription
             return $this;
         }
 
+        $this->output[] = ['type' => 'err', 'buffer' => rtrim($output, "\n")."\n"];
+
+        return $this;
+    }
+
+    /**
+     * Replace the entire output buffer with the given string.
+     *
+     * @param  string  $output
+     * @return $this
+     */
+    public function replaceOutput(string $output)
+    {
         if (strlen($output) > 0) {
-            $this->output[] = ['type' => 'err', 'buffer' => rtrim($output, "\n")."\n"];
+            $this->output = [
+                ['type' => 'out', 'buffer' => rtrim($output, "\n")."\n"],
+            ];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Replace the entire error output buffer with the given string.
+     *
+     * @param  string  $output
+     * @return $this
+     */
+    public function replaceErrorOutput(string $output)
+    {
+        if (strlen($output) > 0) {
+            $this->output = [
+                ['type' => 'err', 'buffer' => rtrim($output, "\n")."\n"],
+            ];
         }
 
         return $this;

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -93,9 +93,14 @@ class FakeProcessDescription
      */
     public function replaceOutput(string $output)
     {
+        $this->output = collect($this->output)->reject(function ($output) {
+            return $output['type'] === 'out';
+        })->values()->all();
+
         if (strlen($output) > 0) {
-            $this->output = [
-                ['type' => 'out', 'buffer' => rtrim($output, "\n")."\n"],
+            $this->output[] = [
+                'type' => 'out',
+                'buffer' => rtrim($output, "\n")."\n"
             ];
         }
 
@@ -110,9 +115,14 @@ class FakeProcessDescription
      */
     public function replaceErrorOutput(string $output)
     {
+        $this->output = collect($this->output)->reject(function ($output) {
+            return $output['type'] === 'err';
+        })->values()->all();
+
         if (strlen($output) > 0) {
-            $this->output = [
-                ['type' => 'err', 'buffer' => rtrim($output, "\n")."\n"],
+            $this->output[] = [
+                'type' => 'err',
+                'buffer' => rtrim($output, "\n")."\n"
             ];
         }
 

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -61,7 +61,9 @@ class FakeProcessDescription
             return $this;
         }
 
-        $this->output[] = ['type' => 'out', 'buffer' => rtrim($output, "\n")."\n"];
+        if (strlen($output) > 0) {
+            $this->output[] = ['type' => 'out', 'buffer' => rtrim($output, "\n")."\n"];
+        }
 
         return $this;
     }

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -50,12 +50,18 @@ class FakeProcessDescription
     /**
      * Describe a line of standard output.
      *
-     * @param  string  $output
+     * @param  array|string  $output
      * @return $this
      */
-    public function output(string $output)
+    public function output(array|string $output)
     {
-        $this->output[] = ['type' => 'out', 'buffer' => $output];
+        if (is_array($output)) {
+            collect($output)->each(fn ($line) => $this->output($line));
+
+            return $this;
+        }
+
+        $this->output[] = ['type' => 'out', 'buffer' => $output."\n"];
 
         return $this;
     }
@@ -63,12 +69,18 @@ class FakeProcessDescription
     /**
      * Describe a line of error output.
      *
-     * @param  string  $output
+     * @param  array|string  $output
      * @return $this
      */
-    public function errorOutput(string $output)
+    public function errorOutput(array|string $output)
     {
-        $this->output[] = ['type' => 'err', 'buffer' => $output];
+        if (is_array($output)) {
+            collect($output)->each(fn ($line) => $this->errorOutput($line));
+
+            return $this;
+        }
+
+        $this->output[] = ['type' => 'err', 'buffer' => $output."\n"];
 
         return $this;
     }
@@ -133,11 +145,11 @@ class FakeProcessDescription
      */
     protected function resolveOutput()
     {
-        return collect($this->output)
+        return rtrim(collect($this->output)
                 ->filter(fn ($output) => $output['type'] === 'out')
                 ->map
                 ->buffer
-                ->implode("\n");
+                ->implode(""), "\n")."\n";
     }
 
     /**
@@ -147,10 +159,10 @@ class FakeProcessDescription
      */
     protected function resolveErrorOutput()
     {
-        return collect($this->output)
+        return rtrim(collect($this->output)
                 ->filter(fn ($output) => $output['type'] === 'err')
                 ->map
                 ->buffer
-                ->implode("\n");
+                ->implode(""), "\n")."\n";
     }
 }

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -100,7 +100,7 @@ class FakeProcessDescription
         if (strlen($output) > 0) {
             $this->output[] = [
                 'type' => 'out',
-                'buffer' => rtrim($output, "\n")."\n"
+                'buffer' => rtrim($output, "\n")."\n",
             ];
         }
 
@@ -122,7 +122,7 @@ class FakeProcessDescription
         if (strlen($output) > 0) {
             $this->output[] = [
                 'type' => 'err',
-                'buffer' => rtrim($output, "\n")."\n"
+                'buffer' => rtrim($output, "\n")."\n",
             ];
         }
 
@@ -193,7 +193,7 @@ class FakeProcessDescription
             ->filter(fn ($output) => $output['type'] === 'out');
 
         return $output->isNotEmpty()
-                    ? rtrim($output->map->buffer->implode(""), "\n")."\n"
+                    ? rtrim($output->map->buffer->implode(''), "\n")."\n"
                     : '';
     }
 
@@ -208,7 +208,7 @@ class FakeProcessDescription
             ->filter(fn ($output) => $output['type'] === 'err');
 
         return $output->isNotEmpty()
-                    ? rtrim($output->map->buffer->implode(""), "\n")."\n"
+                    ? rtrim($output->map->buffer->implode(''), "\n")."\n"
                     : '';
     }
 }

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+use Symfony\Component\Process\Process;
+
+class FakeProcessDescription
+{
+    /**
+     * The process' ID.
+     *
+     * @var int|null
+     */
+    public $processId = 1000;
+
+    /**
+     * All of the process' output in the order it was described.
+     *
+     * @var array
+     */
+    public $output = [];
+
+    /**
+     * The process' exit code.
+     *
+     * @var int
+     */
+    public $exitCode = 0;
+
+    /**
+     * The current output's index.
+     *
+     * @var int
+     */
+    protected $lastOutputIndex = 0;
+
+    /**
+     * The current error output's index.
+     *
+     * @var int
+     */
+    protected $lastErrorOutputIndex = 0;
+
+    /**
+     * Specify the process ID that should be assigned to the process.
+     *
+     * @param  int  $processId
+     * @return $this
+     */
+    public function id(int $processId)
+    {
+        $this->processId = $processId;
+
+        return $this;
+    }
+
+    /**
+     * Describe a line of standard output.
+     *
+     * @param  string  $output
+     * @return $this
+     */
+    public function output(string $output)
+    {
+        $this->output[] = ['type' => 'out', 'buffer' => $output];
+
+        return $this;
+    }
+
+    /**
+     * Describe a line of error output.
+     *
+     * @param  string  $output
+     * @return $this
+     */
+    public function errorOutput(string $output)
+    {
+        $this->output[] = ['type' => 'err', 'buffer' => $output];
+
+        return $this;
+    }
+
+    /**
+     * Specify the process exit code.
+     *
+     * @param  int  $exitCode
+     * @return $this
+     */
+    public function exitCode(int $exitCode)
+    {
+        $this->exitCode = $exitCode;
+
+        return $this;
+    }
+
+    /**
+     * Get the next output for the process.
+     *
+     * @return string
+     */
+    public function getIncrementalOutput()
+    {
+        $outputCount = count($this->output);
+
+        for ($i = $this->lastOutputIndex; $i < $outputCount; $i++) {
+            if ($this->output[$i]['type'] === 'out') {
+                $output = $this->output[$i]['buffer'];
+
+                $this->lastOutputIndex = $i;
+
+                break;
+            }
+
+            $this->lastOutputIndex = $i;
+        }
+
+        return $output ?? '';
+    }
+
+    /**
+     * Get the next error output for the process.
+     *
+     * @return string
+     */
+    public function getIncrementalErrorOutput()
+    {
+        $outputCount = count($this->output);
+
+        for ($i = $this->lastErrorOutputIndex; $i < $outputCount; $i++) {
+            if ($this->output[$i]['type'] === 'err') {
+                $output = $this->output[$i]['buffer'];
+
+                $this->lastErrorOutputIndex = $i;
+
+                break;
+            }
+
+            $this->lastErrorOutputIndex = $i;
+        }
+
+        return $output ?? '';
+    }
+
+    /**
+     * Reset the incremental output.
+     *
+     * @return $this
+     */
+    public function resetIncrementalOutput()
+    {
+        $this->lastOutputIndex = 0;
+        $this->lastErrorOutputIndex = 0;
+
+        return $this;
+    }
+
+    /**
+     * Turn the fake process description into an actual process.
+     *
+     * @param  string  $command
+     * @return \Symfony\Component\Process\Process
+     */
+    public function toSymfonyProcess(string $command)
+    {
+        return Process::fromShellCommandline($command);
+    }
+
+    /**
+     * Conver the process description into a process result.
+     *
+     * @param  string  $command
+     * @return \Illuminate\Contracts\Console\Process\ProcessResult
+     */
+    public function toProcessResult(string $command)
+    {
+        return new FakeProcessResult(
+            command: $command,
+            exitCode: $this->exitCode,
+            output: $this->resolveOutput(),
+            errorOutput: $this->resolveErrorOutput(),
+        );
+    }
+
+    /**
+     * Resolve the standard output as a string.
+     *
+     * @return string
+     */
+    protected function resolveOutput()
+    {
+        return collect($this->output)
+                ->filter(fn ($output) => $output['type'] === 'out')
+                ->map
+                ->buffer
+                ->implode("\n");
+    }
+
+    /**
+     * Resolve the error output as a string.
+     *
+     * @return string
+     */
+    protected function resolveErrorOutput()
+    {
+        return collect($this->output)
+                ->filter(fn ($output) => $output['type'] === 'err')
+                ->map
+                ->buffer
+                ->implode("\n");
+    }
+}

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -28,18 +28,11 @@ class FakeProcessDescription
     public $exitCode = 0;
 
     /**
-     * The current output's index.
+     * The number of times the process should indicate that it is "running".
      *
      * @var int
      */
-    protected $lastOutputIndex = 0;
-
-    /**
-     * The current error output's index.
-     *
-     * @var int
-     */
-    protected $lastErrorOutputIndex = 0;
+    public $runIterations = 0;
 
     /**
      * Specify the process ID that should be assigned to the process.
@@ -94,62 +87,14 @@ class FakeProcessDescription
     }
 
     /**
-     * Get the next output for the process.
+     * Specify how many times the "isRunning" method should return "true".
      *
-     * @return string
-     */
-    public function getIncrementalOutput()
-    {
-        $outputCount = count($this->output);
-
-        for ($i = $this->lastOutputIndex; $i < $outputCount; $i++) {
-            if ($this->output[$i]['type'] === 'out') {
-                $output = $this->output[$i]['buffer'];
-
-                $this->lastOutputIndex = $i;
-
-                break;
-            }
-
-            $this->lastOutputIndex = $i;
-        }
-
-        return $output ?? '';
-    }
-
-    /**
-     * Get the next error output for the process.
-     *
-     * @return string
-     */
-    public function getIncrementalErrorOutput()
-    {
-        $outputCount = count($this->output);
-
-        for ($i = $this->lastErrorOutputIndex; $i < $outputCount; $i++) {
-            if ($this->output[$i]['type'] === 'err') {
-                $output = $this->output[$i]['buffer'];
-
-                $this->lastErrorOutputIndex = $i;
-
-                break;
-            }
-
-            $this->lastErrorOutputIndex = $i;
-        }
-
-        return $output ?? '';
-    }
-
-    /**
-     * Reset the incremental output.
-     *
+     * @param  int  $iterations
      * @return $this
      */
-    public function resetIncrementalOutput()
+    public function runsFor(int $iterations)
     {
-        $this->lastOutputIndex = 0;
-        $this->lastErrorOutputIndex = 0;
+        $this->runIterations = $iterations;
 
         return $this;
     }

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -61,7 +61,7 @@ class FakeProcessDescription
             return $this;
         }
 
-        $this->output[] = ['type' => 'out', 'buffer' => $output."\n"];
+        $this->output[] = ['type' => 'out', 'buffer' => rtrim($output, "\n")."\n"];
 
         return $this;
     }
@@ -80,7 +80,9 @@ class FakeProcessDescription
             return $this;
         }
 
-        $this->output[] = ['type' => 'err', 'buffer' => $output."\n"];
+        if (strlen($output) > 0) {
+            $this->output[] = ['type' => 'err', 'buffer' => rtrim($output, "\n")."\n"];
+        }
 
         return $this;
     }
@@ -145,11 +147,12 @@ class FakeProcessDescription
      */
     protected function resolveOutput()
     {
-        return rtrim(collect($this->output)
-                ->filter(fn ($output) => $output['type'] === 'out')
-                ->map
-                ->buffer
-                ->implode(""), "\n")."\n";
+        $output = collect($this->output)
+            ->filter(fn ($output) => $output['type'] === 'out');
+
+        return $output->isNotEmpty()
+                    ? rtrim($output->map->buffer->implode(""), "\n")."\n"
+                    : '';
     }
 
     /**
@@ -159,10 +162,11 @@ class FakeProcessDescription
      */
     protected function resolveErrorOutput()
     {
-        return rtrim(collect($this->output)
-                ->filter(fn ($output) => $output['type'] === 'err')
-                ->map
-                ->buffer
-                ->implode(""), "\n")."\n";
+        $output = collect($this->output)
+            ->filter(fn ($output) => $output['type'] === 'err');
+
+        return $output->isNotEmpty()
+                    ? rtrim($output->map->buffer->implode(""), "\n")."\n"
+                    : '';
     }
 }

--- a/src/Illuminate/Console/Process/FakeProcessDescription.php
+++ b/src/Illuminate/Console/Process/FakeProcessDescription.php
@@ -148,6 +148,17 @@ class FakeProcessDescription
      * @param  int  $iterations
      * @return $this
      */
+    public function iterations(int $iterations)
+    {
+        return $this->runsFor(iterations: $iterations);
+    }
+
+    /**
+     * Specify how many times the "isRunning" method should return "true".
+     *
+     * @param  int  $iterations
+     * @return $this
+     */
     public function runsFor(int $iterations)
     {
         $this->runIterations = $iterations;

--- a/src/Illuminate/Console/Process/FakeProcessResult.php
+++ b/src/Illuminate/Console/Process/FakeProcessResult.php
@@ -69,7 +69,7 @@ class FakeProcessResult implements ProcessResultContract
             return rtrim(
                 collect($output)
                     ->map(fn ($line) => rtrim($line, "\n")."\n")
-                    ->implode(""),
+                    ->implode(''),
                 "\n"
             );
         }

--- a/src/Illuminate/Console/Process/FakeProcessResult.php
+++ b/src/Illuminate/Console/Process/FakeProcessResult.php
@@ -2,28 +2,55 @@
 
 namespace Illuminate\Console\Process;
 
-use Illuminate\Contracts\Console\Process\ProcessResult as ProcessResultContract;
 use Illuminate\Console\Process\Exceptions\ProcessFailedException;
+use Illuminate\Contracts\Console\Process\ProcessResult as ProcessResultContract;
 use Symfony\Component\Process\Process;
 
-class ProcessResult implements ProcessResultContract
+class FakeProcessResult implements ProcessResultContract
 {
     /**
-     * The underlying process instance.
+     * The command string.
      *
-     * @var \Symfony\Component\Process\Process
+     * @var string
      */
-    protected $process;
+    protected $command;
+
+    /**
+     * The process exit code.
+     *
+     * @var int
+     */
+    protected $exitCode;
+
+    /**
+     * The process output.
+     *
+     * @var string
+     */
+    protected $output;
+
+    /**
+     * The process error output.
+     *
+     * @var string
+     */
+    protected $errorOutput;
 
     /**
      * Create a new process result instance.
      *
-     * @param  \Symfony\Component\Process\Process  $process
+     * @param  string  $command
+     * @param  int  $exitCode
+     * @param  string  $output
+     * @param  string  $errorOutput
      * @return void
      */
-    public function __construct(Process $process)
+    public function __construct(string $command = '', int $exitCode = 0, string $output = '', string $errorOutput = '')
     {
-        $this->process = $process;
+        $this->command = $command;
+        $this->exitCode = $exitCode;
+        $this->output = $output;
+        $this->errorOutput = $errorOutput;
     }
 
     /**
@@ -33,7 +60,18 @@ class ProcessResult implements ProcessResultContract
      */
     public function command()
     {
-        return $this->process->getCommandLine();
+        return $this->command;
+    }
+
+    /**
+     * Create a new fake process result with the given command.
+     *
+     * @param  string  $command
+     * @return self
+     */
+    public function withCommand(string $command)
+    {
+        return new FakeProcessResult($command, $this->exitCode, $this->output, $this->errorOutput);
     }
 
     /**
@@ -43,7 +81,7 @@ class ProcessResult implements ProcessResultContract
      */
     public function successful()
     {
-        return $this->process->isSuccessful();
+        return $this->exitCode === 0;
     }
 
     /**
@@ -63,7 +101,7 @@ class ProcessResult implements ProcessResultContract
      */
     public function exitCode()
     {
-        return $this->process->getExitCode();
+        return $this->exitCode;
     }
 
     /**
@@ -73,7 +111,7 @@ class ProcessResult implements ProcessResultContract
      */
     public function output()
     {
-        return $this->process->getOutput();
+        return $this->output;
     }
 
     /**
@@ -83,7 +121,7 @@ class ProcessResult implements ProcessResultContract
      */
     public function errorOutput()
     {
-        return $this->process->getErrorOutput();
+        return $this->errorOutput;
     }
 
     /**

--- a/src/Illuminate/Console/Process/FakeProcessResult.php
+++ b/src/Illuminate/Console/Process/FakeProcessResult.php
@@ -66,9 +66,12 @@ class FakeProcessResult implements ProcessResultContract
         } elseif (is_string($output)) {
             return rtrim($output, "\n")."\n";
         } elseif (is_array($output)) {
-            return rtrim(collect($output)
+            return rtrim(
+                collect($output)
                     ->map(fn ($line) => rtrim($line, "\n")."\n")
-                    ->implode(""), "\n");
+                    ->implode(""),
+                "\n"
+            );
         }
     }
 

--- a/src/Illuminate/Console/Process/FakeProcessResult.php
+++ b/src/Illuminate/Console/Process/FakeProcessResult.php
@@ -27,14 +27,14 @@ class FakeProcessResult implements ProcessResultContract
      *
      * @var string
      */
-    protected $output;
+    protected $output = '';
 
     /**
      * The process error output.
      *
      * @var string
      */
-    protected $errorOutput;
+    protected $errorOutput = '';
 
     /**
      * Create a new process result instance.
@@ -49,8 +49,27 @@ class FakeProcessResult implements ProcessResultContract
     {
         $this->command = $command;
         $this->exitCode = $exitCode;
-        $this->output = rtrim((is_array($output) ? implode("\n", $output) : $output), "\n")."\n";
-        $this->errorOutput = rtrim((is_array($errorOutput) ? implode("\n", $errorOutput) : $errorOutput), "\n")."\n";
+        $this->output = $this->normalizeOutput($output);
+        $this->errorOutput = $this->normalizeOutput($errorOutput);
+    }
+
+    /**
+     * Normalize the given output into a string with newlines.
+     *
+     * @param  array|string  $output
+     * @return string
+     */
+    protected function normalizeOutput(array|string $output)
+    {
+        if (empty($output)) {
+            return '';
+        } elseif (is_string($output)) {
+            return rtrim($output, "\n")."\n";
+        } elseif (is_array($output)) {
+            return rtrim(collect($output)
+                    ->map(fn ($line) => rtrim($line, "\n")."\n")
+                    ->implode(""), "\n");
+        }
     }
 
     /**

--- a/src/Illuminate/Console/Process/FakeProcessResult.php
+++ b/src/Illuminate/Console/Process/FakeProcessResult.php
@@ -130,7 +130,7 @@ class FakeProcessResult implements ProcessResultContract
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throw($callback = null)
+    public function throw(callable $callback = null)
     {
         if ($this->successful()) {
             return $this;
@@ -152,7 +152,7 @@ class FakeProcessResult implements ProcessResultContract
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throwIf($condition, $callback = null)
+    public function throwIf(bool $condition, callable $callback = null)
     {
         if ($condition) {
             return $this->throw($callback);

--- a/src/Illuminate/Console/Process/FakeProcessResult.php
+++ b/src/Illuminate/Console/Process/FakeProcessResult.php
@@ -41,16 +41,16 @@ class FakeProcessResult implements ProcessResultContract
      *
      * @param  string  $command
      * @param  int  $exitCode
-     * @param  string  $output
-     * @param  string  $errorOutput
+     * @param  array|string  $output
+     * @param  array|string  $errorOutput
      * @return void
      */
-    public function __construct(string $command = '', int $exitCode = 0, string $output = '', string $errorOutput = '')
+    public function __construct(string $command = '', int $exitCode = 0, array|string $output = '', array|string $errorOutput = '')
     {
         $this->command = $command;
         $this->exitCode = $exitCode;
-        $this->output = $output;
-        $this->errorOutput = $errorOutput;
+        $this->output = rtrim((is_array($output) ? implode("\n", $output) : $output), "\n")."\n";
+        $this->errorOutput = rtrim((is_array($errorOutput) ? implode("\n", $errorOutput) : $errorOutput), "\n")."\n";
     }
 
     /**

--- a/src/Illuminate/Console/Process/FakeProcessSequence.php
+++ b/src/Illuminate/Console/Process/FakeProcessSequence.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+use Illuminate\Contracts\Console\Process\ProcessResult as ProcessResultContract;
+use OutOfBoundsException;
+
+class FakeProcessSequence
+{
+    /**
+     * The fake process results and descriptions.
+     *
+     * @var array
+     */
+    protected $processes = [];
+
+    /**
+     * Indicates that invoking this sequence when it is empty should throw an exception.
+     *
+     * @var bool
+     */
+    protected $failWhenEmpty = true;
+
+    /**
+     * The response that should be returned when the sequence is empty.
+     *
+     * @var \Illuminate\Contracts\Console\Process\ProcessResult|\Illuminate\Console\Process\FakeProcessDescription  $process
+     */
+    protected $emptyProcess;
+
+    /**
+     * Create a new fake process sequence instance.
+     *
+     * @param  array  $processes
+     * @return void
+     */
+    public function __construct(array $processes = [])
+    {
+        $this->processes = $processes;
+    }
+
+    /**
+     * Push a new process result or description onto the sequence.
+     *
+     * @param  \Illuminate\Contracts\Console\Process\ProcessResult|\Illuminate\Console\Process\FakeProcessDescription|array|string  $process
+     * @return $this
+     */
+    public function push(ProcessResultContract|FakeProcessDescription|array|string $process)
+    {
+        $this->processes[] = $this->toProcessResult($process);
+
+        return $this;
+    }
+
+    /**
+     * Make the sequence return a default result when it is empty.
+     *
+     * @param  \Illuminate\Contracts\Console\Process\ProcessResult|\Illuminate\Console\Process\FakeProcessDescription|array|string  $process
+     * @return $this
+     */
+    public function whenEmpty(ProcessResultContract|FakeProcessDescription|array|string $process)
+    {
+        $this->failWhenEmpty = false;
+        $this->emptyProcess = $this->toProcessResult($process);
+
+        return $this;
+    }
+
+    /**
+     * Convert the given result into an actual process result or description.
+     *
+     * @param  \Illuminate\Contracts\Console\Process\ProcessResult|\Illuminate\Console\Process\FakeProcessDescription|array|string  $process
+     * @return \Illuminate\Contracts\Console\Process\ProcessResult|\Illuminate\Console\Process\FakeProcessDescription
+     */
+    protected function toProcessResult(ProcessResultContract|FakeProcessDescription|array|string $process)
+    {
+        return is_array($process) || is_string($process)
+                ? new FakeProcessResult(output: $process)
+                : $process;
+    }
+
+    /**
+     * Make the sequence return a default result when it is empty.
+     *
+     * @return $this
+     */
+    public function dontFailWhenEmpty()
+    {
+        return $this->whenEmpty(new FakeProcessResult);
+    }
+
+    /**
+     * Indicate that this sequence has depleted all of its process results.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return count($this->processes) === 0;
+    }
+
+    /**
+     * Get the next process in the sequence.
+     *
+     * @return \Illuminate\Contracts\Console\Process\ProcessResult|\Illuminate\Console\Process\FakeProcessDescription
+     *
+     * @throws \OutOfBoundsException
+     */
+    public function __invoke()
+    {
+        if ($this->failWhenEmpty && count($this->processes) === 0) {
+            throw new OutOfBoundsException('A process was invoked, but the process result sequence is empty.');
+        }
+
+        if (! $this->failWhenEmpty && count($this->processes) === 0) {
+            return value($this->emptyProcess ?? new FakeProcessResult);
+        }
+
+        return array_shift($this->processes);
+    }
+}

--- a/src/Illuminate/Console/Process/FakeProcessSequence.php
+++ b/src/Illuminate/Console/Process/FakeProcessSequence.php
@@ -24,7 +24,7 @@ class FakeProcessSequence
     /**
      * The response that should be returned when the sequence is empty.
      *
-     * @var \Illuminate\Contracts\Console\Process\ProcessResult|\Illuminate\Console\Process\FakeProcessDescription  $process
+     * @var \Illuminate\Contracts\Console\Process\ProcessResult|\Illuminate\Console\Process\FakeProcessDescription
      */
     protected $emptyProcess;
 

--- a/src/Illuminate/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Console/Process/InvokedProcess.php
@@ -61,6 +61,26 @@ class InvokedProcess implements InvokedProcessContract
     }
 
     /**
+     * Get the standard output for the process.
+     *
+     * @return string
+     */
+    public function output()
+    {
+        return $this->process->getOutput();
+    }
+
+    /**
+     * Get the error output for the process.
+     *
+     * @return string
+     */
+    public function errorOutput()
+    {
+        return $this->process->getErrorOutput();
+    }
+
+    /**
      * Get the latest standard output for the process.
      *
      * @return string

--- a/src/Illuminate/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Console/Process/InvokedProcess.php
@@ -96,21 +96,4 @@ class InvokedProcess implements InvokedProcessContract
             throw new ProcessTimedOutException($e, new ProcessResult($this->process));
         }
     }
-
-    /**
-     * Wait for some given output from the process.
-     *
-     * @param  callable  $output
-     * @return $this
-     */
-    public function waitUntil(callable $output)
-    {
-        try {
-            $this->process->waitUntil($output);
-
-            return $this;
-        } catch (SymfonyTimeoutException $e) {
-            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
-        }
-    }
 }

--- a/src/Illuminate/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Console/Process/InvokedProcess.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+use Illuminate\Console\Process\Exceptions\ProcessTimedOutException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyTimeoutException;
+use Symfony\Component\Process\Process;
+
+class InvokedProcess
+{
+    /**
+     * Create a new invoked process instance.
+     *
+     * @param  \Symfony\Component\Process\Process  $process
+     * @return void
+     */
+    public function __construct(Process $process)
+    {
+        $this->process = $process;
+    }
+
+    /**
+     * Get the process ID if the process is still running.
+     *
+     * @return int|null
+     */
+    public function id()
+    {
+        return $this->process->getPid();
+    }
+
+    /**
+     * Send a signal to the process.
+     *
+     * @param  int  $signal
+     * @return $this
+     */
+    public function signal(int $signal)
+    {
+        $this->process->signal($signal);
+
+        return $this;
+    }
+
+    /**
+     * Determine if the process is still running.
+     *
+     * @return bool
+     */
+    public function running()
+    {
+        return $this->process->isRunning();
+    }
+
+    /**
+     * Get the latest standard output for the process.
+     *
+     * @return string
+     */
+    public function latestOutput()
+    {
+        return $this->process->getIncrementalOutput();
+    }
+
+    /**
+     * Get the latest error output for the process.
+     *
+     * @return string
+     */
+    public function latestErrorOutput()
+    {
+        return $this->process->getIncrementalErrorOutput();
+    }
+
+    /**
+     * Wait for the process to finish.
+     *
+     * @param  callable|null  $output
+     * @return \Illuminate\Console\Process\ProcessResult
+     */
+    public function wait($output = null)
+    {
+        try {
+            $this->process->wait($output);
+
+            return new ProcessResult($this->process);
+        } catch (SymfonyTimeoutException $e) {
+            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
+        }
+    }
+
+    /**
+     * Wait for some given output from the process.
+     *
+     * @param  callable  $output
+     * @return $this
+     */
+    public function waitUntil($output)
+    {
+        try {
+            $this->process->waitUntil($output);
+
+            return $this;
+        } catch (SymfonyTimeoutException $e) {
+            throw new ProcessTimedOutException($e, new ProcessResult($this->process));
+        }
+    }
+}

--- a/src/Illuminate/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Console/Process/InvokedProcess.php
@@ -86,7 +86,7 @@ class InvokedProcess implements InvokedProcessContract
      * @param  callable|null  $output
      * @return \Illuminate\Console\Process\ProcessResult
      */
-    public function wait($output = null)
+    public function wait(callable $output = null)
     {
         try {
             $this->process->wait($output);
@@ -103,7 +103,7 @@ class InvokedProcess implements InvokedProcessContract
      * @param  callable  $output
      * @return $this
      */
-    public function waitUntil($output)
+    public function waitUntil(callable $output)
     {
         try {
             $this->process->waitUntil($output);

--- a/src/Illuminate/Console/Process/InvokedProcessPool.php
+++ b/src/Illuminate/Console/Process/InvokedProcessPool.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+class InvokedProcessPool
+{
+    /**
+     * The array of invoked processes.
+     *
+     * @var array
+     */
+    protected $invokedProcesses;
+
+    /**
+     * Create a new invoked process pool.
+     *
+     * @param  array  $invokedProcesses
+     * @return void
+     */
+    public function __construct(array $invokedProcesses)
+    {
+        $this->invokedProcesses = $invokedProcesses;
+    }
+
+    /**
+     * Send a signal to each running process in the pool, returning the processes that were signalled.
+     *
+     * @param  int  $signal
+     * @return \Illuminate\Support\Collection
+     */
+    public function signal(int $signal)
+    {
+        return $this->running()->each->signal($signal);
+    }
+
+    /**
+     * Get the processes in the pool that are still currently running.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function running()
+    {
+        return collect($this->invokedProcesses)->filter->running()->values();
+    }
+
+    /**
+     * Wait for the processes to finish.
+     *
+     * @return \Illuminate\Console\Process\ProcessPoolResults
+     */
+    public function wait()
+    {
+        return new ProcessPoolResults(collect($this->invokedProcesses)->map->wait()->all());
+    }
+}

--- a/src/Illuminate/Console/Process/PendingProcess.php
+++ b/src/Illuminate/Console/Process/PendingProcess.php
@@ -330,7 +330,9 @@ class PendingProcess
     {
         $result = $fake($this);
 
-        if ($result instanceof ProcessResult) {
+        if (is_string($result) || is_array($result)) {
+            return (new FakeProcessResult(output: $result))->withCommand($command);
+        } elseif ($result instanceof ProcessResult) {
             return $result;
         } elseif ($result instanceof FakeProcessResult) {
             return $result->withCommand($command);
@@ -354,6 +356,10 @@ class PendingProcess
     protected function resolveAsynchronousFake(string $command, ?callable $output, Closure $fake)
     {
         $result = $fake($this);
+
+        if (is_string($result) || is_array($result)) {
+            $result = new FakeProcessResult(output: $result);
+        }
 
         if ($result instanceof ProcessResult) {
             return (new FakeInvokedProcess(

--- a/src/Illuminate/Console/Process/PendingProcess.php
+++ b/src/Illuminate/Console/Process/PendingProcess.php
@@ -342,7 +342,7 @@ class PendingProcess
             return $this->resolveSynchronousFake($command, fn () => $result());
         }
 
-        throw new LogicException("Unsupported synchronous process fake result provided.");
+        throw new LogicException('Unsupported synchronous process fake result provided.');
     }
 
     /**
@@ -385,6 +385,6 @@ class PendingProcess
             return $this->resolveAsynchronousFake($command, $output, fn () => $result());
         }
 
-        throw new LogicException("Unsupported asynchronous process fake result provided.");
+        throw new LogicException('Unsupported asynchronous process fake result provided.');
     }
 }

--- a/src/Illuminate/Console/Process/PendingProcess.php
+++ b/src/Illuminate/Console/Process/PendingProcess.php
@@ -365,8 +365,8 @@ class PendingProcess
             return (new FakeInvokedProcess(
                 $command,
                 (new FakeProcessDescription)
-                    ->output($result->output())
-                    ->errorOutput($result->errorOutput())
+                    ->replaceOutput($result->output())
+                    ->replaceErrorOutput($result->errorOutput())
                     ->runsFor(iterations: 0)
                     ->exitCode($result->exitCode())
             ))->withOutputHandler($output);
@@ -374,8 +374,8 @@ class PendingProcess
             return (new FakeInvokedProcess(
                 $command,
                 (new FakeProcessDescription)
-                    ->output($result->output())
-                    ->errorOutput($result->errorOutput())
+                    ->replaceOutput($result->output())
+                    ->replaceErrorOutput($result->errorOutput())
                     ->runsFor(iterations: 0)
                     ->exitCode($result->exitCode())
             ))->withOutputHandler($output);

--- a/src/Illuminate/Console/Process/PendingProcess.php
+++ b/src/Illuminate/Console/Process/PendingProcess.php
@@ -224,14 +224,10 @@ class PendingProcess
     {
         $result = $fake($this);
 
-        // if ($result instanceof FakeProcessResult) {
-        //     return $result->withCommand($command);
-        // } elseif ($result instanceof ProcessResultContract) {
-        //     return $result;
-        // } elseif ($result instanceof FakeProcessDescription) {
-        //     return $result->toProcessResult($command);
-        // }
+        if ($result instanceof FakeProcessDescription) {
+            return new FakeInvokedProcess($command, $result);
+        }
 
-        throw new LogicException("Unsupported synchronous process fake result provided.");
+        throw new LogicException("Unsupported asynchronous process fake result provided.");
     }
 }

--- a/src/Illuminate/Console/Process/PendingProcess.php
+++ b/src/Illuminate/Console/Process/PendingProcess.php
@@ -264,7 +264,7 @@ class PendingProcess
      * @param  array<array-key, string>|string|null  $command
      * @return \Symfony\Component\Process\Process
      */
-    protected function toSymfonyProcess(array|string $command)
+    protected function toSymfonyProcess(array|string|null $command)
     {
         $command = $command ?? $this->command;
 
@@ -336,6 +336,8 @@ class PendingProcess
             return $result->withCommand($command);
         } elseif ($result instanceof FakeProcessDescription) {
             return $result->toProcessResult($command);
+        } elseif ($result instanceof FakeProcessSequence) {
+            return $this->resolveSynchronousFake($command, fn () => $result());
         }
 
         throw new LogicException("Unsupported synchronous process fake result provided.");
@@ -373,6 +375,8 @@ class PendingProcess
             ))->withOutputHandler($output);
         } elseif ($result instanceof FakeProcessDescription) {
             return (new FakeInvokedProcess($command, $result))->withOutputHandler($output);
+        } elseif ($result instanceof FakeProcessSequence) {
+            return $this->resolveAsynchronousFake($command, $output, fn () => $result());
         }
 
         throw new LogicException("Unsupported asynchronous process fake result provided.");

--- a/src/Illuminate/Console/Process/PendingProcess.php
+++ b/src/Illuminate/Console/Process/PendingProcess.php
@@ -223,8 +223,15 @@ class PendingProcess
     {
         $result = $fake($this);
 
-        if ($result instanceof FakeProcessDescription) {
-            return new FakeInvokedProcess($command, $result);
+        if ($result instanceof ProcessResult) {
+            return new FakeInvokedProcess(
+                $command,
+                (new FakeProcessDescription)
+                    ->output($result->output())
+                    ->errorOutput($result->errorOutput())
+                    ->runsFor(iterations: 0)
+                    ->exitCode($result->exitCode())
+            );
         } elseif ($result instanceof FakeProcessResult) {
             return new FakeInvokedProcess(
                 $command,
@@ -234,15 +241,8 @@ class PendingProcess
                     ->runsFor(iterations: 0)
                     ->exitCode($result->exitCode())
             );
-        } elseif ($result instanceof ProcessResult) {
-            return new FakeInvokedProcess(
-                $command,
-                (new FakeProcessDescription)
-                    ->output($result->output())
-                    ->errorOutput($result->errorOutput())
-                    ->runsFor(iterations: 0)
-                    ->exitCode($result->exitCode())
-            );
+        } elseif ($result instanceof FakeProcessDescription) {
+            return new FakeInvokedProcess($command, $result);
         }
 
         throw new LogicException("Unsupported asynchronous process fake result provided.");

--- a/src/Illuminate/Console/Process/PendingProcess.php
+++ b/src/Illuminate/Console/Process/PendingProcess.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyTimeoutException;
+use Symfony\Component\Process\Process;
+
+class PendingProcess
+{
+    /**
+     * The process factory instance.
+     *
+     * @var \Illuminate\Console\Process\Factory
+     */
+    protected $factory;
+
+    /**
+     * The command to invoke the process.
+     *
+     * @var array<array-key, string>|string|null
+     */
+    protected $command;
+
+    /**
+     * The working directory of the process.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * The maximum number of seconds the process may run.
+     *
+     * @var int|null
+     */
+    protected $timeout = 60;
+
+    /**
+     * Create a new pending process instance.
+     *
+     * @param  \Illuminate\Console\Process\Factory  $factory
+     * @return void
+     */
+    public function __construct(Factory $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * Specify the command that will invoke the process.
+     *
+     * @param  array<array-key, string>|string|null  $command
+     * @return $this
+     */
+    public function command($command)
+    {
+        $this->command = $command;
+
+        return $this;
+    }
+
+    /**
+     * Specify the working directory of the process.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function path($path)
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
+     * Specify the maximum number of seconds the process may run.
+     *
+     * @param  int  $timeout
+     * @return $this
+     */
+    public function timeout($timeout)
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the process may run forever without timing out.
+     *
+     * @return $this
+     */
+    public function forever()
+    {
+        $this->timeout = null;
+
+        return $this;
+    }
+
+    /**
+     * Run the process.
+     *
+     * @param  array<array-key, string>|string|null  $command
+     * @param  callable|null  $output
+     * @return \Illuminate\Console\Contracts\ProcessResult
+     */
+    public function run($command = null, $output = null)
+    {
+        try {
+            $process = $this->toSymfonyProcess($command);
+
+            return new ProcessResult(tap($process)->run($output));
+        } catch (SymfonyTimeoutException $e) {
+            throw new ProcessTimedOutException($e, new ProcessResult($process));
+        }
+    }
+
+    /**
+     * Start the process in the background.
+     *
+     * @param  array<array-key, string>|string|null  $command
+     * @return \Illuminate\Console\Process\InvokedProcess
+     */
+    public function start($command = null)
+    {
+        return new InvokedProcess(tap($this->toSymfonyProcess($command))->start());
+    }
+
+    /**
+     * Get a Symfony Process instance from the current pending command.
+     *
+     * @param  array<array-key, string>|string|null  $command
+     * @return \Symfony\Component\Process\Process
+     */
+    protected function toSymfonyProcess($command)
+    {
+        $command = $command ?? $this->command;
+
+        $process = is_iterable($command)
+                ? new Process($command)
+                : Process::fromShellCommandline((string) $command);
+
+        $process->setWorkingDirectory((string) $this->path ?? getcwd());
+        $process->setTimeout($this->timeout);
+
+        return $process;
+    }
+}

--- a/src/Illuminate/Console/Process/PendingProcess.php
+++ b/src/Illuminate/Console/Process/PendingProcess.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console\Process;
 
-use Illuminate\Contracts\Console\Process\ProcessResult as ProcessResultContract;
 use Illuminate\Support\Str;
 use LogicException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException as SymfonyTimeoutException;
@@ -202,10 +201,10 @@ class PendingProcess
     {
         $result = $fake($this);
 
-        if ($result instanceof FakeProcessResult) {
-            return $result->withCommand($command);
-        } elseif ($result instanceof ProcessResultContract) {
+        if ($result instanceof ProcessResult) {
             return $result;
+        } elseif ($result instanceof FakeProcessResult) {
+            return $result->withCommand($command);
         } elseif ($result instanceof FakeProcessDescription) {
             return $result->toProcessResult($command);
         }
@@ -226,6 +225,24 @@ class PendingProcess
 
         if ($result instanceof FakeProcessDescription) {
             return new FakeInvokedProcess($command, $result);
+        } elseif ($result instanceof FakeProcessResult) {
+            return new FakeInvokedProcess(
+                $command,
+                (new FakeProcessDescription)
+                    ->output($result->output())
+                    ->errorOutput($result->errorOutput())
+                    ->runsFor(iterations: 0)
+                    ->exitCode($result->exitCode())
+            );
+        } elseif ($result instanceof ProcessResult) {
+            return new FakeInvokedProcess(
+                $command,
+                (new FakeProcessDescription)
+                    ->output($result->output())
+                    ->errorOutput($result->errorOutput())
+                    ->runsFor(iterations: 0)
+                    ->exitCode($result->exitCode())
+            );
         }
 
         throw new LogicException("Unsupported asynchronous process fake result provided.");

--- a/src/Illuminate/Console/Process/Pool.php
+++ b/src/Illuminate/Console/Process/Pool.php
@@ -67,7 +67,7 @@ class Pool
             collect($this->pendingProcesses)
                 ->each(function ($pendingProcess) {
                     if (! $pendingProcess instanceof PendingProcess) {
-                        throw new InvalidArgumentException("Process pool must only contain pending processes.");
+                        throw new InvalidArgumentException('Process pool must only contain pending processes.');
                     }
                 })->mapWithKeys(function ($pendingProcess, $key) use ($output) {
                     return [$key => $pendingProcess->start(output: $output ? function ($type, $buffer) use ($key, $output) {

--- a/src/Illuminate/Console/Process/Pool.php
+++ b/src/Illuminate/Console/Process/Pool.php
@@ -63,7 +63,7 @@ class Pool implements ArrayAccess
      * @param  callable  $callback
      * @return void
      */
-    public function __construct(Factory $factory, $callback)
+    public function __construct(Factory $factory, callable $callback)
     {
         $this->factory = $factory;
         $this->callback = $callback;
@@ -136,7 +136,7 @@ class Pool implements ArrayAccess
      * @param  callable|null  $output
      * @return array
      */
-    public function wait($output = null)
+    public function wait(callable $output = null)
     {
         if ($this->resolved) {
             return $this->results;

--- a/src/Illuminate/Console/Process/Pool.php
+++ b/src/Illuminate/Console/Process/Pool.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+use ArrayAccess;
+use InvalidArgumentException;
+
+class Pool implements ArrayAccess
+{
+    /**
+     * The process factory instance.
+     *
+     * @var \Illuminate\Console\Process\Factory
+     */
+    protected $factory;
+
+    /**
+     * The callback that resolves the pending processes.
+     *
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * The array of pending processes.
+     *
+     * @var array
+     */
+    protected $pendingProcesses = [];
+
+    /**
+     * Indicates if the process pool has been resolved.
+     *
+     * @var bool
+     */
+    protected $resolved = false;
+
+    /**
+     * The results of the processes.
+     *
+     * @var array
+     */
+    protected $results = [];
+
+    /**
+     * Create a new process pool.
+     *
+     * @param  \Illuminate\Console\Process\Factory  $factory
+     * @param  callable  $callback
+     * @return void
+     */
+    public function __construct(Factory $factory, $callback)
+    {
+        $this->factory = $factory;
+        $this->callback = $callback;
+    }
+
+    /**
+     * Add a process to the pool with a key.
+     *
+     * @param  string  $key
+     * @return \Illuminate\Console\Process\PendingProcess
+     */
+    public function as(string $key)
+    {
+        return tap($this->factory->newPendingProcess(), function ($pendingProcess) use ($key) {
+            $this->pendingProcesses[$key] = $pendingProcess;
+        });
+    }
+
+    /**
+     * Start and wait for the processes to finish.
+     *
+     * @return void
+     */
+    protected function resolve()
+    {
+        if ($this->resolved) {
+            return;
+        }
+
+        call_user_func($this->callback, $this);
+
+        $invokedProcesses = collect($this->pendingProcesses)
+            ->each(function ($pendingProcess) {
+                if (! $pendingProcess instanceof PendingProcess) {
+                    throw new InvalidArgumentException("Process pool must only contain pending processes.");
+                }
+            })->mapWithKeys(function ($pendingProcess, $key) {
+                return [$key => $pendingProcess->start()];
+            });
+
+        while ($invokedProcesses->filter->running()->isNotEmpty()) {
+            usleep(50 * 1000);
+        }
+
+        $this->results = $invokedProcesses->mapWithKeys(function ($pendingProcess, $key) {
+            return [$key => $pendingProcess->wait()];
+        })->all();
+
+        $this->resolved = true;
+    }
+
+    /**
+     * Determine if the given array offset exists.
+     *
+     * @param  int  $offset
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        $this->resolve();
+
+        return isset($this->results[$offset]);
+    }
+
+    /**
+     * Get the result at the given offset.
+     *
+     * @param  int  $offset
+     * @return mixed
+     */
+    public function offsetGet($offset): mixed
+    {
+        $this->resolve();
+
+        return $this->results[$offset];
+    }
+
+    /**
+     * Set the result at the given offset.
+     *
+     * @param  int  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->resolve();
+
+        $this->results[$offset] = $value;
+    }
+
+    /**
+     * Unset the result at the given offset.
+     *
+     * @param  int  $offset
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        $this->resolve();
+
+        unset($this->results[$offset]);
+    }
+
+    /**
+     * Dynamically proxy methods calls to a new pending process.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return \Illuminate\Console\Process\PendingProcess
+     */
+    public function __call($method, $parameters)
+    {
+        return tap($this->factory->{$method}(...$parameters), function ($pendingProcess) {
+            $this->pendingProcesses[] = $pendingProcess;
+        });
+    }
+}

--- a/src/Illuminate/Console/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Console/Process/ProcessPoolResults.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+use ArrayAccess;
+
+class ProcessPoolResults implements ArrayAccess
+{
+    /**
+     * The results of the processes.
+     *
+     * @var array
+     */
+    protected $results = [];
+
+    /**
+     * Create a new process pool result set.
+     *
+     * @param  array  $results
+     * @return void
+     */
+    public function __construct(array $results)
+    {
+        $this->results = $results;
+    }
+
+    /**
+     * Determine if the given array offset exists.
+     *
+     * @param  int  $offset
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->results[$offset]);
+    }
+
+    /**
+     * Get the result at the given offset.
+     *
+     * @param  int  $offset
+     * @return mixed
+     */
+    public function offsetGet($offset): mixed
+    {
+        return $this->results[$offset];
+    }
+
+    /**
+     * Set the result at the given offset.
+     *
+     * @param  int  $offset
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->results[$offset] = $value;
+    }
+
+    /**
+     * Unset the result at the given offset.
+     *
+     * @param  int  $offset
+     * @return void
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->results[$offset]);
+    }
+}

--- a/src/Illuminate/Console/Process/ProcessPoolResults.php
+++ b/src/Illuminate/Console/Process/ProcessPoolResults.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Process;
 
 use ArrayAccess;
+use Illuminate\Support\Collection;
 
 class ProcessPoolResults implements ArrayAccess
 {
@@ -22,6 +23,16 @@ class ProcessPoolResults implements ArrayAccess
     public function __construct(array $results)
     {
         $this->results = $results;
+    }
+
+    /**
+     * Get the results as a collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect()
+    {
+        return new Collection($this->results);
     }
 
     /**

--- a/src/Illuminate/Console/Process/ProcessResult.php
+++ b/src/Illuminate/Console/Process/ProcessResult.php
@@ -92,7 +92,7 @@ class ProcessResult implements ProcessResultContract
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throw($callback = null)
+    public function throw(callable $callback = null)
     {
         if ($this->successful()) {
             return $this;
@@ -114,7 +114,7 @@ class ProcessResult implements ProcessResultContract
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throwIf($condition, $callback = null)
+    public function throwIf(bool $condition, callable $callback = null)
     {
         if ($condition) {
             return $this->throw($callback);

--- a/src/Illuminate/Console/Process/ProcessResult.php
+++ b/src/Illuminate/Console/Process/ProcessResult.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Console\Process;
 
-use Illuminate\Contracts\Console\Process\ProcessResult as ProcessResultContract;
 use Illuminate\Console\Process\Exceptions\ProcessFailedException;
+use Illuminate\Contracts\Console\Process\ProcessResult as ProcessResultContract;
 use Symfony\Component\Process\Process;
 
 class ProcessResult implements ProcessResultContract

--- a/src/Illuminate/Console/Process/ProcessResult.php
+++ b/src/Illuminate/Console/Process/ProcessResult.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Console\Process;
+
+use Illuminate\Console\Contracts\ProcessResult as ProcessResultContract;
+use Illuminate\Console\Process\Exceptions\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class ProcessResult implements ProcessResultContract
+{
+    /**
+     * The underlying process instance.
+     *
+     * @var \Symfony\Component\Process\Process
+     */
+    protected $process;
+
+    /**
+     * Create a new process result instance.
+     *
+     * @param  \Symfony\Component\Process\Process  $process
+     * @return void
+     */
+    public function __construct(Process $process)
+    {
+        $this->process = $process;
+    }
+
+    /**
+     * Get the original command executed by the process.
+     *
+     * @return string
+     */
+    public function command()
+    {
+        return $this->process->getCommandLine();
+    }
+
+    /**
+     * Determine if the process was successful.
+     *
+     * @return bool
+     */
+    public function successful()
+    {
+        return $this->process->isSuccessful();
+    }
+
+    /**
+     * Get the exit code of the process.
+     *
+     * @return int
+     */
+    public function exitCode()
+    {
+        return $this->process->getExitCode();
+    }
+
+    /**
+     * Get the standard output of the process.
+     *
+     * @return string
+     */
+    public function output()
+    {
+        return $this->process->getOutput();
+    }
+
+    /**
+     * Get the error output of the process.
+     *
+     * @return string
+     */
+    public function errorOutput()
+    {
+        return $this->process->getErrorOutput();
+    }
+
+    /**
+     * Throw an exception if the process failed.
+     *
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function throw($callback = null)
+    {
+        if ($this->successful()) {
+            return $this;
+        }
+
+        $exception = new ProcessFailedException($this);
+
+        if ($callback) {
+            $callback($this, $exception);
+        }
+
+        throw $exception;
+    }
+
+    /**
+     * Throw an exception if the process failed and the given condition is true.
+     *
+     * @param  bool  $condition
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function throwIf($condition, $callback = null)
+    {
+        if ($condition) {
+            return $this->throw($callback);
+        }
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
@@ -10,4 +10,49 @@ interface InvokedProcess
      * @return int|null
      */
     public function id();
+
+    /**
+     * Send a signal to the process.
+     *
+     * @param  int  $signal
+     * @return $this
+     */
+    public function signal(int $signal);
+
+    /**
+     * Determine if the process is still running.
+     *
+     * @return bool
+     */
+    public function running();
+
+    /**
+     * Get the latest standard output for the process.
+     *
+     * @return string
+     */
+    public function latestOutput();
+
+    /**
+     * Get the latest error output for the process.
+     *
+     * @return string
+     */
+    public function latestErrorOutput();
+
+    /**
+     * Wait for the process to finish.
+     *
+     * @param  callable|null  $output
+     * @return \Illuminate\Console\Process\ProcessResult
+     */
+    public function wait($output = null);
+
+    /**
+     * Wait for some given output from the process.
+     *
+     * @param  callable  $output
+     * @return $this
+     */
+    public function waitUntil($output);
 }

--- a/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
@@ -27,6 +27,20 @@ interface InvokedProcess
     public function running();
 
     /**
+     * Get the standard output for the process.
+     *
+     * @return string
+     */
+    public function output();
+
+    /**
+     * Get the error output for the process.
+     *
+     * @return string
+     */
+    public function errorOutput();
+
+    /**
      * Get the latest standard output for the process.
      *
      * @return string

--- a/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Console\Process;
+
+interface InvokedProcess
+{
+    /**
+     * Get the process ID if the process is still running.
+     *
+     * @return int|null
+     */
+    public function id();
+}

--- a/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
@@ -46,7 +46,7 @@ interface InvokedProcess
      * @param  callable|null  $output
      * @return \Illuminate\Console\Process\ProcessResult
      */
-    public function wait($output = null);
+    public function wait(callable $output = null);
 
     /**
      * Wait for some given output from the process.
@@ -54,5 +54,5 @@ interface InvokedProcess
      * @param  callable  $output
      * @return $this
      */
-    public function waitUntil($output);
+    public function waitUntil(callable $output);
 }

--- a/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
+++ b/src/Illuminate/Contracts/Console/Process/InvokedProcess.php
@@ -47,12 +47,4 @@ interface InvokedProcess
      * @return \Illuminate\Console\Process\ProcessResult
      */
     public function wait(callable $output = null);
-
-    /**
-     * Wait for some given output from the process.
-     *
-     * @param  callable  $output
-     * @return $this
-     */
-    public function waitUntil(callable $output);
 }

--- a/src/Illuminate/Contracts/Console/Process/ProcessResult.php
+++ b/src/Illuminate/Contracts/Console/Process/ProcessResult.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Console\Contracts;
+namespace Illuminate\Contracts\Console\Process;
 
 interface ProcessResult
 {
@@ -17,6 +17,13 @@ interface ProcessResult
      * @return bool
      */
     public function successful();
+
+    /**
+     * Determine if the process failed.
+     *
+     * @return bool
+     */
+    public function failed();
 
     /**
      * Get the exit code of the process.

--- a/src/Illuminate/Contracts/Console/Process/ProcessResult.php
+++ b/src/Illuminate/Contracts/Console/Process/ProcessResult.php
@@ -52,7 +52,7 @@ interface ProcessResult
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throw($callback = null);
+    public function throw(callable $callback = null);
 
     /**
      * Throw an exception if the process failed and the given condition is true.
@@ -61,5 +61,5 @@ interface ProcessResult
      * @param  callable|null  $callback
      * @return $this
      */
-    public function throwIf($condition, $callback = null);
+    public function throwIf(bool $condition, callable $callback = null);
 }

--- a/src/Illuminate/Support/Facades/Process.php
+++ b/src/Illuminate/Support/Facades/Process.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+use Illuminate\Console\Process\Factory;
+
+/**
+ * @see \Illuminate\Console\Process\Factory
+ */
+class Process extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return Factory::class;
+    }
+}

--- a/tests/Console/ProcessTest.php
+++ b/tests/Console/ProcessTest.php
@@ -57,6 +57,27 @@ class ProcessTest extends TestCase
         $this->assertTrue(str_contains($pool[1]->output(), 'ProcessTest.php'));
     }
 
+    public function testProcessPoolCanReceiveOutputForEachProcessViaStartMethod()
+    {
+        $factory = new Factory;
+
+        $output = [];
+
+        $pool = $factory->pool(function (Pool $pool) {
+            return [
+                $pool->path(__DIR__)->command($this->ls()),
+                $pool->path(__DIR__)->command($this->ls()),
+            ];
+        })->start(function ($type, $buffer, $key) use (&$output) {
+            $output[$key][$type][] = $buffer;
+        });
+
+        $pool->wait();
+
+        $this->assertTrue(count($output[0]['out']) > 0);
+        $this->assertTrue(count($output[1]['out']) > 0);
+    }
+
     public function testProcessPoolResultsCanBeEvaluatedOnTime()
     {
         $factory = new Factory;

--- a/tests/Console/ProcessTest.php
+++ b/tests/Console/ProcessTest.php
@@ -287,7 +287,7 @@ class ProcessTest extends TestCase
         $this->assertEquals("ls command 2\n", $result->output());
 
         $result = $factory->run('ls -la');
-        $this->assertEquals("", $result->output());
+        $this->assertEquals('', $result->output());
     }
 
     public function testProcessFakeSequencesCanThrowWhenSequenceIsEmpty()
@@ -299,7 +299,7 @@ class ProcessTest extends TestCase
         $factory->fake([
             'ls *' => $factory->sequence()
                         ->push('ls command 1')
-                        ->push('ls command 2')
+                        ->push('ls command 2'),
         ]);
 
         $result = $factory->run('ls -la');
@@ -385,7 +385,7 @@ class ProcessTest extends TestCase
         $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
 
         $this->assertFalse($result->successful());
-        $this->assertEquals("", $result->output());
+        $this->assertEquals('', $result->output());
         $this->assertEquals("Hello World\n", $result->errorOutput());
     }
 
@@ -459,7 +459,7 @@ class ProcessTest extends TestCase
         $this->assertEquals("THREE\n", $latestOutput[1]);
         $this->assertEquals("ONE\nTWO\nTHREE\n", $output[1]);
 
-        $this->assertEquals("", $latestOutput[2]);
+        $this->assertEquals('', $latestOutput[2]);
         $this->assertEquals("ONE\nTWO\nTHREE\n", $output[2]);
     }
 

--- a/tests/Console/ProcessTest.php
+++ b/tests/Console/ProcessTest.php
@@ -463,6 +463,36 @@ class ProcessTest extends TestCase
         $this->assertEquals("ONE\nTWO\nTHREE\n", $output[2]);
     }
 
+    public function testBasicFakeAssertions()
+    {
+        $factory = new Factory;
+
+        $factory->fake();
+
+        $result = $factory->run('ls -la');
+
+        $factory->assertRan(function ($process, $result) {
+            return $process->command == 'ls -la';
+        });
+
+        $factory->assertRanTimes(function ($process, $result) {
+            return $process->command == 'ls -la';
+        }, 1);
+
+        $factory->assertNotRan(function ($process, $result) {
+            return $process->command == 'cat foo';
+        });
+    }
+
+    public function testAsssertingThatNothingRan()
+    {
+        $factory = new Factory;
+
+        $factory->fake();
+
+        $factory->assertNothingRan();
+    }
+
     protected function ls()
     {
         return windows_os() ? 'dir' : 'ls';

--- a/tests/Console/ProcessTest.php
+++ b/tests/Console/ProcessTest.php
@@ -1,0 +1,435 @@
+<?php
+
+namespace Illuminate\Tests;
+
+use Illuminate\Console\Process\Exceptions\ProcessFailedException;
+use Illuminate\Console\Process\Factory;
+use Illuminate\Console\Process\Pool;
+use Illuminate\Contracts\Console\Process\ProcessResult;
+use Mockery as m;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ProcessTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testSuccessfulProcess()
+    {
+        $factory = new Factory;
+        $result = $factory->path(__DIR__)->run($this->ls());
+
+        $this->assertInstanceOf(ProcessResult::class, $result);
+        $this->assertTrue($result->successful());
+        $this->assertFalse($result->failed());
+        $this->assertEquals(0, $result->exitCode());
+        $this->assertTrue(str_contains($result->output(), 'ProcessTest.php'));
+        $this->assertEquals('', $result->errorOutput());
+
+        $result->throw();
+        $result->throwIf(true);
+    }
+
+    public function testProcessPool()
+    {
+        $factory = new Factory;
+
+        $pool = $factory->pool(function (Pool $pool) {
+            return [
+                $pool->path(__DIR__)->command($this->ls()),
+                $pool->path(__DIR__)->command($this->ls()),
+            ];
+        });
+
+        $this->assertTrue(count($pool->running()) === 0);
+
+        $pool->start();
+        $pool->wait();
+
+        $this->assertTrue($pool[0]->successful());
+        $this->assertTrue($pool[1]->successful());
+
+        $this->assertTrue(str_contains($pool[0]->output(), 'ProcessTest.php'));
+        $this->assertTrue(str_contains($pool[1]->output(), 'ProcessTest.php'));
+    }
+
+    public function testProcessPoolResultsCanBeEvaluatedOnTime()
+    {
+        $factory = new Factory;
+
+        $pool = $factory->pool(function (Pool $pool) {
+            return [
+                $pool->path(__DIR__)->command($this->ls()),
+                $pool->path(__DIR__)->command($this->ls()),
+            ];
+        });
+
+        $this->assertTrue($pool[0]->successful());
+        $this->assertTrue($pool[1]->successful());
+
+        $this->assertTrue(str_contains($pool[0]->output(), 'ProcessTest.php'));
+        $this->assertTrue(str_contains($pool[1]->output(), 'ProcessTest.php'));
+    }
+
+    public function testProcessPoolResultsCanBeEvaluatedByName()
+    {
+        $factory = new Factory;
+
+        $pool = $factory->pool(function (Pool $pool) {
+            return [
+                $pool->as('first')->path(__DIR__)->command($this->ls()),
+                $pool->as('second')->path(__DIR__)->command($this->ls()),
+            ];
+        });
+
+        $this->assertTrue($pool['first']->successful());
+        $this->assertTrue($pool['second']->successful());
+
+        $this->assertTrue(str_contains($pool['first']->output(), 'ProcessTest.php'));
+        $this->assertTrue(str_contains($pool['second']->output(), 'ProcessTest.php'));
+    }
+
+    public function testOutputCanBeRetrievedViaStartCallback()
+    {
+        $factory = new Factory;
+
+        $output = [];
+
+        $process = $factory->path(__DIR__)->start($this->ls(), function ($type, $buffer) use (&$output) {
+            $output[] = $buffer;
+        });
+
+        $process->wait();
+
+        $this->assertTrue(str_contains(implode('', $output), 'ProcessTest.php'));
+    }
+
+    public function testOutputCanBeRetrievedViaWaitCallback()
+    {
+        $factory = new Factory;
+
+        $output = [];
+
+        $process = $factory->path(__DIR__)->start($this->ls());
+
+        $process->wait(function ($type, $buffer) use (&$output) {
+            $output[] = $buffer;
+        });
+
+        $this->assertTrue(str_contains(implode('', $output), 'ProcessTest.php'));
+    }
+
+    public function testBasicProcessFake()
+    {
+        $factory = new Factory;
+        $factory->fake();
+
+        $result = $factory->run('ls -la');
+
+        $this->assertEquals('', $result->output());
+        $this->assertEquals('', $result->errorOutput());
+        $this->assertEquals(0, $result->exitCode());
+        $this->assertTrue($result->successful());
+    }
+
+    public function testProcessFakeExitCodes()
+    {
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result('test output', exitCode: 1));
+
+        $result = $factory->run('ls -la');
+        $this->assertFalse($result->successful());
+    }
+
+    public function testBasicProcessFakeWithCustomOutput()
+    {
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result('test output'));
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("test output\n", $result->output());
+
+        // Array of output...
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result(['line 1', 'line 2']));
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("line 1\nline 2\n", $result->output());
+
+        // Array of output with empty line...
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result(['line 1', '', 'line 2']));
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("line 1\n\nline 2\n", $result->output());
+
+        // Plain string...
+        $factory = new Factory;
+        $factory->fake(fn () => 'test output');
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("test output\n", $result->output());
+
+        // Plain array...
+        $factory = new Factory;
+        $factory->fake(fn () => ['line 1', 'line 2']);
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("line 1\nline 2\n", $result->output());
+
+        // Plain array with empty line...
+        $factory = new Factory;
+        $factory->fake(fn () => ['line 1', '', 'line 2']);
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("line 1\n\nline 2\n", $result->output());
+
+        // Process description...
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->describe()->output('line 1')->output('line 2'));
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("line 1\nline 2\n", $result->output());
+
+        // Process description with empty line...
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->describe()->output('line 1')->output('')->output('line 2'));
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("line 1\n\nline 2\n", $result->output());
+    }
+
+    public function testProcessFakeWithErrorOutput()
+    {
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result('standard output', 'error output'));
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("standard output\n", $result->output());
+        $this->assertEquals("error output\n", $result->errorOutput());
+
+        // Array of error output...
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->result('standard output', ['line 1', 'line 2']));
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("standard output\n", $result->output());
+        $this->assertEquals("line 1\nline 2\n", $result->errorOutput());
+
+        // Using process description...
+        $factory = new Factory;
+        $factory->fake(fn () => $factory->describe()->output('standard output')->errorOutput('error output'));
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("standard output\n", $result->output());
+        $this->assertEquals("error output\n", $result->errorOutput());
+    }
+
+    public function testCustomizedFakesPerCommand()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            'ls *' => 'ls command',
+            'cat *' => 'cat command',
+        ]);
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("ls command\n", $result->output());
+
+        $result = $factory->run('cat composer.json');
+        $this->assertEquals("cat command\n", $result->output());
+    }
+
+    public function testProcessFakeSequences()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            'ls *' => $factory->sequence()
+                        ->push('ls command 1')
+                        ->push('ls command 2'),
+            'cat *' => 'cat command',
+        ]);
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("ls command 1\n", $result->output());
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("ls command 2\n", $result->output());
+
+        $result = $factory->run('cat composer.json');
+        $this->assertEquals("cat command\n", $result->output());
+    }
+
+    public function testProcessFakeSequencesCanReturnEmptyResultsWhenSequenceIsEmpty()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            'ls *' => $factory->sequence()
+                        ->push('ls command 1')
+                        ->push('ls command 2')
+                        ->dontFailWhenEmpty(),
+        ]);
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("ls command 1\n", $result->output());
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("ls command 2\n", $result->output());
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("", $result->output());
+    }
+
+    public function testProcessFakeSequencesCanThrowWhenSequenceIsEmpty()
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        $factory = new Factory;
+
+        $factory->fake([
+            'ls *' => $factory->sequence()
+                        ->push('ls command 1')
+                        ->push('ls command 2')
+        ]);
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("ls command 1\n", $result->output());
+
+        $result = $factory->run('ls -la');
+        $this->assertEquals("ls command 2\n", $result->output());
+
+        $result = $factory->run('ls -la');
+    }
+
+    public function testStrayProcessesCanBePrevented()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Attempted process');
+
+        $factory = new Factory;
+
+        $factory->preventStrayProcesses();
+
+        $factory->fake([
+            'ls *' => 'ls command',
+        ]);
+
+        $result = $factory->run('cat composer.json');
+    }
+
+    public function testStrayProcessesActuallyRunByDefault()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            'cat *' => 'cat command',
+        ]);
+
+        $result = $factory->path(__DIR__)->run($this->ls());
+        $this->assertTrue(str_contains($result->output(), 'ProcessTest.php'));
+    }
+
+    public function testFakeProcessesCanThrow()
+    {
+        $this->expectException(ProcessFailedException::class);
+
+        $factory = new Factory;
+
+        $factory->fake(fn () => $factory->result(exitCode: 1));
+
+        $result = $factory->path(__DIR__)->run($this->ls());
+        $result->throw();
+    }
+
+    public function testFakeProcessesThrowIfTrue()
+    {
+        $this->expectException(ProcessFailedException::class);
+
+        $factory = new Factory;
+
+        $factory->fake(fn () => $factory->result(exitCode: 1));
+
+        $result = $factory->path(__DIR__)->run($this->ls());
+        $result->throwIf(true);
+    }
+
+    public function testFakeProcessesDontThrowIfFalse()
+    {
+        $factory = new Factory;
+
+        $factory->fake(fn () => $factory->result(exitCode: 1));
+
+        $result = $factory->path(__DIR__)->run($this->ls());
+        $result->throwIf(false);
+
+        $this->assertTrue(true);
+    }
+
+    public function testRealProcessesCanHaveErrorOutput()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $factory = new Factory;
+        $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
+
+        $this->assertFalse($result->successful());
+        $this->assertEquals("", $result->output());
+        $this->assertEquals("Hello World\n", $result->errorOutput());
+    }
+
+    public function testRealProcessesCanThrow()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $this->expectException(ProcessFailedException::class);
+
+        $factory = new Factory;
+        $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
+
+        $result->throw();
+    }
+
+    public function testRealProcessesCanThrowIfTrue()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $this->expectException(ProcessFailedException::class);
+
+        $factory = new Factory;
+        $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
+
+        $result->throwIf(true);
+    }
+
+    public function testRealProcessesDoesntThrowIfFalse()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Requires Linux.');
+        }
+
+        $factory = new Factory;
+        $result = $factory->path(__DIR__)->run('echo "Hello World" >&2; exit 1;');
+
+        $result->throwIf(false);
+
+        $this->assertTrue(true);
+    }
+
+    protected function ls()
+    {
+        return windows_os() ? 'dir' : 'ls';
+    }
+}


### PR DESCRIPTION
This PR continues and expands upon @nunomaduro's work on providing a convenient process layer in Laravel. Some features have been rebuilt and others have been added. 

Notably, the ability to describe fake process lifecycles for async process handling / testing as well as process result sequences. In addition, the ability to interleave incoming output from a pool of processes and key them by name. Functionality for preventing stray processes during testing has also been added.

In addition, the object model has been rebuilt.

### Usage

**Basic API**

The most basic usage of this feature looks like the following:

```php
use Illuminate\Support\Facades\Process;

$result = Process::run('ls -la');

$result->successful();
$result->failed();
$result->exitCode();
$result->output();
$result->errorOutput();
$result->throw();
$result->throwIf(condition);
```

**Building Processes**

A variety of options can be set on the process before actually invoking it, including setting the timeout, idle timeout, TTY support, and environment variables:

```php
$result = Process::timeout(60)->path(base_path())->env([...])->run('ls -la');

$result = Process::forever()->run('ls -la');
```

**Process Output**

A callback may be passed to the `run` function to gather the process output as it is received. The signature on this callback is the same as the underlying Symfony Process callbacks you may be used to:

```php
$result = Process::run('ls -la', function ($type, $buffer) {
    echo $buffer;
});
```

**Asynchronous Processes**

The `start` method may be used to start an asynchronous process. Calling this method returns an implementation of `InvokedProcess`, allowing you to perform other tasks while the external process is running. The `wait` method may be used to resolve the invoked process into a process result, waiting on the process to finish executing if necessary:

```php
$process = Process::forever()->start('ls -la', function ($type, $buffer) {
     ...
});

while ($process->running()) {
    echo $process->pid();
    echo $process->signal(...);
    echo $process->output();
    echo $process->errorOutput();
    echo $process->latestOutput();
    echo $process->latestErrorOutput();
}

$result = $process->wait();

echo $result->output();
```

**Process Pools**

Process pools allow you to manage and interact with a pool of processes at once, then access their results by key. A callback may be passed to the `start` method of the pool to capture output from all processes by key (the third argument given to the closure). The `start` method returns an instance of `InvokedProcessPool`, allowing you to interact with the pool via various methods. Calling the `wait` method on the invoked pool will wait until all processes in the pool have finished running and run an instance of `ProcessPoolResults`, which may be accessed like an array:

```php
$pool = Process::pool(function (Pool $pool) {
    $pool->path(base_path())->command('ls -la');
    $pool->path(base_path())->command('ls -la');
    $pool->path(base_path())->command('ls -la');
})->start(function ($type, $buffer, $key) {
    dump($type, $buffer, $key);
});

// Get a collection of all of the running processes...
echo $pool->running()->count();

// Send a signal to every running process in the pool...
$pool->signal(SIGUSR2);

$results = $pool->wait();

echo $results[0]->output();
```

For convenience, process pool processes may also be assigned string keys, just like HTTP request pools:

```php
$pool = Process::pool(function (Pool $pool) {
    $pool->as('first')->path(base_path())->command('ls -la');
    $pool->as('second')->path(base_path())->command('ls -la');
})->start(function ($type, $buffer, $key) {
    dump($type, $buffer, $key);
});

$results = $pool->wait();

echo $results['first']->output();
```

In addition, for convenience, a `concurrently` method is provided which is the equivalent to calling `start` and `wait` on the process pool to resolve the results synchronously. In this example, we are using array destructuring to assign the pool process results to individual variables:

```php
[$first, $second, $third] = Process::concurrently(function (Pool $pool) {
    $pool->path(base_path())->command('ls -la');
    $pool->path(base_path())->command('ls -la');
    $pool->path(base_path())->command('ls -la');
});

echo $first->output();
```

### Testing

Testing is similar to @nunomaduro's API, with the following basic API:

```php
Process::fake([
    'ls *' => Process::result('Hello World'),
]);

$result = Process::run('ls -la');

Process::assertRan(function ($process, $result) {
    return $process->command == 'ls -la';
});

Process::assertRanTimes(function ($process, $result) {
    return $process->command == 'ls -la';
}, times: 1);

Process::assertNotRan(function ($process, $result) {
    return $process->command == 'cat foo';
});
```

Fake process results can be defined in a variety of ways, from calling `Process::result` to just passing simple strings and arrays:

```php
Process::fake(['ls -la' => 'Hello World']);

Process::fake(['ls -la' => ['Line 1', 'Line 2']]);
```

**Process Sequences**

Like the HTTP fake's functionality, you may also define sequences of results for commands that are invoked multiple times in a request:

```php
Process::fake([
    'ls *' => Process::sequence()
                       ->push(Process::result('first'))
                       ->push(Process::result('second')),
]);

$first = Process::run('ls -la');
$second = Process::run('ls -la');
```

**Async Process Lifecycles**

Finally, you may also describe async process lifecycles in order to test code that starts processes asynchronously and then interacts with them while running. In this example, `running` will return `true` three times as we specified by calling `iterations(3)` when describing our process. In addition, we define several lines of standard output as well as some error output:

```php
Process::fake([
    '*' => Process::describe()
                   ->output('First line of output')
                   ->output('Next line of output')
                   ->errorOutput('Next line of error output')
                   ->exitCode(0)
                   ->iterations(3),
]);

$process = Process::start('test-async-process');

while ($process->running()) {
    echo $process->latestOutput();
}

echo $process->wait()->output();
```

**Preventing Stray Processes**

By default, if `Process::fake` has been called and Laravel isn't able to find a matching fake definition for a given process, the process will actually execute. This behavior is consistent with the HTTP facade's fake functionality. You can prevent this behavior by invoking the `preventStrayProcesses` method. This will cause Laravel to throw an exception when attempting to invoke a process that does not have a corresponding fake definition:

```php
Process::preventStrayProcesses();

Process::fake(['cat *' => Process::result('Hello World')]);

$result = Process::run('ls -la');
```
