### PR TITLE
[10.x] Add support for getting native column type

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -4,16 +4,5 @@ namespace Illuminate\Database\Query\Processors;
 
 class MySqlProcessor extends Processor
 {
-    /**
-     * Process the results of a column listing query.
-     *
-     * @param  array  $results
-     * @return array
-     */
-    public function processColumnListing($results)
-    {
-        return array_map(function ($result) {
-            return ((object) $result)->column_name;
-        }, $results);
-    }
+
 }

--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -4,5 +4,4 @@ namespace Illuminate\Database\Query\Processors;
 
 class MySqlProcessor extends Processor
 {
-
 }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -42,17 +42,12 @@ class PostgresProcessor extends Processor
             $result = (object) $result;
 
             $type = match ($typeName = $result->type_name) {
-                'bit', 'bit varying', 'character', 'character varying'
-                    => is_null($result->length) ? $typeName : $typeName."($result->length)",
-                'numeric' => is_null($result->total) ? $typeName : $typeName."($result->total, $result->places)",
-                'time without time zone'
-                    => is_null($result->precision) ? $typeName : "time($result->precision) without time zone",
-                'time with time zone'
-                    => is_null($result->precision) ? $typeName : "time($result->precision) with time zone",
-                'timestamp without time zone'
-                    => is_null($result->precision) ? $typeName : "timestamp($result->precision) without time zone",
-                'timestamp with time zone'
-                    => is_null($result->precision) ? $typeName : "timestamp($result->precision) with time zone",
+                'bit', 'bit varying', 'character', 'character varying' => is_null($result->length) ? $typeName : $typeName."($result->length)",
+                'numeric' => is_null($result->total) ? $typeName : $typeName."($result->total,$result->places)",
+                'time without time zone' => is_null($result->precision) ? $typeName : "time($result->precision) without time zone",
+                'time with time zone' => is_null($result->precision) ? $typeName : "time($result->precision) with time zone",
+                'timestamp without time zone' => is_null($result->precision) ? $typeName : "timestamp($result->precision) without time zone",
+                'timestamp with time zone' => is_null($result->precision) ? $typeName : "timestamp($result->precision) with time zone",
                 default => $typeName,
             };
 

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -42,8 +42,16 @@ class Processor
      * @param  array  $results
      * @return array
      */
-    public function processColumnListing($results)
+    public function processColumns($results)
     {
-        return $results;
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name,
+                'type_name' => $result->type_name,
+                'type' => $result->type,
+            ];
+        }, $results);
     }
 }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -10,10 +10,16 @@ class SQLiteProcessor extends Processor
      * @param  array  $results
      * @return array
      */
