### PR TITLE
[9.x] Passthrough `PATH` variable to serve command

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -74,6 +74,7 @@ class ServeCommand extends Command
         'XDEBUG_CONFIG',
         'XDEBUG_MODE',
         'XDEBUG_SESSION',
+        'PATH',
     ];
 
     /**

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -68,13 +68,13 @@ class ServeCommand extends Command
     public static $passthroughVariables = [
         'APP_ENV',
         'LARAVEL_SAIL',
+        'PATH',
         'PHP_CLI_SERVER_WORKERS',
         'PHP_IDE_CONFIG',
         'SYSTEMROOT',
         'XDEBUG_CONFIG',
         'XDEBUG_MODE',
         'XDEBUG_SESSION',
-        'PATH',
     ];
 
     /**


### PR DESCRIPTION
I'm setting up the `spatie/dns` package inside a Laravel Sail container. It uses the `ExecutableFinder` class of the Symfony Process component that uses the `PATH` environment variable to search the `dig` executable.

This change fixes the issue by passing the environment variable using the `artisan serve` command that Laravel Sail uses. See: https://github.com/laravel/sail/blob/122af16408841cc750095a4ca3193751eed3f673/runtimes/8.1/supervisord.conf#L8

Edit:
All environment variables are passed through when `artisan serve --no-reload` is used, but this would not be a ideal solution.