### PR TITLE
[9.x] BelongsToMany with custom pivot model: load key column if model is incrementing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -340,7 +340,7 @@ class BelongsToMany extends Relation
     /**
      * If the custom pivot model is incrementing, load the key column as pivot column.
      * 
-     * @param string $class 
+     * @param  string  $class 
      * @return $this 
      */
     protected function loadKeyColumnIfAvailable(string $class)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -334,6 +334,23 @@ class BelongsToMany extends Relation
     {
         $this->using = $class;
 
+        return $this->loadKeyColumnIfAvailable($class);
+    }
+
+    /**
+     * If the custom pivot model is incrementing, load the key column as pivot column.
+     * 
+     * @param string $class 
+     * @return $this 
+     */
+    protected function loadKeyColumnIfAvailable(string $class)
+    {
+        $instance = new $class;
+
+        if ($instance instanceof Model && $instance->incrementing) {
+            return $this->withPivot($instance->getKeyName());
+        }
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -339,9 +339,9 @@ class BelongsToMany extends Relation
 
     /**
      * If the custom pivot model is incrementing, load the key column as pivot column.
-     * 
-     * @param  string  $class 
-     * @return $this 
+     *
+     * @param  string  $class
+     * @return $this
      */
     protected function loadKeyColumnIfAvailable(string $class)
     {


### PR DESCRIPTION
With a custom pivot model that has `$incrementing = true`, the key column should be selected by default instead of having to do a manual `->withPivot('id')`. I described it more in #45593 with an example repository linked. 