-    public function processColumnListing($results)
+    public function processColumns($results)
     {
         return array_map(function ($result) {
-            return ((object) $result)->name;
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name,
+                'type_name' => strtok($result->type, '('),
+                'type' => $result->type,
+            ];
         }, $results);
     }
 }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -15,10 +15,12 @@ class SQLiteProcessor extends Processor
         return array_map(function ($result) {
             $result = (object) $result;
 
+            $type = strtolower($result->type);
+
             return [
                 'name' => $result->name,
-                'type_name' => strtok($result->type, '('),
-                'type' => $result->type,
+                'type_name' => strtok($type, '('),
+                'type' => $type,
             ];
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -61,10 +61,24 @@ class SqlServerProcessor extends Processor
      * @param  array  $results
      * @return array
      */
-    public function processColumnListing($results)
+    public function processColumns($results)
     {
         return array_map(function ($result) {
-            return ((object) $result)->name;
+            $result = (object) $result;
+
+            $type = match ($typeName = $result->type_name) {
+                'binary', 'varbinary', 'char', 'varchar', 'nchar', 'nvarchar'
+                    => $result->length == -1 ? $typeName."(max)" : $typeName."($result->length)",
+                'decimal', 'numeric' => $typeName."($result->precision, $result->places)",
+                'float', 'datetime2', 'datetimeoffset', 'time' => $typeName."($result->precision)",
+                default => $typeName,
+            };
+
+            return [
+                'name' => $result->name,
+                'type_name' => $result->type_name,
+                'type' => $type,
+            ];
         }, $results);
     }
 }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -67,9 +67,8 @@ class SqlServerProcessor extends Processor
             $result = (object) $result;
 
             $type = match ($typeName = $result->type_name) {
-                'binary', 'varbinary', 'char', 'varchar', 'nchar', 'nvarchar'
-                    => $result->length == -1 ? $typeName."(max)" : $typeName."($result->length)",
-                'decimal', 'numeric' => $typeName."($result->precision, $result->places)",
+                'binary', 'varbinary', 'char', 'varchar', 'nchar', 'nvarchar' => $result->length == -1 ? $typeName."(max)" : $typeName."($result->length)",
+                'decimal', 'numeric' => $typeName."($result->precision,$result->places)",
                 'float', 'datetime2', 'datetimeoffset', 'time' => $typeName."($result->precision)",
                 default => $typeName,
             };

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -67,7 +67,7 @@ class SqlServerProcessor extends Processor
             $result = (object) $result;
 
             $type = match ($typeName = $result->type_name) {
-                'binary', 'varbinary', 'char', 'varchar', 'nchar', 'nvarchar' => $result->length == -1 ? $typeName."(max)" : $typeName."($result->length)",
+                'binary', 'varbinary', 'char', 'varchar', 'nchar', 'nvarchar' => $result->length == -1 ? $typeName.'(max)' : $typeName."($result->length)",
                 'decimal', 'numeric' => $typeName."($result->precision,$result->places)",
                 'float', 'datetime2', 'datetimeoffset', 'time' => $typeName."($result->precision)",
                 default => $typeName,

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -276,7 +276,7 @@ class Builder
      */
     public function getColumnListing($table)
     {
-        return array_map(fn($result) => $result['name'], $this->getColumns($table));
+        return array_map(fn ($result) => $result['name'], $this->getColumns($table));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -133,7 +133,9 @@ class Builder
      */
     public function createDatabase($name)
     {
-        throw new LogicException('This database driver does not support creating databases.');
+        return $this->connection->statement(
+            $this->grammar->compileCreateDatabase($name, $this->connection)
+        );
     }
 
     /**
@@ -146,7 +148,9 @@ class Builder
      */
     public function dropDatabaseIfExists($name)
     {
-        throw new LogicException('This database driver does not support dropping databases.');
+        return $this->connection->statement(
+            $this->grammar->compileDropDatabaseIfExists($name)
+        );
     }
 
     /**
@@ -160,7 +164,7 @@ class Builder
         $table = $this->connection->getTablePrefix().$table;
 
         return count($this->connection->selectFromWriteConnection(
-            $this->grammar->compileTableExists(), [$table]
+            $this->grammar->compileTableExists($table)
         )) > 0;
     }
 
@@ -364,13 +368,25 @@ class Builder
     /**
      * Get all of the table names for the database.
      *
-     * @return void
-     *
-     * @throws \LogicException
+     * @return array
      */
     public function getAllTables()
     {
-        throw new LogicException('This database driver does not support getting all tables.');
+        return $this->connection->select(
+            $this->grammar->compileGetAllTables()
+        );
+    }
+
+    /**
+     * Get all of the view names for the database.
+     *
+     * @return array
+     */
+    public function getAllViews()
+    {
+        return $this->connection->select(
+            $this->grammar->compileGetAllViews()
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -68,11 +68,17 @@ class MySqlGrammar extends Grammar
     /**
      * Compile the query to determine the list of tables.
      *
+     * @param  string  $database
+     * @param  string  $table
      * @return string
      */
-    public function compileTableExists()
+    public function compileTableExists($database, $table)
     {
-        return "select * from information_schema.tables where table_schema = ? and table_name = ? and table_type = 'BASE TABLE'";
+        return sprintf(
+            "select * from information_schema.tables where table_schema = %s and table_name = %s and table_type = 'BASE TABLE'",
+            $this->quoteString($database),
+            $this->quoteString($table)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -84,11 +84,18 @@ class MySqlGrammar extends Grammar
     /**
      * Compile the query to determine the list of columns.
      *
+     * @param  string  $database
+     * @param  string  $table
      * @return string
      */
-    public function compileColumnListing()
+    public function compileColumns($database, $table)
     {
-        return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?';
+        return sprintf(
+            'select column_name as `name`, column_type as `type`, data_type as `type_name` '
+                .'from information_schema.columns where table_schema = %s and table_name = %s',
+            $this->quoteString($database),
+            $this->quoteString($table)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -89,11 +89,21 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the query to determine the list of columns.
      *
+     * @param  string  $database
+     * @param  string  $schema
+     * @param  string  $table
      * @return string
      */
-    public function compileColumnListing()
+    public function compileColumns($database, $schema, $table)
     {
-        return 'select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?';
+        return sprintf(
+            'select column_name as "name", data_type as "type_name", '
+                .'character_maximum_length as "length", numeric_precision as "total", numeric_scale as "places", datetime_precision as "precision" '
+                .'from information_schema.columns where table_catalog = %s and table_schema = %s and table_name = %s',
+            $this->quoteString($database),
+            $this->quoteString($schema),
+            $this->quoteString($table)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -71,11 +71,19 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the query to determine if a table exists.
      *
+     * @param  string  $database
+     * @param  string  $schema
+     * @param  string  $table
      * @return string
      */
-    public function compileTableExists()
+    public function compileTableExists($database, $schema, $table)
     {
-        return "select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'";
+        return sprintf(
+            "select * from information_schema.tables where table_catalog = %s and table_schema = %s and table_name = %s and table_type = 'BASE TABLE'",
+            $this->quoteString($database),
+            $this->quoteString($schema),
+            $this->quoteString($table)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -29,11 +29,12 @@ class SQLiteGrammar extends Grammar
     /**
      * Compile the query to determine if a table exists.
      *
+     * @param  string  $table
      * @return string
      */
-    public function compileTableExists()
+    public function compileTableExists($table)
     {
-        return "select * from sqlite_master where type = 'table' and name = ?";
+        return "select * from sqlite_master where type = 'table' and name = ".$this->quoteString($table);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -43,7 +43,7 @@ class SQLiteGrammar extends Grammar
      * @param  string  $table
      * @return string
      */
-    public function compileColumnListing($table)
+    public function compileColumns($table)
     {
         return 'pragma table_info('.$this->wrap(str_replace('.', '__', $table)).')';
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -69,11 +69,15 @@ class SqlServerGrammar extends Grammar
     /**
      * Compile the query to determine if a table exists.
      *
+     * @param  string  $table
      * @return string
      */
-    public function compileTableExists()
+    public function compileTableExists($table)
     {
-        return "select * from sys.sysobjects where id = object_id(?) and xtype in ('U', 'V')";
+        return sprintf(
+            "select * from sys.sysobjects where id = object_id(%s) and xtype in ('U', 'V')",
+            $this->quoteString($table)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -86,9 +86,15 @@ class SqlServerGrammar extends Grammar
      * @param  string  $table
      * @return string
      */
-    public function compileColumnListing($table)
+    public function compileColumns($table)
     {
-        return "select name from sys.columns where object_id = object_id('$table')";
+        return sprintf(
+            'select col.name as name, type.name as type_name, '
+                .'col.max_length as length, col.precision as precision, col.scale as places '
+                .'from sys.columns as col join sys.types as type on col.user_type_id = type.user_type_id '
+                .'where object_id = object_id(%s)',
+            $this->quoteString($table)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -20,20 +20,20 @@ class MySqlBuilder extends Builder
     }
 
     /**
-     * Get the column listing for a given table.
+     * Get the columns for a given table.
      *
      * @param  string  $table
      * @return array
      */
-    public function getColumnListing($table)
+    public function getColumns($table)
     {
         $table = $this->connection->getTablePrefix().$table;
 
         $results = $this->connection->selectFromWriteConnection(
-            $this->grammar->compileColumnListing(), [$this->connection->getDatabaseName(), $table]
+            $this->grammar->compileColumns($this->connection->getDatabaseName(), $table)
         );
 
-        return $this->connection->getPostProcessor()->processColumnListing($results);
+        return $this->connection->getPostProcessor()->processColumns($results);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -5,32 +5,6 @@ namespace Illuminate\Database\Schema;
 class MySqlBuilder extends Builder
 {
     /**
-     * Create a database in the schema.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function createDatabase($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileCreateDatabase($name, $this->connection)
-        );
-    }
-
-    /**
-     * Drop a database from the schema if the database exists.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function dropDatabaseIfExists($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileDropDatabaseIfExists($name)
-        );
-    }
-
-    /**
      * Determine if the given table exists.
      *
      * @param  string  $table
@@ -41,7 +15,7 @@ class MySqlBuilder extends Builder
         $table = $this->connection->getTablePrefix().$table;
 
         return count($this->connection->selectFromWriteConnection(
-            $this->grammar->compileTableExists(), [$this->connection->getDatabaseName(), $table]
+            $this->grammar->compileTableExists($this->connection->getDatabaseName(), $table)
         )) > 0;
     }
 
@@ -111,30 +85,6 @@ class MySqlBuilder extends Builder
 
         $this->connection->statement(
             $this->grammar->compileDropAllViews($views)
-        );
-    }
-
-    /**
-     * Get all of the table names for the database.
-     *
-     * @return array
-     */
-    public function getAllTables()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllTables()
-        );
-    }
-
-    /**
-     * Get all of the view names for the database.
-     *
-     * @return array
-     */
-    public function getAllViews()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllViews()
         );
     }
 }

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -11,32 +11,6 @@ class PostgresBuilder extends Builder
     }
 
     /**
-     * Create a database in the schema.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function createDatabase($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileCreateDatabase($name, $this->connection)
-        );
-    }
-
-    /**
-     * Drop a database from the schema if the database exists.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function dropDatabaseIfExists($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileDropDatabaseIfExists($name)
-        );
-    }
-
-    /**
      * Determine if the given table exists.
      *
      * @param  string  $table
@@ -49,7 +23,7 @@ class PostgresBuilder extends Builder
         $table = $this->connection->getTablePrefix().$table;
 
         return count($this->connection->selectFromWriteConnection(
-            $this->grammar->compileTableExists(), [$database, $schema, $table]
+            $this->grammar->compileTableExists($database, $schema, $table)
         )) > 0;
     }
 

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -150,22 +150,22 @@ class PostgresBuilder extends Builder
     }
 
     /**
-     * Get the column listing for a given table.
+     * Get the columns for a given table.
      *
      * @param  string  $table
      * @return array
      */
-    public function getColumnListing($table)
+    public function getColumns($table)
     {
         [$database, $schema, $table] = $this->parseSchemaAndTable($table);
 
         $table = $this->connection->getTablePrefix().$table;
 
         $results = $this->connection->selectFromWriteConnection(
-            $this->grammar->compileColumnListing(), [$database, $schema, $table]
+            $this->grammar->compileColumns($database, $schema, $table)
         );
 
-        return $this->connection->getPostProcessor()->processColumnListing($results);
+        return $this->connection->getPostProcessor()->processColumns($results);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SQLiteBuilder.php
+++ b/src/Illuminate/Database/Schema/SQLiteBuilder.php
@@ -67,30 +67,6 @@ class SQLiteBuilder extends Builder
     }
 
     /**
-     * Get all of the table names for the database.
-     *
-     * @return array
-     */
-    public function getAllTables()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllTables()
-        );
-    }
-
-    /**
-     * Get all of the view names for the database.
-     *
-     * @return array
-     */
-    public function getAllViews()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllViews()
-        );
-    }
-
-    /**
      * Empty the database file.
      *
      * @return void

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -5,32 +5,6 @@ namespace Illuminate\Database\Schema;
 class SqlServerBuilder extends Builder
 {
     /**
-     * Create a database in the schema.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function createDatabase($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileCreateDatabase($name, $this->connection)
-        );
-    }
-
-    /**
-     * Drop a database from the schema if the database exists.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function dropDatabaseIfExists($name)
-    {
-        return $this->connection->statement(
-            $this->grammar->compileDropDatabaseIfExists($name)
-        );
-    }
-
-    /**
      * Drop all tables from the database.
      *
      * @return void
@@ -50,29 +24,5 @@ class SqlServerBuilder extends Builder
     public function dropAllViews()
     {
         $this->connection->statement($this->grammar->compileDropAllViews());
-    }
-
-    /**
-     * Drop all tables from the database.
-     *
-     * @return array
-     */
-    public function getAllTables()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllTables()
-        );
-    }
-
-    /**
-     * Get all of the view names for the database.
-     *
-     * @return array
-     */
-    public function getAllViews()
-    {
-        return $this->connection->select(
-            $this->grammar->compileGetAllViews()
-        );
     }
 }

--- a/tests/Database/DatabaseMySQLSchemaBuilderTest.php
+++ b/tests/Database/DatabaseMySQLSchemaBuilderTest.php
@@ -23,9 +23,9 @@ class DatabaseMySQLSchemaBuilderTest extends TestCase
         $connection->shouldReceive('getDatabaseName')->andReturn('db');
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = new MySqlBuilder($connection);
-        $grammar->shouldReceive('compileTableExists')->once()->andReturn('sql');
+        $grammar->shouldReceive('compileTableExists')->once()->with('db', 'prefix_table')->andReturn('sql');
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
-        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql', ['db', 'prefix_table'])->andReturn(['prefix_table']);
+        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql')->andReturn(['prefix_table']);
 
         $this->assertTrue($builder->hasTable('table'));
     }

--- a/tests/Database/DatabaseMySQLSchemaBuilderTest.php
+++ b/tests/Database/DatabaseMySQLSchemaBuilderTest.php
@@ -38,11 +38,11 @@ class DatabaseMySQLSchemaBuilderTest extends TestCase
         $connection->shouldReceive('getDatabaseName')->andReturn('db');
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $grammar->shouldReceive('compileColumnListing')->once()->andReturn('sql');
-        $processor->shouldReceive('processColumnListing')->once()->andReturn(['column']);
+        $grammar->shouldReceive('compileColumns')->once()->with('db', 'prefix_table')->andReturn('sql');
+        $processor->shouldReceive('processColumns')->once()->andReturn([['name' => 'column']]);
         $builder = new MySqlBuilder($connection);
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
-        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql', ['db', 'prefix_table'])->andReturn(['column']);
+        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql')->andReturn([['name' => 'column']]);
 
         $this->assertEquals(['column'], $builder->getColumnListing('table'));
     }

--- a/tests/Database/DatabaseMySqlProcessorTest.php
+++ b/tests/Database/DatabaseMySqlProcessorTest.php
@@ -7,18 +7,26 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseMySqlProcessorTest extends TestCase
 {
-    public function testProcessColumnListing()
+    public function testProcessColumns()
     {
         $processor = new MySqlProcessor;
-        $listing = [['column_name' => 'id'], ['column_name' => 'name'], ['column_name' => 'email']];
-        $expected = ['id', 'name', 'email'];
-        $this->assertEquals($expected, $processor->processColumnListing($listing));
+        $listing = [
+            ['name' => 'id', 'type_name' => 'bigint', 'type' => 'bigint'],
+            ['name' => 'name', 'type_name' => 'varchar', 'type' => 'varchar(100)'],
+            ['name' => 'email', 'type_name' => 'varchar', 'type' => 'varchar(100)'],
+        ];
+        $expected = [
+            ['name' => 'id', 'type_name' => 'bigint', 'type' => 'bigint'],
+            ['name' => 'name', 'type_name' => 'varchar', 'type' => 'varchar(100)'],
+            ['name' => 'email', 'type_name' => 'varchar', 'type' => 'varchar(100)'],
+        ];
+        $this->assertEquals($expected, $processor->processColumns($listing));
 
         // convert listing to objects to simulate PDO::FETCH_CLASS
         foreach ($listing as &$row) {
             $row = (object) $row;
         }
 
-        $this->assertEquals($expected, $processor->processColumnListing($listing));
+        $this->assertEquals($expected, $processor->processColumns($listing));
     }
 }

--- a/tests/Database/DatabasePostgresBuilderTest.php
+++ b/tests/Database/DatabasePostgresBuilderTest.php
@@ -146,13 +146,13 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('schema')->andReturn(null);
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
-        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['laravel', 'public', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileColumns')->with('laravel', 'public', 'foo')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?')->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $processor->shouldReceive('processColumns')->andReturn([['name' => 'some_column']]);
         $builder = $this->getBuilder($connection);
 
         $builder->getColumnListing('foo');
@@ -164,13 +164,13 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('myapp,public');
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
-        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileColumns')->with('laravel', 'myapp', 'foo')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?')->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $processor->shouldReceive('processColumns')->andReturn([['name' => 'some_column']]);
         $builder = $this->getBuilder($connection);
 
         $builder->getColumnListing('foo');
@@ -183,13 +183,13 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('$user');
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
-        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['laravel', 'foouser', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileColumns')->with('laravel', 'foouser', 'foo')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?')->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $processor->shouldReceive('processColumns')->andReturn([['name' => 'some_column']]);
         $builder = $this->getBuilder($connection);
 
         $builder->getColumnListing('foo');
@@ -201,13 +201,13 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
-        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileColumns')->with('laravel', 'myapp', 'foo')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?')->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $processor->shouldReceive('processColumns')->andReturn([['name' => 'some_column']]);
         $builder = $this->getBuilder($connection);
 
         $builder->getColumnListing('myapp.foo');
@@ -219,13 +219,13 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileColumnListing')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
-        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', ['mydatabase', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileColumns')->with('mydatabase', 'myapp', 'foo')->andReturn('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?');
+        $connection->shouldReceive('selectFromWriteConnection')->with('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?')->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $processor = m::mock(PostgresProcessor::class);
         $connection->shouldReceive('getPostProcessor')->andReturn($processor);
-        $processor->shouldReceive('processColumnListing')->andReturn(['some_column']);
+        $processor->shouldReceive('processColumns')->andReturn([['name' => 'some_column']]);
         $builder = $this->getBuilder($connection);
 
         $builder->getColumnListing('mydatabase.myapp.foo');

--- a/tests/Database/DatabasePostgresBuilderTest.php
+++ b/tests/Database/DatabasePostgresBuilderTest.php
@@ -53,8 +53,8 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('schema')->andReturn(null);
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
-        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['laravel', 'public', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileTableExists')->with('laravel', 'public', 'foo')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'")->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $builder = $this->getBuilder($connection);
@@ -68,8 +68,8 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('myapp,public');
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
-        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileTableExists')->with('laravel', 'myapp', 'foo')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'")->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $builder = $this->getBuilder($connection);
@@ -84,8 +84,8 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('schema')->andReturn(['myapp', 'public']);
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
-        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileTableExists')->with('laravel', 'myapp', 'foo')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'")->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $builder = $this->getBuilder($connection);
@@ -100,8 +100,8 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('$user');
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
-        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['laravel', 'foouser', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileTableExists')->with('laravel', 'foouser', 'foo')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'")->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $builder = $this->getBuilder($connection);
@@ -115,8 +115,8 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
-        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['laravel', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileTableExists')->with('laravel', 'myapp', 'foo')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'")->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $builder = $this->getBuilder($connection);
@@ -130,8 +130,8 @@ class DatabasePostgresBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
         $grammar = m::mock(PostgresGrammar::class);
         $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
-        $grammar->shouldReceive('compileTableExists')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
-        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'", ['mydatabase', 'myapp', 'foo'])->andReturn(['countable_result']);
+        $grammar->shouldReceive('compileTableExists')->with('mydatabase', 'myapp', 'foo')->andReturn("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'");
+        $connection->shouldReceive('selectFromWriteConnection')->with("select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = 'BASE TABLE'")->andReturn(['countable_result']);
         $connection->shouldReceive('getTablePrefix');
         $connection->shouldReceive('getConfig')->with('database')->andReturn('laravel');
         $builder = $this->getBuilder($connection);

--- a/tests/Database/DatabasePostgresProcessorTest.php
+++ b/tests/Database/DatabasePostgresProcessorTest.php
@@ -20,7 +20,7 @@ class DatabasePostgresProcessorTest extends TestCase
         $expected = [
             ['name' => 'id', 'type_name' => 'bigserial', 'type' => 'bigserial'],
             ['name' => 'name', 'type_name' => 'character varying', 'type' => 'character varying(100)'],
-            ['name' => 'balance', 'type_name' => 'numeric', 'type' => 'numeric(8, 0)'],
+            ['name' => 'balance', 'type_name' => 'numeric', 'type' => 'numeric(8,0)'],
             ['name' => 'birth_date', 'type_name' => 'timestamp without time zone', 'type' => 'timestamp(6) without time zone'],
         ];
 

--- a/tests/Database/DatabasePostgresProcessorTest.php
+++ b/tests/Database/DatabasePostgresProcessorTest.php
@@ -7,20 +7,30 @@ use PHPUnit\Framework\TestCase;
 
 class DatabasePostgresProcessorTest extends TestCase
 {
-    public function testProcessColumnListing()
+    public function testProcessColumns()
     {
         $processor = new PostgresProcessor;
 
-        $listing = [['column_name' => 'id'], ['column_name' => 'name'], ['column_name' => 'email']];
-        $expected = ['id', 'name', 'email'];
+        $listing = [
+            ['name' => 'id', 'type_name' => 'bigserial', 'length' => null, 'total' => 64, 'places' => null, 'precision' => null],
+            ['name' => 'name', 'type_name' => 'character varying', 'length' => 100, 'total' => null, 'places' => null, 'precision' => null],
+            ['name' => 'balance', 'type_name' => 'numeric', 'length' => null, 'total' => 8, 'places' => 0, 'precision' => null],
+            ['name' => 'birth_date', 'type_name' => 'timestamp without time zone', 'length' => null, 'total' => null, 'places' => null, 'precision' => 6],
+        ];
+        $expected = [
+            ['name' => 'id', 'type_name' => 'bigserial', 'type' => 'bigserial'],
+            ['name' => 'name', 'type_name' => 'character varying', 'type' => 'character varying(100)'],
+            ['name' => 'balance', 'type_name' => 'numeric', 'type' => 'numeric(8, 0)'],
+            ['name' => 'birth_date', 'type_name' => 'timestamp without time zone', 'type' => 'timestamp(6) without time zone'],
+        ];
 
-        $this->assertEquals($expected, $processor->processColumnListing($listing));
+        $this->assertEquals($expected, $processor->processColumns($listing));
 
         // convert listing to objects to simulate PDO::FETCH_CLASS
         foreach ($listing as &$row) {
             $row = (object) $row;
         }
 
-        $this->assertEquals($expected, $processor->processColumnListing($listing));
+        $this->assertEquals($expected, $processor->processColumns($listing));
     }
 }

--- a/tests/Database/DatabasePostgresSchemaBuilderTest.php
+++ b/tests/Database/DatabasePostgresSchemaBuilderTest.php
@@ -44,11 +44,11 @@ class DatabasePostgresSchemaBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('database')->andReturn('db');
         $connection->shouldReceive('getConfig')->with('schema')->andReturn('schema');
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
-        $grammar->shouldReceive('compileColumnListing')->once()->andReturn('sql');
-        $processor->shouldReceive('processColumnListing')->once()->andReturn(['column']);
+        $grammar->shouldReceive('compileColumns')->with('db', 'public', 'prefix_table')->once()->andReturn('sql');
+        $processor->shouldReceive('processColumns')->once()->andReturn([['name' => 'column']]);
         $builder = new PostgresBuilder($connection);
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
-        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql', ['db', 'public', 'prefix_table'])->andReturn(['column']);
+        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql')->andReturn([['name' => 'column']]);
 
         $this->assertEquals(['column'], $builder->getColumnListing('table'));
     }

--- a/tests/Database/DatabasePostgresSchemaBuilderTest.php
+++ b/tests/Database/DatabasePostgresSchemaBuilderTest.php
@@ -26,9 +26,9 @@ class DatabasePostgresSchemaBuilderTest extends TestCase
         $connection->shouldReceive('getConfig')->with('schema')->andReturn('schema');
         $connection->shouldReceive('getConfig')->with('search_path')->andReturn('public');
         $builder = new PostgresBuilder($connection);
-        $grammar->shouldReceive('compileTableExists')->once()->andReturn('sql');
+        $grammar->shouldReceive('compileTableExists')->with('db', 'public', 'prefix_table')->once()->andReturn('sql');
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
-        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql', ['db', 'public', 'prefix_table'])->andReturn(['prefix_table']);
+        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql')->andReturn(['prefix_table']);
 
         $this->assertTrue($builder->hasTable('table'));
     }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1175,11 +1175,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame("select * from information_schema.tables where table_catalog = 'db' and table_schema = 'public' and table_name = 'table' and table_type = 'BASE TABLE'", $statement);
     }
 
-    public function testCompileColumnListing()
+    public function testCompileColumns()
     {
-        $statement = $this->getGrammar()->compileColumnListing();
+        $statement = $this->getGrammar()->compileColumns('db', 'public', 'table');
 
-        $this->assertSame('select column_name from information_schema.columns where table_catalog = ? and table_schema = ? and table_name = ?', $statement);
+        $this->assertSame("select column_name as \"name\", data_type as \"type_name\", character_maximum_length as \"length\", numeric_precision as \"total\", numeric_scale as \"places\", datetime_precision as \"precision\" from information_schema.columns where table_catalog = 'db' and table_schema = 'public' and table_name = 'table'", $statement);
     }
 
     protected function getConnection()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1170,9 +1170,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 
     public function testCompileTableExists()
     {
-        $statement = $this->getGrammar()->compileTableExists();
+        $statement = $this->getGrammar()->compileTableExists('db', 'public', 'table');
 
-        $this->assertSame('select * from information_schema.tables where table_catalog = ? and table_schema = ? and table_name = ? and table_type = \'BASE TABLE\'', $statement);
+        $this->assertSame("select * from information_schema.tables where table_catalog = 'db' and table_schema = 'public' and table_name = 'table' and table_type = 'BASE TABLE'", $statement);
     }
 
     public function testCompileColumnListing()

--- a/tests/Database/DatabaseSQLiteProcessorTest.php
+++ b/tests/Database/DatabaseSQLiteProcessorTest.php
@@ -15,7 +15,7 @@ class DatabaseSQLiteProcessorTest extends TestCase
         $expected = [
             ['name' => 'id', 'type_name' => 'integer', 'type' => 'integer'],
             ['name' => 'name', 'type_name' => 'varchar', 'type' => 'varchar'],
-            ['name' => 'is_active', 'type_name' => 'tinyint', 'type' => 'tinyint(1)']
+            ['name' => 'is_active', 'type_name' => 'tinyint', 'type' => 'tinyint(1)'],
         ];
 
         $this->assertEquals($expected, $processor->processColumns($listing));

--- a/tests/Database/DatabaseSQLiteProcessorTest.php
+++ b/tests/Database/DatabaseSQLiteProcessorTest.php
@@ -7,20 +7,24 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseSQLiteProcessorTest extends TestCase
 {
-    public function testProcessColumnListing()
+    public function testProcessColumns()
     {
         $processor = new SQLiteProcessor;
 
-        $listing = [['name' => 'id'], ['name' => 'name'], ['name' => 'email']];
-        $expected = ['id', 'name', 'email'];
+        $listing = [['name' => 'id', 'type' => 'integer'], ['name' => 'name', 'type' => 'varchar'], ['name' => 'is_active', 'type' => 'tinyint(1)']];
+        $expected = [
+            ['name' => 'id', 'type_name' => 'integer', 'type' => 'integer'],
+            ['name' => 'name', 'type_name' => 'varchar', 'type' => 'varchar'],
+            ['name' => 'is_active', 'type_name' => 'tinyint', 'type' => 'tinyint(1)']
+        ];
 
-        $this->assertEquals($expected, $processor->processColumnListing($listing));
+        $this->assertEquals($expected, $processor->processColumns($listing));
 
         // convert listing to objects to simulate PDO::FETCH_CLASS
         foreach ($listing as &$row) {
             $row = (object) $row;
         }
 
-        $this->assertEquals($expected, $processor->processColumnListing($listing));
+        $this->assertEquals($expected, $processor->processColumns($listing));
     }
 }

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Schema\Builder;
-use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -23,8 +23,8 @@ class DatabaseSchemaBuilderTest extends TestCase
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = new Builder($connection);
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('This database driver does not support creating databases.');
+        $connection->shouldReceive('statement')->with($sql = 'sql');
+        $grammar->shouldReceive('compileCreateDatabase')->with('foo', $connection)->once()->andReturn($sql);
 
         $builder->createDatabase('foo');
     }
@@ -36,8 +36,8 @@ class DatabaseSchemaBuilderTest extends TestCase
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = new Builder($connection);
 
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('This database driver does not support dropping databases.');
+        $connection->shouldReceive('statement')->with($sql = 'sql');
+        $grammar->shouldReceive('compileDropDatabaseIfExists')->with('foo')->once()->andReturn($sql);
 
         $builder->dropDatabaseIfExists('foo');
     }
