### PR TITLE
[9.x] Use stable packages only in CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -179,6 +179,6 @@
             "composer/package-versions-deprecated": true
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
This changes the minimum stability for framework to "stable". This is because of recent changes made in Composer that allow a wider selection of dev branches. Using "dev" on a stable branch like 9.x could lead to certain development packages being loaded in CI and giving unexpected results (either failures or success states where it's unwanted). By indicating we only want stable versions of packages we can test more accurate for real-life situations in apps. 

Development branches for framework (currently 10.x and master) can still use "dev" if needed but as soon as they come closer to their release date it's best to also give them the "stable" stability so we're sure packages have stable versions tagged that are compatible.