### PR TITLE
[9.x] Allow any Container contract implementation to be used in Seeder

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\View\Components\TwoColumnDetail;
-use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
@@ -14,7 +14,7 @@ abstract class Seeder
     /**
      * The container instance.
      *
-     * @var \Illuminate\Container\Container
+     * @var \Illuminate\Contracts\Container\Container
      */
     protected $container;
 
@@ -143,7 +143,7 @@ abstract class Seeder
     /**
      * Set the IoC container instance.
      *
-     * @param  \Illuminate\Container\Container  $container
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @return $this
      */
     public function setContainer(Container $container)


### PR DESCRIPTION
When running PHPStan static analysis on my codebase, I noticed an error `Parameter #1 $container of method Illuminate\Database\Seeder::setContainer() expects Illuminate\Container\Container, Illuminate\Contracts\Foundation\Application given.` appearing in a console command I based on [the SeedCommand class in this repository](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Console/Seeds/SeedCommand.php).

On further inspection, I noticed this was due to the fact that the `getSeeder` method passes `$this->laravel` to `setContainer`, where `$this->laravel` can be any `Application` contract implementation, while the `$container` property on the `Seeder` only explicitly allows the `\Illuminate\Container\Container` implementation.

See
https://github.com/laravel/framework/blob/8c9ae320512ca7eb784a7e495840d101eb6f92d4/src/Illuminate/Database/Console/Seeds/SeedCommand.php#L109-L111
and
https://github.com/laravel/framework/blob/8c9ae320512ca7eb784a7e495840d101eb6f92d4/src/Illuminate/Console/Command.php#L21-L26

As far as I can see, no methods are called that are not part of the contract, however I'm not sure if the more general parameter type might cause problems elsewhere. If so, let me know and I will try to correct for that, or rebase on `10.x` to be more safe.