### PR TITLE
[9.x] Add `@includeWithOnly` blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -29,6 +29,19 @@ trait CompilesIncludes
     }
 
     /**
+     * Compile the includeWithOnly statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileIncludeWithOnly($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return "<?php echo \$__env->make({$expression}, [])->render(); ?>";
+    }
+
+    /**
      * Compile the include-if statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -19,6 +19,14 @@ class BladeIncludesTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
     }
 
+    public function testIncludesWithOnlyAreCompiled()
+    {
+        $this->assertSame('<?php echo $__env->make(\'foo\', [])->render(); ?>', $this->compiler->compileString("@includeWithOnly('foo')"));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((\'], [])->render(); ?>', $this->compiler->compileString("@includeWithOnly('foo', ['(('])"));
+        $this->assertSame('<?php echo $__env->make(\'foo\', [\'((a)\' => \'((a)\'], [])->render(); ?>', $this->compiler->compileString("@includeWithOnly('foo', ['((a)' => '((a)'])"));
+        $this->assertSame('<?php echo $__env->make(name(foo), [])->render(); ?>', $this->compiler->compileString('@includeWithOnly(name(foo))'));
+    }
+
     public function testIncludeIfsAreCompiled()
     {
         $this->assertSame('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));


### PR DESCRIPTION
There are times when we want to include a Blade partial, but we don't want to automatically pass all available variables to it. In other words, we don't want the Blade partial to have access to its surrounding context.  This is the default behaviour for the `@component` directive, but there is no such option for `@include*` directives.

```php
@includeWithOnly('greeting', [
    'name' => $user->name,
])
```

## Benefits
The `@includeWithOnly` directive will:
- Make it easier to move between views as the context is always passed explicitly.
- Help avoid name collisions, especially with globally available vars like `$errors`, `$app`, etc.
- Help avoid issues when `isset($variable)` is used in a view and a `$variable` with the same name is automatically and unintentionally passed from the parent context


## Why not just use `@component`?
- We do not always need slots
- `@include` syntax is simpler - it doesn't require a closing tag
- `@include` syntax has a better IDE support