### PR TITLE
[9.x] Add ability to drop an index when modifying a column

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -215,7 +215,17 @@ class Blueprint
                 // index method can be called without a name and it will generate one.
                 if ($column->{$index} === true) {
                     $this->{$index}($column->name);
-                    $column->{$index} = false;
+                    $column->{$index} = null;
+
+                    continue 2;
+                }
+
+                // If the index has been specified on the given column, but it equals false
+                // and the column is supposed to be changed, we will call the drop index
+                // method with an array of column to drop it by its conventional name.
+                elseif ($column->{$index} === false && $column->change) {
+                    $this->{'drop'.ucfirst($index)}([$column->name]);
+                    $column->{$index} = null;
 
                     continue 2;
                 }
@@ -225,7 +235,7 @@ class Blueprint
                 // the index since the developer specified the explicit name for this.
                 elseif (isset($column->{$index})) {
                     $this->{$index}($column->name, $column->{$index});
-                    $column->{$index} = false;
+                    $column->{$index} = null;
 
                     continue 2;
                 }


### PR DESCRIPTION
-> We can already chain an index method on the column definition to [add an index](https://laravel.com/docs/9.x/migrations#creating-indexes):
   ```php
   $table->string('name')->unique();
   ```
-> We could also [modify a column](https://laravel.com/docs/9.x/migrations#updating-column-attributes) to drop its attribute, e.g. set not null:
   ```php
   $table->string('name')->nullable(false)->change();
   ```

This PR adds the ability to drop an index (by its conventional name) when modifying a column:
```php
$table->string('name')->unique(false)->change();
```