### PR TITLE
[9.x] Adds `fragmentIf()` method

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -99,7 +99,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      */
     public function fragmentIf($boolean, $fragment)
     {
-        if ($boolean) {
+        if (value($boolean)) {
             return $this->fragment($fragment);
         }
 

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -91,6 +91,22 @@ class View implements ArrayAccess, Htmlable, ViewContract
     }
 
     /**
+     * Get the evaluated contents of a given fragment if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  string  $fragment
+     * @return string
+     */
+    public function fragmentIf($boolean, $fragment)
+    {
+        if ($boolean) {
+            return $this->fragment($fragment);
+        }
+
+        return $this->render();
+    }
+
+    /**
      * Get the string contents of the view.
      *
      * @param  callable|null  $callback


### PR DESCRIPTION
Adds a `fragmentIf()` method to conditionally return a fragment of a view. This solves the issue of normal request versus xhr requests sent by a library such as htmx.

Before:
```php
if (request()->hasHeader('HX-Request')) {
    return view('products.index')->fragment('products-list');
}

return view('products.index');
```
After:
```php
return view('products.index')->fragmentIf(request()->hasHeader('HX-Request'), 'products-list');
```