### PR TITLE
[9.x] fix: dependency in `cache:table` command

### DIFF
--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -48,27 +48,17 @@ class CacheTableCommand extends Command
     protected $composer;
 
     /**
-     * Create a new cache table command instance.
+     * Execute the console command.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  \Illuminate\Support\Composer  $composer
      * @return void
      */
-    public function __construct(Filesystem $files, Composer $composer)
+    public function handle(Filesystem $files, Composer $composer)
     {
-        parent::__construct();
-
         $this->files = $files;
         $this->composer = $composer;
-    }
 
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function handle()
-    {
         $fullPath = $this->createBaseMigration();
 
         $this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/cache.stub'));

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -40,6 +40,12 @@ class CacheTableCommandTest extends TestCase
         $this->runCommand($command);
     }
 
+    public function testCanGetHelpWithoutInstantiatingDependencies()
+    {
+        $help = (new CacheTableCommand())->getHelp();
+        $this->stringContains('php artisan cache:table', $help);
+    }
+
     protected function runCommand($command, $input = [])
     {
         return $command->run(new ArrayInput($input), new NullOutput);


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Move dependencies to to handle method.

By moving the dependencies to the handle method, we are able to run help and list commands without having to instantiate all of the dependencies of the command before we need them.