### PR TITLE
[9.x] Method explodeExplicitRule working wrong with regex rule - Issue 45520

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -86,9 +86,7 @@ class ValidationRuleParser
     protected function explodeExplicitRule($rule, $attribute)
     {
         if (is_string($rule)) {
-            [$name] = static::parseStringRule($rule);
-
-            return static::ruleIsRegex($name) ? [$rule] : explode('|', $rule);
+            return explode('|', $rule);
         }
 
         if (is_object($rule)) {

--- a/tests/Validation/ValidationForEachTest.php
+++ b/tests/Validation/ValidationForEachTest.php
@@ -211,7 +211,7 @@ class ValidationForEachTest extends TestCase
 
         $rules = [
             'items.*' => Rule::forEach(function () {
-                return ['users.*.type' => 'regex:/^(super|admin)$/i'];
+                return ['users.*.type' => 'regex:/^(super)$/i'];
             }),
         ];
 

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -96,7 +96,7 @@ class ValidationRuleParserTest extends TestCase
         ], $rules);
     }
 
-    public function testExplodeProperlyParsesSingleRegexRule()
+    public function testExplodeFailsParsingSingleRegexRuleContainingPipe()
     {
         $data = ['items' => [['type' => 'foo']]];
 
@@ -104,7 +104,8 @@ class ValidationRuleParserTest extends TestCase
             ['items.*.type' => 'regex:/^(foo|bar)$/i']
         );
 
-        $this->assertSame('regex:/^(foo|bar)$/i', $exploded->rules['items.0.type'][0]);
+        $this->assertSame('regex:/^(foo', $exploded->rules['items.0.type'][0]);
+        $this->assertSame('bar)$/i', $exploded->rules['items.0.type'][1]);
     }
 
     public function testExplodeProperlyParsesRegexWithArrayOfRules()

--- a/tests/Validation/ValidationRuleParserTest.php
+++ b/tests/Validation/ValidationRuleParserTest.php
@@ -108,6 +108,18 @@ class ValidationRuleParserTest extends TestCase
         $this->assertSame('bar)$/i', $exploded->rules['items.0.type'][1]);
     }
 
+    public function testExplodeProperlyParsesSingleRegexRuleNotContainingPipe()
+    {
+        $data = ['items' => [['type' => 'foo']]];
+
+        $exploded = (new ValidationRuleParser($data))->explode(
+            ['items.*.type' => 'regex:/^[\d\-]*$/|max:20']
+        );
+
+        $this->assertSame('regex:/^[\d\-]*$/', $exploded->rules['items.0.type'][0]);
+        $this->assertSame('max:20', $exploded->rules['items.0.type'][1]);
+    }
+
     public function testExplodeProperlyParsesRegexWithArrayOfRules()
     {
         $data = ['items' => [['type' => 'foo']]];


### PR DESCRIPTION
Closes #45520 

This PR reverts a change that I made in PR #40941 ([specifically this change](https://github.com/laravel/framework/pull/40941/files#diff-88815c1c8302eb7f025ae9ba1f232036adbfae6a415d3d84d199ad2f3af15c31L88)), which attempted to handle regex rules containing pipes, if they were the only rule in the string. This didn't work as intended when a string rule contains a regex with subsequent rules (as displayed in PR #45520).

This revert returns the validator to its default and documented behaviour of requiring regex rules containing pipes be split into an array of rule strings.

I have also adjusted the tests to ensure this default behaviour is kept, and that we will be notified of such a change due to test failure.

Let me know if you would like anything adjusted, thanks for your time!