### PR TITLE
[10.x] Remove context parameter from handleError method

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -60,12 +60,11 @@ class HandleExceptions
      * @param  string  $message
      * @param  string  $file
      * @param  int  $line
-     * @param  array  $context
      * @return void
      *
      * @throws \ErrorException
      */
-    public function handleError($level, $message, $file = '', $line = 0, $context = [])
+    public function handleError($level, $message, $file = '', $line = 0)
     {
         if ($this->isDeprecation($level)) {
             $this->handleDeprecationError($message, $file, $line, $level);


### PR DESCRIPTION
This parameter has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0; see also https://www.php.net/manual/en/function.set-error-handler.php#refsect1-function.set-error-handler-parameters. 

I think it makes sense not to implement this on the framework version because of this deprecation. Targetted `10.x` as it changes the method signature.
