### PR TITLE
[9.x] Customize maintenance exception

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -59,8 +59,8 @@ class PreventRequestsDuringMaintenance
 
             if (isset($data['redirect'])) {
                 $path = $data['redirect'] === '/'
-                            ? $data['redirect']
-                            : trim($data['redirect'], '/');
+                    ? $data['redirect']
+                    : trim($data['redirect'], '/');
 
                 if ($request->path() !== $path) {
                     return redirect($path);
@@ -82,7 +82,7 @@ class PreventRequestsDuringMaintenance
     }
 
     /**
-     * @param array $data
+     * @param  array  $data
      *
      * @throws HttpException
      */
@@ -106,11 +106,11 @@ class PreventRequestsDuringMaintenance
     protected function hasValidBypassCookie($request, array $data)
     {
         return isset($data['secret']) &&
-                $request->cookie('laravel_maintenance') &&
-                MaintenanceModeBypassCookie::isValid(
-                    $request->cookie('laravel_maintenance'),
-                    $data['secret']
-                );
+            $request->cookie('laravel_maintenance') &&
+            MaintenanceModeBypassCookie::isValid(
+                $request->cookie('laravel_maintenance'),
+                $data['secret']
+            );
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -84,7 +84,7 @@ class PreventRequestsDuringMaintenance
     /**
      * @param  array  $data
      *
-     * @throws HttpException
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
     public function abort(array $data): void
     {

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -59,8 +59,8 @@ class PreventRequestsDuringMaintenance
 
             if (isset($data['redirect'])) {
                 $path = $data['redirect'] === '/'
-                    ? $data['redirect']
-                    : trim($data['redirect'], '/');
+                            ? $data['redirect']
+                            : trim($data['redirect'], '/');
 
                 if ($request->path() !== $path) {
                     return redirect($path);
@@ -106,11 +106,11 @@ class PreventRequestsDuringMaintenance
     protected function hasValidBypassCookie($request, array $data)
     {
         return isset($data['secret']) &&
-            $request->cookie('laravel_maintenance') &&
-            MaintenanceModeBypassCookie::isValid(
-                $request->cookie('laravel_maintenance'),
-                $data['secret']
-            );
+                $request->cookie('laravel_maintenance') &&
+                MaintenanceModeBypassCookie::isValid(
+                    $request->cookie('laravel_maintenance'),
+                    $data['secret']
+                );
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -75,15 +75,25 @@ class PreventRequestsDuringMaintenance
                 );
             }
 
-            throw new HttpException(
-                $data['status'] ?? 503,
-                'Service Unavailable',
-                null,
-                $this->getHeaders($data)
-            );
+            $this->abort($data);
         }
 
         return $next($request);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @throws HttpException
+     */
+    public function abort(array $data): void
+    {
+        throw new HttpException(
+            $data['status'] ?? 503,
+            'Service Unavailable',
+            null,
+            $this->getHeaders($data)
+        );
     }
 
     /**


### PR DESCRIPTION
That PR allows to customize maintenance exception by implementing `public function abort(array $data): void;` in `PreventRequestsDuringMaintenance.php`.

Like this, the exception could mastered by developper and if customized the response could be too (add headers, choose view etc..) without risk to break the complete middleware logic.

My exception implementation to illustrate
```
<?php

namespace Exceptions;

use Illuminate\Http\Request;
use Illuminate\Support\Facades\Log;
use Inertia\Inertia;
use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException as ParentHttpException;

final class ServiceUnavailableHttpException extends ParentHttpException
{
    public function __construct(
        private Request $request,
        array $headers,
        string $message = 'Service Unavailable',
        \Throwable $previous = null
    ) {
        parent::__construct($headers['Retry-After'], $message, $previous, 503, $headers);
    }

    public function report()
    {
        Log::channel('info')->log($this->getMessage(), $this->context());
    }

    public function render()
    {
        $seconds = $this->getHeaders()['Retry-After'];

        return Inertia::render('Errors/503', [
            'message' => trans('exception.service_unavailable', [
                'seconds' => $seconds,
                'minutes' => ceil($seconds / 60),
            ]),
        ])
            ->toResponse($this->request)
            ->setStatusCode($this->getStatusCode())
            ->withHeaders($this->getHeaders());
    }

    public function context()
    {
        return [
            'sessions.id' => $this->request->session()->getId(),
        ];
    }
}

```