### PR TITLE
[9.x] Fix cookieJar type

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -22,7 +22,7 @@ class CookieJar implements JarContract
     /**
      * The default domain (if specified).
      *
-     * @var string
+     * @var string|null
      */
     protected $domain;
 
@@ -192,7 +192,7 @@ class CookieJar implements JarContract
      * Get the path and domain, or the default values.
      *
      * @param  string  $path
-     * @param  string  $domain
+     * @param  string|null  $domain
      * @param  bool|null  $secure
      * @param  string|null  $sameSite
      * @return array
@@ -206,8 +206,8 @@ class CookieJar implements JarContract
      * Set the default path and domain for the jar.
      *
      * @param  string  $path
-     * @param  string  $domain
-     * @param  bool  $secure
+     * @param  string|null  $domain
+     * @param  bool|null  $secure
      * @param  string|null  $sameSite
      * @return $this
      */


### PR DESCRIPTION
inside the CookieServiceProvider we create the cookie instance by getting the default session config

```
 public function register()
    {
        $this->app->singleton('cookie', function ($app) {
            $config = $app->make('config')->get('session');

            return (new CookieJar)->setDefaultPathAndDomain(
                $config['path'], $config['domain'], $config['secure'], $config['same_site'] ?? null
            );
        });
    }

```

but the session config domain and secure can be null

```
<?php
return [
    'domain' => env('SESSION_DOMAIN'),
    'secure' => env('SESSION_SECURE_COOKIE'),
];

```

by default env doesn has SESSION_DOMAIN and SESSION_SECURE_COOKIE
so those value are null by default I update the method parameter type
