### PR TITLE
Make `collect()` helper consistent with `new Collection()`

### DIFF
--- a/src/Illuminate/Collections/helpers.php
+++ b/src/Illuminate/Collections/helpers.php
@@ -13,7 +13,7 @@ if (! function_exists('collect')) {
      * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
-    function collect($value = null)
+    function collect($value = [])
     {
         return new Collection($value);
     }


### PR DESCRIPTION
Even though using `null` and `[]` as arguments produce the same result, syntactically they are different as PHPStan is unable to infer template types when `null` is passed. 

Currently when using `collect()` PHPStan will report these errors (as seen in larastan issue https://github.com/nunomaduro/larastan/issues/1115):
```
Unable to resolve the template type TKey in call to function collect
Unable to resolve the template type TValue in call to function collect
```

As a workaround you either have to explicitly pass empty array `collect([])` or use `new Collection()`.
I'm not sure if this would be considered as breaking BC or not. If so, maybe target v10?

I tried searching for existing issue/PR regarding this, but couldn't find anything. I apologize if this was addressed and declined already.

