### PR TITLE
[9.x] Improve developer facing Sqlite missing DB error message

### DIFF
--- a/src/Illuminate/Database/SQLiteDatabaseDoesNotExistException.php
+++ b/src/Illuminate/Database/SQLiteDatabaseDoesNotExistException.php
@@ -21,7 +21,7 @@ class SQLiteDatabaseDoesNotExistException extends InvalidArgumentException
      */
     public function __construct($path)
     {
-        parent::__construct("Database ({$path}) does not exist.");
+        parent::__construct("Database file at path [{$path}] does not exist. Ensure this is an absolute path to the database.");
 
         $this->path = $path;
     }


### PR DESCRIPTION
Alternative to https://github.com/laravel/laravel/pull/6075

## Issue

There is an inconsistency between artisan and HTTP requests when using relative file paths as the SQLite database.

## Reproduce it

Create a brand new Laravel project, use Sqlite as a database, run migrations, and interact with the database via Tinker.

Note: `DB_DATABASE` is unchanged and currently set to `"laravel"`.

```sh
composer create-project laravel/laravel sqlite-test \
  && cd sqlite-test \
  && sed -i "s/DB_CONNECTION=mysql/DB_CONNECTION=sqlite/" .env \
  && echo "{{ \App\Models\User::first() }}" > resources/views/welcome.blade.php \
  && php artisan migrate \
  && php artisan tinker --execute="User::create(['name' => 'Tim', 'email' => 'tim@laravel.com', 'password' => 'secret']);"
```

Everything should have worked as expected. Now we will serve the project and visit the homepage.

```sh
(sleep 1 && open http://127.0.0.1:8000)& \
php artisan serve
```

<img width="1446" alt="Screen Shot 2023-01-13 at 11 37 57 am" src="https://user-images.githubusercontent.com/24803032/212210496-aff3394c-a934-4f56-bc25-f9efc438aac9.png">

## Why this happens

When using a relative path in `DB_DATABASE` and starting Laravel from the project root via artisan, the relative path resolves to the same thing as `base_path('laravel')`.

When using the same relative path from a web request, the root is no longer the project root. It is now the `public` directory, so the relative path resolves to the same thing as `public_path('laravel')`.

`/private/tmp/sqlite-test/laravel` < Artisan
`/private/tmp/sqlite-test/public/laravel` < Web request

When the SqliteConnector tries to resolve the realpath, it is unable to find the file `/private/tmp/sqlite-test/public/laravel`, so it returns `false`.

https://github.com/laravel/framework/blob/1fea0692d408bc8ac886c4e6d7cd0727a258a87e/src/Illuminate/Database/Connectors/SQLiteConnector.php#L28-L37

## The improvement (not a fix)

The current exception message is not useful. In Laravel 9.x I would like to solve this by improving the error message presented to the user to at least give some information on how to solve the issue.

<img width="1509" alt="Screen Shot 2023-01-13 at 11 24 31 am" src="https://user-images.githubusercontent.com/24803032/212211452-7527879b-6afe-46fa-93af-a39107f8d52e.png">

Unfortunately the error message doesn't mention the environment variable or the configuration variable, as at this point we don't have any information on which is being used. The component could also be used outside of `laravel/laravel`.

## Inconsistency sucks

You know it. I know it. It sucks that this works in Artisan but doesn't then work in a HTTP request. Just wanna put that out there.

## Future fix

Someone smarter than myself may be able to find a good solution to this, but I've tried a bunch of things and everything seemed to have issues.

Windows vs POSIX, `./laravel` vs `laravel`, who knows what else.