### PR TITLE
Bug fix: Prohibited validator should accept empty value

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1681,7 +1681,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute does not exist.
+     * Validate that an attribute does not exist, or must be empty
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -1689,7 +1689,7 @@ trait ValidatesAttributes
      */
     public function validateProhibited($attribute, $value)
     {
-        return false;
+        return empty($value);
     }
 
     /**


### PR DESCRIPTION
Bug fix to match the behaviour shown in the Laravel documentation for the `prohibited` validation rule. Presently empty values weren't accepted which goes against the documented behaviour:

https://laravel.com/docs/master/validation#rule-prohibited