### PR TITLE
[9.x] Fix bound method contextual binding

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -650,8 +650,13 @@ class Container implements ArrayAccess, ContainerContract
     {
         $pushedToBuildStack = false;
 
-        if (is_array($callback) && ! in_array($className = get_class($callback[0]), $this->buildStack, true)) {
+        if (is_array($callback) && ! in_array(
+            $className = (is_string($callback[0]) ? $callback[0] : get_class($callback[0])),
+            $this->buildStack,
+            true
+        )) {
             $this->buildStack[] = $className;
+
             $pushedToBuildStack = true;
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -650,14 +650,14 @@ class Container implements ArrayAccess, ContainerContract
     {
         $pushedToBuildStack = false;
 
-        if(is_array($callback) &&  ! in_array($className = get_class($callback[0]), $this->buildStack, true)) {
+        if (is_array($callback) && ! in_array($className = get_class($callback[0]), $this->buildStack, true)) {
             $this->buildStack[] = $className;
             $pushedToBuildStack = true;
         }
 
         $result = BoundMethod::call($this, $callback, $parameters, $defaultMethod);
 
-        if($pushedToBuildStack){
+        if ($pushedToBuildStack) {
             array_pop($this->buildStack);
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -648,7 +648,20 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function call($callback, array $parameters = [], $defaultMethod = null)
     {
-        return BoundMethod::call($this, $callback, $parameters, $defaultMethod);
+        $pushedToBuildStack = false;
+
+        if(is_array($callback) &&  ! in_array($className = get_class($callback[0]), $this->buildStack, true)) {
+            $this->buildStack[] = $className;
+            $pushedToBuildStack = true;
+        }
+
+        $result = BoundMethod::call($this, $callback, $parameters, $defaultMethod);
+
+        if($pushedToBuildStack){
+            array_pop($this->buildStack);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -665,6 +665,19 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ContainerConcreteStub::class, $class);
     }
 
+    public function testMethodLevelContextualBinding()
+    {
+        $container = new Container;
+
+        $container->when(ContainerContextualBindingCallTarget::class)
+                ->needs(IContainerContractStub::class)
+                ->give(ContainerImplementationStub::class);
+
+        $result = $container->call([new ContainerContextualBindingCallTarget, 'work']);
+
+        $this->assertInstanceOf(ContainerImplementationStub::class, $result);
+    }
+
     // public function testContainerCanCatchCircularDependency()
     // {
     //     $this->expectException(\Illuminate\Contracts\Container\CircularDependencyException::class);
@@ -781,5 +794,18 @@ class ContainerInjectVariableStubWithInterfaceImplementation implements IContain
     public function __construct(ContainerConcreteStub $concrete, $something)
     {
         $this->something = $something;
+    }
+}
+
+class ContainerContextualBindingCallTarget
+{
+    public function __construct()
+    {
+
+    }
+
+    public function work(IContainerContractStub $stub)
+    {
+        return $stub;
     }
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -669,6 +669,8 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
+        $container->bind(IContainerContractStub::class, ContainerImplementationStubTwo::class);
+
         $container->when(ContainerContextualBindingCallTarget::class)
                 ->needs(IContainerContractStub::class)
                 ->give(ContainerImplementationStub::class);


### PR DESCRIPTION
## Issue description

Using contextual bindings with a method parameter will result in an error. This is because when the container tries to resolve the method dependencies, It encounters a `buildStack` that does not contain the class that contains the method to be called, as it was already popped from the build stack in a previous step.

## Recreation example
The following commit reproduces the issue on a fresh laravel project.
https://github.com/imdhemy/laravel-reproduce/commit/93a9f0dd88e9aa5a156b63ddfa7413ece0fc9eb9

## Error message
You can find the error message here:
`Target [App\Console\Commands\MyInterface] is not instantiable.`
https://github.com/imdhemy/laravel-reproduce/actions/runs/3823527853/jobs/6504792663#step:5:23

## PR description
This PR fixes this by temporarily pushing that class to the build stack so that the container can resolve the method dependencies correctly.
