### PR TITLE
[9.x] Fix dependency in `DocsCommand`

### DIFF
--- a/src/Illuminate/Foundation/Console/DocsCommand.php
+++ b/src/Illuminate/Foundation/Console/DocsCommand.php
@@ -86,20 +86,6 @@ class DocsCommand extends Command
      */
     protected $systemOsFamily = PHP_OS_FAMILY;
 
-    /**
-     * Create a new command instance.
-     *
-     * @param  \Illuminate\Http\Client\Factory  $http
-     * @param  \Illuminate\Contracts\Cache\Repository  $cache
-     * @return void
-     */
-    public function __construct(Http $http, Cache $cache)
-    {
-        parent::__construct();
-
-        $this->http = $http;
-        $this->cache = $cache;
-    }
 
     /**
      * Configure the current command.
@@ -118,10 +104,15 @@ class DocsCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param  \Illuminate\Http\Client\Factory  $http
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return int
      */
-    public function handle()
+    public function handle(Http $http, Cache $cache)
     {
+        $this->http = $http;
+        $this->cache = $cache;
+
         try {
             $this->openUrl();
         } catch (ProcessFailedException $e) {

--- a/tests/Foundation/FoundationDocsCommandTest.php
+++ b/tests/Foundation/FoundationDocsCommandTest.php
@@ -323,6 +323,12 @@ Working directory: expected-working-directory');
         $this->assertSame($this->openedUrl, 'https://laravel.com/docs/8.x');
     }
 
+    public function testCanGetHelpWithoutInstantiatingDependencies()
+    {
+        $help = (new DocsCommand())->getHelp();
+        $this->stringContains('php artisan docs', $help);
+    }
+
     protected function command()
     {
         $this->app->forgetInstance(DocsCommand::class);


### PR DESCRIPTION
Move dependencies to to handle method.

By moving the dependencies to the handle method, we are able to run help and list commands without having to instantiate all of the dependencies of the command before we need them.