### PR TITLE
[9.x] Fixes 45582 issue 🔧

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1094,6 +1094,9 @@ class Builder implements BuilderContract
             $values = $values->toArray();
         }
 
+        // To better mimic the "whereIn" method, we flatten the values
+        $values = Arr::flatten($values);
+
         foreach ($values as &$value) {
             $value = (int) $value;
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1094,7 +1094,6 @@ class Builder implements BuilderContract
             $values = $values->toArray();
         }
 
-        // To better mimic the "whereIn" method, we flatten the values
         $values = Arr::flatten($values);
 
         foreach ($values as &$value) {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -936,10 +936,44 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
+        // associative arrays as values:
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIn('id', [
+            'issue' => 45582,
+            'id' => 2,
+            3,
+        ]);
+        $this->assertSame('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 45582, 1 => 2, 2 => 3], $builder->getBindings());
+
+        // can accept some nested arrays as values.
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIn('id', [
+            ['issue' => 45582],
+            ['id' => 2],
+            [3],
+        ]);
+        $this->assertSame('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 45582, 1 => 2, 2 => 3], $builder->getBindings());
+
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', [1, 2, 3]);
         $this->assertSame('select * from "users" where "id" = ? or "id" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
+    }
+
+    public function testBasicWhereInsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIn('id', [
+            [
+                'a' => 1,
+                'b' => 1,
+            ],
+            ['c' => 2],
+            [3],
+        ]);
     }
 
     public function testBasicWhereNotIns()
@@ -998,6 +1032,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerInRaw('id', ['1a', 2]);
         $this->assertSame('select * from "users" where "id" in (1, 2)', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereIntegerInRaw('id', [
+            ['id' => '1a'],
+            ['id' => 2],
+            ['any' => '3'],
+        ]);
+        $this->assertSame('select * from "users" where "id" in (1, 2, 3)', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 


### PR DESCRIPTION
This fixes #45582 
Since the `Builder\Query` flattens the binding array before applying it a method like `whereIn` can accept an associative array as its second argument (as demonstrated in the added tests).
So to make `whereIntegerInRaw` compatible with `whereIn` we need to flatten the values before casting it to int.
@staudenmeir 

- Missing tests are added.

![image](https://user-images.githubusercontent.com/6961695/211535390-73f6782f-f17f-4f7d-9560-c0ee24a52b76.png)

- The `whereIn` method tries to avoid accepting nested arrays as `$values` with the check below, but it is not enough and can be bypassed with an input like this:
```
 ->whereIn('id', [
     ['id' => 1 ], 
     ['id' => 2 ]
 ]) 
``` 

and due to the above flattening, it will continue to work as if it was called like this:
```
->whereIn('id', [1, 2])
 ```

![image](https://user-images.githubusercontent.com/6961695/211540349-a96ca81e-962a-43d6-8d4a-1fb77e3225ce.png)

