### PR TITLE
[10.x] Add ability to reindex the chunks using collection chunk method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1277,9 +1277,10 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
+     * @param  bool  $preserveKeys
      * @return static<int, static>
      */
-    public function chunk($size)
+    public function chunk($size, $preserveKeys = true)
     {
         if ($size <= 0) {
             return new static;
@@ -1287,7 +1288,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
 
         $chunks = [];
 
-        foreach (array_chunk($this->items, $size, true) as $chunk) {
+        foreach (array_chunk($this->items, $size, $preserveKeys) as $chunk) {
             $chunks[] = new static($chunk);
         }
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -946,9 +946,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
+     * @param  bool  $preserveKeys
      * @return static<int, static>
      */
-    public function chunk($size);
+    public function chunk($size, $preserveKeys = true);
 
     /**
      * Chunk the collection into chunks with a callback.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1214,22 +1214,27 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
+     * @param  bool  $preserveKeys
      * @return static<int, static>
      */
-    public function chunk($size)
+    public function chunk($size, $preserveKeys = true)
     {
         if ($size <= 0) {
             return static::empty();
         }
 
-        return new static(function () use ($size) {
+        return new static(function () use ($size, $preserveKeys) {
             $iterator = $this->getIterator();
 
             while ($iterator->valid()) {
                 $chunk = [];
 
                 while (true) {
-                    $chunk[$iterator->key()] = $iterator->current();
+                    if ($preserveKeys) {
+                        $chunk[$iterator->key()] = $iterator->current();
+                    } else {
+                        $chunk[] = $iterator->current();
+                    }
 
                     if (count($chunk) < $size) {
                         $iterator->next();

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2100,6 +2100,19 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testChunkWithoutPreservingKeys($collection)
+    {
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = $data->chunk(3, false);
+
+        $this->assertEquals([1, 2, 3], $data->first()->toArray());
+        $this->assertEquals([4, 5, 6], $data->get(1)->toArray());
+        $this->assertEquals([10], $data->last()->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSplitIn($collection)
     {
         $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);


### PR DESCRIPTION
Fixes #29685

This PR adds an option to collection's `chunk` method to reindex the chunks numerically or preserve the keys, just like [PHP `array_chunk`](https://www.php.net/manual/en/function.array-chunk.php) method.

Before this PR: 
```php
collect([1, 2, 3, 4, 5, 6, 7])->chunk(3)->toArray();
// [[1, 2, 3], [3 => 4, 4 => 5, 5 => 6], [6 => 7]]
```
After this PR:
```php
collect([1, 2, 3, 4, 5, 6, 7])->chunk(3, false)->toArray();
// [[1, 2, 3], [4, 5, 6], [7]]

collect([1, 2, 3, 4, 5, 6, 7])->chunk(3)->toArray();
// [[1, 2, 3], [3 => 4, 4 => 5, 5 => 6], [6 => 7]]
```