### PR TITLE
[9.x] Allow to set HTTP client for mailers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,8 @@
         "phpstan/phpstan": "^1.4.7",
         "phpunit/phpunit": "^9.5.8",
         "predis/predis": "^1.1.9|^2.0.2",
-        "symfony/cache": "^6.0"
+        "symfony/cache": "^6.0",
+        "symfony/http-client": "^6.0"
     },
     "provide": {
         "psr/container-implementation": "1.1|2.0",

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -169,7 +169,7 @@ class MailManager implements FactoryContract
      */
     protected function createSmtpTransport(array $config)
     {
-        $factory = new EsmtpTransportFactory();
+        $factory = new EsmtpTransportFactory;
 
         $transport = $factory->create(new Dsn(
             ! empty($config['encryption']) && $config['encryption'] === 'tls' ? (($config['port'] == 465) ? 'smtps' : 'smtp') : '',

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -168,7 +169,7 @@ class MailManager implements FactoryContract
      */
     protected function createSmtpTransport(array $config)
     {
-        $factory = new EsmtpTransportFactory;
+        $factory = new EsmtpTransportFactory();
 
         $transport = $factory->create(new Dsn(
             ! empty($config['encryption']) && $config['encryption'] === 'tls' ? (($config['port'] == 465) ? 'smtps' : 'smtp') : '',
@@ -223,7 +224,7 @@ class MailManager implements FactoryContract
      * Create an instance of the Symfony Amazon SES Transport driver.
      *
      * @param  array  $config
-     * @return \Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport
+     * @return \Illuminate\Mail\Transport\SesTransport
      */
     protected function createSesTransport(array $config)
     {
@@ -274,7 +275,7 @@ class MailManager implements FactoryContract
      */
     protected function createMailgunTransport(array $config)
     {
-        $factory = new MailgunTransportFactory();
+        $factory = new MailgunTransportFactory(null, $this->getHttpClient($config));
 
         if (! isset($config['secret'])) {
             $config = $this->app['config']->get('services.mailgun', []);
@@ -296,7 +297,7 @@ class MailManager implements FactoryContract
      */
     protected function createPostmarkTransport(array $config)
     {
-        $factory = new PostmarkTransportFactory();
+        $factory = new PostmarkTransportFactory(null, $this->getHttpClient($config));
 
         $options = isset($config['message_stream_id'])
                     ? ['message_stream' => $config['message_stream_id']]
@@ -367,6 +368,21 @@ class MailManager implements FactoryContract
     protected function createArrayTransport()
     {
         return new ArrayTransport;
+    }
+
+    /**
+     * Get a configured Symfony HTTP client instance.
+     *
+     * @return \Symfony\Contracts\HttpClient\HttpClientInterface|null
+     */
+    protected function getHttpClient(array $config)
+    {
+        if ($options = $config['client'] ?? false) {
+            $maxHostConnections = Arr::pull($options, 'max_host_connections', 6);
+            $maxPendingPushes = Arr::pull($options, 'max_pending_pushes', 50);
+
+            return HttpClient::create($options, $maxHostConnections, $maxPendingPushes);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR allows people to configure custom options for the HTTP client when using the Mailgun or Postmark mailers from Symfony.

All options to be configured can be found on Symfony's docs: https://symfony.com/doc/current/reference/configuration/framework.html#http-client

For example, setting a timeout:

```php
'mailgun' => [
    'transport' => 'mailgun',
    'client' => [
        'timeout' => 7.5 // Seconds
    ],
],
```