### PR TITLE
Add interface that matches with the InteractsWithQueue trait

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Broadcasting;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Support\Arrayable;
@@ -10,7 +11,7 @@ use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionProperty;
 
-class BroadcastEvent implements ShouldQueue
+class BroadcastEvent implements ShouldQueue, QueueableInterface
 {
     use Queueable;
 

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -78,7 +78,7 @@ trait Queueable
      * @param  string|null  $connection
      * @return $this
      */
-    public function onConnection(?string $connection): self
+    public function onConnection(?string $connection): QueueableInterface
     {
         $this->connection = $connection;
 
@@ -91,7 +91,7 @@ trait Queueable
      * @param  string|null  $queue
      * @return $this
      */
-    public function onQueue(?string $queue): self
+    public function onQueue(?string $queue): QueueableInterface
     {
         $this->queue = $queue;
 
@@ -104,7 +104,7 @@ trait Queueable
      * @param  string|null  $connection
      * @return $this
      */
-    public function allOnConnection(?string $connection): self
+    public function allOnConnection(?string $connection): QueueableInterface
     {
         $this->chainConnection = $connection;
         $this->connection = $connection;
@@ -118,7 +118,7 @@ trait Queueable
      * @param  string|null  $queue
      * @return $this
      */
-    public function allOnQueue(?string $queue): self
+    public function allOnQueue(?string $queue): QueueableInterface
     {
         $this->chainQueue = $queue;
         $this->queue = $queue;
@@ -132,7 +132,7 @@ trait Queueable
      * @param  \DateTimeInterface|\DateInterval|array|int|null  $delay
      * @return $this
      */
-    public function delay($delay): self
+    public function delay($delay): QueueableInterface
     {
         $this->delay = $delay;
 
@@ -144,7 +144,7 @@ trait Queueable
      *
      * @return $this
      */
-    public function afterCommit(): self
+    public function afterCommit(): QueueableInterface
     {
         $this->afterCommit = true;
 
@@ -156,7 +156,7 @@ trait Queueable
      *
      * @return $this
      */
-    public function beforeCommit(): self
+    public function beforeCommit(): QueueableInterface
     {
         $this->afterCommit = false;
 
@@ -169,7 +169,7 @@ trait Queueable
      * @param  array|object  $middleware
      * @return $this
      */
-    public function through($middleware): self
+    public function through($middleware): QueueableInterface
     {
         $this->middleware = Arr::wrap($middleware);
 
@@ -182,7 +182,7 @@ trait Queueable
      * @param  array  $chain
      * @return $this
      */
-    public function chain($chain): self
+    public function chain($chain): QueueableInterface
     {
         $this->chained = collect($chain)->map(function ($job) {
             return $this->serializeJob($job);
@@ -197,7 +197,7 @@ trait Queueable
      * @param  mixed  $job
      * @return $this
      */
-    public function prependToChain($job): self
+    public function prependToChain($job): QueueableInterface
     {
         $this->chained = Arr::prepend($this->chained, $this->serializeJob($job));
 
@@ -210,7 +210,7 @@ trait Queueable
      * @param  mixed  $job
      * @return $this
      */
-    public function appendToChain($job): self
+    public function appendToChain($job): QueueableInterface
     {
         $this->chained = array_merge($this->chained, [$this->serializeJob($job)]);
 
@@ -267,7 +267,7 @@ trait Queueable
      * @param  ?\Throwable  $e
      * @return void
      */
-    public function invokeChainCatchCallbacks(?\Throwable $e)
+    public function invokeChainCatchCallbacks(?\Throwable $e): void
     {
         collect($this->chainCatchCallbacks)->each(function ($callback) use ($e) {
             $callback($e);

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -264,10 +264,10 @@ trait Queueable
     /**
      * Invoke all of the chain's failed job callbacks.
      *
-     * @param  \Throwable  $e
+     * @param  ?\Throwable  $e
      * @return void
      */
-    public function invokeChainCatchCallbacks(\Throwable $e)
+    public function invokeChainCatchCallbacks(?\Throwable $e)
     {
         collect($this->chainCatchCallbacks)->each(function ($callback) use ($e) {
             $callback($e);

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -78,7 +78,7 @@ trait Queueable
      * @param  string|null  $connection
      * @return $this
      */
-    public function onConnection($connection)
+    public function onConnection(?string $connection): self
     {
         $this->connection = $connection;
 
@@ -91,7 +91,7 @@ trait Queueable
      * @param  string|null  $queue
      * @return $this
      */
-    public function onQueue($queue)
+    public function onQueue(?string $queue): self
     {
         $this->queue = $queue;
 
@@ -104,7 +104,7 @@ trait Queueable
      * @param  string|null  $connection
      * @return $this
      */
-    public function allOnConnection($connection)
+    public function allOnConnection(?string $connection): self
     {
         $this->chainConnection = $connection;
         $this->connection = $connection;
@@ -118,7 +118,7 @@ trait Queueable
      * @param  string|null  $queue
      * @return $this
      */
-    public function allOnQueue($queue)
+    public function allOnQueue(?string $queue): self
     {
         $this->chainQueue = $queue;
         $this->queue = $queue;
@@ -132,7 +132,7 @@ trait Queueable
      * @param  \DateTimeInterface|\DateInterval|array|int|null  $delay
      * @return $this
      */
-    public function delay($delay)
+    public function delay($delay): self
     {
         $this->delay = $delay;
 
@@ -144,7 +144,7 @@ trait Queueable
      *
      * @return $this
      */
-    public function afterCommit()
+    public function afterCommit(): self
     {
         $this->afterCommit = true;
 
@@ -156,7 +156,7 @@ trait Queueable
      *
      * @return $this
      */
-    public function beforeCommit()
+    public function beforeCommit(): self
     {
         $this->afterCommit = false;
 
@@ -169,7 +169,7 @@ trait Queueable
      * @param  array|object  $middleware
      * @return $this
      */
-    public function through($middleware)
+    public function through($middleware): self
     {
         $this->middleware = Arr::wrap($middleware);
 
@@ -182,7 +182,7 @@ trait Queueable
      * @param  array  $chain
      * @return $this
      */
-    public function chain($chain)
+    public function chain($chain): self
     {
         $this->chained = collect($chain)->map(function ($job) {
             return $this->serializeJob($job);
@@ -197,7 +197,7 @@ trait Queueable
      * @param  mixed  $job
      * @return $this
      */
-    public function prependToChain($job)
+    public function prependToChain($job): self
     {
         $this->chained = Arr::prepend($this->chained, $this->serializeJob($job));
 
@@ -210,7 +210,7 @@ trait Queueable
      * @param  mixed  $job
      * @return $this
      */
-    public function appendToChain($job)
+    public function appendToChain($job): self
     {
         $this->chained = array_merge($this->chained, [$this->serializeJob($job)]);
 
@@ -245,7 +245,7 @@ trait Queueable
      *
      * @return void
      */
-    public function dispatchNextJobInChain()
+    public function dispatchNextJobInChain(): void
     {
         if (! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
@@ -267,7 +267,7 @@ trait Queueable
      * @param  \Throwable  $e
      * @return void
      */
-    public function invokeChainCatchCallbacks($e)
+    public function invokeChainCatchCallbacks(\Throwable $e)
     {
         collect($this->chainCatchCallbacks)->each(function ($callback) use ($e) {
             $callback($e);

--- a/src/Illuminate/Bus/QueueableInterface.php
+++ b/src/Illuminate/Bus/QueueableInterface.php
@@ -100,8 +100,8 @@ interface QueueableInterface
     /**
      * Invoke all of the chain's failed job callbacks.
      *
-     * @param  \Throwable  $e
+     * @param  ?\Throwable  $e
      * @return void
      */
-    public function invokeChainCatchCallbacks(\Throwable $e);
+    public function invokeChainCatchCallbacks(?\Throwable $e);
 }

--- a/src/Illuminate/Bus/QueueableInterface.php
+++ b/src/Illuminate/Bus/QueueableInterface.php
@@ -10,7 +10,7 @@ interface QueueableInterface
      * @param  string|null  $connection
      * @return $this
      */
-    public function onConnection(?string $connection): self;
+    public function onConnection(?string $connection): QueueableInterface;
 
     /**
      * Set the desired queue for the job.
@@ -18,7 +18,7 @@ interface QueueableInterface
      * @param  string|null  $queue
      * @return $this
      */
-    public function onQueue(?string $queue): self;
+    public function onQueue(?string $queue): QueueableInterface;
 
     /**
      * Set the desired connection for the chain.
@@ -26,7 +26,7 @@ interface QueueableInterface
      * @param  string|null  $connection
      * @return $this
      */
-    public function allOnConnection(?string $connection): self;
+    public function allOnConnection(?string $connection): QueueableInterface;
 
     /**
      * Set the desired queue for the chain.
@@ -34,7 +34,7 @@ interface QueueableInterface
      * @param  string|null  $queue
      * @return $this
      */
-    public function allOnQueue(?string $queue): self;
+    public function allOnQueue(?string $queue): QueueableInterface;
 
     /**
      * Set the desired delay in seconds for the job.
@@ -42,21 +42,21 @@ interface QueueableInterface
      * @param  \DateTimeInterface|\DateInterval|array|int|null  $delay
      * @return $this
      */
-    public function delay(\DateInterval|\DateTimeInterface|int|array|null $delay): self;
+    public function delay(\DateInterval|\DateTimeInterface|int|array|null $delay): QueueableInterface;
 
     /**
      * Indicate that the job should be dispatched after all database transactions have committed.
      *
      * @return $this
      */
-    public function afterCommit(): self;
+    public function afterCommit(): QueueableInterface;
 
     /**
      * Indicate that the job should not wait until database transactions have been committed before dispatching.
      *
      * @return $this
      */
-    public function beforeCommit(): self;
+    public function beforeCommit(): QueueableInterface;
 
     /**
      * Specify the middleware the job should be dispatched through.
@@ -64,7 +64,7 @@ interface QueueableInterface
      * @param  array|object  $middleware
      * @return $this
      */
-    public function through($middleware): self;
+    public function through($middleware): QueueableInterface;
 
     /**
      * Set the jobs that should run if this job is successful.
@@ -72,7 +72,7 @@ interface QueueableInterface
      * @param  array  $chain
      * @return $this
      */
-    public function chain(array $chain): self;
+    public function chain(array $chain): QueueableInterface;
 
     /**
      * Prepend a job to the current chain so that it is run after the currently running job.
@@ -80,7 +80,7 @@ interface QueueableInterface
      * @param  mixed  $job
      * @return $this
      */
-    public function prependToChain($job): self;
+    public function prependToChain($job): QueueableInterface;
 
     /**
      * Append a job to the end of the current chain.
@@ -88,7 +88,7 @@ interface QueueableInterface
      * @param  mixed  $job
      * @return $this
      */
-    public function appendToChain($job): self;
+    public function appendToChain($job): QueueableInterface;
 
     /**
      * Dispatch the next job on the chain.

--- a/src/Illuminate/Bus/QueueableInterface.php
+++ b/src/Illuminate/Bus/QueueableInterface.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Bus;
+
+interface QueueableInterface
+{
+    /**
+     * Set the desired connection for the job.
+     *
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function onConnection(?string $connection): self;
+
+    /**
+     * Set the desired queue for the job.
+     *
+     * @param  string|null  $queue
+     * @return $this
+     */
+    public function onQueue(?string $queue): self;
+
+    /**
+     * Set the desired connection for the chain.
+     *
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function allOnConnection(?string $connection): self;
+
+    /**
+     * Set the desired queue for the chain.
+     *
+     * @param  string|null  $queue
+     * @return $this
+     */
+    public function allOnQueue(?string $queue): self;
+
+    /**
+     * Set the desired delay in seconds for the job.
+     *
+     * @param  \DateTimeInterface|\DateInterval|array|int|null  $delay
+     * @return $this
+     */
+    public function delay(\DateInterval|\DateTimeInterface|int|array|null $delay): self;
+
+    /**
+     * Indicate that the job should be dispatched after all database transactions have committed.
+     *
+     * @return $this
+     */
+    public function afterCommit(): self;
+
+    /**
+     * Indicate that the job should not wait until database transactions have been committed before dispatching.
+     *
+     * @return $this
+     */
+    public function beforeCommit(): self;
+
+    /**
+     * Specify the middleware the job should be dispatched through.
+     *
+     * @param  array|object  $middleware
+     * @return $this
+     */
+    public function through($middleware): self;
+
+    /**
+     * Set the jobs that should run if this job is successful.
+     *
+     * @param  array  $chain
+     * @return $this
+     */
+    public function chain(array $chain): self;
+
+    /**
+     * Prepend a job to the current chain so that it is run after the currently running job.
+     *
+     * @param  mixed  $job
+     * @return $this
+     */
+    public function prependToChain($job): self;
+
+    /**
+     * Append a job to the end of the current chain.
+     *
+     * @param  mixed  $job
+     * @return $this
+     */
+    public function appendToChain($job): self;
+
+    /**
+     * Dispatch the next job on the chain.
+     *
+     * @return void
+     */
+    public function dispatchNextJobInChain(): void;
+
+    /**
+     * Invoke all of the chain's failed job callbacks.
+     *
+     * @param  \Throwable  $e
+     * @return void
+     */
+    public function invokeChainCatchCallbacks(\Throwable $e);
+}

--- a/src/Illuminate/Bus/QueueableInterface.php
+++ b/src/Illuminate/Bus/QueueableInterface.php
@@ -103,5 +103,5 @@ interface QueueableInterface
      * @param  ?\Throwable  $e
      * @return void
      */
-    public function invokeChainCatchCallbacks(?\Throwable $e);
+    public function invokeChainCatchCallbacks(?\Throwable $e): void;
 }

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -3,12 +3,14 @@
 namespace Illuminate\Events;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 
-class CallQueuedListener implements ShouldQueue
+class CallQueuedListener implements ShouldQueue, QueueableInterface, InteractsWithQueueInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -13,7 +13,7 @@ trait Dispatchable
      *
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
-    public static function dispatch(...$arguments)
+    public static function dispatch(...$arguments): PendingDispatch
     {
         return new PendingDispatch(new static(...$arguments));
     }
@@ -25,7 +25,7 @@ trait Dispatchable
      * @param  mixed  ...$arguments
      * @return \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent
      */
-    public static function dispatchIf($boolean, ...$arguments)
+    public static function dispatchIf($boolean, ...$arguments): PendingDispatch|Fluent
     {
         if ($boolean instanceof Closure) {
             $dispatchable = new static(...$arguments);
@@ -47,7 +47,7 @@ trait Dispatchable
      * @param  mixed  ...$arguments
      * @return \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent
      */
-    public static function dispatchUnless($boolean, ...$arguments)
+    public static function dispatchUnless($boolean, ...$arguments): PendingDispatch|Fluent
     {
         if ($boolean instanceof Closure) {
             $dispatchable = new static(...$arguments);
@@ -69,7 +69,7 @@ trait Dispatchable
      *
      * @return mixed
      */
-    public static function dispatchSync(...$arguments)
+    public static function dispatchSync(...$arguments): mixed
     {
         return app(Dispatcher::class)->dispatchSync(new static(...$arguments));
     }
@@ -81,7 +81,7 @@ trait Dispatchable
      *
      * @deprecated Will be removed in a future Laravel version.
      */
-    public static function dispatchNow(...$arguments)
+    public static function dispatchNow(...$arguments): mixed
     {
         return app(Dispatcher::class)->dispatchNow(new static(...$arguments));
     }
@@ -91,7 +91,7 @@ trait Dispatchable
      *
      * @return mixed
      */
-    public static function dispatchAfterResponse(...$arguments)
+    public static function dispatchAfterResponse(...$arguments): mixed
     {
         return app(Dispatcher::class)->dispatchAfterResponse(new static(...$arguments));
     }
@@ -102,7 +102,7 @@ trait Dispatchable
      * @param  array  $chain
      * @return \Illuminate\Foundation\Bus\PendingChain
      */
-    public static function withChain($chain)
+    public static function withChain($chain): PendingChain
     {
         return new PendingChain(static::class, $chain);
     }

--- a/src/Illuminate/Foundation/Bus/DispatchableInterface.php
+++ b/src/Illuminate/Foundation/Bus/DispatchableInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Foundation\Bus;
+
+use Illuminate\Support\Fluent;
+
+interface DispatchableInterface
+{
+    public static function dispatch(...$arguments): PendingDispatch;
+    public static function dispatchIf($boolean, ...$arguments): PendingDispatch|Fluent;
+    public static function dispatchUnless($boolean, ...$arguments): PendingDispatch|Fluent;
+    public static function dispatchSync(...$arguments): mixed;
+    public static function dispatchNow(...$arguments): mixed;
+    public static function dispatchAfterResponse(...$arguments): mixed;
+    public static function withChain($chain): PendingChain;
+}

--- a/src/Illuminate/Foundation/Bus/DispatchableInterface.php
+++ b/src/Illuminate/Foundation/Bus/DispatchableInterface.php
@@ -6,11 +6,61 @@ use Illuminate\Support\Fluent;
 
 interface DispatchableInterface
 {
+    /**
+     * Dispatch the job with the given arguments.
+     *
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     */
     public static function dispatch(...$arguments): PendingDispatch;
+
+    /**
+     * Dispatch the job with the given arguments if the given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @param  mixed  ...$arguments
+     * @return \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent
+     */
     public static function dispatchIf($boolean, ...$arguments): PendingDispatch|Fluent;
+
+    /**
+     * Dispatch the job with the given arguments unless the given truth test passes.
+     *
+     * @param  bool|\Closure  $boolean
+     * @param  mixed  ...$arguments
+     * @return \Illuminate\Foundation\Bus\PendingDispatch|\Illuminate\Support\Fluent
+     */
     public static function dispatchUnless($boolean, ...$arguments): PendingDispatch|Fluent;
+
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * Queueable jobs will be dispatched to the "sync" queue.
+     *
+     * @return mixed
+     */
     public static function dispatchSync(...$arguments): mixed;
+
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * @return mixed
+     *
+     * @deprecated Will be removed in a future Laravel version.
+     */
     public static function dispatchNow(...$arguments): mixed;
+
+    /**
+     * Dispatch a command to its appropriate handler after the current process.
+     *
+     * @return mixed
+     */
     public static function dispatchAfterResponse(...$arguments): mixed;
+
+    /**
+     * Set the jobs that should run if this job is successful.
+     *
+     * @param  array  $chain
+     * @return \Illuminate\Foundation\Bus\PendingChain
+     */
     public static function withChain($chain): PendingChain;
 }

--- a/src/Illuminate/Foundation/Console/QueuedCommand.php
+++ b/src/Illuminate/Foundation/Console/QueuedCommand.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 
-class QueuedCommand implements ShouldQueue
+class QueuedCommand implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -3,12 +3,14 @@
 namespace Illuminate\Mail;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 
-class SendQueuedMailable
+class SendQueuedMailable implements InteractsWithQueueInterface, QueueableInterface
 {
     use Queueable, InteractsWithQueue;
 

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -4,12 +4,13 @@ namespace Illuminate\Notifications\Events;
 
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
 
-class BroadcastNotificationCreated implements ShouldBroadcast
+class BroadcastNotificationCreated implements ShouldBroadcast, QueueableInterface
 {
     use Queueable, SerializesModels;
 

--- a/src/Illuminate/Notifications/Events/NotificationFailed.php
+++ b/src/Illuminate/Notifications/Events/NotificationFailed.php
@@ -3,9 +3,10 @@
 namespace Illuminate\Notifications\Events;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Queue\SerializesModels;
 
-class NotificationFailed
+class NotificationFailed implements QueueableInterface
 {
     use Queueable, SerializesModels;
 

--- a/src/Illuminate/Notifications/Events/NotificationSending.php
+++ b/src/Illuminate/Notifications/Events/NotificationSending.php
@@ -3,9 +3,10 @@
 namespace Illuminate\Notifications\Events;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Queue\SerializesModels;
 
-class NotificationSending
+class NotificationSending implements QueueableInterface
 {
     use Queueable, SerializesModels;
 

--- a/src/Illuminate/Notifications/Events/NotificationSent.php
+++ b/src/Illuminate/Notifications/Events/NotificationSent.php
@@ -3,9 +3,10 @@
 namespace Illuminate\Notifications\Events;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Queue\SerializesModels;
 
-class NotificationSent
+class NotificationSent implements QueueableInterface
 {
     use Queueable, SerializesModels;
 

--- a/src/Illuminate/Notifications/Messages/BroadcastMessage.php
+++ b/src/Illuminate/Notifications/Messages/BroadcastMessage.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Notifications\Messages;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 
-class BroadcastMessage
+class BroadcastMessage implements QueueableInterface
 {
     use Queueable;
 

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -3,15 +3,17 @@
 namespace Illuminate\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 
-class SendQueuedNotifications implements ShouldQueue
+class SendQueuedNotifications implements ShouldQueue, InteractsWithQueueInterface, QueueableInterface
 {
     use InteractsWithQueue, Queueable, SerializesModels;
 

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -5,13 +5,19 @@ namespace Illuminate\Queue;
 use Closure;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Laravel\SerializableClosure\SerializableClosure;
 use ReflectionFunction;
 
-class CallQueuedClosure implements ShouldQueue
+class CallQueuedClosure implements
+    ShouldQueue,
+    DispatchableInterface,
+    InteractsWithQueueInterface,
+    QueueableInterface
 {
     use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -72,7 +72,7 @@ trait InteractsWithQueue
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return $this
      */
-    public function setJob(JobContract $job): self
+    public function setJob(JobContract $job): InteractsWithQueueInterface
     {
         $this->job = $job;
 

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\Job as JobContract;
-use InvalidArgumentException;
 use Throwable;
 
 trait InteractsWithQueue
@@ -20,7 +19,7 @@ trait InteractsWithQueue
      *
      * @return int
      */
-    public function attempts()
+    public function attempts(): int
     {
         return $this->job ? $this->job->attempts() : 1;
     }
@@ -30,10 +29,10 @@ trait InteractsWithQueue
      *
      * @return void
      */
-    public function delete()
+    public function delete(): void
     {
         if ($this->job) {
-            return $this->job->delete();
+            $this->job->delete();
         }
     }
 
@@ -43,18 +42,14 @@ trait InteractsWithQueue
      * @param  \Throwable|string|null  $exception
      * @return void
      */
-    public function fail($exception = null)
+    public function fail(Throwable|string $exception = null): void
     {
         if (is_string($exception)) {
             $exception = new ManuallyFailedException($exception);
         }
 
-        if ($exception instanceof Throwable || is_null($exception)) {
-            if ($this->job) {
-                return $this->job->fail($exception);
-            }
-        } else {
-            throw new InvalidArgumentException('The fail method requires a string or an instance of Throwable.');
+        if ($this->job) {
+            $this->job->fail($exception);
         }
     }
 
@@ -64,10 +59,10 @@ trait InteractsWithQueue
      * @param  int  $delay
      * @return void
      */
-    public function release($delay = 0)
+    public function release(int $delay = 0): void
     {
         if ($this->job) {
-            return $this->job->release($delay);
+            $this->job->release($delay);
         }
     }
 
@@ -77,7 +72,7 @@ trait InteractsWithQueue
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return $this
      */
-    public function setJob(JobContract $job)
+    public function setJob(JobContract $job): self
     {
         $this->job = $job;
 

--- a/src/Illuminate/Queue/InteractsWithQueueInterface.php
+++ b/src/Illuminate/Queue/InteractsWithQueueInterface.php
@@ -45,5 +45,5 @@ interface InteractsWithQueueInterface
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @return $this
      */
-    public function setJob(JobContract $job): void;
+    public function setJob(JobContract $job): InteractsWithQueueInterface;
 }

--- a/src/Illuminate/Queue/InteractsWithQueueInterface.php
+++ b/src/Illuminate/Queue/InteractsWithQueueInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use Illuminate\Contracts\Queue\Job as JobContract;
+
+/**
+ * Interface that defines the contract of the InteractsWithQueue trait.
+ */
+interface InteractsWithQueueInterface
+{
+    /**
+     * Get the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function attempts(): int;
+
+    /**
+     * Delete the job from the queue.
+     *
+     * @return void
+     */
+    public function delete(): void;
+
+    /**
+     * Fail the job from the queue.
+     *
+     * @param  \Throwable|string|null  $exception
+     * @return void
+     */
+    public function fail(\Throwable|string $exception = null): void;
+
+    /**
+     * Release the job back into the queue after (n) seconds.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function release(int $delay = 0): void;
+
+    /**
+     * Set the base queue job instance.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return $this
+     */
+    public function setJob(JobContract $job): void;
+}

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -9,6 +9,7 @@ use Illuminate\Bus\BatchFactory;
 use Illuminate\Bus\DatabaseBatchRepository;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -17,6 +18,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Illuminate\Queue\CallQueuedClosure;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -504,17 +506,17 @@ class BusBatchTest extends TestCase
     }
 }
 
-class ChainHeadJob implements ShouldQueue
+class ChainHeadJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable, Batchable;
 }
 
-class SecondTestJob implements ShouldQueue
+class SecondTestJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable, Batchable;
 }
 
-class ThirdTestJob implements ShouldQueue
+class ThirdTestJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable, Batchable;
 }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -4,11 +4,13 @@ namespace Illuminate\Tests\Bus;
 
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -160,7 +162,7 @@ class StandAloneHandler
     }
 }
 
-class ShouldNotBeDispatched implements ShouldQueue
+class ShouldNotBeDispatched implements ShouldQueue, QueueableInterface, InteractsWithQueueInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Console/JobSchedulingTest.php
+++ b/tests/Integration/Console/JobSchedulingTest.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
 
@@ -82,7 +84,7 @@ class JobSchedulingTest extends TestCase
     }
 }
 
-class JobWithDefaultQueue implements ShouldQueue
+class JobWithDefaultQueue implements ShouldQueue, QueueableInterface, InteractsWithQueueInterface
 {
     use Queueable, InteractsWithQueue;
 
@@ -92,7 +94,7 @@ class JobWithDefaultQueue implements ShouldQueue
     }
 }
 
-class JobWithDefaultQueueTwo implements ShouldQueue
+class JobWithDefaultQueueTwo implements ShouldQueue, QueueableInterface, InteractsWithQueueInterface
 {
     use Queueable, InteractsWithQueue;
 
@@ -102,12 +104,12 @@ class JobWithDefaultQueueTwo implements ShouldQueue
     }
 }
 
-class JobWithoutDefaultQueue implements ShouldQueue
+class JobWithoutDefaultQueue implements ShouldQueue, QueueableInterface, InteractsWithQueueInterface
 {
     use Queueable, InteractsWithQueue;
 }
 
-class JobWithDefaultConnection implements ShouldQueue
+class JobWithDefaultConnection implements ShouldQueue, QueueableInterface, InteractsWithQueueInterface
 {
     use Queueable, InteractsWithQueue;
 
@@ -117,7 +119,7 @@ class JobWithDefaultConnection implements ShouldQueue
     }
 }
 
-class JobWithoutDefaultConnection implements ShouldQueue
+class JobWithoutDefaultConnection implements ShouldQueue, QueueableInterface, InteractsWithQueueInterface
 {
     use Queueable, InteractsWithQueue;
 }

--- a/tests/Integration/Console/UniqueJobSchedulingTest.php
+++ b/tests/Integration/Console/UniqueJobSchedulingTest.php
@@ -3,11 +3,14 @@
 namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
 
@@ -53,7 +56,7 @@ class UniqueJobSchedulingTest extends TestCase
     }
 }
 
-class TestJob implements ShouldQueue
+class TestJob implements ShouldQueue, InteractsWithQueueInterface, QueueableInterface, DispatchableInterface
 {
     use InteractsWithQueue, Queueable, Dispatchable;
 }

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -4,11 +4,13 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Support\Facades\Event;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
@@ -126,7 +128,7 @@ class CallQueuedHandlerTest extends TestCase
     }
 }
 
-class CallQueuedHandlerTestJob
+class CallQueuedHandlerTestJob implements InteractsWithQueueInterface
 {
     use InteractsWithQueue;
 
@@ -159,7 +161,9 @@ abstract class AbstractCallQueuedHandlerTestJobWithMiddleware
     }
 }
 
-class CallQueuedHandlerTestJobWithMiddleware extends AbstractCallQueuedHandlerTestJobWithMiddleware
+class CallQueuedHandlerTestJobWithMiddleware extends AbstractCallQueuedHandlerTestJobWithMiddleware implements
+    InteractsWithQueueInterface,
+    QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -3,9 +3,12 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
@@ -246,7 +249,7 @@ class JobChainingTest extends TestCase
     }
 }
 
-class JobChainingTestFirstJob implements ShouldQueue
+class JobChainingTestFirstJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 
@@ -262,7 +265,7 @@ class JobChainingTestFirstJob implements ShouldQueue
     }
 }
 
-class JobChainingTestSecondJob implements ShouldQueue
+class JobChainingTestSecondJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 
@@ -278,7 +281,7 @@ class JobChainingTestSecondJob implements ShouldQueue
     }
 }
 
-class JobChainingTestThirdJob implements ShouldQueue
+class JobChainingTestThirdJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 
@@ -294,7 +297,7 @@ class JobChainingTestThirdJob implements ShouldQueue
     }
 }
 
-class JobChainingTestDeletingJob implements ShouldQueue
+class JobChainingTestDeletingJob implements ShouldQueue, DispatchableInterface, InteractsWithQueueInterface, QueueableInterface
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
@@ -307,7 +310,7 @@ class JobChainingTestDeletingJob implements ShouldQueue
     }
 }
 
-class JobChainingTestReleasingJob implements ShouldQueue
+class JobChainingTestReleasingJob implements ShouldQueue, DispatchableInterface, InteractsWithQueueInterface, QueueableInterface
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
@@ -317,7 +320,7 @@ class JobChainingTestReleasingJob implements ShouldQueue
     }
 }
 
-class JobChainingTestFailingJob implements ShouldQueue
+class JobChainingTestFailingJob implements ShouldQueue, DispatchableInterface, InteractsWithQueueInterface, QueueableInterface
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
@@ -327,7 +330,7 @@ class JobChainingTestFailingJob implements ShouldQueue
     }
 }
 
-class JobChainAddingPrependingJob implements ShouldQueue
+class JobChainAddingPrependingJob implements ShouldQueue, DispatchableInterface, InteractsWithQueueInterface, QueueableInterface
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
@@ -337,7 +340,7 @@ class JobChainAddingPrependingJob implements ShouldQueue
     }
 }
 
-class JobChainAddingAppendingJob implements ShouldQueue
+class JobChainAddingAppendingJob implements ShouldQueue, DispatchableInterface, InteractsWithQueueInterface, QueueableInterface
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
@@ -347,7 +350,7 @@ class JobChainAddingAppendingJob implements ShouldQueue
     }
 }
 
-class JobChainAddingExistingJob implements ShouldQueue
+class JobChainAddingExistingJob implements ShouldQueue, DispatchableInterface, InteractsWithQueueInterface, QueueableInterface
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
@@ -360,7 +363,7 @@ class JobChainAddingExistingJob implements ShouldQueue
     }
 }
 
-class JobChainAddingAddedJob implements ShouldQueue
+class JobChainAddingAddedJob implements ShouldQueue, DispatchableInterface, InteractsWithQueueInterface, QueueableInterface
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
@@ -373,7 +376,7 @@ class JobChainAddingAddedJob implements ShouldQueue
     }
 }
 
-class JobChainingTestThrowJob implements ShouldQueue
+class JobChainingTestThrowJob implements ShouldQueue, DispatchableInterface, InteractsWithQueueInterface, QueueableInterface
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Queue/JobDispatchingTest.php
+++ b/tests/Integration/Queue/JobDispatchingTest.php
@@ -3,8 +3,10 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Orchestra\Testbench\TestCase;
 
 class JobDispatchingTest extends TestCase
@@ -72,7 +74,7 @@ class JobDispatchingTest extends TestCase
     }
 }
 
-class Job implements ShouldQueue
+class Job implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 

--- a/tests/Integration/Queue/JobEncryptionTest.php
+++ b/tests/Integration/Queue/JobEncryptionTest.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
@@ -90,7 +92,7 @@ class JobEncryptionTest extends DatabaseTestCase
     }
 }
 
-class JobEncryptionTestEncryptedJob implements ShouldQueue, ShouldBeEncrypted
+class JobEncryptionTestEncryptedJob implements ShouldQueue, ShouldBeEncrypted, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 
@@ -102,7 +104,7 @@ class JobEncryptionTestEncryptedJob implements ShouldQueue, ShouldBeEncrypted
     }
 }
 
-class JobEncryptionTestNonEncryptedJob implements ShouldQueue
+class JobEncryptionTestNonEncryptedJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 

--- a/tests/Integration/Queue/QueueConnectionTest.php
+++ b/tests/Integration/Queue/QueueConnectionTest.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\DatabaseTransactionsManager;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Illuminate\Support\Facades\Bus;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
@@ -73,7 +75,7 @@ class QueueConnectionTest extends TestCase
     }
 }
 
-class QueueConnectionTestJob implements ShouldQueue
+class QueueConnectionTestJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Cache\Repository as Cache;
@@ -190,7 +191,7 @@ class RateLimitedTest extends TestCase
     }
 }
 
