### PR TITLE
[9.x] Add support for casting arrays containing enums

### DIFF
--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -50,7 +50,7 @@ class AsEnumCollection implements Castable
             {
                 $value = $value !== null
                     ? (new Collection($value))->map(function ($enum) {
-                        return $this->getStorableAnumValue($enum);
+                        return $this->getStorableEnumValue($enum);
                     })->toJson()
                     : null;
 
@@ -60,7 +60,7 @@ class AsEnumCollection implements Castable
             public function serialize($model, string $key, $value, array $attributes)
             {
                 return (new Collection($value))->map(function ($enum) {
-                    return $this->getStorableAnumValue($enum);
+                    return $this->getStorableEnumValue($enum);
                 })->toArray();
             }
 
@@ -68,7 +68,7 @@ class AsEnumCollection implements Castable
              * @param  \UnitEnum|int|string  $enum
              * @return string|int
              */
-            protected function getStorableAnumValue($enum)
+            protected function getStorableEnumValue($enum)
             {
                 // Enum is already the backed value, no need to convert it again.
                 if (is_string($enum) || is_int($enum)) {

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -9,74 +9,74 @@ use Illuminate\Support\Collection;
 
 class AsEnumCollection implements Castable
 {
-	/**
-	 * Get the caster class to use when casting from / to this cast target.
-	 *
-	 * @param array $arguments
-	 * @return object|string
-	 */
-	public static function castUsing(array $arguments)
-	{
-		return new class($arguments) implements CastsAttributes
-		{
-			protected $arguments;
-			
-			public function __construct(array $arguments)
-			{
-				$this->arguments = $arguments;
-			}
-			
-			public function get($model, $key, $value, $attributes)
-			{
-				if ( !isset($attributes[$key]) || is_null($attributes[$key]) ) {
-					return;
-				}
-				
-				$data = json_decode($attributes[$key], true);
-				
-				if ( !is_array($data) ) {
-					return;
-				}
-				
-				$enumClass = $this->arguments[0];
-				
-				return (new Collection($data))->map(function ($value) use ($enumClass) {
-					return is_subclass_of($enumClass,
-						BackedEnum::class) ? $enumClass::from($value) : constant($enumClass . '::' . $value);
-				});
-			}
-			
-			public function set($model, $key, $value, $attributes)
-			{
-				$value = $value !== null
-					? (new Collection($value))->map(function ($enum) {
-						return $this->getStorableAnumValue($enum);
-					  })->toJson()
-					: null;
-				
-				return [$key => $value];
-			}
-			
-			public function serialize($model, string $key, $value, array $attributes)
-			{
-				return (new Collection($value))->map(function ($enum) {
-					return $this->getStorableAnumValue($enum);
-				})->toArray();
-			}
-			
-			/**
-			 * @param \UnitEnum|int|string $enum
-			 * @return string|int
-			 */
-			protected function getStorableAnumValue($enum)
-			{
-				// Enum is already the backed value, no need to convert it again.
-				if ( is_string($enum) || is_int($enum) ) {
-					return $enum;
-				}
-				
-				return $enum instanceof BackedEnum ? $enum->value : $enum->name;
-			}
-		};
-	}
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return object|string
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            protected $arguments;
+
+            public function __construct(array $arguments)
+            {
+                $this->arguments = $arguments;
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                if (! isset($attributes[$key]) || is_null($attributes[$key])) {
+                    return;
+                }
+
+                $data = json_decode($attributes[$key], true);
+
+                if (! is_array($data)) {
+                    return;
+                }
+
+                $enumClass = $this->arguments[0];
+
+                return (new Collection($data))->map(function ($value) use ($enumClass) {
+                    return is_subclass_of($enumClass,
+                        BackedEnum::class) ? $enumClass::from($value) : constant($enumClass.'::'.$value);
+                });
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                $value = $value !== null
+                    ? (new Collection($value))->map(function ($enum) {
+                        return $this->getStorableAnumValue($enum);
+                    })->toJson()
+                    : null;
+
+                return [$key => $value];
+            }
+
+            public function serialize($model, string $key, $value, array $attributes)
+            {
+                return (new Collection($value))->map(function ($enum) {
+                    return $this->getStorableAnumValue($enum);
+                })->toArray();
+            }
+
+            /**
+             * @param  \UnitEnum|int|string  $enum
+             * @return string|int
+             */
+            protected function getStorableAnumValue($enum)
+            {
+                // Enum is already the backed value, no need to convert it again.
+                if (is_string($enum) || is_int($enum)) {
+                    return $enum;
+                }
+
+                return $enum instanceof BackedEnum ? $enum->value : $enum->name;
+            }
+        };
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -51,7 +51,7 @@ class AsEnumCollection implements Castable
 				$value = $value !== null
 					? (new Collection($value))->map(function ($enum) {
 						return $this->getStorableAnumValue($enum);
-					})->toJson()
+					  })->toJson()
 					: null;
 				
 				return [$key => $value];

--- a/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
+++ b/src/Illuminate/Database/Eloquent/Casts/AsEnumCollection.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Casts;
+
+use BackedEnum;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Support\Collection;
+
+class AsEnumCollection implements Castable
+{
+	/**
+	 * Get the caster class to use when casting from / to this cast target.
+	 *
+	 * @param array $arguments
+	 * @return object|string
+	 */
+	public static function castUsing(array $arguments)
+	{
+		return new class($arguments) implements CastsAttributes
+		{
+			protected $arguments;
+			
+			public function __construct(array $arguments)
+			{
+				$this->arguments = $arguments;
+			}
+			
+			public function get($model, $key, $value, $attributes)
+			{
+				if ( !isset($attributes[$key]) || is_null($attributes[$key]) ) {
+					return;
+				}
+				
+				$data = json_decode($attributes[$key], true);
+				
+				if ( !is_array($data) ) {
+					return;
+				}
+				
+				$enumClass = $this->arguments[0];
+				
+				return (new Collection($data))->map(function ($value) use ($enumClass) {
+					return is_subclass_of($enumClass,
+						BackedEnum::class) ? $enumClass::from($value) : constant($enumClass . '::' . $value);
+				});
+			}
+			
+			public function set($model, $key, $value, $attributes)
+			{
+				$value = $value !== null
+					? (new Collection($value))->map(function ($enum) {
+						return $this->getStorableAnumValue($enum);
+					})->toJson()
+					: null;
+				
+				return [$key => $value];
+			}
+			
+			public function serialize($model, string $key, $value, array $attributes)
+			{
+				return (new Collection($value))->map(function ($enum) {
+					return $this->getStorableAnumValue($enum);
+				})->toArray();
+			}
+			
+			/**
+			 * @param \UnitEnum|int|string $enum
+			 * @return string|int
+			 */
+			protected function getStorableAnumValue($enum)
+			{
+				// Enum is already the backed value, no need to convert it again.
+				if ( is_string($enum) || is_int($enum) ) {
+					return $enum;
+				}
+				
+				return $enum instanceof BackedEnum ? $enum->value : $enum->name;
+			}
+		};
+	}
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1180,21 +1180,22 @@ trait HasAttributes
      */
     protected function setEnumCastableAttribute($key, $value)
     {
-        $enumClass = $this->getCasts()[$key];
-
-        if (! isset($value)) {
-            $this->attributes[$key] = null;
-        } elseif (is_object($value)) {
-            $this->attributes[$key] = $this->getStorableEnumValue($value);
-        } else {
-            $this->attributes[$key] = $this->getStorableEnumValue(
-                $this->getEnumCaseFromValue($enumClass, $value)
+	    $enumClass = $this->getCasts()[$key];
+	
+	    if ( !isset($value) ) {
+		    $this->attributes[$key] = null;
+	    } elseif ( is_object($value) ) {
+		    $this->attributes[$key] = $this->getStorableEnumValue($value);
+	    } else {
+		    $this->attributes[$key] = $this->getStorableEnumValue($this->getEnumCaseFromValue($enumClass, $value));
+	    }
+    }
 
     /**
      * Set the value of an enum array castable attribute.
      *
      * @param  string  $key
-     * @param  \UnitEnum|string|int  $value
+     * @param  array|string  $value
      * @return void
      */
     protected function setEnumArrayCastableAttribute($key, $value)
@@ -1234,9 +1235,9 @@ trait HasAttributes
      */
     protected function getStorableEnumValue($value)
     {
-        return $value instanceof BackedEnum
-                ? $value->value
-                : $value->name;
+	    return $value instanceof BackedEnum ? $value->value : $value->name;
+    }
+	
     /**
      * Get the storable value from the given enum.
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1180,15 +1180,15 @@ trait HasAttributes
      */
     protected function setEnumCastableAttribute($key, $value)
     {
-	    $enumClass = $this->getCasts()[$key];
-	
-	    if ( !isset($value) ) {
-		    $this->attributes[$key] = null;
-	    } elseif ( is_object($value) ) {
-		    $this->attributes[$key] = $this->getStorableEnumValue($value);
-	    } else {
-		    $this->attributes[$key] = $this->getStorableEnumValue($this->getEnumCaseFromValue($enumClass, $value));
-	    }
+        $enumClass = $this->getCasts()[$key];
+
+        if (! isset($value)) {
+            $this->attributes[$key] = null;
+        } elseif (is_object($value)) {
+            $this->attributes[$key] = $this->getStorableEnumValue($value);
+        } else {
+            $this->attributes[$key] = $this->getStorableEnumValue($this->getEnumCaseFromValue($enumClass, $value));
+        }
     }
 
     /**
@@ -1235,9 +1235,9 @@ trait HasAttributes
      */
     protected function getStorableEnumValue($value)
     {
-	    return $value instanceof BackedEnum ? $value->value : $value->name;
+        return $value instanceof BackedEnum ? $value->value : $value->name;
     }
-	
+
     /**
      * Get the storable value from the given enum.
      *
@@ -1740,9 +1740,9 @@ trait HasAttributes
     protected function isClassSerializable($key)
     {
         return ! $this->isEnumCastable($key)
-	        && ! $this->isEnumArrayCastable($key)
-	        && $this->isClassCastable($key)
-	        && method_exists($this->resolveCasterClass($key), 'serialize');
+            && ! $this->isEnumArrayCastable($key)
+            && $this->isClassCastable($key)
+            && method_exists($this->resolveCasterClass($key), 'serialize');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1188,7 +1188,7 @@ trait HasAttributes
             $this->attributes[$key] = $this->getStorableEnumValue($value);
         } else {
             $this->attributes[$key] = $this->getStorableEnumValue(
-				$this->getEnumCaseFromValue($enumClass, $value)
+                $this->getEnumCaseFromValue($enumClass, $value)
             );
         }
     }
@@ -1238,8 +1238,8 @@ trait HasAttributes
     protected function getStorableEnumValue($value)
     {
         return $value instanceof BackedEnum
-	        ? $value->value
-	        : $value->name;
+            ? $value->value
+            : $value->name;
     }
 
     /**
@@ -1251,7 +1251,7 @@ trait HasAttributes
     protected function getStorableEnumArrayValue($value)
     {
         return json_encode(
-			array_map(fn ($value) => $this->getStorableEnumValue($value), $value)
+            array_map(fn ($value) => $this->getStorableEnumValue($value), $value)
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1237,7 +1237,9 @@ trait HasAttributes
      */
     protected function getStorableEnumValue($value)
     {
-        return $value instanceof BackedEnum ? $value->value : $value->name;
+        return $value instanceof BackedEnum
+	        ? $value->value
+	        : $value->name;
     }
 
     /**
@@ -1248,7 +1250,9 @@ trait HasAttributes
      */
     protected function getStorableEnumArrayValue($value)
     {
-        return json_encode(array_map(fn ($value) => $this->getStorableEnumValue($value), $value));
+        return json_encode(
+			array_map(fn ($value) => $this->getStorableEnumValue($value), $value)
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -314,6 +314,10 @@ trait HasAttributes
                 $attributes[$key] = isset($attributes[$key]) ? $this->getStorableEnumValue($attributes[$key]) : null;
             }
 
+            if ($this->isEnumArrayCastable($key)) {
+                $attributes[$key] = isset($attributes[$key]) ? $this->getStorableEnumArrayValue($attributes[$key]) : null;
+            }
+
             if ($attributes[$key] instanceof Arrayable) {
                 $attributes[$key] = $attributes[$key]->toArray();
             }
@@ -789,6 +793,10 @@ trait HasAttributes
             return $this->getEnumCastableAttributeValue($key, $value);
         }
 
+        if ($this->isEnumArrayCastable($key)) {
+            return $this->getEnumArrayCastableAttributeValue($key, $value);
+        }
+
         if ($this->isClassCastable($key)) {
             return $this->getClassCastableAttributeValue($key, $value);
         }
@@ -844,6 +852,26 @@ trait HasAttributes
         }
 
         return $this->getEnumCaseFromValue($castType, $value);
+    }
+
+    /**
+     * Cast the given attribute to an array of enums.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function getEnumArrayCastableAttributeValue($key, $value)
+    {
+        if (is_null($value)) {
+            return;
+        }
+
+        $castType = Str::before($this->getCasts()[$key], ':array');
+
+        $value = is_array($value) ? $value : $this->fromJson($value);
+
+        return array_map(fn (string $value) => $this->getEnumCaseFromValue($castType, $value), $value);
     }
 
     /**
@@ -964,6 +992,12 @@ trait HasAttributes
 
         if ($this->isEnumCastable($key)) {
             $this->setEnumCastableAttribute($key, $value);
+
+            return $this;
+        }
+
+        if ($this->isEnumArrayCastable($key)) {
+            $this->setEnumArrayCastableAttribute($key, $value);
 
             return $this;
         }
@@ -1155,6 +1189,25 @@ trait HasAttributes
         } else {
             $this->attributes[$key] = $this->getStorableEnumValue(
                 $this->getEnumCaseFromValue($enumClass, $value)
+
+    /**
+     * Set the value of an enum array castable attribute.
+     *
+     * @param  string  $key
+     * @param  \UnitEnum|string|int  $value
+     * @return void
+     */
+    protected function setEnumArrayCastableAttribute($key, $value)
+    {
+        $enumClass = Str::before($this->getCasts()[$key], ':array');
+
+        if (! isset($value)) {
+            $this->attributes[$key] = null;
+        } else {
+            $value = is_array($value) ? $value : $this->fromJson($value);
+
+            $this->attributes[$key] = $this->getStorableEnumArrayValue(
+                array_map(fn ($value) => is_object($value) ? $value : $this->getEnumCaseFromValue($enumClass, $value), $value)
             );
         }
     }
@@ -1184,6 +1237,15 @@ trait HasAttributes
         return $value instanceof BackedEnum
                 ? $value->value
                 : $value->name;
+    /**
+     * Get the storable value from the given enum.
+     *
+     * @param  array  $value
+     * @return string
+     */
+    protected function getStorableEnumArrayValue($value)
+    {
+        return json_encode(array_map(fn ($value) => $this->getStorableEnumValue($value), $value));
     }
 
     /**
@@ -1621,6 +1683,33 @@ trait HasAttributes
     }
 
     /**
+     * Determine if the given key is cast using an array of enums.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isEnumArrayCastable($key)
+    {
+        $casts = $this->getCasts();
+
+        if (! array_key_exists($key, $casts)) {
+            return false;
+        }
+
+        $castType = $casts[$key];
+
+        if (in_array($castType, static::$primitiveCastTypes)) {
+            return false;
+        }
+
+        if (! Str::endsWith($castType, ':array')) {
+            return false;
+        }
+
+        return function_exists('enum_exists') && enum_exists(Str::before($castType, ':array'));
+    }
+
+    /**
      * Determine if the key is deviable using a custom class.
      *
      * @param  string  $key
@@ -1649,9 +1738,10 @@ trait HasAttributes
      */
     protected function isClassSerializable($key)
     {
-        return ! $this->isEnumCastable($key) &&
-            $this->isClassCastable($key) &&
-            method_exists($this->resolveCasterClass($key), 'serialize');
+        return ! $this->isEnumCastable($key)
+	        && ! $this->isEnumArrayCastable($key)
+	        && $this->isClassCastable($key)
+	        && method_exists($this->resolveCasterClass($key), 'serialize');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1187,7 +1187,9 @@ trait HasAttributes
         } elseif (is_object($value)) {
             $this->attributes[$key] = $this->getStorableEnumValue($value);
         } else {
-            $this->attributes[$key] = $this->getStorableEnumValue($this->getEnumCaseFromValue($enumClass, $value));
+            $this->attributes[$key] = $this->getStorableEnumValue(
+				$this->getEnumCaseFromValue($enumClass, $value)
+            );
         }
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3009,7 +3009,7 @@ class EloquentModelCastingStub extends Model
         'asStringableAttribute' => AsStringable::class,
         'asEncryptedCollectionAttribute' => AsEncryptedCollection::class,
         'asEncryptedArrayObjectAttribute' => AsEncryptedArrayObject::class,
-        'asEnumCollectionAttribute' => AsEnumCollection::class.':'.StringStatus::class,
+        'asEnumCollectionAttribute' => AsEnumCollection::class.':'.'StringStatus',
     ];
 
     public function jsonAttributeValue()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -301,25 +301,24 @@ class DatabaseEloquentModelTest extends TestCase
         $model->asEncryptedArrayObjectAttribute = ['foo' => 'baz'];
         $this->assertTrue($model->isDirty('asEncryptedArrayObjectAttribute'));
     }
