### PR TITLE
[9.x] Add `decimal` validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -555,6 +555,34 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute has decimal figures between a set of values.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array<int, int|string>  $parameters
+     * @return bool
+     */
+    public function validateDecimal($attribute, $value, $parameters)
+    {
+        if (!$this->validateNumeric($attribute, $value)) {
+            return false;
+        }
+
+        $this->requireParameterCount(1, $parameters, 'decimal');
+
+        $matches = [];
+        preg_match('/^\d*.(\d*)$/', $value, $matches);
+
+        $decimals = strlen(end($matches));
+
+        if ($decimals < $parameters[0]) {
+            return false;
+        }
+
+        return !isset($parameters[1]) || $decimals <= $parameters[1];
+    }
+
+    /**
      * Validate that an attribute is different from another attribute.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -555,7 +555,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute has decimal figures between a set of values.
+     * Validate that an attribute has a given number of decimal places.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -571,15 +571,13 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'decimal');
 
         $matches = [];
+
         preg_match('/^\d*.(\d*)$/', $value, $matches);
 
         $decimals = strlen(end($matches));
 
-        if ($decimals < $parameters[0]) {
-            return false;
-        }
-
-        return !isset($parameters[1]) || $decimals <= $parameters[1];
+        return $decimals >= $parameters[0] &&
+               (! isset($parameters[1]) || $decimals <= $parameters[1]);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2448,6 +2448,43 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateDecimal()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Decimal:2,3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.2345'], ['foo' => 'Decimal:2,3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.234'], ['foo' => 'Decimal:2,3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:2,3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'Decimal:2,3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.234'], ['foo' => 'Decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'Decimal:2']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Decimal:0,1']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'Decimal:0,1']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:0,1']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateInt()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR adds `decimal` validation rule to check that an attribute is numeric and consists of decimal part digits between a set of values.

### Usage

`decimal:min,max`: parameter(s) defines minimum and maximum (optional) number of acceptable digits (both inclusive) in decimal part

### Examples

- `decimal:1,3`: requires values to have one, two or three digits in fractional part
- `decimal:0,3`: requires values to have at most three digits in fractional part
- `decimal:3`: requires values to have at least three digits in fractional part