### PR TITLE
[9.x] Alternative to fix method contextual binding

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -650,14 +650,14 @@ class Container implements ArrayAccess, ContainerContract
     {
         $pushedToBuildStack = false;
 
-        if(is_array($callback) &&  ! in_array($className = get_class($callback[0]), $this->buildStack, true)) {
+        if (is_array($callback) && ! in_array($className = get_class($callback[0]), $this->buildStack, true)) {
             $this->buildStack[] = $className;
             $pushedToBuildStack = true;
         }
 
         $result = BoundMethod::call($this, $callback, $parameters, $defaultMethod);
 
-        if($pushedToBuildStack){
+        if ($pushedToBuildStack) {
             array_pop($this->buildStack);
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -648,7 +648,20 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function call($callback, array $parameters = [], $defaultMethod = null)
     {
-        return BoundMethod::call($this, $callback, $parameters, $defaultMethod);
+        $pushedToBuildStack = false;
+
+        if(is_array($callback) &&  ! in_array($className = get_class($callback[0]), $this->buildStack, true)) {
+            $this->buildStack[] = $className;
+            $pushedToBuildStack = true;
+        }
+
+        $result = BoundMethod::call($this, $callback, $parameters, $defaultMethod);
+
+        if($pushedToBuildStack){
+            array_pop($this->buildStack);
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
## Issue description
1. Create a class that has a method with a parameter that has a type hint.
 * For instance, a command class with a handle method that has a parameter with a type hint of an interface.
2. Configure a contextual binding for that parameter to a concrete class.
3. Try to run the command.
4. You will get an error that the given interface is not instantiable.

## Recreation example
The following commit reproduces the issue on a fresh laravel project.
https://github.com/imdhemy/laravel-reproduce/commit/93a9f0dd88e9aa5a156b63ddfa7413ece0fc9eb9

## Error message
You can find the error message here:
`Target [App\Console\Commands\MyInterface] is not instantiable.`
https://github.com/imdhemy/laravel-reproduce/actions/runs/3823527853/jobs/6504792663#step:5:23

## PR description
This is because when the container tries to resolve the method dependencies, It encounters a `buildStack` that does not contain the class that contains the method to be called, as it was already popped from the build stack in a previous step.

This PR fixes this by temporarily pushing that class to the build stack so that the container can resolve the method dependencies correctly.
