### PR TITLE
[10.x] Add support for native column modifying

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1077,7 +1077,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Indicates whether native alter operations will be used when dropping or renaming columns, even if Doctrine DBAL is installed.
+     * Indicates whether native alter operations will be used when dropping, renaming or modifying columns, even if Doctrine DBAL is installed.
      *
      * @return bool
      */

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1077,7 +1077,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Indicates whether native alter operations will be used when dropping, renaming or modifying columns, even if Doctrine DBAL is installed.
+     * Indicates whether native alter operations will be used when dropping, renaming, or modifying columns, even if Doctrine DBAL is installed.
      *
      * @return bool
      */

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -119,7 +119,7 @@ class Blueprint
      */
     public function toSql(Connection $connection, Grammar $grammar)
     {
-        $this->addImpliedCommands($grammar);
+        $this->addImpliedCommands($connection, $grammar);
 
         $statements = [];
 
@@ -183,10 +183,11 @@ class Blueprint
     /**
      * Add the commands that are implied by the blueprint's state.
      *
+     * @param  \Illuminate\Database\Connection  $connection
      * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    protected function addImpliedCommands(Grammar $grammar)
+    protected function addImpliedCommands(Connection $connection, Grammar $grammar)
     {
         if (count($this->getAddedColumns()) > 0 && ! $this->creating()) {
             array_unshift($this->commands, $this->createCommand('add'));
@@ -198,7 +199,7 @@ class Blueprint
 
         $this->addFluentIndexes();
 
-        $this->addFluentCommands($grammar);
+        $this->addFluentCommands($connection, $grammar);
     }
 
     /**
@@ -236,12 +237,17 @@ class Blueprint
     /**
      * Add the fluent commands specified on any columns.
      *
+     * @param  \Illuminate\Database\Connection  $connection
      * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    public function addFluentCommands(Grammar $grammar)
+    public function addFluentCommands(Connection $connection, Grammar $grammar)
     {
         foreach ($this->columns as $column) {
+            if ($column->change && ! $connection->usingNativeSchemaOperations()) {
+                continue;
+            }
+
             foreach ($grammar->getFluentCommands() as $commandName) {
                 $this->addCommand($commandName, compact('column'));
             }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -243,17 +243,7 @@ class Blueprint
     {
         foreach ($this->columns as $column) {
             foreach ($grammar->getFluentCommands() as $commandName) {
-                $attributeName = lcfirst($commandName);
-
-                if (! isset($column->{$attributeName})) {
-                    continue;
-                }
-
-                $value = $column->{$attributeName};
-
-                $this->addCommand(
-                    $commandName, compact('value', 'column')
-                );
+                $this->addCommand($commandName, compact('column'));
             }
         }
     }
@@ -1785,35 +1775,5 @@ class Blueprint
         return array_filter($this->columns, function ($column) {
             return (bool) $column->change;
         });
-    }
-
-    /**
-     * Determine if the blueprint has auto-increment columns.
-     *
-     * @return bool
-     */
-    public function hasAutoIncrementColumn()
-    {
-        return ! is_null(collect($this->getAddedColumns())->first(function ($column) {
-            return $column->autoIncrement === true;
-        }));
-    }
-
-    /**
-     * Get the auto-increment column starting values.
-     *
-     * @return array
-     */
-    public function autoIncrementingStartingValues()
-    {
-        if (! $this->hasAutoIncrementColumn()) {
-            return [];
-        }
-
-        return collect($this->getAddedColumns())->mapWithKeys(function ($column) {
-            return $column->autoIncrement === true
-                        ? [$column->name => $column->get('startingValue', $column->get('from'))]
-                        : [$column->name => null];
-        })->filter()->all();
     }
 }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -46,7 +46,7 @@ class Builder
     public static $defaultMorphKeyType = 'int';
 
     /**
-     * Indicates whether Doctrine DBAL usage will be prevented if possible when dropping, renaming and modifying columns.
+     * Indicates whether Doctrine DBAL usage will be prevented if possible when dropping, renaming, and modifying columns.
      *
      * @var bool
      */
