### PR TITLE
[9.x] Added support for testing authorization usages

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 use Illuminate\Contracts\Events\Dispatcher as EventsDispatcherContract;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
@@ -283,6 +284,22 @@ trait MocksApplicationServices
 
             $this->fail('The following expected notification were not dispatched: ['.$notification.']');
         });
+
+        return $this;
+    }
+
+    /**
+     * Specify a policy that is expected to be called.
+     *
+     * @param  string  $ability
+     * @param  array|mixed  $arguments
+     * @return $this
+     */
+    protected function expectsAuthorization($ability, $arguments)
+    {
+        $mock = Mockery::mock(Gate::class)->makePartial();
+
+        $mock->shouldReceive('authorize')->with($ability, $arguments);
 
         return $this;
     }


### PR DESCRIPTION
This PR adds support for testing policy usages in controllers easily.

This can be done using `expectsAuthorization()` method which is added to `MockApplicationServices` trait. With this method there is no need to write separate tests for unauthorized users.

Let's say we have a `PostController` and `index()` method to get all posts:

```php
class PostController extends Controller
{
    public function index()
    {
        $this->authorize('view-any', Post::class);

        return PostResource::collection(Post::paginate(50));
    }
}
```

Authorization can be tested in `PostControllerTest` as following:

```php
class PostControllerTest extends TestCase
{
    public function testUserCanViewPosts(): void
    {
        Post::factory()->count(5)->create();

        $this->expectsAuthorization('view-any', Post::class);

        $response = $this->postJson(route('posts.index'));

        $response->assertOk();
    }
}
```