### PR TITLE
[9.x] Ignore whitespaces/newlines when finding relations in `model:show` command

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -218,7 +218,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
                 $file->seek($method->getStartLine() - 1);
                 $code = '';
                 while ($file->key() < $method->getEndLine()) {
-                    $code .= $file->current();
+                    $code .= trim($file->current());
                     $file->next();
                 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `show:model` relies on reading methods' source code to finding relations. It's done by finding if the pattern `\$this->{$possibleRelationMethod}(` appears in the method.
In most situation, it would work:

```php
public function user()
{
    return $this->belongsTo(User::class);
}
```

But if there are whitespaces/newlines after `$this`, the command would failed to detect:

```php
public function user()
{
    return $this
        ->belongsTo(User::class)
        ->withDefault([
            'name' => 'Guest Author',
        ]);
}
```
[^1]

This PR fixes this issue by trimming each line of the relation method's source code, so the pattern `\$this->{$possibleRelationMethod}(` can be correctly detected.
```php
public function user(){return $this->belongsTo(User::class)->withDefault(['name' => 'Guest Author',]);}
```


[^1]: Example code from [Laravel Documentation](https://github.com/laravel/docs/blob/47c1478fabf24409e9b1cb6cffed23a91ad279a8/eloquent-relationships.md?plain=1#L266-L270)
