### PR TITLE
[10.x] Fix `Str::isUuid()` returning false when given a `Str::uuid()`

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -14,6 +14,7 @@ use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
 use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Uid\Ulid;
 use Traversable;
 use voku\helper\ASCII;
@@ -426,11 +427,15 @@ class Str
     /**
      * Determine if a given string is a valid UUID.
      *
-     * @param  string  $value
+     * @param  string|\Ramsey\Uuid\UuidInterface  $value
      * @return bool
      */
     public static function isUuid($value)
     {
+        if ($value instanceof UuidInterface) {
+            return true;
+        }
+
         if (! is_string($value)) {
             return false;
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -422,6 +422,13 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::isUuid($uuid));
     }
 
+    public function testIsUuidWithANewlyGeneratedUuid()
+    {
+        $uuid = Str::uuid();
+
+        $this->assertTrue(Str::isUuid($uuid));
+    }
+
     public function testIsJson()
     {
         $this->assertTrue(Str::isJson('1'));


### PR DESCRIPTION
Currently, `Str::isUuid(Str::uuid())` returns false, because `isUuid()` only supports strings, and `Str::uuid()` returns a `UuidInterface`.

This fixes a bug described here: https://github.com/laravel/framework/pull/28412, because [the `uuid` validation rule](https://github.com/laravel/framework/blob/9d198bd947dbf1eb0a9499344754eb8426cb7a73/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L2205) uses `Str::isUuid()`.
