### PR TITLE
[9.x] Ensures channel name matches from start of string

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -371,6 +371,6 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function channelNameMatchesPattern($channel, $pattern)
     {
-        return preg_match('/'.preg_replace('/\{(.*?)\}/', '([^\.]+)', $pattern).'$/', $channel);
+        return preg_match('/^'.preg_replace('/\{(.*?)\}/', '([^\.]+)', $pattern).'$/', $channel);
     }
 }

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -336,6 +336,8 @@ class BroadcasterTest extends TestCase
             ['something.23.test.42', 'something.test.{id}', false],
             ['something-23-test-42', 'something-{id}-test', false],
             ['23:test', '{id}:test:abcd', false],
+            ['customer.order.1', 'order.{id}', false],
+            ['customerorder.1', 'order.{id}', false],
         ];
     }
 }


### PR DESCRIPTION
This fixes a bug with the channel matching.

Previously `'customer.order.1'` would match the pattern `'order.{id}'` because it was not checking that the pattern started at the beginning (`^`) of the string.

Both of the additional data sets fail with the previous implementation.