### PR TITLE
[9.x] Add withBasicAuth method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -110,6 +110,18 @@ trait MakesHttpRequests
     }
 
     /**
+     * Add basic auth header for the request.
+     *
+     * @param  string  $username
+     * @param  string  $password
+     * @return $this
+     */
+    public function withBasicAuth(string $username, string $password)
+    {
+        return $this->withToken(base64_encode("$username:$password"), 'Basic');
+    }
+
+    /**
      * Remove the authorization token from the request.
      *
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -110,7 +110,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * Add basic auth header for the request.
+     * Add a basic authentication header to the request with the given credentials.
      *
      * @param  string  $username
      * @param  string  $password

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -26,6 +26,25 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('Basic foobar', $this->defaultHeaders['Authorization']);
     }
 
+    public function testWithBasicAuthSetsAuthorizationHeader()
+    {
+        $callback = function ($username, $password) {
+            return base64_encode("$username:$password");
+        };
+
+        $username = "foo";
+        $password = "bar";
+
+        $this->withBasicAuth($username, $password);
+        $this->assertSame("Basic " . $callback($username, $password), $this->defaultHeaders['Authorization']);
+
+        $password = "buzz";
+
+        $this->withBasicAuth($username, $password);
+        $this->assertSame("Basic " . $callback($username, $password), $this->defaultHeaders['Authorization']);
+
+    }
+
     public function testWithoutTokenRemovesAuthorizationHeader()
     {
         $this->withToken('foobar');


### PR DESCRIPTION
This PR adds the possibility to easily attach a basic auth header in test cases. I think it can be useful when we are testing endpoints with basic auth.

So instead of this
```php
$this->withToken(base64_encode("username:password"), "Basic")->get('/');
```
We can use this
```php
$this->withBasicAuth('username', 'password')->get('/');
```