### PR TITLE
[10.x] Update redirector to use status 303

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -43,7 +43,7 @@ class Redirector
      * @param  mixed  $fallback
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function back($status = 302, $headers = [], $fallback = false)
+    public function back($status = 303, $headers = [], $fallback = false)
     {
         return $this->createRedirect($this->generator->previous($fallback), $status, $headers);
     }
@@ -55,7 +55,7 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function refresh($status = 302, $headers = [])
+    public function refresh($status = 303, $headers = [])
     {
         return $this->to($this->generator->getRequest()->path(), $status, $headers);
     }
@@ -69,7 +69,7 @@ class Redirector
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function guest($path, $status = 302, $headers = [], $secure = null)
+    public function guest($path, $status = 303, $headers = [], $secure = null)
     {
         $request = $this->generator->getRequest();
 
@@ -93,7 +93,7 @@ class Redirector
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function intended($default = '/', $status = 302, $headers = [], $secure = null)
+    public function intended($default = '/', $status = 303, $headers = [], $secure = null)
     {
         $path = $this->session->pull('url.intended', $default);
 
@@ -109,7 +109,7 @@ class Redirector
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function to($path, $status = 302, $headers = [], $secure = null)
+    public function to($path, $status = 303, $headers = [], $secure = null)
     {
         return $this->createRedirect($this->generator->to($path, [], $secure), $status, $headers);
     }
@@ -122,7 +122,7 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function away($path, $status = 302, $headers = [])
+    public function away($path, $status = 303, $headers = [])
     {
         return $this->createRedirect($path, $status, $headers);
     }
@@ -135,7 +135,7 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function secure($path, $status = 302, $headers = [])
+    public function secure($path, $status = 303, $headers = [])
     {
         return $this->to($path, $status, $headers, true);
     }
@@ -149,7 +149,7 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function route($route, $parameters = [], $status = 302, $headers = [])
+    public function route($route, $parameters = [], $status = 303, $headers = [])
     {
         return $this->to($this->generator->route($route, $parameters), $status, $headers);
     }
@@ -164,7 +164,7 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function signedRoute($route, $parameters = [], $expiration = null, $status = 302, $headers = [])
+    public function signedRoute($route, $parameters = [], $expiration = null, $status = 303, $headers = [])
     {
         return $this->to($this->generator->signedRoute($route, $parameters, $expiration), $status, $headers);
     }
@@ -179,7 +179,7 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function temporarySignedRoute($route, $expiration, $parameters = [], $status = 302, $headers = [])
+    public function temporarySignedRoute($route, $expiration, $parameters = [], $status = 303, $headers = [])
     {
         return $this->to($this->generator->temporarySignedRoute($route, $expiration, $parameters), $status, $headers);
     }
@@ -193,7 +193,7 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function action($action, $parameters = [], $status = 302, $headers = [])
+    public function action($action, $parameters = [], $status = 303, $headers = [])
     {
         return $this->to($this->generator->action($action, $parameters), $status, $headers);
     }

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -57,7 +57,7 @@ class RoutingRedirectorTest extends TestCase
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(303, $response->getStatusCode());
         $this->assertEquals($this->session, $response->getSession());
     }
 


### PR DESCRIPTION
Currently the Redirector class uses status code `302` for redirects (if no other status was passed in), this is an issue when making a `POST/PUT/PATCH/DELETE` request and the response is a redirect it will use the same request method for the redirect, this will cause a `405 Method not allowed`.

[Inertia already fixes this in most cases](https://github.com/inertiajs/inertia-laravel/blob/master/src/Middleware.php#L102) but it can still occur if the redirect runs from a middleware before the Inertia middleware e.g. `RedirectIfAuthenticated`.

To replicate, create a new breeze app, login, go to profile page and logout from different tab, now try to save profile details in the first tab.