### PR TITLE
[9.x] CLI Prompts

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -16,6 +16,7 @@ class Command extends SymfonyCommand
         Concerns\HasParameters,
         Concerns\InteractsWithIO,
         Concerns\InteractsWithSignals,
+        Concerns\PromptsForMissingInput,
         Macroable;
 
     /**

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Concerns;
 
+use Illuminate\Contracts\Console\PromptsForMissingInput as PromptsForMissingInputContract;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -18,7 +19,9 @@ trait PromptsForMissingInput
     {
         parent::interact($input, $output);
 
-        $this->promptForMissingArguments($input, $output);
+        if ($this instanceof PromptsForMissingInputContract) {
+            $this->promptForMissingArguments($input, $output);
+        }
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait PromptsForMissingInput
+{
+    /**
+     * Interact with the user before validating the input.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        parent::interact($input, $output);
+
+        $this->promptForMissingArguments($input, $output);
+    }
+
+    /**
+     * Prompt the user for any missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function promptforMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        $prompted = collect($this->getDefinition()->getArguments())
+            ->filter(fn ($argument) => $argument->isRequired() && is_null($input->getArgument($argument->getName())))
+            ->each(fn ($argument) => $input->setArgument(
+                $argument->getName(),
+                $this->askPersistently('What is '.lcfirst($argument->getDescription()).'?')
+            ))
+            ->isNotEmpty();
+
+        if ($prompted) {
+            $this->afterPromptingForMissingArguments($input, $output);
+        }
+    }
+
+    /**
+     * Perform actions after the user was prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        //
+    }
+
+    /**
+     * Whether the input contains any options that differ from the default values.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @return bool
+     */
+    protected function didReceiveOptions(InputInterface $input)
+    {
+        return collect($this->getDefinition()->getOptions())
+            ->reject(fn ($option) => $input->getOption($option->getName()) === $option->getDefault())
+            ->isNotEmpty();
+    }
+
+    /**
+     * Continue asking a question until an answer is provided.
+     *
+     * @param  string  $question
+     * @return string
+     */
+    private function askPersistently($question)
+    {
+        $answer = null;
+
+        while ($answer === null) {
+            $answer = $this->components->ask($question);
+
+            if ($answer === null) {
+                $this->components->error('The answer is required.');
+            }
+        }
+
+        return $answer;
+    }
+}

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -31,7 +31,7 @@ trait PromptsForMissingInput
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
-    protected function promptforMissingArguments(InputInterface $input, OutputInterface $output)
+    protected function promptForMissingArguments(InputInterface $input, OutputInterface $output)
     {
         $prompted = collect($this->getDefinition()->getArguments())
             ->filter(fn ($argument) => $argument->isRequired() && is_null($input->getArgument($argument->getName())))

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -37,13 +37,26 @@ trait PromptsForMissingInput
             ->filter(fn ($argument) => $argument->isRequired() && is_null($input->getArgument($argument->getName())))
             ->each(fn ($argument) => $input->setArgument(
                 $argument->getName(),
-                $this->askPersistently('What is '.lcfirst($argument->getDescription()).'?')
+                $this->askPersistently(
+                    $this->promptForMissingInputUsing()[$argument->getName()] ??
+                    'What is '.lcfirst($argument->getDescription()).'?'
+                )
             ))
             ->isNotEmpty();
 
         if ($prompted) {
             $this->afterPromptingForMissingArguments($input, $output);
         }
+    }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array
+     */
+    protected function promptForMissingInputUsing()
+    {
+        return [];
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
+++ b/src/Illuminate/Console/Concerns/PromptsForMissingInput.php
@@ -38,7 +38,7 @@ trait PromptsForMissingInput
             ->each(fn ($argument) => $input->setArgument(
                 $argument->getName(),
                 $this->askPersistently(
-                    $this->promptForMissingInputUsing()[$argument->getName()] ??
+                    $this->promptForMissingArgumentsUsing()[$argument->getName()] ??
                     'What is '.lcfirst($argument->getDescription()).'?'
                 )
             ))
@@ -54,7 +54,7 @@ trait PromptsForMissingInput
      *
      * @return array
      */
-    protected function promptForMissingInputUsing()
+    protected function promptForMissingArgumentsUsing()
     {
         return [];
     }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Finder\Finder;
 
 abstract class GeneratorCommand extends Command implements PromptsForMissingInput
 {
@@ -232,6 +233,40 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
         return is_dir(app_path('Models'))
                     ? $rootNamespace.'Models\\'.$model
                     : $rootNamespace.$model;
+    }
+
+    /**
+     * Get a list of possible model names.
+     *
+     * @return array<int, string>
+     */
+    protected function possibleModels()
+    {
+        $modelPath = is_dir(app_path('Models')) ? app_path('Models') : app_path();
+
+        return collect((new Finder)->files()->depth(0)->in($modelPath))
+            ->map(fn ($file) => $file->getBasename('.php'))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Get a list of possible event names.
+     *
+     * @return array<int, string>
+     */
+    protected function possibleEvents()
+    {
+        $eventPath = app_path('Events');
+
+        if (! is_dir($eventPath)) {
+            return [];
+        }
+
+        return collect((new Finder)->files()->depth(0)->in($eventPath))
+            ->map(fn ($file) => $file->getBasename('.php'))
+            ->values()
+            ->all();
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -481,7 +481,7 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
      *
      * @return array
      */
-    protected function promptForMissingInputUsing()
+    protected function promptForMissingArgumentsUsing()
     {
         return [
             'name' => 'What should the '.strtolower($this->type).' be named?',

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -9,6 +9,8 @@ use Symfony\Component\Console\Input\InputArgument;
 
 abstract class GeneratorCommand extends Command
 {
+    use Concerns\PromptsForMissingInput;
+
     /**
      * The filesystem instance.
      *

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -472,7 +472,19 @@ abstract class GeneratorCommand extends Command implements PromptsForMissingInpu
     protected function getArguments()
     {
         return [
-            ['name', InputArgument::REQUIRED, 'The name of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the '.strtolower($this->type)],
+        ];
+    }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array
+     */
+    protected function promptForMissingInputUsing()
+    {
+        return [
+            'name' => 'What should the '.strtolower($this->type).' be named?',
         ];
     }
 }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -3,14 +3,13 @@
 namespace Illuminate\Console;
 
 use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 
-abstract class GeneratorCommand extends Command
+abstract class GeneratorCommand extends Command implements PromptsForMissingInput
 {
-    use Concerns\PromptsForMissingInput;
-
     /**
      * The filesystem instance.
      *

--- a/src/Illuminate/Console/QuestionHelper.php
+++ b/src/Illuminate/Console/QuestionHelper.php
@@ -47,6 +47,11 @@ class QuestionHelper extends SymfonyQuestionHelper
                 $text = sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($choices[$default] ?? $default));
 
                 break;
+
+            default:
+                $text = sprintf('<info>%s</info> [<comment>%s</comment>]', $text, OutputFormatter::escape($default));
+
+                break;
         }
 
         $output->writeln($text);

--- a/src/Illuminate/Console/View/Components/Ask.php
+++ b/src/Illuminate/Console/View/Components/Ask.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Console\View\Components;
+
+class Ask extends Component
+{
+    /**
+     * Renders the component using the given arguments.
+     *
+     * @param  string  $question
+     * @param  string  $default
+     * @return mixed
+     */
+    public function render($question, $default = null)
+    {
+        return $this->usingQuestionHelper(fn () => $this->output->ask($question, $default));
+    }
+}

--- a/src/Illuminate/Console/View/Components/AskWithCompletion.php
+++ b/src/Illuminate/Console/View/Components/AskWithCompletion.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Console\View\Components;
+
+use Symfony\Component\Console\Question\Question;
+
+class AskWithCompletion extends Component
+{
+    /**
+     * Renders the component using the given arguments.
+     *
+     * @param  string  $question
+     * @param  array|callable  $choices
+     * @param  string  $default
+     * @return mixed
+     */
+    public function render($question, $choices, $default = null)
+    {
+        $question = new Question($question, $default);
+
+        is_callable($choices)
+            ? $question->setAutocompleterCallback($choices)
+            : $question->setAutocompleterValues($choices);
+
+        return $this->usingQuestionHelper(
+            fn () => $this->output->askQuestion($question)
+        );
+    }
+}

--- a/src/Illuminate/Console/View/Components/Choice.php
+++ b/src/Illuminate/Console/View/Components/Choice.php
@@ -12,13 +12,17 @@ class Choice extends Component
      * @param  string  $question
      * @param  array<array-key, string>  $choices
      * @param  mixed  $default
+     * @param  int  $attempts
+     * @param  bool  $multiple
      * @return mixed
      */
-    public function render($question, $choices, $default = null)
+    public function render($question, $choices, $default = null, $attempts = null, $multiple = false)
     {
         return $this->usingQuestionHelper(
             fn () => $this->output->askQuestion(
-                new ChoiceQuestion($question, $choices, $default)
+                (new ChoiceQuestion($question, $choices, $default))
+                    ->setMaxAttempts($attempts)
+                    ->setMultiselect($multiple)
             ),
         );
     }

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 /**
  * @method void alert(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method mixed ask(string $question, string $default = null)
+ * @method mixed askWithCompletion(string $question, array|callable $choices, string $default = null)
  * @method void bulletList(array $elements, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method mixed choice(string $question, array $choices, $default = null, int $attempts = null, bool $multiple = false)
  * @method bool confirm(string $question, bool $default = false)

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 
 /**
  * @method void alert(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
+ * @method mixed ask(string $question, string $default = null)
  * @method void bulletList(array $elements, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method mixed choice(string $question, array $choices, $default = null)
  * @method bool confirm(string $question, bool $default = false)

--- a/src/Illuminate/Console/View/Components/Factory.php
+++ b/src/Illuminate/Console/View/Components/Factory.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
  * @method void alert(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method mixed ask(string $question, string $default = null)
  * @method void bulletList(array $elements, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
- * @method mixed choice(string $question, array $choices, $default = null)
+ * @method mixed choice(string $question, array $choices, $default = null, int $attempts = null, bool $multiple = false)
  * @method bool confirm(string $question, bool $default = false)
  * @method void error(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)
  * @method void info(string $string, int $verbosity = \Symfony\Component\Console\Output\OutputInterface::VERBOSITY_NORMAL)

--- a/src/Illuminate/Contracts/Console/PromptsForMissingInput.php
+++ b/src/Illuminate/Contracts/Console/PromptsForMissingInput.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Contracts\Console;
+
+interface PromptsForMissingInput
+{
+    //
+}

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -2,15 +2,13 @@
 
 namespace Illuminate\Database\Console\Migrations;
 
-use Illuminate\Console\Concerns\PromptsForMissingInput;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Str;
 
-class MigrateMakeCommand extends BaseCommand
+class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
 {
-    use PromptsForMissingInput;
-
     /**
      * The console command signature.
      *

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -135,7 +135,7 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
      *
      * @return array
      */
-    protected function promptForMissingInputUsing()
+    protected function promptForMissingArgumentsUsing()
     {
         return [
             'name' => 'What should the migration be named?',

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -129,4 +129,16 @@ class MigrateMakeCommand extends BaseCommand implements PromptsForMissingInput
 
         return parent::getMigrationPath();
     }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array
+     */
+    protected function promptForMissingInputUsing()
+    {
+        return [
+            'name' => 'What should the migration be named?',
+        ];
+    }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -2,12 +2,15 @@
 
 namespace Illuminate\Database\Console\Migrations;
 
+use Illuminate\Console\Concerns\PromptsForMissingInput;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Str;
 
 class MigrateMakeCommand extends BaseCommand
 {
+    use PromptsForMissingInput;
+
     /**
      * The console command signature.
      *

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -131,8 +131,8 @@ class ListenerMakeCommand extends GeneratorCommand
     /**
      * Interact further with the user if they were prompted for missing arguments.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -6,7 +6,9 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'make:listener')]
 class ListenerMakeCommand extends GeneratorCommand
@@ -124,5 +126,29 @@ class ListenerMakeCommand extends GeneratorCommand
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the listener already exists'],
             ['queued', null, InputOption::VALUE_NONE, 'Indicates the event listener should be queued'],
         ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $event = $this->components->askWithCompletion(
+            'What event should be listened for?',
+            $this->possibleEvents(),
+            'none'
+        );
+
+        if ($event && $event !== 'none') {
+            $input->setOption('event', $event);
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -43,7 +43,7 @@ class MailMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $type = 'Mail';
+    protected $type = 'Mailable';
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -6,7 +6,9 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'make:model')]
 class ModelMakeCommand extends GeneratorCommand
@@ -232,5 +234,37 @@ class ModelMakeCommand extends GeneratorCommand
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API resource controller'],
             ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
         ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        collect($this->components->choice('Would you like any of the following?', [
+            'none',
+            'all',
+            'migration',
+            'seed',
+            'factory',
+            'policy',
+            'resource controller',
+            'form requests',
+        ], default: 0, multiple: true))
+        ->reject('none')
+        ->map(fn ($option) => match ($option) {
+            'resource controller' => 'resource',
+            'form requests' => 'requests',
+            default => $option,
+        })
+        ->each(fn ($option) => $input->setOption($option, true));
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -252,12 +252,12 @@ class ModelMakeCommand extends GeneratorCommand
         collect($this->components->choice('Would you like any of the following?', [
             'none',
             'all',
-            'migration',
-            'seed',
             'factory',
+            'form requests',
+            'migration',
             'policy',
             'resource controller',
-            'form requests',
+            'seed',
         ], default: 0, multiple: true))
         ->reject('none')
         ->map(fn ($option) => match ($option) {

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -156,8 +156,8 @@ class ObserverMakeCommand extends GeneratorCommand
     /**
      * Interact further with the user if they were prompted for missing arguments.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -5,7 +5,9 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\GeneratorCommand;
 use InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'make:observer')]
 class ObserverMakeCommand extends GeneratorCommand
@@ -149,5 +151,29 @@ class ObserverMakeCommand extends GeneratorCommand
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the observer already exists'],
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observer applies to'],
         ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $model = $this->components->askWithCompletion(
+            'What model should this observer apply to?',
+            $this->possibleModels(),
+            'none'
+        );
+
+        if ($model && $model !== 'none') {
+            $input->setOption('model', $model);
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -215,8 +215,8 @@ class PolicyMakeCommand extends GeneratorCommand
     /**
      * Interact further with the user if they were prompted for missing arguments.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -6,7 +6,9 @@ use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use LogicException;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'make:policy')]
 class PolicyMakeCommand extends GeneratorCommand
@@ -208,5 +210,29 @@ class PolicyMakeCommand extends GeneratorCommand
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the policy applies to'],
             ['guard', 'g', InputOption::VALUE_OPTIONAL, 'The guard that the policy relies on'],
         ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $model = $this->components->askWithCompletion(
+            'What model should this policy apply to?',
+            $this->possibleModels(),
+            'none'
+        );
+
+        if ($model && $model !== 'none') {
+            $input->setOption('model', $model);
+        }
     }
 }

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -136,14 +136,14 @@ class TestMakeCommand extends GeneratorCommand
             return;
         }
 
-        $option = $this->components->choice('Which type of test would you like', [
+        $type = $this->components->choice('Which type of test would you like', [
             'feature',
             'unit',
             'pest feature',
             'pest unit',
         ], default: 0);
 
-        match ($option) {
+        match ($type) {
             'feature' => null,
             'unit' => $input->setOption('unit', true),
             'pest feature' => $input->setOption('pest', true),

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -5,7 +5,9 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'make:test')]
 class TestMakeCommand extends GeneratorCommand
@@ -119,5 +121,33 @@ class TestMakeCommand extends GeneratorCommand
             ['unit', 'u', InputOption::VALUE_NONE, 'Create a unit test'],
             ['pest', 'p', InputOption::VALUE_NONE, 'Create a Pest test'],
         ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $option = $this->components->choice('Which type of test would you like', [
+            'feature',
+            'unit',
+            'pest feature',
+            'pest unit',
+        ], default: 0);
+
+        match ($option) {
+            'feature' => null,
+            'unit' => $input->setOption('unit', true),
+            'pest feature' => $input->setOption('pest', true),
+            'pest unit' => tap($input)->setOption('pest', true)->setOption('unit', true),
+        };
     }
 }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -297,6 +298,18 @@ class ControllerMakeCommand extends GeneratorCommand
             ['requests', 'R', InputOption::VALUE_NONE, 'Generate FormRequest classes for store and update'],
             ['singleton', 's', InputOption::VALUE_NONE, 'Generate a singleton resource controller class'],
             ['creatable', null, InputOption::VALUE_NONE, 'Indicate that a singleton resource should be creatable'],
+        ];
+    }
+
+    /**
+     * The questions that should be asked per missing input arguments.
+     *
+     * @return array
+     */
+    protected function missingInputQuestions()
+    {
+        return [
+            'name' => 'What should the controller be named?'
         ];
     }
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -6,7 +6,9 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'make:controller')]
 class ControllerMakeCommand extends GeneratorCommand
@@ -296,5 +298,47 @@ class ControllerMakeCommand extends GeneratorCommand
             ['singleton', 's', InputOption::VALUE_NONE, 'Generate a singleton resource controller class'],
             ['creatable', null, InputOption::VALUE_NONE, 'Indicate that a singleton resource should be creatable'],
         ];
+    }
+
+    /**
+     * Interact further with the user if they were prompted for missing arguments.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->didReceiveOptions($input)) {
+            return;
+        }
+
+        $type = $this->components->choice('Which type of controller would you like', [
+            'empty',
+            'api',
+            'invokable',
+            'resource',
+            'singleton',
+        ], default: 0);
+
+        match ($type) {
+            'empty' => null,
+            'api' => $input->setOption('api', true),
+            'invokable' => $input->setOption('invokable', true),
+            'resource' => tap($input)->setOption('resource', true),
+            'singleton' => tap($input)->setOption('singleton', true),
+        };
+
+        if (in_array($type, ['api', 'resource', 'singleton'])) {
+            $model = $this->components->askWithCompletion(
+                "What model should this $type controller be for?",
+                $this->possibleModels(),
+                'none'
+            );
+
+            if ($model && $model !== 'none') {
+                $input->setOption('model', $model);
+            }
+        }
     }
 }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -321,13 +321,9 @@ class ControllerMakeCommand extends GeneratorCommand
             'singleton',
         ], default: 0);
 
-        match ($type) {
-            'empty' => null,
-            'api' => $input->setOption('api', true),
-            'invokable' => $input->setOption('invokable', true),
-            'resource' => $input->setOption('resource', true),
-            'singleton' => $input->setOption('singleton', true),
-        };
+        if ($type !== 'empty') {
+            $input->setOption($type, true);
+        }
 
         if (in_array($type, ['api', 'resource', 'singleton'])) {
             $model = $this->components->askWithCompletion(

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -301,18 +301,6 @@ class ControllerMakeCommand extends GeneratorCommand
     }
 
     /**
-     * The questions that should be asked per missing input arguments.
-     *
-     * @return array
-     */
-    protected function missingInputQuestions()
-    {
-        return [
-            'name' => 'What should the controller be named?',
-        ];
-    }
-
-    /**
      * Interact further with the user if they were prompted for missing arguments.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand;
 use InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -309,7 +308,7 @@ class ControllerMakeCommand extends GeneratorCommand
     protected function missingInputQuestions()
     {
         return [
-            'name' => 'What should the controller be named?'
+            'name' => 'What should the controller be named?',
         ];
     }
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -325,8 +325,8 @@ class ControllerMakeCommand extends GeneratorCommand
             'empty' => null,
             'api' => $input->setOption('api', true),
             'invokable' => $input->setOption('invokable', true),
-            'resource' => tap($input)->setOption('resource', true),
-            'singleton' => tap($input)->setOption('singleton', true),
+            'resource' => $input->setOption('resource', true),
+            'singleton' => $input->setOption('singleton', true),
         };
 
         if (in_array($type, ['api', 'resource', 'singleton'])) {


### PR DESCRIPTION
This PR introduces the ability to automatically prompt the user for missing command arguments instead of returning an error.

This functionality has been added to all `make:*` commands.

**Before**

![image](https://user-images.githubusercontent.com/4977161/212221423-c6b62de6-cf87-47fc-b55f-752c38d801bc.png)

**After**

![image](https://user-images.githubusercontent.com/4977161/212221750-dd25cceb-2f7d-42f7-90c5-37058edc6396.png)

This functionality can be added to any command by implementing the new `Illuminate\Contracts\Console\PromptsForMissingInput` interface:

```php
use Illuminate\Console\Command;
use Illuminate\Contracts\Console\PromptsForMissingInput;

class MyCommand extends Command implements PromptsForMissingInput
{
    // ...
}
```

Commands that implement `PromptsForMissingInput` will be checked for any **required** arguments that were not provided, and then use the argument description to prompt for the value.

It also exposes a hook that is called only after the user is prompted for missing arguments, allowing additional actions to be performed. I've used this to add additional prompts on a few of the `make:*` commands that have commonly needed options:

## Additional prompt for `make:model`

The `make:model` command can prompt for additional classes:

![image](https://user-images.githubusercontent.com/4977161/212223700-25320dc9-4dbc-45ec-b53b-17b6e05f83d4.png)

> **Note** Multiple options can be separated by commas, and the choices can be tab completed.

It will only prompt for options when the required argument is not provided. In other words, it won't prompt for options when calling `make:model Post`.

The following illustrates the different scenarios where prompts will and won't show:

* `make:model` Prompts for model name and additional classes.
* `make:model --migration` Prompts only for the model name.
* `make:model Post` Does not prompt for anything.
* `make:model --no-interaction` Does not prompt for anything.

## Additional prompt for `make:listener`

The `make:listener` command can prompt for the event class being listened for, with tab completion for events in the `app/Events` directory:

![image](https://user-images.githubusercontent.com/4977161/212836761-b0d13ab4-5523-48c9-9b2e-091b97102c2f.png)

> **Note** Anything you can pass to `--event` can be passed here, not just events in the `app/Events` directory. You can also just press enter to not specify anything.

## Additional prompt for `make:observer` and `make:policy`

The `make:observer` and `make:policy` commands will prompt for the model, also with tab completion of models in the standard locations:

![image](https://user-images.githubusercontent.com/4977161/212836597-f7f621c4-7235-491d-9187-c0c01e844d26.png)

![image](https://user-images.githubusercontent.com/4977161/212836635-dd806257-9630-47dd-95dc-c0179762f908.png)

> **Note** Again, anything you can pass to `--model` is accepted here, not just the models that are tab completed.

## Additional prompt for `make:test`

The `make:test` command will prompt for the type of test you would like:

![image](https://user-images.githubusercontent.com/4977161/212837522-1815cedf-72e0-4882-989e-05a92649ab37.png)

## Additional prompts for `make:controller`

The `make:controller` command will prompt for the type of controller you would like. If `api`, `resource`, or `singleton` is selected, it will also prompt for the model:

![image](https://user-images.githubusercontent.com/4977161/212841929-cf6ef65e-2e38-4959-9932-a160a99aae3f.png)

---

I went with the name `PromptsForMissingInput` rather than `PromptsForMissingArguments` to leave the door open for prompting when an option that requires a value is passed without the value.

I realise this is a pretty big DX change, so I would appreciate feedback. I'd like to stress that these prompts will only show when an error would otherwise be displayed and only in interactive terminal sessions. If you always pass the required arguments, then nothing will change for you. But if you're like me and can never remember which `make:model` options you want, then you would now be able to run the command without arguments and be prompted for the common options instead of needing to run it with `--help` first.