### PR TITLE
[9.x] Str::after() minor tweaks

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -73,7 +73,7 @@ class Str
      *
      * @param  string  $subject
      * @param  string  $search
-     * @param  bool    $last
+     * @param  bool  $last
      * @return string
      */
     public static function after($subject, $search, $last = false)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -69,15 +69,26 @@ class Str
     }
 
     /**
-     * Return the remainder of a string after the first occurrence of a given value.
+     * Return the remainder of a string after the first (or last) occurrence of a given value.
      *
      * @param  string  $subject
      * @param  string  $search
+     * @param  bool    $last
      * @return string
      */
-    public static function after($subject, $search)
+    public static function after($subject, $search, $last = false)
     {
-        return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+        if ($search === '') {
+            return $subject;
+        }
+
+        $position = $last ? mb_strrpos($subject, (string) $search) : mb_strpos($subject, (string) $search);
+
+        if ($position === false) {
+            return $subject;
+        }
+
+        return static::substr($subject, $position + static::length($search));
     }
 
     /**
@@ -89,17 +100,7 @@ class Str
      */
     public static function afterLast($subject, $search)
     {
-        if ($search === '') {
-            return $subject;
-        }
-
-        $position = strrpos($subject, (string) $search);
-
-        if ($position === false) {
-            return $subject;
-        }
-
-        return substr($subject, $position + strlen($search));
+        return static::after($subject, $search, true);
     }
 
     /**


### PR DESCRIPTION
In the original version of the `after()` method, `$subject` is split into an array then reversed and the first element of the resulting array is returned.

```php
return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
```

So, a temporary array is created every time.

In the modified version we use the same logic used in `afterLast()`, which means, we only use string search and manipulation to return the substring.

Also, the behavior of `after()` has been modified to allow it to return the remainder of a string after the first **or** last occurrence (controlled by the new `$last` parameter).

Stopping using array manipulation was the main goal of this change. The overall behavior of both functions wasn't changed.