### PR TITLE
[9.x] Return rounding to decimal cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1324,10 +1324,10 @@ trait HasAttributes
     {
         if (extension_loaded('bcmath')) {
             if (((string) $value)[0] != '-') {
-                return bcadd($value, '0.' . str_repeat('0', $decimals) . '5', $decimals);
+                return bcadd($value, '0.'.str_repeat('0', $decimals).'5', $decimals);
             }
 
-            return bcsub($value, '0.' . str_repeat('0', $decimals) . '5', $decimals);
+            return bcsub($value, '0.'.str_repeat('0', $decimals).'5', $decimals);
         }
 
         if (! is_numeric($value)) {
@@ -1336,10 +1336,6 @@ trait HasAttributes
 
         if (is_string($value) && Str::contains($value, 'e', true)) {
             throw new RuntimeException('The "decimal" model cast is unable to handle string based floats with exponents.');
-        }
-
-        if ($decimals >= ini_get('precision')) {
-            throw new RuntimeException('$decimals precision is higher then floating point precision, please use ext-bcmath.');
         }
 
         return number_format($value, $decimals, '.', '');

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -141,10 +141,10 @@ class EloquentModelDecimalCastingTest extends DatabaseTestCase
         };
 
         $model->amount = '0.89898989898989898989898989898989898989898989';
-        $this->assertSame('0.89898989898989898989', $model->amount);
+        $this->assertSame('0.89898989898989898990', $model->amount);
     }
 
-    public function testItDoesntRoundNumbers()
+    public function testItRoundsNumbers()
     {
         $model = new class extends Model
         {
@@ -156,7 +156,22 @@ class EloquentModelDecimalCastingTest extends DatabaseTestCase
         };
 
         $model->amount = '0.99';
-        $this->assertSame('0.9', $model->amount);
+        $this->assertSame('1.0', $model->amount);
+    }
+
+    public function testItWorksOnNegativeNumbers()
+    {
+        $model = new class extends Model
+        {
+            public $timestamps = false;
+
+            protected $casts = [
+                'amount' => 'decimal:1',
+            ];
+        };
+
+        $model->amount = '-0.50';
+        $this->assertSame('-0.5', $model->amount);
     }
 
     public function testDecimalsAreCastable()


### PR DESCRIPTION
Alternative to https://github.com/laravel/framework/pull/45456

The initial problem was that large numbers/precision was not correct. This reverts the changes to rounding and use bcmath when preferred.
For 9.x just let it lose precision, for 10.x perhaps throw an exception, if you want to only suggest ext-bcmath instead of requiring.