### PR TITLE
Added userIs() method to guards

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -83,6 +83,16 @@ trait GuardHelpers
     }
 
     /**
+     * Compares the authenticated user with a given user
+     *
+     * @return bool
+     */
+    public function userIs(AuthenticatableContract $user)
+    {
+        return $this->user->getAuthIdentifier() === $user->getAuthIdentifier();
+    }
+
+    /**
      * Set the current user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -83,7 +83,7 @@ trait GuardHelpers
     }
 
     /**
-     * Compares the authenticated user with a given user
+     * Compares the authenticated user with a given user.
      *
      * @return bool
      */

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Contracts\Auth;
 
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+
 interface Guard
 {
     /**
@@ -46,6 +48,14 @@ interface Guard
      * @return bool
      */
     public function hasUser();
+
+
+    /**
+     * Compares the authenticated user with a given user
+     *
+     * @return bool
+     */
+    public function userIs(AuthenticatableContract $user);
 
     /**
      * Set the current user.

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -48,8 +48,7 @@ interface Guard
      * @return bool
      */
     public function hasUser();
-
-
+    
     /**
      * Compares the authenticated user with a given user.
      *

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -51,7 +51,7 @@ interface Guard
 
 
     /**
-     * Compares the authenticated user with a given user
+     * Compares the authenticated user with a given user.
      *
      * @return bool
      */

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -282,6 +282,26 @@ class AuthGuardTest extends TestCase
         $this->assertFalse($guard->hasUser());
     }
 
+    public function testUserIsReturnsTrueWhenUsersAreEqual()
+    {
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
+        $mock = $this->getGuard();
+        $mock->setUser($user);
+        $this->assertTrue($mock->userIs($user));
+    }
+
+    public function testUserIsReturnsFalseWhenUsersArentEqual()
+    {
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthIdentifier')->andReturn(1);
+        $anotherUser = m::mock(Authenticatable::class);
+        $anotherUser->shouldReceive('getAuthIdentifier')->andReturn(2);
+        $mock = $this->getGuard();
+        $mock->setUser($user);
+        $this->assertFalse($mock->userIs($anotherUser));
+    }
+
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()
     {
         $user = m::mock(Authenticatable::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
More than once I compare the authenticated user against another user instance. It is code which repeats a lot. 

```php
if(auth()->user()->id === $post->user->id){
```
could be a lot easier to read:

```php
if(auth()->userIs($post->user)){
```
It makes the DX better with adding a bit syntactic sugar. We read actually what we are doing.
