### PR TITLE
[9.x] Replace raw invisible characters in regex expressions with counterpart Unicode regex notations

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -53,7 +53,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return preg_replace('~^[\s﻿​]+|[\s﻿​]+$~u', '', $value) ?? trim($value);
+        return preg_replace('~^[\s\p{Cf}]+|[\s\p{Cf}]+$~u', '', $value) ?? trim($value);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1073,7 +1073,7 @@ class Str
      */
     public static function squish($value)
     {
-        return preg_replace('~(\s|\x{3164})+~u', ' ', preg_replace('~^[\s﻿]+|[\s﻿]+$~u', '', $value));
+        return preg_replace('~(\s|\x{3164})+~u', ' ', preg_replace('~^[\s\p{Cf}]+|[\s\p{Cf}]+$~u', '', $value));
     }
 
     /**

--- a/tests/Http/Middleware/TrimStringsTest.php
+++ b/tests/Http/Middleware/TrimStringsTest.php
@@ -16,13 +16,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => 'This title does not contains any zero-width space',
+            'title' => 'This title does not contain any zero-width space',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title does not contains any zero-width space', $req->title);
+            $this->assertEquals('This title does not contain any zero-width space', $req->title);
         });
     }
 
@@ -34,13 +34,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '​This title contains a zero-width space at the begining',
+            'title' => '​This title contains a zero-width space at the beginning',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width space at the begining', $req->title);
+            $this->assertEquals('This title contains a zero-width space at the beginning', $req->title);
         });
     }
 
@@ -70,13 +70,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '﻿This title contains a zero-width non-breakable space at the begining',
+            'title' => '﻿This title contains a zero-width non-breakable space at the beginning',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width non-breakable space at the begining', $req->title);
+            $this->assertEquals('This title contains a zero-width non-breakable space at the beginning', $req->title);
         });
     }
 
@@ -88,13 +88,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '﻿﻿This title contains a zero-width non-breakable space at the begining',
+            'title' => '﻿﻿This title contains a zero-width non-breakable space at the beginning',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width non-breakable space at the begining', $req->title);
+            $this->assertEquals('This title contains a zero-width non-breakable space at the beginning', $req->title);
         });
     }
 
@@ -106,13 +106,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '﻿​﻿This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the begining and the end​',
+            'title' => '﻿​﻿This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the beginning and the end​',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the begining and the end', $req->title);
+            $this->assertEquals('This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the beginning and the end', $req->title);
         });
     }
 }


### PR DESCRIPTION
#41971 introduced regex selector update for invisible Unicode characters with additions in #44906.

This PR updates regex expressions by replacing raw invisible characters with counterpart Unicode regex notations to increase visibility of source code in text editors that don't support display of invisible characters labels or in VCS editors.

It also expands matching characters from ﻿U+FEFF|U+200B (in case of \Illuminate\Foundation\Http\Middleware::transform()) or from U+FEFF (in case of \Illuminate\Support\Str::squish()) to all characters of same group (\p{Cf} - invisible formatting indicator).