### PR TITLE
[9.x] Added a bootstrapping and bootstrapped event for pre and post boostrapping

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -236,6 +236,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $this->hasBeenBootstrapped = true;
 
+        $this['events']->dispatch('bootstrapping', [$this]);
+
         foreach ($bootstrappers as $bootstrapper) {
             $this['events']->dispatch('bootstrapping: '.$bootstrapper, [$this]);
 
@@ -243,6 +245,8 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
             $this['events']->dispatch('bootstrapped: '.$bootstrapper, [$this]);
         }
+
+        $this['events']->dispatch('bootstrapped', [$this]);
     }
 
     /**
@@ -271,6 +275,17 @@ class Application extends Container implements ApplicationContract, CachesConfig
     }
 
     /**
+     * Register a callback to run before any bootstrapping.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function preBootstrapping(Closure $callback)
+    {
+        $this['events']->listen('bootstrapping', $callback);
+    }
+
+    /**
      * Register a callback to run after a bootstrapper.
      *
      * @param  string  $bootstrapper
@@ -280,6 +295,17 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function afterBootstrapping($bootstrapper, Closure $callback)
     {
         $this['events']->listen('bootstrapped: '.$bootstrapper, $callback);
+    }
+
+    /**
+     * Register a callback to run after all bootstrapping.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function postBootstrapping(Closure $callback)
+    {
+        $this['events']->listen('bootstrapped', $callback);
     }
 
     /**

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -315,6 +315,26 @@ class FoundationApplicationTest extends TestCase
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades'));
     }
 
+    public function testPreBootstrappingAddsClosure()
+    {
+        $app = new Application;
+        $closure = function () {
+            //
+        };
+        $app->preBootstrapping($closure);
+        $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapping'));
+    }
+
+    public function testPostBootstrappingAddsClosure()
+    {
+        $app = new Application;
+        $closure = function () {
+            //
+        };
+        $app->postBootstrapping($closure);
+        $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped'));
+    }
+
     public function testTerminationCallbacksCanAcceptAtNotation()
     {
         $app = new Application;


### PR DESCRIPTION
Laravel currently supports listening to pre- and post-events for individual bootstrappers, but if you want to do something after all the bootstrappers have been run, or before any have been, you have to hardcode references to the default bootstrappers and hope nothing has changed.

This PR adds the `bootstrapping` and `bootstrapped` events, following the theme of `bootstrapping: BootstrapperName` and `bootstrapped: BootstrapperName`. This should allow developers to react to bootstrapping without having to worry whether `Kernel::$bootstrappers` has been modified in some way. In fact, the very existence of these two new events may remove any need to modify the bootstrappers array.

I have also added tests for both of these.

## `bootstrapping`
This event is fired before `Application` loops through the bootstrappers and can be hooked into using:
```php
Application::preBootstrapping(Closure $callback)
```

## `bootstrapped`
This event is fired after `Application` loops through the bootstrappers and can be hooked into using:
```php
Application::postBootstrapping(Closure $callback)
```