### PR TITLE
[9.x] Fix credentials check

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -148,7 +148,9 @@ class EloquentUserProvider implements UserProvider
      */
     public function validateCredentials(UserContract $user, array $credentials)
     {
-        $plain = $credentials['password'];
+        if (is_null($plain = $credentials['password'])) {
+            return false;
+        }
 
         return $this->hasher->check($plain, $user->getAuthPassword());
     }


### PR DESCRIPTION
Right now, because of recent Testbench changes, some tests of our first party libraries fail:

https://github.com/laravel/fortify/actions/runs/3659211237/jobs/6441135700#step:5:21

This is because sometimes, a `null` password is sent through to the `AbstractHasher` class to check. I believe that instead of fixing this in every library, we can fix this in Laravel itself. 

In the `EloquentUserProvider`, when the password is taken from the credentials array we'll check if it's `null`. If it is, then we'll automatically fail the check because it's not a valid password.