### PR TITLE
Allow get object properties from "dot" notation

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -326,6 +326,8 @@ class Arr
         foreach (explode('.', $key) as $segment) {
             if (static::accessible($array) && static::exists($array, $segment)) {
                 $array = $array[$segment];
+            } elseif (is_object($array) && isset($array->{$segment})) {
+                $array = $array->{$segment};
             } else {
                 return value($default);
             }


### PR DESCRIPTION
Right now, it is not possible to access an object or class from dot notation, sometimes it is necessary. From the "data_get" helper it is possible to do so, with this change the same functionality is achieved.

Example:
```
$test = [
    'code' => 'php',
    'list' => [
        (object)['name' => 'one'],
        ['name' => 'two']
    ]
];

// Fail
dump(Arr::get($test, 'list.0.name'));

// Done
dump(data_get($test, 'list.0.name'));
```