### PR TITLE
[10.x] Improve log mail mailer output

### DIFF
--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -33,7 +33,13 @@ class LogTransport implements TransportInterface
      */
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
-        $this->logger->debug($message->toString());
+        $string = $message->toString();
+
+        if (str_contains($string, 'Content-Transfer-Encoding: quoted-printable')) {
+            $string = quoted_printable_decode($string);
+        }
+
+        $this->logger->debug($string);
 
         return new SentMessage($message, $envelope ?? Envelope::create($message));
     }

--- a/tests/Mail/MailLogTransportTest.php
+++ b/tests/Mail/MailLogTransportTest.php
@@ -40,7 +40,7 @@ class MailLogTransportTest extends TestCase
         $message = (new Message(new Email))
             ->from('noreply@example.com', 'no-reply')
             ->to('taylor@example.com', 'Taylor')
-            ->html(<<<BODY
+            ->html(<<<'BODY'
             Hi,
 
             <a href="https://example.com/reset-password=5e113c71a4c210aff04b3fa66f1b1299">Click here to reset your password</a>.
@@ -72,7 +72,8 @@ class MailLogTransportTest extends TestCase
 
     private function getLoggedEmailMessage(Message $message): string
     {
-        $logger = new class extends NullLogger {
+        $logger = new class extends NullLogger
+        {
             public string $loggedValue = '';
 
             public function log($level, string|\Stringable $message, array $context = []): void

--- a/tests/Mail/MailLogTransportTest.php
+++ b/tests/Mail/MailLogTransportTest.php
@@ -2,12 +2,14 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Illuminate\Mail\Message;
 use Illuminate\Mail\Transport\LogTransport;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Orchestra\Testbench\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\Mime\Email;
 
 class MailLogTransportTest extends TestCase
 {
@@ -33,6 +35,29 @@ class MailLogTransportTest extends TestCase
         $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
     }
 
+    public function testItDecodesTheMessageBeforeLogging()
+    {
+        $message = (new Message(new Email))
+            ->from('noreply@example.com', 'no-reply')
+            ->to('taylor@example.com', 'Taylor')
+            ->html(<<<BODY
+            Hi,
+
+            <a href="https://example.com/reset-password=5e113c71a4c210aff04b3fa66f1b1299">Click here to reset your password</a>.
+
+            All the best,
+
+            Burt & Irving = Magic
+            BODY)
+            ->text('A text part');
+
+        $actualLoggedValue = $this->getLoggedEmailMessage($message);
+
+        $this->assertStringNotContainsString("=\r\n", $actualLoggedValue);
+        $this->assertStringContainsString('Burt & Irving = Magic', $actualLoggedValue);
+        $this->assertStringContainsString('https://example.com/reset-password=5e113c71a4c210aff04b3fa66f1b1299', $actualLoggedValue);
+    }
+
     public function testGetLogTransportWithPsrLogger()
     {
         $this->app['config']->set('mail.driver', 'log');
@@ -42,5 +67,23 @@ class MailLogTransportTest extends TestCase
         $transportLogger = app('mailer')->getSymfonyTransport()->logger();
 
         $this->assertEquals($logger, $transportLogger);
+    }
+
+    private function getLoggedEmailMessage(Message $message): string
+    {
+        $logger = new class extends NullLogger {
+            public string $loggedValue = '';
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->loggedValue = (string) $message;
+            }
+        };
+
+        (new LogTransport($logger))->send(
+            $message->getSymfonyMessage()
+        );
+
+        return $logger->loggedValue;
     }
 }

--- a/tests/Mail/MailLogTransportTest.php
+++ b/tests/Mail/MailLogTransportTest.php
@@ -47,14 +47,15 @@ class MailLogTransportTest extends TestCase
 
             All the best,
 
-            Burt & Irving = Magic
+            Burt & Irving
             BODY)
             ->text('A text part');
 
         $actualLoggedValue = $this->getLoggedEmailMessage($message);
 
         $this->assertStringNotContainsString("=\r\n", $actualLoggedValue);
-        $this->assertStringContainsString('Burt & Irving = Magic', $actualLoggedValue);
+        $this->assertStringContainsString('href=', $actualLoggedValue);
+        $this->assertStringContainsString('Burt & Irving', $actualLoggedValue);
         $this->assertStringContainsString('https://example.com/reset-password=5e113c71a4c210aff04b3fa66f1b1299', $actualLoggedValue);
     }
 


### PR DESCRIPTION
I use the `log` mail mailer during local development for proof reading and to copy links for testing. This is less convenient than it could be, because the content of the email is encoded with [quoted printable encoding](https://github.com/symfony/mime/blob/4b7b349f67d15cd0639955c8179a76c89f6fd610/Encoder/QpContentEncoder.php#L36) (via [this code](https://github.com/symfony/mime/blob/4b7b349f67d15cd0639955c8179a76c89f6fd610/Part/TextPart.php#L203) in Symfony's `TextPart` class).

Quoted printable encoding causes line-wrapping with a `=\r\n` separator, and it also encodes certain special characters. For example, a simple password reset email currently gets logged like this:

```
From: no-reply <noreply@example.com>
To: Taylor <taylor@example.com>
MIME-Version: 1.0
Date: Thu, 12 Jan 2023 12:12:09 +0000
Message-ID: <a6a0b6596c8bd38f0a8e94210ca9c04a@example.com>
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: quoted-printable

Hi,

<a href=3D"https://example.com/reset-password=3D5e113c71a4c210aff0=
4b3fa66f1b1299">Click here to reset your password</a>.

All the best,=


Burt & Irving
```

Note how it encodes the `href=`, that it wraps the password reset url, and that it also wraps after "All the best" for some reason.

This PR decodes the message with `quoted_printable_decode()` before it gets logged, which gets rid of all the encodings and wrappings, making the log message easier to read.

After `quoted_printable_decode()`, the message gets logged like this, exactly how you'd expect:

```
From: no-reply <noreply@example.com>
To: Taylor <taylor@example.com>
MIME-Version: 1.0
Date: Thu, 12 Jan 2023 12:12:09 +0000
Message-ID: <a6a0b6596c8bd38f0a8e94210ca9c04a@example.com>
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: quoted-printable

Hi,

<a href="https://example.com/reset-password=5e113c71a4c210aff04b3fa66f1b1299">Click here to reset your password</a>.

All the best,

Burt & Irving
```