### PR TITLE
[9.x] "Unfreeze" uuids on test teardown

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -223,6 +223,7 @@ abstract class TestCase extends BaseTestCase
         Component::forgetFactory();
         Queue::createPayloadUsing(null);
         HandleExceptions::forgetApp();
+        Str::createUuidsNormally();
 
         if ($this->callbackException) {
             throw $this->callbackException;


### PR DESCRIPTION
Currently when you freeze the uuid generation in one test, then that uuid generation is still frozen in another test.
```php
public function first_test()
{
    dump(Str::freezeUuids()->toString());
    dump(Str::uuid()->toString());
}

public function second_test()
{
    // All dumps return the same uuid,
    // while in this second test we are not using Str::freezeUuids()
    dump(Str::uuid()->toString());
}
```
This seems weird behavior, as other test helpers (storage fake, event fake, queue fake, ...) are all contained within a single test. This PR fixes that by "unfreezing" the uuid generation in testcase teardown.