### PR TITLE
[9.x] Add missing and missingAny Collection methods

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -595,6 +595,48 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     }
 
     /**
+     * Determine if an item is missing from the collection by key.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if (array_key_exists($value, $this->items)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if any of the keys are missing from the collection.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @return bool
+     */
+    public function missingAny($key)
+    {
+        if ($this->isEmpty()) {
+            return true;
+        }
+
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if ($this->missing($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  callable|string  $value

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -548,6 +548,22 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function hasAny($key);
 
     /**
+     * Determine if an item is missing from the collection by key.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @return bool
+     */
+    public function missing($key);
+
+    /**
+     * Determine if any of the keys are missing from the collection.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @return bool
+     */
+    public function missingAny($key);
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -610,6 +610,44 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     }
 
     /**
+     * Determine if an item is missing from the collection by key.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        $keys = array_flip(is_array($key) ? $key : func_get_args());
+
+        foreach ($this as $key => $value) {
+            if (array_key_exists($key, $keys)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if any of the keys are missing from the collection.
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @return bool
+     */
+    public function missingAny($key)
+    {
+        $keys = array_flip(is_array($key) ? $key : func_get_args());
+
+        foreach ($keys as $key => $value) {
+            if ($this->missing($key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  callable|string  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2299,6 +2299,38 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testMissing($collection)
+    {
+        $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+
+        $this->assertFalse($data->missing('first'));
+        $this->assertTrue($data->missing('third'));
+        $this->assertFalse($data->missing(['first', 'second']));
+        $this->assertFalse($data->missing(['third', 'first']));
+        $this->assertTrue($data->missing(['third', 'fourth']));
+        $this->assertFalse($data->missing('first', 'second'));
+        $this->assertTrue($data->missing([]));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMissingAny($collection)
+    {
+        $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+
+        $this->assertFalse($data->missingAny('first'));
+        $this->assertTrue($data->missingAny('third'));
+        $this->assertTrue($data->missingAny(['first', 'fourth']));
+        $this->assertFalse($data->missingAny(['first', 'second']));
+        $this->assertTrue($data->missingAny(['third', 'fourth']));
+        $this->assertTrue($data->missingAny('third', 'fourth'));
+        $this->assertFalse($data->missingAny([]));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testImplode($collection)
     {
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);


### PR DESCRIPTION
Hey there!

I'd like to propose adding the `missing()` and `missingAny()` methods to the Collection class in.

I found that I was using the inverse of the `has()` method (`! $collection->has()`) quite frequently in my code and thought it would be more convenient to have a dedicated method for this purpose.

Here's a simple example of how the `missing()` and `missingAny()` methods could be used:

**missing()**
```php
$collection = collect(['apple', 'banana', 'orange']);

if ($collection->missing('mango')) {
    // true, because mango is missing
}

if ($collection->missing(['orange', 'mango'])) {
    // false, because orange is present
}
```

**missingAny()**
```php
$collection = collect(['apple', 'banana', 'orange']);

if ($collection->missingAny(['banana', 'mango'])) {
    // true, because at least mango is missing
}

if ($collection->missingAny(['banana', 'orange'])) {
    // false, because both banana and orange are present
}
```
In addition to being more convenient to use, these methods fit nicely with the existing `has()` and `hasAny()` methods in terms of naming and functionality.

I'd love to see these methods added to the Collection class. Let me know what you think!