### PR TITLE
Add enum class to migration enum accepted values

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
-use function PHPUnit\Framework\isInstanceOf;
 
 class Blueprint
 {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
+use function PHPUnit\Framework\isInstanceOf;
 
 class Blueprint
 {
@@ -1033,11 +1034,15 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array  $allowed
+     * @param  array|Enum  $allowed
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function enum($column, array $allowed)
+    public function enum($column, array|Enum $allowed)
     {
+        if ($allowed instanceof Enum) {
+            $allowed = $allowed->getAcceptedValues();
+        }
+
         return $this->addColumn('enum', $column, compact('allowed'));
     }
 

--- a/src/Illuminate/Database/Schema/Enum.php
+++ b/src/Illuminate/Database/Schema/Enum.php
@@ -12,8 +12,7 @@ class Enum
 
     public function getAcceptedValues(): array
     {
-        $enumClass = new $this->type;
-        $cases = $enumClass->cases();
+        $cases = $this->type::cases();
 
         $arrayOfCasesValues = [];
         foreach ($cases as $case) {

--- a/src/Illuminate/Database/Schema/Enum.php
+++ b/src/Illuminate/Database/Schema/Enum.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Database\Schema;
+
+class Enum
+{
+    public function __construct(
+        private string $type,
+    )
+    {
+    }
+
+    public function getAcceptedValues(): array
+    {
+        $enumClass = new $this->type;
+        $cases = $enumClass->cases();
+
+        $arrayOfCasesValues = [];
+        foreach ($cases as $case) {
+            $arrayOfCasesValues[] = $case->value;
+        }
+
+        return $arrayOfCasesValues;
+    }
+}


### PR DESCRIPTION
When we want to add an enum column ,and have a corresponding enum to that column, it is very annoying to write all enum case's values one by one or with other tricks. with this new feature it is very easy and fast to do we just give enum class we have and then it adds the cases.
instead of
`
            $table->enum('test_column', [TestEnum::TEST1->value, TestEnum::TEST2->value, TestEnum::TEST3->value]);
`
we now have
`
            $table->enum('test_column', new \Illuminate\Database\Schema\Enum(TestEnum::class));
`
