### PR TITLE
[9.x] Support Lazy Collections in BatchFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BatchFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BatchFake.php
@@ -79,7 +79,9 @@ class BatchFake extends Batch
      */
     public function add($jobs)
     {
-        $this->added[] = array_merge($this->added, $jobs);
+        foreach ($jobs as $job) {
+            $this->added[] = $job;
+        }
 
         return $this;
     }


### PR DESCRIPTION
Add support for LazyCollections when using `withFakeBatch`

Given a basic job batch example
```php
use Batchable;

Model::cursor()
    ->map(fn (Model $model) => new ModelJob($model))
    ->chunk(1000)
    ->each(function (LazyCollection $jobs) {
        $this->batch->add($jobs);
    });
```

and associated test case
```php
[$job] = (new ModelJobBatch())->withFakeBatch();

$job->handle();
```

Receives 
`TypeError : array_merge(): Argument #2 must be of type array, Illuminate\Support\LazyCollection given`
