### PR TITLE
Cookie::queue facade method has invalid docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -8,7 +8,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Symfony\Component\HttpFoundation\Cookie forget(string $name, string|null $path = null, string|null $domain = null)
  * @method static bool hasQueued(string $key, string|null $path = null)
  * @method static \Symfony\Component\HttpFoundation\Cookie|null queued(string $key, mixed $default = null, string|null $path = null)
- * @method static void queue(array ...$parameters)
+ * @method static void queue(string $key, string $value, and int $minutes)
  * @method static void expire(string $name, string|null $path = null, string|null $domain = null)
  * @method static void unqueue(string $name, string|null $path = null)
  * @method static \Illuminate\Cookie\CookieJar setDefaultPathAndDomain(string $path, string|null $domain, bool|null $secure = false, string|null $sameSite = null)

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -8,7 +8,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Symfony\Component\HttpFoundation\Cookie forget(string $name, string|null $path = null, string|null $domain = null)
  * @method static bool hasQueued(string $key, string|null $path = null)
  * @method static \Symfony\Component\HttpFoundation\Cookie|null queued(string $key, mixed $default = null, string|null $path = null)
- * @method static void queue(string $key, string $value, and int $minutes)
+ * @method static void queue(string $key, string $value, int $minutes)
  * @method static void expire(string $name, string|null $path = null, string|null $domain = null)
  * @method static void unqueue(string $name, string|null $path = null)
  * @method static \Illuminate\Cookie\CookieJar setDefaultPathAndDomain(string $path, string|null $domain, bool|null $secure = false, string|null $sameSite = null)


### PR DESCRIPTION
Cookie::queue facade method has invalid expected input in the dockblock. Currently it expects array of parameters in the framework, but in the Laravel documentation it has to be three parameters. String $key, string $value, and int $minutes.