### PR TITLE
[9.x] Fix issue on which class to check for increment and decrement methods when custom castable is used

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1613,7 +1613,7 @@ trait HasAttributes
     protected function isClassDeviable($key)
     {
         return $this->isClassCastable($key) &&
-            method_exists($castType = $this->parseCasterClass($this->getCasts()[$key]), 'increment') &&
+            method_exists($castType = $this->resolveCasterClass($key), 'increment') &&
             method_exists($castType, 'decrement');
     }
 


### PR DESCRIPTION
This is an alternative solution related to the pull request https://github.com/laravel/framework/pull/45444 on issue  https://github.com/laravel/framework/issues/45418

This code uses the existing [resolveCasterClass](https://github.com/laravel/framework/blob/3dff5847ef8b9033ab1a414829abb543f1a9038a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L1641-L1663) method to resolve the custom cast type ([Sjord](https://github.com/Sjord)).
 
Previously, increment/decrement methods were checked only against the caster class even if the caster implements [Castable](https://github.com/laravel/framework/blob/b9203fca96960ef9cd8860cb4ec99d1279353a8d/src/Illuminate/Contracts/Database/Eloquent/Castable.php) interface. The deviate methods are now checked and invoked on the same resulting cast type class.