### PR TITLE
[10.x] upgarde egulias/EmailValidator to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-openssl": "*",
         "doctrine/inflector": "^2.0.6",
         "dragonmantank/cron-expression": "^3.3.2",
-        "egulias/email-validator": "^3.2.5",
+        "egulias/email-validator": "^4.0",
         "fruitcake/php-cors": "^1.2",
         "laravel/serializable-closure": "^1.2.2",
         "league/commonmark": "^2.3.8",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "egulias/email-validator": "^3.2.1",
+        "egulias/email-validator": "^4.0",
         "illuminate/collections": "^10.0",
         "illuminate/container": "^10.0",
         "illuminate/contracts": "^10.0",


### PR DESCRIPTION
Hi,

Version 4 has been released and I don't see any breaking changes.

[egulias/EmailValidator](https://github.com/egulias/EmailValidator/releases/tag/4.0.0)