### PR TITLE
[9.x] Add 402 exception view

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/402.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/402.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::minimal')
+
+@section('title', __('Payment Required'))
+@section('code', '402')
+@section('message', __('Payment Required'))


### PR DESCRIPTION
Currently no error page exists for exceptions with an HTTP status code of **402 Payment Required**.
Even though it's a [nonstandard response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402), it's [used by multiple large companies](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_client_errors) to indicate functionality limited due to a payment being required.

Personally, I'm using it in a SaaS project where certain features are only available on a paid plan. If the locked functionality involves entire (public-facing) pages/routes, it makes sense to show a default error view. For example: when users who are not entitled to use the paid feature of embedding a scheduling page on their own site still try to embed the page, they should be greeted with the new 402 exception view.