### PR TITLE
[9.x] Update EnumeratesValues docblocks to indicate nullable keys

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -530,7 +530,7 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair.
      *
-     * @param  callable|string  $key
+     * @param  callable|string|null  $key
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return static
@@ -565,7 +565,7 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair using strict comparison.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  mixed  $value
      * @return static
      */
@@ -577,7 +577,7 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
      * @return static
@@ -592,7 +592,7 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair using strict comparison.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @return static
      */
@@ -604,7 +604,7 @@ trait EnumeratesValues
     /**
      * Filter items such that the value of the given key is between the given values.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @return static
      */
@@ -616,7 +616,7 @@ trait EnumeratesValues
     /**
      * Filter items such that the value of the given key is not between the given values.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @return static
      */
@@ -630,7 +630,7 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @param  bool  $strict
      * @return static
@@ -645,7 +645,7 @@ trait EnumeratesValues
     /**
      * Filter items by the given key value pair using strict comparison.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @param  \Illuminate\Contracts\Support\Arrayable|iterable  $values
      * @return static
      */


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When filtering based on the immediate elements in the array one must provide a key of `null` , this change updates the docblocks show this is allowed.
