### PR TITLE
[9.x] Generalise collection pluck method return-type

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -719,7 +719,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      *
      * @param  string|int|array<array-key, string>  $value
      * @param  string|null  $key
-     * @return static<int, mixed>
+     * @return static<array-key, mixed>
      */
     public function pluck($value, $key = null)
     {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -564,7 +564,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @param  string|array<array-key, string>  $value
      * @param  string|null  $key
-     * @return \Illuminate\Support\Collection<int, mixed>
+     * @return \Illuminate\Support\Collection<array-key, mixed>
      */
     public function pluck($value, $key = null)
     {

--- a/types/Database/Eloquent/Collection.php
+++ b/types/Database/Eloquent/Collection.php
@@ -158,8 +158,8 @@ assertType('array<User>', $collection->getDictionary());
 assertType('array<User>', $collection->getDictionary($collection));
 assertType('array<User>', $collection->getDictionary([new User]));
 
-assertType('Illuminate\Support\Collection<int, mixed>', $collection->pluck('string'));
-assertType('Illuminate\Support\Collection<int, mixed>', $collection->pluck(['string']));
+assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck('string'));
+assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->pluck(['string']));
 
 assertType('Illuminate\Support\Collection<int, int>', $collection->keys());
 

--- a/types/Support/Collection.php
+++ b/types/Support/Collection.php
@@ -851,8 +851,8 @@ assertType('int', $collection->make([1])->pipe(function ($collection) {
 
 assertType('mixed', $collection->pipeInto(User::class));
 
-assertType('Illuminate\Support\Collection<int, mixed>', $collection->make(['string' => 'string'])->pluck('string'));
-assertType('Illuminate\Support\Collection<int, mixed>', $collection->make(['string' => 'string'])->pluck('string', 'string'));
+assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->make(['string' => 'string'])->pluck('string'));
+assertType('Illuminate\Support\Collection<(int|string), mixed>', $collection->make(['string' => 'string'])->pluck('string', 'string'));
 
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject());
 assertType('Illuminate\Support\Collection<int, User>', $collection->reject(new User));


### PR DESCRIPTION
When passing a value for `$key`, the resulting collection may have string keys instead of integer keys.

See also: https://github.com/laravel/framework/blob/a0e6dd38050f4cae310f63a28bf3b77517053891/src/Illuminate/Collections/Arr.php#L496-L530

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
