### PR TITLE
[9.x] Prevent queries during response preparation

### DIFF
--- a/src/Illuminate/Routing/Events/PreparingResponse.php
+++ b/src/Illuminate/Routing/Events/PreparingResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Routing\Events;
+
+class PreparingResponse
+{
+    /**
+     * The request object.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+    /**
+     * The response object being resolved.
+     *
+     * @var mixed
+     */
+    public $response;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $response
+     */
+    public function __construct($request, $response)
+    {
+        $this->request = $request;
+
+        $this->response = $response;
+    }
+}

--- a/src/Illuminate/Routing/Events/ResponsePrepared.php
+++ b/src/Illuminate/Routing/Events/ResponsePrepared.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Routing\Events;
+
+class ResponsePrepared
+{
+    /**
+     * The request object.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+    /**
+     * The response object being resolved.
+     *
+     * @var \Symfony\Component\HttpFoundation\Response
+     */
+    public $response;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     */
+    public function __construct($request, $response)
+    {
+        $this->request = $request;
+
+        $this->response = $response;
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -15,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Events\PreparingResponse;
+use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Events\Routing;
 use Illuminate\Support\Arr;
@@ -872,7 +874,11 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function prepareResponse($request, $response)
     {
-        return static::toResponse($request, $response);
+        $this->events->dispatch(new PreparingResponse($request, $response));
+
+        return tap(static::toResponse($request, $response), function ($response) use ($request) {
+            $this->events->dispatch(new ResponsePrepared($request, $response));
+        });
     }
 
     /**

--- a/tests/Integration/Foundation/ApplicationTest.php
+++ b/tests/Integration/Foundation/ApplicationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\View;
+use Illuminate\View\ViewException;
+use Orchestra\Testbench\TestCase;
+use RuntimeException;
+
+class ApplicationTest extends TestCase
+{
+    public function testItCanThrowOnViewResolution()
+    {
+        View::addLocation(__DIR__.'/views');
+        Schema::create('foo', function ($table) {
+            $table->id();
+        });
+        Schema::create('bar', function ($table) {
+            $table->id();
+        });
+        Route::get('test-route', function () {
+            DB::table('foo')->get();
+
+            return view('bar');
+        });
+        DB::enableQueryLog();
+        $this->withoutExceptionHandling();
+
+        $this->get('test-route')->assertOk();
+        $this->assertCount(2, DB::getQueryLog());
+
+        $this->app->preventQueriesWhilePreparingResponse();
+        $this->expectException(ViewException::class);
+        $this->expectExceptionMessage('Queries are being prevented. Attempting to run query [select count(*) as aggregate from "bar"].');
+
+        $this->get('test-route');
+    }
+
+    public function testItCanThrowOnJsonResourceResolution()
+    {
+        Schema::create('foo', function ($table) {
+            $table->id();
+        });
+        Schema::create('bar', function ($table) {
+            $table->id();
+        });
+        Route::get('test-route', function () {
+            DB::table('foo')->get();
+
+            return new class('xxxx') extends JsonResource
+            {
+                public function toArray($request)
+                {
+                    return [
+                        'bar_count' => $this->when(true, DB::table('bar')->count()),
+                    ];
+                }
+            };
+        });
+        DB::enableQueryLog();
+        $this->withoutExceptionHandling();
+
+        $this->get('test-route')->assertOk();
+        $this->assertCount(2, DB::getQueryLog());
+
+        $this->app->preventQueriesWhilePreparingResponse();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Queries are being prevented. Attempting to run query [select count(*) as aggregate from "bar"].');
+
+        $this->get('test-route');
+    }
+
+    public function testItCanRunQueriesAfterResponseResolved()
+    {
+        Schema::create('foo', function ($table) {
+            $table->id();
+        });
+        Route::get('test-route', function () {
+            return new class('xxxx') extends JsonResource
+            {
+                public function toArray($request)
+                {
+                    return [
+                        //
+                    ];
+                }
+            };
+        })->middleware(TestMiddleware::class);
+        DB::enableQueryLog();
+        $this->withoutExceptionHandling();
+
+        $this->app->preventQueriesWhilePreparingResponse();
+        $this->get('test-route')->assertOk();
+
+        $this->assertCount(1, DB::getQueryLog());
+    }
+
+    public function testItcanRestoreValue()
+    {
+        Schema::create('foo', function ($table) {
+            $table->id();
+        });
+        Route::get('test-route', function () {
+            return new class('xxxx') extends JsonResource
+            {
+                public function toArray($request)
+                {
+                    return [
+                        //
+                    ];
+                }
+            };
+        })->middleware(TestMiddleware::class);
+        DB::enableQueryLog();
+        $this->withoutExceptionHandling();
+
+        $this->app->preventQueriesWhilePreparingResponse();
+        $this->app->allowQueriesWhilePreparingResponse();
+        $this->get('test-route')->assertOk();
+
+        $this->assertCount(1, DB::getQueryLog());
+    }
+}
+
+class TestMiddleware
+{
+    public function handle($request, $next)
+    {
+        tap($next($request), function () {
+            DB::table('foo')->count();
+        });
+    }
+}

--- a/tests/Integration/Foundation/views/bar.blade.php
+++ b/tests/Integration/Foundation/views/bar.blade.php
@@ -1,0 +1,1 @@
+Bar count: {{ DB::table('bar')->count() }}


### PR DESCRIPTION
Related PR of Octane: https://github.com/laravel/octane/pull/631

## The problem

In many contexts, queries within a response object can be problematic and hard to detect. The response object may be a `view()`, a `JsonResource`, or something else entirely.

Two database queries are run in the following view. For some applications this may be totally fine, while others may find this problematic from a performance / resources / conventions perspective.

```blade
@foreach(['users' => 'Users', 'teams' => 'Teams'] as $table => $title)
  <dl>
      <dt>Total {{ $title }}</dt>
      <dd>{{ DB::table($table)->count() }}</dd>
  </dl>
@endforeach
```

## The solution

To help applications detect these issues, I propose we introduce a new opt-in mechanism that will throw exceptions when a query is run while the response is being prepared.


```php
// in a service provider or middleware

App::preventQueriesWhilePreparingResponse();
```

Response preparation involves the following code: https://github.com/laravel/framework/blob/c0affdde5074514655947ecaaecc2f58ef129623/src/Illuminate/Routing/Router.php#L885-L914

If an exception is thrown while the response is passing through this method, an exception will be thrown.

This means apps can throw if a query occurs in a blade view, as seen above, or while a `JsonResource` is being resolved. The following resource would throw an exception.

```php
class TeamResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'name' => $this->name,
            'member_count' => $this->members()->count(), // query
        ];
    }
}
```

As soon as this resource is a collection, like in a `UserResource` that includes all the users teams, this will trigger a query for every team included in the resource.

There are other places where "response preparation" occurs, such as the exception handler, but this feature does not concern itself with that. It is only related to values returned from a Controller.

```php
public function show(Team $team)
{
    return TeamResource::make($team);

    return view('teams.show', ['team' => $team]);
}
```

## Doing it manually

As part of this main feature is a lower level feature for preventing queries for certain parts of an application.

```php

DB::preventQueries(function () {
   // queries here will throw an exception.
});

// queries can run again.

DB::preventQueries();

// queries here will throw an exception.

DB::allowQueries();

// queries can run again.
```

This manual mechanism is handy when an application wants to prevent queries while a view is being prepared manually. Take the following example:

```php
public function update(UpdateTeamRequest $request, Team $team)
{
    $team->update($request->validated());

    return response()->json($team);
}
```

This will allow queries to run when the `toArray` method is called even with `preventQueriesWhilePreparingResponse` in use. In this type of scenario where you are preparing the response yourself you may opt-in to prevent queries:
```php
public function update(UpdateTeamRequest $request, Team $team)
{
    $team->update($request->validated());

    return DB::preventQueries(fn () => response()->json($team));
}
```

> **Note** This could impact things like dispatching jobs to the queue. This is a sharp knife. Use wisely.