### PR TITLE
[9.x] Fix the session manager callCustomCreator return type

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -13,7 +13,7 @@ class SessionManager extends Manager
      * Call a custom driver creator.
      *
      * @param  string  $driver
-     * @return mixed
+     * @return \Illuminate\Session\Store
      */
     protected function callCustomCreator($driver)
     {


### PR DESCRIPTION
callCustomCreator method always return the session store