@@ -113,7 +113,7 @@ class Builder
     }
 
     /**
-     * Attempt to use native schema operations for dropping, renaming and modifying columns, even if Doctrine DBAL is installed.
+     * Attempt to use native schema operations for dropping, renaming, and modifying columns, even if Doctrine DBAL is installed.
      *
      * @param  bool  $value
      * @return void

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -46,7 +46,7 @@ class Builder
     public static $defaultMorphKeyType = 'int';
 
     /**
-     * Indicates whether Doctrine DBAL usage will be prevented if possible when dropping and renaming columns.
+     * Indicates whether Doctrine DBAL usage will be prevented if possible when dropping, renaming and modifying columns.
      *
      * @var bool
      */
@@ -113,7 +113,7 @@ class Builder
     }
 
     /**
-     * Attempt to use native schema operations for dropping and renaming columns, even if Doctrine DBAL is installed.
+     * Attempt to use native schema operations for dropping, renaming and modifying columns, even if Doctrine DBAL is installed.
      *
      * @param  bool  $value
      * @return void

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -84,7 +84,7 @@ abstract class Grammar extends BaseGrammar
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @param  \Illuminate\Database\Connection  $connection
-     * @return array
+     * @return array|string
      *
      * @throws \RuntimeException
      */
@@ -162,7 +162,7 @@ abstract class Grammar extends BaseGrammar
     }
 
     /**
-     * Compile the blueprint's column definitions.
+     * Compile the blueprint's added column definitions.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @return array
@@ -286,7 +286,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Wrap a value in keyword identifiers.
      *
-     * @param  \Illuminate\Database\Query\Expression|string  $value
+     * @param  \Illuminate\Support\Fluent|\Illuminate\Database\Query\Expression|string  $value
      * @param  bool  $prefixAlias
      * @return string
      */

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -239,24 +239,24 @@ class MySqlGrammar extends Grammar
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-        if ($connection->usingNativeSchemaOperations()) {
-            $columns = [];
-
-            foreach ($blueprint->getChangedColumns() as $column) {
-                $sql = sprintf('%s %s%s %s',
-                    is_null($column->renameTo) ? 'modify' : 'change',
-                    $this->wrap($column),
-                    is_null($column->renameTo) ? '' : ' '.$this->wrap($column->renameTo),
-                    $this->getType($column)
-                );
-
-                $columns[] = $this->addModifiers($sql, $blueprint, $column);
-            }
-
-            return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
+        if (! $connection->usingNativeSchemaOperations()) {
+            return parent::compileChange($blueprint, $command, $connection);
         }
 
-        return parent::compileChange($blueprint, $command, $connection);
+        $columns = [];
+
+        foreach ($blueprint->getChangedColumns() as $column) {
+            $sql = sprintf('%s %s%s %s',
+                is_null($column->renameTo) ? 'modify' : 'change',
+                $this->wrap($column),
+                is_null($column->renameTo) ? '' : ' '.$this->wrap($column->renameTo),
+                $this->getType($column)
+            );
+
+            $columns[] = $this->addModifiers($sql, $blueprint, $column);
+        }
+
+        return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Schema\Grammars;
 
 use Doctrine\DBAL\Schema\Index;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
@@ -16,7 +17,7 @@ class SQLiteGrammar extends Grammar
      *
      * @var string[]
      */
-    protected $modifiers = ['VirtualAs', 'StoredAs', 'Nullable', 'Default', 'Increment'];
+    protected $modifiers = ['Increment', 'Nullable', 'Default', 'VirtualAs', 'StoredAs'];
 
     /**
      * The columns available as serials.
@@ -727,7 +728,11 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        return $column->useCurrent ? 'datetime default CURRENT_TIMESTAMP' : 'datetime';
+        if ($column->useCurrent) {
+            $column->default(new Expression('CURRENT_TIMESTAMP'));
+        }
+
+        return 'datetime';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Schema\Grammars;
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
 
@@ -20,7 +21,7 @@ class SqlServerGrammar extends Grammar
      *
      * @var string[]
      */
-    protected $modifiers = ['Increment', 'Collate', 'Nullable', 'Default', 'Persisted'];
+    protected $modifiers = ['Collate', 'Nullable', 'Default', 'Persisted', 'Increment'];
 
     /**
      * The columns available as serials.
@@ -697,9 +698,11 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        $columnType = $column->precision ? "datetime2($column->precision)" : 'datetime';
+        if ($column->useCurrent) {
+            $column->default(new Expression('CURRENT_TIMESTAMP'));
+        }
 
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        return $column->precision ? "datetime2($column->precision)" : 'datetime';
     }
 
     /**
@@ -712,9 +715,11 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        $columnType = $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
+        if ($column->useCurrent) {
+            $column->default(new Expression('CURRENT_TIMESTAMP'));
+        }
 
-        return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
+        return $column->precision ? "datetimeoffset($column->precision)" : 'datetimeoffset';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -146,29 +146,29 @@ class SqlServerGrammar extends Grammar
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-        if ($connection->usingNativeSchemaOperations()) {
-            $changes = [$this->compileDropDefaultConstraint($blueprint, $command)];
-
-            foreach ($blueprint->getChangedColumns() as $column) {
-                $sql = sprintf('alter table %s alter column %s %s',
-                    $this->wrapTable($blueprint),
-                    $this->wrap($column),
-                    $this->getType($column)
-                );
-
-                foreach ($this->modifiers as $modifier) {
-                    if (method_exists($this, $method = "modify{$modifier}")) {
-                        $sql .= $this->{$method}($blueprint, $column);
-                    }
-                }
-
-                $changes[] = $sql;
-            }
-
-            return $changes;
+        if (! $connection->usingNativeSchemaOperations()) {
+            return parent::compileChange($blueprint, $command, $connection);
         }
 
-        return parent::compileChange($blueprint, $command, $connection);
+        $changes = [$this->compileDropDefaultConstraint($blueprint, $command)];
+
+        foreach ($blueprint->getChangedColumns() as $column) {
+            $sql = sprintf('alter table %s alter column %s %s',
+                $this->wrapTable($blueprint),
+                $this->wrap($column),
+                $this->getType($column)
+            );
+
+            foreach ($this->modifiers as $modifier) {
+                if (method_exists($this, $method = "modify{$modifier}")) {
+                    $sql .= $this->{$method}($blueprint, $column);
+                }
+            }
+
+            $changes[] = $sql;
+        }
+
+        return $changes;
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -66,6 +66,19 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` auto_increment = 1000', $statements[1]);
     }
 
+    public function testAddColumnsWithMultipleAutoIncrementStartingValue()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->id()->from(100);
+        $blueprint->string('name')->from(200);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals([
+            'alter table `users` add `id` bigint unsigned not null auto_increment primary key, add `name` varchar(255) not null',
+            'alter table `users` auto_increment = 100',
+        ], $statements);
+    }
+
     public function testEngineCreateTable()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -850,7 +850,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->dateTime('foo')->useCurrent();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` datetime default CURRENT_TIMESTAMP not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` datetime not null default CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithOnUpdateCurrent()
@@ -859,7 +859,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->dateTime('foo')->useCurrentOnUpdate();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` datetime on update CURRENT_TIMESTAMP not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` datetime not null on update CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithDefaultCurrentAndOnUpdateCurrent()
@@ -868,7 +868,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->dateTime('foo')->useCurrent()->useCurrentOnUpdate();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` datetime not null default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP', $statements[0]);
     }
 
     public function testAddingDateTimeWithDefaultCurrentOnUpdateCurrentAndPrecision()
@@ -877,7 +877,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->dateTime('foo', 3)->useCurrent()->useCurrentOnUpdate();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` datetime(3) default CURRENT_TIMESTAMP(3) on update CURRENT_TIMESTAMP(3) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` datetime(3) not null default CURRENT_TIMESTAMP(3) on update CURRENT_TIMESTAMP(3)', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -964,7 +964,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at', 1)->useCurrent();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `created_at` timestamp(1) default CURRENT_TIMESTAMP(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp(1) not null default CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampWithOnUpdateCurrentSpecifyingPrecision()
@@ -973,7 +973,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at', 1)->useCurrentOnUpdate();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `created_at` timestamp(1) on update CURRENT_TIMESTAMP(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp(1) not null on update CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampWithDefaultCurrentAndOnUpdateCurrentSpecifyingPrecision()
@@ -982,7 +982,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at', 1)->useCurrent()->useCurrentOnUpdate();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `created_at` timestamp(1) default CURRENT_TIMESTAMP(1) on update CURRENT_TIMESTAMP(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp(1) not null default CURRENT_TIMESTAMP(1) on update CURRENT_TIMESTAMP(1)', $statements[0]);
     }
 
     public function testAddingTimestampTz()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -27,7 +27,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" serial not null primary key, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -35,7 +35,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" serial primary key not null, add column "email" varchar(255) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" serial not null primary key, add column "email" varchar(255) not null', $statements[0]);
     }
 
     public function testCreateTableWithAutoIncrementStartingValue()
@@ -48,7 +48,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" serial not null primary key, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
         $this->assertSame('alter sequence users_id_seq restart with 1000', $statements[1]);
     }
 
@@ -61,7 +61,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals([
-            'alter table "users" add column "id" bigserial primary key not null, add column "code" serial primary key not null, add column "name" varchar(255) not null',
+            'alter table "users" add column "id" bigserial not null primary key, add column "code" serial not null primary key, add column "name" varchar(255) not null',
             'alter sequence users_id_seq restart with 100',
             'alter sequence users_code_seq restart with 200',
         ], $statements);
@@ -76,7 +76,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" serial not null primary key, "email" varchar(255) not null)', $statements[0]);
         $this->assertSame('comment on column "users"."email" is \'my first comment\'', $statements[1]);
     }
 
@@ -90,7 +90,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create temporary table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+        $this->assertSame('create temporary table "users" ("id" serial not null primary key, "email" varchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -355,7 +355,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" serial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" serial not null primary key', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -365,7 +365,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" smallserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" smallserial not null primary key', $statements[0]);
     }
 
     public function testAddingMediumIncrementingID()
@@ -375,7 +375,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" serial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" serial not null primary key', $statements[0]);
     }
 
     public function testAddingID()
@@ -385,14 +385,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" bigserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" bigserial not null primary key', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->id('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" bigserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" bigserial not null primary key', $statements[0]);
     }
 
     public function testAddingForeignID()
@@ -423,7 +423,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" bigserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" bigserial not null primary key', $statements[0]);
     }
 
     public function testAddingString()
@@ -520,7 +520,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" bigserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" bigserial not null primary key', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -537,7 +537,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" serial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" serial not null primary key', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -554,7 +554,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" serial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" serial not null primary key', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -571,7 +571,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" smallserial not null primary key', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -588,7 +588,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" smallserial not null primary key', $statements[0]);
     }
 
     public function testAddingFloat()
@@ -917,25 +917,25 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->increments('foo')->generatedAs();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer generated by default as identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null generated by default as identity primary key', $statements[0]);
         // With always modifier
         $blueprint = new Blueprint('users');
         $blueprint->increments('foo')->generatedAs()->always();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer generated always as identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null generated always as identity primary key', $statements[0]);
         // With sequence options
         $blueprint = new Blueprint('users');
         $blueprint->increments('foo')->generatedAs('increment by 10 start with 100');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer generated by default as identity (increment by 10 start with 100) primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null generated by default as identity (increment by 10 start with 100) primary key', $statements[0]);
         // Not a primary key
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo')->generatedAs();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer generated by default as identity not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null generated by default as identity', $statements[0]);
     }
 
     public function testAddingVirtualAs()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -52,6 +52,21 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('alter sequence users_id_seq restart with 1000', $statements[1]);
     }
 
+    public function testAddColumnsWithMultipleAutoIncrementStartingValue()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->id()->from(100);
+        $blueprint->increments('code')->from(200);
+        $blueprint->string('name')->from(300);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals([
+            'alter table "users" add column "id" bigserial primary key not null, add column "code" serial primary key not null, add column "name" varchar(255) not null',
+            'alter sequence users_id_seq restart with 100',
+            'alter sequence users_code_seq restart with 200',
+        ], $statements);
+    }
+
     public function testCreateTableAndCommentColumn()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -27,7 +27,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" integer primary key autoincrement not null, "email" varchar not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -36,7 +36,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(2, $statements);
         $expected = [
-            'alter table "users" add column "id" integer not null primary key autoincrement',
+            'alter table "users" add column "id" integer primary key autoincrement not null',
             'alter table "users" add column "email" varchar not null',
         ];
         $this->assertEquals($expected, $statements);
@@ -52,7 +52,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create temporary table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+        $this->assertSame('create temporary table "users" ("id" integer primary key autoincrement not null, "email" varchar not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -260,7 +260,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -270,7 +270,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingMediumIncrementingID()
@@ -280,7 +280,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingID()
@@ -290,14 +290,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->id('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingForeignID()
@@ -328,7 +328,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingString()
@@ -379,7 +379,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -396,7 +396,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -413,7 +413,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -430,7 +430,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -447,7 +447,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer primary key autoincrement not null', $statements[0]);
     }
 
     public function testAddingFloat()
@@ -873,7 +873,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertCount(2, $statements);
         $expected = [
             'alter table "products" add column "price" integer not null',
-            'alter table "products" add column "discounted_virtual" integer as ("price" - 5) not null',
+            'alter table "products" add column "discounted_virtual" integer not null as ("price" - 5)',
         ];
         $this->assertSame($expected, $statements);
     }

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -130,6 +130,147 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
         $this->assertEquals(['alter table "users" drop column "name"'], $blueprint->toSql($connection, new SQLiteGrammar));
     }
 
+    public function testNativeColumnModifyingOnMySql()
+    {
+        $connection = $this->db->connection();
+        $schema = $connection->getSchemaBuilder();
+
+        $schema->useNativeSchemaOperationsIfPossible();
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->double('amount', 6, 2)->nullable()->invisible()->after('name')->change();
+            $table->timestamp('added_at', 4)->nullable(false)->useCurrent()->useCurrentOnUpdate()->change();
+            $table->enum('difficulty', ['easy', 'hard'])->default('easy')->charset('utf8mb4')->collation('unicode')->change();
+            $table->multiPolygon('positions')->srid(1234)->storedAs('expression')->change();
+            $table->string('old_name', 50)->renameTo('new_name')->change();
+            $table->bigIncrements('id')->first()->from(10)->comment('my comment')->change();
+        });
+
+        $this->assertEquals([
+            'alter table `users` '
+            .'modify `amount` double(6, 2) null invisible after `name`, '
+            .'modify `added_at` timestamp(4) not null default CURRENT_TIMESTAMP(4) on update CURRENT_TIMESTAMP(4), '
+            ."modify `difficulty` enum('easy', 'hard') character set utf8mb4 collate 'unicode' not null default 'easy', "
+            .'modify `positions` multipolygon as (expression) stored srid 1234, '
+            .'change `old_name` `new_name` varchar(50) not null, '
+            ."modify `id` bigint unsigned not null auto_increment primary key comment 'my comment' first",
+            'alter table `users` auto_increment = 10',
+        ], $blueprint->toSql($connection, new MySqlGrammar));
+    }
+
+    public function testNativeColumnModifyingOnPostgreSql()
+    {
+        $connection = $this->db->connection();
+        $schema = $connection->getSchemaBuilder();
+
+        $schema->useNativeSchemaOperationsIfPossible();
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->integer('code')->autoIncrement()->from(10)->comment('my comment')->change();
+        });
+
+        $this->assertEquals([
+            'alter table "users" '
+            .'alter column "code" type serial, '
+            .'alter column "code" set not null, '
+            .'alter column "code" drop default, '
+            .'alter column "code" drop identity if exists',
+            'alter sequence users_code_seq restart with 10',
+            'comment on column "users"."code" is \'my comment\'',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->char('name', 40)->nullable()->default('easy')->collation('unicode')->change();
+        });
+
+        $this->assertEquals([
+            'alter table "users" '
+            .'alter column "name" type char(40) collate "unicode", '
+            .'alter column "name" drop not null, '
+            .'alter column "name" set default \'easy\', '
+            .'alter column "name" drop identity if exists',
+            'comment on column "users"."name" is NULL',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->integer('foo')->generatedAs('expression')->always()->change();
+        });
+
+        $this->assertEquals([
+            'alter table "users" '
+            .'alter column "foo" type integer, '
+            .'alter column "foo" set not null, '
+            .'alter column "foo" drop default, '
+            .'alter column "foo" drop identity if exists, '
+            .'alter column "foo" add  generated always as identity (expression)',
+            'comment on column "users"."foo" is NULL',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->point('foo')->isGeometry()->projection(1234)->change();
+        });
+
+        $this->assertEquals([
+            'alter table "users" '
+            .'alter column "foo" type geometry(point, 1234), '
+            .'alter column "foo" set not null, '
+            .'alter column "foo" drop default, '
+            .'alter column "foo" drop identity if exists',
+            'comment on column "users"."foo" is NULL',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->timestamp('added_at', 2)->useCurrent()->storedAs(null)->change();
+        });
+
+        $this->assertEquals([
+            'alter table "users" '
+            .'alter column "added_at" type timestamp(2) without time zone, '
+            .'alter column "added_at" set not null, '
+            .'alter column "added_at" set default CURRENT_TIMESTAMP, '
+            .'alter column "added_at" drop expression if exists, '
+            .'alter column "added_at" drop identity if exists',
+            'comment on column "users"."added_at" is NULL',
+        ], $blueprint->toSql($connection, new PostgresGrammar));
+    }
+
+    public function testNativeColumnModifyingOnSqlServer()
+    {
+        $connection = $this->db->connection();
+        $schema = $connection->getSchemaBuilder();
+
+        $schema->useNativeSchemaOperationsIfPossible();
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->timestamp('added_at', 4)->nullable(false)->useCurrent()->change();
+        });
+
+        $this->assertEquals([
+            "DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE [dbo].[users] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' FROM sys.columns WHERE [object_id] = OBJECT_ID('[dbo].[users]') AND [name] in ('added_at') AND [default_object_id] <> 0;EXEC(@sql)",
+            'alter table "users" alter column "added_at" datetime2(4) not null',
+            'alter table "users" add default CURRENT_TIMESTAMP for "added_at"',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->char('name', 40)->nullable()->default('easy')->collation('unicode')->change();
+        });
+
+        $this->assertEquals([
+            "DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE [dbo].[users] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' FROM sys.columns WHERE [object_id] = OBJECT_ID('[dbo].[users]') AND [name] in ('name') AND [default_object_id] <> 0;EXEC(@sql)",
+            'alter table "users" alter column "name" nchar(40) collate unicode null',
+            'alter table "users" add default \'easy\' for "name"',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->integer('foo')->change();
+        });
+
+        $this->assertEquals([
+            "DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE [dbo].[users] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' FROM sys.columns WHERE [object_id] = OBJECT_ID('[dbo].[users]') AND [name] in ('foo') AND [default_object_id] <> 0;EXEC(@sql)",
+            'alter table "users" alter column "foo" int not null',
+        ], $blueprint->toSql($connection, new SqlServerGrammar));
+    }
+
     public function testChangingColumnWithCollationWorks()
     {
         $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -113,16 +113,16 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection = m::mock(Connection::class);
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `created` datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `created` datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new PostgresGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
+        $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new SQLiteGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
+        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
     public function testDefaultCurrentTimestamp()
@@ -134,16 +134,16 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $connection = m::mock(Connection::class);
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
+        $this->assertEquals(['alter table `users` add `created` timestamp not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new MySqlGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new PostgresGrammar));
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new PostgresGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
+        $this->assertEquals(['alter table "users" add column "created" datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new SQLiteGrammar));
 
         $blueprint = clone $base;
-        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
+        $this->assertEquals(['alter table "users" add "created" datetime not null default CURRENT_TIMESTAMP'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 
     public function testUnsignedDecimalTable()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -25,7 +25,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table "users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" int not null identity primary key, "email" nvarchar(255) not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -33,7 +33,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "id" int identity primary key not null, "email" nvarchar(255) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" int not null identity primary key, "email" nvarchar(255) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -42,7 +42,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table "prefix_users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
+        $this->assertSame('create table "prefix_users" ("id" int not null identity primary key, "email" nvarchar(255) not null)', $statements[0]);
     }
 
     public function testCreateTemporaryTable()
@@ -55,7 +55,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table "#users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
+        $this->assertSame('create table "#users" ("id" int not null identity primary key, "email" nvarchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -305,7 +305,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "id" int identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" int not null identity primary key', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -315,7 +315,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "id" smallint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" smallint not null identity primary key', $statements[0]);
     }
 
     public function testAddingMediumIncrementingID()
@@ -325,7 +325,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "id" int identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" int not null identity primary key', $statements[0]);
     }
 
     public function testAddingID()
@@ -335,14 +335,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "id" bigint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" bigint not null identity primary key', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->id('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" bigint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" bigint not null identity primary key', $statements[0]);
     }
 
     public function testAddingForeignID()
@@ -373,7 +373,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "id" bigint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" bigint not null identity primary key', $statements[0]);
     }
 
     public function testAddingString()
@@ -424,7 +424,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" bigint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" bigint not null identity primary key', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -441,7 +441,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" int identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" int not null identity primary key', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -458,7 +458,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" int identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" int not null identity primary key', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -475,7 +475,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" tinyint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" tinyint not null identity primary key', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -492,7 +492,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add "foo" smallint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" smallint not null identity primary key', $statements[0]);
     }
 
     public function testAddingFloat()

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -81,7 +81,7 @@ class MigratorTest extends TestCase
 
         $this->expectTwoColumnDetail('CreatePeopleTable');
         $this->expectBulletList([
-            'create table "people" ("id" integer not null primary key autoincrement, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)',
+            'create table "people" ("id" integer primary key autoincrement not null, "name" varchar not null, "email" varchar not null, "password" varchar not null, "remember_token" varchar, "created_at" datetime, "updated_at" datetime)',
             'create unique index "people_email_unique" on "people" ("email")',
         ]);
 


### PR DESCRIPTION
Related to #45258, this PR adds support for native column modifying and drops necessity of installing `doctrine/dbal` when modifying columns using `change()` on MariaDB, MySQL, PostgreSQL and SQL Server.

### Supported databases, modifiers and types:

| Database | Native Support | Supported column modifiers | Supported column types |
| --- | --- | --- | --- |
| MariaDB  | ✅ ([docs](https://mariadb.com/kb/en/alter-table/#modify-column)) | _Same as MySQL_ | All types |
| MySQL | ✅ ([docs](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html#alter-table-redefine-column)) | `after`, `first`, `autoIncrement`, `from`, `storedAs`, `storedAsJson`, `virtualAs`, `virtualAsJson`, `invisible`, `unsigned`, `nullable`, `default`, `charset`, `collation`, `comment`, `useCurrent`, `useCurrentOnUpdate`, `srid`, `renameTo`<sup>2</sup> | All types |
| PostgreSQL | ✅ ([docs](https://www.postgresql.org/docs/current/sql-altertable.html)) | `autoIncrement`<sup>3</sup>, `from`, `storedAs`<sup>4</sup>, `generatedAs`, `always`, `nullable`, `default`, `collation`, `comment`, `useCurrent`, `isGeometry`, `projection` |  All types except `enum`<sup>5</sup> |
| SQLite | ❌ ([docs](https://www.postgresql.org/docs/current/sql-altertable.html)) | _N/A_ | _N/A_
| SQL Server | ✅ ([docs](https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver16)) | `autoIncrement`<sup>6</sup>, `nullable`, `default`, `collation`, `persisted`, `useCurrent` | All types except `enum`<sup>7</sup> |

### Notes:
1. According to [MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html#alter-table-redefine-column), for column definition changes using CHANGE or MODIFY, **the definition must include the data type and all attributes** that should apply to the new column, **other than index attributes** such as PRIMARY KEY or UNIQUE. Attributes present in the original definition but not specified for the new definition are not carried forward. Suppose that a column `col1` is defined as:
   ```php
   $table->integer('col1')->unsigned()->default(1)->comment('my column'); // `col1` int unsigned not null default '1' comment 'my column'
   ```
   and you modify the column as follows, intending to change only INT to BIGINT:
   ```php
   $table->bigInteger('col1')->change(); // alter table `t1` modify `col1` bigint not null
   ```
   That statement changes the data type from INT to BIGINT, but it also drops the UNSIGNED, DEFAULT, and COMMENT attributes. To retain them, the statement must include them explicitly:
   ```php
   $table->bigInteger('col1')->unsigned()->default(1)->comment('my column')->change(); // alter table `t1` modify `col1` bigint unsigned not null default '1' comment 'my column'
   ```
   The same approach is also used on **PostgreSQL** and **SQL Server**, you have to redeclare all the attributes you want to keep on the column definition.
2. Currently Laravel compiles added and modified column before other commands, It means to change and rename a same column you should call `renameColumn` command after `change` command:
   ```php
   $table->enum('difficulty', ['easy', 'hard'])->change();
   $table->renameColumn('difficulty', 'hardness');
   ```
   However, this PR adds `renameTo` column modifier on MySQL to rename and modify a column at one go:
   ```php
   $table->enum('difficulty', ['easy', 'hard'])->renameTo('hardness')->change();
   ```
3. Laravel compiles `autoIncrement` on PostgreSQL as `primary key` and also causes column type to be `serial`. This PR partially supports `autoIncrement`, it means the `autoIncrement` modifier still causes a column type to be `serial` type and you may use `from` modifier to set it's starting value, but it doesn't add or drop the primary key. You may use `primary()` and `primary(false)` commands explicitly to achieve this.
4. PostgreSQL doesn't have a native alter command for modifying the expression of a generated column or turning a regular column to a stored generated column, it means `storedAs` modifier is not supported on this PR. However, it is supported to set `storedAs(null)` explicitly on PostgreSQL >= 13.0 to drop the generated column expression (turns a stored generated column into a normal base column). 
5. PostgeSQL [has native `enum`](https://www.postgresql.org/docs/10/datatype-enum.html) but the syntax is different, Laravel uses a check constraint on a `varchar` when adding an `enum` type. This PR doesn't handle modifying `enum` type on PostgreSQL.
6. Laravel compiles `autoIncrement` modifier as `identity primary key` on SQL Server. SQL Server doesn't support adding / dropping `identity` and `primary key` when using alter column. So this PR also doesn't support that. You may use `primary()` and `primary(false)` commands explicitly to achieve this.
7. SQL server doesn't have a native `enum` and Laravel is using a check constraint on a `nvarchar` when adding an `enum` type. This PR doesn't support modifying `enum` on SQL Server.

### What if I have already installed `doctrine/dbal`?
Just like #45258, if you have already installed Doctrine DBAL, you have to call `Schema::useNativeSchemaOperationsIfPossible()` method within the `boot` method of your `App\Providers\AppServiceProvider` class or within your migrations files to be able to use native schema operations.