### PR TITLE
[9.x] Add isLocked to Cache Facade

### DIFF
--- a/src/Illuminate/Bus/UniqueLock.php
+++ b/src/Illuminate/Bus/UniqueLock.php
@@ -64,7 +64,7 @@ class UniqueLock
      * @param  mixed  $job
      * @return string
      */
-    protected function getKey($job)
+    public function getKey($job)
     {
         $uniqueId = method_exists($job, 'uniqueId')
                     ? $job->uniqueId()

--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -55,7 +55,7 @@ class ArrayLock extends Lock
      *
      * @return bool
      */
-    protected function exists()
+    public function exists()
     {
         return isset($this->store->locks[$this->name]);
     }

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -215,4 +215,25 @@ class ArrayStore extends TaggableStore implements LockProvider
     {
         return $this->lock($name, 0, $owner);
     }
+
+    /**
+     * Determine if a lock with the given name is locked
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function isLocked($name)
+    {
+        $lock = $this->lock($name);
+
+        if (!$lock->exists()) {
+            return false;
+        }
+
+        if($this->locks[$name]['expiresAt'] == null) {
+            return true;
+        }
+
+        return $this->locks[$name]['expiresAt']->isFuture();
+    }
 }

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -217,20 +217,20 @@ class ArrayStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Determine if a lock with the given name is locked
+     * Determine if a lock with the given name is locked.
      *
-     * @param string $name
+     * @param  string  $name
      * @return bool
      */
     public function isLocked($name)
     {
         $lock = $this->lock($name);
 
-        if (!$lock->exists()) {
+        if (! $lock->exists()) {
             return false;
         }
 
-        if($this->locks[$name]['expiresAt'] == null) {
+        if ($this->locks[$name]['expiresAt'] == null) {
             return true;
         }
 

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -72,6 +72,16 @@ class RedisLock extends Lock
     }
 
     /**
+     * Determine if the current lock exists.
+     *
+     * @return bool
+     */
+    public function exists()
+    {
+        return $this->redis->get($this->name) !== null;
+    }
+
+    /**
      * Get the name of the Redis connection being used to manage the lock.
      *
      * @return string

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -213,6 +213,17 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
+     * Determine if a lock with the given name is locked
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function isLocked($name)
+    {
+        return $this->lock($name)->exists();
+    }
+
+    /**
      * Remove an item from the cache.
      *
      * @param  string  $key

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -213,9 +213,9 @@ class RedisStore extends TaggableStore implements LockProvider
     }
 
     /**
-     * Determine if a lock with the given name is locked
+     * Determine if a lock with the given name is locked.
      *
-     * @param string $name
+     * @param  string  $name
      * @return bool
      */
     public function isLocked($name)

--- a/src/Illuminate/Queue/UniqueAware.php
+++ b/src/Illuminate/Queue/UniqueAware.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Bus\UniqueLock;
+use Illuminate\Cache\Repository;
+use Illuminate\Container\Container;
+
+trait UniqueAware
+{
+    /**
+     * Check if the current job can be dispatched based on its uniqueness
+     *
+     * @return boolean
+     */
+    public function isLocked()
+    {
+        return Container::getInstance()->make(Repository::class)->isLocked($this->getLockCacheKey());
+    }
+
+    /**
+     * Return the lock cache key for the current job
+     *
+     * @return string
+     */
+    public function getLockCacheKey(): string
+    {
+        $lock = new UniqueLock(Container::getInstance()->make(Repository::class));
+
+        return $lock->getKey($this);
+    }
+}

--- a/src/Illuminate/Queue/UniqueAware.php
+++ b/src/Illuminate/Queue/UniqueAware.php
@@ -9,9 +9,9 @@ use Illuminate\Container\Container;
 trait UniqueAware
 {
     /**
-     * Check if the current job can be dispatched based on its uniqueness
+     * Check if the current job can be dispatched based on its uniqueness.
      *
-     * @return boolean
+     * @return bool
      */
     public function isLocked()
     {
@@ -19,7 +19,7 @@ trait UniqueAware
     }
 
     /**
-     * Return the lock cache key for the current job
+     * Return the lock cache key for the current job.
      *
      * @return string
      */

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -49,6 +49,7 @@ namespace Illuminate\Support\Facades;
  * @method static string getPrefix()
  * @method static \Illuminate\Contracts\Cache\Lock lock(string $name, int $seconds = 0, string|null $owner = null)
  * @method static \Illuminate\Contracts\Cache\Lock restoreLock(string $name, string $owner)
+ * @method static bool isLocked(string $name)
  *
  * @see \Illuminate\Cache\CacheManager
  * @mixin \Illuminate\Cache\Repository

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -273,4 +273,19 @@ class CacheArrayStoreTest extends TestCase
 
         $this->assertFalse($wannabeOwner->release());
     }
+
+    public function testCanCheckIfLockExists()
+    {
+        $store = new ArrayStore;
+        $this->assertFalse($store->isLocked('foo'));
+
+        $lock = $store->lock('foo', 10);
+        $lock->acquire();
+
+        $this->assertTrue($store->isLocked('foo'));
+
+        $lock->release();
+
+        $this->assertFalse($store->isLocked('foo'));
+    }
 }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Cache;
 
-use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\RedisStore;
 use Illuminate\Contracts\Redis\Factory;
 use Mockery as m;

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -4,8 +4,6 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Exception;
 use Illuminate\Bus\Queueable;
-use Illuminate\Cache\Repository;
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;


### PR DESCRIPTION
Currently it is not possible to inquire about the lock status of a lock before attempting to acquire it. This is needed in order to perform conditional logic for dispatching unique jobs. For example, if I want to throw an error if an instance of a job already has a lock, that is not possible with the current implementation. 
```php
$myUniqueJob = new UniqueJob()

// Will dispatch, since no lock as been acquired yet
dispatch($myUniqueJob)

// Will not dispatch the job silently, since it cannot acquire a lock
dispatch($myUniqueJob)

// PR allows
throw_if($myUniqueJob->isLocked());
```

I have currently only implemented test cases for the array and redis drivers, but can handle the other drivers if this PR moves forward.