### PR TITLE
Allows to use 'dot' format in validation translation file

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -306,7 +306,7 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        return $this->translator->get('validation.attributes.' . $name);
+        return $this->translator->get('validation.attributes.'.$name);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -306,7 +306,7 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        return Arr::get($this->translator->get('validation.attributes'), $name);
+        return $this->translator->get('validation.attributes.' . $name);
     }
 
     /**


### PR DESCRIPTION
This commit allows using "dot" syntax in validation's translation file. Before it wasn't possible due to assumption that validation.attributes is always an array. 
