### PR TITLE
 [9.x] Allow modification of the enum validation method

### DIFF
--- a/src/Illuminate/Validation/Rules/Enum.php
+++ b/src/Illuminate/Validation/Rules/Enum.php
@@ -15,14 +15,28 @@ class Enum implements Rule
     protected $type;
 
     /**
+     * The method used to translate a value into the enum.
+     *
+     * @var string
+     */
+    protected $method;
+
+    /**
      * Create a new rule instance.
      *
      * @param  string  $type
+     * @param  string  $method
      * @return void
      */
-    public function __construct($type)
+    public function __construct($type, $method = 'tryFrom')
     {
         $this->type = $type;
+        $this->method = $method;
+    }
+
+    public function method($method)
+    {
+        $this->method = $method;
     }
 
     /**
@@ -38,12 +52,12 @@ class Enum implements Rule
             return true;
         }
 
-        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type) || ! method_exists($this->type, 'tryFrom')) {
+        if (is_null($value) || ! function_exists('enum_exists') || ! enum_exists($this->type) || ! method_exists($this->type, $this->method)) {
             return false;
         }
 
         try {
-            return ! is_null($this->type::tryFrom($value));
+            return ! is_null($this->type::{$this->method}($value));
         } catch (TypeError $e) {
             return false;
         }

--- a/tests/Validation/Enums.php
+++ b/tests/Validation/Enums.php
@@ -19,3 +19,20 @@ enum PureEnum
     case one;
     case two;
 }
+
+enum MethodStatus: int
+{
+    case Pending = 1;
+    case Done = 2;
+
+    public static function tryFromName($value)
+    {
+        foreach (self::cases() as $enum) {
+            if ($enum->name === $value) {
+                return $enum;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Validation/ValidationEnumRuleTest.php
+++ b/tests/Validation/ValidationEnumRuleTest.php
@@ -20,24 +20,26 @@ if (PHP_VERSION_ID >= 80100) {
  */
 class ValidationEnumRuleTest extends TestCase
 {
-    public function testvalidationPassesWhenPassingCorrectEnum()
+    public function testValidationPassesWhenPassingCorrectEnum()
     {
         $v = new Validator(
             resolve('translator'),
             [
                 'status' => 'pending',
                 'int_status' => 1,
+                'method_status' => 'Pending',
             ],
             [
                 'status' => new Enum(StringStatus::class),
                 'int_status' => new Enum(IntegerStatus::class),
+                'method_status' => new Enum(MethodStatus::class, 'tryFromName'),
             ]
         );
 
         $this->assertFalse($v->fails());
     }
 
-    public function testvalidationPassesWhenPassingInstanceOfEnum()
+    public function testValidationPassesWhenPassingInstanceOfEnum()
     {
         $v = new Validator(
             resolve('translator'),
@@ -52,7 +54,7 @@ class ValidationEnumRuleTest extends TestCase
         $this->assertFalse($v->fails());
     }
 
-    public function testvalidationPassesWhenPassingInstanceOfPureEnum()
+    public function testValidationPassesWhenPassingInstanceOfPureEnum()
     {
         $v = new Validator(
             resolve('translator'),
@@ -169,6 +171,37 @@ class ValidationEnumRuleTest extends TestCase
             ],
             [
                 'status' => new Enum(IntegerStatus::class),
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['The selected status is invalid.'], $v->messages()->get('status'));
+    }
+
+    public function testValidationPassesWhenPassingMethodToEnum()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => 'Done',
+            ],
+            [
+                'status' => new Enum(MethodStatus::class, 'tryFromName'),
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    public function testValidationFailsWhenMethodDoesNotExist()
+    {
+        $v = new Validator(
+            resolve('translator'),
+            [
+                'status' => 'Done',
+            ],
+            [
+                'status' => new Enum(MethodStatus::class, 'doesnotexist'),
             ]
         );
 


### PR DESCRIPTION
The [current implementation of enum validation](https://github.com/hobbii/laravel-framework/blob/b6b4a19673d65401f99bee13b0db64b6c6492866/src/Illuminate/Validation/Rules/Enum.php) only relies on checking the value of the enum. However, a common pattern today is to use the value for storing in the database while using another static method for the actual lookup of the enum.

This should be used by client of the API sending a locale code (like `en`) instead of providing the value matched by the enum (`1`).

Example:

```php
enum LanguageEnum: int
{
    case English = 1;
    case German = 2;
    case French = 3;

    public function getCode(): string
    {
        return match ($this) {
            self::English => 'en',
            self::German => 'de',
            self::French => 'fr',
        };
    }

    public static function tryFromCode(string $code): ?LanguageEnum
    {
        return collect(LanguageEnum::cases())->first(fn (LanguageEnum $language) => $language->getCode() === $code);
    }

    public static function tryFromName(string $name): ?ContextTypeEnum
    {
        return collect(ContextTypeEnum::cases())->first(fn (ContextTypeEnum $language) => $language->name === $name);
    }
}
```

Before I could only rely on the integer values for the lookup:
```php
$rules = [new Enum(LanguageEnum::class)];
```

With this change I can instead rely on other methods for the lookup:

```php
$rules = [new Enum(LanguageEnum::class, 'tryFromCode')];
$rules = [new Enum(LanguageEnum::class, 'tryFromName')];
```