### PR TITLE
[9.x] Log facade to accept any number of arguments of any type

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -720,7 +720,7 @@ class LogManager
      */
     protected function mergeContexts($userPassedContext)
     {
-        return array_reduce($userPassedContext, function($carry, $argument) {
+        return array_reduce($userPassedContext, function ($carry, $argument) {
             if (is_array($argument)) {
                 $carry = array_merge($carry, $argument);
             } else {

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -22,7 +22,7 @@ use Throwable;
 /**
  * @mixin \Illuminate\Log\Logger
  */
-class LogManager
+class LogManager implements LoggerInterface
 {
     use ParsesLogConfiguration;
 
@@ -595,10 +595,13 @@ class LogManager
      * System is unusable.
      *
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function emergency($message, ...$context): void
+    public function emergency($message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 1);
+
         $this->driver()->emergency($message, $this->mergeContexts($context));
     }
 
@@ -609,10 +612,13 @@ class LogManager
      * trigger the SMS alerts and wake you up.
      *
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function alert($message, ...$context): void
+    public function alert($message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 1);
+
         $this->driver()->alert($message, $this->mergeContexts($context));
     }
 
@@ -622,10 +628,13 @@ class LogManager
      * Example: Application component unavailable, unexpected exception.
      *
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function critical($message, ...$context): void
+    public function critical($message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 1);
+
         $this->driver()->critical($message, $this->mergeContexts($context));
     }
 
@@ -634,10 +643,13 @@ class LogManager
      * be logged and monitored.
      *
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function error($message, ...$context): void
+    public function error($message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 1);
+
         $this->driver()->error($message, $this->mergeContexts($context));
     }
 
@@ -648,10 +660,13 @@ class LogManager
      * that are not necessarily wrong.
      *
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function warning($message, ...$context): void
+    public function warning($message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 1);
+
         $this->driver()->warning($message, $this->mergeContexts($context));
     }
 
@@ -659,10 +674,13 @@ class LogManager
      * Normal but significant events.
      *
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function notice($message, ...$context): void
+    public function notice($message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 1);
+
         $this->driver()->notice($message, $this->mergeContexts($context));
     }
 
@@ -672,10 +690,13 @@ class LogManager
      * Example: User logs in, SQL logs.
      *
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function info($message, ...$context): void
+    public function info($message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 1);
+
         $this->driver()->info($message, $this->mergeContexts($context));
     }
 
@@ -683,10 +704,13 @@ class LogManager
      * Detailed debug information.
      *
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function debug($message, ...$context): void
+    public function debug($message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 1);
+
         $this->driver()->debug($message, $this->mergeContexts($context));
     }
 
@@ -695,10 +719,13 @@ class LogManager
      *
      * @param  mixed  $level
      * @param  string  $message
+     * @param  array  $context
      * @return void
      */
-    public function log($level, $message, ...$context): void
+    public function log($level, $message, $context = []): void
     {
+        $context = array_slice(func_get_args(), 2);
+
         $this->driver()->log($level, $message, $this->mergeContexts($context));
     }
 
@@ -715,7 +742,7 @@ class LogManager
     }
 
     /**
-     * @param $userPassedContext
+     * @param  $userPassedContext
      * @return array
      */
     protected function mergeContexts($userPassedContext)

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -22,7 +22,7 @@ use Throwable;
 /**
  * @mixin \Illuminate\Log\Logger
  */
