### PR TITLE
Fix: acceptsAnyContentType returns false even if */* is provided

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -126,6 +126,8 @@ trait InteractsWithContentTypes
                 return true;
             }
         }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -117,9 +117,15 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return count($acceptable) === 0 || (
-            isset($acceptable[0]) && ($acceptable[0] === '*/*' || $acceptable[0] === '*')
-        );
+        if (count($acceptable) === 0) {
+            return true;
+        }
+
+        foreach ($acceptable as $key => $accept) {
+            if ($accept === '*/*' || $accept === '*') {
+                return true;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
based on this [docs from mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values)

the accept any value of `*/*` is not the first accept value...

this is also true from the return value of `getAcceptableContentTypes`

that means when using safari... 

which has a default accept header of `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8`

the function `acceptsAnyContentType` will return `false` even thou `*/*` is provided 2nd to the last of the comma separated values of accept.