### PR TITLE
[9.x] HasManyThrough - Cursor DocBlock

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -549,7 +549,7 @@ class HasManyThrough extends Relation
     /**
      * Get a generator for the given query.
      *
-     * @return \Generator
+     * @return \Illuminate\Support\LazyCollection
      */
     public function cursor()
     {


### PR DESCRIPTION
In order to support IDE completion HasManyThrough - Cursor should return `Illuminate\Support\LazyCollection`