-class LogManager implements LoggerInterface
+class LogManager
 {
     use ParsesLogConfiguration;
 
@@ -595,12 +595,11 @@ class LogManager implements LoggerInterface
      * System is unusable.
      *
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function emergency($message, array $context = []): void
+    public function emergency($message, ...$context): void
     {
-        $this->driver()->emergency($message, $context);
+        $this->driver()->emergency($message, $this->mergeContexts($context));
     }
 
     /**
@@ -610,12 +609,11 @@ class LogManager implements LoggerInterface
      * trigger the SMS alerts and wake you up.
      *
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function alert($message, array $context = []): void
+    public function alert($message, ...$context): void
     {
-        $this->driver()->alert($message, $context);
+        $this->driver()->alert($message, $this->mergeContexts($context));
     }
 
     /**
@@ -624,12 +622,11 @@ class LogManager implements LoggerInterface
      * Example: Application component unavailable, unexpected exception.
      *
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function critical($message, array $context = []): void
+    public function critical($message, ...$context): void
     {
-        $this->driver()->critical($message, $context);
+        $this->driver()->critical($message, $this->mergeContexts($context));
     }
 
     /**
@@ -637,12 +634,11 @@ class LogManager implements LoggerInterface
      * be logged and monitored.
      *
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function error($message, array $context = []): void
+    public function error($message, ...$context): void
     {
-        $this->driver()->error($message, $context);
+        $this->driver()->error($message, $this->mergeContexts($context));
     }
 
     /**
@@ -652,24 +648,22 @@ class LogManager implements LoggerInterface
      * that are not necessarily wrong.
      *
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function warning($message, array $context = []): void
+    public function warning($message, ...$context): void
     {
-        $this->driver()->warning($message, $context);
+        $this->driver()->warning($message, $this->mergeContexts($context));
     }
 
     /**
      * Normal but significant events.
      *
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function notice($message, array $context = []): void
+    public function notice($message, ...$context): void
     {
-        $this->driver()->notice($message, $context);
+        $this->driver()->notice($message, $this->mergeContexts($context));
     }
 
     /**
@@ -678,24 +672,22 @@ class LogManager implements LoggerInterface
      * Example: User logs in, SQL logs.
      *
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function info($message, array $context = []): void
+    public function info($message, ...$context): void
     {
-        $this->driver()->info($message, $context);
+        $this->driver()->info($message, $this->mergeContexts($context));
     }
 
     /**
      * Detailed debug information.
      *
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function debug($message, array $context = []): void
+    public function debug($message, ...$context): void
     {
-        $this->driver()->debug($message, $context);
+        $this->driver()->debug($message, $this->mergeContexts($context));
     }
 
     /**
@@ -703,12 +695,11 @@ class LogManager implements LoggerInterface
      *
      * @param  mixed  $level
      * @param  string  $message
-     * @param  array  $context
      * @return void
      */
-    public function log($level, $message, array $context = []): void
+    public function log($level, $message, ...$context): void
     {
-        $this->driver()->log($level, $message, $context);
+        $this->driver()->log($level, $message, $this->mergeContexts($context));
     }
 
     /**
@@ -721,5 +712,22 @@ class LogManager implements LoggerInterface
     public function __call($method, $parameters)
     {
         return $this->driver()->$method(...$parameters);
+    }
+
+    /**
+     * @param $userPassedContext
+     * @return array
+     */
+    protected function mergeContexts($userPassedContext)
+    {
+        return array_reduce($userPassedContext, function($carry, $argument) {
+            if (is_array($argument)) {
+                $carry = array_merge($carry, $argument);
+            } else {
+                $carry[] = $argument;
+            }
+
+            return $carry;
+        }, []);
     }
 }

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -670,17 +670,17 @@ class LogManagerTest extends TestCase
             $context = $message->context;
         });
 
-        $object = (object)[];
+        $object = (object) [];
 
         $manager->error('foo', 'text', 15, [
-            'key' => 'value'
+            'key' => 'value',
         ], $object);
 
         $this->assertSame([
             'text',
             15,
             'key' => 'value',
-            $object
+            $object,
         ], $context);
     }
 

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -661,6 +661,29 @@ class LogManagerTest extends TestCase
         $this->assertEmpty($manager->sharedContext());
     }
 
