### PR TITLE
[10.x] Fix RateLimiter callback return substitution (#44820)

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -74,8 +74,12 @@ class RateLimiter
         if ($this->tooManyAttempts($key, $maxAttempts)) {
             return false;
         }
+    
+        if (is_null($result = $callback())) {
+            $result = true;
+        }
 
-        return tap($callback(), function () use ($key, $decaySeconds) {
+        return tap($result, function () use ($key, $decaySeconds) {
             $this->hit($key, $decaySeconds);
         });
     }

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -75,7 +75,7 @@ class RateLimiter
             return false;
         }
 
-        return tap($callback() ?: true, function () use ($key, $decaySeconds) {
+        return tap($callback(), function () use ($key, $decaySeconds) {
             $this->hit($key, $decaySeconds);
         });
     }


### PR DESCRIPTION
This breaking update allows users to control return values explicitly without converting to boolean and fixes the substitution of false with true.

### Bug description:

The `RateLimiter::attempt` [method](https://github.com/laravel/framework/blob/127a9caa8ed3965aeae0eb388967fc1030fc8f86/src/Illuminate/Cache/RateLimiter.php#L78) contains `?:` operator and casts the return value of `$callback` function to `true` for all list of values considered as false. 

```php
    public function attempt($key, $maxAttempts, Closure $callback, $decaySeconds = 60)
    {
        if ($this->tooManyAttempts($key, $maxAttempts)) {
            return false;
        }

        return tap($callback() ?: true, function () use ($key, $decaySeconds) {
            $this->hit($key, $decaySeconds);
        });
    }
```

### Steps To Reproduce:

```php

$return = RateLimiter::attempt('key', 10, fn() => false, 1); // $return = true, not false

$return = RateLimiter::attempt('key', 10, fn() => [], 1); // $return = true, not []
$return = RateLimiter::attempt('key', 10, fn() => 0, 1); // $return = true, not 0
$return = RateLimiter::attempt('key', 10, fn() => 0.0, 1); // $return = true, not 0.0
$return = RateLimiter::attempt('key', 10, fn() => "", 1); // $return = true, not an empty string

// etc.
```

Case: 3rd-party APIs may return empty arrays as a successful response.

Brings backward incompatibility to those who depend on `true` return. 