### PR TITLE
Add whereUlid(param) support for routing

### DIFF
--- a/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
+++ b/src/Illuminate/Routing/CreatesRegularExpressionRouteConstraints.php
@@ -40,6 +40,17 @@ trait CreatesRegularExpressionRouteConstraints
     }
 
     /**
+     * Specify that the given route parameters must be ULIDs.
+     *
+     * @param  array|string  $parameters
+     * @return $this
+     */
+    public function whereUlid($parameters)
+    {
+        return $this->assignExpressionToParameters($parameters, '[0-7][0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{25}');
+    }
+
+    /**
      * Specify that the given route parameters must be UUIDs.
      *
      * @param  array|string  $parameters

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -83,6 +83,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\RouteRegistrar whereAlpha(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereAlphaNumeric(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereNumber(array|string $parameters)
+ * @method static \Illuminate\Routing\RouteRegistrar whereUlid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereUuid(array|string $parameters)
  * @method static \Illuminate\Routing\RouteRegistrar whereIn(array|string $parameters, array $values)
  * @method static \Illuminate\Routing\RouteRegistrar as(string $value)


### PR DESCRIPTION
Allows route()->whereUlid() support for routing, which currently only allows for whereUuid().

I didn't add any tests because:
(a) the regex is simple
(b) there were no existing test for the other regex params that I found to build off of
(c) there may also be discussion as to whether lower-case should be supported, or whether the regex should be fine-tuned to support actually generatable ULID's (there's further refinement that's technically possible, but there's a question of whether you hit diminishing returns)