### PR TITLE
[9.x] Add `setVisible` and `setHidden` to Eloquent Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -528,7 +528,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Set the visible attributes across the entire collection.
      *
-     * @param  array<string>  $visible
+     * @param  array<int, string>  $visible
      * @return $this
      */
     public function setVisible($visible)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -539,7 +539,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Set the hidden attributes across the entire collection.
      *
-     * @param  array<string>  $hidden
+     * @param  array<int, string>  $hidden
      * @return $this
      */
     public function setHidden($hidden)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -526,6 +526,28 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Set the visible attributes across the entire collection.
+     *
+     * @param  array<string>  $visible
+     * @return $this
+     */
+    public function setVisible($visible)
+    {
+        return $this->each->setVisible($visible);
+    }
+
+    /**
+     * Set the hidden attributes across the entire collection.
+     *
+     * @param  array<string>  $hidden
+     * @return $this
+     */
+    public function setHidden($hidden)
+    {
+        return $this->each->setHidden($hidden);
+    }
+
+    /**
      * Append an attribute across the entire collection.
      *
      * @param  array<array-key, string>|string  $attributes

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -462,6 +462,22 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([], $c[0]->getHidden());
     }
 
+    public function testSetVisibleReplacesVisibleOnEntireCollection()
+    {
+        $c = new Collection([new TestEloquentCollectionModel]);
+        $c = $c->setVisible(['hidden']);
+
+        $this->assertEquals(['hidden'], $c[0]->getVisible());
+    }
+
+    public function testSetHiddenReplacesHiddenOnEntireCollection()
+    {
+        $c = new Collection([new TestEloquentCollectionModel]);
+        $c = $c->setHidden(['visible']);
+
+        $this->assertEquals(['visible'], $c[0]->getHidden());
+    }
+
     public function testAppendsAddsTestOnEntireCollection()
     {
         $c = new Collection([new TestEloquentCollectionModel]);


### PR DESCRIPTION
This PR adds `setVisible` and `setHidden` methods to Eloquent Collections.

We already have the `makeVisible` and `makeHidden` methods, but `makeVisible` is only useful when a property is usually hidden or when the model has a non-empty `$visible` property, and `makeHidden` is only useful when you want to be explicit about what is excluded, not what is included.

Example:

I want to return an array of users with just the ID and name, hiding other attributes such as `email` and any future attributes that may be added.


```php
// This is effectively a no-op because these fields are not typically hidden.
$users->makeVisible(['id', 'name'])->toArray(); ❌
/*
[
    [
        'id' => 1,
        'name' => 'Test User',
        'email' => 'test@example.com'
    ]
]
*/

// This only gives us the desired result until a new non-hidden attribute is added to the model.
$users->makeHidden(['email'])->toArray(); 😐️
/*
[
    [
        'id' => 1,
        'name' => 'Test User',
    ]
]
*/

// This allows us to be explicit about the data we want, and it won't leak as new attributes are added to the model.
$users->setVisible(['id', 'name'])->toArray(); ✅
/*
[
    [
        'id' => 1,
        'name' => 'Test User',
    ]
]
*/
```

This is especially useful when passing collections to Inertia.