### PR TITLE
[9.x] Add "incrementEach" to the Query\Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3393,32 +3393,6 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Atomically increments columns values by the given amounts.
-     *
-     * @param  array<string, float|int|numeric-string>  $columns
-     * @param  array<string, mixed>  $extra
-     * @return int
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function incrementColumns(array $columns, array $extra = [])
-    {
-        foreach ($columns as $column => $amount) {
-            if (! is_numeric($amount)) {
-                throw new InvalidArgumentException("Non-numeric value passed as increment amount for column: '$column'.");
-            }
-
-            if (! is_string($column)) {
-                throw new InvalidArgumentException('Non-associative array passed to incrementMany method.');
-            }
-
-            $columns[$column] = $this->raw("{$this->grammar->wrap($column)} + $amount");
-        }
-
-        return $this->update(array_merge($columns, $extra));
-    }
-
-    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column
@@ -3434,7 +3408,31 @@ class Builder implements BuilderContract
             throw new InvalidArgumentException('Non-numeric value passed to increment method.');
         }
 
-        return $this->incrementColumns([$column => $amount], $extra);
+        return $this->incrementEach([$column => $amount], $extra);
+    }
+
+    /**
+     * Increment the given column's values by the given amounts.
+     *
+     * @param  array<string, float|int|numeric-string>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function incrementEach(array $columns, array $extra = [])
+    {
+        foreach ($columns as $column => $amount) {
+            if (! is_numeric($amount)) {
+                throw new InvalidArgumentException("Non-numeric value passed as increment amount for column: '$column'.");
+            } elseif (! is_string($column)) {
+                throw new InvalidArgumentException('Non-associative array passed to incrementEach method.');
+            }
+
+            $columns[$column] = $this->raw("{$this->grammar->wrap($column)} + $amount");
+        }
+
+        return $this->update(array_merge($columns, $extra));
     }
 
     /**
@@ -3453,11 +3451,31 @@ class Builder implements BuilderContract
             throw new InvalidArgumentException('Non-numeric value passed to decrement method.');
         }
 
-        $wrapped = $this->grammar->wrap($column);
+        return $this->decrementEach([$column => $amount], $extra);
+    }
 
-        $columns = array_merge([$column => $this->raw("$wrapped - $amount")], $extra);
+    /**
+     * Decrement the given column's values by the given amounts.
+     *
+     * @param  array<string, float|int|numeric-string>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function decrementEach(array $columns, array $extra = [])
+    {
+        foreach ($columns as $column => $amount) {
+            if (! is_numeric($amount)) {
+                throw new InvalidArgumentException("Non-numeric value passed as decrement amount for column: '$column'.");
+            } elseif (! is_string($column)) {
+                throw new InvalidArgumentException('Non-associative array passed to decrementEach method.');
+            }
 
-        return $this->update($columns);
+            $columns[$column] = $this->raw("{$this->grammar->wrap($column)} - $amount");
+        }
+
+        return $this->update(array_merge($columns, $extra));
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3393,6 +3393,32 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Atomically increments columns values by the given amounts.
+     *
+     * @param  array<string, float|int|numeric-string>  $columns
+     * @param  array<string, mixed>  $extra
+     * @return int
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function incrementColumns(array $columns, array $extra = [])
+    {
+        foreach ($columns as $column => $amount) {
+            if (! is_numeric($amount)) {
+                throw new InvalidArgumentException("Non-numeric value passed as increment amount for column: '$column'.");
+            }
+
+            if (! is_string($column)) {
+                throw new InvalidArgumentException('Non-associative array passed to incrementMany method.');
+            }
+
+            $columns[$column] = $this->raw("{$this->grammar->wrap($column)} + $amount");
+        }
+
+        return $this->update(array_merge($columns, $extra));
+    }
+
+    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column
@@ -3408,11 +3434,7 @@ class Builder implements BuilderContract
             throw new InvalidArgumentException('Non-numeric value passed to increment method.');
         }
 
-        $wrapped = $this->grammar->wrap($column);
-
-        $columns = array_merge([$column => $this->raw("$wrapped + $amount")], $extra);
-
-        return $this->update($columns);
+        return $this->incrementColumns([$column => $amount], $extra);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1983,15 +1983,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectErrorMessage('Non-numeric value passed as increment amount for column: \'col\'.');
         $builder = $this->getBuilder();
-        $builder->from('users')->incrementColumns(['col' => 'a']);
+        $builder->from('users')->incrementEach(['col' => 'a']);
     }
 
     public function testIncrementManyArgumentValidation2()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectErrorMessage('Non-associative array passed to incrementMany method.');
+        $this->expectErrorMessage('Non-associative array passed to incrementEach method.');
         $builder = $this->getBuilder();
-        $builder->from('users')->incrementColumns([11 => 11]);
+        $builder->from('users')->incrementEach([11 => 11]);
     }
 
     public function testWhereNotWithArrayConditions()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1978,6 +1978,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 'bar', 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testIncrementManyArgumentValidation1()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Non-numeric value passed as increment amount for column: \'col\'.');
+        $builder = $this->getBuilder();
+        $builder->from('users')->incrementColumns(['col' => 'a']);
+    }
+
+    public function testIncrementManyArgumentValidation2()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Non-associative array passed to incrementMany method.');
+        $builder = $this->getBuilder();
+        $builder->from('users')->incrementColumns([11 => 11]);
+    }
+
     public function testWhereNotWithArrayConditions()
     {
         $builder = $this->getBuilder();

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -27,6 +27,119 @@ class QueryBuilderTest extends DatabaseTestCase
         ]);
     }
 
+    public function testIncrement()
+    {
+        Schema::create('accounting', function (Blueprint $table) {
+            $table->increments('id');
+            $table->float('wallet_1');
+            $table->float('wallet_2');
+            $table->integer('user_id');
+            $table->string('name', 20);
+        });
+
+        DB::table('accounting')->insert([
+            [
+                'wallet_1' => 100,
+                'wallet_2' => 200,
+                'user_id' => 1,
+                'name' => 'Taylor',
+            ],
+            [
+                'wallet_1' => 15,
+                'wallet_2' => 300,
+                'user_id' => 2,
+                'name' => 'Otwell',
+            ],
+        ]);
+        $connection = DB::table('accounting')->getConnection();
+        $connection->enableQueryLog();
+
+        DB::table('accounting')->where('user_id', 2)->incrementColumns([
+            'wallet_1' => 10,
+            'wallet_2' => -20,
+        ], ['name' => 'foo']);
+
+        $queryLogs = $connection->getQueryLog();
+        $this->assertCount(1, $queryLogs);
+
+        $rows = DB::table('accounting')->get();
+
+        $this->assertCount(2, $rows);
+        // other rows are not affected.
+        $this->assertEquals([
+            'id' => 1,
+            'wallet_1' => 100,
+            'wallet_2' => 200,
+            'user_id' => 1,
+            'name' => 'Taylor',
+        ], (array) $rows[0]);
+
+        $this->assertEquals([
+            'id' => 2,
+            'wallet_1' => 15 + 10,
+            'wallet_2' => 300 - 20,
+            'user_id' => 2,
+            'name' => 'foo',
+        ], (array) $rows[1]);
+
+        // without the second argument.
+        $affectedRowsCount = DB::table('accounting')->where('user_id', 2)->incrementColumns([
+            'wallet_1' => 20,
+            'wallet_2' => 20,
+        ]);
+
+        $this->assertEquals(1, $affectedRowsCount);
+
+        $rows = DB::table('accounting')->get();
+
+        $this->assertEquals([
+            'id' => 2,
+            'wallet_1' => 15 + (10 + 20),
+            'wallet_2' => 300 + (-20 + 20),
+            'user_id' => 2,
+            'name' => 'foo',
+        ], (array) $rows[1]);
+
+        // Test Can affect multiple rows at once.
+        $affectedRowsCount = DB::table('accounting')->incrementColumns([
+            'wallet_1' => 31.5,
+            'wallet_2' => '-32.5',
+        ]);
+
+        $this->assertEquals(2, $affectedRowsCount);
+
+        $rows = DB::table('accounting')->get();
+        $this->assertEquals([
+            'id' => 1,
+            'wallet_1' => 100 + 31.5,
+            'wallet_2' => 200 - 32.5,
+            'user_id' => 1,
+            'name' => 'Taylor',
+        ], (array) $rows[0]);
+
+        $this->assertEquals([
+            'id' => 2,
+            'wallet_1' => 15 + (10 + 20 + 31.5),
+            'wallet_2' => 300 + (-20 + 20 - 32.5),
+            'user_id' => 2,
+            'name' => 'foo',
+        ], (array) $rows[1]);
+
+        // In case of a conflict, the second argument wins and sets a fixed value:
+        $affectedRowsCount = DB::table('accounting')->incrementColumns([
+            'wallet_1' => 3000,
+        ], ['wallet_1' => 1.5]);
+
+        $this->assertEquals(2, $affectedRowsCount);
+
+        $rows = DB::table('accounting')->get();
+
+        $this->assertEquals(1.5, $rows[0]->wallet_1);
+        $this->assertEquals(1.5, $rows[1]->wallet_1);
+
+        Schema::drop('accounting');
+    }
+
     public function testSole()
     {
         $expected = ['id' => '1', 'title' => 'Foo Post'];

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -54,7 +54,7 @@ class QueryBuilderTest extends DatabaseTestCase
         $connection = DB::table('accounting')->getConnection();
         $connection->enableQueryLog();
 
-        DB::table('accounting')->where('user_id', 2)->incrementColumns([
+        DB::table('accounting')->where('user_id', 2)->incrementEach([
             'wallet_1' => 10,
             'wallet_2' => -20,
         ], ['name' => 'foo']);
@@ -83,7 +83,7 @@ class QueryBuilderTest extends DatabaseTestCase
         ], (array) $rows[1]);
 
         // without the second argument.
-        $affectedRowsCount = DB::table('accounting')->where('user_id', 2)->incrementColumns([
+        $affectedRowsCount = DB::table('accounting')->where('user_id', 2)->incrementEach([
             'wallet_1' => 20,
             'wallet_2' => 20,
         ]);
@@ -101,7 +101,7 @@ class QueryBuilderTest extends DatabaseTestCase
         ], (array) $rows[1]);
 
         // Test Can affect multiple rows at once.
-        $affectedRowsCount = DB::table('accounting')->incrementColumns([
+        $affectedRowsCount = DB::table('accounting')->incrementEach([
             'wallet_1' => 31.5,
             'wallet_2' => '-32.5',
         ]);
@@ -126,7 +126,7 @@ class QueryBuilderTest extends DatabaseTestCase
         ], (array) $rows[1]);
 
         // In case of a conflict, the second argument wins and sets a fixed value:
-        $affectedRowsCount = DB::table('accounting')->incrementColumns([
+        $affectedRowsCount = DB::table('accounting')->incrementEach([
             'wallet_1' => 3000,
         ], ['wallet_1' => 1.5]);
 


### PR DESCRIPTION
This is useful when the user wants to atomically increment multiple columns by a single query.
For example, subtract from `wallet1` and add the same amount to `wallet2` in order to transfer money.
```php
DB::table('users')->where('id', 2)->incrementColumns([
     'wallet_1' => -30,
     'wallet_2' => 30,
], ['updated_at' => now()]);
```
or keep a proper update of pre-calculated  columns:
```php
DB::table('products')->where('id', 2)->incrementColumns([
     'in_store' => 2,
     'in_stock' => 3,
     'total' => 5,
], ['updated_at' => now()]);
```


- The logic can be reused in `increment` to avoid code duplication.
- The method is named `incrementColumns` to indicate that it "increments many columns" (not sure if it is the best name).
- A comprehensive set of integration tests is included. Since the `increment` now uses `incrementColumns` the tests also cover it as well, plus some unit tests