-	
-	
-	public function testDirtyOnEnumCollectionObject()
-	{
-		$model = new EloquentModelCastingStub;
-		$model->setRawAttributes([
-			'asEnumCollectionAttribute' => json_encode(['draft', 'pending']),
-		]);
-		$model->syncOriginal();
-		
-		$this->assertInstanceOf(BaseCollection::class, $model->asEnumCollectionAttribute);
-		$this->assertFalse($model->isDirty('asEnumCollectionAttribute'));
-		
-		$model->asEnumCollectionAttribute = ['draft', 'pending'];
-		$this->assertFalse($model->isDirty('asEnumCollectionAttribute'));
-		
-		$model->asEnumCollectionAttribute = ['draft', 'done'];
-		$this->assertTrue($model->isDirty('asEnumCollectionAttribute'));
-	}
+
+    public function testDirtyOnEnumCollectionObject()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setRawAttributes([
+            'asEnumCollectionAttribute' => json_encode(['draft', 'pending']),
+        ]);
+        $model->syncOriginal();
+
+        $this->assertInstanceOf(BaseCollection::class, $model->asEnumCollectionAttribute);
+        $this->assertFalse($model->isDirty('asEnumCollectionAttribute'));
+
+        $model->asEnumCollectionAttribute = ['draft', 'pending'];
+        $this->assertFalse($model->isDirty('asEnumCollectionAttribute'));
+
+        $model->asEnumCollectionAttribute = ['draft', 'done'];
+        $this->assertTrue($model->isDirty('asEnumCollectionAttribute'));
+    }
 
     public function testCleanAttributes()
     {
@@ -3010,7 +3009,7 @@ class EloquentModelCastingStub extends Model
         'asStringableAttribute' => AsStringable::class,
         'asEncryptedCollectionAttribute' => AsEncryptedCollection::class,
         'asEncryptedArrayObjectAttribute' => AsEncryptedArrayObject::class,
-        'asEnumCollectionAttribute' => AsEnumCollection::class . ':' . StringStatus::class,
+        'asEnumCollectionAttribute' => AsEnumCollection::class.':'.StringStatus::class,
     ];
 
     public function jsonAttributeValue()
