### PR TITLE
Adds `fragments()` and `fragmentsIf()` method

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -10,8 +10,6 @@ use Illuminate\Contracts\Support\MessageProvider;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Enumerable;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -10,6 +10,8 @@ use Illuminate\Contracts\Support\MessageProvider;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Enumerable;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -91,6 +93,22 @@ class View implements ArrayAccess, Htmlable, ViewContract
     }
 
     /**
+     * Get the evaluated contents for a given array of fragments.
+     *
+     * @param  mixed  $fragments
+     * @return string
+     */
+    public function fragments($fragments)
+    {
+        return collect(is_array($fragments)
+            ? $fragments
+            : func_get_args()
+        )->map(function ($fragment) {
+            return $this->fragment($fragment);
+        })->implode('');
+    }
+
+    /**
      * Get the evaluated contents of a given fragment if the given condition is true.
      *
      * @param  bool  $boolean
@@ -101,6 +119,22 @@ class View implements ArrayAccess, Htmlable, ViewContract
     {
         if (value($boolean)) {
             return $this->fragment($fragment);
+        }
+
+        return $this->render();
+    }
+
+    /**
+     * Get the evaluated contents for a given array of fragments if the given condition is true.
+     *
+     * @param  bool  $boolean
+     * @param  string[]  ...$fragments
+     * @return string
+     */
+    public function fragmentsIf($boolean, ...$fragments)
+    {
+        if (value($boolean)) {
+            return $this->fragments(...$fragments);
         }
 
         return $this->render();

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -93,17 +93,12 @@ class View implements ArrayAccess, Htmlable, ViewContract
     /**
      * Get the evaluated contents for a given array of fragments.
      *
-     * @param  mixed  $fragments
+     * @param  array  $fragments
      * @return string
      */
-    public function fragments($fragments)
+    public function fragments(array $fragments)
     {
-        return collect(is_array($fragments)
-            ? $fragments
-            : func_get_args()
-        )->map(function ($fragment) {
-            return $this->fragment($fragment);
-        })->implode('');
+        return collect($fragments)->map(fn ($f) => $this->fragment($f))->implode('');
     }
 
     /**
@@ -126,13 +121,13 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * Get the evaluated contents for a given array of fragments if the given condition is true.
      *
      * @param  bool  $boolean
-     * @param  string[]  ...$fragments
+     * @param  array  $fragments
      * @return string
      */
-    public function fragmentsIf($boolean, ...$fragments)
+    public function fragmentsIf($boolean, array $fragments)
     {
         if (value($boolean)) {
-            return $this->fragments(...$fragments);
+            return $this->fragments($fragments);
         }
 
         return $this->render();


### PR DESCRIPTION
Adds `fragments()` and `fragmentsIf()` function.
With htmx (and probably similar libraries) you can swap [out of bounds](https://htmx.org/attributes/hx-swap-oob/), allowing you to update multiple sections of a page, requiring multiple fragments. The current way to do this is by concatenating two (or more) fragments:

```php
return view('welcome')->fragment('fragment1') . view('welcome')->fragment('fragment2');
```

With `fragments()` this is simplified to:
```php
return view('welcome')->fragments(['fragment1', 'fragment2']);
```
or
```php
return view('welcome')->fragments('fragment1', 'fragment2');
```

---
Also a `fragmentsIf()` to conditionally return these fragments have been added in this PR. This is basically an expansion on PR #45656, allowing you to conditionally return multiple fragments:
```php
return view('welcome')->fragmentsIf(request()->hasHeader('HX-Request'), ['fragment1', 'fragment2']);
```
or
```php
return view('welcome')->fragmentsIf(request()->hasHeader('HX-Request'), 'fragment1', 'fragment2');
```