### PR TITLE
[9.x] Add option for not store meta data using session database driver

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -89,8 +89,10 @@ class SessionManager extends Manager
 
         $lifetime = $this->config->get('session.lifetime');
 
+        $includeMeta = $this->config->get('session.include_meta_data');
+
         return $this->buildSession(new DatabaseSessionHandler(
-            $this->getDatabaseConnection(), $table, $lifetime, $this->container
+            $this->getDatabaseConnection(), $table, $lifetime, $includeMeta ? $this->container : null
         ));
     }
 


### PR DESCRIPTION
when using the session driver database

in the DatabaseSessionHandler class constructor we can pass null as the container property.

if the container is null those **user_id , ip_address ,user_agent** will not persist in the db.

so we have all prepared for users to opt to not save those meta data.

as I know there is no easy way for users to decide not include those meta data through configuration.

because in the session manager we always pass the container to the DatabaseSessionHandler when getting the driver.

this pr is to allow user weather or not to include those meta thought a the session config

if pr approve I will create a new pr to include the config in other laravel repo