@@ -3101,10 +3100,10 @@ class Uppercase implements CastsInboundAttributes
 }
 
 if (PHP_VERSION_ID >= 80100) {
-	enum StringStatus: string
-	{
-		case draft = 'draft';
-		case pending = 'pending';
-		case done = 'done';
-	}
+    enum StringStatus : string
+    {
+        case draft = 'draft';
+        case pending = 'pending';
+        case done = 'done';
+    }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -45,7 +45,7 @@ use ReflectionClass;
 use stdClass;
 
 if (PHP_VERSION_ID >= 80100) {
-	include 'Enums.php';
+    include 'Enums.php';
 }
 
 class DatabaseEloquentModelTest extends TestCase
@@ -305,10 +305,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->asEncryptedArrayObjectAttribute = ['foo' => 'baz'];
         $this->assertTrue($model->isDirty('asEncryptedArrayObjectAttribute'));
     }
-	
-	/**
-	 * @requires PHP >= 8.1
-	 */
+
+    /**
+     * @requires PHP >= 8.1
+     */
     public function testDirtyOnEnumCollectionObject()
     {
         $model = new EloquentModelCastingStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -44,6 +44,10 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
 
+if (PHP_VERSION_ID >= 80100) {
+	include 'Enums.php';
+}
+
 class DatabaseEloquentModelTest extends TestCase
 {
     use InteractsWithTime;
@@ -301,7 +305,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->asEncryptedArrayObjectAttribute = ['foo' => 'baz'];
         $this->assertTrue($model->isDirty('asEncryptedArrayObjectAttribute'));
     }
-
+	
+	/**
+	 * @requires PHP >= 8.1
+	 */
     public function testDirtyOnEnumCollectionObject()
     {
         $model = new EloquentModelCastingStub;
@@ -3009,7 +3016,7 @@ class EloquentModelCastingStub extends Model
         'asStringableAttribute' => AsStringable::class,
         'asEncryptedCollectionAttribute' => AsEncryptedCollection::class,
         'asEncryptedArrayObjectAttribute' => AsEncryptedArrayObject::class,
-        'asEnumCollectionAttribute' => AsEnumCollection::class.':'.'StringStatus',
+        'asEnumCollectionAttribute' => AsEnumCollection::class.':'.StringStatus::class,
     ];
 
     public function jsonAttributeValue()
@@ -3096,14 +3103,5 @@ class Uppercase implements CastsInboundAttributes
     public function set($model, string $key, $value, array $attributes)
     {
         return is_string($value) ? strtoupper($value) : $value;
-    }
-}
-
-if (PHP_VERSION_ID >= 80100) {
-    enum StringStatus : string
-    {
-        case draft = 'draft';
-        case pending = 'pending';
-        case done = 'done';
     }
 }

