### PR TITLE
[9.x] Disables `facades` worflow

### DIFF
--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: true
 
     name: Facade DocBlocks
+    if: ${{ false }}  # Disable until this supports generic annotations...
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request disables the `facades` workflow - until it supports correctly generic annotations.