### PR TITLE
[9.x] Add `unless` to JsonResource

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -93,7 +93,7 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a value if the given "value" is (or resolves to) truthy.
+     * Retrieve a value if the given "condition" is (or resolves to) truthy.
      *
      * @param  bool  $condition
      * @param  mixed  $value
@@ -110,7 +110,7 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a value if the given "value" is (or resolves to) falsy.
+     * Retrieve a value if the given "condition" is (or resolves to) falsy.
      *
      * @param  bool  $condition
      * @param  mixed  $value

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -93,7 +93,7 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a value based on a given condition.
+     * Retrieve a value if the given "value" is (or resolves to) truthy.
      *
      * @param  bool  $condition
      * @param  mixed  $value
@@ -107,6 +107,21 @@ trait ConditionallyLoadsAttributes
         }
 
         return func_num_args() === 3 ? value($default) : new MissingValue;
+    }
+
+    /**
+     * Retrieve a value if the given "value" is (or resolves to) falsy.
+     *
+     * @param  bool  $condition
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    public function unless($condition, $value, $default = null)
+    {
+        $arguments = func_num_args() === 2 ? [$value] : [$value, $default];
+
+        return $this->when(! $condition, ...$arguments);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -93,7 +93,7 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a value if the given "condition" is (or resolves to) truthy.
+     * Retrieve a value if the given "condition" is truthy.
      *
      * @param  bool  $condition
      * @param  mixed  $value
@@ -110,7 +110,7 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
-     * Retrieve a value if the given "condition" is (or resolves to) falsy.
+     * Retrieve a value if the given "condition" is falsy.
      *
      * @param  bool  $condition
      * @param  mixed  $value

--- a/tests/Integration/Http/Fixtures/PostResourceWithUnlessOptionalData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithUnlessOptionalData.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithUnlessOptionalData extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'first' => $this->unless(false, 'value'),
+            'second' => $this->unless(true, 'value'),
+            'third' => $this->unless(true, function () {
+                return 'value';
+            }),
+            'fourth' => $this->unless(false, 'value', 'default'),
+            'fifth' => $this->unless(false, 'value', function () {
+                return 'default';
+            }),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -168,7 +168,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function testResourcesMayDosntHaveOptionalValues()
+    public function testResourcesMayHaveOptionalValues()
     {
         Route::get('/', function () {
             return new PostResourceWithUnlessOptionalData(new Post([

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -31,13 +31,13 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithJsonOptionsAndTyp
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAppendedAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
-use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithUnlessOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalHasAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalRelationshipCounts;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithoutWrap;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithUnlessOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\ReallyEmptyPostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\ResourceWithPreservedKeys;
 use Illuminate\Tests\Integration\Http\Fixtures\SerializablePostResource;

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -168,7 +168,7 @@ class ResourceTest extends TestCase
         ]);
     }
 
-    public function testResourcesMayHaveOptionalValues()
+    public function testResourcesMayHaveOptionalValuesUsingUnless()
     {
         Route::get('/', function () {
             return new PostResourceWithUnlessOptionalData(new Post([

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -31,6 +31,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithJsonOptionsAndTyp
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAppendedAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithUnlessOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalHasAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
@@ -163,6 +164,31 @@ class ResourceTest extends TestCase
                 'third' => 'value',
                 'fourth' => 'default',
                 'fifth' => 'default',
+            ],
+        ]);
+    }
+
+    public function testResourcesMayDosntHaveOptionalValues()
+    {
+        Route::get('/', function () {
+            return new PostResourceWithUnlessOptionalData(new Post([
+                'id' => 5,
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/',
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                'id' => 5,
+                'first' => 'value',
+                'fourth' => 'value',
+                'fifth' => 'value',
             ],
         ]);
     }


### PR DESCRIPTION
This PR adds an `unless` method to the JSON resource class for retrieving a value if the given "condition" is (or resolves to) falsy.