--- a/tests/Database/Enums.php
+++ b/tests/Database/Enums.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+enum StringStatus: string
+{
+	case draft = 'draft';
+	case pending = 'pending';
+	case done = 'done';
+}
+
+enum IntegerStatus: int
+{
+	case draft = 0;
+	case pending = 1;
+	case done = 2;
+}
+
+enum ArrayableStatus: string implements Arrayable
+{
+	case pending = 'pending';
+	case done = 'done';
+	
+	public function description(): string
+	{
+		return match ($this) {
+			self::pending => 'pending status description',
+			self::done => 'done status description'
+		};
+	}
+	
+	public function toArray()
+	{
+		return [
+			'name' => $this->name,
+			'value' => $this->value,
+			'description' => $this->description(),
+		];
+	}
+}

--- a/tests/Database/Enums.php
+++ b/tests/Database/Enums.php
@@ -6,37 +6,37 @@ use Illuminate\Contracts\Support\Arrayable;
 
 enum StringStatus: string
 {
-	case draft = 'draft';
-	case pending = 'pending';
-	case done = 'done';
+    case draft = 'draft';
+    case pending = 'pending';
+    case done = 'done';
 }
 
 enum IntegerStatus: int
 {
-	case draft = 0;
-	case pending = 1;
-	case done = 2;
+    case draft = 0;
+    case pending = 1;
+    case done = 2;
 }
 
 enum ArrayableStatus: string implements Arrayable
 {
-	case pending = 'pending';
-	case done = 'done';
-	
-	public function description(): string
-	{
-		return match ($this) {
-			self::pending => 'pending status description',
-			self::done => 'done status description'
-		};
-	}
-	
-	public function toArray()
-	{
-		return [
-			'name' => $this->name,
-			'value' => $this->value,
-			'description' => $this->description(),
-		];
-	}
+    case pending = 'pending';
+    case done = 'done';
+
+    public function description(): string
+    {
+        return match ($this) {
+            self::pending => 'pending status description',
+            self::done => 'done status description'
+        };
+    }
+
+    public function toArray()
+    {
+        return [
+            'name' => $this->name,
+            'value' => $this->value,
+            'description' => $this->description(),
+        ];
+    }
 }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -21,9 +23,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         Schema::create('enum_casts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('string_status', 100)->nullable();
-            $table->json('string_status_array')->nullable();
+            $table->json('string_status_collection')->nullable();
             $table->integer('integer_status')->nullable();
-            $table->json('integer_status_array')->nullable();
+            $table->json('integer_status_collection')->nullable();
             $table->string('arrayable_status')->nullable();
         });
     }
