### PR TITLE
[9.x] Add `notFound` helper to Http Client response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -205,6 +205,16 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Determine if the response was a 404 "Not Found" response.
+     *
+     * @return bool
+     */
+    public function notFound()
+    {
+        return $this->status() === 404;
+    }
+
+    /**
      * Determine if the response indicates a client or server error occurred.
      *
      * @return bool

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -78,6 +78,17 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->forbidden());
     }
 
+    public function testNotFoundResponse()
+    {
+        $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 404),
+        ]);
+
+        $response = $this->factory->post('http://laravel.com');
+
+        $this->assertTrue($response->notFound());
+    }
+
     public function testResponseBodyCasting()
     {
         $this->factory->fake([


### PR DESCRIPTION

This PR adds some syntactic sugar to the Http Client Response class.

In a project we had to use the following code to check if a response was `404 Not Found`

```php
$response = Http::get('https://laravel.com');

if ($response->status() === 404) {
    doSomething();
}
```

You could still replace the `404` literal with a constant `Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND`, but that adds a unnecessary dependency there.

With this PR you can do the following, which is a bit cleaner.

```php
$response = Http::get('https://laravel.com');

if ($response->notFound()) {
    doSomething();
}
```
