### PR TITLE
[9.x] Add withoutForeignKeyConstraints() to disable foreign key constraints in a callback

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -412,18 +412,20 @@ class Builder
     }
 
     /**
-     * Disable foreign key constraints in a callback.
+     * Disable foreign key constraints during the execution of a callback.
      *
      * @param  \Closure  $callback
-     * @return void
+     * @return mixed
      */
     public function withoutForeignKeyConstraints(Closure $callback)
     {
         $this->disableForeignKeyConstraints();
 
-        $callback();
+        $result = $callback();
 
         $this->enableForeignKeyConstraints();
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -412,6 +412,20 @@ class Builder
     }
 
     /**
+     * Disable foreign key constraints in a callback.
+     *
+     * @return void
+     */
+    public function withoutForeignKeyConstraints(Closure $callback)
+    {
+        $this->disableForeignKeyConstraints();
+
+        $callback();
+
+        $this->enableForeignKeyConstraints();
+    }
+
+    /**
      * Execute the blueprint to build / modify the table.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -414,6 +414,7 @@ class Builder
     /**
      * Disable foreign key constraints in a callback.
      *
+     * @param  \Closure  $callback
      * @return void
      */
     public function withoutForeignKeyConstraints(Closure $callback)


### PR DESCRIPTION
If you want to disable foreign key constraints today you:

```php
Schema::disableForeignKeyConstraints();

Schema::dropIfExists('table1');
Schema::dropIfExists('table2');

Schema::enableForeignKeyConstraints();
```

My suggestion is to add this in a callback instead of remembering to disable and enable again afterwards:

```php
Schema::withoutForeignKeyConstraints(function () {
    Schema::dropIfExists('table1');
    Schema::dropIfExists('table2');
});
```

I've not added tests, since I could not find any for `disableForeignKeyConstraints()` and `enableForeignKeyConstraints()`. If this idea is something that is interesting I could look into how to add tests for it.