@@ -32,18 +34,18 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         DB::table('enum_casts')->insert([
             'string_status' => 'pending',
-            'string_status_array' => json_encode(['pending', 'done']),
+            'string_status_collection' => json_encode(['pending', 'done']),
             'integer_status' => 1,
-            'integer_status_array' => json_encode([1, 2]),
+            'integer_status_collection' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ]);
 
         $model = EloquentModelEnumCastingTestModel::first();
 
         $this->assertEquals(StringStatus::pending, $model->string_status);
-        $this->assertEquals([StringStatus::pending, StringStatus::done], $model->string_status_array);
+        $this->assertEquals([StringStatus::pending, StringStatus::done], $model->string_status_collection->all());
         $this->assertEquals(IntegerStatus::pending, $model->integer_status);
-        $this->assertEquals([IntegerStatus::pending, IntegerStatus::done], $model->integer_status_array);
+        $this->assertEquals([IntegerStatus::pending, IntegerStatus::done], $model->integer_status_collection->all());
         $this->assertEquals(ArrayableStatus::pending, $model->arrayable_status);
     }
 
@@ -51,18 +53,18 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         DB::table('enum_casts')->insert([
             'string_status' => null,
-            'string_status_array' => null,
+            'string_status_collection' => null,
             'integer_status' => null,
-            'integer_status_array' => null,
+            'integer_status_collection' => null,
             'arrayable_status' => null,
         ]);
 
         $model = EloquentModelEnumCastingTestModel::first();
 
         $this->assertEquals(null, $model->string_status);
-        $this->assertEquals(null, $model->string_status_array);
+        $this->assertEquals(null, $model->string_status_collection);
         $this->assertEquals(null, $model->integer_status);
-        $this->assertEquals(null, $model->integer_status_array);
+        $this->assertEquals(null, $model->integer_status_collection);
         $this->assertEquals(null, $model->arrayable_status);
     }
 
@@ -70,17 +72,17 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => StringStatus::pending,
-            'string_status_array' => [StringStatus::pending, StringStatus::done],
+            'string_status_collection' => [StringStatus::pending, StringStatus::done],
             'integer_status' => IntegerStatus::pending,
-            'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
+            'integer_status_collection' => [IntegerStatus::pending, IntegerStatus::done],
             'arrayable_status' => ArrayableStatus::pending,
         ]);
 
         $this->assertEquals([
             'string_status' => 'pending',
-            'string_status_array' => json_encode(['pending', 'done']),
+            'string_status_collection' => ['pending', 'done'],
             'integer_status' => 1,
-            'integer_status_array' => json_encode([1, 2]),
+            'integer_status_collection' => [1, 2],
             'arrayable_status' => [
                 'name' => 'pending',
                 'value' => 'pending',
@@ -93,17 +95,17 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => null,
-            'string_status_array' => null,
+            'string_status_collection' => null,
             'integer_status' => null,
-            'integer_status_array' => null,
+            'integer_status_collection' => null,
             'arrayable_status' => null,
         ]);
 
         $this->assertEquals([
             'string_status' => null,
-            'string_status_array' => null,
+            'string_status_collection' => null,
             'integer_status' => null,
-            'integer_status_array' => null,
+            'integer_status_collection' => null,
             'arrayable_status' => null,
         ], $model->toArray());
     }
@@ -112,9 +114,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => StringStatus::pending,
-            'string_status_array' => [StringStatus::pending, StringStatus::done],
+            'string_status_collection' => [StringStatus::pending, StringStatus::done],
             'integer_status' => IntegerStatus::pending,
-            'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
+            'integer_status_collection' => [IntegerStatus::pending, IntegerStatus::done],
             'arrayable_status' => ArrayableStatus::pending,
         ]);
 
