### PR TITLE
Update `decimal` validation rule to allow validation of signed numbers

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -572,7 +572,7 @@ trait ValidatesAttributes
 
         $matches = [];
 
-        preg_match('/^\d*.(\d*)$/', $value, $matches);
+        preg_match('/^[+-]?\d*.(\d*)$/', $value, $matches);
 
         $decimals = strlen(end($matches));
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2457,16 +2457,19 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '1.2345'], ['foo' => 'Decimal:2,3']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => '1.234'], ['foo' => 'Decimal:2,3']);
+        $v = new Validator($trans, ['foo' => '-1.234'], ['foo' => 'Decimal:2,3']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:2,3']);
+        $v = new Validator($trans, ['foo' => '+1.23'], ['foo' => 'Decimal:2,3']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'Decimal:2,3']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:2']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '-1.23'], ['foo' => 'Decimal:2']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '1.233'], ['foo' => 'Decimal:2']);
@@ -2478,7 +2481,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Decimal:0,1']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => '1.2'], ['foo' => 'Decimal:0,1']);
+        $v = new Validator($trans, ['foo' => '-1.2'], ['foo' => 'Decimal:0,1']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => '1.23'], ['foo' => 'Decimal:0,1']);


### PR DESCRIPTION
This PR allows signed numbers to pass through `decimal` validation rule.

### Previously

- `decimal:2` will fail validation of `-1.23` even though it is numeric and has exactly two decimal places.

### Now

- `decimal:2` will pass the validation of `-1.23`

### Extension

Even though no positive numbers start with `+` sign, there might be a scenario where handling numeric values inside string quotes include the sign. This PR extends the existing validation rule to allow presence of it.

- `decimal:2` will pass validation of `+1.23`