### PR TITLE
[9.x] Reverts prohibited validator should accept empty value

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1689,7 +1689,7 @@ trait ValidatesAttributes
      */
     public function validateProhibited($attribute, $value)
     {
-        return $value === '';
+        return false;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Validation;
 
+use Countable;
 use DateTime;
 use DateTimeImmutable;
 use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
@@ -1635,6 +1636,76 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertTrue($v->messages()->has('foo.0.email'));
         $this->assertFalse($v->messages()->has('foo.1.email'));
+    }
+
+    /** @dataProvider prohibitedRulesData */
+    public function testProhibitedRulesAreConsistent($rules, $data, $result)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $this->assertSame($result, (new Validator($trans, $data, $rules))->passes());
+    }
+
+    public function prohibitedRulesData()
+    {
+        $emptyCountable = new class implements Countable {
+            public function count()
+            {
+                return 0;
+            }
+        };
+
+        return [
+            // prohibited...
+            // correct as per the docs. potentially incorrect behaviour.
+            [['p' => 'prohibited'], [], true],
+            [['p' => 'prohibited'], ['p' => ''], true],
+            [['p' => 'prohibited'], ['p' => ' '], true],
+            [['p' => 'prohibited'], ['p' => null], false],
+            [['p' => 'prohibited'], ['p' => []], false],
+            [['p' => 'prohibited'], ['p' => $emptyCountable], false],
+            [['p' => 'prohibited'], ['p' => 'foo'], false],
+
+            // prohibited_if...
+            // incorrect as per the docs. incorrect behaviour.
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1], true],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => ''], true],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => ' '], true],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => null], true],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => []], true],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => $emptyCountable], true],
+            [['p' => 'prohibited_if:bar,1'], ['bar' => 1, 'p' => 'foo'], false],
+
+            // prohibited_unless...
+            // incorrect as per the docs.
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2], true],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => ''], true],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => ' '], true],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => null], true],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => []], true],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => $emptyCountable], true],
+            [['p' => 'prohibited_unless:bar,1'], ['bar' => 2, 'p' => 'foo'], false],
+
+            // prohibites, with "p" values...
+            // matches the first one, but is incorrect as per the docs.
+            [['p' => 'prohibits:bar'], [], true],
+            [['p' => 'prohibits:bar'], ['bar' => 2, 'p' => ''], true],
+            [['p' => 'prohibits:bar'], ['bar' => 2, 'p' => ' '], true],
+            [['p' => 'prohibits:bar'], ['bar' => 2, 'p' => null], false],
+            [['p' => 'prohibits:bar'], ['bar' => 2, 'p' => []], false],
+            [['p' => 'prohibits:bar'], ['bar' => 2, 'p' => $emptyCountable], false],
+            [['p' => 'prohibits:bar'], ['bar' => 2, 'p' => 'foo'], false],
+
+            // prohibites, with "bar" values...
+            // correct, and correct per the docs.
+            [['p' => 'prohibits:bar'], ['p' => 'foo'], true],
+            [['p' => 'prohibits:bar'], ['bar' => '', 'p' => 'foo'], false],
+            [['p' => 'prohibits:bar'], ['bar' => ' ', 'p' => 'foo'], false],
+            [['p' => 'prohibits:bar'], ['bar' => null, 'p' => 'foo'], false],
+            [['p' => 'prohibits:bar'], ['bar' => [], 'p' => 'foo'], false],
+            [['p' => 'prohibits:bar'], ['bar' => $emptyCountable, 'p' => 'foo'], false],
+            [['p' => 'prohibits:bar'], ['bar' => 'foo', 'p' => 'foo'], false],
+        ];
     }
 
     public function testFailedFileUploads()


### PR DESCRIPTION
Reverts #45644

This change did not allow empty strings to pass. You will see by the test suite that empty strings would already pass.

You can run the tests against the old version and the new version and they continue to pass, however I believe that the tests introduced here show a really big inconsistency of expected behaviour as well as documentated behaviour.

I have submitted this so that we revert the change before we release tomorrow. I will follow up with a PR that attempts to standardise the functionality across these rules in a sensible manner.