@@ -123,9 +125,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $this->assertEquals([
             'id' => $model->id,
             'string_status' => 'pending',
-            'string_status_array' => json_encode(['pending', 'done']),
+            'string_status_collection' => json_encode(['pending', 'done']),
             'integer_status' => 1,
-            'integer_status_array' => json_encode([1, 2]),
+            'integer_status_collection' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(', ', ',', $value);
@@ -136,9 +138,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => 'pending',
-            'string_status_array' => ['pending', 'done'],
+            'string_status_collection' => ['pending', 'done'],
             'integer_status' => 1,
-            'integer_status_array' => [1, 2],
+            'integer_status_collection' => [1, 2],
             'arrayable_status' => 'pending',
         ]);
 
@@ -147,9 +149,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $this->assertEquals([
             'id' => $model->id,
             'string_status' => 'pending',
-            'string_status_array' => json_encode(['pending', 'done']),
+            'string_status_collection' => json_encode(['pending', 'done']),
             'integer_status' => 1,
-            'integer_status_array' => json_encode([1, 2]),
+            'integer_status_collection' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(', ', ',', $value);
@@ -160,9 +162,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => null,
-            'string_status_array' => null,
+            'string_status_collection' => null,
             'integer_status' => null,
-            'integer_status_array' => null,
+            'integer_status_collection' => null,
             'arrayable_status' => null,
         ]);
 
@@ -171,9 +173,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $this->assertEquals((object) [
             'id' => $model->id,
             'string_status' => null,
-            'string_status_array' => null,
+            'string_status_collection' => null,
             'integer_status' => null,
-            'integer_status_array' => null,
+            'integer_status_collection' => null,
             'arrayable_status' => null,
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
@@ -247,9 +249,9 @@ class EloquentModelEnumCastingTestModel extends Model
 
     public $casts = [
         'string_status' => StringStatus::class,
-        'string_status_array' => StringStatus::class.':array',
+        'string_status_collection' => AsEnumCollection::class . ':' . StringStatus::class,
         'integer_status' => IntegerStatus::class,
-        'integer_status_array' => IntegerStatus::class.':array',
+        'integer_status_collection' => AsEnumCollection::class . ':' . IntegerStatus::class,
         'arrayable_status' => ArrayableStatus::class,
     ];
 }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -32,9 +32,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         DB::table('enum_casts')->insert([
             'string_status' => 'pending',
-            'string_status_array' => json_encode(['pending','done']),
+            'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
-            'integer_status_array' => json_encode([1,2]),
+            'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ]);
 

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 
 if (PHP_VERSION_ID >= 80100) {
     include 'Enums.php';
@@ -127,7 +128,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
-        ], DB::table('enum_casts')->where('id', $model->id)->first());
+        ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
+            return str_replace(',', ', ', str_replace(', ', ',', $value));
+        })->all());
     }
 
     public function testEnumsAreNotConvertedOnSaveWhenAlreadyCorrect()
@@ -149,7 +152,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
-        ], DB::table('enum_casts')->where('id', $model->id)->first());
+        ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
+            return str_replace(',', ', ', str_replace(', ', ',', $value));
+        })->all());
     }
 
     public function testEnumsAcceptNullOnSave()

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -21,7 +21,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         Schema::create('enum_casts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('string_status', 100)->nullable();
+            $table->json('string_status_array', 100)->nullable();
             $table->integer('integer_status')->nullable();
+            $table->json('integer_status_array')->nullable();
             $table->string('arrayable_status')->nullable();
         });
     }
@@ -30,14 +32,18 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         DB::table('enum_casts')->insert([
             'string_status' => 'pending',
+            'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
+            'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ]);
 
         $model = EloquentModelEnumCastingTestModel::first();
 
         $this->assertEquals(StringStatus::pending, $model->string_status);
+        $this->assertEquals([StringStatus::pending, StringStatus::done], $model->string_status_array);
         $this->assertEquals(IntegerStatus::pending, $model->integer_status);
+        $this->assertEquals([IntegerStatus::pending, IntegerStatus::done], $model->integer_status_array);
         $this->assertEquals(ArrayableStatus::pending, $model->arrayable_status);
     }
 
@@ -45,14 +51,18 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         DB::table('enum_casts')->insert([
             'string_status' => null,
+            'string_status_array' => null,
             'integer_status' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ]);
 
         $model = EloquentModelEnumCastingTestModel::first();
 
         $this->assertEquals(null, $model->string_status);
+        $this->assertEquals(null, $model->string_status_array);
         $this->assertEquals(null, $model->integer_status);
+        $this->assertEquals(null, $model->integer_status_array);
         $this->assertEquals(null, $model->arrayable_status);
     }
 
@@ -60,13 +70,17 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => StringStatus::pending,
+            'string_status_array' => [StringStatus::pending, StringStatus::done],
             'integer_status' => IntegerStatus::pending,
+            'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
             'arrayable_status' => ArrayableStatus::pending,
         ]);
 
         $this->assertEquals([
             'string_status' => 'pending',
+            'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
+            'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => [
                 'name' => 'pending',
                 'value' => 'pending',
@@ -79,13 +93,17 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => null,
+            'string_status_array' => null,
             'integer_status' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ]);
 
         $this->assertEquals([
             'string_status' => null,
+            'string_status_array' => null,
             'integer_status' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ], $model->toArray());
     }
@@ -94,7 +112,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => StringStatus::pending,
+            'string_status_array' => [StringStatus::pending, StringStatus::done],
             'integer_status' => IntegerStatus::pending,
+            'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
             'arrayable_status' => ArrayableStatus::pending,
         ]);
 
