### PR TITLE
[9.x] Test for @php blade tag 🔍

### DIFF
--- a/tests/View/Blade/BladePhpStatementsTest.php
+++ b/tests/View/Blade/BladePhpStatementsTest.php
@@ -11,6 +11,14 @@ class BladePhpStatementsTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testStringWithParenthesisWithEndPHP()
+    {
+        $string = "@php(\$data = ['related_to' => 'issue#45388'];) {{ \$data }} @endphp";
+        $expected = "<?php(\$data = ['related_to' => 'issue#45388'];) {{ \$data }} ?>";
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testPhpStatementsWithoutExpressionAreIgnored()
     {
         $string = '@php';


### PR DESCRIPTION
This missing edge case test for ```@php``` blade tags was the reason behind https://github.com/laravel/framework/issues/45388 and introducing the breaking change in PR: https://github.com/laravel/framework/pull/45333

So having it avoids reintroducing the breaking change again. I added this to complement the https://github.com/laravel/framework/pull/45490 since that one also changes the blade compiler.