### PR TITLE
[9.x] Improves `with()` can return other than `TValue`

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -412,10 +412,11 @@ if (! function_exists('with')) {
      * Return the given value, optionally passed through the given callback.
      *
      * @template TValue
+     * @template TReturn
      *
      * @param  TValue  $value
-     * @param  (callable(TValue): TValue)|null  $callback
-     * @return TValue
+     * @param  (callable(TValue): (TReturn))|null  $callback
+     * @return ($callback is null ? TValue : TReturn)
      */
     function with($value, callable $callback = null)
     {

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -4,12 +4,37 @@ use function PHPStan\Testing\assertType;
 
 assertType('User', with(new User()));
 assertType('bool', with(new User())->save());
+
 assertType('User', with(new User(), function (User $user) {
     return $user;
 }));
+assertType('User', with(new User(), function (User $user): User {
+    return $user;
+}));
 
-assertType('int|User', with(new User(), function ($user) {
-    assertType('int|User', $user);
+assertType('User', with(new User(), function ($user) {
+    /** @var User $user */
+    return $user;
+}));
+assertType('User', with(new User(), function ($user): User {
+    /** @var User $user */
+    return $user;
+}));
+
+assertType('int', with(new User(), function ($user) {
+    assertType('User', $user);
 
     return 10;
+}));
+assertType('int', with(new User(), function ($user): int {
+    assertType('User', $user);
+
+    return 10;
+}));
+
+assertType('mixed', with(new User(), function ($user) {
+    return $user;
+}));
+assertType('mixed', with(new User(), function ($user): mixed {
+    return $user;
 }));

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -35,9 +35,6 @@ assertType('int', with(new User(), function ($user): int {
 assertType('mixed', with(new User(), function ($user) {
     return $user;
 }));
-assertType('mixed', with(new User(), function ($user): mixed {
-    return $user;
-}));
 assertType('User', with(new User(), function ($user): User {
     return $user;
 }));

--- a/types/Support/Helpers.php
+++ b/types/Support/Helpers.php
@@ -38,3 +38,6 @@ assertType('mixed', with(new User(), function ($user) {
 assertType('mixed', with(new User(), function ($user): mixed {
     return $user;
 }));
+assertType('User', with(new User(), function ($user): User {
+    return $user;
+}));


### PR DESCRIPTION
This avoids the current limitation where `TValue` need to cover both parameter and return value as `int|User` when given parameter is `User` and return value is `int`.

```php
assertType('int|User', with(new User(), function ($user) {
    assertType('int|User', $user);

    return 10;
}));
```

Fixes 

![image](https://user-images.githubusercontent.com/172966/210296775-6fad3c44-aeb8-4b62-954c-0a7ac15f11c4.png)

