### PR TITLE
[9.x] Precognitive validation with nested arrays doesn't throw validation error

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -117,7 +117,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
         )->stopOnFirstFailure($this->stopOnFirstFailure);
 
         if ($this->isPrecognitive()) {
-            $rules = $this->filterPrecognitiveRules($validator->getRules());
+            $rules = $this->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
 
             $validator->setRules($rules);
         }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -110,18 +110,19 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function createDefaultValidator(ValidationFactory $factory)
     {
         $rules = $this->container->call([$this, 'rules']);
-        $data = $this->validationData();
 
-        if ($this->isPrecognitive()) {
-            $response = $this->explodePrecognitiveRules($rules, $data);
-
-            $rules = $this->filterPrecognitiveRules($response->rules);
-        }
-
-        return $factory->make(
-            $data, $rules,
+        $validator = $factory->make(
+            $this->validationData(), $rules,
             $this->messages(), $this->attributes()
         )->stopOnFirstFailure($this->stopOnFirstFailure);
+
+        if ($this->isPrecognitive()) {
+            $rules = $this->filterPrecognitiveRules($validator->getRules());
+
+            $validator->setRules($rules);
+        }
+
+        return $validator;
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -110,13 +110,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected function createDefaultValidator(ValidationFactory $factory)
     {
         $rules = $this->container->call([$this, 'rules']);
+        $data = $this->validationData();
 
         if ($this->isPrecognitive()) {
-            $rules = $this->filterPrecognitiveRules($rules);
+            $response = $this->explodePrecognitiveRules($rules, $data);
+
+            $rules = $this->filterPrecognitiveRules($response->rules);
         }
 
         return $factory->make(
-            $this->validationData(), $rules,
+            $data, $rules,
             $this->messages(), $this->attributes()
         )->stopOnFirstFailure($this->stopOnFirstFailure);
     }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -117,9 +117,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
         )->stopOnFirstFailure($this->stopOnFirstFailure);
 
         if ($this->isPrecognitive()) {
-            $rules = $this->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
-
-            $validator->setRules($rules);
+            $validator->setRules(
+                $this->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders())
+            );
         }
 
         return $validator;

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -112,13 +112,11 @@ class FoundationServiceProvider extends AggregateServiceProvider
     public function registerRequestValidation()
     {
         Request::macro('validate', function (array $rules, ...$params) {
-            $rules = $this->isPrecognitive()
-                ? $this->filterPrecognitiveRules($rules)
-                : $rules;
-
             return tap(validator($this->all(), $rules, ...$params), function ($validator) {
                 if ($this->isPrecognitive()) {
-                    $validator->after(Precognition::afterValidationHook($this));
+                    $rules = $this->filterPrecognitiveRules($validator->getRules());
+
+                    $validator->setRules($rules)->after(Precognition::afterValidationHook($this));
                 }
             })->validate();
         });

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -114,7 +114,7 @@ class FoundationServiceProvider extends AggregateServiceProvider
         Request::macro('validate', function (array $rules, ...$params) {
             return tap(validator($this->all(), $rules, ...$params), function ($validator) {
                 if ($this->isPrecognitive()) {
-                    $rules = $this->filterPrecognitiveRules($validator->getRules());
+                    $rules = $this->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
 
                     $validator->setRules($rules)->after(Precognition::afterValidationHook($this));
                 }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -114,9 +114,10 @@ class FoundationServiceProvider extends AggregateServiceProvider
         Request::macro('validate', function (array $rules, ...$params) {
             return tap(validator($this->all(), $rules, ...$params), function ($validator) {
                 if ($this->isPrecognitive()) {
-                    $rules = $this->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
-
-                    $validator->setRules($rules)->after(Precognition::afterValidationHook($this));
+                    $validator->after(Precognition::afterValidationHook($this))
+                        ->setRules(
+                            $this->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders())
+                        );
                 }
             })->validate();
         });

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -26,13 +26,13 @@ trait ValidatesRequests
             $validator = $this->getValidationFactory()->make($request->all(), $validator);
         }
 
-        return tap($validator, function ($validator) use ($request) {
-            if ($request->isPrecognitive()) {
-                $rules = $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
+        if ($request->isPrecognitive()) {
+            $rules = $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
 
-                $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
-            }
-        })->validate();
+            $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
+        }
+
+        $validator->validate();
     }
 
     /**
@@ -53,13 +53,13 @@ trait ValidatesRequests
             $request->all(), $rules, $messages, $customAttributes
         );
 
-        return tap($validator, function ($validator) use ($request) {
-            if ($request->isPrecognitive()) {
-                $rules = $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
+        if ($request->isPrecognitive()) {
+            $rules = $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
 
-                $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
-            }
-        })->validate();
+            $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
+        }
+
+        return $validator->validate();
     }
 
     /**

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -28,7 +28,7 @@ trait ValidatesRequests
 
         return tap($validator, function ($validator) use ($request) {
             if ($request->isPrecognitive()) {
-                $rules = $request->filterPrecognitiveRules($validator->getRules());
+                $rules = $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
 
                 $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
             }
@@ -55,7 +55,7 @@ trait ValidatesRequests
 
         return tap($validator, function ($validator) use ($request) {
             if ($request->isPrecognitive()) {
-                $rules = $request->filterPrecognitiveRules($validator->getRules());
+                $rules = $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
 
                 $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
             }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -27,12 +27,13 @@ trait ValidatesRequests
         }
 
         if ($request->isPrecognitive()) {
-            $rules = $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
-
-            $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
+            $validator->after(Precognition::afterValidationHook($request))
+                ->setRules(
+                    $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders())
+                );
         }
 
-        $validator->validate();
+        return $validator->validate();
     }
 
     /**
@@ -54,9 +55,10 @@ trait ValidatesRequests
         );
 
         if ($request->isPrecognitive()) {
-            $rules = $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders());
-
-            $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
+            $validator->after(Precognition::afterValidationHook($request))
+                ->setRules(
+                    $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders())
+                );
         }
 
         return $validator->validate();

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -23,20 +23,14 @@ trait ValidatesRequests
         $request = $request ?: request();
 
         if (is_array($validator)) {
-            $rules = $request->isPrecognitive()
-                ? $request->filterPrecognitiveRules($validator)
-                : $validator;
-
-            $validator = $this->getValidationFactory()->make($request->all(), $rules);
-        } elseif ($request->isPrecognitive()) {
-            $validator->setRules(
-                $request->filterPrecognitiveRules($validator->getRules())
-            );
+            $validator = $this->getValidationFactory()->make($request->all(), $validator);
         }
 
         return tap($validator, function ($validator) use ($request) {
             if ($request->isPrecognitive()) {
-                $validator->after(Precognition::afterValidationHook($request));
+                $rules = $request->filterPrecognitiveRules($validator->getRules());
+
+                $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
             }
         })->validate();
     }
@@ -55,17 +49,15 @@ trait ValidatesRequests
     public function validate(Request $request, array $rules,
                              array $messages = [], array $customAttributes = [])
     {
-        $rules = $request->isPrecognitive()
-            ? $request->filterPrecognitiveRules($rules)
-            : $rules;
-
         $validator = $this->getValidationFactory()->make(
             $request->all(), $rules, $messages, $customAttributes
         );
 
         return tap($validator, function ($validator) use ($request) {
             if ($request->isPrecognitive()) {
-                $validator->after(Precognition::afterValidationHook($request));
+                $rules = $request->filterPrecognitiveRules($validator->getRules());
+
+                $validator->setRules($rules)->after(Precognition::afterValidationHook($request));
             }
         })->validate();
     }

--- a/src/Illuminate/Http/Concerns/CanBePrecognitive.php
+++ b/src/Illuminate/Http/Concerns/CanBePrecognitive.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Concerns;
 
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationRuleParser;
 
 trait CanBePrecognitive
 {
@@ -21,6 +22,18 @@ trait CanBePrecognitive
         return Collection::make($rules)
             ->only(explode(',', $this->header('Precognition-Validate-Only')))
             ->all();
+    }
+
+    /**
+     * Parse the human-friendly rules into a full rules array.
+     *
+     * @param  array  $rules
+     * @param  array  $data
+     * @return \stdClass
+     */
+    public function explodePrecognitiveRules($rules, $data)
+    {
+        return (new ValidationRuleParser($data))->explode($rules);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/CanBePrecognitive.php
+++ b/src/Illuminate/Http/Concerns/CanBePrecognitive.php
@@ -25,18 +25,6 @@ trait CanBePrecognitive
     }
 
     /**
-     * Parse the human-friendly rules into a full rules array.
-     *
-     * @param  array  $rules
-     * @param  array  $data
-     * @return \stdClass
-     */
-    public function explodePrecognitiveRules($rules, $data)
-    {
-        return (new ValidationRuleParser($data))->explode($rules);
-    }
-
-    /**
      * Determine if the request is attempting to be precognitive.
      *
      * @return bool

--- a/src/Illuminate/Http/Concerns/CanBePrecognitive.php
+++ b/src/Illuminate/Http/Concerns/CanBePrecognitive.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Http\Concerns;
 
 use Illuminate\Support\Collection;
-use Illuminate\Validation\ValidationRuleParser;
 
 trait CanBePrecognitive
 {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1098,9 +1098,11 @@ class Validator implements ValidatorContract
      */
     public function getRulesWithoutPlaceholders()
     {
-        return collect($this->rules)->mapWithKeys(fn ($value, $key) => [
-            $this->replacePlaceholderInString($key) => $value,
-        ])->all();
+        return collect($this->rules)
+            ->mapWithKeys(fn ($value, $key) => [
+                $this->replacePlaceholderInString($key) => $value,
+            ])
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1092,6 +1092,18 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Get the validation rules with key placeholders removed.
+     *
+     * @return array
+     */
+    public function getRulesWithoutPlaceholders()
+    {
+        return collect($this->rules)->mapWithKeys(fn ($value, $key) => [
+            $this->replacePlaceholderInString($key) => $value,
+        ])->all();
+    }
+
+    /**
      * Set the validation rules.
      *
      * @param  array  $rules

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1100,7 +1100,7 @@ class Validator implements ValidatorContract
     {
         return collect($this->rules)
             ->mapWithKeys(fn ($value, $key) => [
-                $this->replacePlaceholderInString($key) => $value,
+                str_replace($this->dotPlaceholder, '\\.', $key) => $value,
             ])
             ->all();
     }

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -520,6 +520,7 @@ class PrecognitionTest extends TestCase
             'Precognition-Validate-Only' => 'nested,nested.0.name',
         ]);
 
+        $response->assertStatus(422);
         $this->assertFalse($this->app['ClassWasInstantiated']);
         $response->assertJsonValidationErrors('nested.0.name');
         $response->assertHeader('Precognition', 'true');

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -512,8 +512,8 @@ class PrecognitionTest extends TestCase
 
         $response = $this->postJson('test-route', [
             'nested' => [
-                ['namsse' => 'sdsd']
-            ]
+                ['namsse' => 'sdsd'],
+            ],
         ], [
             'Precognition' => 'true',
             'Precognition-Validate-Only' => 'nested,nested.0.name',
@@ -527,7 +527,7 @@ class PrecognitionTest extends TestCase
                     [
                         'name' => [
                             'The nested.0.name field is required.',
-                        ]
+                        ],
                     ],
                 ],
             ],
@@ -540,15 +540,15 @@ class PrecognitionTest extends TestCase
         Route::post('test-route', function (Request $request) {
             $request->validate([
                 'nested' => ['required', 'array', 'min:1'],
-                'nested.*.name' => ['required', 'string']
+                'nested.*.name' => ['required', 'string'],
             ]);
             fail();
         })->middleware(PrecognitionInvokingController::class);
 
         $response = $this->postJson('test-route', [
             'nested' => [
-                ['namsse' => 'sdsd']
-            ]
+                ['namsse' => 'sdsd'],
+            ],
         ], [
             'Precognition' => 'true',
             'Precognition-Validate-Only' => 'nested,nested.0.name',
@@ -562,7 +562,7 @@ class PrecognitionTest extends TestCase
                     [
                         'name' => [
                             'The nested.0.name field is required.',
-                        ]
+                        ],
                     ],
                 ],
             ],
@@ -577,8 +577,8 @@ class PrecognitionTest extends TestCase
 
         $response = $this->postJson('test-route', [
             'nested' => [
-                ['namsse' => 'sdsd']
-            ]
+                ['namsse' => 'sdsd'],
+            ],
         ], [
             'Precognition' => 'true',
             'Precognition-Validate-Only' => 'nested,nested.0.name',
@@ -592,7 +592,7 @@ class PrecognitionTest extends TestCase
                     [
                         'name' => [
                             'The nested.0.name field is required.',
-                        ]
+                        ],
                     ],
                 ],
             ],
@@ -607,8 +607,8 @@ class PrecognitionTest extends TestCase
 
         $response = $this->postJson('test-route', [
             'nested' => [
-                ['namsse' => 'sdsd']
-            ]
+                ['namsse' => 'sdsd'],
+            ],
         ], [
             'Precognition' => 'true',
             'Precognition-Validate-Only' => 'nested,nested.0.name',
@@ -622,7 +622,7 @@ class PrecognitionTest extends TestCase
                     [
                         'name' => [
                             'The nested.0.name field is required.',
-                        ]
+                        ],
                     ],
                 ],
             ],
@@ -1036,7 +1036,7 @@ class PrecognitionTestController
         precognitive(function () use ($request) {
             $this->validate($request, [
                 'nested' => ['required', 'array', 'min:1'],
-                'nested.*.name' => ['required', 'string']
+                'nested.*.name' => ['required', 'string'],
             ]);
 
             fail();
@@ -1050,7 +1050,7 @@ class PrecognitionTestController
         precognitive(function () {
             $this->validateWith([
                 'nested' => ['required', 'array', 'min:1'],
-                'nested.*.name' => ['required', 'string']
+                'nested.*.name' => ['required', 'string'],
             ]);
 
             fail();
@@ -1206,7 +1206,7 @@ class NestedPrecognitionTestRequest extends FormRequest
     {
         return [
             'nested' => ['required', 'array', 'min:1'],
-            'nested.*.name' => ['required', 'string']
+            'nested.*.name' => ['required', 'string'],
         ];
     }
 }

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -517,7 +517,7 @@ class PrecognitionTest extends TestCase
             ]
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'nested , nested.0.name',
+            'Precognition-Validate-Only' => 'nested,nested.0.name',
         ]);
 
         $this->assertFalse($this->app['ClassWasInstantiated']);

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -630,6 +630,23 @@ class PrecognitionTest extends TestCase
         $response->assertHeader('Precognition', 'true');
     }
 
+    public function testItCanPassValidationForEscapedDotsAfterFilteringWithPrecognition()
+    {
+        Route::post('test-route', function (PrecognitionRequestWithEscapedDots $request) {
+            fail();
+        })->middleware(PrecognitionInvokingController::class);
+
+        $response = $this->postJson('test-route', [
+            'escaped.dot' => 'value',
+        ], [
+            'Precognition' => 'true',
+            'Precognition-Validate-Only' => 'escaped.dot',
+        ]);
+
+        $response->assertNoContent();
+        $response->assertHeader('Precognition', 'true');
+    }
+
     public function testItCanFilterRulesWithEscapedDotsUsingFormRequest()
     {
         Route::post('test-route', function (PrecognitionRequestWithEscapedDots $request) {
@@ -640,7 +657,7 @@ class PrecognitionTest extends TestCase
             //
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped.dot',
+            'Precognition-Validate-Only' => 'escaped\\.dot',
         ]);
 
         $response->assertStatus(422);
@@ -659,7 +676,7 @@ class PrecognitionTest extends TestCase
     {
         Route::post('test-route', function (Request $request) {
             $request->validate([
-                'escaped\.dot' => 'required',
+                'escaped\\.dot' => 'required',
             ]);
 
             fail();
@@ -669,7 +686,7 @@ class PrecognitionTest extends TestCase
             //
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped.dot',
+            'Precognition-Validate-Only' => 'escaped\\.dot',
         ]);
 
         $response->assertStatus(422);
@@ -693,7 +710,7 @@ class PrecognitionTest extends TestCase
             //
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped.dot',
+            'Precognition-Validate-Only' => 'escaped\\.dot',
         ]);
 
         $response->assertStatus(422);
@@ -717,7 +734,7 @@ class PrecognitionTest extends TestCase
             //
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped.dot',
+            'Precognition-Validate-Only' => 'escaped\\.dot',
         ]);
 
         $response->assertStatus(422);
@@ -1009,7 +1026,7 @@ class PrecognitionTestController
     {
         precognitive(function () use ($request) {
             $this->validate($request, [
-                'escaped\.dot' => 'required',
+                'escaped\\.dot' => 'required',
             ]);
 
             fail();
@@ -1022,7 +1039,7 @@ class PrecognitionTestController
     {
         precognitive(function () {
             $this->validateWith([
-                'escaped\.dot' => 'required',
+                'escaped\\.dot' => 'required',
             ]);
 
             fail();
@@ -1216,7 +1233,7 @@ class PrecognitionRequestWithEscapedDots extends FormRequest
     public function rules()
     {
         return [
-            'escaped\.dot' => ['required'],
+            'escaped\\.dot' => ['required'],
         ];
     }
 }

--- a/tests/Integration/Routing/PrecognitionTest.php
+++ b/tests/Integration/Routing/PrecognitionTest.php
@@ -640,7 +640,7 @@ class PrecognitionTest extends TestCase
             'escaped.dot' => 'value',
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped.dot',
+            'Precognition-Validate-Only' => 'escaped\.dot',
         ]);
 
         $response->assertNoContent();
@@ -657,7 +657,7 @@ class PrecognitionTest extends TestCase
             //
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped\\.dot',
+            'Precognition-Validate-Only' => 'escaped\.dot',
         ]);
 
         $response->assertStatus(422);
@@ -676,7 +676,7 @@ class PrecognitionTest extends TestCase
     {
         Route::post('test-route', function (Request $request) {
             $request->validate([
-                'escaped\\.dot' => 'required',
+                'escaped\.dot' => 'required',
             ]);
 
             fail();
@@ -686,7 +686,7 @@ class PrecognitionTest extends TestCase
             //
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped\\.dot',
+            'Precognition-Validate-Only' => 'escaped\.dot',
         ]);
 
         $response->assertStatus(422);
@@ -710,7 +710,7 @@ class PrecognitionTest extends TestCase
             //
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped\\.dot',
+            'Precognition-Validate-Only' => 'escaped\.dot',
         ]);
 
         $response->assertStatus(422);
@@ -734,7 +734,7 @@ class PrecognitionTest extends TestCase
             //
         ], [
             'Precognition' => 'true',
-            'Precognition-Validate-Only' => 'escaped\\.dot',
+            'Precognition-Validate-Only' => 'escaped\.dot',
         ]);
 
         $response->assertStatus(422);
@@ -1026,7 +1026,7 @@ class PrecognitionTestController
     {
         precognitive(function () use ($request) {
             $this->validate($request, [
-                'escaped\\.dot' => 'required',
+                'escaped\.dot' => 'required',
             ]);
 
             fail();
@@ -1039,7 +1039,7 @@ class PrecognitionTestController
     {
         precognitive(function () {
             $this->validateWith([
-                'escaped\\.dot' => 'required',
+                'escaped\.dot' => 'required',
             ]);
 
             fail();
@@ -1233,7 +1233,7 @@ class PrecognitionRequestWithEscapedDots extends FormRequest
     public function rules()
     {
         return [
-            'escaped\\.dot' => ['required'],
+            'escaped\.dot' => ['required'],
         ];
     }
 }


### PR DESCRIPTION
Hello everybody,

I belive i have found a bug on the way the `filterPrecognitiveRules` method on the `CanBePrecognitive` trait works. The reason is that the string `nested.*.name` have not being parsed to the corisponding `nested.0.name` yet because the validator instance only looks after `nested.*.name` and builds the rules array based on the incoming data turning `nested.*.name` into n number of elements. This means that when we try to filter for only keys containing `nested` and `nested.0.name` within `filterPrecognitiveRules` our rules haven't been parsed yet which mean that the rule for key `nested.0.name` just get dropped. And never actually validated.

I have attached a test case for this bug.