### PR TITLE
[10.x] Improve decimal cast precision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,7 @@
         }
     },
     "suggest": {
-        "ext-bcmath": "Required to use the multiple_of validation rule.",
+        "ext-bcmath": "Required to use the multiple_of validation rule and the Eloquent model decimal attribute cast.",
         "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -31,8 +31,6 @@ use LogicException;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
-use RuntimeException;
-use TypeError;
 
 trait HasAttributes
 {
@@ -1311,21 +1309,7 @@ trait HasAttributes
      */
     protected function asDecimal($value, $decimals)
     {
-        if (extension_loaded('bcmath')) {
-            return bcadd($value, 0, $decimals);
-        }
-
-        if (! is_numeric($value)) {
-            throw new TypeError('$value must be numeric.');
-        }
-
-        if (is_string($value) && Str::contains($value, 'e', true)) {
-            throw new RuntimeException('The "decimal" model cast is unable to handle string based floats with exponents.');
-        }
-
-        [$int, $fraction] = explode('.', $value) + [1 => ''];
-
-        return Str::of($int)->padLeft('1', '0').'.'.Str::of($fraction)->limit($decimals, '')->padRight($decimals, '0');
+        return bcadd($value, '0', $decimals);
     }
 
     /**

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-bcmath": "Required to use the decimal attribute cast.",
         "ext-json": "*",
         "illuminate/collections": "^10.0",
         "illuminate/container": "^10.0",
@@ -36,6 +35,7 @@
         }
     },
     "suggest": {
+        "ext-bcmath": "Required to use the decimal attribute cast (*).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^3.5.1).",
         "fakerphp/faker": "Required to use the eloquent factory builder (^1.21).",
         "illuminate/console": "Required to use the database commands (^10.0).",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "ext-bcmath": "Required to use the decimal attribute cast.",
         "ext-json": "*",
         "illuminate/collections": "^10.0",
         "illuminate/container": "^10.0",


### PR DESCRIPTION
Remove manual manipulation and require `bcmath` to use the decimal cast.

This should be noted in the 10.x upgrade guide.