### PR TITLE
[9.x] Add "snakecase" validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1197,6 +1197,19 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is snakecase.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateSnakecase($attribute, $value, $parameters)
+    {
+        return Str::snake($value) === $value;
+    }
+
+    /**
      * Validate the MIME type of a file is an image MIME type.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1857,6 +1857,42 @@ class ValidationValidatorTest extends TestCase
         ], $v->messages()->keys());
     }
 
+    public function testSnakecase()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'lower' => 'lowercase',
+            'mixed' => 'MixedCase',
+            'upper' => 'UPPERCASE',
+            'lower_multibyte' => 'carácter_multibyte',
+            'mixed_multibyte' => 'carÁcter_multibyte',
+            'upper_multibyte' => 'CARÁCTER_MULTIBYTE',
+            'lower_multibyte_space' => 'carácter multibyte',
+            'mixed_multibyte_space' => 'carÁcter multibyte',
+            'upper_multibyte_space' => 'CARÁCTER MULTIBYTE',
+        ], [
+            'lower' => 'snakecase',
+            'mixed' => 'snakecase',
+            'upper' => 'snakecase',
+            'lower_multibyte' => 'snakecase',
+            'mixed_multibyte' => 'snakecase',
+            'upper_multibyte' => 'snakecase',
+            'lower_multibyte_space' => 'snakecase',
+            'mixed_multibyte_space' => 'snakecase',
+            'upper_multibyte_space' => 'snakecase',
+        ]);
+
+        $this->assertSame([
+            'mixed',
+            'upper',
+            'mixed_multibyte',
+            'upper_multibyte',
+            'lower_multibyte_space',
+            'mixed_multibyte_space',
+            'upper_multibyte_space',
+        ], $v->messages()->keys());
+    }
+
     public function testLessThan()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
we can validate whether requested values are snake or not.

## Usage
`Validator::make(['property' => 'zipCode'], ['property' => 'required|string|snakecase']);`

this pull request were inspired by [Add "lowercase" validation rule](https://github.com/laravel/framework/pull/44883).