### PR TITLE
[9.x] Support where and orderby over relation aggregations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -800,6 +800,10 @@ trait QueriesRelationships
      */
     public function WhereHasAggregate($relation, $column, $function, $operator = null, $value = null, $boolean = 'and')
     {
+        if ($operator instanceof Closure) {
+            throw new InvalidArgumentException('The aggregation operator can not be a closure.');
+        }
+
         return $this->relationAggregate(
             $relation,
             $column,

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1254,7 +1254,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         // alias has a dynamic hash, so replace with a static string for comparison
         $alias = 'self_alias_hash';
-        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+        $aliasRegex = '/\b(laravel_reserved_\d+)(\b|$)/i';
 
         $sql = preg_replace($aliasRegex, $alias, $sql);
 
@@ -1371,7 +1371,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         // alias has a dynamic hash, so replace with a static string for comparison
         $alias = 'self_alias_hash';
-        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+        $aliasRegex = '/\b(laravel_reserved_\d+)(\b|$)/i';
 
         $sql = preg_replace($aliasRegex, $alias, $sql);
 
@@ -1540,7 +1540,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         // alias has a dynamic hash, so replace with a static string for comparison
         $alias = 'self_alias_hash';
-        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+        $aliasRegex = '/\b(laravel_reserved_\d+)(\b|$)/i';
 
         $sql = preg_replace($aliasRegex, $alias, $builder->toSql());
 
@@ -1610,7 +1610,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         // alias has a dynamic hash, so replace with a static string for comparison
         $alias = 'self_alias_hash';
-        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+        $aliasRegex = '/\b(laravel_reserved_\d+)(\b|$)/i';
 
         $sql = preg_replace($aliasRegex, $alias, $builder->toSql());
 
@@ -1690,7 +1690,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         // alias has a dynamic hash, so replace with a static string for comparison
         $alias = 'self_alias_hash';
-        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+        $aliasRegex = '/\b(laravel_reserved_\d+)(\b|$)/i';
 
         $nestedSql = preg_replace($aliasRegex, $alias, $nestedSql);
         $dotSql = preg_replace($aliasRegex, $alias, $dotSql);
@@ -1706,7 +1706,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         // alias has a dynamic hash, so replace with a static string for comparison
         $alias = 'self_alias_hash';
-        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+        $aliasRegex = '/\b(laravel_reserved_\d+)(\b|$)/i';
 
         $sql = preg_replace($aliasRegex, $alias, $sql);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1564,6 +1564,75 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame(['foo', 2], $builder->getBindings());
     }
 
+    public function testOrderByCount()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->orderByCount('foo', 'desc');
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".* from "eloquent_builder_test_model_parent_stubs" order by (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") desc', $builder->toSql());
+    }
+
+    public function testOrderByCountWithConstraintsAndHavingInSubquery()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->where('bar', 'baz')
+            ->orderByCount(['foo' => fn ($q) => $q->having('bam', '>', 'qux')]);
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".* from "eloquent_builder_test_model_parent_stubs" where "bar" = ? order by (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) asc', $builder->toSql());
+        $this->assertEquals(['baz', 'qux'], $builder->getBindings());
+    }
+
+    public function testOrderByMin()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->orderByMin('foo', 'bam');
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".* from "eloquent_builder_test_model_parent_stubs" order by (select min("eloquent_builder_test_model_close_related_stubs"."bam") from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") asc', $builder->toSql());
+    }
+
+    public function testOrderByMinOnBelongsToMany()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->orderByMin('roles', 'id', 'desc');
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".* from "eloquent_builder_test_model_parent_stubs" order by (select min("eloquent_builder_test_model_far_related_stubs"."id") from "eloquent_builder_test_model_far_related_stubs" inner join "user_role" on "eloquent_builder_test_model_far_related_stubs"."id" = "user_role"."related_id" where "eloquent_builder_test_model_parent_stubs"."id" = "user_role"."self_id") desc', $builder->toSql());
+    }
+
+    public function testOrderByMinOnSelfRelated()
+    {
+        $model = new EloquentBuilderTestModelSelfRelatedStub;
+
+        $builder = $model->orderByMin('childFoos', 'created_at');
+
+        // alias has a dynamic hash, so replace with a static string for comparison
+        $alias = 'self_alias_hash';
+        $aliasRegex = '/\b(laravel_reserved_\d)(\b|$)/i';
+
+        $sql = preg_replace($aliasRegex, $alias, $builder->toSql());
+
+        $this->assertSame('select "self_related_stubs".* from "self_related_stubs" order by (select min("self_alias_hash"."created_at") from "self_related_stubs" as "self_alias_hash" where "self_related_stubs"."id" = "self_alias_hash"."parent_id") asc', $sql);
+    }
+
+    public function testOrderByAggregateAndSelfRelationConstrain()
+    {
+        EloquentBuilderTestStub::resolveRelationUsing('children', function ($model) {
+            return $model->hasMany(EloquentBuilderTestStub::class, 'parent_id', 'id')->where('enum_value', 'foo');
+        });
+
+        $model = new EloquentBuilderTestStub;
+        $this->mockConnectionForModel($model, '');
+        $relationHash = $model->children()->getRelationCountHash(false);
+
+        $builder = $model->orderByCount('children');
+
+        $this->assertSame(vsprintf('select "table".* from "table" order by (select count(*) from "table" as "%s" where "table"."id" = "%s"."parent_id" and "enum_value" = ?) asc', [$relationHash, $relationHash]), $builder->toSql());
+        $this->assertSame(['foo'], $builder->getBindings());
+    }
+
     public function testHasNestedWithConstraints()
     {
         $model = new EloquentBuilderTestModelParentStub;


### PR DESCRIPTION
This PR adds the `where` and `orderBy` clauses over relationships.

---

Examples of `where` clause (assume comments table has a `likes` column):

```php
Post::whereHasCount('comments', '>', 10);
Post::whereHasMax('comments', 'likes', '<=', 5);
Post::whereHasMin('comments', 'likes', '>=', 100);
Post::whereHasSum('comments', 'likes', '>', '1000');
Post::whereHasAvg('comments', 'likes', '>', 1000);
```
They all are using `whereHasAggregate()` method.
This method is able to be used with other functions like `distinct` or custom functions.

---

Examples of `orderBy` clause:

```php
Post::orderByCount('comments');
Post::orderByMax('comments', 'likes', 'desc');
Post::orderByMin('comments', 'likes');
Post::orderBySum('comments', 'likes');
Post::orderByAvg('comments', 'likes');
```

Similar to the `where` methods, the `orderBy` methods are using `orderByAggregate()` method.
And it is able to be used with other functions like `distinct` or custom functions.

---

### Implementation Notes:
At a higher level, these methods are using the same logic from `withAggregate()` method and in order to avoid duplicating code another method was created to have that logic [`relationAggregate()`]. 
In summary we have this hierarchy:

```mermaid
flowchart TB
    subgraph withAggregate
        withCount
        withMax
        withMin
        withSum
        withAvg
        withExists
    end
    subgraph whereHasAggregate
        whereHasCount
        whereHasMax
        whereHasMin
        whereHasSum
        whereHasAvg
    end
    subgraph orderByAggregate
        orderByCount
        orderByMax
        orderByMin
        orderBySum
        orderByAvg
    end
    relationAggregate-->withAggregate;
    relationAggregate-->whereHasAggregate;
    relationAggregate-->orderByAggregate;
```


