### PR TITLE
[9.x] Add phpDoc to Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -23,6 +23,40 @@ use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
 use LogicException;
 
+/**
+ * @method static \Illuminate\Database\Eloquent\Model|static make(array $attributes = [])
+ * @method static \Illuminate\Database\Eloquent\Builder withGlobalScope(string $identifier, \Illuminate\Database\Eloquent\Scope|\Closure $scope)
+ * @method static \Illuminate\Database\Eloquent\Builder withoutGlobalScope(\Illuminate\Database\Eloquent\Scope|string $scope)
+ * @method static \Illuminate\Database\Eloquent\Builder withoutGlobalScopes(array|null $scopes = null)
+ * @method static \Illuminate\Database\Eloquent\Builder whereKey(mixed $id)
+ * @method static \Illuminate\Database\Eloquent\Builder whereKeyNot(mixed $id)
+ * @method static \Illuminate\Database\Eloquent\Builder where(\Closure|string|array|\Illuminate\Database\Query\Expression $column, mixed $operator = null, mixed $value = null, string $boolean = 'and')
+ * @method static \Illuminate\Database\Eloquent\Model|static|null firstWhere(\Closure|string|array|\Illuminate\Database\Query\Expression $column, mixed $operator = null, mixed $value = null, string $boolean = 'and')
+ * @method static \Illuminate\Database\Eloquent\Builder orWhere(\Closure|array|string|\Illuminate\Database\Query\Expression $column, mixed $operator = null, mixed $value = null)
+ * @method static \Illuminate\Database\Eloquent\Builder whereNot(\Closure|string|array|\Illuminate\Database\Query\Expression $column, mixed $operator = null, mixed $value = null, string $boolean = 'and')
+ * @method static \Illuminate\Database\Eloquent\Builder orWhereNot(\Closure|array|string|\Illuminate\Database\Query\Expression $column, mixed $operator = null, mixed $value = null)
+ * @method static \Illuminate\Database\Eloquent\Builder latest(string|\Illuminate\Database\Query\Expression|null $column = null)
+ * @method static \Illuminate\Database\Eloquent\Builder oldest(string|\Illuminate\Database\Query\Expression|null $column = null)
+ * @method static \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|null find(mixed $id, array|string $columns = ['*'])
+ * @method static \Illuminate\Database\Eloquent\Collection findMany(\Illuminate\Contracts\Support\Arrayable|array $ids, array|string $columns = ['*'])
+ * @method static \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[] findOrFail(mixed $id, array|string $columns = ['*'])
+ * @method static \Illuminate\Database\Eloquent\Model|static findOrNew(mixed $id, array|string $columns = ['*'])
+ * @method static \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static[]|static|mixed findOr(mixed $id, \Closure|array|string $columns = ['*'], \Closure|null $callback = null)
+ * @method static \Illuminate\Database\Eloquent\Model|static firstOrNew(array $attributes = [], array $values = [])
+ * @method static \Illuminate\Database\Eloquent\Model|static firstOrCreate(array $attributes = [], array $values = [])
+ * @method static \Illuminate\Database\Eloquent\Model|static updateOrCreate(array $attributes, array $values = [])
+ * @method static \Illuminate\Database\Eloquent\Model|static firstOrFail(array|string $columns = ['*'])
+ * @method static \Illuminate\Database\Eloquent\Model|static|mixed firstOr(\Closure|array|string $columns = ['*'], \Closure|null $callback = null)
+ * @method static \Illuminate\Database\Eloquent\Collection|static[] get(array|string $columns = ['*'])
+ * @method static \Illuminate\Contracts\Pagination\LengthAwarePaginator paginate(int|null|\Closure $perPage = null, array|string $columns = ['*'], string $pageName = 'page', int|null $page = null)
+ * @method static \Illuminate\Contracts\Pagination\Paginator simplePaginate(int|null $perPage = null, array|string $columns = ['*'], string $pageName = 'page', int|null $page = null)
+ * @method static \Illuminate\Contracts\Pagination\CursorPaginator cursorPaginate(int|null $perPage = null, array|string $columns = ['*'], string $cursorName = 'cursor', \Illuminate\Pagination\Cursor|string|null $cursor = null)
+ * @method static \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Builder create(array $attributes = [])
+ * @method static \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Builder forceCreate(array $attributes)
+ * @method static int upsert(array $values, array|string $uniqueBy, array|null $update = null)
+ *
+ * @see \Illuminate\Database\Eloquent\Builder
+ */
 abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToString, HasBroadcastChannel, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,


### PR DESCRIPTION
This PR adds phpDoc to Eloquent\Model, so IDE's and other analyzer tools can better understand the code, and it also increases developer productivity.

Before this PR:
![1](https://user-images.githubusercontent.com/43762190/210008658-b81e1ab0-6057-416f-a632-4373890e7b86.png)

After this PR:
![2](https://user-images.githubusercontent.com/43762190/210008709-f1846653-3efe-4866-b13c-c54fe4a991c0.png)
![3](https://user-images.githubusercontent.com/43762190/210008710-21a9d68e-13dd-4853-8c91-c9ac127f606d.png)

This PR does not break the code. I tried to put only the methods that are not used internally by Laravel. :)