### PR TITLE
Added year() and current_year() helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -573,6 +573,32 @@ if (! function_exists('now')) {
     }
 }
 
+if (! function_exists('year')) {
+    /**
+     * Gets the current year.
+     *
+     * @param  \DateTimeZone|string|null  $tz
+     * @return int
+     */
+    function year($tz = null): int
+    {
+        return Date::now($tz)->year;
+    }
+}
+
+if (! function_exists('current_year')) {
+    /**
+     * Gets the current year.
+     *
+     * @param  \DateTimeZone|string|null  $tz
+     * @return int
+     */
+    function current_year($tz = null): int
+    {
+        return Date::now($tz)->year;
+    }
+}
+
 if (! function_exists('old')) {
     /**
      * Retrieve an old input item.

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -274,4 +274,21 @@ class FoundationHelpersTest extends TestCase
         // Should fallback to en_US
         $this->assertSame('Australian Capital Territory', fake()->state());
     }
+
+
+    public function testYear()
+    {
+        $year = year();
+
+        $this->assertIsInt($year);
+        $this->assertEquals(date('Y'), $year);
+    }
+
+    public function testCurrentYear()
+    {
+        $year = current_year();
+
+        $this->assertIsInt($year);
+        $this->assertEquals(date('Y'), $year);
+    }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -7,6 +7,7 @@ use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Mix;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -281,7 +282,7 @@ class FoundationHelpersTest extends TestCase
         $year = year();
 
         $this->assertIsInt($year);
-        $this->assertEquals(date('Y'), $year);
+        $this->assertEquals(Date::now()->year, $year);
     }
 
     public function testCurrentYear()
@@ -289,6 +290,6 @@ class FoundationHelpersTest extends TestCase
         $year = current_year();
 
         $this->assertIsInt($year);
-        $this->assertEquals(date('Y'), $year);
+        $this->assertEquals(Date::now()->year, $year);
     }
 }


### PR DESCRIPTION
In this pull request new helpers have been added: `year()` and `current_year()`. 

Both helpers returns the current year and can be used as a shortcut to retrieve the current year:


```php

year(); // returns 2023

current_year(); // returns 2023

```