-class RateLimitedTestJob
+class RateLimitedTestJob implements QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Queue/RateLimitedTest.php
+++ b/tests/Integration/Queue/RateLimitedTest.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Queue\Middleware\RateLimited;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
@@ -191,7 +192,7 @@ class RateLimitedTest extends TestCase
     }
 }
 
-class RateLimitedTestJob implements QueueableInterface
+class RateLimitedTestJob implements QueueableInterface, InteractsWithQueueInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Queue/RateLimitedWithRedisTest.php
+++ b/tests/Integration/Queue/RateLimitedWithRedisTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Queue\Job;
@@ -11,6 +12,7 @@ use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 use Illuminate\Support\Str;
 use Mockery as m;
@@ -184,7 +186,7 @@ class RateLimitedWithRedisTest extends TestCase
     }
 }
 
-class RedisRateLimitedTestJob
+class RedisRateLimitedTestJob implements QueueableInterface, InteractsWithQueueInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Queue/ThrottlesExceptionsTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsTest.php
@@ -5,9 +5,11 @@ namespace Illuminate\Tests\Integration\Queue;
 use Exception;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Queue\Middleware\ThrottlesExceptions;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
@@ -107,7 +109,7 @@ class ThrottlesExceptionsTest extends TestCase
     }
 }
 
