### PR TITLE
Anonymous component paths

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -124,6 +124,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $rawBlocks = [];
 
     /**
+     * The array of anonymous component paths to search for components in.
+     *
+     * @var array
+     */
+    protected $anonymousComponentPaths = [];
+
+    /**
      * The array of anonymous component namespaces to autoload from.
      *
      * @var array
@@ -683,6 +690,21 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Register a new anonymous component path.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function anonymousComponentPath(string $path)
+    {
+        $this->anonymousComponentPaths[] = $path;
+
+        Container::getInstance()
+                ->make(ViewFactory::class)
+                ->addNamespace(md5($path), $path);
+    }
+
+    /**
      * Register an anonymous component namespace.
      *
      * @param  string  $directory
@@ -709,6 +731,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function componentNamespace($namespace, $prefix)
     {
         $this->classComponentNamespaces[$prefix] = $namespace;
+    }
+
+    /**
+     * Get the registered anonymous component paths.
+     *
+     * @return array
+     */
+    public function getAnonymousComponentPaths()
+    {
+        return $this->anonymousComponentPaths;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -291,7 +291,54 @@ class ComponentTagCompiler
             return $class;
         }
 
-        $guess = collect($this->blade->getAnonymousComponentNamespaces())
+        if (! is_null($guess = $this->guessAnonymousComponentUsingNamespaces($viewFactory, $component)) ||
+            ! is_null($guess = $this->guessAnonymousComponentUsingPaths($viewFactory, $component))) {
+            return $guess;
+        }
+
+        if (Str::startsWith($component, 'mail::')) {
+            return $component;
+        }
+
+        throw new InvalidArgumentException(
+            "Unable to locate a class or view for component [{$component}]."
+        );
+    }
+
+    /**
+     * Attempt to find an anonymous component using the registered anonymous component paths.
+     *
+     * @param  \Illuminate\Contracts\View\Factory  $viewFactory
+     * @param  string  $component
+     * @return string|null
+     */
+    protected function guessAnonymousComponentUsingPaths(Factory $viewFactory, string $component)
+    {
+        foreach ($this->blade->getAnonymousComponentPaths() as $path) {
+            try {
+                if (! is_null($guess = match (true) {
+                    $viewFactory->exists($guess = md5($path).ViewFinderInterface::HINT_PATH_DELIMITER.$component) => $guess,
+                    $viewFactory->exists($guess = md5($path).ViewFinderInterface::HINT_PATH_DELIMITER.$component.'.index') => $guess,
+                    default => null,
+                })) {
+                    return $guess;
+                }
+            } catch (InvalidArgumentException $e) {
+                //
+            }
+        }
+    }
+
+    /**
+     * Attempt to find an anonymous component using the registered anonymous component namespaces.
+     *
+     * @param  \Illuminate\Contracts\View\Factory  $viewFactory
+     * @param  string  $component
+     * @return string|null
+     */
+    protected function guessAnonymousComponentUsingNamespaces(Factory $viewFactory, string $component)
+    {
+        return collect($this->blade->getAnonymousComponentNamespaces())
             ->filter(function ($directory, $prefix) use ($component) {
                 return Str::startsWith($component, $prefix.'::');
             })
@@ -311,18 +358,6 @@ class ComponentTagCompiler
                     return $view;
                 }
             });
-
-        if (! is_null($guess)) {
-            return $guess;
-        }
-
-        if (Str::startsWith($component, 'mail::')) {
-            return $component;
-        }
-
-        throw new InvalidArgumentException(
-            "Unable to locate a class or view for component [{$component}]."
-        );
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -314,6 +314,10 @@ class ComponentTagCompiler
      */
     protected function guessAnonymousComponentUsingPaths(Factory $viewFactory, string $component)
     {
+        if (str_contains($component, ViewFinderInterface::HINT_PATH_DELIMITER)) {
+            return;
+        }
+
         foreach ($this->blade->getAnonymousComponentPaths() as $path) {
             try {
                 if (! is_null($guess = match (true) {

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -577,7 +577,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $app->shouldReceive('getNamespace')->once()->andReturn('App\\');
 
         $factory->shouldReceive('exists')->andReturnUsing(function ($arg) {
-            return $arg === 'ddd41f081fefd4c3fd2c5ab82a8f0f70::panel';
+            return $arg === md5('test-directory').'::panel';
         });
 
         Container::setInstance($container);
@@ -585,14 +585,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $blade = m::mock(BladeCompiler::class)->makePartial();
 
         $blade->shouldReceive('getAnonymousComponentPaths')->once()->andReturn([
-            __DIR__,
+            'test-directory',
         ]);
 
         $compiler = $this->compiler([], [], $blade);
 
         $result = $compiler->compileTags('<x-panel />');
 
-        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'panel', ['view' => 'ddd41f081fefd4c3fd2c5ab82a8f0f70::panel','data' => []])
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'panel', ['view' => '8ee975052836fdc7da2267cf8a580b80::panel','data' => []])
 <?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag && \$constructor = (new ReflectionClass(Illuminate\View\AnonymousComponent::class))->getConstructor()): ?>
 <?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
 <?php endif; ?>

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -577,6 +577,39 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $app->shouldReceive('getNamespace')->once()->andReturn('App\\');
 
         $factory->shouldReceive('exists')->andReturnUsing(function ($arg) {
+            return $arg === md5('test-directory').'::panel.index';
+        });
+
+        Container::setInstance($container);
+
+        $blade = m::mock(BladeCompiler::class)->makePartial();
+
+        $blade->shouldReceive('getAnonymousComponentPaths')->once()->andReturn([
+            'test-directory',
+        ]);
+
+        $compiler = $this->compiler([], [], $blade);
+
+        $result = $compiler->compileTags('<x-panel />');
+
+        $this->assertSame("##BEGIN-COMPONENT-CLASS##@component('Illuminate\View\AnonymousComponent', 'panel', ['view' => '8ee975052836fdc7da2267cf8a580b80::panel.index','data' => []])
+<?php if (isset(\$attributes) && \$attributes instanceof Illuminate\View\ComponentAttributeBag && \$constructor = (new ReflectionClass(Illuminate\View\AnonymousComponent::class))->getConstructor()): ?>
+<?php \$attributes = \$attributes->except(collect(\$constructor->getParameters())->map->getName()->all()); ?>
+<?php endif; ?>
+<?php \$component->withAttributes([]); ?>\n".
+            '@endComponentClass##END-COMPONENT-CLASS##', trim($result));
+    }
+
+    public function testClasslessIndexComponentsWithAnonymousComponentPath()
+    {
+        $container = new Container;
+
+        $container->instance(Application::class, $app = m::mock(Application::class));
+        $container->instance(Factory::class, $factory = m::mock(Factory::class));
+
+        $app->shouldReceive('getNamespace')->once()->andReturn('App\\');
+
+        $factory->shouldReceive('exists')->andReturnUsing(function ($arg) {
             return $arg === md5('test-directory').'::panel';
         });
 


### PR DESCRIPTION
This PR allows the registration of custom, root-level anonymous component search paths.

```php
Blade::anonymousComponentPath(base_path().'/some/random/path');
```