### PR TITLE
[11.x] Add missing() in Session contract

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -64,6 +64,14 @@ interface Session
     public function exists($key);
 
     /**
+     * Determine if the given key is missing from the session data.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function missing($key);
+
+    /**
      * Checks if a key is present and not null.
      *
      * @param  string|array  $key


### PR DESCRIPTION
Add the `missing()` method in the `Session` interface contract, since my editor complained about undefined method when using it via a `Request` instance. For example: `$request->session()->missing('key')`.