### PR TITLE
[9.x] Allow egulias/email-validator v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "brick/math": "^0.10.2",
         "doctrine/inflector": "^2.0",
         "dragonmantank/cron-expression": "^3.3.2",
-        "egulias/email-validator": "^3.2.1",
+        "egulias/email-validator": "^3.2.1|^4.0",
         "fruitcake/php-cors": "^1.2",
         "laravel/serializable-closure": "^1.2.2",
         "league/commonmark": "^2.2.1",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.0.2",
         "ext-json": "*",
-        "egulias/email-validator": "^3.2.1",
+        "egulias/email-validator": "^3.2.1|^4.0",
         "illuminate/collections": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/contracts": "^9.0",


### PR DESCRIPTION
Hi,

Version 4 has been released and I don't see any breaking changes.

[egulias/EmailValidator](https://github.com/egulias/EmailValidator/releases/tag/4.0.0)

Already being used by symfony

https://github.com/symfony/mailer/blob/29729ac0b4e5113f24c39c46746bd6afb79e0aaa/composer.json#L20