### PR TITLE
[9.x] Exception Handler prepareResponse add previous Exception

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -547,7 +547,7 @@ class Handler implements ExceptionHandlerContract
         }
 
         if (! $this->isHttpException($e)) {
-            $e = new HttpException(500, $e->getMessage());
+            $e = new HttpException(500, $e->getMessage(), $e);
         }
 
         return $this->toIlluminateResponse(


### PR DESCRIPTION
The Exception Handler sometimes needs to convert a plain Exception to an HttpException.

- In the prepareException function the previous exception is always added to the new one
- In the prepareResponse function the previous exception is lost