-class CircuitBreakerTestJob
+class CircuitBreakerTestJob implements InteractsWithQueueInterface, QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 
@@ -126,7 +128,7 @@ class CircuitBreakerTestJob
     }
 }
 
-class CircuitBreakerSuccessfulJob
+class CircuitBreakerSuccessfulJob implements InteractsWithQueueInterface, QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
+++ b/tests/Integration/Queue/ThrottlesExceptionsWithRedisTest.php
@@ -5,10 +5,12 @@ namespace Illuminate\Tests\Integration\Queue;
 use Exception;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Queue\Middleware\ThrottlesExceptionsWithRedis;
 use Illuminate\Support\Str;
 use Mockery as m;
@@ -123,7 +125,7 @@ class ThrottlesExceptionsWithRedisTest extends TestCase
     }
 }
 
-class CircuitBreakerWithRedisTestJob
+class CircuitBreakerWithRedisTestJob implements InteractsWithQueueInterface, QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 
@@ -149,7 +151,7 @@ class CircuitBreakerWithRedisTestJob
     }
 }
 
-class CircuitBreakerWithRedisSuccessfulJob
+class CircuitBreakerWithRedisSuccessfulJob implements InteractsWithQueueInterface, QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Queue/UniqueJobTest.php
+++ b/tests/Integration/Queue/UniqueJobTest.php
@@ -4,13 +4,16 @@ namespace Illuminate\Tests\Integration\Queue;
 
 use Exception;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Support\Facades\Bus;
 use Orchestra\Testbench\TestCase;
 
