### PR TITLE
[9.x] Add DatabaseTruncates option for setting up test DB

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTruncates.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncates.php
@@ -32,7 +32,17 @@ trait DatabaseTruncates
         }
 
         // Seed the database on subsequent runs.
-        $this->artisan('db:seed', ['--class' => $this->seeder()]);
+        if ($seeder = $this->seeder()) {
+            // Use a specific seeder class.
+            $this->artisan('db:seed', ['--class' => $seeder]);
+
+            return;
+        }
+
+        if ($this->shouldSeed()) {
+            // Use the default seeder class.
+            $this->artisan('db:seed');
+        }
     }
 
     protected function excludeTables()

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncates.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncates.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Foundation\Testing\Traits\CanConfigureMigrationCommands;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+trait DatabaseTruncates
+{
+    use CanConfigureMigrationCommands;
+
+    protected static array $allTables;
+
+    protected function truncateTables()
+    {
+        // Always remove any test data before the application is destroyed.
+        $this->beforeApplicationDestroyed(function () {
+            Schema::disableForeignKeyConstraints();
+            collect(static::$allTables ??= DB::connection()->getDoctrineSchemaManager()->listTableNames())
+                ->diff($this->excludeTables())
+                ->filter(fn ($table) => DB::table($table)->exists())
+                ->each(fn ($table) => DB::table($table)->truncate());
+        });
+
+        // Migrate and seed the database on first run.
+        if (! RefreshDatabaseState::$migrated) {
+            $this->artisan('migrate:fresh', $this->migrateFreshUsing());
+            RefreshDatabaseState::$migrated = true;
+
+            return;
+        }
+
+        // Seed the database on subsequent runs.
+        $this->artisan('db:seed', ['--class' => $this->seeder()]);
+    }
+
+    protected function excludeTables()
+    {
+        return [
+            'migrations',
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Testing/DatabaseTruncates.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTruncates.php
@@ -48,7 +48,7 @@ trait DatabaseTruncates
     protected function excludeTables()
     {
         return [
-            'migrations',
+            $this->app['config']->get('database.migrations'),
         ];
     }
 }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -131,6 +131,10 @@ abstract class TestCase extends BaseTestCase
             $this->runDatabaseMigrations();
         }
 
+        if (isset($uses[DatabaseTruncates::class])) {
+            $this->truncateTables();
+        }
+
         if (isset($uses[DatabaseTransactions::class])) {
             $this->beginDatabaseTransaction();
         }

--- a/src/Illuminate/Testing/Concerns/TestDatabases.php
+++ b/src/Illuminate/Testing/Concerns/TestDatabases.php
@@ -42,6 +42,7 @@ trait TestDatabases
             $databaseTraits = [
                 Testing\DatabaseMigrations::class,
                 Testing\DatabaseTransactions::class,
+                Testing\DatabaseTruncates::class,
                 Testing\RefreshDatabase::class,
             ];
 


### PR DESCRIPTION
This PR adds another option to handle database state in tests.

The `DatabaseTruncates` trait is a drop in replacement for `DatabaseMigrations` however it only truncates tables with data instead of dropping and migrating the whole database.

In my dusk test suite I have seen a 60-70% time reduction in database setup operations; migrate, seed, rollback/truncate.

7 dusk tests, that all change 12 of 91 tables the following time was spent on database setup:
`DatabaseMigrations` 12.06 seconds - 1.72s/t
`DatabaseTruncates` 4.61 seconds - 0.65s/t

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