@@ -48,9 +48,9 @@ class DatabaseSchemaBuilderTest extends TestCase
         $grammar = m::mock(stdClass::class);
         $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $builder = new Builder($connection);
-        $grammar->shouldReceive('compileTableExists')->once()->andReturn('sql');
+        $grammar->shouldReceive('compileTableExists')->with('prefix_table')->once()->andReturn('sql');
         $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
-        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql', ['prefix_table'])->andReturn(['prefix_table']);
+        $connection->shouldReceive('selectFromWriteConnection')->once()->with('sql')->andReturn(['prefix_table']);
 
         $this->assertTrue($builder->hasTable('table'));
     }

--- a/tests/Integration/Database/DBAL/TimestampTypeTest.php
+++ b/tests/Integration/Database/DBAL/TimestampTypeTest.php
@@ -38,9 +38,14 @@ class TimestampTypeTest extends DatabaseTestCase
 
         $this->assertTrue(Schema::hasColumn('test', 'datetime_to_timestamp'));
         // Only Postgres and MySQL actually have a timestamp type
-        in_array($this->driver, ['pgsql', 'mysql'])
-            ? $this->assertSame('timestamp', Schema::getColumnType('test', 'datetime_to_timestamp'))
-            : $this->assertSame('datetime', Schema::getColumnType('test', 'datetime_to_timestamp'));
+        $this->assertSame(
+            match ($this->driver) {
+                'mysql' => 'timestamp',
+                'pgsql' => 'timestamp without time zone',
+                default => 'datetime',
+            },
+            Schema::getColumnType('test', 'datetime_to_timestamp')
+        );
     }
 
     public function testChangeTimestampColumnToDatetimeColumn()