@@ -154,7 +157,12 @@ class UniqueJobTest extends TestCase
     }
 }
 
-class UniqueTestJob implements ShouldQueue, ShouldBeUnique
+class UniqueTestJob implements
+    ShouldQueue,
+    ShouldBeUnique,
+    InteractsWithQueueInterface,
+    QueueableInterface,
+    DispatchableInterface
 {
     use InteractsWithQueue, Queueable, Dispatchable;
 
@@ -166,7 +174,12 @@ class UniqueTestJob implements ShouldQueue, ShouldBeUnique
     }
 }
 
-class UniqueTestFailJob implements ShouldQueue, ShouldBeUnique
+class UniqueTestFailJob implements
+    ShouldQueue,
+    ShouldBeUnique,
+    InteractsWithQueueInterface,
+    QueueableInterface,
+    DispatchableInterface
 {
     use InteractsWithQueue, Queueable, Dispatchable;
 

--- a/tests/Integration/Queue/WithoutOverlappingJobsTest.php
+++ b/tests/Integration/Queue/WithoutOverlappingJobsTest.php
@@ -5,10 +5,12 @@ namespace Illuminate\Tests\Integration\Queue;
 use Exception;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\CallQueuedHandler;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
@@ -161,7 +163,7 @@ class WithoutOverlappingJobsTest extends TestCase
     }
 }
 
