### PR TITLE
[9.x]  Replace raw invisible characters in regex expressions with counterpart Unicode regex notations

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -53,7 +53,7 @@ class TrimStrings extends TransformsRequest
             return $value;
         }
 
-        return preg_replace('~^[\s﻿​]+|[\s﻿​]+$~u', '', $value) ?? trim($value);
+        return preg_replace('~^[\s\x{FEFF}\x{200B}]+|[\s\x{FEFF}\x{200B}]+$~u', '', $value) ?? trim($value);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1073,7 +1073,7 @@ class Str
      */
     public static function squish($value)
     {
-        return preg_replace('~(\s|\x{3164})+~u', ' ', preg_replace('~^[\s﻿]+|[\s﻿]+$~u', '', $value));
+        return preg_replace('~(\s|\x{3164})+~u', ' ', preg_replace('~^[\s\x{FEFF}]+|[\s\x{FEFF}]+$~u', '', $value));
     }
 
     /**

--- a/tests/Http/Middleware/TrimStringsTest.php
+++ b/tests/Http/Middleware/TrimStringsTest.php
@@ -16,13 +16,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => 'This title does not contains any zero-width space',
+            'title' => 'This title does not contain any zero-width space',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title does not contains any zero-width space', $req->title);
+            $this->assertEquals('This title does not contain any zero-width space', $req->title);
         });
     }
 
@@ -34,13 +34,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '​This title contains a zero-width space at the begining',
+            'title' => '​This title contains a zero-width space at the beginning',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width space at the begining', $req->title);
+            $this->assertEquals('This title contains a zero-width space at the beginning', $req->title);
         });
     }
 
@@ -70,13 +70,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '﻿This title contains a zero-width non-breakable space at the begining',
+            'title' => '﻿This title contains a zero-width non-breakable space at the beginning',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width non-breakable space at the begining', $req->title);
+            $this->assertEquals('This title contains a zero-width non-breakable space at the beginning', $req->title);
         });
     }
 
@@ -88,13 +88,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '﻿﻿This title contains a zero-width non-breakable space at the begining',
+            'title' => '﻿﻿This title contains a zero-width non-breakable space at the beginning',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a zero-width non-breakable space at the begining', $req->title);
+            $this->assertEquals('This title contains a zero-width non-breakable space at the beginning', $req->title);
         });
     }
 
@@ -106,13 +106,13 @@ class TrimStringsTest extends TestCase
         $request = new Request;
 
         $request->merge([
-            'title' => '﻿​﻿This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the begining and the end​',
+            'title' => '﻿​﻿This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the beginning and the end​',
         ]);
 
         $middleware = new TrimStrings;
 
         $middleware->handle($request, function ($req) {
-            $this->assertEquals('This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the begining and the end', $req->title);
+            $this->assertEquals('This title contains a combination of zero-width non-breakable space and zero-width spaces characters at the beginning and the end', $req->title);
         });
     }
 }


### PR DESCRIPTION
It is always a good practice to avoid or at least minimize the usage of unescaped non-ascii characters in source code, especially if they are invisible characters.

#41949 introduced an addition to TrimStrings middleware's regex to filter out "Zero Width No-Break Space" (\x{FEFF}) characters, however it was implemented as a raw unescaped invisible character in the source code.

![image](https://user-images.githubusercontent.com/5486970/212861289-867b67b8-a27e-4879-aed0-f93f1b9ec92f.png)

#44906 added one more invisible character "Zero Width Space" (\x{200B}) to the same regex.

![image](https://user-images.githubusercontent.com/5486970/212862324-88b1e5a1-d145-4fed-b672-9384d0631b3e.png)

However, these symbols aren't visible in GitHub diff

![image](https://user-images.githubusercontent.com/5486970/212866466-c25cd646-9aea-4fa6-80cd-c8ab10cc3131.png)

as well as in some text editors like Notepad++ (even with Show All Characters option turned on)

![image](https://user-images.githubusercontent.com/5486970/212872736-d53746e4-47ba-474e-a57a-3daa372595ad.png)

This PR adds more readability to the source code by replacing those invisible characters in both places where they are used with their counterpart Unicode regex notations without affecting the functionality.

 \Illuminate\Foundation\Http\Middleware::transform():
![image](https://user-images.githubusercontent.com/5486970/212868728-670660db-3d3c-4233-9fa2-6d8a6cfaed8e.png)

\Illuminate\Support\Str::squish():
![image](https://user-images.githubusercontent.com/5486970/212869912-e09a9c8b-e25c-484e-8b6a-edb015a7d14a.png)

There's no need to modify corresponding tests that use "real-life" unescaped raw invisible characters as functionality hasn't changed, however there were added some spelling corrections.
