### PR TITLE
[9.x] Remove `__construct()` function to accommodate most use cases.

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/listener.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.stub
@@ -9,16 +9,6 @@ use Illuminate\Queue\InteractsWithQueue;
 class {{ class }}
 {
     /**
-     * Create the event listener.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Handle the event.
      *
      * @param  \{{ eventNamespace }}  $event


### PR DESCRIPTION
A small DX update that I feal might accomodate to most use cases.

When I generate a new event listener using the `php artisan make:listener` command, the first thing I do is remove the `__construct()` method from it as it is very rarely used. I believe that 90%+ of developers either do the same or leave it blank, while 10%- of devs would probobly make use of the method.

🔴  Haven't actually done the research, this is mostly based on my personal experience.
