### PR TITLE
[9.x] Document that model encrypter can also be null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -179,7 +179,7 @@ trait HasAttributes
     /**
      * The encrypter instance that is used to encrypt attributes.
      *
-     * @var \Illuminate\Contracts\Encryption\Encrypter
+     * @var \Illuminate\Contracts\Encryption\Encrypter|null
      */
     public static $encrypter;
 
@@ -1289,7 +1289,7 @@ trait HasAttributes
     /**
      * Set the encrypter instance that will be used to encrypt attributes.
      *
-     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
+     * @param  \Illuminate\Contracts\Encryption\Encrypter|null  $encrypter
      * @return void
      */
     public static function encryptUsing($encrypter)


### PR DESCRIPTION
When using a custom encrypter for tests, you need to manually unset the encrypter after use (otherwise it might affect other tests). Since static properties cannot be unset with `unset()` the encrypter needs to be set to null (which is fine because models use `??` to use either a custom encrypter or the default).

This PR changes the documented type of the custom encrypter so PHPStan allows this:

```php
protected function tearDown(): void
{
    MyModel::encryptUsing(null);
    parent::tearDown();
}
```