### PR TITLE
[10.x] Allow empty Alpine x-data attribute on Blade components

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -421,7 +421,9 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             }
 
             if ($value === true) {
-                $value = $key;
+                // We make an exception for Alpine's x-data attribute. This allows us to initialize
+                // an Alpine component with empty state, e.g.: <x-button x-data @click="..."/>
+                $value = $key === 'x-data' ? '' : $key;
             }
 
             $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -421,8 +421,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             }
 
             if ($value === true) {
-                // We make an exception for Alpine's x-data attribute. This allows us to initialize
-                // an Alpine component with empty state, e.g.: <x-button x-data @click="..."/>
+                // Exception for Alpine...
                 $value = $key === 'x-data' ? '' : $key;
             }
 

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -95,6 +95,16 @@ class ViewComponentAttributeBagTest extends TestCase
         ]));
     }
 
+    public function testItMakesAnExceptionForAlpineXdata()
+    {
+        $bag = new ComponentAttributeBag([
+            'required' => true,
+            'x-data' => true,
+        ]);
+
+        $this->assertSame('required="required" x-data=""', (string) $bag);
+    }
+
     public function testAttibuteExistence()
     {
         $bag = new ComponentAttributeBag(['name' => 'test']);


### PR DESCRIPTION
When using Alpine, you can initialize a component without state like this:

```blade
<button x-data @click="$event.target.innerHTML += '!'">Click me</button>
```

You'd assume you can do the same when using a Blade component:

```blade
<x-button x-data @click="$event.target.innerHTML += '!'">Click me</x-button>
```

But alas, the Blade component above causes the following console error:

<img width="635" alt="image" src="https://user-images.githubusercontent.com/7202674/211543173-75355bda-2265-4634-be54-d6bf8193dd37.png">

As you can see in the screenshot above, the attribute gets rendered as `x-data="x-data"`, which causes an error. For other attributes, this behavior works as intended, like with `required="required"` on a radiobutton.

This PR makes a specific exception for Alpine so that an empty `x-data` attribute is rendered as `x-data=""`, which is valid and doesn't cause an error.

I know this isn't the most elegant solution, but since Alpine (and its close cousin Livewire, which in v3 is based around Alpine if I'm not mistaken) are widely used in the Laravel community, it seemed to me that making this exception is worth it.
