### PR TITLE
[9.x] Output only unique asset / preload tags

### DIFF
--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -340,7 +340,8 @@ class Vite implements Htmlable
 
         [$stylesheets, $scripts] = $tags->partition(fn ($tag) => str_starts_with($tag, '<link'));
 
-        $preloads = $preloads->sortByDesc(fn ($args) => $this->isCssPath($args[1]))
+        $preloads = $preloads->unique('1')
+            ->sortByDesc(fn ($args) => $this->isCssPath($args[1]))
             ->map(fn ($args) => $this->makePreloadTagForChunk(...$args));
 
         return new HtmlString($preloads->join('').$stylesheets->join('').$scripts->join(''));

--- a/src/Illuminate/Foundation/Vite.php
+++ b/src/Illuminate/Foundation/Vite.php
@@ -338,9 +338,9 @@ class Vite implements Htmlable
             }
         }
 
-        [$stylesheets, $scripts] = $tags->partition(fn ($tag) => str_starts_with($tag, '<link'));
+        [$stylesheets, $scripts] = $tags->unique()->partition(fn ($tag) => str_starts_with($tag, '<link'));
 
-        $preloads = $preloads->unique('1')
+        $preloads = $preloads->unique()
             ->sortByDesc(fn ($args) => $this->isCssPath($args[1]))
             ->map(fn ($args) => $this->makePreloadTagForChunk(...$args));
 

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -982,6 +982,57 @@ class FoundationViteTest extends TestCase
         rmdir(public_path($buildDir));
     }
 
+    public function testItOnlyOutputsUniquePreloadTags()
+    {
+        $buildDir = Str::random();
+        $this->makeViteManifest([
+            "resources/js/app.css" =>  [
+                "file" =>  "assets/app-versioned.css",
+                "src" =>  "resources/js/app.css"
+            ],
+            "resources/js/Pages/Welcome.vue" =>  [
+                "file" =>  "assets/Welcome-versioned.js",
+                "src" =>  "resources/js/Pages/Welcome.vue",
+                "imports" =>  [
+                    "resources/js/app.js"
+                ]
+            ],
+            "resources/js/app.js" =>  [
+                "file" =>  "assets/app-versioned.js",
+                "src" =>  "resources/js/app.js",
+                "css" =>  [
+                    "assets/app-versioned.css"
+                ]
+            ]
+        ], $buildDir);
+
+        $result = app(Vite::class)(['resources/js/app.js', 'resources/js/Pages/Welcome.vue'], $buildDir);
+
+        $this->assertSame(
+            '<link rel="preload" as="style" href="https://example.com/'.$buildDir.'/assets/app-versioned.css" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/app-versioned.js" />'
+            .'<link rel="modulepreload" href="https://example.com/'.$buildDir.'/assets/Welcome-versioned.js" />'
+            .'<link rel="stylesheet" href="https://example.com/'.$buildDir.'/assets/app-versioned.css" />'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/app-versioned.js"></script>'
+            .'<script type="module" src="https://example.com/'.$buildDir.'/assets/Welcome-versioned.js"></script>',
+        $result->toHtml());
+
+        $this->assertSame([
+            "https://example.com/$buildDir/assets/app-versioned.css" => [
+                'rel="preload"',
+                'as="style"',
+            ],
+            "https://example.com/$buildDir/assets/app-versioned.js" => [
+                'rel="modulepreload"',
+            ],
+            "https://example.com/$buildDir/assets/Welcome-versioned.js" => [
+                'rel="modulepreload"',
+            ],
+        ], ViteFacade::preloadedAssets());
+
+        $this->cleanViteManifest($buildDir);
+    }
+
     protected function makeViteManifest($contents = null, $path = 'build')
     {
         app()->singleton('path.public', fn () => __DIR__);

--- a/tests/Foundation/FoundationViteTest.php
+++ b/tests/Foundation/FoundationViteTest.php
@@ -986,24 +986,24 @@ class FoundationViteTest extends TestCase
     {
         $buildDir = Str::random();
         $this->makeViteManifest([
-            "resources/js/app.css" =>  [
-                "file" =>  "assets/app-versioned.css",
-                "src" =>  "resources/js/app.css"
+            'resources/js/app.css' =>  [
+                'file' =>  'assets/app-versioned.css',
+                'src' =>  'resources/js/app.css',
             ],
-            "resources/js/Pages/Welcome.vue" =>  [
-                "file" =>  "assets/Welcome-versioned.js",
-                "src" =>  "resources/js/Pages/Welcome.vue",
-                "imports" =>  [
-                    "resources/js/app.js"
-                ]
+            'resources/js/Pages/Welcome.vue' =>  [
+                'file' =>  'assets/Welcome-versioned.js',
+                'src' =>  'resources/js/Pages/Welcome.vue',
+                'imports' =>  [
+                    'resources/js/app.js',
+                ],
             ],
-            "resources/js/app.js" =>  [
-                "file" =>  "assets/app-versioned.js",
-                "src" =>  "resources/js/app.js",
-                "css" =>  [
-                    "assets/app-versioned.css"
-                ]
-            ]
+            'resources/js/app.js' =>  [
+                'file' =>  'assets/app-versioned.js',
+                'src' =>  'resources/js/app.js',
+                'css' =>  [
+                    'assets/app-versioned.css',
+                ],
+            ],
         ], $buildDir);
 
         $result = app(Vite::class)(['resources/js/app.js', 'resources/js/Pages/Welcome.vue'], $buildDir);


### PR DESCRIPTION
It is currently possible, depending on your Vite configuration, to have the `@vite` directive output duplicate standard script / stylesheet tags in addition to asset preload tags.

These additional tags are ignored by the browser, however it is nice to not have duplicate tags output into the source, so we just "unique" the tags and preloads before outputting them both.