### PR TITLE
[9.x] Fix `MethodNotAllowedHttpException` exception message

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -123,8 +123,8 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             $others,
             sprintf(
                 'The %s method is not supported for route %s. Supported methods: %s.',
-                $request->path(),
                 $method,
+                $request->path(),
                 implode(', ', $others)
             )
         );

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RouteCollectionTest extends TestCase
@@ -268,6 +269,7 @@ class RouteCollectionTest extends TestCase
     public function testRouteCollectionDontMatchNonMatchingDoubleSlashes()
     {
         $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The route foo could not be found.');
 
         $this->routeCollection->add(new Route('GET', 'foo', [
             'uses' => 'FooController@index',
@@ -279,6 +281,20 @@ class RouteCollectionTest extends TestCase
         $request->server->set(
             'REQUEST_URI', '//foo'
         );
+        $this->routeCollection->match($request);
+    }
+
+    public function testRouteCollectionRequestMethodNotAllowed()
+    {
+        $this->expectException(MethodNotAllowedHttpException::class);
+        $this->expectExceptionMessage('The POST method is not supported for route users. Supported methods: GET, HEAD.');
+
+        $this->routeCollection->add(
+            new Route('GET', 'users', ['uses' => 'UsersController@index', 'as' => 'users'])
+        );
+
+        $request = Request::create('users', 'POST');
+
         $this->routeCollection->match($request);
     }
 


### PR DESCRIPTION
The changes introduced in #45206 contains a mistake in the ordering of input parameters of `sprintf()` rendering the message to be wrong.