### PR TITLE
Load schema to in memory database

### DIFF
--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -61,6 +61,12 @@ class SqliteSchemaState extends SchemaState
      */
     public function load($path)
     {
+        if ($this->connection->getDatabaseName() === ':memory:') {
+            $this->connection->getPdo()->exec($this->files->get($path));
+
+            return;
+        }
+
         $process = $this->makeProcess($this->baseCommand().' < "${:LARAVEL_LOAD_PATH}"');
 
         $process->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [

--- a/tests/Database/DatabaseSqliteSchemaStateTest.php
+++ b/tests/Database/DatabaseSqliteSchemaStateTest.php
@@ -4,7 +4,9 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Schema\SqliteSchemaState;
 use Illuminate\Database\SQLiteConnection;
+use Illuminate\Filesystem\Filesystem;
 use Mockery as m;
+use PDO;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
@@ -21,6 +23,7 @@ class DatabaseSqliteSchemaStateTest extends TestCase
         $config = ['driver' => 'sqlite', 'database' => 'database/database.sqlite', 'prefix' => '', 'foreign_key_constraints' => true, 'name' => 'sqlite'];
         $connection = m::mock(SQLiteConnection::class);
         $connection->shouldReceive('getConfig')->andReturn($config);
+        $connection->shouldReceive('getDatabaseName')->andReturn($config['database']);
 
         $process = m::spy(Process::class);
         $processFactory = function () use ($process) {
@@ -36,4 +39,20 @@ class DatabaseSqliteSchemaStateTest extends TestCase
         ]);
     }
 
+    public function testLoadSchemaToInMemory(): void
+    {
+        $config = ['driver' => 'sqlite', 'database' => ':memory:', 'prefix' => '', 'foreign_key_constraints' => true, 'name' => 'sqlite'];
+        $connection = m::mock(SQLiteConnection::class);
+        $connection->shouldReceive('getConfig')->andReturn($config);
+        $connection->shouldReceive('getDatabaseName')->andReturn($config['database']);
+        $connection->shouldReceive('getPdo')->andReturn($pdo = m::spy(PDO::class));
+
+        $files = m::mock(Filesystem::class);
+        $files->shouldReceive('get')->andReturn('CREATE TABLE IF NOT EXISTS "migrations" ("id" integer not null primary key autoincrement, "migration" varchar not null, "batch" integer not null);');
+
+        $schemaState = new SqliteSchemaState($connection, $files);
+        $schemaState->load('database/schema/sqlite-schema.dump');
+
+        $pdo->shouldHaveReceived('exec')->with('CREATE TABLE IF NOT EXISTS "migrations" ("id" integer not null primary key autoincrement, "migration" varchar not null, "batch" integer not null);');
+    }
 }

--- a/tests/Database/DatabaseSqliteSchemaStateTest.php
+++ b/tests/Database/DatabaseSqliteSchemaStateTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Schema\SqliteSchemaState;
+use Illuminate\Database\SQLiteConnection;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class DatabaseSqliteSchemaStateTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testLoadSchemaToDatabase(): void
+    {
+        $config = ['driver' => 'sqlite', 'database' => 'database/database.sqlite', 'prefix' => '', 'foreign_key_constraints' => true, 'name' => 'sqlite'];
+        $connection = m::mock(SQLiteConnection::class);
+        $connection->shouldReceive('getConfig')->andReturn($config);
+
+        $process = m::spy(Process::class);
+        $processFactory = function () use ($process) {
+            return $process;
+        };
+
+        $schemaState = new SqliteSchemaState($connection, null, $processFactory);
+        $schemaState->load('database/schema/sqlite-schema.dump');
+
+        $process->shouldHaveReceived('mustRun')->with(null, [
+            'LARAVEL_LOAD_DATABASE' => 'database/database.sqlite',
+            'LARAVEL_LOAD_PATH' => 'database/schema/sqlite-schema.dump',
+        ]);
+    }
+
+}

--- a/tests/Database/DatabaseSqliteSchemaStateTest.php
+++ b/tests/Database/DatabaseSqliteSchemaStateTest.php
@@ -26,12 +26,13 @@ class DatabaseSqliteSchemaStateTest extends TestCase
         $connection->shouldReceive('getDatabaseName')->andReturn($config['database']);
 
         $process = m::spy(Process::class);
-        $processFactory = function () use ($process) {
-            return $process;
-        };
+        $processFactory = m::mock(new ProcessFactory($process));
 
         $schemaState = new SqliteSchemaState($connection, null, $processFactory);
         $schemaState->load('database/schema/sqlite-schema.dump');
+
+        $processFactory->shouldHaveReceived('__invoke')
+            ->with('sqlite3 "${:LARAVEL_LOAD_DATABASE}" < "${:LARAVEL_LOAD_PATH}"');
 
         $process->shouldHaveReceived('mustRun')->with(null, [
             'LARAVEL_LOAD_DATABASE' => 'database/database.sqlite',
@@ -54,5 +55,20 @@ class DatabaseSqliteSchemaStateTest extends TestCase
         $schemaState->load('database/schema/sqlite-schema.dump');
 
         $pdo->shouldHaveReceived('exec')->with('CREATE TABLE IF NOT EXISTS "migrations" ("id" integer not null primary key autoincrement, "migration" varchar not null, "batch" integer not null);');
+    }
+}
+
+class ProcessFactory
+{
+    private $process;
+
+    public function __construct($process)
+    {
+        $this->process = $process;
+    }
+
+    public function __invoke()
+    {
+        return $this->process;
     }
 }


### PR DESCRIPTION
in my case, there are more than 400 migrations, when I run all tests, it will take about 2 minutes, even using an in-memory database.

this PR can load schema to in-memory database. it will make the test faster