### PR TITLE
Tests written for throwIf function on HTTP Client is not correctly entering throwIf function.

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -1472,8 +1472,8 @@ class HttpClientTest extends TestCase
 
         try {
             $this->factory
-                ->throwIf(true)
-                ->get('http://foo.com/get');
+                ->get('http://foo.com/get')
+                ->throwIf(true);
         } catch (RequestException $e) {
             $exception = $e;
         }
@@ -1507,6 +1507,7 @@ class HttpClientTest extends TestCase
 
         try {
             $this->factory
+                ->get('http://foo.com/get')
                 ->throwIf(function ($response) {
                     $this->assertInstanceOf(Response::class, $response);
                     $this->assertSame(403, $response->status());
@@ -1518,8 +1519,7 @@ class HttpClientTest extends TestCase
 
                     $this->assertInstanceOf(RequestException::class, $e);
                     $hitThrowCallback = true;
-                })
-                ->get('http://foo.com/get');
+                });
         } catch (RequestException $e) {
             $exception = $e;
         }
@@ -1538,6 +1538,7 @@ class HttpClientTest extends TestCase
         $hitThrowCallback = false;
 
         $response = $this->factory
+            ->get('http://foo.com/get')
             ->throwIf(function ($response) {
                 $this->assertInstanceOf(Response::class, $response);
                 $this->assertSame(403, $response->status());
@@ -1545,8 +1546,7 @@ class HttpClientTest extends TestCase
                 return false;
             }, function ($response, $e) use (&$hitThrowCallback) {
                 $hitThrowCallback = true;
-            })
-            ->get('http://foo.com/get');
+            });
 
         $this->assertSame(403, $response->status());
         $this->assertFalse($hitThrowCallback);


### PR DESCRIPTION
## Problem
When the test for the HTTP Client's `throwIf` function is run, it's entering the `throw` function and not the `throwIf` function as it should. This causes the test to pass without actually validating what it's supposed to.

## Solution
Move the `get` call before the `throwIf` as done in the other tests to allow the correct function to be called.