### PR TITLE
[9.x] Add destroyable singletons

### DIFF
--- a/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingSingletonResourceRegistration.php
@@ -101,6 +101,19 @@ class PendingSingletonResourceRegistration
     }
 
     /**
+     * Indicate that the resource should have a deletion route.
+     *
+     * @param  bool  $destroyable
+     * @return $this
+     */
+    public function destroyable($destroyable = true)
+    {
+        $this->options['destroyable'] = $destroyable;
+
+        return $this;
+    }
+
+    /**
      * Set the route names for controller actions.
      *
      * @param  array|string  $names

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -259,6 +259,14 @@ class ResourceRegistrar
             );
         }
 
+        if (isset($options['destroyable'])) {
+            $methods = array_merge(['destroy'], $methods);
+
+            return $this->getResourceMethods(
+                $methods, array_values(Arr::except($options, ['destroyable']))
+            );
+        }
+
         return $methods;
     }
 

--- a/tests/Integration/Routing/RouteSingletonTest.php
+++ b/tests/Integration/Routing/RouteSingletonTest.php
@@ -62,6 +62,31 @@ class RouteSingletonTest extends TestCase
         $this->assertSame('singleton destroy', $response->getContent());
     }
 
+    public function testDestroyableSingleton()
+    {
+        Route::singleton('avatar', CreatableSingletonTestController::class)->destroyable();
+
+        $this->assertSame('http://localhost/avatar', route('avatar.show'));
+        $response = $this->get('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton show', $response->getContent());
+
+        $this->assertSame('http://localhost/avatar/edit', route('avatar.edit'));
+        $response = $this->get('/avatar/edit');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton edit', $response->getContent());
+
+        $this->assertSame('http://localhost/avatar', route('avatar.update'));
+        $response = $this->put('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton update', $response->getContent());
+
+        $this->assertSame('http://localhost/avatar', route('avatar.destroy'));
+        $response = $this->delete('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton destroy', $response->getContent());
+    }
+
     public function testApiSingleton()
     {
         Route::apiSingleton('avatar', SingletonTestController::class);
@@ -94,6 +119,26 @@ class RouteSingletonTest extends TestCase
         $response = $this->put('/avatar');
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertSame('singleton update', $response->getContent());
+    }
+
+    public function testDestroyableApiSingleton()
+    {
+        Route::apiSingleton('avatar', CreatableSingletonTestController::class)->destroyable();
+
+        $this->assertSame('http://localhost/avatar', route('avatar.show'));
+        $response = $this->get('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton show', $response->getContent());
+
+        $this->assertSame('http://localhost/avatar', route('avatar.update'));
+        $response = $this->put('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton update', $response->getContent());
+
+        $this->assertSame('http://localhost/avatar', route('avatar.destroy'));
+        $response = $this->delete('/avatar');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton destroy', $response->getContent());
     }
 
     public function testSingletonOnly()
@@ -181,6 +226,31 @@ class RouteSingletonTest extends TestCase
     public function testCreatableNestedSingleton()
     {
         Route::singleton('videos.thumbnail', NestedSingletonTestController::class)->creatable();
+
+        $response = $this->get('/videos/123/thumbnail');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton show for 123', $response->getContent());
+
+        $response = $this->get('/videos/123/thumbnail/edit');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton edit for 123', $response->getContent());
+
+        $response = $this->put('/videos/123/thumbnail');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton update for 123', $response->getContent());
+
+        $response = $this->patch('/videos/123/thumbnail');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton update for 123', $response->getContent());
+
+        $response = $this->delete('/videos/123/thumbnail');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame('singleton destroy for 123', $response->getContent());
+    }
+
+    public function testDestroyableNestedSingleton()
+    {
+        Route::singleton('videos.thumbnail', NestedSingletonTestController::class)->destroyable();
 
         $response = $this->get('/videos/123/thumbnail');
         $this->assertEquals(200, $response->getStatusCode());


### PR DESCRIPTION
This PR aims to create an easy way to mark singleton routes as 'destroyable'. A destroyable singleton may be deleted, but it may not be created (by default). This is useful when its a resource with a default state and deleting it just resets it to that state, or when it is a resource the user cannot create on his own.

Before:

```php
Route::singleton(...)->creatable()->except('create', 'store');
```

After:

```php
Route::singleton(...)->destroyable();
```

When singleton routes came out we rewrote our routes to make use of them, but 8.42.2 (https://github.com/laravel/framework/commit/6ddf3b017ccb8486c8dc5ff5a09d051a40e094ca) changed how they worked by not making them not have a destroy action by default anymore, which this PR is trying to solve.