### PR TITLE
[9.x] fix: dependency in `cache:forget` command

### DIFF
--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -42,25 +42,15 @@ class ForgetCommand extends Command
     protected $cache;
 
     /**
-     * Create a new cache clear command instance.
+     * Execute the console command.
      *
      * @param  \Illuminate\Cache\CacheManager  $cache
      * @return void
      */
-    public function __construct(CacheManager $cache)
+    public function handle(CacheManager $cache)
     {
-        parent::__construct();
-
         $this->cache = $cache;
-    }
 
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function handle()
-    {
         $this->cache->store($this->argument('store'))->forget(
             $this->argument('key')
         );

--- a/tests/Cache/ForgetCommandTest.php
+++ b/tests/Cache/ForgetCommandTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\Console\ForgetCommand;
+use PHPUnit\Framework\TestCase;
+
+class ForgetCommandTest extends TestCase
+{
+    public function testCanGetHelpWithoutInstantiatingDependencies()
+    {
+        $help = (new ForgetCommand())->getHelp();
+        $this->stringContains('php artisan cache:forget', $help);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Move dependencies to to handle method.

By moving the dependencies to the handle method, we are able to run help and list commands without having to instantiate all of the dependencies of the command before we need them.