### PR TITLE
[9.x] Trait for adding observer event methods to models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/ObservesEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/ObservesEvents.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Support\Str;
+
+trait ObservesEvents
+{
+    public static function bootObservesEvents()
+    {
+        $events = [
+            'retrieved', 'creating', 'created', 'updating', 'updated',
+            'saving', 'saved', 'deleting', 'deleted', 'trashed',
+            'forceDeleted', 'restoring', 'restored', 'replicating'
+        ];
+
+        foreach ($events as $event) {
+            if (!method_exists(static::class, $event)) {
+                continue;
+            }
+
+            $method = 'on' . Str::studly($event);
+
+            if (!method_exists(static::class, $method)) {
+                continue;
+            }
+
+            static::$event(function ($model) use ($method) {
+                $model->$method();
+            });
+        }
+    }
+}


### PR DESCRIPTION
This is just a proposal, not sure if you would want this in the core. Also, looking at the `HasEvents` trait, there is probably a much better way of implementing this.

This would allow people to add this trait to their models so they could add observer event methods e.g. `onCreating`. It could even be included in models by default so they wouldn't have to add a `use` statement to their models.

It is useful for models that only require 1 or 2 events that may not warrant an entire separate observer class. The syntax is also nicer (imo) than using the current [closure approach](https://laravel.com/docs/9.x/eloquent#events-using-closures).

Example:

```php
namespace App\Models;

use App\Jobs\SendNewPostNotifications;
use Illuminate\Database\Eloquent\Concerns\ObservesEvents;
use Illuminate\Database\Eloquent\Model;
use Illuminate\Support\Str;

class Post extends Model
{
    use ObservesEvents;

    public function onCreating()
    {
        $this->slug = Str::slug($this->title);
    }

    public function onCreated()
    {
        SendNewPostNotifications::dispatch($this);
    }
}
```

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
