### PR TITLE
fix for single line @php statements but also for multi-line @php with parentheses and @endphp

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -380,7 +380,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function storePhpBlocks($value)
     {
-        return preg_replace_callback('/(?<!@)@php(.*?)@endphp/s', function ($matches) {
+        return preg_replace_callback('/(?<!@)@php(?! ?\()(.*?)@endphp/s', function ($matches) {
             return $this->storeRawBlock("<?php{$matches[1]}?>");
         }, $value);
     }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -380,7 +380,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function storePhpBlocks($value)
     {
-        return preg_replace_callback('/(?<!@)@php(?! ?\()(.*?)@endphp/s', function ($matches) {
+        return preg_replace_callback('/(?<!@)@php((?:(?!(?<![@<])@php\b).)*?)@endphp/s', function ($matches) {
             return $this->storeRawBlock("<?php{$matches[1]}?>");
         }, $value);
     }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -84,4 +84,11 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testCompilationOfMixedPhpStatements()
+    {
+        $string = '@php($set = true) @php ($hello = \'hi\') @php echo "Hello world" @endphp';
+        $expected = '<?php ($set = true); ?> <?php ($hello = \'hi\'); ?> <?php echo "Hello world" ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -91,4 +91,19 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $expected = '<?php ($set = true); ?> <?php ($hello = \'hi\'); ?> <?php echo "Hello world" ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
+
+    public function testCompilationOfMixedUsageStatements()
+    {
+        $string = '@php (
+            $classes = [
+                \'admin-font-mono\', // Font weight
+            ])
+        @endphp';
+        $expected = '<?php (
+            $classes = [
+                \'admin-font-mono\', // Font weight
+            ])
+        ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
 }


### PR DESCRIPTION
I've changed the regex to work a bit different. At first we had a negative lookahead on the parentheses. But as seen in #45388, people actually use parentheses which makes it look like a single-line statement instead, but then include the `@endphp`. Since the  regex was greedy and ate other `@php`-statements in the process of searching for full blocks it didn't work.

I've added another test and change the regex to be omitting possible other `@php`-blocks making only the `@php/@endphp` pairs really working.