### PR TITLE
[9.x] Fail queued job with a string message

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use Exception;
 use Illuminate\Contracts\Queue\Job as JobContract;
 use InvalidArgumentException;
 use Throwable;
@@ -40,11 +41,15 @@ trait InteractsWithQueue
     /**
      * Fail the job from the queue.
      *
-     * @param  \Throwable|null  $exception
+     * @param  \Throwable|string|null  $exception
      * @return void
      */
     public function fail($exception = null)
     {
+        if (is_string($exception)) {
+            $exception = new Exception($exception);
+        }
+
         if ($exception instanceof Throwable || is_null($exception)) {
             if ($this->job) {
                 return $this->job->fail($exception);

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue;
 
-use Exception;
 use Illuminate\Contracts\Queue\Job as JobContract;
 use Illuminate\Queue\ManuallyFailedException;
 use InvalidArgumentException;

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue;
 
 use Exception;
 use Illuminate\Contracts\Queue\Job as JobContract;
+use Illuminate\Queue\ManuallyFailedException;
 use InvalidArgumentException;
 use Throwable;
 
@@ -47,7 +48,7 @@ trait InteractsWithQueue
     public function fail($exception = null)
     {
         if (is_string($exception)) {
-            $exception = new Exception($exception);
+            $exception = new ManuallyFailedException($exception);
         }
 
         if ($exception instanceof Throwable || is_null($exception)) {
@@ -55,7 +56,7 @@ trait InteractsWithQueue
                 return $this->job->fail($exception);
             }
         } else {
-            throw new InvalidArgumentException('The fail method requires an instance of Throwable.');
+            throw new InvalidArgumentException('The fail method requires a string or an instance of Throwable.');
         }
     }
 

--- a/tests/Queue/InteractsWithQueueTest.php
+++ b/tests/Queue/InteractsWithQueueTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Tests\Queue;
+
+use Exception;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\InteractsWithQueue;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class InteractsWithQueueTest extends TestCase
+{
+    public function testCreatesAnExceptionFromString()
+    {
+        $queueJob = m::mock(Job::class);
+        $queueJob->shouldReceive('fail')->withArgs(function ($e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Whoops!', $e->getMessage());
+
+            return true;
+        });
+
+        $job = new class
+        {
+            use InteractsWithQueue;
+
+            public $job;
+        };
+
+        $job->job = $queueJob;
+        $job->fail('Whoops!');
+    }
+}


### PR DESCRIPTION
A shortcut so you can fail a job with a `string` message instead of manually instantiating an `Exception`.

```php
class MyJob implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable;

    public function handle()
    {
        // Before:
        $this->fail(new \Exception('Whoops!'));

        // After:
        $this->fail('Whoops!');
    }
}
```