@@ -55,9 +60,14 @@ class TimestampTypeTest extends DatabaseTestCase
 
         $this->assertTrue(Schema::hasColumn('test', 'timestamp_to_datetime'));
         // Postgres only has a timestamp type
-        $this->driver === 'pgsql'
-            ? $this->assertSame('timestamp', Schema::getColumnType('test', 'timestamp_to_datetime'))
-            : $this->assertSame('datetime', Schema::getColumnType('test', 'timestamp_to_datetime'));
+        $this->assertSame(
+            match ($this->driver) {
+                'pgsql' => 'timestamp without time zone',
+                'mssql' => 'datetime2',
+                default => 'datetime',
+            },
+            Schema::getColumnType('test', 'timestamp_to_datetime')
+        );
     }
 
     public function testChangeStringColumnToTimestampColumn()

--- a/tests/Integration/Database/DBAL/TimestampTypeTest.php
+++ b/tests/Integration/Database/DBAL/TimestampTypeTest.php
@@ -63,7 +63,7 @@ class TimestampTypeTest extends DatabaseTestCase
         $this->assertSame(
             match ($this->driver) {
                 'pgsql' => 'timestamp without time zone',
-                'mssql' => 'datetime2',
+                'sqlsrv' => 'datetime2',
                 default => 'datetime',
             },
             Schema::getColumnType('test', 'timestamp_to_datetime')

--- a/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/MySql/DatabaseMySqlSchemaBuilderAlterTableWithEnumTest.php
@@ -42,7 +42,7 @@ class DatabaseMySqlSchemaBuilderAlterTableWithEnumTest extends MySqlTestCase
             $table->unsignedInteger('age')->charset('')->change();
         });
 