-class OverlappingTestJob
+class OverlappingTestJob implements InteractsWithQueueInterface, QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 
@@ -196,7 +198,7 @@ class FailedOverlappingTestJob extends OverlappingTestJob
     }
 }
 
-class OverlappingTestJobWithSharedKeyOne
+class OverlappingTestJobWithSharedKeyOne implements InteractsWithQueueInterface, QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 
@@ -213,7 +215,7 @@ class OverlappingTestJobWithSharedKeyOne
     }
 }
 
-class OverlappingTestJobWithSharedKeyTwo
+class OverlappingTestJobWithSharedKeyTwo implements InteractsWithQueueInterface, QueueableInterface
 {
     use InteractsWithQueue, Queueable;
 

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -3,9 +3,11 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Bus\DispatchableInterface;
 use Orchestra\Testbench\TestCase;
 use Queue;
 
@@ -126,7 +128,7 @@ class WorkCommandTest extends TestCase
     }
 }
 
-class FirstJob implements ShouldQueue
+class FirstJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 
@@ -138,7 +140,7 @@ class FirstJob implements ShouldQueue
     }
 }
 
-class SecondJob implements ShouldQueue
+class SecondJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 
@@ -150,7 +152,7 @@ class SecondJob implements ShouldQueue
     }
 }
 
