### PR TITLE
[9.x] Improve `JsonResource::class` values

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Http\Resources;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Stringable;
 
 trait ConditionallyLoadsAttributes
 {
@@ -33,12 +35,33 @@ trait ConditionallyLoadsAttributes
                 );
             }
 
-            if ($value instanceof self && is_null($value->resource)) {
-                $data[$key] = null;
-            }
+            $data[$key] = $this->prepareValue($value);
         }
 
         return $this->removeMissingValues($data);
+    }
+
+    /**
+     * Prepares the given value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function prepareValue($value)
+    {
+        if ($value instanceof self && is_null($value->resource)) {
+            return null;
+        }
+
+        if ($value instanceof Arrayable) {
+            return $value->toArray();
+        }
+
+        if ($value instanceof Stringable) {
+            return $value->__toString();
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
This PR improves the value of the `JsonResource::class`.

## Example:

### Resource:

```php
return JsonResource::make([
  'array' => [1, 2, 3],
  'object' => (object) ['a' => 'b'],
  'arrayable' => $arrayableObject,
  'htmlString' => $htmlStringObject,
  'stringable' => $stringableObject,
]);
```

### Before

<img width="500" alt="image" src="https://user-images.githubusercontent.com/9979458/210509410-2e53752d-897a-4628-a2e4-072369abd9e5.png">

### After

<img width="524" alt="image" src="https://user-images.githubusercontent.com/9979458/210509700-1fd53b71-6c08-4cf0-b7f5-0ed38e8a80e1.png">

Thanks.