-        $this->assertSame('integer', Schema::getColumnType('users', 'age'));
+        $this->assertSame('int', Schema::getColumnType('users', 'age'));
     }
 
     public function testGetAllTablesAndColumnListing()

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -63,7 +63,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $blueprint->build($this->getConnection(), new SQLiteGrammar);
 
         $this->assertArrayHasKey(TinyInteger::NAME, Type::getTypesMap());
-        $this->assertSame('tinyinteger', Schema::getColumnType('test', 'test_column'));
+        $this->assertSame('tinyint', Schema::getColumnType('test', 'test_column'));
     }
 
     public function testRegisterCustomDoctrineTypeASecondTime()
@@ -85,7 +85,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $blueprint->build($this->getConnection(), new SQLiteGrammar);
 
         $this->assertArrayHasKey(TinyInteger::NAME, Type::getTypesMap());
-        $this->assertSame('tinyinteger', Schema::getColumnType('test', 'test_column'));
+        $this->assertSame('tinyint', Schema::getColumnType('test', 'test_column'));
     }
 
     public function testChangeToTextColumn()


### PR DESCRIPTION
Related to #45487, currently we are using Doctrine DBAL to get column type using `Schema::getColumnType` method. DBAL maps every native column type to its Doctrine type equivalent and doesn't support many column types used by Laravel on different databases.

This PR changes `Schema::getColumnType` method to return the actual column type instead of its Doctrine equivalent, also gives us the ability to write integration tests for native column modifying added on #45487. This may also be used on `db:table` and `model:show` commands.

After this PR, you'll be able to get eighter data type name or full type definition of the given column:

```php
Schema::getColumnType('products', 'id');           // bigint
Schema::getColumnType('products', 'id', true);     // bigint unsigned
Schema::getColumnType('products', 'status');       // enum
Schema::getColumnType('products', 'status', true); // enum('active','suspended','deleted')
Schema::getColumnType('products', 'name');         // varchar
Schema::getColumnType('products', 'name', true);   // varchar(255)
Schema::getColumnType('products', 'price');        // decimal
Schema::getColumnType('products', 'price', true);  // decimal(8,2)
```

PS: This PR also cleans up all `Schema\Builder` classes, many functions were overridden without change.