-class ThirdJob implements ShouldQueue
+class ThirdJob implements ShouldQueue, DispatchableInterface, QueueableInterface
 {
     use Dispatchable, Queueable;
 

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Mail;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\View\Factory;
@@ -95,7 +96,7 @@ class MailableQueuedTest extends TestCase
     }
 }
 
-class MailableQueueableStub extends Mailable implements ShouldQueue
+class MailableQueueableStub extends Mailable implements ShouldQueue, QueueableInterface
 {
     use Queueable;
 

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher as Bus;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -170,7 +171,7 @@ class NotificationChannelManagerTestNotCancelledNotification extends Notificatio
     }
 }
 
-class NotificationChannelManagerTestQueuedNotification extends Notification implements ShouldQueue
+class NotificationChannelManagerTestQueuedNotification extends Notification implements ShouldQueue, QueueableInterface
 {
     use Queueable;
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -102,7 +103,7 @@ class NotificationSenderTest extends TestCase
 
         $sender = new NotificationSender($manager, $bus, $events);
 
-        $sender->send($notifiable, new DummyMultiChannelNotificationWithConditionalMiddlware);
+        $sender->send($notifiable, new DummyMultiChannelNotificationWithConditionalMiddleware);
     }
 
     public function testItCanSendQueuedWithViaConnectionsNotifications()
