### PR TITLE
[9.x] Fix session store not able to read number index array

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -98,22 +98,7 @@ class Store implements Session
      */
     protected function loadSession()
     {
-        if (empty($session = $this->readFromHandler())) {
-            return;
-        }
-
-        $attributes = [];
-        foreach ($session as $key => $value) {
-            if (array_key_exists($key, $this->attributes)) {
-                $attributes[$key] = $value;
-
-                continue;
-            }
-
-            $attributes[$key] = $value;
-        }
-
-        $this->attributes = $attributes;
+        $this->attributes = array_replace($this->attributes, $this->readFromHandler());
 
         $this->marshalErrorBag();
     }

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -98,8 +98,12 @@ class Store implements Session
      */
     protected function loadSession()
     {
+        if (empty($session = $this->readFromHandler())) {
+            return;
+        }
+
         $attributes = [];
-        foreach ($this->readFromHandler() as $key => $value) {
+        foreach ($session as $key => $value) {
             if (array_key_exists($key, $this->attributes)) {
                 $attributes[$key] = $value;
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -98,7 +98,18 @@ class Store implements Session
      */
     protected function loadSession()
     {
-        $this->attributes = array_merge($this->attributes, $this->readFromHandler());
+        $attributes = [];
+        foreach ($this->readFromHandler() as $key => $value) {
+            if (array_key_exists($key, $this->attributes)) {
+                $attributes[$key] = $value;
+
+                continue;
+            }
+
+            $attributes[$key] = $value;
+        }
+
+        $this->attributes = $attributes;
 
         $this->marshalErrorBag();
     }

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -24,11 +24,13 @@ class SessionStoreTest extends TestCase
     public function testSessionIsLoadedFromHandler()
     {
         $session = $this->getSession();
-        $session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(serialize(['foo' => 'bar', 'bagged' => ['name' => 'taylor']]));
+        $session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(serialize([9988 => 'value', 'foo' => 'bar', 'bagged' => ['name' => 'taylor']]));
         $session->start();
 
         $this->assertSame('bar', $session->get('foo'));
         $this->assertSame('baz', $session->get('bar', 'baz'));
+        $this->assertSame('value', $session->get('9988'));
+        $this->assertTrue($session->has('9988'));
         $this->assertTrue($session->has('foo'));
         $this->assertFalse($session->has('bar'));
         $this->assertTrue($session->isStarted());


### PR DESCRIPTION
when we get the number index array from the sessionhandler eg FileSessionHandler
like this

    $data = [
        999 => 'bar',
        'foo' => 'bar2'
    ];
we are not able to get 999 out because in the store class loadSession method
we are using array_merge , array merge will reset the index
https://www.php.net/manual/en/function.array-merge.php

its still possible to put the number index key and value in the store put method

```
public function put($key, $value = null)
    {
        if (! is_array($key)) {
            $key = [$key => $value];
        }

        foreach ($key as $arrayKey => $arrayValue) {
            Arr::set($this->attributes, $arrayKey, $arrayValue);
        }
    }
```
so I can put
```
put('999',''value')
```
but inside put method we build an array, php will force to cast the string 999 to number index 999
```
$key = [$key => $value];
```
as describe here:
https://stackoverflow.com/questions/4100488/a-numeric-string-as-array-key-in-php

that's why later we trigger strore class save() method those array will save to the file
```
[999=> 'value'];
```

reason why I am not using the + operator
```
$this->attributes = $this->attributes + $this->readFromHandler();
```
because previously we are using array_merge 
the  + operator ($arr + $arr2) is not merging array

issue # 
45610