@@ -103,7 +123,31 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $this->assertEquals((object) [
             'id' => $model->id,
             'string_status' => 'pending',
+            'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
+            'integer_status_array' => json_encode([1, 2]),
+            'arrayable_status' => 'pending',
+        ], DB::table('enum_casts')->where('id', $model->id)->first());
+    }
+
+    public function testEnumsAreNotConvertedOnSaveWhenAlreadyCorrect()
+    {
+        $model = new EloquentModelEnumCastingTestModel([
+            'string_status' => 'pending',
+            'string_status_array' => ['pending', 'done'],
+            'integer_status' => 1,
+            'integer_status_array' => [1, 2],
+            'arrayable_status' => 'pending',
+        ]);
+
+        $model->save();
+
+        $this->assertEquals((object) [
+            'id' => $model->id,
+            'string_status' => 'pending',
+            'string_status_array' => json_encode(['pending', 'done']),
+            'integer_status' => 1,
+            'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
@@ -112,7 +156,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => null,
+            'string_status_array' => null,
             'integer_status' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ]);
 
@@ -121,7 +167,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $this->assertEquals((object) [
             'id' => $model->id,
             'string_status' => null,
+            'string_status_array' => null,
             'integer_status' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
@@ -195,7 +243,9 @@ class EloquentModelEnumCastingTestModel extends Model
 
     public $casts = [
         'string_status' => StringStatus::class,
+        'string_status_array' => StringStatus::class.':array',
         'integer_status' => IntegerStatus::class,
+        'integer_status_array' => IntegerStatus::class.':array',
         'arrayable_status' => ArrayableStatus::class,
     ];
 }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -32,9 +32,9 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
     {
         DB::table('enum_casts')->insert([
             'string_status' => 'pending',
-            'string_status_array' => json_encode(['pending', 'done']),
+            'string_status_array' => json_encode(['pending','done']),
             'integer_status' => 1,
-            'integer_status_array' => json_encode([1, 2]),
+            'integer_status_array' => json_encode([1,2]),
             'arrayable_status' => 'pending',
         ]);
 

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 
 if (PHP_VERSION_ID >= 80100) {
     include 'Enums.php';

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
@@ -249,9 +248,9 @@ class EloquentModelEnumCastingTestModel extends Model
 
     public $casts = [
         'string_status' => StringStatus::class,
-        'string_status_collection' => AsEnumCollection::class . ':' . StringStatus::class,
+        'string_status_collection' => AsEnumCollection::class.':'.StringStatus::class,
         'integer_status' => IntegerStatus::class,
-        'integer_status_collection' => AsEnumCollection::class . ':' . IntegerStatus::class,
+        'integer_status_collection' => AsEnumCollection::class.':'.IntegerStatus::class,
         'arrayable_status' => ArrayableStatus::class,
     ];
 }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -128,7 +128,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
-        ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
+        ], (object) collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(',', ', ', str_replace(', ', ',', $value));
         })->all());
     }
@@ -152,7 +152,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'integer_status' => 1,
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
-        ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
+        ], (object) collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(',', ', ', str_replace(', ', ',', $value));
         })->all());
     }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Illuminate\Database\Eloquent\Casts\AsEnumArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
@@ -23,8 +24,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             $table->increments('id');
             $table->string('string_status', 100)->nullable();
             $table->json('string_status_collection')->nullable();
+            $table->json('string_status_array')->nullable();
             $table->integer('integer_status')->nullable();
             $table->json('integer_status_collection')->nullable();
+            $table->json('integer_status_array')->nullable();
             $table->string('arrayable_status')->nullable();
         });
     }
@@ -34,8 +37,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         DB::table('enum_casts')->insert([
             'string_status' => 'pending',
             'string_status_collection' => json_encode(['pending', 'done']),
+            'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
             'integer_status_collection' => json_encode([1, 2]),
+            'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ]);
 
@@ -43,8 +48,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
 
         $this->assertEquals(StringStatus::pending, $model->string_status);
         $this->assertEquals([StringStatus::pending, StringStatus::done], $model->string_status_collection->all());
+        $this->assertEquals([StringStatus::pending, StringStatus::done], $model->string_status_array->toArray());
         $this->assertEquals(IntegerStatus::pending, $model->integer_status);
         $this->assertEquals([IntegerStatus::pending, IntegerStatus::done], $model->integer_status_collection->all());
+        $this->assertEquals([IntegerStatus::pending, IntegerStatus::done], $model->integer_status_array->toArray());
         $this->assertEquals(ArrayableStatus::pending, $model->arrayable_status);
     }
 
@@ -53,8 +60,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         DB::table('enum_casts')->insert([
             'string_status' => null,
             'string_status_collection' => null,
+            'string_status_array' => null,
             'integer_status' => null,
             'integer_status_collection' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ]);
 
@@ -62,8 +71,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
 
         $this->assertEquals(null, $model->string_status);
         $this->assertEquals(null, $model->string_status_collection);
+        $this->assertEquals(null, $model->string_status_array);
         $this->assertEquals(null, $model->integer_status);
         $this->assertEquals(null, $model->integer_status_collection);
+        $this->assertEquals(null, $model->integer_status_array);
         $this->assertEquals(null, $model->arrayable_status);
     }
 
@@ -72,16 +83,20 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => StringStatus::pending,
             'string_status_collection' => [StringStatus::pending, StringStatus::done],
+            'string_status_array' => [StringStatus::pending, StringStatus::done],
             'integer_status' => IntegerStatus::pending,
             'integer_status_collection' => [IntegerStatus::pending, IntegerStatus::done],
+            'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
             'arrayable_status' => ArrayableStatus::pending,
         ]);
 
         $this->assertEquals([
             'string_status' => 'pending',
             'string_status_collection' => ['pending', 'done'],
+            'string_status_array' => ['pending', 'done'],
             'integer_status' => 1,
             'integer_status_collection' => [1, 2],
+            'integer_status_array' => [1, 2],
             'arrayable_status' => [
                 'name' => 'pending',
                 'value' => 'pending',
@@ -95,16 +110,20 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => null,
             'string_status_collection' => null,
+            'string_status_array' => null,
             'integer_status' => null,
             'integer_status_collection' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ]);
 
         $this->assertEquals([
             'string_status' => null,
             'string_status_collection' => null,
+            'string_status_array' => null,
             'integer_status' => null,
             'integer_status_collection' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ], $model->toArray());
     }
