### PR TITLE
[10.x] Macro traits

### DIFF
--- a/src/Illuminate/Macroable/MacroTrait.php
+++ b/src/Illuminate/Macroable/MacroTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ReflectionClass;
+
+class MacroTrait
+{
+    protected $reflected;
+
+    public function __construct($target)
+    {
+        $this->reflected = new ReflectionClass($target);
+    }
+
+    public function __get(string $name): mixed
+    {
+        $property = $this->reflected->getProperty($name);
+
+        $property->setAccessible(true);
+
+        return $property->getValue($this->target);
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        $property = $this->reflected->getProperty($name);
+
+        $property->setAccessible(true);
+
+        $property->setValue($this->target, $value);
+    }
+
+    public function __call(string $name, array $params = []): mixed
+    {
+        $method = $this->reflected->getMethod($name);
+
+        $method->setAccessible(true);
+
+        return $method->invoke($this->target, ...$params);
+    }
+}

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Support;
 
 use BadMethodCallException;
+use Illuminate\Support\MacroTrait;
 use Illuminate\Support\Traits\Macroable;
 use PHPUnit\Framework\TestCase;
 
@@ -85,6 +86,26 @@ class SupportMacroableTest extends TestCase
         $this->assertSame('foo', $instance->methodThree());
     }
 
+    public function testMacroTraits()
+    {
+        TestMacroable::trait(TestTrait::class);
+        $instance = new TestMacroable;
+        $this->assertSame('instance-Adam', $instance->methodOne('Adam'));
+    }
+
+    public function testMacroTraitsNoReplace()
+    {
+        TestMacroable::macro('methodThree', function () {
+            return 'bar';
+        });
+        TestMacroable::trait(TestTrait::class, false);
+        $instance = new TestMacroable;
+        $this->assertSame('bar', $instance->methodThree());
+
+        TestMacroable::trait(TestTrait::class);
+        $this->assertSame('foo', $instance->methodThree());
+    }
+
     public function testFlushMacros()
     {
         TestMacroable::macro('flushMethod', function () {
@@ -158,5 +179,23 @@ class TestMixin
         return function () {
             return 'foo';
         };
+    }
+}
+
+class TestTrait extends MacroTrait
+{
+    public function methodOne($value)
+    {
+        return $this->methodTwo($value);
+    }
+
+    protected function methodTwo($value)
+    {
+        return $this->protectedVariable.'-'.$value;
+    }
+
+    protected function methodThree()
+    {
+        return 'foo';
     }
 }


### PR DESCRIPTION
I recently tried to add some macros to the `Request` class, and digging through the code I found the [mixin](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Macroable/Traits/Macroable.php#L40) method. It did *almost* what I expected it to do, except that it's too verbose. Having to write a new function in every method is a bit annoying, and does not improve the DX over using `::macro` that much (beyond having the code encapsulated in a different file).

So this PR is a proof-of-concept of the API I'd like to have :).

Note: I've taken the funky magic methods from Caleb/Spatie's [invade function](https://github.com/spatie/invade/blob/main/src/Invader.php). I'm not sure if there's anything already available in core to clean that up.

## Example usage

The TLDR of what this new feature would allow can be seen in the updated test in the PR, but here it is again for clarity.

Instead of writing this:

```php
// To set up the mixin...
TestMacroable::mixin(new TestMixin);

// To define the mixin...
class TestMixin
{
    public function methodOne()
    {
        return function ($value) {
            return $this->methodTwo($value);
        };
    }

    protected function methodTwo()
    {
        return function ($value) {
            return $this->protectedVariable.'-'.$value;
        };
    }

    protected function methodThree()
    {
        return function () {
            return 'foo';
        };
    }
}
```

You'd be able to write this:

```php
// To set up the trait...
TestMacroable::trait(TestTrait::class);

// To define the trait...
class TestTrait extends MacroTrait
{
    public function methodOne($value)
    {
        return $this->methodTwo($value);
    }

    protected function methodTwo($value)
    {
        return $this->protectedVariable.'-'.$value;
    }

    protected function methodThree()
    {
        return 'foo';
    }
}
```

## Alternatives

Something that doesn't sit right with this solution is calling these "traits" and declaring them as classes. I did that because the name `mixin` was already in use and I couldn't come up with anything better. But now I just realized we could take advantage of the fact that the "trait" solution takes a string argument instead of an object. So an alternative solution would be to use the same API (call them "mixins"), but if we pass a string we assume it's a class name and apply it using this logic.

I do like this better, but I will refrain from changing anything else before I get some feedback. I'm aware that this includes a fair bit of magic and maybe it won't be merged because of that (or other reasons).