### PR TITLE
[9.x] Fix decimal cast precision issue

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -31,6 +31,7 @@ use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
+use TypeError;
 
 trait HasAttributes
 {
@@ -1318,7 +1319,15 @@ trait HasAttributes
      */
     protected function asDecimal($value, $decimals)
     {
-        return number_format($value, $decimals, '.', '');
+        $value = (string) $value;
+
+        if (! is_numeric($value)) {
+            throw new TypeError('$value must be numeric.');
+        }
+
+        [$int, $fraction] = explode('.', $value) + [1 => ''];
+
+        return $int.'.'.Str::of($fraction)->limit($decimals, '')->padLeft($decimals, '0');
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/45454

## Problem

Currently we are handling floats via `format_number`. Because of `number_format`, we are losing precision, if the precision is long enough.

## Solution

This is a 2 part solution. This PR is part one to address this issue in the _least_ breaking way possible for `9.x` and then a follow up PR will fix this using `bcmath` instead.

To solve this for `9.x` we are now manually handling the formatting via the `Str` helper.

## Breaking

`number_format` rounds numbers when the precision is being reduced. This is no longer the case and I'm not aware of any _good_ way to handle this.

```php
$model = new class extends Model {
    protected $casts = [
        'amount' => 'decimal:1',
    ];
};

$model->amount = '0.99';

// The following test...
// Before ✅
// After ❌

$this->assertSame('1.0', $model->amount);

// The following test...
// Before ❌
// After ✅

$this->assertSame('0.9', $model->amount);
```

I'm proposing that in `10.x` we change this manual string manipulation into a basic `bcmath` call: https://github.com/laravel/framework/pull/45457

I feel that making `bcmath` a requirement to use an existing feature could be a breaking change for some applications(?)