### PR TITLE
Add missing throwUnless function to the HTTP Client

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -353,7 +353,7 @@ class Response implements ArrayAccess
     {
         return $this->throwIf(! $condition);
     }
-    
+
     /**
      * Determine if the given offset exists.
      *

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -351,7 +351,7 @@ class Response implements ArrayAccess
      */
     public function throwUnless($condition)
     {
-        return $this->throwIf(! $condition);
+        return ! value($condition, $this) ? $this->throw(func_get_args()[1] ?? null) : $this;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -341,6 +341,20 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Throw an exception if a server or client error occurred and the given condition evaluates to false.
+     *
+     * @param  \Closure|bool  $condition
+     * @param  \Closure|null  $throwCallback
+     * @return $this
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwUnless($condition)
+    {
+        return $this->throwIf(! $condition);
+    }
+    
+    /**
      * Determine if the given offset exists.
      *
      * @param  string  $offset

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -335,9 +335,9 @@ class Response implements ArrayAccess
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throwIf($condition)
+    public function throwIf($condition, $throwCallback = null)
     {
-        return value($condition, $this) ? $this->throw(func_get_args()[1] ?? null) : $this;
+        return value($condition, $this) ? $this->throw($throwCallback) : $this;
     }
 
     /**
@@ -349,9 +349,9 @@ class Response implements ArrayAccess
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throwUnless($condition)
+    public function throwUnless($condition, $throwCallback = null)
     {
-        return ! value($condition, $this) ? $this->throw(func_get_args()[1] ?? null) : $this;
+        return $this->throwIf(! value($condition, $this), $throwCallback);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1482,6 +1482,26 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $exception);
     }
 
+    public function testRequestExceptionIsThrownIfTheThrowUnlessOnThePendingRequestIsSetToFalseOnFailure()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory
+                ->throwUnless(false)
+                ->get('http://foo.com/get');
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
     public function testRequestExceptionIsNotThrownIfTheThrowIfOnThePendingRequestIsSetToFalseOnFailure()
     {
         $this->factory->fake([
@@ -1490,6 +1510,19 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory
             ->throwIf(false)
+            ->get('http://foo.com/get');
+
+        $this->assertSame(403, $response->status());
+    }
+
+    public function testRequestExceptionIsNotThrownIfTheThrowUnlessOnThePendingRequestIsSetToTrueOnFailure()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $response = $this->factory
+            ->throwUnless(true)
             ->get('http://foo.com/get');
 
         $this->assertSame(403, $response->status());
@@ -1529,6 +1562,40 @@ class HttpClientTest extends TestCase
         $this->assertTrue($hitThrowCallback);
     }
 
+    public function testRequestExceptionIsThrownIfTheThrowUnlessClosureOnThePendingRequestReturnsFalse()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $exception = null;
+
+        $hitThrowCallback = false;
+
+        try {
+            $this->factory
+                ->throwUnless(function ($response) {
+                    $this->assertInstanceOf(Response::class, $response);
+                    $this->assertSame(403, $response->status());
+
+                    return false;
+                }, function ($response, $e) use (&$hitThrowCallback) {
+                    $this->assertInstanceOf(Response::class, $response);
+                    $this->assertSame(403, $response->status());
+
+                    $this->assertInstanceOf(RequestException::class, $e);
+                    $hitThrowCallback = true;
+                })
+                ->get('http://foo.com/get');
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+        $this->assertTrue($hitThrowCallback);
+    }
+
     public function testRequestExceptionIsNotThrownIfTheThrowIfClosureOnThePendingRequestReturnsFalse()
     {
         $this->factory->fake([
@@ -1543,6 +1610,29 @@ class HttpClientTest extends TestCase
                 $this->assertSame(403, $response->status());
 
                 return false;
+            }, function ($response, $e) use (&$hitThrowCallback) {
+                $hitThrowCallback = true;
+            })
+            ->get('http://foo.com/get');
+
+        $this->assertSame(403, $response->status());
+        $this->assertFalse($hitThrowCallback);
+    }
+
+    public function testRequestExceptionIsNotThrownIfTheThrowUnlessClosureOnThePendingRequestReturnsTrue()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response(['error'], 403),
+        ]);
+
+        $hitThrowCallback = false;
+
+        $response = $this->factory
+            ->throwIf(function ($response) {
+                $this->assertInstanceOf(Response::class, $response);
+                $this->assertSame(403, $response->status());
+
+                return true;
             }, function ($response, $e) use (&$hitThrowCallback) {
                 $hitThrowCallback = true;
             })
@@ -1649,6 +1739,24 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $exception);
     }
 
+    public function testRequestExceptionIsThrowUnlessConditionIsSatisfied()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response('', 400),
+        ]);
+
+        $exception = null;
+
+        try {
+            $this->factory->get('http://foo.com/api')->throwUnless(false);
+        } catch (RequestException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception);
+        $this->assertInstanceOf(RequestException::class, $exception);
+    }
+
     public function testRequestExceptionIsNotThrownIfConditionIsNotSatisfied()
     {
         $this->factory->fake([
@@ -1656,6 +1764,17 @@ class HttpClientTest extends TestCase
         ]);
 
         $response = $this->factory->get('http://foo.com/api')->throwIf(false);
+
+        $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
+    }
+
+    public function testRequestExceptionIsNotThrownUnlessConditionIsNotSatisfied()
+    {
+        $this->factory->fake([
+            '*' => $this->factory::response(['result' => ['foo' => 'bar']], 400),
+        ]);
+
+        $response = $this->factory->get('http://foo.com/api')->throwUnless(true);
 
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1580,10 +1580,6 @@ class HttpClientTest extends TestCase
 
                     return false;
                 }, function ($response, $e) use (&$hitThrowCallback) {
-                    $this->assertInstanceOf(Response::class, $response);
-                    $this->assertSame(403, $response->status());
-
-                    $this->assertInstanceOf(RequestException::class, $e);
                     $hitThrowCallback = true;
                 })
                 ->get('http://foo.com/get');
@@ -1634,6 +1630,10 @@ class HttpClientTest extends TestCase
 
                 return true;
             }, function ($response, $e) use (&$hitThrowCallback) {
+                $this->assertInstanceOf(Response::class, $response);
+                $this->assertSame(403, $response->status());
+
+                $this->assertInstanceOf(RequestException::class, $e);
                 $hitThrowCallback = true;
             })
             ->get('http://foo.com/get');

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1739,24 +1739,6 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $exception);
     }
 
-    public function testRequestExceptionIsThrowUnlessConditionIsSatisfied()
-    {
-        $this->factory->fake([
-            '*' => $this->factory::response('', 400),
-        ]);
-
-        $exception = null;
-
-        try {
-            $this->factory->get('http://foo.com/api')->throwUnless(false);
-        } catch (RequestException $e) {
-            $exception = $e;
-        }
-
-        $this->assertNotNull($exception);
-        $this->assertInstanceOf(RequestException::class, $exception);
-    }
-
     public function testRequestExceptionIsNotThrownIfConditionIsNotSatisfied()
     {
         $this->factory->fake([
@@ -1764,17 +1746,6 @@ class HttpClientTest extends TestCase
         ]);
 
         $response = $this->factory->get('http://foo.com/api')->throwIf(false);
-
-        $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
-    }
-
-    public function testRequestExceptionIsNotThrownUnlessConditionIsNotSatisfied()
-    {
-        $this->factory->fake([
-            '*' => $this->factory::response(['result' => ['foo' => 'bar']], 400),
-        ]);
-
-        $response = $this->factory->get('http://foo.com/api')->throwUnless(true);
 
         $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
     }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1482,26 +1482,6 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(RequestException::class, $exception);
     }
 
-    public function testRequestExceptionIsThrownIfTheThrowUnlessOnThePendingRequestIsSetToFalseOnFailure()
-    {
-        $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
-        ]);
-
-        $exception = null;
-
-        try {
-            $this->factory
-                ->throwUnless(false)
-                ->get('http://foo.com/get');
-        } catch (RequestException $e) {
-            $exception = $e;
-        }
-
-        $this->assertNotNull($exception);
-        $this->assertInstanceOf(RequestException::class, $exception);
-    }
-
     public function testRequestExceptionIsNotThrownIfTheThrowIfOnThePendingRequestIsSetToFalseOnFailure()
     {
         $this->factory->fake([
@@ -1510,19 +1490,6 @@ class HttpClientTest extends TestCase
 
         $response = $this->factory
             ->throwIf(false)
-            ->get('http://foo.com/get');
-
-        $this->assertSame(403, $response->status());
-    }
-
-    public function testRequestExceptionIsNotThrownIfTheThrowUnlessOnThePendingRequestIsSetToTrueOnFailure()
-    {
-        $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
-        ]);
-
-        $response = $this->factory
-            ->throwUnless(true)
             ->get('http://foo.com/get');
 
         $this->assertSame(403, $response->status());
@@ -1562,36 +1529,6 @@ class HttpClientTest extends TestCase
         $this->assertTrue($hitThrowCallback);
     }
 
-    public function testRequestExceptionIsThrownIfTheThrowUnlessClosureOnThePendingRequestReturnsFalse()
-    {
-        $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
-        ]);
-
-        $exception = null;
-
-        $hitThrowCallback = false;
-
-        try {
-            $this->factory
-                ->throwUnless(function ($response) {
-                    $this->assertInstanceOf(Response::class, $response);
-                    $this->assertSame(403, $response->status());
-
-                    return false;
-                }, function ($response, $e) use (&$hitThrowCallback) {
-                    $hitThrowCallback = true;
-                })
-                ->get('http://foo.com/get');
-        } catch (RequestException $e) {
-            $exception = $e;
-        }
-
-        $this->assertNotNull($exception);
-        $this->assertInstanceOf(RequestException::class, $exception);
-        $this->assertTrue($hitThrowCallback);
-    }
-
     public function testRequestExceptionIsNotThrownIfTheThrowIfClosureOnThePendingRequestReturnsFalse()
     {
         $this->factory->fake([
@@ -1607,33 +1544,6 @@ class HttpClientTest extends TestCase
 
                 return false;
             }, function ($response, $e) use (&$hitThrowCallback) {
-                $hitThrowCallback = true;
-            })
-            ->get('http://foo.com/get');
-
-        $this->assertSame(403, $response->status());
-        $this->assertFalse($hitThrowCallback);
-    }
-
-    public function testRequestExceptionIsNotThrownIfTheThrowUnlessClosureOnThePendingRequestReturnsTrue()
-    {
-        $this->factory->fake([
-            '*' => $this->factory->response(['error'], 403),
-        ]);
-
-        $hitThrowCallback = false;
-
-        $response = $this->factory
-            ->throwIf(function ($response) {
-                $this->assertInstanceOf(Response::class, $response);
-                $this->assertSame(403, $response->status());
-
-                return true;
-            }, function ($response, $e) use (&$hitThrowCallback) {
-                $this->assertInstanceOf(Response::class, $response);
-                $this->assertSame(403, $response->status());
-
-                $this->assertInstanceOf(RequestException::class, $e);
                 $hitThrowCallback = true;
             })
             ->get('http://foo.com/get');


### PR DESCRIPTION
## Problem
The current Laravel 9.x documentation gives the following examples for throwing exceptions on the HTTP Client response:
```
$response = Http::post(/* ... */);
 
// Throw an exception if a client or server error occurred...
$response->throw();
 
// Throw an exception if an error occurred and the given condition is true...
$response->throwIf($condition);
 
// Throw an exception if an error occurred and the given closure resolves to true...
$response->throwIf(fn ($response) => true);
 
// Throw an exception if an error occurred and the given condition is false...
$response->throwUnless($condition);
 
// Throw an exception if an error occurred and the given closure resolves to false...
$response->throwUnless(fn ($response) => false);
 
return $response['user']['id'];
```

However, the `throwUnless` function does not exist and throws the following exception:
```
Call to undefined method GuzzleHttp\\Psr7\\Response::throwUnless()
```

Source: https://laravel.com/docs/9.x/http-client#throwing-exceptions

## Solution
Add a `throwUnless` function to the `Illuminate\Http\Client\Response` class that uses the already existing `throwIf` function with a negation unary operator to invert the condition.

A second argument has also been added to the `throwIf` to take in the `$throwCallback` and default it to `null` instead of using `func_get_args()[1] ?? null`.