### PR TITLE
[9.x] Fixes blade tags issue #45424  🔧

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -505,6 +505,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($template)
     {
         preg_match_all('/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( [\S\s]*? ) \))?/x', $template, $matches);
+
         for ($i = 0; isset($matches[0][$i]); $i++) {
             $match = [
                 $matches[0][$i],
@@ -516,9 +517,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
             // Here we check to see if we have properly found the closing parenthesis by
             // regex pattern or not, and will recursively continue on to the next ")"
-            // then check again until the tokenizer confirms we found the right one
-            while (isset($match[4]) && Str::endsWith($match[0], ')') && ! $this->isProperMatch($match[0])) {
+            // then check again until the tokenizer confirms we find the right one.
+            while (isset($match[4]) &&
+                   Str::endsWith($match[0], ')') &&
+                   ! $this->hasEvenNumberOfParentheses($match[0])) {
                 $rest = Str::before(Str::after($template, $match[0]), ')');
+
                 $match[0] = $match[0].$rest.')';
                 $match[3] = $match[3].$rest.')';
                 $match[4] = $match[4].$rest;
@@ -528,6 +532,34 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         return $template;
+    }
+
+    /**
+     * Determine if the given expression has the same number of opening and closing parentheses.
+     *
+     * @param  string  $expression
+     * @return bool
+     */
+    protected function hasEvenNumberOfParentheses(string $expression)
+    {
+        $tokens = token_get_all('<?php '.$expression);
+
+        if (Arr::last($tokens) !== ')') {
+            return false;
+        }
+
+        $opening = 0;
+        $closing = 0;
+
+        foreach ($tokens as $token) {
+            if ($token == ')') {
+                $closing++;
+            } elseif ($token == '(') {
+                $opening++;
+            }
+        }
+
+        return $opening === $closing;
     }
 
     /**
@@ -919,26 +951,5 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function withoutComponentTags()
     {
         $this->compilesComponentTags = false;
-    }
-
-    protected function isProperMatch($match)
-    {
-        $tokens = token_get_all('<?php '.$match);
-
-        if (Arr::last($tokens) !== ')') {
-            return false;
-        }
-
-        $openings = 0;
-        $closings = 0;
-        foreach ($tokens as $token) {
-            if ($token == ')') {
-                $closings++;
-            } elseif ($token == '(') {
-                $openings++;
-            }
-        }
-
-        return $openings === $closings;
     }
 }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -499,16 +499,35 @@ class BladeCompiler extends Compiler implements CompilerInterface
     /**
      * Compile Blade statements that start with "@".
      *
-     * @param  string  $value
+     * @param  string  $template
      * @return string
      */
-    protected function compileStatements($value)
+    protected function compileStatements($template)
     {
-        return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', function ($match) {
-                return $this->compileStatement($match);
-            }, $value
-        );
+        preg_match_all('/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', $template, $matches);
+        for ($i = 0; isset($matches[0][$i]); $i++) {
+            $match = [
+                $matches[0][$i],
+                $matches[1][$i],
+                $matches[2][$i],
+                $matches[3][$i] ?: null,
+                $matches[4][$i] ?: null,
+            ];
+
+            // Here we check to see if we have properly found the closing parenthesis by
+            // regex pattern or not, and will recursively continue on to the next ")"
+            // then check again until the tokenizer confirms we found the right one
+            while (isset($match[4]) && Str::endsWith($match[0], ')') && Arr::last(token_get_all('<?php '.$match[0])) !== ')') {
+                $rest = Str::before(Str::after($template, $match[0]), ')');
+                $match[0] = $match[0].$rest.')';
+                $match[3] = $match[3].$rest.')';
+                $match[4] = $match[4].$rest;
+            }
+
+            $template = Str::replaceFirst($match[0], $this->compileStatement($match), $template);
+        }
+
+        return $template;
     }
 
     /**

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -7,12 +7,14 @@ class BladeIncludesTest extends AbstractBladeTestCase
     public function testEachsAreCompiled()
     {
         $this->assertSame('<?php echo $__env->renderEach(\'foo\', \'bar\'); ?>', $this->compiler->compileString('@each(\'foo\', \'bar\')'));
+        $this->assertSame('<?php echo $__env->renderEach(\'foo\', \'(bar))\'); ?>', $this->compiler->compileString('@each(\'foo\', \'(bar))\')'));
         $this->assertSame('<?php echo $__env->renderEach(name(foo)); ?>', $this->compiler->compileString('@each(name(foo))'));
     }
 
     public function testIncludesAreCompiled()
     {
         $this->assertSame('<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((a)\' => \'((a)\'], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'foo\', [\'((a)\' => \'((a)\'])'));
         $this->assertSame('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
     }
 
@@ -31,6 +33,7 @@ class BladeIncludesTest extends AbstractBladeTestCase
     public function testIncludeUnlessesAreCompiled()
     {
         $this->assertSame('<?php echo $__env->renderUnless(true, \'foo\', ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeUnless(true, \'foo\', ["foo" => "bar"])'));
+        $this->assertSame('<?php echo $__env->renderUnless(true, \'foo\', ["foo" => "bar_))-))>"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeUnless(true, \'foo\', ["foo" => "bar_))-))>"])'));
         $this->assertSame('<?php echo $__env->renderUnless($undefined ?? true, \'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeUnless($undefined ?? true, \'foo\')'));
     }
 
@@ -38,5 +41,6 @@ class BladeIncludesTest extends AbstractBladeTestCase
     {
         $this->assertSame('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
         $this->assertSame('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
+        $this->assertSame('<?php echo $__env->first(["issue", "#45424)"], ["foo()" => "bar)-))"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["issue", "#45424)"], ["foo()" => "bar)-))"])'));
     }
 }

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -14,6 +14,7 @@ class BladeIncludesTest extends AbstractBladeTestCase
     public function testIncludesAreCompiled()
     {
         $this->assertSame('<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((\'], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'foo\', [\'((\'])'));
         $this->assertSame('<?php echo $__env->make(\'foo\', [\'((a)\' => \'((a)\'], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'foo\', [\'((a)\' => \'((a)\'])'));
         $this->assertSame('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
     }
@@ -42,5 +43,7 @@ class BladeIncludesTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
         $this->assertSame('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
         $this->assertSame('<?php echo $__env->first(["issue", "#45424)"], ["foo()" => "bar)-))"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["issue", "#45424)"], ["foo()" => "bar)-))"])'));
+        $this->assertSame('<?php echo $__env->first(["issue", "#45424)"], ["foo" => "bar(-(("], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["issue", "#45424)"], ["foo" => "bar(-(("])'));
+        $this->assertSame('<?php echo $__env->first(["issue", "#45424)"], [(string) "foo()" => "bar(-(("], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["issue", "#45424)"], [(string) "foo()" => "bar(-(("])'));
     }
 }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -44,6 +44,21 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testStringWithOpeningParenthesisCanBeCompiled()
+    {
+        $string = "@php(\$data = ['single' => ':(('])";
+        $expected = "<?php (\$data = ['single' => ':((']); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@php(\$data = ['single' => (string)':(('])";
+        $expected = "<?php (\$data = ['single' => (string)':((']); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@php(\$data = ['single' => '(()(('])";
+        $expected = "<?php (\$data = ['single' => '(()((']); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testStringWithParenthesisCanBeCompiled()
     {
         $string = "@php(\$data = ['single' => ')'])";

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -11,6 +11,14 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testStringWithParenthesisWithEndPHP()
+    {
+        $string = "@php(\$data = ['related_to' => 'issue#45388'];) {{ \$data }} @endphp";
+        $expected = "<?php(\$data = ['related_to' => 'issue#45388'];) {{ \$data }} ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testPhpStatementsWithoutExpressionAreIgnored()
     {
         $string = '@php';
@@ -52,14 +60,6 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
 
         $string = "@php(\$data = ['single' => (string)':(('])";
         $expected = "<?php (\$data = ['single' => (string)':((']); ?>";
-        $this->assertEquals($expected, $this->compiler->compileString($string));
-
-        $string = "@php(\$data = ['single' => (string)':(('])
-foo
-@php(\$data = ['single' => (string)':(('])";
-        $expected = "<?php (\$data = ['single' => (string)':((']); ?>
-foo
-<?php (\$data = ['single' => (string)':((']); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         $string = "@php(\$data = ['single' => '(()(('])";
@@ -115,6 +115,29 @@ foo
         $string = "@php(\$data = ['test' => \"\\\"escaped\\\"\"])";
 
         $expected = "<?php (\$data = ['test' => \"\\\"escaped\\\"\"]); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testUnclosedParenthesisForBladeTags()
+    {
+        $string = "<span @class(['(']></span>";
+        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toCssClasses([]) ?>\"(['(']></span>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class(['']></span>";
+        $expected = "<span class=\"<?php echo \Illuminate\Support\Arr::toCssClasses([]) ?>\"(['']></span>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class([')']></span>";
+        $expected = "<span @class([')']></span>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "<span @class(['))']></span>";
+        $expected = "<span @class(['))']></span>";
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -44,15 +44,26 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
-    public function testStringWithParenthesisCannotBeCompiled()
+    public function testStringWithParenthesisCanBeCompiled()
     {
-        $string = "@php(\$data = ['test' => ')'])";
+        $string = "@php(\$data = ['single' => ')'])";
+        $expected = "<?php (\$data = ['single' => ')']); ?>";
 
-        $expected = "<?php (\$data = ['test' => ')']); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
 
-        $actual = "<?php (\$data = ['test' => '); ?>'])";
+        $string = "@php(\$data = ['(multiple)-))' => '((-))'])";
+        $expected = "<?php (\$data = ['(multiple)-))' => '((-))']); ?>";
 
-        $this->assertEquals($actual, $this->compiler->compileString($string));
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = "@php(\$data = [(int)'(multiple)-))' => (bool)'((casty))'])";
+        $expected = "<?php (\$data = [(int)'(multiple)-))' => (bool)'((casty))']); ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $this->assertSame('<?php echo $__env->renderEach(\'foo\', \'b)a)r\'); ?>', $this->compiler->compileString('@each(\'foo\', \'b)a)r\')'));
+        $this->assertSame('<?php echo $__env->make(\'test_for\', [\'issue))\' => \'(issue#45424))\'], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'test_for\', [\'issue))\' => \'(issue#45424))\'])'));
+        $this->assertSame('( <?php echo $__env->make(\'test_for\', [\'not_too_much))\' => \'(issue#45424))\'], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>))', $this->compiler->compileString('( @include(\'test_for\', [\'not_too_much))\' => \'(issue#45424))\'])))'));
     }
 
     public function testStringWithEmptyStringDataValue()

--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -54,6 +54,14 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $expected = "<?php (\$data = ['single' => (string)':((']); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
+        $string = "@php(\$data = ['single' => (string)':(('])
+foo
+@php(\$data = ['single' => (string)':(('])";
+        $expected = "<?php (\$data = ['single' => (string)':((']); ?>
+foo
+<?php (\$data = ['single' => (string)':((']); ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+
         $string = "@php(\$data = ['single' => '(()(('])";
         $expected = "<?php (\$data = ['single' => '(()((']); ?>";
         $this->assertEquals($expected, $this->compiler->compileString($string));

--- a/tests/View/Blade/BladePushTest.php
+++ b/tests/View/Blade/BladePushTest.php
@@ -17,6 +17,17 @@ test
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testPushIsCompiledWithParenthesis()
+    {
+        $string = '@push(\'foo):))\')
+test
+@endpush';
+        $expected = '<?php $__env->startPush(\'foo):))\'); ?>
+test
+<?php $__env->stopPush(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testPushOnceIsCompiled()
     {
         $string = '@pushOnce(\'foo\', \'bar\')

--- a/tests/View/Blade/BladeSectionTest.php
+++ b/tests/View/Blade/BladeSectionTest.php
@@ -7,6 +7,7 @@ class BladeSectionTest extends AbstractBladeTestCase
     public function testSectionStartsAreCompiled()
     {
         $this->assertSame('<?php $__env->startSection(\'foo\'); ?>', $this->compiler->compileString('@section(\'foo\')'));
+        $this->assertSame('<?php $__env->startSection(\'issue#18317 :))\'); ?>', $this->compiler->compileString('@section(\'issue#18317 :))\')'));
         $this->assertSame('<?php $__env->startSection(name(foo)); ?>', $this->compiler->compileString('@section(name(foo))'));
     }
 }

--- a/tests/View/Blade/BladeStackTest.php
+++ b/tests/View/Blade/BladeStackTest.php
@@ -9,5 +9,9 @@ class BladeStackTest extends AbstractBladeTestCase
         $string = '@stack(\'foo\')';
         $expected = '<?php echo $__env->yieldPushContent(\'foo\'); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = '@stack(\'foo))\')';
+        $expected = '<?php echo $__env->yieldPushContent(\'foo))\'); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladeUnsetStatementsTest.php
+++ b/tests/View/Blade/BladeUnsetStatementsTest.php
@@ -9,5 +9,9 @@ class BladeUnsetStatementsTest extends AbstractBladeTestCase
         $string = '@unset ($unset)';
         $expected = '<?php unset($unset); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
+
+        $string = '@unset ($unset)))';
+        $expected = '<?php unset($unset); ?>))';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
solves #45424 

The solution seems a bit hacky, but the idea, however, is simple:
- Without changing the regex pattern, we perform our first search to get matches. 
- Then by using PHP tokenizer, we check if we are in trouble or not. 
- If we are in trouble, we try to fix it by adding the next candidate section to the matched string to see if we can reach the proper closing parenthesis or not.
- We try the same process until we find the proper match for the closing parenthesis of the blade tag.


```php
@include ( 
  'partial1', ['hell)o' => ')-)--)']  
)
```

in this example, regex finds the :
``` @include (   'partial1', ['hell) ``` first and the loop adds these portions until it reaches the closing:
```)o' => '```
```)-```
```)--```
```']  )```   <=== the closing one.

### Performance:
- Let me note that this part of the code is NOT run during each and every request/response life cycle since the compiled versions of blade files get cached.

- Some tests are included to prove the fix.

As I know, Taylor likes to find a proper regex for it and does not like such solutions, maybe the regex can be found somewhere in open-source IDE syntax highlighters like VS code, or people from Jetbrain can help since they can highlight the syntax properly.