### PR TITLE
only unlink a file after checking if the file exists

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -284,14 +284,16 @@ class Filesystem
         $success = true;
 
         foreach ($paths as $path) {
-            try {
-                if (@unlink($path)) {
-                    clearstatcache(false, $path);
-                } else {
+            if (file_exists($path)) {
+                try {
+                    if (@unlink($path)) {
+                        clearstatcache(false, $path);
+                    } else {
+                        $success = false;
+                    }
+                } catch (ErrorException $e) {
                     $success = false;
                 }
-            } catch (ErrorException $e) {
-                $success = false;
             }
         }
 


### PR DESCRIPTION
Using tinkerwell I always get the following error message: 
```
PHP Warning:  unlink(/......./storage/framework/sessions/{identifier}): No such file or directory in /....../vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php on line 286
```
The tinkerwell team told me this was a bug in laravel :-) - I resolved this by checking if a file exists before trying to remove it. 