### PR TITLE
[9.x] `make:migration` remove `--fullpath` option

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -17,8 +17,7 @@ class MigrateMakeCommand extends BaseCommand
         {--create= : The table to be created}
         {--table= : The table to migrate}
         {--path= : The location where the migration file should be created}
-        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
-        {--fullpath : Output the full path of the migration}';
+        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}';
 
     /**
      * The console command description.
@@ -109,10 +108,6 @@ class MigrateMakeCommand extends BaseCommand
         $file = $this->creator->create(
             $name, $this->getMigrationPath(), $table, $create
         );
-
-        if (! $this->option('fullpath')) {
-            $file = pathinfo($file, PATHINFO_FILENAME);
-        }
 
         $this->components->info(sprintf('Migration [%s] created successfully.', $file));
     }


### PR DESCRIPTION
# Background
When using `php artisan make:*` commands, almost all provide the full relative path to the file in the console output e.g. `Model [app/MyModel.php] created successfully.` This is great as many terminals support clicking this path and opening it in your editor.

<details>
<summary>All the default `make` commands provide the full relative path, except for `make:migration`. I've tested each of them listed here.</summary>
<ul>
    <li><code>make:cast</code></li>
    <li><code>make:channel</code></li>
    <li><code>make:command</code></li>
    <li><code>make:component</code></li>
    <li><code>make:controller</code></li>
    <li><code>make:event</code></li>
    <li><code>make:exception</code></li>
    <li><code>make:factory</code></li>
    <li><code>make:job</code></li>
    <li><code>make:listener</code></li>
    <li><code>make:mail</code></li>
    <li><code>make:middleware</code></li>
    <li><code>make:model</code></li>
    <li><code>make:notification</code></li>
    <li><code>make:observer</code></li>
    <li><code>make:policy</code></li>
    <li><code>make:provider</code></li>
    <li><code>make:request</code></li>
    <li><code>make:resource</code></li>
    <li><code>make:rule</code></li>
    <li><code>make:scope</code></li>
    <li><code>make:seeder</code></li>
    <li><code>make:test</code></li>
</ul>
</details>

Looking into it I see a `--fullpath` option was added to `make:migration` in #28669. My guess is that maybe Nuno's Artisan improvements added the relative paths and this command was left as is.

# Proposed Change
I would like to propose removing the `--fullpath` option from the `make:migration` command to bring its default behaviour in line with every other `make` command.

I think this is the more desirable behaviour - I know I would find it useful to be able to open the migration in my editor without having to remember to provide an option unique to this command.

This small PR implements simply removes that option. See before and after screenshots below.

If needed I could also add a `--filename` or similar option to opt in to the current behaviour while making the full relative path the default.

### Before
<img width="804" alt="CleanShot 2023-01-06 at 08 24 56@2x" src="https://user-images.githubusercontent.com/23709612/210964259-9a98a6f4-3c72-4613-abea-f4fbe0f40cca.png">


### After
<img width="797" alt="CleanShot 2023-01-06 at 08 25 08@2x" src="https://user-images.githubusercontent.com/23709612/210964268-b6dfe654-67a6-422a-ba93-f841feb87282.png">

Granted, this is only a small change so might not be worth it if it's considered a breaking change or upsetting people's workflows. Happy to close in that case. Thanks!
