### PR TITLE
[9.x] Move facades job to separate workflow

### DIFF
--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -1,22 +1,21 @@
-name: static analysis
+name: facades
 
 on:
   push:
     branches:
       - master
       - '*.x'
-  pull_request:
+
+if: ${{ github.repository_owner == 'laravel' }}
 
 jobs:
-  types:
+  update:
     runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: true
-      matrix:
-        directory: [src, types]
 
-    name: ${{ matrix.directory == 'src' && 'Source Code' || 'Types' }}
+    name: Facade DocBlocks
 
     steps:
       - name: Checkout code
@@ -36,5 +35,11 @@ jobs:
           max_attempts: 5
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
 
-      - name: Execute type checking
-        run: vendor/bin/phpstan --configuration="phpstan.${{ matrix.directory }}.neon.dist"
+      - name: Update facade docblocks
+        run: php -f bin/facades.php
+
+      - name: Commit facade docblocks
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update facade docblocks
+          file_pattern: src/


### PR DESCRIPTION
Right now, all PR's have an open list of GHA checks because there's one check for facades that's being skipped. Since GitHub doesn't allows to auto-collapse this list I'm moving the job to a different workflow to circumvent this. This will clean up PRs and make it easier to see if a PR has passing builds or not.

<img width="945" alt="Screenshot 2022-12-27 at 12 00 59" src="https://user-images.githubusercontent.com/594614/209657263-da44518b-ed08-4262-a084-586cfd9b81a8.png">
