### PR TITLE
Revert "fix single line @php statements to not be parsed as php blocks"

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -387,7 +387,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function storePhpBlocks($value)
     {
-        return preg_replace_callback('/(?<!@)@php(?! ?\()(.*?)@endphp/s', function ($matches) {
+        return preg_replace_callback('/(?<!@)@php(.*?)@endphp/s', function ($matches) {
             return $this->storeRawBlock("<?php{$matches[1]}?>");
         }, $value);
     }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -84,11 +84,4 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
-
-    public function testCompilationOfMixedPhpStatements()
-    {
-        $string = '@php($set = true) @php ($hello = \'hi\') @php echo "Hello world" @endphp';
-        $expected = '<?php ($set = true); ?> <?php ($hello = \'hi\'); ?> <?php echo "Hello world" ?>';
-        $this->assertEquals($expected, $this->compiler->compileString($string));
-    }
 }


### PR DESCRIPTION
Reverts laravel/framework#45333