### PR TITLE
Proof-of-concept: Component attribute bag merge strategies.

### DIFF
--- a/src/Illuminate/View/Strategies/AppendStrategy.php
+++ b/src/Illuminate/View/Strategies/AppendStrategy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\View\Strategies;
+
+use Illuminate\View\StrategyInterface;
+
+class AppendStrategy implements StrategyInterface
+{
+    public function __invoke($defaultsValue, $value): string
+    {
+        return implode(' ', array_unique(array_filter([$defaultsValue, $value])));
+    }
+}

--- a/src/Illuminate/View/Strategies/OverrideStrategy.php
+++ b/src/Illuminate/View/Strategies/OverrideStrategy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\View\Strategies;
+
+use Illuminate\View\StrategyInterface;
+
+class OverrideStrategy implements StrategyInterface
+{
+    public function __invoke($defaultsValue, $value): string
+    {
+        return $value;
+    }
+}

--- a/src/Illuminate/View/Strategies/TailwindStrategy.php
+++ b/src/Illuminate/View/Strategies/TailwindStrategy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\View\Strategies;
+
+use Illuminate\Support\Str;
+use Illuminate\View\StrategyInterface;
+
+class TailwindStrategy implements StrategyInterface
+{
+    public function __invoke($defaultsValue, $value): string
+    {
+        return collect(explode(" ", $defaultsValue))
+            ->mapWithKeys(fn($v) => [Str::of($v)->match("/.*?\-/")->toString() => $v])
+            ->merge(
+                collect(explode(" ", $value))
+                    ->mapWithKeys(fn($v) => [Str::of($v)->match("/.*?\-/")->toString() => $v])
+            )
+            ->flatten()
+            ->join(' ');
+    }
+}

--- a/src/Illuminate/View/StrategyInterface.php
+++ b/src/Illuminate/View/StrategyInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\View;
+
+interface StrategyInterface
+{
+    /**
+     * Merge $defaultValue with $value.
+     *
+     * @param $defaultValue
+     * @param $value
+     * @return string
+     */
+    public function __invoke($defaultValue, $value): string;
+}


### PR DESCRIPTION
Hello, me again (And happy new year!)

I ran into an issue with the `ComponentAttributeBag` while working with a Tailwind project. The default strategy for merging the `class` attribute appends the prop value onto the default value.

I had a button component with the `bg-red-500` class. When I wanted to make the button blue and added `bg-blue-500` my button remained red; having two of the same utility and variant combinations with Tailwind can cause unexpected outcomes.

e.g:

```blade
<!-- components/button.blade.php -->
<button {{ $attributes->merge(["class" => "bg-red-500"]) }}>
    {{$slot}}
</button>
```

```blade
<!-- home.blade.php -->
<x-button class="bg-blue-500">
</x-button>
```

This is a proof-of-concept pull request that adds merge strategies to the `ComponentAttributeBag`. It contains three strategies:
- OverrideStrategy (default)
- AppendStrategy
- TailwindStrategy

By default the `AppendStrategy` is used for `class` attributes; `OverrideStrategy` is used for everything else. Users can change the strategy mapping using the `view.strategies` configuration option, or by passing an overriding mapping to the `merge` function.

Still needs some work (mainly tests and some decommissioning) but what do you guys think?