### PR TITLE
[9.x] Test for eloquent destroy method 🔍

### DIFF
--- a/tests/Integration/Database/Fixtures/PostStringyKey.php
+++ b/tests/Integration/Database/Fixtures/PostStringyKey.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PostStringyKey extends Model
+{
+    public $table = 'my_posts';
+
+    public $primaryKey = 'my_id';
+}


### PR DESCRIPTION
Tries to cover all the aspects of the `destroy` method, which has no integration tests.
Including the fired eloquent events and the number of run queries and etc.
