### PR TITLE
[10.x] Set visibility of suffix property to protected in SqsQueue

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -36,7 +36,7 @@ class SqsQueue extends Queue implements QueueContract, ClearableQueue
      *
      * @var string
      */
-    private $suffix;
+    protected $suffix;
 
     /**
      * Create a new Amazon SQS queue instance.


### PR DESCRIPTION
In the `Illuminate\Queue\SqsQueue` class, the visibility of the `$suffix` property is currently private.

This pull request changes the visibility to protected, allowing the class to be safely extended.