@@ -161,7 +162,7 @@ class DummyNotificationWithEmptyStringVia extends Notification
     }
 }
 
-class DummyNotificationWithDatabaseVia extends Notification
+class DummyNotificationWithDatabaseVia extends Notification implements QueueableInterface
 {
     use Queueable;
 
@@ -177,7 +178,7 @@ class DummyNotificationWithDatabaseVia extends Notification
     }
 }
 
-class DummyNotificationWithViaConnections extends Notification implements ShouldQueue
+class DummyNotificationWithViaConnections extends Notification implements ShouldQueue, QueueableInterface
 {
     use Queueable;
 
@@ -194,7 +195,7 @@ class DummyNotificationWithViaConnections extends Notification implements Should
     }
 }
 
-class DummyNotificationWithMiddleware extends Notification implements ShouldQueue
+class DummyNotificationWithMiddleware extends Notification implements ShouldQueue, QueueableInterface
 {
     use Queueable;
 
@@ -211,7 +212,7 @@ class DummyNotificationWithMiddleware extends Notification implements ShouldQueu
     }
 }
 
-class DummyMultiChannelNotificationWithConditionalMiddlware extends Notification implements ShouldQueue
+class DummyMultiChannelNotificationWithConditionalMiddleware extends Notification implements ShouldQueue, QueueableInterface
 {
     use Queueable;
 

--- a/tests/Queue/InteractsWithQueueTest.php
+++ b/tests/Queue/InteractsWithQueueTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Queue;
 use Exception;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +21,7 @@ class InteractsWithQueueTest extends TestCase
             return true;
         });
 
