### PR TITLE
[9.x] Fix method contextual binding

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -119,7 +119,7 @@ class BoundMethod
     protected static function getMethodDependencies($container, $callback, array $parameters = [])
     {
         $shouldPopFromBuildStack = false;
-        if ( // Allows contextual binding of method parameters when buildStack is empty
+        if ( // Allows contextual binding of method parameters when buildStack is missing the callback class
             is_array($callback) &&
             ! empty($contextual = $container->contextual) &&
             array_key_exists($className = get_class($callback[0]), $contextual)) {
@@ -133,7 +133,7 @@ class BoundMethod
             static::addDependencyForCallParameter($container, $parameter, $parameters, $dependencies);
         }
         $dependencies = array_merge($dependencies, array_values($parameters));
-        
+
         if ($shouldPopFromBuildStack) {
             $container->popFromBuildStack();
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -89,7 +89,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * The stack of concretions currently being built.
      *
-     * @var array[]
+     * @var string[]
      */
     protected $buildStack = [];
 
@@ -1465,5 +1465,22 @@ class Container implements ArrayAccess, ContainerContract
     public function __set($key, $value)
     {
         $this[$key] = $value;
+    }
+
+    public function pushToBuildStack(string $concrete): void
+    {
+        if (! in_array($concrete, $this->buildStack, true)) {
+            $this->buildStack[] = $concrete;
+        }
+    }
+
+    public function getBuildStack(): array
+    {
+        return $this->buildStack;
+    }
+
+    public function popFromBuildStack(): ?string
+    {
+        return array_pop($this->buildStack);
     }
 }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -229,6 +229,38 @@ class ContainerCallTest extends TestCase
             return $foo;
         });
     }
+
+    public function testPushToBuildStack(): void
+    {
+        $sut = new Container();
+
+        $sut->pushToBuildStack('foo');
+
+        $this->assertSame(['foo'], $sut->getBuildStack());
+    }
+
+    public function testPushToBuildStackWithAlreadyExistingEntry(): void
+    {
+        $sut = new Container();
+
+        $sut->pushToBuildStack('foo');
+        $sut->pushToBuildStack('foo');
+
+        $this->assertSame(['foo'], $sut->getBuildStack());
+    }
+
+    public function testPopFromBuildStack(): void
+    {
+        $sut = new Container();
+
+        $sut->pushToBuildStack('foo');
+        $sut->pushToBuildStack('bar');
+
+        $this->assertSame('bar', $sut->popFromBuildStack());
+        $this->assertSame('foo', $sut->popFromBuildStack());
+        $this->assertNull($sut->popFromBuildStack());
+        $this->assertEmpty($sut->getBuildStack());
+    }
 }
 
 class ContainerTestCallStub


### PR DESCRIPTION
To put it simply, try to:

1. Create a class that has a method with a parameter that has a type hint.
 * For instance, a command class with a handle method that has a parameter with a type hint of an interface.
2. Configure a contextual binding for that parameter to a concrete class.
3. Try to run the command.
4. You will get an error that the given interface is not instantiable.

This is because when the container tries to resolve the method dependencies, It encounters a `buildStack` that does not contain the class that contains the method to be called, as it was already popped from the build stack in a previous step.

This PR fixes this by temporarily pushing that class to the build stack so that the container can resolve the method dependencies correctly.