@@ -114,8 +133,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => StringStatus::pending,
             'string_status_collection' => [StringStatus::pending, StringStatus::done],
+            'string_status_array' => [StringStatus::pending, StringStatus::done],
             'integer_status' => IntegerStatus::pending,
             'integer_status_collection' => [IntegerStatus::pending, IntegerStatus::done],
+            'integer_status_array' => [IntegerStatus::pending, IntegerStatus::done],
             'arrayable_status' => ArrayableStatus::pending,
         ]);
 
@@ -125,8 +146,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'id' => $model->id,
             'string_status' => 'pending',
             'string_status_collection' => json_encode(['pending', 'done']),
+            'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
             'integer_status_collection' => json_encode([1, 2]),
+            'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(', ', ',', $value);
@@ -138,8 +161,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => 'pending',
             'string_status_collection' => ['pending', 'done'],
+            'string_status_array' => ['pending', 'done'],
             'integer_status' => 1,
             'integer_status_collection' => [1, 2],
+            'integer_status_array' => [1, 2],
             'arrayable_status' => 'pending',
         ]);
 
@@ -149,8 +174,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'id' => $model->id,
             'string_status' => 'pending',
             'string_status_collection' => json_encode(['pending', 'done']),
+            'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
             'integer_status_collection' => json_encode([1, 2]),
+            'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
         ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
             return str_replace(', ', ',', $value);
@@ -162,8 +189,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         $model = new EloquentModelEnumCastingTestModel([
             'string_status' => null,
             'string_status_collection' => null,
+            'string_status_array' => null,
             'integer_status' => null,
             'integer_status_collection' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ]);
 
@@ -173,8 +202,10 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
             'id' => $model->id,
             'string_status' => null,
             'string_status_collection' => null,
+            'string_status_array' => null,
             'integer_status' => null,
             'integer_status_collection' => null,
+            'integer_status_array' => null,
             'arrayable_status' => null,
         ], DB::table('enum_casts')->where('id', $model->id)->first());
     }
@@ -249,8 +280,10 @@ class EloquentModelEnumCastingTestModel extends Model
     public $casts = [
         'string_status' => StringStatus::class,
         'string_status_collection' => AsEnumCollection::class.':'.StringStatus::class,
+        'string_status_array' => AsEnumArrayObject::class.':'.StringStatus::class,
         'integer_status' => IntegerStatus::class,
         'integer_status_collection' => AsEnumCollection::class.':'.IntegerStatus::class,
+        'integer_status_array' => AsEnumArrayObject::class.':'.IntegerStatus::class,
         'arrayable_status' => ArrayableStatus::class,
     ];
 }

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -21,7 +21,7 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
         Schema::create('enum_casts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('string_status', 100)->nullable();
-            $table->json('string_status_array', 100)->nullable();
+            $table->json('string_status_array')->nullable();
             $table->integer('integer_status')->nullable();
             $table->json('integer_status_array')->nullable();
             $table->string('arrayable_status')->nullable();

--- a/tests/Integration/Database/EloquentModelEnumCastingTest.php
+++ b/tests/Integration/Database/EloquentModelEnumCastingTest.php
@@ -121,15 +121,15 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
 
         $model->save();
 
-        $this->assertEquals((object) [
+        $this->assertEquals([
             'id' => $model->id,
             'string_status' => 'pending',
             'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
-        ], (object) collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
-            return str_replace(',', ', ', str_replace(', ', ',', $value));
+        ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
+            return str_replace(', ', ',', $value);
         })->all());
     }
 
@@ -145,15 +145,15 @@ class EloquentModelEnumCastingTest extends DatabaseTestCase
 
         $model->save();
 
-        $this->assertEquals((object) [
+        $this->assertEquals([
             'id' => $model->id,
             'string_status' => 'pending',
             'string_status_array' => json_encode(['pending', 'done']),
             'integer_status' => 1,
             'integer_status_array' => json_encode([1, 2]),
             'arrayable_status' => 'pending',
-        ], (object) collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
-            return str_replace(',', ', ', str_replace(', ', ',', $value));
+        ], collect(DB::table('enum_casts')->where('id', $model->id)->first())->map(function ($value) {
+            return str_replace(', ', ',', $value);
         })->all());
     }
 

--- a/tests/Integration/Database/Enums.php
+++ b/tests/Integration/Database/Enums.php
@@ -6,12 +6,14 @@ use Illuminate\Contracts\Support\Arrayable;
 
 enum StringStatus: string
 {
+    case draft = 'draft';
     case pending = 'pending';
     case done = 'done';
 }
 
 enum IntegerStatus: int
 {
+    case draft = 0;
     case pending = 1;
     case done = 2;
 }


### PR DESCRIPTION
Today I encountered a situation in an app where I had a database column in JSON that represented an array with enums.

Currently it is not possible to cast the values inside the array to real enums. The array would just contain the backed string or integer values. It would have been quite cumbersome to write a specific cast every time this situation happens.

After some searching I noticed that Spatie's Laravel Enum package [does have support](https://github.com/spatie/laravel-enum/pull/43) for this using the `:array` suffix, which I found nice.

This PR implements the casting for enums in an array:

```php
class SomeModel extends Model
{
    protected $casts = [
        'user_type' => UserType::class,
        'user_types' => UserType::class . ':array',
    ];
}
```

Under the hood, when casting the value, this will store a JSON array with the backed values. When reading the attribute, the json is converted to an array and the backed values are converted to real enums.

Syntax improvements are welcome :)

Thanks!