### PR TITLE
[7.x] Support Views in SQLServerGrammer

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -29,13 +29,13 @@ class SqlServerGrammar extends Grammar
     protected $serials = ['tinyInteger', 'smallInteger', 'mediumInteger', 'integer', 'bigInteger'];
 
     /**
-     * Compile the query to determine if a table exists.
+     * Compile the query to determine if a table or view exists.
      *
      * @return string
      */
     public function compileTableExists()
     {
-        return "select * from sysobjects where type = 'U' and name = ?";
+        return "select * from sysobjects where type in ('U', 'V') and name = ?";
     }
 
     /**
@@ -48,7 +48,7 @@ class SqlServerGrammar extends Grammar
     {
         return "select col.name from sys.columns as col
                 join sys.objects as obj on col.object_id = obj.object_id
-                where obj.type = 'U' and obj.object_id = object_id('$table')";
+                where obj.type in ('U', 'V') and obj.name = '$table'";
     }
 
     /**


### PR DESCRIPTION
As @madbarron wrote in a [6.x](https://github.com/laravel/framework/pull/37307) and [8.x](https://github.com/laravel/framework/pull/37348) PR:
> SqlServerGrammar assumes that the model is backed by a table, but some unfortunate souls attach to views in SQL Server. Since we now check mass assignment keys against the database columns, we need to be able to fetch the columns for views.
> 
> This revision removes the "table" object type specification when hitting the DB for schema info, so that views also work. SQL Server will not allow multiple objects to have the same name in the same namespace, so this should not introduce any problems with matching multiple items.

Let's bring this change to Laravel Framework 7.x