### PR TITLE
[9.x] Allow fake() helper in unit tests

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -461,7 +461,11 @@ if (! function_exists('fake') && class_exists(\Faker\Factory::class)) {
      */
     function fake($locale = null)
     {
-        $locale ??= app('config')->get('app.faker_locale') ?? 'en_US';
+        if (app()->bound('config')) {
+            $locale ??= app('config')->get('app.faker_locale');
+        }
+
+        $locale ??= 'en_US';
 
         $abstract = \Faker\Generator::class.':'.$locale;
 


### PR DESCRIPTION
This PR adds the ability to use the `fake()` helper in unit tests. The only thing stopping us from using it is that it's retrieving the `faker_locale` from the config. It's already defaulting to `en_US` if none is configured. If we only fetch if the `config` is actually bound in the container, it works even in unit tests (where the `config` is not bound).