### PR TITLE
[9.x] Fix method contextual binding

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -123,8 +123,7 @@ class BoundMethod
             is_array($callback) &&
             ! empty($contextual = $container->contextual) &&
             array_key_exists($className = get_class($callback[0]), $contextual)) {
-            $container->pushToBuildStack($className);
-            $shouldPopFromBuildStack = true;
+            $shouldPopFromBuildStack = $container->pushToBuildStack($className);
         }
 
         $dependencies = [];

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -119,7 +119,7 @@ class BoundMethod
     protected static function getMethodDependencies($container, $callback, array $parameters = [])
     {
         $shouldPopFromBuildStack = false;
-        if ( // Allows contextual binding of method parameters when buildStack is empty
+        if ( // Allows contextual binding of method parameters when buildStack is missing the callback class
             is_array($callback) &&
             ! empty($contextual = $container->contextual) &&
             array_key_exists($className = get_class($callback[0]), $contextual)) {
@@ -133,7 +133,7 @@ class BoundMethod
             static::addDependencyForCallParameter($container, $parameter, $parameters, $dependencies);
         }
         $dependencies = array_merge($dependencies, array_values($parameters));
-        
+
         if ($shouldPopFromBuildStack) {
             $container->popFromBuildStack();
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1471,6 +1471,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         if (! in_array($concrete, $this->buildStack, true)) {
             $this->buildStack[] = $concrete;
+
             return true;
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1467,11 +1467,14 @@ class Container implements ArrayAccess, ContainerContract
         $this[$key] = $value;
     }
 
-    public function pushToBuildStack(string $concrete): void
+    public function pushToBuildStack(string $concrete): bool
     {
         if (! in_array($concrete, $this->buildStack, true)) {
             $this->buildStack[] = $concrete;
+            return true;
         }
+
+        return false;
     }
 
     public function getBuildStack(): array

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -89,7 +89,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * The stack of concretions currently being built.
      *
-     * @var array[]
+     * @var string[]
      */
     protected $buildStack = [];
 
@@ -1465,5 +1465,22 @@ class Container implements ArrayAccess, ContainerContract
     public function __set($key, $value)
     {
         $this[$key] = $value;
+    }
+
+    public function pushToBuildStack(string $concrete): void
+    {
+        if (! in_array($concrete, $this->buildStack, true)) {
+            $this->buildStack[] = $concrete;
+        }
+    }
+
+    public function getBuildStack(): array
+    {
+        return $this->buildStack;
+    }
+
+    public function popFromBuildStack(): ?string
+    {
+        return array_pop($this->buildStack);
     }
 }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -229,6 +229,38 @@ class ContainerCallTest extends TestCase
             return $foo;
         });
     }
+
+    public function testPushToBuildStack(): void
+    {
+        $sut = new Container();
+
+        $sut->pushToBuildStack('foo');
+
+        $this->assertSame(['foo'], $sut->getBuildStack());
+    }
+
+    public function testPushToBuildStackWithAlreadyExistingEntry(): void
+    {
+        $sut = new Container();
+
+        $sut->pushToBuildStack('foo');
+        $sut->pushToBuildStack('foo');
+
+        $this->assertSame(['foo'], $sut->getBuildStack());
+    }
+
+    public function testPopFromBuildStack(): void
+    {
+        $sut = new Container();
+
+        $sut->pushToBuildStack('foo');
+        $sut->pushToBuildStack('bar');
+
+        $this->assertSame('bar', $sut->popFromBuildStack());
+        $this->assertSame('foo', $sut->popFromBuildStack());
+        $this->assertNull($sut->popFromBuildStack());
+        $this->assertEmpty($sut->getBuildStack());
+    }
 }
 
 class ContainerTestCallStub

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -234,19 +234,22 @@ class ContainerCallTest extends TestCase
     {
         $sut = new Container();
 
-        $sut->pushToBuildStack('foo');
+        $pushed = $sut->pushToBuildStack('foo');
 
         $this->assertSame(['foo'], $sut->getBuildStack());
+        $this->assertTrue($pushed);
     }
 
     public function testPushToBuildStackWithAlreadyExistingEntry(): void
     {
         $sut = new Container();
 
-        $sut->pushToBuildStack('foo');
-        $sut->pushToBuildStack('foo');
+        $firstPush = $sut->pushToBuildStack('foo');
+        $secondPush = $sut->pushToBuildStack('foo');
 
         $this->assertSame(['foo'], $sut->getBuildStack());
+        $this->assertTrue($firstPush);
+        $this->assertFalse($secondPush);
     }
 
     public function testPopFromBuildStack(): void


### PR DESCRIPTION
This PR reopens #45482.

This commit reproduces the issue:
https://github.com/imdhemy/laravel-reproduce/commit/93a9f0dd88e9aa5a156b63ddfa7413ece0fc9eb9

You can find the error message here:
`Target [App\Console\Commands\MyInterface] is not instantiable.`
https://github.com/imdhemy/laravel-reproduce/actions/runs/3823527853/jobs/6504792663#step:5:23