### PR TITLE
When & unless helpers

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -395,6 +395,50 @@ if (! function_exists('transform')) {
     }
 }
 
+if (! function_exists('unless')) {
+    /**
+     * Apply the callback if the given "value" is (or resolves to) falsy and return it.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    function unless($value, callable $callback, $default = null) {
+        if (! $value) {
+            return $callback($value);
+        }
+
+        if (is_callable($default)) {
+            return $default($value);
+        }
+
+        return $default;
+    }
+}
+
+if (! function_exists('when')) {
+    /**
+     * Apply the callback if the given "value" is (or resolves to) truthy and return it.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    function when($value, callable $callback, $default = null) {
+        if ($value) {
+            return $callback($value);
+        }
+
+        if (is_callable($default)) {
+            return $default();
+        }
+
+        return $default;
+    }
+}
+
 if (! function_exists('windows_os')) {
     /**
      * Determine whether the current environment is Windows based.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -404,7 +404,8 @@ if (! function_exists('unless')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function unless($value, callable $callback, $default = null) {
+    function unless($value, callable $callback, $default = null)
+    {
         if (! $value) {
             return $callback($value);
         }
@@ -426,13 +427,14 @@ if (! function_exists('when')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function when($value, callable $callback, $default = null) {
+    function when($value, callable $callback, $default = null)
+    {
         if ($value) {
             return $callback($value);
         }
 
         if (is_callable($default)) {
-            return $default();
+            return $default($value);
         }
 
         return $default;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -930,42 +930,42 @@ class SupportHelpersTest extends TestCase
 
     public function testWhen()
     {
-        $this->assertSame('foobar', when('foo', function($value) {
+        $this->assertSame('foobar', when('foo', function ($value) {
             return $value.'bar';
         }));
 
-        $this->assertSame('baz', when(false, function($value) {
+        $this->assertSame('baz', when(false, function ($value) {
             return $value.'bar';
         }, 'baz'));
 
-        $this->assertSame('baz', when(0, function($value) {
+        $this->assertSame('baz', when(0, function ($value) {
             return $value.'bar';
         }, 'baz'));
 
-        $this->assertSame('baz', when(false, function($value) {
+        $this->assertSame('baz', when(false, function ($value) {
             return $value.'bar';
-        }, function() {
+        }, function () {
             return 'baz';
         }));
     }
 
     public function testUnless()
     {
-        $this->assertSame('bar', unless(false, function($value) {
+        $this->assertSame('bar', unless(false, function ($value) {
             return $value.'bar';
         }));
 
-        $this->assertSame('0bar', unless(0, function($value) {
+        $this->assertSame('0bar', unless(0, function ($value) {
             return $value.'bar';
         }));
 
-        $this->assertSame('baz', unless('foo', function($value) {
+        $this->assertSame('baz', unless('foo', function ($value) {
             return $value.'bar';
         }, 'baz'));
 
-        $this->assertSame('baz', unless('foo', function($value) {
+        $this->assertSame('baz', unless('foo', function ($value) {
             return $value.'bar';
-        }, function() {
+        }, function () {
             return 'baz';
         }));
     }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -927,6 +927,48 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testWhen()
+    {
+        $this->assertSame('foobar', when('foo', function($value) {
+            return $value.'bar';
+        }));
+
+        $this->assertSame('baz', when(false, function($value) {
+            return $value.'bar';
+        }, 'baz'));
+
+        $this->assertSame('baz', when(0, function($value) {
+            return $value.'bar';
+        }, 'baz'));
+
+        $this->assertSame('baz', when(false, function($value) {
+            return $value.'bar';
+        }, function() {
+            return 'baz';
+        }));
+    }
+
+    public function testUnless()
+    {
+        $this->assertSame('bar', unless(false, function($value) {
+            return $value.'bar';
+        }));
+
+        $this->assertSame('0bar', unless(0, function($value) {
+            return $value.'bar';
+        }));
+
+        $this->assertSame('baz', unless('foo', function($value) {
+            return $value.'bar';
+        }, 'baz'));
+
+        $this->assertSame('baz', unless('foo', function($value) {
+            return $value.'bar';
+        }, function() {
+            return 'baz';
+        }));
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
These are two little helpers I often use to get rid of intermediary variable assignments.

Example:

```php
$id = $model->getOriginal('related_id');
$related = $id ? Related::find($id) : null;

// becomes
$related = when($model->getOriginal('related_id'), function($value) {
    return Related::find($value)
});

// or using short syntax
$related = when($model->getOriginal('related_id'), fn($value) => Related::find($value));
```

The callback's value is returned if the provided value is truthy.

It has the same signature as other `when()` and `unless()` methods throughout the framework. So a default value can be specified (callable if you like):

```php
$related = when($model->getOriginal('related_id'), function($value) {
    return Related::find($value)
}, 'something else');

$related = when($model->getOriginal('related_id'), function($value) {
    return Related::find($value)
}, function($value) {
    return Related::first();
});
```

    