### PR TITLE
[9.x] Fix docblock

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -135,7 +135,7 @@ class CookieJar implements JarContract
     /**
      * Queue a cookie to send with the next response.
      *
-     * @param  mixed  $parameters
+     * @param  mixed  ...$parameters
      * @return void
      */
     public function queue(...$parameters)


### PR DESCRIPTION
This was changed to `mixed` in https://github.com/laravel/framework/pull/45662, however variadic function should include the `...`.

The `$parameters` _argument_ will always be an array, however the use of `...` indicates that it accepts multiple _parameters_ that are of type `mixed`.

See: https://phpstan.org/writing-php-code/phpdocs-basics#variadic-functions