### PR TITLE
[9.x] Add Stringable surround method

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -452,6 +452,17 @@ class Stringable implements JsonSerializable
     }
 
     /**
+     * Surround the string with the given values.
+     *
+     * @param  array  $values
+     * @return static
+     */
+    public function surround(...$values)
+    {
+        return $this->append(...$values)->prepend(...$values);
+    }
+
+    /**
      * Determine if the string matches the given pattern.
      *
      * @param  string  $pattern

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -1179,4 +1179,10 @@ class SupportStringableTest extends TestCase
 
         $this->stringable('not a date')->toDate();
     }
+
+    public function testSurround()
+    {
+        $this->assertSame('FooBarFoo', (string) $this->stringable('Bar')->surround('Foo'));
+        $this->assertSame('FooBatBarFooBat', (string) $this->stringable('Bar')->surround('Foo', 'Bat'));
+    }
 }


### PR DESCRIPTION
Adds a `surround` method to the `Stringable` support class that will surround the string with the given values.

```php
return str('foo')->surround('bar')

// barfoobar
```

Basically a shorthand method for
```php
return str('foo')->append('bar')->prepend('bar')
```

I've found this particularly useful when building query params for a like query that allows matching either side:
```php
User::where('email', 'like', str('gmail')->surround('%'))
```
