### PR TITLE
feat: Add support for unsigned route closures

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1340,13 +1340,13 @@ class Route
     {
         if ($this->action['uses'] instanceof Closure) {
             $this->action['uses'] = serialize(
-                new SerializableClosure($this->action['uses'])
+                new SerializableClosure($this->action['uses'], false)
             );
         }
 
         if (isset($this->action['missing']) && $this->action['missing'] instanceof Closure) {
             $this->action['missing'] = serialize(
-                new SerializableClosure($this->action['missing'])
+                new SerializableClosure($this->action['missing'], false)
             );
         }
 


### PR DESCRIPTION
Add support for serializing closures in routes unsigned.

This PR depends on the work created in https://github.com/laravel/serializable-closure/pull/62.

The reasoning below is a copy/paste from the other pr.


## Why? 

When caching routes in the Laravel/framework, they are currently being cached signed. This means if you cache your routes and then set/change your `APP_KEY` your route caches are invalid.

This option allows the route caching logic to disable signing when caching the routes, which then means `APP_KEY` can be changed without the route caching being invalid.

## Usecase
When building a docker image it is currently impossible to cache your routes while building the image (if any routes are closures) as the `APP_KEY` should not be exposed to the build steps of the docker image.  

Caching the routes while building the image has a lot of advantages, as each instance does not have to cache it themselves. This can also prevent potential crashes of running out of storage when using k8s, as you cannot guarantee the amount of storage available outside of the image size unless you start mounting volumes etc. 
