### PR TITLE
[9.x] Add Method to get request data as an array

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -374,7 +374,7 @@ trait InteractsWithInput
      * @param  array  $default
      * @return array
      */
-    public function array($key, $default = [])
+    public function asArray($key, $default = [])
     {
         if ($this->isNotFilled($key)) {
             return $default;

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -368,6 +368,30 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve input as an array.
+     *
+     * @param  string  $key
+     * @param  array  $default
+     * @return array
+     */
+    public function array($key, $default = [])
+    {
+        if ($this->isNotFilled($key)) {
+            return $default;
+        }
+
+        if (is_array($this->input($key))) {
+            return $this->input($key);
+        }
+
+        if (is_string($this->input($key)) && str($this->input($key))->contains(',')) {
+            return explode(',',$this->input($key));
+        }
+
+        return [$this->input($key)];
+    }
+
+    /**
      * Retrieve input from the request as a Carbon instance.
      *
      * @param  string  $key

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -385,7 +385,7 @@ trait InteractsWithInput
         }
 
         if (is_string($this->input($key)) && str($this->input($key))->contains(',')) {
-            return explode(',',$this->input($key));
+            return explode(',', $this->input($key));
         }
 
         return [$this->input($key)];

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -666,7 +666,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame([1], $request->array('int'));
         $this->assertSame(['hello'], $request->array('string'));
         $this->assertSame([], $request->array('unknown'));
-        $this->assertSame([1, 2, 3], $request->array('unknown_with_default',[1,2,3]));
+        $this->assertSame([1, 2, 3], $request->array('unknown_with_default',[1, 2, 3]));
         $this->assertSame(['hello', 'hi', 'hola'], $request->array('comma_seperated'));
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -666,7 +666,7 @@ class HttpRequestTest extends TestCase
         $this->assertSame([1], $request->array('int'));
         $this->assertSame(['hello'], $request->array('string'));
         $this->assertSame([], $request->array('unknown'));
-        $this->assertSame([1, 2, 3], $request->array('unknown_with_default',[1, 2, 3]));
+        $this->assertSame([1, 2, 3], $request->array('unknown_with_default', [1, 2, 3]));
         $this->assertSame(['hello', 'hi', 'hola'], $request->array('comma_seperated'));
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -641,11 +641,11 @@ class HttpRequestTest extends TestCase
         $this->assertSame(123.456, $request->float('unknown_key', 123.456));
     }
 
-    public function testArrayMethod()
+    public function testAsArrayMethod()
     {
         $request = Request::create('/?bar[]=foo1&bar[]=foo2');
 
-        $this->assertSame(['foo1', 'foo2'], $request->array('bar'));
+        $this->assertSame(['foo1', 'foo2'], $request->asArray('bar'));
 
         $request = Request::create('/', 'GET', [
             'bar' => [
@@ -661,13 +661,13 @@ class HttpRequestTest extends TestCase
             'comma_seperated' => 'hello,hi,hola',
         ]);
 
-        $this->assertSame(['foo1', 'foo2'], $request->array('bar'));
-        $this->assertSame(['in1' => 'foo1', 'in2' => 'foo2'], $request->array('indexed_bar'));
-        $this->assertSame([1], $request->array('int'));
-        $this->assertSame(['hello'], $request->array('string'));
-        $this->assertSame([], $request->array('unknown'));
-        $this->assertSame([1, 2, 3], $request->array('unknown_with_default', [1, 2, 3]));
-        $this->assertSame(['hello', 'hi', 'hola'], $request->array('comma_seperated'));
+        $this->assertSame(['foo1', 'foo2'], $request->asArray('bar'));
+        $this->assertSame(['in1' => 'foo1', 'in2' => 'foo2'], $request->asArray('indexed_bar'));
+        $this->assertSame([1], $request->asArray('int'));
+        $this->assertSame(['hello'], $request->asArray('string'));
+        $this->assertSame([], $request->asArray('unknown'));
+        $this->assertSame([1, 2, 3], $request->asArray('unknown_with_default', [1, 2, 3]));
+        $this->assertSame(['hello', 'hi', 'hola'], $request->asArray('comma_seperated'));
     }
 
     public function testCollectMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -645,7 +645,7 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/?bar[]=foo1&bar[]=foo2');
 
-        $this->assertSame(['foo1','foo2'], $request->array('bar'));
+        $this->assertSame(['foo1', 'foo2'], $request->array('bar'));
 
         $request = Request::create('/', 'GET', [
             'bar' => [
@@ -661,13 +661,13 @@ class HttpRequestTest extends TestCase
             'comma_seperated' => 'hello,hi,hola',
         ]);
 
-        $this->assertSame(['foo1','foo2'], $request->array('bar'));
+        $this->assertSame(['foo1', 'foo2'], $request->array('bar'));
         $this->assertSame(['in1' => 'foo1', 'in2' => 'foo2'], $request->array('indexed_bar'));
         $this->assertSame([1], $request->array('int'));
         $this->assertSame(['hello'], $request->array('string'));
         $this->assertSame([], $request->array('unknown'));
-        $this->assertSame([1,2,3], $request->array('unknown_with_default',[1,2,3]));
-        $this->assertSame(['hello','hi','hola'], $request->array('comma_seperated'));
+        $this->assertSame([1, 2, 3], $request->array('unknown_with_default',[1,2,3]));
+        $this->assertSame(['hello', 'hi', 'hola'], $request->array('comma_seperated'));
     }
 
     public function testCollectMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -641,6 +641,35 @@ class HttpRequestTest extends TestCase
         $this->assertSame(123.456, $request->float('unknown_key', 123.456));
     }
 
+    public function testArrayMethod()
+    {
+        $request = Request::create('/?bar[]=foo1&bar[]=foo2');
+
+        $this->assertSame(['foo1','foo2'], $request->array('bar'));
+
+        $request = Request::create('/', 'GET', [
+            'bar' => [
+                'foo1',
+                'foo2',
+            ],
+            'indexed_bar' => [
+                'in1' => 'foo1',
+                'in2' => 'foo2',
+            ],
+            'int' => 1,
+            'string' => 'hello',
+            'comma_seperated' => 'hello,hi,hola',
+        ]);
+
+        $this->assertSame(['foo1','foo2'], $request->array('bar'));
+        $this->assertSame(['in1' => 'foo1', 'in2' => 'foo2'], $request->array('indexed_bar'));
+        $this->assertSame([1], $request->array('int'));
+        $this->assertSame(['hello'], $request->array('string'));
+        $this->assertSame([], $request->array('unknown'));
+        $this->assertSame([1,2,3], $request->array('unknown_with_default',[1,2,3]));
+        $this->assertSame(['hello','hi','hola'], $request->array('comma_seperated'));
+    }
+
     public function testCollectMethod()
     {
         $request = Request::create('/', 'GET', ['users' => [1, 2, 3]]);


### PR DESCRIPTION
This adds methods to conveniently retrieve and cast request data as an array. and even add the ability to cast a comma separated into an array

Before

```php
$input = [];

if (request()->filled('array')) {
    if (is_array(request()->get('array'))) {
        $input = request()->get('array');
    }else{
        $input = [request()->get('array')];
    }
}
```

After

```php
$input = request()->array('array');
```
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

if the value is not an array this method will cast the value as an array

```php
//https://example.com/?array=23

$input = request()->array('array');
//will results in [23]
``` 

if the value is comma separated this method will cast it into an array

```php
//https://example.com/?array=23,24,55,60

$input = request()->array('array');
//will results in [23,24,55,60]
``` 