### PR TITLE
[9.x] Add alpha_num_ascii validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -378,6 +378,22 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute contains only one-byte alpha-numeric characters.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAlphaNumAscii($attribute, $value)
+    {
+        if (preg_match('/.*[^\x01-\x7E].*/u', $value) === 1) {
+            return false;
+        }
+
+        return $this->validateAlphaNum($attribute, $value);
+    }
+
+    /**
      * Validate that an attribute is an array.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4209,6 +4209,28 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateAlphaNumAscii()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['x' => 'asls13dlks'], ['x' => 'AlphaNumAscii']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://g232oogle.com'], ['x' => 'AlphaNumAscii']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '१२३'], ['x' => 'AlphaNumAscii']); // numbers in Hindi
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => '٧٨٩'], ['x' => 'AlphaNumAscii']); // eastern arabic numerals
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'नमस्कार'], ['x' => 'AlphaNumAscii']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => 'ＡＢＣ１２３'], ['x' => 'AlphaNumAscii']); // full-width alphanumeric
+        $this->assertTrue($v->fails());
+    }
+
     public function testValidateAlphaDash()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
The `alpha_num` rule must be used to validate that the field consists entirely of alphabetic and numeric characters.
However, in cultures such as Japan, where multibyte characters are used routinely, full-width alphanumeric characters such as `Ａ` (unicode: \uff21) or `１` (unicode: \uff11)  may be accepted as input instead of half-width alphanumeric characters such as `A` (unicode: A) or `1` (unicode: 1).
This can be converted to half-width alphanumeric characters programmatically, but it would be better if FormRequest could check it and return it as an error.

This PR implements a validation rule that checks for AlphaNum and single-byte alphanumeric characters (i.e., ASCII).

As an alternative, you can write `regex:/^[a-zA-Z0-9]$/`, but it would be easier to use if it is defined as a rule.

## Usage
```php
public function rules(): array
{
    return [
        'attribute_1' => ['alpha_num'], // 🙆‍♀ ABC123, 🙆‍♀ ＡＢＣ１２３
        'attribute_2' => ['alpha_num_ascii'], // 🙆‍♀ ABC123, 🙅‍♀ ＡＢＣ１２３
    ];
}
```