### PR TITLE
[9.x] Added encoding in limit and large negative number fix

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -492,7 +492,7 @@ class Str
     {
         if (mb_strwidth($value, $encoding) <= $limit) {
             return $value;
-        } else if ($limit < 0 && mb_strwidth($value, $encoding) <= abs($limit)) {
+        } elseif ($limit < 0 && mb_strwidth($value, $encoding) <= abs($limit)) {
             return $end;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -486,6 +486,7 @@ class Str
      * @param  string  $value
      * @param  int  $limit
      * @param  string  $end
+     * @param  string  $encoding
      * @return string
      */
     public static function limit($value, $limit = 100, $end = '...', $encoding = 'UTF-8')

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -488,7 +488,7 @@ class Str
      * @param  string  $end
      * @return string
      */
-    public static function limit($value, $limit = 100, $encoding = 'UTF-8', $end = '...')
+    public static function limit($value, $limit = 100, $end = '...', $encoding = 'UTF-8')
     {
         if (mb_strwidth($value, $encoding) <= $limit) {
             return $value;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -488,13 +488,15 @@ class Str
      * @param  string  $end
      * @return string
      */
-    public static function limit($value, $limit = 100, $end = '...')
+    public static function limit($value, $limit = 100, $encoding = 'UTF-8', $end = '...')
     {
-        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+        if (mb_strwidth($value, $encoding) <= $limit) {
             return $value;
+        } else if ($limit < 0 && mb_strwidth($value, $encoding) <= abs($limit)) {
+            return $end;
         }
 
-        return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
+        return rtrim(mb_strimwidth($value, 0, $limit, '', $encoding)).$end;
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -378,9 +378,9 @@ class Stringable implements JsonSerializable
      * @param  string  $end
      * @return static
      */
-    public function limit($limit = 100, $end = '...')
+    public function limit($limit = 100, $encoding = 'UTF-8', $end = '...')
     {
-        return new static(Str::limit($this->value, $limit, $end));
+        return new static(Str::limit($this->value, $limit, $encoding, $end));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -378,9 +378,9 @@ class Stringable implements JsonSerializable
      * @param  string  $end
      * @return static
      */
-    public function limit($limit = 100, $encoding = 'UTF-8', $end = '...')
+    public function limit($limit = 100, $end = '...', $encoding = 'UTF-8')
     {
-        return new static(Str::limit($this->value, $limit, $encoding, $end));
+        return new static(Str::limit($this->value, $limit, $end, $encoding));
     }
 
     /**

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -376,6 +376,7 @@ class Stringable implements JsonSerializable
      *
      * @param  int  $limit
      * @param  string  $end
+     * @param  string  $encoding
      * @return static
      */
     public function limit($limit = 100, $end = '...', $encoding = 'UTF-8')

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -464,12 +464,12 @@ class SupportStrTest extends TestCase
 
         $string = 'The PHP framework for web artisans.';
         $this->assertSame('The PHP...', Str::limit($string, 7));
-        $this->assertSame('The PHP', Str::limit($string, 7, ''));
+        $this->assertSame('The PHP', Str::limit($string, 7, '', ''));
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));
-        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
+        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', ''));
     }
 
     public function testLength()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -464,12 +464,12 @@ class SupportStrTest extends TestCase
 
         $string = 'The PHP framework for web artisans.';
         $this->assertSame('The PHP...', Str::limit($string, 7));
-        $this->assertSame('The PHP', Str::limit($string, 7, 'UTF-8', ''));
+        $this->assertSame('The PHP', Str::limit($string, 7, '', 'UTF-8'));
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));
-        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, 'UTF-8', ''));
+        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', 'UTF-8'));
     }
 
     public function testLength()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -464,12 +464,12 @@ class SupportStrTest extends TestCase
 
         $string = 'The PHP framework for web artisans.';
         $this->assertSame('The PHP...', Str::limit($string, 7));
-        $this->assertSame('The PHP', Str::limit($string, 7, '', ''));
+        $this->assertSame('The PHP', Str::limit($string, 7, 'UTF-8', ''));
         $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));
-        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, '', ''));
+        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, 'UTF-8', ''));
     }
 
     public function testLength()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -790,12 +790,12 @@ class SupportStringableTest extends TestCase
 
         $string = 'The PHP framework for web artisans.';
         $this->assertSame('The PHP...', (string) $this->stringable($string)->limit(7));
-        $this->assertSame('The PHP', (string) $this->stringable($string)->limit(7, 'UTF-8', ''));
+        $this->assertSame('The PHP', (string) $this->stringable($string)->limit(7, '', 'UTF-8'));
         $this->assertSame('The PHP framework for web artisans.', (string) $this->stringable($string)->limit(100));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', (string) $this->stringable($nonAsciiString)->limit(6));
-        $this->assertSame('这是一', (string) $this->stringable($nonAsciiString)->limit(6, 'UTF-8', ''));
+        $this->assertSame('这是一', (string) $this->stringable($nonAsciiString)->limit(6, '', 'UTF-8'));
     }
 
     public function testLength()

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -790,12 +790,12 @@ class SupportStringableTest extends TestCase
 
         $string = 'The PHP framework for web artisans.';
         $this->assertSame('The PHP...', (string) $this->stringable($string)->limit(7));
-        $this->assertSame('The PHP', (string) $this->stringable($string)->limit(7, ''));
+        $this->assertSame('The PHP', (string) $this->stringable($string)->limit(7, 'UTF-8', ''));
         $this->assertSame('The PHP framework for web artisans.', (string) $this->stringable($string)->limit(100));
 
         $nonAsciiString = '这是一段中文';
         $this->assertSame('这是一...', (string) $this->stringable($nonAsciiString)->limit(6));
-        $this->assertSame('这是一', (string) $this->stringable($nonAsciiString)->limit(6, ''));
+        $this->assertSame('这是一', (string) $this->stringable($nonAsciiString)->limit(6, 'UTF-8', ''));
     }
 
     public function testLength()


### PR DESCRIPTION
1. Added encoding in limit()
2. Previously `Str::limit('Laravel', -10);` would cause an error due to out of range but now it will show the ending of the limit() rather showing error. Just like `Str::limit('Laravel', -10);` would result in full string (**Laravel**).

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
