### PR TITLE
[9.x] Add `Str::dot()` method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -202,7 +202,7 @@ class Str
     }
 
     /**
-     * Convert a value to camel case.
+     * Convert a string to camel case.
      *
      * @param  string  $value
      * @return string
@@ -264,6 +264,19 @@ class Str
         }
 
         return true;
+    }
+
+    /**
+     * Convert a string to "dot" notation.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function dot($value)
+    {
+       return static::snake(static::replace(
+           ['-', '_'], ' ', implode(static::ucsplit($value))
+       ), '.');
     }
 
     /**
@@ -1099,7 +1112,7 @@ class Str
     }
 
     /**
-     * Convert a value to studly caps case.
+     * Convert a string to studly caps case.
      *
      * @param  string  $value
      * @return string

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -269,14 +269,14 @@ class Str
     /**
      * Convert a string to "dot" notation.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     public static function dot($value)
     {
-       return static::snake(static::replace(
+        return static::snake(static::replace(
            ['-', '_'], ' ', implode(static::ucsplit($value))
-       ), '.');
+        ), '.');
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -155,7 +155,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Convert a value to camel case.
+     * Convert a string to camel case.
      *
      * @return static
      */
@@ -197,6 +197,16 @@ class Stringable implements JsonSerializable
     public function dirname($levels = 1)
     {
         return new static(dirname($this->value, $levels));
+    }
+
+    /**
+     * Convert a string to "dot" notation.
+     *
+     * @return $this
+     */
+    public function dot()
+    {
+        return new static(Str::dot($this->value));
     }
 
     /**
@@ -770,7 +780,7 @@ class Stringable implements JsonSerializable
     }
 
     /**
-     * Convert a value to studly caps case.
+     * Convert a string to studly caps case.
      *
      * @return static
      */

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -715,6 +715,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('fooBarBaz', Str::camel('foo-bar_baz'));
     }
 
+    public function testDot()
+    {
+        $this->assertSame('laravel.p.h.p.framework', Str::dot('Laravel_p_h_p_framework'));
+        $this->assertSame('laravel.php.framework', Str::dot('Laravel_php_framework'));
+        $this->assertSame('laravel.ph.p.framework', Str::dot('Laravel-phP-framework'));
+        $this->assertSame('laravel.php.framework', Str::dot('Laravel  -_-  php   -_-   framework   '));
+
+        $this->assertSame('foo.bar', Str::dot('FooBar'));
+        $this->assertSame('foo.bar', Str::dot('foo_bar'));
+        $this->assertSame('foo.bar.baz', Str::dot('Foo-barBaz'));
+        $this->assertSame('foo.bar.baz', Str::dot('foo-bar_baz'));
+    }
+
     public function testSubstr()
     {
         $this->assertSame('Ё', Str::substr('БГДЖИЛЁ', -1));


### PR DESCRIPTION
## Description

This PR adds an additional `Str::dot()` helper method used for converting strings into "dot" notation:

```php
// foo.bar.baz
Str::dot('FooBarBaz'); 

// foo.bar.baz
Str::dot('foo Bar Baz'); 

// foo.ba.r.baz
Str::dot('fooBaRBaz'); 
```

## Purpose

This method would be particularly useful in generating guesses for dot notated paths for the `data_get($path)` or `Arr::get($path)` helpers, based on a string or a class name.

For example, if we have an array of `$data` that contains a user having a location:

```php
$data = [
    'user' => [
        // ...
        'location' => [
            'name' => 'Foo',
        ],
    ],
];

// "user.location"
$key = Str::dot(
    class_basename(UserLocation::class)
);

// ['name' => 'Foo']
$location = data_get($data, $key);
```

Let me know if you'd like anything adjusted. Thanks for your time!

> **Note**: I've also converted a couple of the doc blocks that displayed `Covert a value` to `Convert a string`, for consistency across all other stringable methods.