### PR TITLE
[9.x] Remove extra code in Model.php to optimize performance 🏃🏻‍♂️

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1543,9 +1543,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function newQueryForRestoration($ids)
     {
-        return is_array($ids)
-            ? $this->newQueryWithoutScopes()->whereIn($this->getQualifiedKeyName(), $ids)
-            : $this->newQueryWithoutScopes()->whereKey($ids);
+        return $this->newQueryWithoutScopes()->whereKey($ids);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1153,9 +1153,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
      */
     public function saveOrFail(array $options = [])
     {
-        return $this->getConnection()->transaction(function () use ($options) {
-            return $this->save($options);
-        });
+        return $this->getConnection()->transaction(fn () => $this->save($options));
     }
 
     /**
@@ -1426,9 +1424,7 @@ abstract class Model implements Arrayable, ArrayAccess, CanBeEscapedWhenCastToSt
             return false;
         }
 
-        return $this->getConnection()->transaction(function () {
-            return $this->delete();
-        });
+        return $this->getConnection()->transaction(fn () => $this->delete());
     }
 
     /**


### PR DESCRIPTION
#### First Commit:
- The `whereKey` method can accept an array of ids so the check is not really needed.
- It also kinda optimizes since the `whereKey` method now uses the `whreIntegerInRaw` (instead of `whereIn`) for numeric ids.

#### Second commit:
- The second commit converts anonymous function to arrow functions.