### PR TITLE
[9.x] Wrap the json_encode call with the echoFormat

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -33,14 +33,15 @@ trait CompilesJson
     /**
      * Wraps the given value in a json_encode function call.
      *
-     * @param  string     $value
-     * @param  int        $options
-     * @param  int|string $depth
+     * @param  string  $value
+     * @param  int  $options
+     * @param  int|string  $depth
      * @return string
      */
     protected function wrapJsonHandler($value, $options, $depth)
     {
         $value = "json_encode($value, $options, $depth)";
+
         return sprintf($this->echoFormat, $value);
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesJson.php
@@ -25,6 +25,22 @@ trait CompilesJson
 
         $depth = isset($parts[2]) ? trim($parts[2]) : 512;
 
-        return "<?php echo json_encode($parts[0], $options, $depth) ?>";
+        $wrapped = $this->wrapJsonHandler($parts[0], $options, $depth);
+
+        return "<?php echo $wrapped ?>";
+    }
+
+    /**
+     * Wraps the given value in a json_encode function call.
+     *
+     * @param  string     $value
+     * @param  int        $options
+     * @param  int|string $depth
+     * @return string
+     */
+    protected function wrapJsonHandler($value, $options, $depth)
+    {
+        $value = "json_encode($value, $options, $depth)";
+        return sprintf($this->echoFormat, $value);
     }
 }

--- a/tests/View/Blade/BladeJsonTest.php
+++ b/tests/View/Blade/BladeJsonTest.php
@@ -7,7 +7,7 @@ class BladeJsonTest extends AbstractBladeTestCase
     public function testStatementIsCompiledWithSafeDefaultEncodingOptions()
     {
         $string = 'var foo = @json($var);';
-        $expected = 'var foo = <?php echo json_encode($var, 15, 512) ?>;';
+        $expected = 'var foo = <?php echo e(json_encode($var, 15, 512)) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
@@ -15,7 +15,16 @@ class BladeJsonTest extends AbstractBladeTestCase
     public function testEncodingOptionsCanBeOverwritten()
     {
         $string = 'var foo = @json($var, JSON_HEX_TAG);';
-        $expected = 'var foo = <?php echo json_encode($var, JSON_HEX_TAG, 512) ?>;';
+        $expected = 'var foo = <?php echo e(json_encode($var, JSON_HEX_TAG, 512)) ?>;';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testStatementIsCompiledWithCorrectEchoFormat()
+    {
+        $this->compiler->withDoubleEncoding();
+        $string = 'var foo = @json($var, JSON_HEX_TAG);';
+        $expected = 'var foo = <?php echo e(json_encode($var, JSON_HEX_TAG, 512), true) ?>;';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }


### PR DESCRIPTION
This commit updates the CompilesJson concern to use the BladeCompiler's current `echoFormat` when compiling the json expression. See https://github.com/laravel/framework/issues/45542

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
