### PR TITLE
[9.x] Allow returning an array from `Collection::keyBy(Func)` like is currently possible in `Collection::groupBy(Func)`

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -542,13 +542,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         foreach ($this->items as $key => $item) {
             $resolvedKeys = $keyBy($item, $key);
 
-            if (!is_array($resolvedKeys)) {
+            if (! is_array($resolvedKeys)) {
                 $resolvedKeys = [$resolvedKeys];
             }
 
             foreach ($resolvedKeys as $resolvedKey) {
                 if (is_object($resolvedKey)) {
-                    $resolvedKey = (string)$resolvedKey;
+                    $resolvedKey = (string) $resolvedKey;
                 }
 
                 $results[$resolvedKey] = $item;

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -540,13 +540,19 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
         $results = [];
 
         foreach ($this->items as $key => $item) {
-            $resolvedKey = $keyBy($item, $key);
+            $resolvedKeys = $keyBy($item, $key);
 
-            if (is_object($resolvedKey)) {
-                $resolvedKey = (string) $resolvedKey;
+            if (!is_array($resolvedKeys)) {
+                $resolvedKeys = [$resolvedKeys];
             }
 
-            $results[$resolvedKey] = $item;
+            foreach ($resolvedKeys as $resolvedKey) {
+                if (is_object($resolvedKey)) {
+                    $resolvedKey = (string)$resolvedKey;
+                }
+
+                $results[$resolvedKey] = $item;
+            }
         }
 
         return new static($results);

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -561,14 +561,14 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             foreach ($this as $key => $item) {
                 $resolvedKeys = $keyBy($item, $key);
 
-                if (!is_array($resolvedKeys)) {
+                if (! is_array($resolvedKeys)) {
                     $resolvedKeys = [$resolvedKeys];
                 }
 
                 foreach ($resolvedKeys as $resolvedKey) {
 
                     if (is_object($resolvedKey)) {
-                        $resolvedKey = (string)$resolvedKey;
+                        $resolvedKey = (string) $resolvedKey;
                     }
 
                     yield $resolvedKey => $item;

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -559,13 +559,20 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
             $keyBy = $this->valueRetriever($keyBy);
 
             foreach ($this as $key => $item) {
-                $resolvedKey = $keyBy($item, $key);
+                $resolvedKeys = $keyBy($item, $key);
 
-                if (is_object($resolvedKey)) {
-                    $resolvedKey = (string) $resolvedKey;
+                if (!is_array($resolvedKeys)) {
+                    $resolvedKeys = [$resolvedKeys];
                 }
 
-                yield $resolvedKey => $item;
+                foreach ($resolvedKeys as $resolvedKey) {
+
+                    if (is_object($resolvedKey)) {
+                        $resolvedKey = (string)$resolvedKey;
+                    }
+
+                    yield $resolvedKey => $item;
+                }
             }
         });
     }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -566,7 +566,6 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
                 }
 
                 foreach ($resolvedKeys as $resolvedKey) {
-
                     if (is_object($resolvedKey)) {
                         $resolvedKey = (string) $resolvedKey;
                     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3454,6 +3454,29 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testKeyByWhenClosureReturningArrayOfKeys($collection)
+    {
+        $data = new $collection([
+            $entry1 = ['id' => 1, 'keys' => ['a', 'b']],
+            $entry2 = ['id' => 2, 'keys' => ['b']],
+            $entry3 = ['id' => 3, 'keys' => ['c']],
+            ['id' => 4, 'keys' => []],
+        ]);
+
+        $result = $data->keyBy(function ($item) {
+            return $item['keys'];
+        });
+
+        $this->assertEquals([
+            'a' => $entry1,
+            'b' => $entry2,
+            'c' => $entry3,
+        ], $result->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testKeyByObject($collection)
     {
         $data = new $collection([


### PR DESCRIPTION
Currently the `Collection::groupBy(Func)` method allows grouping a collection by multiple keys by returning an array from the function given to `groupBy`. I suggest that we allow the same from the `keyBy` method. 

I myself have needed this type of functionality, and I therefor decided to create a PR. The following could be a case where I would use the feature:

```php
// A bunch of matches between some number of players (already sorted)
$matches = collect([
    ['id' => 1, 'players' => ['Player A', 'Player B']],
    ['id' => 2, 'players' => ['Player C', 'Player A']],
    ['id' => 3, 'players' => ['Player C', 'Player B']]
]);

// Find the latest match for each player
dump($matches->keyBy(fn(array $match) => $match['players'])->all());
```

Results in:

```
^ array:3 [
  "Player A" => array:2 [
    "id" => 2
    "players" => array:2 [
      0 => "Player C"
      1 => "Player A"
    ]
  ]
  "Player B" => array:2 [
    "id" => 3
    "players" => array:2 [
      0 => "Player C"
      1 => "Player B"
    ]
  ]
  "Player C" => array:2 [
    "id" => 3
    "players" => array:2 [
      0 => "Player C"
      1 => "Player B"
    ]
  ]
]
```

This change is not technically backwards-compatible, since previous code that returned an array would throw an error, and will now no longer throw an error. I'm not sure whether it is truly considered a BC-break, since the previous behavior wasn't ever useful.