### PR TITLE
[9.x] Improves `Cache` facade types

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -84,9 +84,11 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache by key.
      *
+     * @template TCacheValue
+     *
      * @param  array|string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  TCacheValue|(\Closure(): TCacheValue)  $default
+     * @return TCacheValue
      */
     public function get($key, $default = null): mixed
     {
@@ -175,9 +177,11 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Retrieve an item from the cache and delete it.
      *
+     * @template TCacheValue
+     *
      * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  TCacheValue|(\Closure(): TCacheValue)  $default
+     * @return TCacheValue
      */
     public function pull($key, $default = null)
     {
@@ -372,10 +376,12 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get an item from the cache, or execute the given Closure and store the result.
      *
+     * @template TCacheValue
+     *
      * @param  string  $key
      * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
      */
     public function remember($key, $ttl, Closure $callback)
     {
@@ -396,9 +402,11 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCacheValue
+     *
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
      */
     public function sear($key, Closure $callback)
     {
@@ -408,9 +416,11 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCacheValue
+     *
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
      */
     public function rememberForever($key, Closure $callback)
     {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -62,7 +62,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Determine if an item exists in the cache.
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @return bool
      */
     public function has($key): bool
@@ -88,7 +88,7 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @param  array|string  $key
      * @param  TCacheValue|(\Closure(): TCacheValue)  $default
-     * @return TCacheValue
+     * @return (TCacheValue is null ? mixed : TCacheValue)
      */
     public function get($key, $default = null): mixed
     {
@@ -179,9 +179,9 @@ class Repository implements ArrayAccess, CacheContract
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  TCacheValue|(\Closure(): TCacheValue)  $default
-     * @return TCacheValue
+     * @return (TCacheValue is null ? mixed : TCacheValue)
      */
     public function pull($key, $default = null)
     {

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -12,9 +12,9 @@ interface Repository extends CacheInterface
      *
      * @template TCacheValue
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  TCacheValue|(\Closure(): TCacheValue)  $default
-     * @return TCacheValue
+     * @return (TCacheValue is null ? mixed : TCacheValue)
      */
     public function pull($key, $default = null);
 

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -10,9 +10,11 @@ interface Repository extends CacheInterface
     /**
      * Retrieve an item from the cache and delete it.
      *
+     * @template TCacheValue
+     *
      * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
+     * @param  TCacheValue|(\Closure(): TCacheValue)  $default
+     * @return TCacheValue
      */
     public function pull($key, $default = null);
 
@@ -66,28 +68,34 @@ interface Repository extends CacheInterface
     /**
      * Get an item from the cache, or execute the given Closure and store the result.
      *
+     * @template TCacheValue
+     *
      * @param  string  $key
      * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
      */
     public function remember($key, $ttl, Closure $callback);
 
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCacheValue
+     *
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
      */
     public function sear($key, Closure $callback);
 
     /**
      * Get an item from the cache, or execute the given Closure and store the result forever.
      *
+     * @template TCacheValue
+     *
      * @param  string  $key
-     * @param  \Closure  $callback
-     * @return mixed
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
      */
     public function rememberForever($key, Closure $callback);
 

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @template TCacheValue
- *
  * @method static \Illuminate\Contracts\Cache\Repository store(string|null $name = null)
  * @method static \Illuminate\Contracts\Cache\Repository driver(string|null $driver = null)
  * @method static \Illuminate\Cache\Repository repository(\Illuminate\Contracts\Cache\Store $store)
@@ -16,10 +14,10 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Cache\CacheManager extend(string $driver, \Closure $callback)
  * @method static bool has(string $key)
  * @method static bool missing(string $key)
- * @method static TCacheValue get(array|string $key, TCacheValue|(\Closure(): TCacheValue) $default = null)
+ * @method static mixed get(array|string $key, mixed $default = null)
  * @method static array many(array $keys)
- * @method static iterable getMultiple(iterable<string> $keys, mixed $default = null)
- * @method static TCacheValue pull(string $key, TCacheValue|(\Closure(): TCacheValue) $default = null)
+ * @method static iterable getMultiple(iterable $keys, mixed $default = null)
+ * @method static mixed pull(string $key, mixed $default = null)
  * @method static bool put(array|string $key, mixed $value, \DateTimeInterface|\DateInterval|int|null $ttl = null)
  * @method static bool set(string $key, mixed $value, null|int|\DateInterval $ttl = null)
  * @method static bool putMany(array $values, \DateTimeInterface|\DateInterval|int|null $ttl = null)
@@ -28,12 +26,12 @@ namespace Illuminate\Support\Facades;
  * @method static int|bool increment(string $key, mixed $value = 1)
  * @method static int|bool decrement(string $key, mixed $value = 1)
  * @method static bool forever(string $key, mixed $value)
- * @method static TCacheValue remember(string $key, \Closure|\DateTimeInterface|\DateInterval|int|null $ttl, \Closure(): TCacheValue $callback)
- * @method static TCacheValue sear(string $key, \Closure(): TCacheValue $callback)
- * @method static TCacheValue rememberForever(string $key, \Closure(): TCacheValue $callback)
+ * @method static mixed remember(string $key, \Closure|\DateTimeInterface|\DateInterval|int|null $ttl, \Closure $callback)
+ * @method static mixed sear(string $key, \Closure $callback)
+ * @method static mixed rememberForever(string $key, \Closure $callback)
  * @method static bool forget(string $key)
  * @method static bool delete(string $key)
- * @method static bool deleteMultiple(iterable<string> $keys)
+ * @method static bool deleteMultiple(iterable $keys)
  * @method static bool clear()
  * @method static \Illuminate\Cache\TaggedCache tags(array|mixed $names)
  * @method static bool supportsTags()
@@ -53,6 +51,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Contracts\Cache\Lock restoreLock(string $name, string $owner)
  *
  * @see \Illuminate\Cache\CacheManager
+ * @mixin \Illuminate\Cache\Repository
  */
 class Cache extends Facade
 {

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @template TCacheValue
+ *
  * @method static \Illuminate\Contracts\Cache\Repository store(string|null $name = null)
  * @method static \Illuminate\Contracts\Cache\Repository driver(string|null $driver = null)
  * @method static \Illuminate\Cache\Repository repository(\Illuminate\Contracts\Cache\Store $store)
@@ -14,10 +16,10 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Cache\CacheManager extend(string $driver, \Closure $callback)
  * @method static bool has(string $key)
  * @method static bool missing(string $key)
- * @method static mixed get(array|string $key, mixed $default = null)
+ * @method static TCacheValue get(array|string $key, TCacheValue|(\Closure(): TCacheValue) $default = null)
  * @method static array many(array $keys)
  * @method static iterable getMultiple(iterable<string> $keys, mixed $default = null)
- * @method static mixed pull(string $key, mixed $default = null)
+ * @method static TCacheValue pull(string $key, TCacheValue|(\Closure(): TCacheValue) $default = null)
  * @method static bool put(array|string $key, mixed $value, \DateTimeInterface|\DateInterval|int|null $ttl = null)
  * @method static bool set(string $key, mixed $value, null|int|\DateInterval $ttl = null)
  * @method static bool putMany(array $values, \DateTimeInterface|\DateInterval|int|null $ttl = null)
@@ -26,9 +28,9 @@ namespace Illuminate\Support\Facades;
  * @method static int|bool increment(string $key, mixed $value = 1)
  * @method static int|bool decrement(string $key, mixed $value = 1)
  * @method static bool forever(string $key, mixed $value)
- * @method static mixed remember(string $key, \Closure|\DateTimeInterface|\DateInterval|int|null $ttl, \Closure $callback)
- * @method static mixed sear(string $key, \Closure $callback)
- * @method static mixed rememberForever(string $key, \Closure $callback)
+ * @method static TCacheValue remember(string $key, \Closure|\DateTimeInterface|\DateInterval|int|null $ttl, \Closure(): TCacheValue $callback)
+ * @method static TCacheValue sear(string $key, \Closure(): TCacheValue $callback)
+ * @method static TCacheValue rememberForever(string $key, \Closure(): TCacheValue $callback)
  * @method static bool forget(string $key)
  * @method static bool delete(string $key)
  * @method static bool deleteMultiple(iterable<string> $keys)

--- a/types/Cache/Repository.php
+++ b/types/Cache/Repository.php
@@ -1,36 +1,27 @@
 <?php
 
 use Illuminate\Cache\Repository;
-use Illuminate\Contracts\Cache\Repository as RepositoryInterface;
 use function PHPStan\Testing\assertType;
-
-/** @var RepositoryInterface $cache */
-$cache = resolve(RepositoryInterface::class);
-
-assertType('int', $cache->pull('cache', 13));
-assertType('int', $cache->pull('cache', function (): int {
-    return 12;
-}));
-assertType('int', $cache->sear('cache', function (): int {
-    return 15;
-}));
-assertType('int', $cache->rememberForever('cache', function (): int {
-    return 18;
-}));
 
 /** @var Repository $cache */
 $cache = resolve(Repository::class);
 
+assertType('mixed', $cache->get('key'));
 assertType('int', $cache->get('cache', 27));
 assertType('int', $cache->get('cache', function (): int {
     return 26;
 }));
+
+assertType('mixed', $cache->pull('key'));
 assertType('int', $cache->pull('cache', 28));
 assertType('int', $cache->pull('cache', function (): int {
     return 30;
 }));
 assertType('int', $cache->sear('cache', function (): int {
     return 33;
+}));
+assertType('int', $cache->remember('cache', now(), function (): int {
+    return 36;
 }));
 assertType('int', $cache->rememberForever('cache', function (): int {
     return 36;

--- a/types/Contracts/Cache/Repository.php
+++ b/types/Contracts/Cache/Repository.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Contracts\Cache\Repository;
+use function PHPStan\Testing\assertType;
+
+/** @var Repository $cache */
+$cache = resolve(Repository::class);
+
+assertType('mixed', $cache->get('key'));
+assertType('mixed', $cache->get('cache', 27));
+assertType('mixed', $cache->get('cache', function (): int {
+    return 26;
+}));
+
+assertType('mixed', $cache->pull('key'));
+assertType('int', $cache->pull('cache', 28));
+assertType('int', $cache->pull('cache', function (): int {
+    return 30;
+}));
+assertType('int', $cache->sear('cache', function (): int {
+    return 33;
+}));
+assertType('int', $cache->remember('cache', now(), function (): int {
+    return 36;
+}));
+assertType('int', $cache->rememberForever('cache', function (): int {
+    return 36;
+}));

--- a/types/Support/Cache.php
+++ b/types/Support/Cache.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\Repository as RepositoryInterface;
+use function PHPStan\Testing\assertType;
+
+/** @var RepositoryInterface $cache */
+$cache = resolve(RepositoryInterface::class);
+
+assertType('int', $cache->pull('cache', 13));
+assertType('int', $cache->pull('cache', function (): int {
+    return 12;
+}));
+assertType('int', $cache->sear('cache', function (): int {
+    return 15;
+}));
+assertType('int', $cache->rememberForever('cache', function (): int {
+    return 18;
+}));
+
+/** @var Repository $cache */
+$cache = resolve(Repository::class);
+
+assertType('int', $cache->get('cache', 27));
+assertType('int', $cache->get('cache', function (): int {
+    return 26;
+}));
+assertType('int', $cache->pull('cache', 28));
+assertType('int', $cache->pull('cache', function (): int {
+    return 30;
+}));
+assertType('int', $cache->sear('cache', function (): int {
+    return 33;
+}));
+assertType('int', $cache->rememberForever('cache', function (): int {
+    return 36;
+}));

--- a/types/Support/Facades/Cache.php
+++ b/types/Support/Facades/Cache.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use function PHPStan\Testing\assertType;
+
+assertType('mixed', Cache::get('key'));
+assertType('int', Cache::get('cache', 27));
+assertType('int', Cache::get('cache', function (): int {
+    return 26;
+}));
+
+assertType('mixed', Cache::pull('key'));
+assertType('int', Cache::pull('cache', 28));
+assertType('int', Cache::pull('cache', function (): int {
+    return 30;
+}));
+assertType('int', Cache::sear('cache', function (): int {
+    return 33;
+}));
+assertType('int', Cache::remember('cache', now(), function (): int {
+    return 36;
+}));
+assertType('int', Cache::rememberForever('cache', function (): int {
+    return 36;
+}));


### PR DESCRIPTION
This pull request improves `Cache` facade types, as initial proposed by https://github.com/laravel/framework/pull/45325. So, the following types are correctly inferred by PHPStan, and hopefully, in the future, by PHPStorm:

```php
Cache::get('key')); // mixed
Cache::get('key', 1)); // int
Cache::get('key', fn () => 1); // int

Cache::pull('key')); // mixed
Cache::pull('key', 1)); // int
Cache::pull('key', fn () => 1); // int

Cache::sear('key', fn () => 1); // int
Cache::remember('key', now(), fn () => 1); // int
Cache::rememberForever('key', fn () => 1); // int
```