### PR TITLE
[10.x] Fix: Macroable - Parent's macros get overridden by descendants

### DIFF
--- a/src/Illuminate/Macroable/Traits/Macroable.php
+++ b/src/Illuminate/Macroable/Traits/Macroable.php
@@ -25,10 +25,6 @@ trait Macroable
      */
     public static function macro($name, $macro)
     {
-        if (empty(static::$macros[static::class])) {
-            static::$macros[static::class] = [];
-        }
-
         static::$macros[static::class][$name] = $macro;
     }
 

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -39,6 +39,31 @@ class SupportMacroableTest extends TestCase
         $this->assertFalse($macroable::hasMacro('bar'));
     }
 
+    public function testRegisterMacroInChildClass()
+    {
+        $macroable = $this->macroable;
+        $childMacroable = new ChildMacroable;
+
+        $macroable::macro('originalMethod', function () {
+            return 'parent - originalMethod';
+        });
+
+        $childMacroable::macro('originalMethod', function () {
+            return 'child - originalMethod';
+        });
+
+        $childMacroable::macro('newMethod', function () {
+            return 'child - newMethod';
+        });
+
+        $this->assertSame('parent - originalMethod', $macroable->originalMethod());
+        $this->assertSame('child - originalMethod', $childMacroable->originalMethod());
+        $this->assertSame('child - newMethod', $childMacroable->newMethod());
+
+        $this->expectException(BadMethodCallException::class);
+        $macroable->newMethod();
+    }
+
     public function testRegisterMacroAndCallWithoutStatic()
     {
         $macroable = $this->macroable;
@@ -123,6 +148,10 @@ class SupportMacroableTest extends TestCase
 class EmptyMacroable
 {
     use Macroable;
+}
+
+class ChildMacroable extends EmptyMacroable
+{
 }
 
 class TestMacroable


### PR DESCRIPTION
See the discussion here: #45392

Not sure that I like this approach, any ideas?