### PR TITLE
[9.x] Splat (...) operators type casting should be mixed

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -135,7 +135,7 @@ class CookieJar implements JarContract
     /**
      * Queue a cookie to send with the next response.
      *
-     * @param  array  $parameters
+     * @param  mixed  $parameters
      * @return void
      */
     public function queue(...$parameters)


### PR DESCRIPTION
Queue method has invalid expected input in the docblock. Currently it expects array of parameters in the CookieJar class. It affects the auto generated Facade @method docblock and gives warning to some strict IDE or PHP intellisense extensions. The splat operator, known as the elipsis ( ... ) operator in PHP currently has mixed type casting parameter even though it outputs an array.