### PR TITLE
the static::$toMailCallback and the static::$createUrlCallback is doe…

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -59,9 +59,13 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
-        if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
-        }
+        
+        if (static::$toMailCallback && method_exists($this, static::$toMailCallback)) {
+
+			$callableFunction = static::$toMailCallback;
+
+			return $this->$callableFunction($notifiable, $this->token);
+		}
 
         return $this->buildMailMessage($this->resetUrl($notifiable));
     }
@@ -90,9 +94,12 @@ class ResetPassword extends Notification
      */
     protected function resetUrl($notifiable)
     {
-        if (static::$createUrlCallback) {
-            return call_user_func(static::$createUrlCallback, $notifiable, $this->token);
-        }
+        if (static::$createUrlCallback && method_exists($this, static::$createUrlCallback)) {
+
+			$callableFunction = static::$createUrlCallback;
+
+			return $this->$callableFunction($notifiable, $this->token);
+		}
 
         return url(route('password.reset', [
             'token' => $this->token,


### PR DESCRIPTION
I'm create an notification with _php artisan make:notification BlaBlaNotification_

I'm extends ResetPassword class in the BlaBlaNotification 

`class TestResetPassword extends ResetPassword`

i am create a variable of static::$createUrlCallback and assign "test" value

`public static $createUrlCallback = "test";`

and i created a function on name is "test"


```
public function test(){
	dd("stop");
}
```

I got an error when I send the request to the controller class containing the the BlaBlaNotification

Controller
`Notification::send(User::first(), new BlaBlaNotification("foo"));`

_The error:
TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, function "test" not found or invalid function name in file C:\\blabla\vendor\laravel\framework\src\Illuminate\Auth\Notifications\ResetPassword.php on line 119_

I typed function_exist(static::$createUrlCallback) on line 93 in the ResetPassword class and saw it returned "false"
For this reason, I thought that the call_user_func function could not reach the "test" method in the BlaBlaNotification class.
I thought it would be correct to set it this way.