### PR TITLE
[9.x] Better validation error massage for rules with list of values

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -460,6 +460,26 @@ trait FormatsMessages
     }
 
     /**
+     * Get the displayable list of the values.
+     *
+     * @param  string  $attribute
+     * @param  array  $values
+     * @return string
+     */
+    public function getDisplayableValues($attribute, $values)
+    {
+        $list = [];
+
+        foreach ($values as $value) {
+            $displayable = $this->getDisplayableValue($attribute, $value);
+
+            $list[] = str_contains($displayable, ',') ? '"'.$displayable.'"' : $displayable;
+        }
+
+        return implode(', ', $list);
+    }
+
+    /**
      * Transform an array of attributes to their displayable form.
      *
      * @param  array  $values

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -67,7 +67,11 @@ trait ReplacesAttributes
      */
     protected function replaceDateFormat($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':format', $parameters[0], $message);
+        foreach ($parameters as &$parameter) {
+            $parameter = str_contains($parameter, ',') ? '"'.$parameter.'"' : $parameter;
+        }
+
+        return str_replace([':format', ':formats'], [$parameters[0], implode(', ', $parameters)], $message);
     }
 
     /**
@@ -213,11 +217,7 @@ trait ReplacesAttributes
      */
     protected function replaceIn($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return str_replace(':values', $this->getDisplayableValues($attribute, $parameters), $message);
     }
 
     /**
@@ -259,11 +259,7 @@ trait ReplacesAttributes
      */
     protected function replaceRequiredArrayKeys($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return str_replace(':values', $this->getDisplayableValues($attribute, $parameters), $message);
     }
 
     /**
@@ -483,13 +479,9 @@ trait ReplacesAttributes
     {
         $other = $this->getDisplayableAttribute($parameters[0]);
 
-        $values = [];
+        $values = $this->getDisplayableValues($parameters[0], array_slice($parameters, 1));
 
-        foreach (array_slice($parameters, 1) as $value) {
-            $values[] = $this->getDisplayableValue($parameters[0], $value);
-        }
-
-        return str_replace([':other', ':values'], [$other, implode(', ', $values)], $message);
+        return str_replace([':other', ':values'], [$other, $values], $message);
     }
 
     /**
@@ -523,13 +515,9 @@ trait ReplacesAttributes
     {
         $other = $this->getDisplayableAttribute($parameters[0]);
 
-        $values = [];
+        $values = $this->getDisplayableValues($parameters[0], array_slice($parameters, 1));
 
-        foreach (array_slice($parameters, 1) as $value) {
-            $values[] = $this->getDisplayableValue($parameters[0], $value);
-        }
-
-        return str_replace([':other', ':values'], [$other, implode(', ', $values)], $message);
+        return str_replace([':other', ':values'], [$other, $values], $message);
     }
 
     /**
@@ -667,11 +655,7 @@ trait ReplacesAttributes
      */
     protected function replaceEndsWith($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return str_replace(':values', $this->getDisplayableValues($attribute, $parameters), $message);
     }
 
     /**
@@ -685,11 +669,7 @@ trait ReplacesAttributes
      */
     protected function replaceDoesntEndWith($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return str_replace(':values', $this->getDisplayableValues($attribute, $parameters), $message);
     }
 
     /**
@@ -703,11 +683,7 @@ trait ReplacesAttributes
      */
     protected function replaceStartsWith($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return str_replace(':values', $this->getDisplayableValues($attribute, $parameters), $message);
     }
 
     /**
@@ -721,10 +697,6 @@ trait ReplacesAttributes
      */
     protected function replaceDoesntStartWith($message, $attribute, $rule, $parameters)
     {
-        foreach ($parameters as &$parameter) {
-            $parameter = $this->getDisplayableValue($attribute, $parameter);
-        }
-
-        return str_replace(':values', implode(', ', $parameters), $message);
+        return str_replace(':values', $this->getDisplayableValues($attribute, $parameters), $message);
     }
 }


### PR DESCRIPTION
This PR fixes 2 issues:

First, it encloses values that contain `,` character within double quote `"` in the validation error message for all rules that accept list of values:

```php
Validator::make(['name' => 'bar'], ['name' => 'starts_with:foo,"b, ar",baz'])->validate();

// Before this PR:
// The name must start with one of the following: foo, b, ar, baz.

// After this PR:
// The name must start with one of the following: foo, "b, ar", baz.
```

Second, the `date_format` validation rule accepts list of formats (related to laravel/docs#8422), this PR adds `:formats` placeholder for this rule.
```php
Validator::make(['birthdate' => 'Tue, 27 Dec 2022'], ['name' => 'date_format:d M Y,Y-m-d'])->validate();

// Before this PR, using `:format` placeholder:
// The birthdate does not match the format d M Y.
```