### PR TITLE
[9.x] Fix restore's return type in SoftDeletes trait.

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -103,7 +103,7 @@ trait SoftDeletes
     /**
      * Restore a soft-deleted model instance.
      *
-     * @return bool|null
+     * @return bool
      */
     public function restore()
     {
@@ -131,7 +131,7 @@ trait SoftDeletes
     /**
      * Restore a soft-deleted model instance without raising any events.
      *
-     * @return bool|null
+     * @return bool
      */
     public function restoreQuietly()
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Content

Eloquent Model's save method can only return bool, so restore's return type also have to be bool.

## Reference

https://github.com/laravel/framework/blob/99263998eb4e4b5cd0d536737c00cb4ba5f36ff0/src/Illuminate/Database/Eloquent/Model.php#L1103