-        $job = new class
+        $job = new class implements InteractsWithQueueInterface
         {
             use InteractsWithQueue;
 

--- a/tests/Queue/QueueSizeTest.php
+++ b/tests/Queue/QueueSizeTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Queue;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
@@ -27,12 +28,12 @@ class QueueSizeTest extends TestCase
     }
 }
 
-class TestJob1 implements ShouldQueue
+class TestJob1 implements ShouldQueue, QueueableInterface
 {
     use Queueable;
 }
 
-class TestJob2 implements ShouldQueue
+class TestJob2 implements ShouldQueue, QueueableInterface
 {
     use Queueable;
 }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\InteractsWithQueueInterface;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Queue\SyncQueue;
 use LogicException;
@@ -118,7 +119,7 @@ class FailingSyncQueueTestHandler
     }
 }
 
-class SyncQueueJob implements ShouldQueue
+class SyncQueueJob implements ShouldQueue, InteractsWithQueueInterface
 {
     use InteractsWithQueue;
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Support\Testing\Fakes\BatchRepositoryFake;
 use Illuminate\Support\Testing\Fakes\BusFake;
@@ -594,7 +595,7 @@ class BusJobStub
     //
 }
 
-class ChainedJobStub
+class ChainedJobStub implements QueueableInterface
 {
     use Queueable;
 }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Support;
 
 use BadMethodCallException;
 use Illuminate\Bus\Queueable;
+use Illuminate\Bus\QueueableInterface;
 use Illuminate\Foundation\Application;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
@@ -364,7 +365,7 @@ class JobToFakeStub
     }
 }
 
-class JobWithChainStub
+class JobWithChainStub implements QueueableInterface
 {
     use Queueable;
 
@@ -379,7 +380,7 @@ class JobWithChainStub
     }
 }
 
-class JobWithChainAndParameterStub
+class JobWithChainAndParameterStub implements QueueableInterface
 {
     use Queueable;
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Description

This pull request introduces 3 new interfaces - QueueableInterface, DispatchableInterface and InteractsWithQueueInterface. These interfaces provide a clear, consistent way to define the contracts for classes that interact with the queue system in Laravel.

## Benefit to the users

One of the main benefits of using interfaces in PHP over traits is that they can be type hinted. This means that when a method or function expects an object of a certain type, you can specify that it must implement a certain interface. This allows for better type safety and makes it easier to catch errors early in the development process. On the other hand, in PHP you cannot type hint a trait, so if you want to make sure a class implements certain methods you need to rely on documentation or conventions. By using interfaces, we can ensure that classes that interact with the queue system in Laravel have a clear and consistent set of methods and behavior and can be type hinted to make sure they are used correctly.

## The reasons it does not break any existing features

To avoid any breaking changes, I decided to implement the appropriate interfaces on all classes that already utilize the corresponding traits. This way, these classes will keep their current functionality while also adhering to a clear, consistent contract that aligns with that functionality. In summary, this change will not affect the behavior of existing code and only adds a new way of defining contracts using interfaces.

## Paving the way to type safety

I believe this change, the introduction of 3 new interfaces, is a step towards achieving more strongly typed functions in Laravel. In the next major release, developers will have the option to use these interfaces, which may involve breaking changes, to provide explicit types for function parameters, instead of relying on typeless parameters.