### PR TITLE
[9.x] Return model when casting attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1070,6 +1070,8 @@ trait HasAttributes
         } else {
             unset($this->attributeCastCache[$key]);
         }
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelAttributeCastingTest.php
@@ -47,6 +47,10 @@ class DatabaseEloquentModelAttributeCastingTest extends DatabaseTestCase
 
         $this->assertSame('DRIES', $model->uppercase);
 
+        $model = $model->setAttribute('uppercase', 'james');
+
+        $this->assertInstanceOf(TestEloquentModelWithAttributeCast::class, $model);
+
         $model = new TestEloquentModelWithAttributeCast;
 
         $model->address = $address = new AttributeCastAddress('110 Kingsbrook St.', 'My Childhood House');


### PR DESCRIPTION
Right now, when setting an attribute directly through `setAttribute` that has an Attribute cast, it won't return anything while the behavior of all the other calls to `setAttribute` is to return the model. Given that the return of `setAttributeMarkedMutatedAttributeValue` is `mixed` but nothing was returned, it seems to me that this was forgotten. 

`setMutatedAttributeValue` also doesn't explicitly returns the model but people can decide for themselves to do that or not in the mutator.

Fixes https://github.com/laravel/framework/issues/45537