### PR TITLE
[9.x] Add binary file response content test assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -63,7 +63,7 @@ class TestResponse implements ArrayAccess
      *
      * @var string
      */
-    protected $binaryFileContent;
+    protected $fileContent;
 
     /**
      * Create a new test response instance.
@@ -599,9 +599,9 @@ class TestResponse implements ArrayAccess
      * @param  $value
      * @return $this
      */
-    public function assertBinaryFileContent($value)
+    public function assertFileContent($value)
     {
-        PHPUnit::assertSame($value, $this->binaryFileContent());
+        PHPUnit::assertSame($value, $this->fileContent());
 
         return $this;
     }
@@ -1593,17 +1593,17 @@ class TestResponse implements ArrayAccess
      *
      * @return string
      */
-    public function binaryFileContent()
+    public function fileContent()
     {
-        if (! is_null($this->binaryFileContent)) {
-            return $this->binaryFileContent;
+        if (! is_null($this->fileContent)) {
+            return $this->fileContent;
         }
 
         if (! $this->baseResponse instanceof BinaryFileResponse) {
             PHPUnit::fail('The response is not a binary file response.');
         }
 
-        return $this->binaryFileContent = $this->bufferContent();
+        return $this->fileContent = $this->bufferContent();
     }
 
     protected function bufferContent()

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1585,7 +1585,7 @@ class TestResponse implements ArrayAccess
             PHPUnit::fail('The response is not a streamed response.');
         }
 
-        return $this->streamedContent = $this->captureContent();
+        return $this->streamedContent = $this->bufferContent();
     }
 
     /**
@@ -1603,10 +1603,10 @@ class TestResponse implements ArrayAccess
             PHPUnit::fail('The response is not a binary file response.');
         }
 
-        return $this->binaryFileContent = $this->captureContent();
+        return $this->binaryFileContent = $this->bufferContent();
     }
 
-    protected function captureContent()
+    protected function bufferContent()
     {
         $content = '';
 

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -263,7 +263,7 @@ class TestResponseTest extends TestCase
         }
     }
 
-    public function testAssertBinaryFileContent()
+    public function testAssertFileContent()
     {
         $files = new Filesystem;
         $tempDir = __DIR__.'/tmp';

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -272,17 +272,17 @@ class TestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse(new BinaryFileResponse($tempDir.'/file.txt'));
 
-        $response->assertBinaryFileContent('expected response data');
+        $response->assertFileContent('expected response data');
 
         try {
-            $response->assertBinaryFileContent('expected');
+            $response->assertFileContent('expected');
             $this->fail('xxxx');
         } catch (AssertionFailedError $e) {
             $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
         }
 
         try {
-            $response->assertBinaryFileContent('expected response data with extra');
+            $response->assertFileContent('expected response data with extra');
             $this->fail('xxxx');
         } catch (AssertionFailedError $e) {
             $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -263,6 +263,34 @@ class TestResponseTest extends TestCase
         }
     }
 
+    public function testAssertBinaryFileContent()
+    {
+        $files = new Filesystem;
+        $tempDir = __DIR__.'/tmp';
+        $files->makeDirectory($tempDir, 0755, false, true);
+        $files->put($tempDir.'/file.txt', 'expected response data');
+
+        $response = TestResponse::fromBaseResponse(new BinaryFileResponse($tempDir.'/file.txt'));
+
+        $response->assertBinaryFileContent('expected response data');
+
+        try {
+            $response->assertBinaryFileContent('expected');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
+        }
+
+        try {
+            $response->assertBinaryFileContent('expected response data with extra');
+            $this->fail('xxxx');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame('Failed asserting that two strings are identical.', $e->getMessage());
+        }
+
+        $files->deleteDirectory($tempDir);
+    }
+
     public function testAssertSee()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
This PR adds an assertion to test the file content of `response()->download()` in feature tests:

```
$this->get('/download')
    ->assertOk()
    ->assertDownload('foobar.txt')
    ->assertFileContent('foobar');
```

I [recently added](https://github.com/laravel/framework/pull/45298) an assertion to test the file content of `response()->stream()`, and this mirrors that.