### PR TITLE
[9.x] Added `elapsed` method in Benchmark

### DIFF
--- a/src/Illuminate/Support/Benchmark.php
+++ b/src/Illuminate/Support/Benchmark.php
@@ -47,4 +47,29 @@ class Benchmark
 
         dd($result);
     }
+    
+    
+    /**
+     * Measure elapsed time of a callback, then dump and die.
+     *
+     * @param  \Closure $callback
+     * @param  int  $iterations
+     * @return never
+     */
+    public static function elapsed(Closure $callback, int $iterations = 1): void
+    {
+        $start = hrtime(true);
+
+        for ($i = 0; $i < $iterations; ++$i) {
+            $callback();
+        }
+        
+        $end = hrtime(true);
+
+        $eta = $end - $start;
+
+        $eta /= 1e+6;
+
+        dd($eta);
+    }
 }


### PR DESCRIPTION
Both `measure` and `dd` methods in Benchmark class return an 'average' time of the given callback https://github.com/laravel/framework/issues/45587

So i added the `elapsed` method for getting overall 'elapsed time' of the give callback. Good for when you want to measure execution times of statements over multiple iterations. [Credit](https://stackoverflow.com/a/69572700/9341962)