### PR TITLE
[9.x] add `alwaysBail` option for validator

### DIFF
--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -11,6 +11,7 @@ namespace Illuminate\Support\Facades;
  * @method static void replacer(string $rule, \Closure|string $replacer)
  * @method static void includeUnvalidatedArrayKeys()
  * @method static void excludeUnvalidatedArrayKeys()
+ * @method static void alwaysBail(bool $alwaysBail = true)
  * @method static void resolver(\Closure $resolver)
  * @method static \Illuminate\Contracts\Translation\Translator getTranslator()
  * @method static \Illuminate\Validation\PresenceVerifierInterface getPresenceVerifier()

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -74,6 +74,13 @@ class Factory implements FactoryContract
     protected $excludeUnvalidatedArrayKeys = true;
 
     /**
+     * Indicates that the validation should always stop on the first rule failure.
+     *
+     * @var bool
+     */
+    protected $alwaysBail = false;
+
+    /**
      * The Validator resolver instance.
      *
      * @var \Closure
@@ -123,6 +130,8 @@ class Factory implements FactoryContract
         }
 
         $validator->excludeUnvalidatedArrayKeys = $this->excludeUnvalidatedArrayKeys;
+
+        $validator->alwaysBail = $this->alwaysBail;
 
         $this->addExtensions($validator);
 
@@ -266,6 +275,16 @@ class Factory implements FactoryContract
     public function excludeUnvalidatedArrayKeys()
     {
         $this->excludeUnvalidatedArrayKeys = true;
+    }
+
+    /**
+     * Indicates that the validation should always stop on the first rule failure.
+     *
+     * @return void
+     */
+    public function alwaysBail($alwaysBail = true)
+    {
+        $this->alwaysBail = $alwaysBail;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -166,6 +166,13 @@ class Validator implements ValidatorContract
     public $excludeUnvalidatedArrayKeys = false;
 
     /**
+     * Indicates that the validation should always stop on the first rule failure.
+     *
+     * @var bool
+     */
+    public $alwaysBail = false;
+
+    /**
      * All of the custom validator extensions.
      *
      * @var array
@@ -842,7 +849,7 @@ class Validator implements ValidatorContract
     {
         $cleanedAttribute = $this->replacePlaceholderInString($attribute);
 
-        if ($this->hasRule($attribute, ['Bail'])) {
+        if ($this->hasRule($attribute, ['Bail']) || $this->alwaysBail) {
             return $this->messages->has($cleanedAttribute);
         }
 


### PR DESCRIPTION
By default Inertia shares only the first validation error, so there is no point in further validating the field if won't be displayed (especially if the following validation rules are querying the database).

This PR adds an option to always stop running the validation rules for the field after the first failure, without having to specify `bail` it in the validation rules.

Usage:
AppServiceProvider.php
```php 
use Illuminate\Support\Facades\Validator;

public function boot()
{
    Validator::alwaysBail();

    // or pass in a boolean
    
     Validator::alwaysBail(! Str::startsWith(request()->path(), 'api'));
}
```