### PR TITLE
[9.x] Load Schema to Sqlite In Memory Database

### DIFF
--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -61,6 +61,12 @@ class SqliteSchemaState extends SchemaState
      */
     public function load($path)
     {
+        if ($this->connection->getDatabaseName() === ':memory:') {
+            $this->connection->getPdo()->exec($this->files->get($path));
+
+            return;
+        }
+        
         $process = $this->makeProcess($this->baseCommand().' < "${:LARAVEL_LOAD_PATH}"');
 
         $process->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [


### PR DESCRIPTION
allow load schema to in memory database, it can make test faster