+    public function testContextCanIncludeAnyNumberOfArguments()
+    {
+        $manager = new LogManager($this->app);
+
+        $stack = $manager->stack(['single']);
+        $stack->listen(function ($message) use (&$context) {
+            $context = $message->context;
+        });
+
+        $object = (object)[];
+
+        $manager->error('foo', 'text', 15, [
+            'key' => 'value'
+        ], $object);
+
+        $this->assertSame([
+            'text',
+            15,
+            'key' => 'value',
+            $object
+        ], $context);
+    }
+
     public function testLogManagerCreateCustomFormatterWithTap()
     {
         $config = $this->app['config'];


### PR DESCRIPTION
Log facade is one of the crucial elements of Laravel development – this is how you get feedback when things go wrong, as well as when things go well or when you just want to get some extra visibility over your app.

Laravel framework binds LogManager class under the 'log' key in its container and currently it implements a PSR LoggerInterface:
```php
public function emergency(string|\Stringable $message, array $context = []): void;
```

Where we can pass a message as well as a context - any supplemental data that we need. If we refer to the [PSR documentation](https://www.php-fig.org/psr/psr-3/):

```
1.3 Context
Every method accepts an array as context data. This is meant to hold any extraneous information that does not fit well in a string. The array can contain anything. Implementors MUST ensure they treat context data with as much lenience as possible. A given value in the context MUST NOT throw an exception nor raise any php error, warning or notice.
```

Imagine a scenario like this:
```php
try {
    $details = $api->request(); // $api is some kind of a third-party SDK
} catch (ClientException $e) {
    // $e->getResponse() might have a nice JSON error message but might have a CDN's HTML error or something else
    Log::emergency("Oh no, we got a failed API request!", json_decode($e->getResponse()->getContent()));
}
```

A very usual situation indeed – somewhere in our code we have a failing third-party integration and we want to log the output from that API, perhaps there is something useful in there that's going to help us troubleshoot this later.

The problem here is that the second parameter of Log::emergency() call HAS to be an array and if json_decode() doesn't return an array for whatever reason, our Laravel application is going to crash!

```Illuminate\Log\LogManager::emergency(): Argument #2 ($context) must be of type array, bool given, called in vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php on line 338 in vendor/psy/psysh/src/Exception/TypeErrorException.php on line 53.```

Oh, that's not nice! Remember JavaScript's console.log() command? You can pass anything to it and it's never going to kill your application:
```js
console.log('plain message')
// plain message
console.log('plain message', 123, [])
// plain message 123 []
```

The idea is simple - because we use the logging capability to troubleshoot things, the last thing we want is for the application to crash BECAUSE of the logging. I believe I should be able to pass just about anything to Log facade and it should just work in one capacity or another.

This pull-request is one of the possible implementations where I removed the "array" type from the method signatures in LogManager class. This doesn't violate the LoggerInterface contract that the class implements. Moreover, it's been done before if we look closer in the Logger class:

```php
    /**
     * @param  \Illuminate\Contracts\Support\Arrayable|\Illuminate\Contracts\Support\Jsonable|\Illuminate\Support\Stringable|array|string  $message
     * @param  array  $context
     * @return void
     */
    public function info($message, array $context = []): void
    {
        $this->writeLog(__FUNCTION__, $message, $context);
    }
```

Compare it with the actual LoggerInterface signature:

```php
    /**
     * @param string|\Stringable $message
     * @param mixed[] $context
     *
     * @return void
     */
    public function info(string|\Stringable $message, array $context = []): void;
```

As we can see the string|\Stringable type was removed from the signature so that Laravel can use the formatMessage() method later to display Stringable and Jsonable objects nicely.

I propose we do the same with the $context with the same goal - make it a bit more flexible and convenient.

With the updates proposed, I can do stuff like this:
```php
Log::emergency("Hello", $results, 'Another message');
```

And it just all goes to the log driver, to the logs. I don't have to worry about the number of arguments I pass or the types of arguments I pass (which are hard to predict sometimes). I never have to worry about Log throwing an error again.

Any feedback, opinions, and alternative implementations are welcome! :) 